### PR TITLE
chore: 整理 .env.example，删除死变量和旧兼容变量，精简注释

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,51 @@ dist/
 # 根级历史残留，防止误建。
 data/
 
+# 历史目录和误运行路径兜底：这些位置不再是主线配置入口，
+# 但一旦残留真实 .env、prompt、知识库或成员映射，仍不能进入 Git。
+.env
+# 真实环境变量文件可能残留在旧模块或误运行子目录，显式兜底避免迁移期误提交。
+**/.env
+config/.env
+config/member_id_mapping.json
+config/world.md
+config/context_modules.toml
+config/prompts/*.md
+!config/prompts/*.example.md
+config/context/*.md
+!config/context/*.example.md
+config/knowledge/**/*.md
+config/knowledge/**/*.markdown
+!config/knowledge/**/*.example.md
+!config/knowledge/**/*.example.markdown
+llm/.env
+llm/config/.env
+llm/config/member_id_mapping.json
+llm/config/world.md
+llm/config/context_modules.toml
+llm/config/prompts/*.md
+!llm/config/prompts/*.example.md
+llm/config/context/*.md
+!llm/config/context/*.example.md
+llm/config/knowledge/**/*.md
+llm/config/knowledge/**/*.markdown
+!llm/config/knowledge/**/*.example.md
+!llm/config/knowledge/**/*.example.markdown
+qq-maid-core/.env
+qq-maid-core/config/.env
+qq-maid-core/config/member_id_mapping.json
+qq-maid-core/config/world.md
+qq-maid-core/config/context_modules.toml
+qq-maid-core/config/prompts/*.md
+!qq-maid-core/config/prompts/*.example.md
+qq-maid-core/config/context/*.md
+!qq-maid-core/config/context/*.example.md
+qq-maid-core/config/knowledge/**/*.md
+qq-maid-core/config/knowledge/**/*.markdown
+!qq-maid-core/config/knowledge/**/*.example.md
+!qq-maid-core/config/knowledge/**/*.example.markdown
+qq-maid-gateway-rs/config/.env
+
 # ========== runtime 运行目录 ==========
 # 只提交 README、.example 模板和 static/index.html；
 # 不提交真实配置、运行产物、二进制和部署脚本副本。
@@ -11,10 +56,8 @@ runtime/config/.env
 runtime/config/member_id_mapping.json
 runtime/config/world.md
 runtime/config/context_modules.toml
-runtime/config/prompts/innerworld_lore.md
-runtime/config/prompts/maid_system.md
-runtime/config/prompts/mode_rules.md
-runtime/config/prompts/session_context.md
+runtime/config/prompts/*.md
+!runtime/config/prompts/*.example.md
 runtime/config/context/*.md
 !runtime/config/context/*.example.md
 runtime/config/knowledge/**/*.md

--- a/qq-maid-core/README.md
+++ b/qq-maid-core/README.md
@@ -111,7 +111,7 @@ runtime/.env
 - `PROMPT_DIR`、`MEMBER_ID_MAPPING_FILE`：固定 prompt 和成员映射。
 - `KNOWLEDGE_DIR`：Markdown 知识目录；留空时使用 `config/knowledge`，启动时自动同步到 SQLite FTS5，普通聊天按需检索片段。
 - `RSS_*`：RSS / Atom 轮询、去重、推送和 SSRF 防护相关配置。
-- `OPENAI_SEARCH_MODEL`：联网查询模型配置。`SEARCH_CONTEXT_SIZE`、`SEARCH_MAX_RESULTS` 目前只保留在模板中，当前 `/查` flow 仍使用查询模块默认值。
+- `OPENAI_SEARCH_MODEL`：联网查询模型配置。`SEARCH_CONTEXT_SIZE`、`SEARCH_MAX_RESULTS` 当前没有环境变量入口，`/查` flow 使用查询模块默认值。
 - `QWEATHER_API_KEY`、`QWEATHER_API_HOST`、`QWEATHER_GEO_HOST`：天气配置；当前 `QWEATHER_API_KEY` 为必需项。
 
 模型配置支持单模型和候选链两种写法：

--- a/runtime/.env.example
+++ b/runtime/.env.example
@@ -1,75 +1,80 @@
-# QQ 官方机器人配置
-# 新变量名优先；兼容 QQ_APPID / QQ_SECRET 旧变量名。
+# =============================================================================
+# QQ 官方机器人
+# =============================================================================
 QQ_BOT_APP_ID=你的QQ机器人AppID
 QQ_BOT_APP_SECRET=你的QQ机器人AppSecret
 QQ_BOT_SANDBOX=false
 # QQ_BOT_API_BASE=https://api.sgroup.qq.com
 QQ_BOT_TOKEN_REFRESH_MARGIN_SECONDS=60
 
