### PR TITLE
[codex] 修复知识库 frontmatter 检索污染

### DIFF
--- a/qq-maid-core/src/runtime/knowledge/chunking.rs
+++ b/qq-maid-core/src/runtime/knowledge/chunking.rs
@@ -1,7 +1,9 @@
+use std::collections::HashSet;
+
 use super::text::{build_index_text, hash_text};
 
 // 修改分块正文语义时必须提升版本，确保 file_hash 未变的已索引知识文件也会重建。
-pub(super) const CHUNKING_VERSION: i64 = 3;
+pub(super) const CHUNKING_VERSION: i64 = 4;
 
 const TARGET_CHUNK_CHARS: usize = 900;
 const SOFT_CHUNK_CHARS: usize = 1200;
@@ -58,15 +60,231 @@ struct MarkdownBlock {
 }
 
 pub(super) fn chunk_markdown(relative_path: &str, content: &str) -> Vec<MarkdownChunk> {
-    ChunkEmitter::new(relative_path).emit(parse_blocks(content))
+    let parsed = strip_frontmatter(content);
+    ChunkEmitter::new(
+        relative_path,
+        parsed.metadata.search_terms,
+        parsed.metadata.title,
+    )
+    .emit(parse_blocks(parsed.body, parsed.body_start_line))
 }
 
