### PR TITLE
fix: 去掉 CI paths 过滤，恢复全量触发

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,19 +2,9 @@ name: CI
 
 on:
   pull_request:
-    paths:
-      - "**.rs"
-      - "**/Cargo.toml"
-      - "Cargo.lock"
-      - ".github/workflows/ci.yml"
   push:
     branches:
       - master
-    paths:
-      - "**.rs"
-      - "**/Cargo.toml"
-      - "Cargo.lock"
-      - ".github/workflows/ci.yml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 问题

paths 过滤与 required status check 冲突：文档类 PR 不触发 CI，导致 Rust checks 永远 pending，无法合并。

## 改动

移除 pull_request 和 push 的 paths 过滤，恢复为所有 PR 和 master push 均触发 CI。workflow_dispatch 不受影响。