-# Rust gateway -> Rust Core /v1/respond 地址
-QQ_MAID_RESPOND_URL=http://127.0.0.1:8787/v1/respond
-
-# 第一版仅以 C2C 文本主链路为验收门槛；富媒体发送失败会 fallback 到文本。
-QQ_MAID_ENABLE_MARKDOWN=true
-QQ_MAID_ENABLE_IMAGE=false
-# 旧兼容变量；未设置 QQ_MAID_GROUP_MESSAGE_MODE 时：true->active，false->off，未设置->mention。
-QQ_MAID_ENABLE_GROUP_MESSAGES=false
-
-# Gateway 日志默认脱敏；verbose 只用于临时排障，会打印 extracted content。
+# 日志默认脱敏；verbose 只用于临时排障，会打印 extracted content。
 QQ_MAID_GATEWAY_VERBOSE_LOG=false
 
-# 普通群消息默认 mention：处理命令、@机器人和回复机器人消息。
-# off=忽略普通群消息，command=只处理 / 命令，mention=命令/@/回复机器人，active=处理过滤后的普通群消息。
-QQ_MAID_GROUP_MESSAGE_MODE=mention
-# 旧变量 QQ_MAID_ENABLE_GROUP_MESSAGES 仅在未设置新变量时兼容：false->off，true->active，未设置->mention。
+# 富媒体发送失败会 fallback 到文本。
+QQ_MAID_ENABLE_MARKDOWN=true
+QQ_MAID_ENABLE_IMAGE=false
 
-# Gateway 内部主动推送入口，默认只监听本机，供 RSS 调度与 Todo 每日提醒调用。
+# 群消息处理策略：
+# off=忽略，command=只处理 / 命令，mention=命令/@/回复机器人，active=处理普通群消息。
+QQ_MAID_GROUP_MESSAGE_MODE=mention
+
+# Gateway 主动推送入口（供 RSS 调度与 Todo 每日提醒调用），默认只监听本机。
 QQ_MAID_PUSH_ENABLED=true
 QQ_MAID_PUSH_HOST=127.0.0.1
 QQ_MAID_PUSH_PORT=8788
 # 可选共享 token；配置后 Core 侧 RSS_PUSH_TOKEN 必须一致。
 QQ_MAID_PUSH_TOKEN=
 
+# Gateway -> Core /v1/respond 地址
+QQ_MAID_RESPOND_URL=http://127.0.0.1:8787/v1/respond
+
+# =============================================================================
+# LLM Provider 与模型
+# =============================================================================
 # openai / deepseek / auto
 LLM_PROVIDER=auto
 
+# 主模型，支持候选链：从左到右尝试，可恢复错误会 fallback 到下一个候选。
+LLM_MODEL=openai:gpt-5.4-mini
+# LLM_MODEL=openai:gpt-5.4-mini,deepseek:deepseek-chat
+TITLE_MODEL=openai:gpt-5.4-mini
+# 以下留空时沿用 LLM_MODEL，也支持候选链语法。
+TODO_MODEL=
+MEMORY_MODEL=
+COMPACT_MODEL=
+TRANSLATION_MODEL=
+
+# -----------------------------------------------------------------------------
 # OpenAI
+# -----------------------------------------------------------------------------
 OPENAI_API_KEY=你的OpenAI_API_Key
 OPENAI_MODEL=openai:gpt-5.5
+# 单地址用 OPENAI_BASE_URL；多地址用 OPENAI_BASE_URLS（逗号分隔，取第一个非空，优先级更高）。
 OPENAI_BASE_URL=
 OPENAI_BASE_URLS=
-# auto 优先使用 Responses API，必要时降级 Chat Completions；chat_only 只走 Chat Completions。
-# /查 联网搜索仍需要支持 Responses web_search 的 OpenAI 端点，chat_only 兼容网关不会自动支持。
+# auto 优先 Responses API，必要时降级 Chat Completions；chat_only 只走 Chat Completions。
 # GLM / Qwen / Ollama 等 OpenAI 兼容网关请设置为 chat_only 跳过 Responses API。
 OPENAI_API_MODE=auto
 
