### PR TITLE
fix: 修复未闭合代码围栏分块

### DIFF
--- a/qq-maid-core/src/runtime/knowledge/chunking.rs
+++ b/qq-maid-core/src/runtime/knowledge/chunking.rs
@@ -372,8 +372,23 @@ fn split_code_block(block: &MarkdownBlock) -> Vec<MarkdownBlock> {
         return vec![block.clone()];
     }
     let opener = lines[0];
-    let closer = lines[lines.len() - 1];
-    let content = &lines[1..lines.len() - 1];
+    let Some(fence) = CodeFence::open(opener.trim()) else {
+        return vec![block.clone()];
+    };
+    let last_line = lines[lines.len() - 1];
+    let closed = fence.closes(last_line.trim());
+    // 未闭合 fenced code block 到 EOF 时，最后一行仍是真实代码内容；
+    // 不能把它当作 closer，否则会被复制进每个切片并污染检索索引。
+    let closer = if closed {
+        last_line.to_owned()
+    } else {
+        fence.marker.clone()
+    };
+    let content = if closed {
+        &lines[1..lines.len() - 1]
+    } else {
+        &lines[1..]
+    };
     let mut blocks = Vec::new();
     let mut start = 0;
     while start < content.len() {
@@ -392,7 +407,7 @@ fn split_code_block(block: &MarkdownBlock) -> Vec<MarkdownBlock> {
         text.push('\n');
         text.push_str(&content[start..end].join("\n"));
         text.push('\n');
-        text.push_str(closer);
+        text.push_str(&closer);
         blocks.push(MarkdownBlock {
             text,
             start_line: block.start_line + start,

--- a/qq-maid-core/src/runtime/knowledge/mod.rs
+++ b/qq-maid-core/src/runtime/knowledge/mod.rs
@@ -368,6 +368,39 @@ mod tests {
     }
 
     #[test]
+    fn markdown_chunks_split_unclosed_code_fence_without_repeating_last_line() {
+        let mut content = String::from("# 代码\n\n```rust\n");
+        for index in 0..70 {
+            content.push_str(&format!("let value_{index} = {index};\n"));
+        }
+        content.push_str("let last_unique_rag_token = 70;");
+
+        let chunks = chunk_markdown("unclosed-code.md", &content);
+
+        assert!(chunks.len() >= 2);
+        for chunk in &chunks {
+            assert_eq!(chunk.chunk_type, "code");
+            assert_eq!(chunk.code_language.as_deref(), Some("rust"));
+            assert!(chunk.body.starts_with("```rust\n"));
+            assert!(chunk.body.ends_with("```"));
+        }
+        assert_eq!(
+            chunks
+                .iter()
+                .filter(|chunk| chunk.body.contains("last_unique_rag_token"))
+                .count(),
+            1
+        );
+        assert_eq!(
+            chunks
+                .iter()
+                .filter(|chunk| chunk.search_text.contains("last_unique_rag_token"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
     fn markdown_chunks_preserve_short_valuable_config_items() {
         let chunks = chunk_markdown(
             "config.md",


### PR DESCRIPTION
## 变更
- 修复 oversized fenced code block 在未闭合时把最后一行真实代码误当 closing fence 的问题
- 未闭合代码块拆分时保留最后一行内容，并为切片合成同类型结束围栏
- 增加回归测试，确保最后一行唯一关键词只进入真实所在切片和索引文本

## 验证
- cargo test -p qq-maid-core runtime::knowledge::tests::markdown_chunks_split_unclosed_code_fence_without_repeating_last_line --all-features
- git diff --check
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features