-fn parse_blocks(content: &str) -> Vec<MarkdownBlock> {
-    let mut parser = BlockParser::default();
+fn parse_blocks(content: &str, start_line: usize) -> Vec<MarkdownBlock> {
+    parse_blocks_with_title(content, start_line, None)
+}
+
+fn parse_blocks_with_title(
+    content: &str,
+    start_line: usize,
+    document_title: Option<String>,
+) -> Vec<MarkdownBlock> {
+    let mut parser = BlockParser {
+        document_title,
+        ..BlockParser::default()
+    };
     for (offset, line) in content.lines().enumerate() {
-        parser.push_line(line, offset + 1);
+        parser.push_line(line, start_line + offset);
     }
     parser.finish()
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct FrontmatterMetadata {
+    title: Option<String>,
+    search_terms: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ParsedMarkdown<'a> {
+    body: &'a str,
+    body_start_line: usize,
+    metadata: FrontmatterMetadata,
+}
+
+fn strip_frontmatter(content: &str) -> ParsedMarkdown<'_> {
+    let (content, _had_bom) = content
+        .strip_prefix('\u{feff}')
+        .map(|rest| (rest, true))
+        .unwrap_or((content, false));
+    let Some(first_line_end) = line_end_index(content) else {
+        return ParsedMarkdown {
+            body: content,
+            body_start_line: 1,
+            metadata: FrontmatterMetadata::default(),
+        };
+    };
+    if content[..first_line_end].trim_end_matches('\r') != "---" {
+        return ParsedMarkdown {
+            body: content,
+            body_start_line: 1,
+            metadata: FrontmatterMetadata::default(),
+        };
+    }
+
+    let mut cursor = first_line_end + 1;
+    let mut current_line = 2;
+    while cursor <= content.len() {
+        let line_end = line_end_index(&content[cursor..])
+            .map(|index| cursor + index)
+            .unwrap_or(content.len());
+        let line = content[cursor..line_end].trim_end_matches('\r');
+        if line == "---" {
+            let body_start = if line_end < content.len() {
+                line_end + 1
+            } else {
+                line_end
+            };
+            return ParsedMarkdown {
+                body: &content[body_start..],
+                body_start_line: current_line + 1,
+                metadata: parse_frontmatter_metadata(&content[first_line_end + 1..cursor]),
+            };
+        }
+        if line_end == content.len() {
+            break;
+        }
+        cursor = line_end + 1;
+        current_line += 1;
+    }
+
+    // 只有开头分隔符但没有闭合标记时按普通 Markdown 处理，避免误删整篇正文。
+    ParsedMarkdown {
+        body: content,
+        body_start_line: 1,
+        metadata: FrontmatterMetadata::default(),
+    }
+}
+
+fn line_end_index(text: &str) -> Option<usize> {
+    text.find('\n')
+}
+
+fn parse_frontmatter_metadata(yaml: &str) -> FrontmatterMetadata {
+    let mut title = None;
+    let mut terms = Vec::<String>::new();
+    let mut active_list_key: Option<&str> = None;
+
+    for raw_line in yaml.lines() {
+        let trimmed = raw_line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if let Some(key) = active_list_key {
+            if let Some(item) = parse_yaml_list_item(raw_line) {
+                if matches!(key, "synonyms" | "aliases") {
+                    push_metadata_term(&mut terms, &item);
+                }
+                continue;
+            }
+            active_list_key = None;
+        }
+        let Some((key, value)) = parse_yaml_pair(trimmed) else {
+            continue;
+        };
+        if !matches!(key, "title" | "synonyms" | "aliases") {
+            continue;
+        }
+        if value.is_empty() {
+            active_list_key = Some(key);
+            continue;
+        }
+        if let Some(items) = parse_inline_string_array(value) {
+            for item in items {
+                if key == "title" && title.is_none() {
+                    title = Some(item.clone());
+                }
+                push_metadata_term(&mut terms, &item);
+            }
+            continue;
+        }
+        if let Some(value) = parse_yaml_string(value) {
+            if key == "title" && title.is_none() {
+                title = Some(value.clone());
+            }
+            push_metadata_term(&mut terms, &value);
+        }
+    }
+
+    dedup_metadata_terms(&mut terms);
+    FrontmatterMetadata {
+        title: title.filter(|value| !value.trim().is_empty()),
+        search_terms: terms,
+    }
+}
+
+fn parse_yaml_pair(line: &str) -> Option<(&str, &str)> {
+    let (key, value) = line.split_once(':')?;
+    let key = key.trim();
+    if key
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+    {
+        Some((key, value.trim()))
+    } else {
+        None
+    }
+}
+
+fn parse_yaml_list_item(line: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    let value = trimmed.strip_prefix("- ")?;
+    parse_yaml_string(value.trim())
+}
+
+fn parse_inline_string_array(value: &str) -> Option<Vec<String>> {
+    let inner = value.strip_prefix('[')?.strip_suffix(']')?;
+    let mut items = Vec::new();
+    for item in inner.split(',') {
+        if let Some(value) = parse_yaml_string(item.trim()) {
+            items.push(value);
+        }
+    }
+    Some(items)
+}
+
+fn parse_yaml_string(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || matches!(trimmed, "[]" | "{}") {
+        return None;
+    }
+    if trimmed.starts_with('{') || trimmed.starts_with('[') {
+        return None;
+    }
+    let unquoted = trimmed
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .or_else(|| {
+            trimmed
+                .strip_prefix('\'')
+                .and_then(|value| value.strip_suffix('\''))
+        })
+        .unwrap_or(trimmed)
+        .trim();
+    if unquoted.is_empty() || is_plain_yaml_scalar_non_string(unquoted) {
+        None
+    } else {
+        Some(unquoted.to_owned())
+    }
+}
+
+fn is_plain_yaml_scalar_non_string(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    if matches!(lower.as_str(), "true" | "false" | "null" | "~") {
+        return true;
+    }
+    value.parse::<i64>().is_ok() || value.parse::<f64>().is_ok()
+}
+
+fn push_metadata_term(terms: &mut Vec<String>, value: &str) {
+    let value = value.trim();
+    if !value.is_empty() {
+        terms.push(value.to_owned());
+    }
+}
+
+fn dedup_metadata_terms(terms: &mut Vec<String>) {
+    let mut seen = HashSet::<String>::new();
+    terms.retain(|term| seen.insert(build_index_text(term)));
 }
 
 #[derive(Default)]
@@ -240,13 +458,21 @@ impl CodeFence {
 
 struct ChunkEmitter<'a> {
     relative_path: &'a str,
+    frontmatter_terms: Vec<String>,
+    frontmatter_title: Option<String>,
     chunks: Vec<MarkdownChunk>,
 }
 
 impl<'a> ChunkEmitter<'a> {
-    fn new(relative_path: &'a str) -> Self {
+    fn new(
+        relative_path: &'a str,
+        frontmatter_terms: Vec<String>,
+        frontmatter_title: Option<String>,
+    ) -> Self {
         Self {
             relative_path,
+            frontmatter_terms,
+            frontmatter_title,
             chunks: Vec::new(),
         }
     }
@@ -313,7 +539,16 @@ impl<'a> ChunkEmitter<'a> {
         let mut searchable = String::new();
         searchable.push_str(self.relative_path);
         searchable.push('\n');
-        if let Some(title) = &block.document_title {
+        let include_frontmatter_terms = should_attach_frontmatter_terms(block, kind);
+        let document_title = block
+            .document_title
+            .clone()
+            .or_else(|| self.frontmatter_title.clone());
+        if let Some(title) = block.document_title.as_ref().or_else(|| {
+            include_frontmatter_terms
+                .then_some(())
+                .and(self.frontmatter_title.as_ref())
+        }) {
             searchable.push_str(title);
             searchable.push('\n');
         }
@@ -321,11 +556,17 @@ impl<'a> ChunkEmitter<'a> {
             searchable.push_str(path);
             searchable.push('\n');
         }
+        if include_frontmatter_terms && !self.frontmatter_terms.is_empty() {
+            // Frontmatter 只作为受控文档级检索信号进入正文 chunk；
+            // 不保留 YAML 字段名、缩进和重复别名，避免元数据片段挤占 BM25 前排。
+            searchable.push_str(&self.frontmatter_terms.join("\n"));
+            searchable.push('\n');
+        }
         searchable.push_str(&body);
         self.chunks.push(MarkdownChunk {
             chunk_id,
             relative_path: self.relative_path.to_owned(),
-            document_title: block.document_title.clone(),
+            document_title,
             heading_path: block.heading_path.clone(),
             chunk_index: index,
             chunk_type: kind.as_str().to_owned(),
@@ -337,6 +578,11 @@ impl<'a> ChunkEmitter<'a> {
             code_language: block.code_language.clone(),
         });
     }
+}
+
+fn should_attach_frontmatter_terms(block: &MarkdownBlock, kind: BlockKind) -> bool {
+    block.heading_path.is_some()
+        || matches!(kind, BlockKind::Text | BlockKind::List | BlockKind::Table)
 }
 
 fn should_start_new_chunk(pending: &[MarkdownBlock], next: &MarkdownBlock) -> bool {

--- a/qq-maid-core/src/runtime/knowledge/mod.rs
+++ b/qq-maid-core/src/runtime/knowledge/mod.rs
@@ -421,6 +421,80 @@ mod tests {
     }
 
     #[test]
+    fn markdown_frontmatter_is_not_returned_as_body_but_metadata_can_recall_content() {
+        let chunks = chunk_markdown(
+            "DID.md",
+            "\u{feff}---\n\
+title: DID\n\
+synonyms:\n\
+  - 解离性身份障碍\n\
+  - DID\n\
+  - did\n\
+  - did是什么病\n\
+  - did多重人格\n\
+aliases: [多重人格, DID]\n\
+ignored:\n\
+  nested: value\n\
+---\n\n\
+> 触发警告：以下内容涉及精神健康。\n\n\
+## DID 是什么病？\n\n\
+DID 是解离性身份障碍的英文缩写。",
+        );
+
+        assert_eq!(chunks.len(), 2);
+        assert!(chunks[0].body.contains("触发警告"));
+        assert!(chunks[1].body.contains("DID 是解离性身份障碍"));
+        let combined_body = chunks
+            .iter()
+            .map(|chunk| chunk.body.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(!combined_body.contains("synonyms:"));
+        assert!(!combined_body.contains("did多重人格"));
+        assert!(!combined_body.contains("nested: value"));
+        assert!(!chunks[0].search_text.contains("多重人格"));
+        assert!(chunks[1].search_text.contains("重人"));
+        assert_eq!(
+            chunks[1]
+                .search_text
+                .split_whitespace()
+                .filter(|token| *token == "did")
+                .count(),
+            1
+        );
+        assert!(!chunks[1].search_text.contains("synonyms"));
+        assert!(!chunks[1].search_text.contains("nested"));
+    }
+
+    #[test]
+    fn markdown_unclosed_frontmatter_marker_is_treated_as_normal_content() {
+        let chunks = chunk_markdown(
+            "broken.md",
+            "---\ntitle: 未闭合元数据\n\n## 正文\n\n正文不能因为缺少闭合标记被丢弃。",
+        );
+
+        let combined_body = chunks
+            .iter()
+            .map(|chunk| chunk.body.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(combined_body.contains("title: 未闭合元数据"));
+        assert!(combined_body.contains("正文不能因为缺少闭合标记被丢弃"));
+    }
+
+    #[test]
+    fn markdown_code_fence_dashes_are_not_treated_as_frontmatter() {
+        let chunks = chunk_markdown(
+            "code-yaml.md",
+            "```yaml\n---\ntitle: fenced\n---\n```\n\n正文保留在代码块之后。",
+        );
+
+        assert!(chunks[0].body.contains("```yaml"));
+        assert!(chunks[0].body.contains("title: fenced"));
+        assert!(chunks.iter().any(|chunk| chunk.body.contains("正文保留")));
+    }
+
+    #[test]
     fn markdown_chunks_store_v2_metadata_for_order_and_source_location() {
         let chunks = chunk_markdown(
             "meta.md",
@@ -555,6 +629,58 @@ mod tests {
         assert!(context.text.contains("RAG-ADJACENT-TARGET"));
         assert!(context.text.contains("AlphaTimeout"));
         assert!(context.text.contains("片段：相邻补充"));
+    }
+
+    #[test]
+    fn search_uses_frontmatter_synonyms_to_return_body_chunks() {
+        let base = std::env::temp_dir().join(format!(
+            "qq-maid-knowledge-frontmatter-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let knowledge_dir = base.join("knowledge");
+        fs::create_dir_all(&knowledge_dir).unwrap();
+        fs::write(
+            knowledge_dir.join("DID.md"),
+            "---\n\
+title: DID\n\
+synonyms:\n\
+  - 解离性身份障碍\n\
+  - DID\n\
+  - did\n\
+  - did是什么病\n\
+  - did多重人格\n\
+---\n\n\
+> 触发警告：以下内容涉及精神健康。\n\n\
+## DID 是什么病？\n\n\
+DID 是解离性身份障碍的英文缩写。",
+        )
+        .unwrap();
+        let index = test_index(&knowledge_dir);
+        index.sync().unwrap();
+
+        for query in ["DID 是什么病", "解离性身份障碍", "did多重人格"] {
+            let context = index.search_context(query).unwrap();
+            assert!(
+                context.text.contains("DID 是解离性身份障碍的英文缩写"),
+                "query {query:?} should return DID body, got: {}",
+                context.text
+            );
+            assert!(!context.text.contains("synonyms:"));
+            assert!(!context.text.contains("  - did多重人格"));
+        }
+
+        let raw_top4 = index.store.search(&query_text("DID 是什么病"), 4).unwrap();
+        assert!(
+            raw_top4
+                .iter()
+                .any(|result| result.body.contains("DID 是解离性身份障碍")),
+            "top4 should contain substantive DID body: {raw_top4:#?}"
+        );
+        assert!(
+            raw_top4
+                .iter()
+                .all(|result| !result.body.contains("synonyms:"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 变更

- 在 Markdown 切片前严格识别并剥离文件头 YAML frontmatter，避免原始 YAML 字段名、列表符号和别名列表生成正文 chunk 或直接进入 FTS。
- 仅提取 title、synonyms、aliases 的字符串/字符串数组作为受控文档级检索词，按现有 build_index_text 归一化去重后挂到正文 chunk。
- 将 CHUNKING_VERSION 提升到 4，使未改文件也会在下一次知识库同步时重建旧索引。
- 补充 DID/frontmatter、未闭合 frontmatter、代码围栏 --- 和 synonym 召回回归测试。

## 根因

旧实现没有 frontmatter 识别，开头 YAML 中的 title/synonyms/aliases 会按普通 Markdown 正文进入 chunk body，并由 search_text 写入 knowledge_chunks_fts。关键词密度高的元数据 chunk 会在 BM25 排序中靠前，进一步挤占 select_results 的 4 条总数和每文件 2 条上限。

## 验证

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test -p qq-maid-core knowledge
- cargo test -p qq-maid-core
- cargo test --workspace
- cargo build --workspace --release --all-features
- git diff --check
