### PR TITLE
chore: CI 仅在生产代码变更时触发

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,19 @@ name: CI
 
 on:
   pull_request:
+    paths:
+      - "**.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/ci.yml"
   push:
     branches:
       - master
+    paths:
+      - "**.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/ci.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - "**.rs"
-      - "Cargo.toml"
+      - "**/Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/ci.yml"
   push:
@@ -12,7 +12,7 @@ on:
       - master
     paths:
       - "**.rs"
-      - "Cargo.toml"
+      - "**/Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/ci.yml"
   workflow_dispatch:


### PR DESCRIPTION
## 改动

为 CI 工作流添加 `paths` 过滤，仅在 Rust 生产代码变更时运行。

## 触发条件

| 路径 | 说明 |
|------|------|
| `**.rs` | Rust 源码 |
| `Cargo.toml` | 工作区清单 |
| `Cargo.lock` | 依赖锁文件 |
| `.github/workflows/ci.yml` | CI 自身 |

## 不再触发 CI 的变更

- `README.md`、`CHANGELOG.md`、`AGENTS.md` 等纯文档
- `docs/` 目录
- `.gitignore`、`LICENSE` 等配置

`workflow_dispatch` 手动触发不受影响。