-# ========== GLM（智谱 AI）配置示例 ==========
-# 取消注释并替换为你的 GLM API Key
+# GLM（智谱 AI）配置示例：
 # OPENAI_API_KEY=你的GLM_API_KEY
 # OPENAI_BASE_URL=https://open.bigmodel.cn/api/paas/v4
 # OPENAI_API_MODE=chat_only
 # LLM_MODEL=openai:glm-4-flash
 # TITLE_MODEL=openai:glm-4-flash
 
+# -----------------------------------------------------------------------------
 # DeepSeek fallback
+# -----------------------------------------------------------------------------
 DEEPSEEK_API_KEY=
 DEEPSEEK_BASE_URL=https://api.deepseek.com
 DEEPSEEK_MODEL=deepseek:deepseek-chat
 
-# Rust Core module
-# LLM_MODEL 支持单模型或按优先级从左到右的候选链；
-# 可恢复的上游错误会尝试下一个候选，所有候选失败后仍返回错误。
-LLM_MODEL=openai:gpt-5.4-mini
-# LLM_MODEL=openai:gpt-5.4-mini,deepseek:deepseek-chat
-TITLE_MODEL=openai:gpt-5.4-mini
-TODO_MODEL=
-MEMORY_MODEL=
-COMPACT_MODEL=
-# 翻译命令和 RSS 翻译共用；留空时沿用 LLM_MODEL，也支持同样的候选链语法。
-TRANSLATION_MODEL=
+# -----------------------------------------------------------------------------
+# LLM 调用参数与本地服务
+# -----------------------------------------------------------------------------
 LLM_STREAM=true
-# 某些 OpenAI 兼容网关的 SSE 不完全兼容；若流式成功结束但正文为空，
-# 当前实现会自动补一次同请求的非流式重试，避免普通聊天回空。
+# 某些 OpenAI 兼容网关 SSE 不完全兼容；流式成功但正文为空时会自动补一次非流式重试。
 # /v1/respond 输出模式：final / streaming（仅 /查 的流式路径会用到）
 LLM_SEND_MODE=final
 LLM_REQUEST_TIMEOUT_SECONDS=90
@@ -81,32 +86,34 @@ LLM_TRACE_CHAT_OUTPUT=false
 LLM_SERVER_HOST=127.0.0.1
 LLM_SERVER_PORT=8787
 
-# 本地 Web 控制台默认关闭；启用后提供 /console/ 和 /api/v1/markdown/render。
+# =============================================================================
+# 本地 Web 控制台（默认关闭）
+# =============================================================================
+# 启用后提供 /console/ 和 /api/v1/markdown/render。
 WEB_CONSOLE_ENABLED=false
-# 控制台跨域 allowlist，留空表示仅同源；多个 origin 用英文逗号分隔。
+# 跨域 allowlist，留空表示仅同源；多个 origin 用英文逗号分隔。
 WEB_CONSOLE_ALLOWED_ORIGINS=
 
-# Rust data and config
+# =============================================================================
+# 数据与配置路径
+# =============================================================================
 # 相对路径按 runtime 运行目录解析；生产建议使用外部绝对路径。
 APP_DB_FILE=data/storage/app.db
-# PROMPT_DIR 留空时使用默认 config/prompts；默认目录缺真实 prompt 会回退到公开内置通用 prompt。
+MEMBER_ID_MAPPING_FILE=config/member_id_mapping.json
+# PROMPT_DIR 留空时使用默认 config/prompts；缺文件会回退到内置通用 prompt。
 # 显式配置 PROMPT_DIR 后，缺文件或空文件会作为配置错误处理。
 PROMPT_DIR=
-# Markdown 知识目录；留空时使用 config/knowledge。
-# 将 .md 文件放入该目录并重启后会自动同步到 APP_DB_FILE，普通聊天按需检索片段。
+# Markdown 知识目录；留空时使用 config/knowledge，启动时自动同步到 SQLite FTS5。
 KNOWLEDGE_DIR=
-MEMBER_ID_MAPPING_FILE=config/member_id_mapping.json
-# 服务器外部私有配置示例：
+# 外部私有配置示例：
 # PROMPT_DIR=/opt/qqbot/private/config/prompts
 # MEMBER_ID_MAPPING_FILE=/opt/qqbot/private/config/member_id_mapping.json
 # KNOWLEDGE_DIR=/opt/qqbot/private/config/knowledge
 # APP_DB_FILE=/opt/qqbot/data/app.db
