### PR TITLE
[codex] 优化安全拦截错误提示

### DIFF
--- a/qq-maid-gateway-rs/src/respond.rs
+++ b/qq-maid-gateway-rs/src/respond.rs
@@ -623,6 +623,9 @@ fn respond_error_info_to_qq_text(info: &RespondErrorInfo) -> String {
     match info.code.as_str() {
         "timeout" => "LLM 服务处理超时，请稍后再试".to_owned(),
         "config" => "LLM 服务配置未完成，请联系维护者处理".to_owned(),
+        "safety_blocked" => {
+            "这条消息触发了上游安全拦截，我没法按原样继续。可以换个说法再试。".to_owned()
+        }
         "invalid_request" | "bad_request" => safe_message
             .map(|message| format!("请求格式有误：{message}"))
             .unwrap_or_else(|| "请求格式有误，请调整后再试".to_owned()),
@@ -1134,6 +1137,30 @@ Connection: close
             respond_error_to_qq_text(&error),
             "上游服务暂时不可用，请稍后再试"
         );
+    }
+
+    #[test]
+    fn status_error_safety_blocked_uses_fixed_user_message() {
+        let error = RespondError::Status {
+            status: StatusCode::OK,
+            body: serde_json::json!({
+                "ok": false,
+                "error": {
+                    "code": "safety_blocked",
+                    "message": "Chat Completions returned HTTP 400: {\"error\":{\"message\":\"request blocked by moderation policy\",\"type\":\"prompt_blocked\"}}",
+                    "stage": "http",
+                }
+            })
+            .to_string(),
+        };
+
+        let qq_text = respond_error_to_qq_text(&error);
+        assert_eq!(
+            qq_text,
+            "这条消息触发了上游安全拦截，我没法按原样继续。可以换个说法再试。"
+        );
+        assert!(!qq_text.contains("请求格式有误"));
+        assert!(!qq_text.contains("prompt_blocked"));
     }
 
     #[test]

--- a/qq-maid-llm/src/provider/openai/chat.rs
+++ b/qq-maid-llm/src/provider/openai/chat.rs
@@ -194,6 +194,11 @@ async fn chat_status_error(status: StatusCode, response: reqwest::Response) -> L
             status.as_u16()
         )
     };
+    // OpenAI 兼容网关可能把安全拦截放在 HTTP 400 返回体中；这不是本地请求格式错误，
+    // 需要保留独立错误码，避免 Gateway 向用户展示“请求格式有误”的误导文案。
+    if is_prompt_blocked_error(&detail) {
+        return LlmError::new("safety_blocked", message, "http");
+    }
     match status.as_u16() {
         401 | 403 => LlmError::config(message),
         400 | 404 | 422 => LlmError::new("bad_request", message, "http"),
@@ -210,6 +215,14 @@ fn truncate_error_detail(value: &str, limit: usize) -> String {
     let mut truncated = value.chars().take(limit).collect::<String>();
     truncated.push_str("...");
     truncated
+}
+
+fn is_prompt_blocked_error(detail: &str) -> bool {
+    let lower = detail.to_ascii_lowercase();
+    lower.contains("prompt_blocked")
+        || lower.contains("moderation policy")
+        || lower.contains("content policy")
+        || lower.contains("safety policy")
 }
 
 pub(crate) async fn non_stream_completion(
@@ -573,6 +586,39 @@ mod tests {
 
         assert_eq!(outcome.reply, "retry ok");
         assert_eq!(state.lock().await.requests.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn prompt_blocked_error_keeps_safety_code() {
+        let (base_url, _state) = spawn_mock_chat(
+            vec![
+                json!({
+                    "error": {
+                        "message": "request blocked by moderation policy",
+                        "type": "prompt_blocked"
+                    }
+                })
+                .to_string(),
+            ],
+            StatusCode::BAD_REQUEST,
+        )
+        .await;
+        let client =
+            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+
+        let err = non_stream_completion(
+            &client,
+            "openai",
+            "gpt-test",
+            1200,
+            &[ChatMessage::user("hi")],
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.code, "safety_blocked");
+        assert_eq!(err.stage, "http");
+        assert!(err.message.contains("prompt_blocked"));
     }
 
     #[tokio::test]

--- a/qq-maid-llm/src/provider/status.rs
+++ b/qq-maid-llm/src/provider/status.rs
@@ -188,6 +188,12 @@ fn safe_error_summary(error: &LlmError) -> String {
     if error.code == "timeout" || lower.contains("timed out") || lower.contains("timeout") {
         return "上游请求超时".to_owned();
     }
+    if error.code == "safety_blocked"
+        || lower.contains("prompt_blocked")
+        || lower.contains("moderation policy")
+    {
+        return format!("上游安全策略拦截{status}");
+    }
     if lower.contains("unauthorized")
         || lower.contains("authentication")
         || lower.contains("api key")
@@ -272,6 +278,21 @@ mod tests {
         );
 
         assert_eq!(safe_error_summary(&error), "上游网络请求失败");
+    }
+
+    #[test]
+    fn safety_blocked_summary_does_not_expose_provider_detail() {
+        let error = LlmError::new(
+            "safety_blocked",
+            "Chat Completions returned HTTP 400: prompt_blocked moderation policy detail",
+            "http",
+        );
+
+        let summary = safe_error_summary(&error);
+
+        assert_eq!(summary, "上游安全策略拦截（HTTP 400）");
+        assert!(!summary.contains("prompt_blocked"));
+        assert!(!summary.contains("moderation"));
     }
 
     #[test]


### PR DESCRIPTION
## 变更

- 将 OpenAI Chat Completions 返回体中的 `prompt_blocked` / moderation policy 等安全拦截，从 `bad_request` 细分为 `safety_blocked`。
- Gateway 收到 `safety_blocked` 时返回固定、安全的 QQ 用户提示，不再显示“请求格式有误”，也不透传上游错误详情。
- 上游健康摘要新增安全策略拦截分类，避免诊断信息泄露 provider 原始返回。

## 根因

Chat Completions 的 HTTP 400 过去统一映射为 `bad_request`。当上游把安全拦截也放在 HTTP 400 返回体中时，Gateway 会按 `bad_request` 生成“请求格式有误：...”文案，既误导用户，也可能暴露上游原始错误片段。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p qq-maid-llm`
- `cargo test -p qq-maid-gateway-rs`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
