### PR TITLE
[codex] 提升知识分块版本

### DIFF
--- a/qq-maid-core/src/runtime/knowledge/chunking.rs
+++ b/qq-maid-core/src/runtime/knowledge/chunking.rs
@@ -1,6 +1,7 @@
 use super::text::{build_index_text, hash_text};
 
-pub(super) const CHUNKING_VERSION: i64 = 2;
+// 修改分块正文语义时必须提升版本，确保 file_hash 未变的已索引知识文件也会重建。
+pub(super) const CHUNKING_VERSION: i64 = 3;
 
 const TARGET_CHUNK_CHARS: usize = 900;
 const SOFT_CHUNK_CHARS: usize = 1200;

--- a/qq-maid-core/src/runtime/knowledge/mod.rs
+++ b/qq-maid-core/src/runtime/knowledge/mod.rs
@@ -565,12 +565,41 @@ mod tests {
         ));
         let knowledge_dir = base.join("knowledge");
         fs::create_dir_all(&knowledge_dir).unwrap();
-        fs::write(knowledge_dir.join("version.md"), "# 版本\n\nRAG-VERSION").unwrap();
+        let content = "# 版本\n\nRAG-VERSION";
+        let file_hash = hash_text(content);
+        fs::write(knowledge_dir.join("version.md"), content).unwrap();
         let index = test_index(&knowledge_dir);
+        index
+            .store
+            .replace_document(
+                "version.md",
+                &file_hash,
+                Some("2026-06-26T00:00:00Z"),
+                &[KnowledgeChunkDraft {
+                    chunk_id: "version-md-old:0000:old".to_owned(),
+                    relative_path: "version.md".to_owned(),
+                    document_title: Some("旧索引".to_owned()),
+                    heading_path: Some("旧索引".to_owned()),
+                    chunk_index: 0,
+                    chunk_type: "text".to_owned(),
+                    body: "旧版本切片内容".to_owned(),
+                    content_hash: "old-chunk-hash".to_owned(),
+                    file_hash: file_hash.clone(),
+                    modified_at: Some("2026-06-26T00:00:00Z".to_owned()),
+                    start_line: Some(1),
+                    end_line: Some(1),
+                    code_language: None,
+                    // 文件内容不变时，只能靠 chunking_version 差异触发派生索引重建。
+                    chunking_version: CHUNKING_VERSION - 1,
+                    search_text: build_index_text("旧版本切片内容"),
+                }],
+            )
+            .unwrap();
 
-        assert_eq!(index.sync().unwrap().added_files, 1);
+        let rebuild = index.sync().unwrap();
         let second = index.sync().unwrap();
 
+        assert_eq!(rebuild.updated_files, 1);
         assert_eq!(second.unchanged_files, 1);
     }
 


### PR DESCRIPTION
## 变更
- 将知识库 CHUNKING_VERSION 从 2 提升到 3，确保未闭合 fenced code block 分块语义变化后，已索引且文件内容未变的 Markdown 会自动重建派生索引。
- 补强版本变化重建测试，构造相同 file_hash 但旧 chunking_version 的既有索引，断言同步会走 updated_files。

## 原因
KnowledgeIndex::sync_file 在 file_hash 和 chunking_version 都相同时直接返回 Unchanged。未闭合 fenced code block 的正文切片语义已经变化，如果不提升版本，生产中旧索引会继续保留错误切片，直到用户手动改文件或清库。

## 验证
- cargo fmt --all -- --check
- cargo test -p qq-maid-core
- git diff --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features
- make deploy remote（用户执行；release 构建和远端部署成功，最后因 make 将 remote 视为额外 target 报 No rule to make target 'remote'）