-# 本地双仓库示例（从 runtime/ 工作目录解析）：
-# PROMPT_DIR=../qqbot-private/config/prompts
-# MEMBER_ID_MAPPING_FILE=../qqbot-private/config/member_id_mapping.json
-# KNOWLEDGE_DIR=../qqbot-private/config/knowledge
 
+# =============================================================================
 # RSS / Atom 订阅
+# =============================================================================
 RSS_ENABLED=true
 RSS_POLL_INTERVAL_SECONDS=300
 RSS_HTTP_TIMEOUT_SECONDS=15
@@ -122,21 +129,28 @@ RSS_PUSH_MESSAGE_TYPE=markdown
 # 默认拦截 localhost、内网、link-local 和 metadata 地址；仅受控测试环境可开启。
 RSS_ALLOW_PRIVATE_URLS=false
 
-# Todo 每日提醒：只提醒可验证 private target 的个人待办，群待办不会主动推送。
+# =============================================================================
+# Todo 每日提醒
+# =============================================================================
+# 只提醒可验证 private target 的个人待办，群待办不会主动推送。
 TODO_DAILY_REMINDER_ENABLED=false
-# 严格使用 HH:MM 24 小时制，固定按 Asia/Shanghai 解释。
+# HH:MM 24 小时制，固定按 Asia/Shanghai 解释。
 TODO_DAILY_REMINDER_TIME=09:00
 
-# Query
+# =============================================================================
+# 联网搜索（/查）
+# =============================================================================
 OPENAI_SEARCH_MODEL=gpt-5.5
-SEARCH_CONTEXT_SIZE=low
-SEARCH_MAX_RESULTS=5
 
-# Weather
+# =============================================================================
+# 天气（和风天气）
+# =============================================================================
 QWEATHER_API_KEY=你的和风天气APIKey
 QWEATHER_API_HOST=https://你的和风天气APIHost
-# 如果控制台分配的 GeoAPI Host 和 API Host 相同，可留空复用
+# GeoAPI Host 和 API Host 相同时可留空复用。
 QWEATHER_GEO_HOST=
 
-# 默认日志
+# =============================================================================
+# 日志
+# =============================================================================
 RUST_LOG=info,qq_maid_gateway_rs=debug

--- a/runtime/.env.example
+++ b/runtime/.env.example
@@ -53,6 +53,7 @@ OPENAI_MODEL=openai:gpt-5.5
 OPENAI_BASE_URL=
 OPENAI_BASE_URLS=
 # auto 优先 Responses API，必要时降级 Chat Completions；chat_only 只走 Chat Completions。
+# /查 联网查询仍要求 OpenAI Responses web_search 兼容端点，chat_only 不覆盖该路径。
 # GLM / Qwen / Ollama 等 OpenAI 兼容网关请设置为 chat_only 跳过 Responses API。
 OPENAI_API_MODE=auto
 


### PR DESCRIPTION
## 改动

- 整理 `runtime/.env.example`：删除代码不再读取的 `SEARCH_CONTEXT_SIZE`、`SEARCH_MAX_RESULTS`，精简旧兼容变量说明，并保留仍有配置价值的注释与外部私有配置示例。
- 更新 Core 配置说明：明确 `/查` 当前使用查询模块默认值，不再描述已删除的搜索环境变量入口。
- 补齐 `.gitignore` 私有配置兜底：恢复根级和旧目录 `.env`、私有 prompt、知识库、成员映射等迁移期忽略规则。
- 加强 `runtime/config/prompts/` 忽略：改为忽略所有私有 `*.md`，仅反向放行 `*.example.md` 模板，避免新增私有 prompt 被普通 commit 带入。

## Review 修复

- 修复“旧配置/根级敏感文件兜底忽略被移除”：新增显式 `**/.env` 兜底，并保留旧 `config/`、`llm/config/`、`qq-maid-core/config/`、`qq-maid-gateway-rs/config/.env` 等历史私有配置路径忽略。
- 修复“runtime/config/prompts/ 只忽略固定文件名”：使用通配规则覆盖后续新增私有 prompt，同时继续放行公开 example 模板。

## 验证

- `git diff --check` 通过
- `git check-ignore -q .env` 通过
- `git check-ignore -q runtime/config/prompts/custom.md` 通过
- `git check-ignore -q runtime/config/prompts/custom.example.md` 返回未忽略，确认 example 模板可提交
- 本轮仅修改配置模板、文档说明和 `.gitignore`，未复跑 cargo 格式化、clippy、测试或 release 构建
