### PR TITLE
[codex] 修复群聊 pending 发起人校验

### DIFF
--- a/qq-maid-core/src/runtime/pending/mod.rs
+++ b/qq-maid-core/src/runtime/pending/mod.rs
@@ -76,13 +76,31 @@ pub enum PendingTodoAction {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum PendingOperation {
     /// 创建新记忆
-    MemoryCreate { memory: PendingMemory },
+    MemoryCreate {
+        /// 发起 pending 的用户标识；旧会话缺失该字段时按历史行为兼容。
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        initiator_user_id: Option<String>,
+        memory: PendingMemory,
+    },
     /// 更新已有记忆
-    MemoryUpdate { update: PendingMemoryUpdate },
+    MemoryUpdate {
+        /// 发起 pending 的用户标识；旧会话缺失该字段时按历史行为兼容。
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        initiator_user_id: Option<String>,
+        update: PendingMemoryUpdate,
+    },
     /// 删除记忆
-    MemoryDelete { delete: PendingMemoryDelete },
+    MemoryDelete {
+        /// 发起 pending 的用户标识；旧会话缺失该字段时按历史行为兼容。
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        initiator_user_id: Option<String>,
+        delete: PendingMemoryDelete,
+    },
     /// 新增待办事项
     TodoAdd {
+        /// 发起 pending 的用户标识；与 owner_key 分开保存，避免 user_id 缺失时绕过校验。
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        initiator_user_id: Option<String>,
         /// 所有者标识键
         owner_key: String,
         /// 待办草稿
@@ -98,12 +116,16 @@ pub enum PendingOperation {
     },
     /// 标记待办为完成
     TodoDone {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        initiator_user_id: Option<String>,
         owner_key: String,
         item: TodoItem,
         created_at: String,
     },
     /// 编辑待办事项
     TodoEdit {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        initiator_user_id: Option<String>,
         owner_key: String,
         /// 编辑前的待办项
         before: TodoItem,
@@ -113,12 +135,16 @@ pub enum PendingOperation {
     },
     /// 删除单个待办
     TodoDelete {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        initiator_user_id: Option<String>,
         owner_key: String,
         item: TodoItem,
         created_at: String,
     },
     /// 按条件批量删除待办
     TodoBulkDelete {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        initiator_user_id: Option<String>,
         owner_key: String,
         /// 要删除的待办 ID 列表
         item_ids: Vec<String>,
@@ -130,6 +156,8 @@ pub enum PendingOperation {
     },
     /// 需要用户从多个候选中选择操作的待办
     TodoSelectCandidate {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        initiator_user_id: Option<String>,
         owner_key: String,
         /// 待执行的操作类型
         action: PendingTodoAction,
@@ -161,6 +189,39 @@ impl PendingOperation {
             | Self::TodoDelete { owner_key, .. }
             | Self::TodoBulkDelete { owner_key, .. }
             | Self::TodoSelectCandidate { owner_key, .. } => Some(owner_key.as_str()),
+        }
+    }
+
+    /// 获取 pending 发起人。旧持久化数据没有该字段时返回 `None`，继续按历史行为处理。
+    pub fn initiator_user_id(&self) -> Option<&str> {
+        match self {
+            Self::MemoryCreate {
+                initiator_user_id, ..
+            }
+            | Self::MemoryUpdate {
+                initiator_user_id, ..
+            }
+            | Self::MemoryDelete {
+                initiator_user_id, ..
+            }
+            | Self::TodoAdd {
+                initiator_user_id, ..
+            }
+            | Self::TodoDone {
+                initiator_user_id, ..
+            }
+            | Self::TodoEdit {
+                initiator_user_id, ..
+            }
+            | Self::TodoDelete {
+                initiator_user_id, ..
+            }
+            | Self::TodoBulkDelete {
+                initiator_user_id, ..
+            }
+            | Self::TodoSelectCandidate {
+                initiator_user_id, ..
+            } => initiator_user_id.as_deref(),
         }
     }
 }
@@ -293,4 +354,27 @@ fn is_confirm_match(compact: &str, word: &str) -> bool {
         rest,
         "就这个" | "就这样" | "执行" | "保存" | "写入" | "删除" | "新增" | "修改"
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn legacy_pending_without_initiator_deserializes() {
+        let pending: PendingOperation = serde_json::from_value(json!({
+            "kind": "memory_create",
+            "memory": {
+                "content": "旧 pending",
+                "source_text": "/memory 旧 pending",
+                "type": "note",
+                "scope": "general",
+                "created_at": "2026-06-27T12:00:00+08:00"
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(pending.initiator_user_id(), None);
+    }
 }

--- a/qq-maid-core/src/runtime/pending/mod.rs
+++ b/qq-maid-core/src/runtime/pending/mod.rs
@@ -5,7 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::storage::todo::{TodoItem, TodoItemDraft};
+use crate::storage::todo::{TodoItem, TodoItemDraft, TodoStatus};
 
 /// 待确认的记忆创建操作。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -148,6 +148,12 @@ pub enum PendingOperation {
         owner_key: String,
         /// 要删除的待办 ID 列表
         item_ids: Vec<String>,
+        /// 发起时匹配到的条目数量，用于确认后按原始范围反馈。
+        #[serde(default)]
+        matched_count: usize,
+        /// 批量删除限定的目标状态；旧 pending 缺失该字段时兼容为已完成清理。
+        #[serde(default = "default_todo_bulk_delete_status")]
+        status: TodoStatus,
         /// 操作摘要
         summary: String,
         /// 删除条件的原始描述
@@ -172,6 +178,10 @@ pub enum PendingOperation {
 
 fn default_todo_add_allow_revision() -> bool {
     true
+}
+
+fn default_todo_bulk_delete_status() -> TodoStatus {
+    TodoStatus::Completed
 }
 
 impl PendingOperation {

--- a/qq-maid-core/src/runtime/respond/memory_flow.rs
+++ b/qq-maid-core/src/runtime/respond/memory_flow.rs
@@ -55,11 +55,11 @@ impl RustRespondService {
     pub(super) async fn handle_memory_flow(
         &self,
         user_text: &str,
-        _meta: &SessionMeta,
+        meta: &SessionMeta,
         session: &mut SessionRecord,
     ) -> Result<Option<RespondResponse>, LlmError> {
         if let Some(command) = parse_memory_management_command(user_text) {
-            let reply = self.handle_memory_management_command(&command, session)?;
+            let reply = self.handle_memory_management_command(&command, meta, session)?;
             return Ok(Some(self.append_pending_response(
                 session,
                 user_text,
@@ -120,6 +120,7 @@ impl RustRespondService {
                 session,
                 user_text,
                 PendingOperation::MemoryCreate {
+                    initiator_user_id: meta.user_id.clone(),
                     memory: memory.clone(),
                 },
                 structured_command_body(reply),
@@ -305,7 +306,10 @@ impl RustRespondService {
         };
 
         match pending {
-            PendingOperation::MemoryCreate { memory } => {
+            PendingOperation::MemoryCreate {
+                initiator_user_id,
+                memory,
+            } => {
                 let reply_kind = classify_reply(user_text, memory_lexicon());
                 if matches!(reply_kind, PendingReplyKind::Cancel) {
                     return Ok(Some(self.clear_pending_response(
@@ -352,6 +356,7 @@ impl RustRespondService {
                         session,
                         user_text,
                         PendingOperation::MemoryCreate {
+                            initiator_user_id,
                             memory: revised.clone(),
                         },
                         structured_command_body(reply),
@@ -363,7 +368,10 @@ impl RustRespondService {
                     session, user_text, reply, "memory",
                 )?))
             }
-            PendingOperation::MemoryUpdate { update } => {
+            PendingOperation::MemoryUpdate {
+                initiator_user_id,
+                update,
+            } => {
                 let reply_kind = classify_reply(user_text, memory_lexicon());
                 if matches!(reply_kind, PendingReplyKind::Cancel) {
                     return Ok(Some(self.clear_pending_response(
@@ -415,6 +423,7 @@ impl RustRespondService {
                         session,
                         user_text,
                         PendingOperation::MemoryUpdate {
+                            initiator_user_id,
                             update: revised.clone(),
                         },
                         structured_command_body(reply),
@@ -429,7 +438,7 @@ impl RustRespondService {
                     "memory_update",
                 )?))
             }
-            PendingOperation::MemoryDelete { delete } => {
+            PendingOperation::MemoryDelete { delete, .. } => {
                 let reply_kind = classify_reply(user_text, memory_lexicon());
                 if matches!(reply_kind, PendingReplyKind::Cancel) {
                     return Ok(Some(self.clear_pending_response(
@@ -465,6 +474,7 @@ impl RustRespondService {
     fn handle_memory_management_command(
         &self,
         command: &ParsedCommand,
+        meta: &SessionMeta,
         session: &mut SessionRecord,
     ) -> Result<super::common::CommandBody, LlmError> {
         let argument = command.argument.trim();
@@ -512,7 +522,10 @@ impl RustRespondService {
                     created_at: now_iso_cn(),
                 };
                 let reply = format_memory_update_confirm(&record, &update);
-                session.pending_operation = Some(PendingOperation::MemoryUpdate { update });
+                session.pending_operation = Some(PendingOperation::MemoryUpdate {
+                    initiator_user_id: meta.user_id.clone(),
+                    update,
+                });
                 Ok(structured_command_body(reply))
             }
             "memory_delete" => {
@@ -523,6 +536,7 @@ impl RustRespondService {
                     return Ok(format_memory_no_list_index_reply(argument).into());
                 };
                 session.pending_operation = Some(PendingOperation::MemoryDelete {
+                    initiator_user_id: meta.user_id.clone(),
                     delete: PendingMemoryDelete {
                         id: record.id.clone(),
                         content: record.content.clone(),

--- a/qq-maid-core/src/runtime/respond/pending.rs
+++ b/qq-maid-core/src/runtime/respond/pending.rs
@@ -30,6 +30,20 @@ impl RustRespondService {
             return Ok(None);
         };
 
+        // 新 pending 会保存发起人；旧持久化 pending 没有该字段时继续按历史行为兼容。
+        // 一旦记录了发起人，后续确认、取消、修订和候选选择都必须来自同一个 user_id。
+        if pending
+            .initiator_user_id()
+            .is_some_and(|initiator| meta.user_id.as_deref() != Some(initiator))
+        {
+            return Ok(Some(self.append_pending_response(
+                session,
+                user_text,
+                CommandBody::plain("这个操作由其他成员发起，请由发起人继续。"),
+                "pending_initiator_mismatch",
+            )?));
+        }
+
         match pending {
             PendingOperation::TodoAdd { .. }
             | PendingOperation::TodoDone { .. }

--- a/qq-maid-core/src/runtime/respond/tests/memory.rs
+++ b/qq-maid-core/src/runtime/respond/tests/memory.rs
@@ -7,6 +7,7 @@ use super::{super::memory_flow::short_memory_id, support::*};
 use crate::runtime::{
     memory::{CreateMemoryRequest, ListMemoryQuery},
     pending::PendingOperation,
+    respond::RespondRequest,
 };
 
 #[tokio::test]
@@ -82,6 +83,183 @@ async fn memory_create_update_and_delete_use_confirmation() {
         .unwrap();
     assert!(deleted.contains("已删除记忆"));
     assert!(service.memory_store.get(&memory_id).is_err());
+}
+
+#[tokio::test]
+async fn memory_pending_rejects_other_group_member_and_keeps_draft() {
+    let service = test_service();
+
+    service
+        .respond(message("/memory 如果不确定前台，请礼貌询问"))
+        .await
+        .unwrap();
+
+    let rejected = service
+        .respond(message_in_scope("确认", "group:g1", "u2", "g1"))
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+
+    assert!(rejected.contains("由其他成员发起"));
+    assert!(
+        service
+            .memory_store
+            .list(ListMemoryQuery::default())
+            .unwrap()
+            .is_empty()
+    );
+    let session = service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap();
+    assert!(matches!(
+        session.pending_operation,
+        Some(PendingOperation::MemoryCreate { .. })
+    ));
+
+    let confirmed = service
+        .respond(message("确认"))
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+    assert!(confirmed.contains("已记下"));
+    assert_eq!(
+        service
+            .memory_store
+            .list(ListMemoryQuery::default())
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn memory_pending_rejects_missing_user_id() {
+    let service = test_service();
+
+    service
+        .respond(message("/memory 如果不确定前台，请礼貌询问"))
+        .await
+        .unwrap();
+
+    let rejected = service
+        .respond(RespondRequest {
+            content: "确认".to_owned(),
+            scope_key: "group:g1".to_owned(),
+            user_id: None,
+            group_id: Some("g1".to_owned()),
+            platform: "qq_official".to_owned(),
+            event_type: "FakeEvent".to_owned(),
+            ..RespondRequest::default()
+        })
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+
+    assert!(rejected.contains("由其他成员发起"));
+    let session = service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap();
+    assert!(session.pending_operation.is_some());
+    assert!(
+        service
+            .memory_store
+            .list(ListMemoryQuery::default())
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn memory_pending_rejects_other_member_cancel_and_revision() {
+    let service = test_service();
+
+    service
+        .respond(message("/memory 如果不确定前台，请礼貌询问"))
+        .await
+        .unwrap();
+
+    let cancelled_by_other = service
+        .respond(message_in_scope("取消", "group:g1", "u2", "g1"))
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+    assert!(cancelled_by_other.contains("由其他成员发起"));
+
+    let revised_by_other = service
+        .respond(message_in_scope(
+            "改成前台不确定时先询问本人再记录",
+            "group:g1",
+            "u2",
+            "g1",
+        ))
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+    assert!(revised_by_other.contains("由其他成员发起"));
+
+    let session = service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap();
+    assert!(matches!(
+        session.pending_operation,
+        Some(PendingOperation::MemoryCreate { .. })
+    ));
+    assert!(
+        service
+            .memory_store
+            .list(ListMemoryQuery::default())
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn memory_pending_private_flow_stays_normal() {
+    let service = test_service();
+
+    service
+        .respond(RespondRequest {
+            content: "/memory 如果不确定前台，请礼貌询问".to_owned(),
+            scope_key: "private:u1".to_owned(),
+            user_id: Some("u1".to_owned()),
+            platform: "qq_official".to_owned(),
+            event_type: "FakeEvent".to_owned(),
+            ..RespondRequest::default()
+        })
+        .await
+        .unwrap();
+
+    let confirmed = service
+        .respond(RespondRequest {
+            content: "确认".to_owned(),
+            scope_key: "private:u1".to_owned(),
+            user_id: Some("u1".to_owned()),
+            platform: "qq_official".to_owned(),
+            event_type: "FakeEvent".to_owned(),
+            ..RespondRequest::default()
+        })
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+
+    assert!(confirmed.contains("已记下"));
+    assert_eq!(
+        service
+            .memory_store
+            .list(ListMemoryQuery::default())
+            .unwrap()
+            .len(),
+        1
+    );
 }
 
 #[tokio::test]
@@ -247,7 +425,7 @@ async fn memory_pending_create_plain_revision_and_failure_keep_pending() {
         .get_or_create_active(&test_meta())
         .unwrap();
     match session.pending_operation {
-        Some(PendingOperation::MemoryCreate { memory }) => {
+        Some(PendingOperation::MemoryCreate { memory, .. }) => {
             assert_eq!(memory.content, "前台不确定时先询问本人再记录");
             assert_eq!(
                 memory.source_text,
@@ -273,7 +451,7 @@ async fn memory_pending_create_plain_revision_and_failure_keep_pending() {
         .get_or_create_active(&test_meta())
         .unwrap();
     match session.pending_operation {
-        Some(PendingOperation::MemoryCreate { memory }) => {
+        Some(PendingOperation::MemoryCreate { memory, .. }) => {
             assert_eq!(memory.content, "前台不确定时先询问本人再记录");
             assert_eq!(
                 memory.source_text,
@@ -360,7 +538,7 @@ async fn memory_pending_update_plain_revision_uses_full_draft_revision() {
         .get_or_create_active(&test_meta())
         .unwrap();
     match session.pending_operation {
-        Some(PendingOperation::MemoryUpdate { update }) => {
+        Some(PendingOperation::MemoryUpdate { update, .. }) => {
             assert_eq!(update.content, "前台不确定时先询问本人再记录");
             assert_eq!(update.memory_type, "preference");
             assert_eq!(update.scope, "front_detection");

--- a/qq-maid-core/src/runtime/respond/tests/pending.rs
+++ b/qq-maid-core/src/runtime/respond/tests/pending.rs
@@ -119,6 +119,40 @@ async fn pending_operation_keeps_confirm_cancel_and_revision_priority() {
 }
 
 #[tokio::test]
+async fn pending_operation_rejects_other_group_member_for_todo() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+
+    service
+        .respond(message("/todo add 无时间买牛奶"))
+        .await
+        .unwrap();
+
+    let rejected = service
+        .respond(message_in_scope("确认", "group:g1", "u2", "g1"))
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+    assert!(rejected.contains("由其他成员发起"));
+    assert!(service.todo_store.list_pending(&owner).unwrap().is_empty());
+    let session = service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap();
+    assert!(session.pending_operation.is_some());
+
+    let confirmed = service
+        .respond(message("确认"))
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+    assert!(confirmed.contains("已新增待办：买牛奶"));
+    assert_eq!(service.todo_store.list_pending(&owner).unwrap().len(), 1);
+}
+
+#[tokio::test]
 async fn pending_operation_blocks_business_slash_commands_until_resolved() {
     let service = test_service();
 

--- a/qq-maid-core/src/runtime/respond/tests/todo.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo.rs
@@ -4,7 +4,10 @@ use std::sync::{
 };
 
 use super::support::*;
-use crate::runtime::todo::{TodoItemDraft, TodoStatus, TodoStore, TodoTimePrecision};
+use crate::runtime::{
+    pending::PendingOperation,
+    todo::{TodoItemDraft, TodoStatus, TodoStore, TodoTimePrecision},
+};
 
 #[tokio::test]
 async fn todo_root_aliases_list_pending_items() {
@@ -942,7 +945,7 @@ async fn todo_delete_reuses_completed_list_index() {
         .unwrap()
         .text
         .unwrap();
-    assert!(confirm.contains("确认删除这 1 条已完成待办？来源：已完成列表第 2 条"));
+    assert!(confirm.contains("确认删除这条待办"));
     assert!(confirm.contains("昨天完成"));
     assert!(!confirm.contains("[2]"));
     service.respond(message("确认")).await.unwrap();
@@ -1054,7 +1057,7 @@ async fn todo_done_and_undo_use_list_snapshots_and_return_titles() {
         .unwrap()
         .text
         .unwrap();
-    assert_eq!(reused, "请先发送 /todo 查看未完成待办。");
+    assert_eq!(reused, "请先发送 /todo 查看待办列表。");
 
     let completed = service.respond(message("/todo undo")).await.unwrap();
     assert_eq!(completed.command.as_deref(), Some("todo_undo"));
@@ -1097,7 +1100,7 @@ async fn todo_done_and_undo_require_matching_list_snapshot() {
         .unwrap()
         .text
         .unwrap();
-    assert_eq!(no_pending_snapshot, "请先发送 /todo 查看未完成待办。");
+    assert_eq!(no_pending_snapshot, "请先发送 /todo 查看待办列表。");
     assert_eq!(
         service.todo_store.list_all(&owner).unwrap()[0].status,
         TodoStatus::Pending
@@ -1112,7 +1115,7 @@ async fn todo_done_and_undo_require_matching_list_snapshot() {
         .unwrap();
     assert_eq!(
         completed_snapshot_is_not_pending,
-        "请先发送 /todo 查看未完成待办。"
+        "未找到匹配的未完成待办：1"
     );
 
     service.respond(message("/todo")).await.unwrap();
@@ -1144,6 +1147,144 @@ async fn todo_all_lists_all_statuses_by_created_at_desc() {
     assert!(text.contains("5. 昨天完成"));
     assert!(text.contains("6. 前天完成"));
     assert!(text.contains("已取消"));
+}
+
+#[tokio::test]
+async fn todo_delete_uses_latest_all_snapshot_for_any_status() {
+    let (service, _base) = test_service_with_base();
+    seed_completed_time_todos(&service.todo_store);
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+
+    let all = service
+        .respond(message("/todo all"))
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+    assert!(all.contains("1. 未完成旧截止"));
+    assert!(all.contains("2. 已取消完成"));
+
+    let cancelled_confirm = service
+        .respond(message("/todo delete 2"))
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+    assert!(cancelled_confirm.contains("确认删除这条待办"));
+    assert!(cancelled_confirm.contains("已取消完成"));
+    let deleted = service
+        .respond(message("确认"))
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+    assert!(deleted.contains("已删除待办：已取消完成"));
+    assert!(
+        service
+            .todo_store
+            .list_all(&owner)
+            .unwrap()
+            .iter()
+            .all(|item| item.id != "5")
+    );
+
+    service.respond(message("/todo all")).await.unwrap();
+    let pending_confirm = service
+        .respond(message("/todo delete 1"))
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+    assert!(pending_confirm.contains("未完成旧截止"));
+    service.respond(message("确认")).await.unwrap();
+    assert_eq!(
+        service
+            .todo_store
+            .list_all(&owner)
+            .unwrap()
+            .iter()
+            .find(|item| item.id == "6")
+            .unwrap()
+            .status,
+        TodoStatus::Cancelled
+    );
+}
+
+#[tokio::test]
+async fn todo_delete_uses_last_visible_snapshot_after_list_override() {
+    let (service, _base) = test_service_with_base();
+    seed_completed_time_todos(&service.todo_store);
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+
+    service.respond(message("/todo all")).await.unwrap();
+    let done = service
+        .respond(message("/todo done"))
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+    assert!(done.contains("1. 今天完成"));
+
+    let confirm = service
+        .respond(message("/todo delete 1"))
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+    assert!(confirm.contains("今天完成"));
+    assert!(!confirm.contains("未完成旧截止"));
+    service.respond(message("确认")).await.unwrap();
+
+    let all = service.todo_store.list_all(&owner).unwrap();
+    assert_eq!(
+        all.iter().find(|item| item.id == "3").unwrap().status,
+        TodoStatus::Cancelled
+    );
+    assert_eq!(
+        all.iter().find(|item| item.id == "6").unwrap().status,
+        TodoStatus::Pending
+    );
+}
+
+#[tokio::test]
+async fn todo_delete_expired_all_snapshot_mentions_all_command() {
+    let (service, _base) = test_service_with_base();
+    seed_completed_time_todos(&service.todo_store);
+
+    service.respond(message("/todo all")).await.unwrap();
+    let mut session = service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap();
+    session.last_todo_query.as_mut().unwrap().created_at = "2000-01-01T00:00:00+08:00".to_owned();
+    service.session_store.save(&mut session).unwrap();
+
+    let reply = service
+        .respond(message("/todo delete 1"))
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+    assert_eq!(
+        reply,
+        "当前全部待办序号已失效，请重新执行 /todo all 获取最新列表。"
+    );
+}
+
+#[tokio::test]
+async fn todo_list_snapshot_is_isolated_by_group_member() {
+    let (service, _base) = test_service_with_base();
+    seed_completed_time_todos(&service.todo_store);
+
+    service.respond(message("/todo all")).await.unwrap();
+    let reply = service
+        .respond(message_in_scope("/todo delete 1", "group:g1", "u2", "g1"))
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+
+    assert_eq!(reply, "当前待办序号已失效，请重新执行 /todo 获取最新列表。");
 }
 
 #[tokio::test]
@@ -1263,6 +1404,177 @@ async fn todo_delete_done_prepares_all_completed_cleanup() {
 }
 
 #[tokio::test]
+async fn todo_delete_cancelled_aliases_prepare_confirmation_and_pending_ids() {
+    for command in [
+        "/todo delete cancelled",
+        "/todo delete canceled",
+        "/todo delete 已取消",
+    ] {
+        let (service, _base) = test_service_with_base();
+        seed_completed_time_todos(&service.todo_store);
+
+        let confirm = service
+            .respond(message(command))
+            .await
+            .unwrap()
+            .text
+            .unwrap();
+        assert!(confirm.contains("确认删除这 1 条已取消待办？来源：全部已取消待办"));
+        assert!(confirm.contains("已取消完成"));
+
+        let session = service
+            .session_store
+            .get_or_create_active(&test_meta())
+            .unwrap();
+        match session.pending_operation {
+            Some(PendingOperation::TodoBulkDelete {
+                initiator_user_id,
+                item_ids,
+                matched_count,
+                status,
+                ..
+            }) => {
+                assert_eq!(initiator_user_id.as_deref(), Some("u1"));
+                assert_eq!(item_ids, vec!["5".to_owned()]);
+                assert_eq!(matched_count, 1);
+                assert_eq!(status, TodoStatus::Cancelled);
+            }
+            other => panic!("unexpected pending operation: {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn todo_delete_cancelled_confirm_uses_fixed_ids_and_status_owner_scope_filters() {
+    let (service, _base) = test_service_with_base();
+    seed_completed_time_todos(&service.todo_store);
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    let other_owner = TodoStore::owner(Some("u2"), "group:g1");
+    let other_cancelled = service
+        .todo_store
+        .create(
+            &other_owner,
+            TodoItemDraft {
+                title: "其他用户已取消".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    service
+        .todo_store
+        .cancel(&other_owner, &other_cancelled.id)
+        .unwrap();
+
+    service
+        .respond(message("/todo delete cancelled"))
+        .await
+        .unwrap();
+    let new_cancelled = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "确认期间新增已取消".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    service
+        .todo_store
+        .cancel(&owner, &new_cancelled.id)
+        .unwrap();
+
+    let deleted = service
+        .respond(message("确认"))
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+    assert!(deleted.contains("已删除 1 条已取消待办。来源：全部已取消待办"));
+
+    let own_all = service.todo_store.list_all(&owner).unwrap();
+    assert!(own_all.iter().all(|item| item.id != "5"));
+    assert_eq!(
+        own_all
+            .iter()
+            .find(|item| item.id == new_cancelled.id)
+            .unwrap()
+            .status,
+        TodoStatus::Cancelled
+    );
+    assert_eq!(
+        own_all.iter().find(|item| item.id == "6").unwrap().status,
+        TodoStatus::Pending
+    );
+    assert_eq!(
+        own_all.iter().find(|item| item.id == "1").unwrap().status,
+        TodoStatus::Completed
+    );
+    assert_eq!(
+        service.todo_store.list_all(&other_owner).unwrap()[0].status,
+        TodoStatus::Cancelled
+    );
+}
+
+#[tokio::test]
+async fn todo_delete_cancelled_cancel_and_empty_do_not_delete_or_create_pending() {
+    let (service, _base) = test_service_with_base();
+    seed_completed_time_todos(&service.todo_store);
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+
+    service
+        .respond(message("/todo delete cancelled"))
+        .await
+        .unwrap();
+    let cancelled = service
+        .respond(message("取消"))
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+    assert_eq!(cancelled, "已取消，不删除待办。");
+    assert!(
+        service
+            .todo_store
+            .list_all(&owner)
+            .unwrap()
+            .iter()
+            .any(|item| item.id == "5" && item.status == TodoStatus::Cancelled)
+    );
+    let session = service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap();
+    assert!(session.pending_operation.is_none());
+
+    service
+        .respond(message("/todo delete cancelled"))
+        .await
+        .unwrap();
+    service.respond(message("确认")).await.unwrap();
+    let empty = service
+        .respond(message("/todo delete cancelled"))
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+    assert_eq!(empty, "当前没有已取消待办需要删除。");
+    let session = service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap();
+    assert!(session.pending_operation.is_none());
+}
+
+#[tokio::test]
 async fn todo_completed_time_query_no_result_and_direct_delete_no_deletable_items() {
     let (service, _base) = test_service_with_base();
     seed_completed_time_todos(&service.todo_store);
@@ -1327,7 +1639,7 @@ async fn todo_non_completed_query_clears_last_completed_query() {
 
     assert_eq!(
         delete,
-        "用法：/todo delete 列表序号或关键词；清理已完成任务用 /todo delete done"
+        "用法：/todo delete 列表序号或关键词；清理已取消任务用 /todo delete cancelled"
     );
 }
 
@@ -1356,7 +1668,7 @@ async fn todo_expired_last_completed_query_is_not_reused() {
 
     assert_eq!(
         delete,
-        "用法：/todo delete 列表序号或关键词；清理已完成任务用 /todo delete done"
+        "用法：/todo delete 列表序号或关键词；清理已取消任务用 /todo delete cancelled"
     );
 }
 

--- a/qq-maid-core/src/runtime/respond/todo_flow/completed_query.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/completed_query.rs
@@ -52,15 +52,6 @@ pub(super) fn valid_last_completed_todo_bulk_query(
     valid_last_completed_todo_query(session, owner, |query_type| query_type == "completed-time")
 }
 
-pub(super) fn valid_last_completed_todo_index_query(
-    session: &mut SessionRecord,
-    owner: &TodoOwner,
-) -> Option<LastTodoQuery> {
-    valid_last_completed_todo_query(session, owner, |query_type| {
-        matches!(query_type, "completed-time" | "completed-list")
-    })
-}
-
 fn valid_last_completed_todo_query(
     session: &mut SessionRecord,
     owner: &TodoOwner,
@@ -75,11 +66,4 @@ fn valid_last_completed_todo_query(
         return None;
     }
     Some(query)
-}
-
-pub(super) fn valid_last_completed_todo_list_query(
-    session: &mut SessionRecord,
-    owner: &TodoOwner,
-) -> Option<LastTodoQuery> {
-    valid_last_completed_todo_query(session, owner, |query_type| query_type == "completed-list")
 }

--- a/qq-maid-core/src/runtime/respond/todo_flow/format.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/format.rs
@@ -6,7 +6,7 @@
 use crate::{
     runtime::{
         pending::PendingTodoAction,
-        todo::{TodoItem, TodoItemDraft, display_draft_time, display_todo_time},
+        todo::{TodoItem, TodoItemDraft, TodoStatus, display_draft_time, display_todo_time},
     },
     util::time_context::format_todo_time_for_display,
 };
@@ -347,19 +347,21 @@ pub(super) fn format_todo_bulk_delete_summary(items: &[TodoItem]) -> String {
     rows.join("\n")
 }
 
-pub(super) fn format_todo_bulk_delete_confirm(
+pub(super) fn format_todo_bulk_delete_confirm_for_status(
     count: usize,
+    status: TodoStatus,
     source_condition: &str,
     summary: &str,
 ) -> CommandBody {
+    let status_label = todo_bulk_delete_status_label(&status);
     let text = format!(
-        "确认删除这 {count} 条已完成待办？来源：{}\n{}\n\n{}",
+        "确认删除这 {count} 条{status_label}待办？来源：{}\n{}\n\n{}",
         source_condition.trim(),
         summary.trim(),
         build_todo_confirm_hint()
     );
     let markdown = [
-        format!("# 确认删除 {count} 条已完成待办"),
+        format!("# 确认删除 {count} 条{status_label}待办"),
         format!("来源：{}", escape_markdown_inline(source_condition.trim())),
         String::new(),
         summary
@@ -385,32 +387,61 @@ pub(super) fn format_todo_bulk_delete_result(
     skipped_count: usize,
     source_condition: &str,
 ) -> CommandBody {
-    if cancelled.is_empty() {
-        return simple_todo_notice("没有可删除的已完成待办。");
+    format_todo_bulk_delete_result_for_status(
+        TodoStatus::Completed,
+        cancelled.len(),
+        skipped_count,
+        source_condition,
+        Some(cancelled),
+    )
+}
+
+pub(super) fn format_todo_bulk_delete_result_for_status(
+    status: TodoStatus,
+    deleted_count: usize,
+    skipped_count: usize,
+    source_condition: &str,
+    items: Option<&[TodoItem]>,
+) -> CommandBody {
+    let status_label = todo_bulk_delete_status_label(&status);
+    if deleted_count == 0 {
+        return simple_todo_notice(&format!("没有可删除的{status_label}待办。"));
     }
     let mut rows = vec![format!(
-        "已删除 {} 条已完成待办。来源：{}",
-        cancelled.len(),
+        "已删除 {} 条{status_label}待办。来源：{}",
+        deleted_count,
         source_condition.trim()
     )];
     if skipped_count > 0 {
         rows.push(format!(
-            "跳过 {skipped_count} 条已不存在、已取消或状态已变化的待办。"
+            "跳过 {skipped_count} 条已不存在或状态已变化的待办。"
         ));
     }
-    rows.extend(format_completed_todo_rows(cancelled));
-    let mut markdown_rows = vec![format!("# 已删除 {} 条已完成待办", cancelled.len())];
+    if let Some(items) = items {
+        rows.extend(format_completed_todo_rows(items));
+    }
+    let mut markdown_rows = vec![format!("# 已删除 {} 条{status_label}待办", deleted_count)];
     markdown_rows.push(format!(
         "来源：{}",
         escape_markdown_inline(source_condition.trim())
     ));
     if skipped_count > 0 {
         markdown_rows.push(format!(
-            "> 跳过 {skipped_count} 条已不存在、已取消或状态已变化的待办。"
+            "> 跳过 {skipped_count} 条已不存在或状态已变化的待办。"
         ));
     }
-    markdown_rows.extend(format_completed_todo_rows_markdown(cancelled));
+    if let Some(items) = items {
+        markdown_rows.extend(format_completed_todo_rows_markdown(items));
+    }
     CommandBody::dual(rows.join("\n"), markdown_rows.join("\n"))
+}
+
+fn todo_bulk_delete_status_label(status: &TodoStatus) -> &'static str {
+    match status {
+        TodoStatus::Pending => "未完成",
+        TodoStatus::Completed => "已完成",
+        TodoStatus::Cancelled => "已取消",
+    }
 }
 
 pub(super) fn format_todo_edit_confirm(before: &TodoItem, draft: &TodoItemDraft) -> CommandBody {
@@ -534,24 +565,23 @@ pub(super) fn format_todo_no_match_reply(target: &str) -> CommandBody {
     simple_todo_notice(&format!("没有找到匹配的未完成待办：{}", target.trim()))
 }
 
-pub(super) fn format_todo_missing_pending_index_reply(index: usize) -> CommandBody {
+pub(super) fn format_todo_missing_snapshot_index_reply(
+    index: usize,
+    source_label: &str,
+    source_command: &str,
+) -> CommandBody {
     simple_todo_notice(&format!(
-        "当前待办序号已失效或不存在第 {index} 条，请重新执行 /todo 获取最新列表。"
+        "当前{source_label}序号已失效或不存在第 {index} 条，请重新执行 {source_command} 获取最新列表。"
     ))
 }
 
-pub(super) fn format_todo_missing_completed_index_reply(index: usize) -> CommandBody {
+pub(super) fn format_todo_snapshot_unavailable_reply(
+    source_label: &str,
+    source_command: &str,
+) -> CommandBody {
     simple_todo_notice(&format!(
-        "当前已完成待办序号已失效或不存在第 {index} 条，请重新执行 /todo done 获取最新列表。"
+        "当前{source_label}序号已失效，请重新执行 {source_command} 获取最新列表。"
     ))
-}
-
-pub(super) fn format_todo_pending_snapshot_unavailable_reply() -> CommandBody {
-    simple_todo_notice("当前待办序号已失效，请重新执行 /todo 获取最新列表。")
-}
-
-pub(super) fn format_todo_completed_snapshot_unavailable_reply() -> CommandBody {
-    simple_todo_notice("当前已完成待办序号已失效，请重新执行 /todo done 获取最新列表。")
 }
 
 pub(super) fn format_todo_edit_usage_reply() -> CommandBody {
@@ -559,7 +589,9 @@ pub(super) fn format_todo_edit_usage_reply() -> CommandBody {
 }
 
 pub(super) fn format_todo_delete_usage_reply() -> CommandBody {
-    CommandBody::plain("用法：/todo delete 列表序号或关键词；清理已完成任务用 /todo delete done")
+    CommandBody::plain(
+        "用法：/todo delete 列表序号或关键词；清理已取消任务用 /todo delete cancelled",
+    )
 }
 
 pub(super) fn format_todo_inline_markdown(item: &TodoItem) -> String {

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -12,7 +12,9 @@ use crate::{
     runtime::{
         pending::{PendingOperation, PendingTodoAction},
         session::{LastTodoQuery, SessionMeta, SessionRecord, now_iso_cn},
-        todo::{TodoItem, TodoItemDraft, TodoOwner, TodoStore, enrich_draft_time_from_text},
+        todo::{
+            TodoItem, TodoItemDraft, TodoOwner, TodoStatus, TodoStore, enrich_draft_time_from_text,
+        },
     },
     util::time_context::request_time_context,
 };
@@ -34,19 +36,17 @@ mod target;
 mod train_todo;
 
 use command::parse_todo_command;
-use completed_query::{
-    parse_completed_todo_time_query, valid_last_completed_todo_bulk_query,
-    valid_last_completed_todo_list_query,
-};
+use completed_query::{parse_completed_todo_time_query, valid_last_completed_todo_bulk_query};
 use draft::{
     TodoEditPatch, apply_todo_edit_patch, enrich_todo_edit_patch_time_from_text,
     parse_todo_draft_json, parse_todo_edit_patch_json,
 };
 use format::*;
 use target::{
-    TodoTarget, is_completed_todo_cleanup_target, parse_todo_edit_argument, parse_todo_number_list,
-    remember_todo_query, resolve_todo_numbers_from_snapshot, resolve_todo_target,
-    todo_target_label, valid_last_todo_list_query,
+    TodoTarget, is_cancelled_todo_cleanup_target, is_completed_todo_cleanup_target,
+    parse_todo_edit_argument, parse_todo_number_list, remember_todo_query,
+    resolve_todo_numbers_from_snapshot, resolve_todo_target, todo_target_label,
+    valid_last_visible_todo_query,
 };
 
 impl RustRespondService {
@@ -70,8 +70,8 @@ impl RustRespondService {
                 (format_todo_list_reply(&items), "todo_list".to_owned())
             }
             "todo_all" => {
-                session.last_todo_query = None;
                 let items = self.todo_store.list_all(&owner).map_err(todo_error)?;
+                remember_todo_query(session, &owner, "all", "全部待办", &items);
                 (format_todo_all_reply(&items), "todo_all".to_owned())
             }
             "todo_search" => {
@@ -205,6 +205,7 @@ impl RustRespondService {
                             initiator_user_id.clone(),
                             query.result_ids,
                             query.condition,
+                            TodoStatus::Completed,
                         )?
                     } else {
                         (format_todo_delete_usage_reply(), "todo_delete".to_owned())
@@ -224,6 +225,24 @@ impl RustRespondService {
                         initiator_user_id.clone(),
                         items,
                         "全部已完成待办".to_owned(),
+                        TodoStatus::Completed,
+                    )?
+                } else if is_cancelled_todo_cleanup_target(argument) {
+                    let items = self.todo_store.list_cancelled(&owner).map_err(todo_error)?;
+                    remember_todo_query(
+                        session,
+                        &owner,
+                        "cancelled-list",
+                        "全部已取消待办",
+                        &items,
+                    );
+                    self.prepare_todo_bulk_delete_from_items(
+                        session,
+                        &owner,
+                        initiator_user_id.clone(),
+                        items,
+                        "全部已取消待办".to_owned(),
+                        TodoStatus::Cancelled,
                     )?
                 } else if let Some(completed_query) = parse_completed_todo_time_query(argument) {
                     let items = self
@@ -243,6 +262,7 @@ impl RustRespondService {
                         initiator_user_id.clone(),
                         items,
                         completed_query.source_condition,
+                        TodoStatus::Completed,
                     )?
                 } else {
                     self.prepare_todo_match_operation(
@@ -264,42 +284,34 @@ impl RustRespondService {
                         "todo_edit",
                     )?));
                 };
-                let target = resolve_todo_target(session, &owner, &target, false);
+                let target = resolve_todo_target(session, &owner, &target, true);
                 let target_label = todo_target_label(&target);
                 let candidates = match &target {
-                    TodoTarget::PendingListIndex { id, .. } => {
-                        self.match_pending_todo_id(&owner, id)?
-                    }
-                    TodoTarget::CompletedListIndex { .. } => Vec::new(),
-                    TodoTarget::MissingPendingListIndex(index) => {
+                    TodoTarget::ListIndex { id, .. } => self.match_pending_todo_id(&owner, id)?,
+                    TodoTarget::MissingListIndex {
+                        index,
+                        source_label,
+                        source_command,
+                    } => {
                         return Ok(Some(self.append_pending_response(
                             session,
                             user_text,
-                            format_todo_missing_pending_index_reply(*index),
+                            format_todo_missing_snapshot_index_reply(
+                                *index,
+                                source_label,
+                                source_command,
+                            ),
                             "todo_edit",
                         )?));
                     }
-                    TodoTarget::MissingCompletedListIndex(index) => {
+                    TodoTarget::ListUnavailable {
+                        source_label,
+                        source_command,
+                    } => {
                         return Ok(Some(self.append_pending_response(
                             session,
                             user_text,
-                            format_todo_missing_completed_index_reply(*index),
-                            "todo_edit",
-                        )?));
-                    }
-                    TodoTarget::PendingListUnavailable => {
-                        return Ok(Some(self.append_pending_response(
-                            session,
-                            user_text,
-                            format_todo_pending_snapshot_unavailable_reply(),
-                            "todo_edit",
-                        )?));
-                    }
-                    TodoTarget::CompletedListUnavailable => {
-                        return Ok(Some(self.append_pending_response(
-                            session,
-                            user_text,
-                            format_todo_completed_snapshot_unavailable_reply(),
+                            format_todo_snapshot_unavailable_reply(source_label, source_command),
                             "todo_edit",
                         )?));
                     }
@@ -378,38 +390,31 @@ impl RustRespondService {
             PendingTodoAction::Delete => "todo_delete",
         }
         .to_owned();
-        let target =
-            resolve_todo_target(session, owner, target, action == PendingTodoAction::Delete);
+        let target = resolve_todo_target(session, owner, target, true);
         let target_label = todo_target_label(&target);
         let candidates = match &target {
-            TodoTarget::PendingListIndex { id, .. } => self.match_pending_todo_id(owner, id)?,
-            TodoTarget::CompletedListIndex {
-                id,
-                source_condition,
-                ..
+            TodoTarget::ListIndex { id, .. } if action == PendingTodoAction::Delete => {
+                self.match_todo_id_for_delete(owner, id)?
+            }
+            TodoTarget::ListIndex { id, .. } => self.match_pending_todo_id(owner, id)?,
+            TodoTarget::MissingListIndex {
+                index,
+                source_label,
+                source_command,
             } => {
-                if action == PendingTodoAction::Delete {
-                    return self.prepare_todo_bulk_delete_from_ids(
-                        session,
-                        owner,
-                        initiator_user_id,
-                        vec![id.clone()],
-                        source_condition.clone(),
-                    );
-                }
-                Vec::new()
+                return Ok((
+                    format_todo_missing_snapshot_index_reply(*index, source_label, source_command),
+                    command,
+                ));
             }
-            TodoTarget::MissingPendingListIndex(index) => {
-                return Ok((format_todo_missing_pending_index_reply(*index), command));
-            }
-            TodoTarget::MissingCompletedListIndex(index) => {
-                return Ok((format_todo_missing_completed_index_reply(*index), command));
-            }
-            TodoTarget::PendingListUnavailable => {
-                return Ok((format_todo_pending_snapshot_unavailable_reply(), command));
-            }
-            TodoTarget::CompletedListUnavailable => {
-                return Ok((format_todo_completed_snapshot_unavailable_reply(), command));
+            TodoTarget::ListUnavailable {
+                source_label,
+                source_command,
+            } => {
+                return Ok((
+                    format_todo_snapshot_unavailable_reply(source_label, source_command),
+                    command,
+                ));
             }
             TodoTarget::Query(query) => self
                 .todo_store
@@ -473,6 +478,22 @@ impl RustRespondService {
         Ok(items.into_iter().filter(|item| item.id == id).collect())
     }
 
+    /// 删除命令已经通过最近列表快照拿到内部 ID，这里按 owner/scope 再查一次当前项。
+    /// 与编辑/完成不同，删除允许从 `/todo all` 指向未完成、已完成或已取消项；
+    /// 确认阶段会根据保存的内部 ID 和当前状态执行对应的安全删除语义。
+    fn match_todo_id_for_delete(
+        &self,
+        owner: &TodoOwner,
+        id: &str,
+    ) -> Result<Vec<TodoItem>, LlmError> {
+        Ok(self
+            .todo_store
+            .get_by_id(owner, id)
+            .map_err(todo_error)?
+            .into_iter()
+            .collect())
+    }
+
     /// 按最近一次 `/todo` 列表中的可见编号批量完成待办。
     fn complete_todo_list_numbers(
         &self,
@@ -484,9 +505,9 @@ impl RustRespondService {
             Ok(numbers) => numbers,
             Err(message) => return Ok((CommandBody::plain(message), "todo_done".to_owned())),
         };
-        let Some(query) = valid_last_todo_list_query(session, owner) else {
+        let Some(query) = valid_last_visible_todo_query(session, owner) else {
             return Ok((
-                CommandBody::plain("请先发送 /todo 查看未完成待办。"),
+                CommandBody::plain("请先发送 /todo 查看待办列表。"),
                 "todo_done".to_owned(),
             ));
         };
@@ -540,7 +561,7 @@ impl RustRespondService {
             Ok(numbers) => numbers,
             Err(message) => return Ok((CommandBody::plain(message), "todo_undo".to_owned())),
         };
-        let Some(query) = valid_last_completed_todo_list_query(session, owner) else {
+        let Some(query) = valid_last_visible_todo_query(session, owner) else {
             return Ok((
                 CommandBody::plain("请先发送 /todo done 查看已完成待办。"),
                 "todo_undo".to_owned(),
@@ -593,10 +614,11 @@ impl RustRespondService {
         initiator_user_id: Option<String>,
         item_ids: Vec<String>,
         source_condition: String,
+        status: TodoStatus,
     ) -> Result<(CommandBody, String), LlmError> {
         let items = self
             .todo_store
-            .list_completed_by_ids(owner, &item_ids)
+            .list_by_ids_with_status(owner, &item_ids, status.clone())
             .map_err(todo_error)?;
         self.prepare_todo_bulk_delete_from_items(
             session,
@@ -604,6 +626,7 @@ impl RustRespondService {
             initiator_user_id,
             items,
             source_condition,
+            status,
         )
     }
 
@@ -615,10 +638,14 @@ impl RustRespondService {
         initiator_user_id: Option<String>,
         items: Vec<TodoItem>,
         source_condition: String,
+        status: TodoStatus,
     ) -> Result<(CommandBody, String), LlmError> {
         if items.is_empty() {
             return Ok((
-                CommandBody::plain("没有可删除的已完成待办。"),
+                CommandBody::plain(match status {
+                    TodoStatus::Cancelled => "当前没有已取消待办需要删除。",
+                    _ => "没有可删除的已完成待办。",
+                }),
                 "todo_delete".to_owned(),
             ));
         }
@@ -628,12 +655,19 @@ impl RustRespondService {
             initiator_user_id,
             owner_key: owner.key.clone(),
             item_ids,
+            matched_count: items.len(),
+            status: status.clone(),
             summary: summary.clone(),
             source_condition: source_condition.clone(),
             created_at: now_iso_cn(),
         });
         Ok((
-            format_todo_bulk_delete_confirm(items.len(), &source_condition, &summary),
+            format_todo_bulk_delete_confirm_for_status(
+                items.len(),
+                status,
+                &source_condition,
+                &summary,
+            ),
             "todo_delete".to_owned(),
         ))
     }

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -58,6 +58,7 @@ impl RustRespondService {
         session: &mut SessionRecord,
     ) -> Result<Option<RespondResponse>, LlmError> {
         let owner = TodoStore::owner(meta.user_id.as_deref(), &meta.scope_key);
+        let initiator_user_id = meta.user_id.clone();
         let Some(command) = parse_todo_command(user_text) else {
             return Ok(None);
         };
@@ -126,6 +127,7 @@ impl RustRespondService {
                             TrainTodoAddOutcome::Handled { reply, pending } => {
                                 if let Some(pending_add) = pending {
                                     session.pending_operation = Some(PendingOperation::TodoAdd {
+                                        initiator_user_id: initiator_user_id.clone(),
                                         owner_key: pending_add.owner_key,
                                         draft: pending_add.draft,
                                         allow_revision: false,
@@ -142,6 +144,7 @@ impl RustRespondService {
                                     Ok(draft) => {
                                         session.pending_operation =
                                             Some(PendingOperation::TodoAdd {
+                                                initiator_user_id: initiator_user_id.clone(),
                                                 owner_key: owner.key.clone(),
                                                 draft: draft.clone(),
                                                 allow_revision: true,
@@ -159,6 +162,7 @@ impl RustRespondService {
                         match self.parse_todo_draft(argument, None).await? {
                             Ok(draft) => {
                                 session.pending_operation = Some(PendingOperation::TodoAdd {
+                                    initiator_user_id: initiator_user_id.clone(),
                                     owner_key: owner.key.clone(),
                                     draft: draft.clone(),
                                     allow_revision: true,
@@ -198,6 +202,7 @@ impl RustRespondService {
                         self.prepare_todo_bulk_delete_from_ids(
                             session,
                             &owner,
+                            initiator_user_id.clone(),
                             query.result_ids,
                             query.condition,
                         )?
@@ -216,6 +221,7 @@ impl RustRespondService {
                     self.prepare_todo_bulk_delete_from_items(
                         session,
                         &owner,
+                        initiator_user_id.clone(),
                         items,
                         "全部已完成待办".to_owned(),
                     )?
@@ -234,6 +240,7 @@ impl RustRespondService {
                     self.prepare_todo_bulk_delete_from_items(
                         session,
                         &owner,
+                        initiator_user_id.clone(),
                         items,
                         completed_query.source_condition,
                     )?
@@ -241,6 +248,7 @@ impl RustRespondService {
                     self.prepare_todo_match_operation(
                         session,
                         &owner,
+                        initiator_user_id.clone(),
                         PendingTodoAction::Delete,
                         argument,
                     )?
@@ -308,6 +316,7 @@ impl RustRespondService {
                     [item] => match self.parse_todo_edit_draft(&edit_text, item).await? {
                         Ok(draft) => {
                             session.pending_operation = Some(PendingOperation::TodoEdit {
+                                initiator_user_id: initiator_user_id.clone(),
                                 owner_key: owner.key.clone(),
                                 before: item.clone(),
                                 draft: draft.clone(),
@@ -323,6 +332,7 @@ impl RustRespondService {
                     _ => {
                         let candidates = candidates.into_iter().take(5).collect::<Vec<_>>();
                         session.pending_operation = Some(PendingOperation::TodoSelectCandidate {
+                            initiator_user_id: initiator_user_id.clone(),
                             owner_key: owner.key.clone(),
                             action: PendingTodoAction::Edit,
                             candidates: candidates.clone(),
@@ -358,6 +368,7 @@ impl RustRespondService {
         &self,
         session: &mut SessionRecord,
         owner: &TodoOwner,
+        initiator_user_id: Option<String>,
         action: PendingTodoAction,
         target: &str,
     ) -> Result<(CommandBody, String), LlmError> {
@@ -381,6 +392,7 @@ impl RustRespondService {
                     return self.prepare_todo_bulk_delete_from_ids(
                         session,
                         owner,
+                        initiator_user_id,
                         vec![id.clone()],
                         source_condition.clone(),
                     );
@@ -409,11 +421,13 @@ impl RustRespondService {
             [item] => {
                 session.pending_operation = Some(match &action {
                     PendingTodoAction::Done => PendingOperation::TodoDone {
+                        initiator_user_id: initiator_user_id.clone(),
                         owner_key: owner.key.clone(),
                         item: item.clone(),
                         created_at: now_iso_cn(),
                     },
                     PendingTodoAction::Delete => PendingOperation::TodoDelete {
+                        initiator_user_id: initiator_user_id.clone(),
                         owner_key: owner.key.clone(),
                         item: item.clone(),
                         created_at: now_iso_cn(),
@@ -430,6 +444,7 @@ impl RustRespondService {
             _ => {
                 let candidates = candidates.into_iter().take(5).collect::<Vec<_>>();
                 session.pending_operation = Some(PendingOperation::TodoSelectCandidate {
+                    initiator_user_id,
                     owner_key: owner.key.clone(),
                     action: action.clone(),
                     candidates: candidates.clone(),
@@ -575,6 +590,7 @@ impl RustRespondService {
         &self,
         session: &mut SessionRecord,
         owner: &TodoOwner,
+        initiator_user_id: Option<String>,
         item_ids: Vec<String>,
         source_condition: String,
     ) -> Result<(CommandBody, String), LlmError> {
@@ -582,7 +598,13 @@ impl RustRespondService {
             .todo_store
             .list_completed_by_ids(owner, &item_ids)
             .map_err(todo_error)?;
-        self.prepare_todo_bulk_delete_from_items(session, owner, items, source_condition)
+        self.prepare_todo_bulk_delete_from_items(
+            session,
+            owner,
+            initiator_user_id,
+            items,
+            source_condition,
+        )
     }
 
     /// 根据 TodoItem 列表准备批量删除的待确认操作。
@@ -590,6 +612,7 @@ impl RustRespondService {
         &self,
         session: &mut SessionRecord,
         owner: &TodoOwner,
+        initiator_user_id: Option<String>,
         items: Vec<TodoItem>,
         source_condition: String,
     ) -> Result<(CommandBody, String), LlmError> {
@@ -602,6 +625,7 @@ impl RustRespondService {
         let item_ids = items.iter().map(|item| item.id.clone()).collect::<Vec<_>>();
         let summary = format_todo_bulk_delete_summary(&items);
         session.pending_operation = Some(PendingOperation::TodoBulkDelete {
+            initiator_user_id,
             owner_key: owner.key.clone(),
             item_ids,
             summary: summary.clone(),

--- a/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
@@ -12,7 +12,7 @@ use crate::{
             pending_revision_failed_reply, should_parse_pending_revision, todo_lexicon,
         },
         session::{SessionRecord, now_iso_cn},
-        todo::TodoOwner,
+        todo::{TodoOwner, TodoStatus},
     },
 };
 
@@ -222,17 +222,60 @@ impl RustRespondService {
                     )?));
                 }
                 if matches!(reply_kind, PendingReplyKind::Confirm) {
-                    let deleted = self
-                        .todo_store
-                        .cancel(owner, &item.id)
-                        .map_err(todo_error)?;
-                    let reply = CommandBody::dual(
-                        format!("已删除待办：{}", format_todo_inline(&deleted)),
-                        format!(
-                            "# 已删除待办\n\n- {}",
-                            format_todo_inline_markdown(&deleted)
-                        ),
-                    );
+                    let reply = match item.status {
+                        TodoStatus::Pending => {
+                            let deleted = self
+                                .todo_store
+                                .cancel(owner, &item.id)
+                                .map_err(todo_error)?;
+                            CommandBody::dual(
+                                format!("已删除待办：{}", format_todo_inline(&deleted)),
+                                format!(
+                                    "# 已删除待办\n\n- {}",
+                                    format_todo_inline_markdown(&deleted)
+                                ),
+                            )
+                        }
+                        TodoStatus::Completed => {
+                            let outcome = self
+                                .todo_store
+                                .cancel_completed_by_ids(owner, std::slice::from_ref(&item.id))
+                                .map_err(todo_error)?;
+                            let Some(deleted) = outcome.cancelled.first() else {
+                                return Ok(Some(self.clear_pending_response(
+                                    session,
+                                    user_text,
+                                    CommandBody::plain("没有可删除的已完成待办。"),
+                                    "todo_confirm",
+                                )?));
+                            };
+                            CommandBody::dual(
+                                format!("已删除待办：{}", format_todo_inline(deleted)),
+                                format!(
+                                    "# 已删除待办\n\n- {}",
+                                    format_todo_inline_markdown(deleted)
+                                ),
+                            )
+                        }
+                        TodoStatus::Cancelled => {
+                            let outcome = self
+                                .todo_store
+                                .delete_cancelled_by_ids(owner, std::slice::from_ref(&item.id))
+                                .map_err(todo_error)?;
+                            if outcome.deleted_count == 0 {
+                                return Ok(Some(self.clear_pending_response(
+                                    session,
+                                    user_text,
+                                    CommandBody::plain("当前没有已取消待办需要删除。"),
+                                    "todo_confirm",
+                                )?));
+                            }
+                            CommandBody::dual(
+                                format!("已删除待办：{}", format_todo_inline(&item)),
+                                format!("# 已删除待办\n\n- {}", format_todo_inline_markdown(&item)),
+                            )
+                        }
+                    };
                     return Ok(Some(self.clear_pending_response(
                         session,
                         user_text,
@@ -249,6 +292,8 @@ impl RustRespondService {
             }
             PendingOperation::TodoBulkDelete {
                 item_ids,
+                matched_count,
+                status,
                 source_condition,
                 ..
             } => {
@@ -262,15 +307,39 @@ impl RustRespondService {
                     )?));
                 }
                 if matches!(reply_kind, PendingReplyKind::Confirm) {
-                    let outcome = self
-                        .todo_store
-                        .cancel_completed_by_ids(owner, &item_ids)
-                        .map_err(todo_error)?;
-                    let reply = format_todo_bulk_delete_result(
-                        &outcome.cancelled,
-                        outcome.skipped_ids.len(),
-                        &source_condition,
-                    );
+                    let reply = match status {
+                        TodoStatus::Completed => {
+                            let outcome = self
+                                .todo_store
+                                .cancel_completed_by_ids(owner, &item_ids)
+                                .map_err(todo_error)?;
+                            format_todo_bulk_delete_result(
+                                &outcome.cancelled,
+                                outcome.skipped_ids.len(),
+                                &source_condition,
+                            )
+                        }
+                        TodoStatus::Cancelled => {
+                            let outcome = self
+                                .todo_store
+                                .delete_cancelled_by_ids(owner, &item_ids)
+                                .map_err(todo_error)?;
+                            let source_count = if matched_count == 0 {
+                                item_ids.len()
+                            } else {
+                                matched_count
+                            };
+                            let skipped_count = source_count.saturating_sub(outcome.deleted_count);
+                            format_todo_bulk_delete_result_for_status(
+                                TodoStatus::Cancelled,
+                                outcome.deleted_count,
+                                skipped_count,
+                                &source_condition,
+                                None,
+                            )
+                        }
+                        TodoStatus::Pending => CommandBody::plain("不支持批量删除未完成待办。"),
+                    };
                     return Ok(Some(self.clear_pending_response(
                         session,
                         user_text,

--- a/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
@@ -41,6 +41,7 @@ impl RustRespondService {
 
         match pending {
             PendingOperation::TodoAdd {
+                initiator_user_id,
                 owner_key,
                 draft,
                 allow_revision,
@@ -88,6 +89,7 @@ impl RustRespondService {
                             session,
                             user_text,
                             PendingOperation::TodoAdd {
+                                initiator_user_id,
                                 owner_key,
                                 draft: revised.clone(),
                                 allow_revision: true,
@@ -148,6 +150,7 @@ impl RustRespondService {
                 )?))
             }
             PendingOperation::TodoEdit {
+                initiator_user_id,
                 owner_key,
                 before,
                 draft,
@@ -184,6 +187,7 @@ impl RustRespondService {
                             session,
                             user_text,
                             PendingOperation::TodoEdit {
+                                initiator_user_id,
                                 owner_key,
                                 before: before.clone(),
                                 draft: revised.clone(),
@@ -282,6 +286,7 @@ impl RustRespondService {
                 )?))
             }
             PendingOperation::TodoSelectCandidate {
+                initiator_user_id,
                 action,
                 candidates,
                 edit_text,
@@ -330,6 +335,7 @@ impl RustRespondService {
                         session,
                         user_text,
                         PendingOperation::TodoDone {
+                            initiator_user_id: initiator_user_id.clone(),
                             owner_key: owner.key.clone(),
                             item: item.clone(),
                             created_at: now_iso_cn(),
@@ -341,6 +347,7 @@ impl RustRespondService {
                         session,
                         user_text,
                         PendingOperation::TodoDelete {
+                            initiator_user_id: initiator_user_id.clone(),
                             owner_key: owner.key.clone(),
                             item: item.clone(),
                             created_at: now_iso_cn(),
@@ -355,6 +362,7 @@ impl RustRespondService {
                                 session,
                                 user_text,
                                 PendingOperation::TodoEdit {
+                                    initiator_user_id,
                                     owner_key: owner.key.clone(),
                                     before: item.clone(),
                                     draft: draft.clone(),

--- a/qq-maid-core/src/runtime/respond/todo_flow/target.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/target.rs
@@ -13,29 +13,29 @@ use crate::runtime::{
 
 use crate::runtime::respond::common::{LAST_QUERY_TTL_SECONDS, query_is_fresh};
 
-use super::{
-    completed_query::valid_last_completed_todo_index_query, format::format_todo_number_usage_reply,
-};
+use super::format::format_todo_number_usage_reply;
 
 /// 待办操作目标的解析结果：通过最近列表序号或关键词匹配。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum TodoTarget {
-    /// 最近待办列表里的可见序号，已映射到内部 ID。
-    PendingListIndex { index: usize, id: String },
-    /// 最近已完成列表里的可见序号，已映射到内部 ID，并保留来源条件。
-    CompletedListIndex {
+    /// 最近用户实际看到的 Todo 列表里的可见序号，已映射到内部 ID。
+    ListIndex {
         index: usize,
         id: String,
+        source_label: String,
         source_condition: String,
     },
-    /// 最近待办列表里没有该序号
-    MissingPendingListIndex(usize),
-    /// 最近已完成列表里没有该序号
-    MissingCompletedListIndex(usize),
-    /// 当前没有可复用的待办列表快照
-    PendingListUnavailable,
-    /// 当前没有可复用的已完成列表快照
-    CompletedListUnavailable,
+    /// 最近列表里没有该序号。
+    MissingListIndex {
+        index: usize,
+        source_label: String,
+        source_command: String,
+    },
+    /// 当前没有可复用的列表快照，或最近快照已经过期。
+    ListUnavailable {
+        source_label: String,
+        source_command: String,
+    },
     /// 使用关键词搜索匹配
     Query(String),
 }
@@ -47,12 +47,12 @@ pub(super) struct TodoNumberResolution {
     pub(super) missing: Vec<usize>,
 }
 
-pub(super) fn valid_last_todo_list_query(
+fn valid_last_pending_todo_query(
     session: &mut SessionRecord,
     owner: &TodoOwner,
 ) -> Option<LastTodoQuery> {
     let query = session.last_todo_query.clone()?;
-    if query.owner_key != owner.key || query.query_type != "list" {
+    if query.owner_key != owner.key || !matches!(query.query_type.as_str(), "list" | "search") {
         return None;
     }
     if !query_is_fresh(&query.created_at, LAST_QUERY_TTL_SECONDS) {
@@ -62,12 +62,12 @@ pub(super) fn valid_last_todo_list_query(
     Some(query)
 }
 
-fn valid_last_pending_todo_query(
+pub(super) fn valid_last_visible_todo_query(
     session: &mut SessionRecord,
     owner: &TodoOwner,
 ) -> Option<LastTodoQuery> {
     let query = session.last_todo_query.clone()?;
-    if query.owner_key != owner.key || !matches!(query.query_type.as_str(), "list" | "search") {
+    if query.owner_key != owner.key || !is_visible_todo_query_type(&query.query_type) {
         return None;
     }
     if !query_is_fresh(&query.created_at, LAST_QUERY_TTL_SECONDS) {
@@ -161,7 +161,7 @@ pub(super) fn resolve_todo_target(
     session: &mut SessionRecord,
     owner: &TodoOwner,
     target: &str,
-    allow_completed_list_index: bool,
+    use_latest_visible_snapshot: bool,
 ) -> TodoTarget {
     let target = target.trim();
     if target.is_empty() {
@@ -174,49 +174,109 @@ pub(super) fn resolve_todo_target(
     let Ok(index) = target.parse::<usize>() else {
         return TodoTarget::Query(target.to_owned());
     };
+    if use_latest_visible_snapshot {
+        let Some(query) = session.last_todo_query.clone().filter(|query| {
+            query.owner_key == owner.key && is_visible_todo_query_type(&query.query_type)
+        }) else {
+            return TodoTarget::ListUnavailable {
+                source_label: "待办".to_owned(),
+                source_command: "/todo".to_owned(),
+            };
+        };
+        let source_label = todo_query_source_label(&query);
+        let source_command = todo_query_source_command(&query);
+        if !query_is_fresh(&query.created_at, LAST_QUERY_TTL_SECONDS) {
+            session.last_todo_query = None;
+            return TodoTarget::ListUnavailable {
+                source_label,
+                source_command,
+            };
+        }
+        if let Some(id) = query
+            .result_ids
+            .get(index.saturating_sub(1))
+            .filter(|_| index > 0)
+        {
+            return TodoTarget::ListIndex {
+                index,
+                id: id.clone(),
+                source_label,
+                source_condition: format!("{}第 {index} 条", query.condition),
+            };
+        }
+        return TodoTarget::MissingListIndex {
+            index,
+            source_label,
+            source_command,
+        };
+    }
     if let Some(query) = valid_last_pending_todo_query(session, owner) {
         if let Some(id) = query
             .result_ids
             .get(index.saturating_sub(1))
             .filter(|_| index > 0)
         {
-            return TodoTarget::PendingListIndex {
+            return TodoTarget::ListIndex {
                 index,
                 id: id.clone(),
+                source_label: todo_query_source_label(&query),
+                source_condition: format!("{}第 {index} 条", query.condition),
             };
         }
-        return TodoTarget::MissingPendingListIndex(index);
+        return TodoTarget::MissingListIndex {
+            index,
+            source_label: todo_query_source_label(&query),
+            source_command: todo_query_source_command(&query),
+        };
     }
-    if allow_completed_list_index {
-        if let Some(query) = valid_last_completed_todo_index_query(session, owner) {
-            if let Some(id) = query
-                .result_ids
-                .get(index.saturating_sub(1))
-                .filter(|_| index > 0)
-            {
-                return TodoTarget::CompletedListIndex {
-                    index,
-                    id: id.clone(),
-                    source_condition: format!("{}第 {index} 条", query.condition),
-                };
-            }
-            return TodoTarget::MissingCompletedListIndex(index);
-        }
-        return TodoTarget::CompletedListUnavailable;
+    TodoTarget::ListUnavailable {
+        source_label: "待办".to_owned(),
+        source_command: "/todo".to_owned(),
     }
-    TodoTarget::PendingListUnavailable
 }
 
 pub(super) fn todo_target_label(target: &TodoTarget) -> String {
     match target {
-        TodoTarget::PendingListIndex { index, .. }
-        | TodoTarget::CompletedListIndex { index, .. }
-        | TodoTarget::MissingPendingListIndex(index)
-        | TodoTarget::MissingCompletedListIndex(index) => format!("第 {index} 条"),
-        TodoTarget::PendingListUnavailable => "当前待办序号".to_owned(),
-        TodoTarget::CompletedListUnavailable => "当前已完成待办序号".to_owned(),
+        TodoTarget::ListIndex { index, .. } | TodoTarget::MissingListIndex { index, .. } => {
+            format!("第 {index} 条")
+        }
+        TodoTarget::ListUnavailable { source_label, .. } => {
+            format!("当前{source_label}序号")
+        }
         TodoTarget::Query(query) => query.clone(),
     }
+}
+
+pub(super) fn todo_query_source_label(query: &LastTodoQuery) -> String {
+    match query.query_type.as_str() {
+        "list" | "search" => "待办".to_owned(),
+        "all" => "全部待办".to_owned(),
+        "completed-list" | "completed-time" => "已完成待办".to_owned(),
+        "cancelled-list" => "已取消待办".to_owned(),
+        _ => "待办".to_owned(),
+    }
+}
+
+pub(super) fn todo_query_source_command(query: &LastTodoQuery) -> String {
+    match query.query_type.as_str() {
+        "completed-list" => "/todo done".to_owned(),
+        "cancelled-list" => "/todo delete cancelled".to_owned(),
+        "all" => "/todo all".to_owned(),
+        "search" if !query.condition.trim().is_empty() => {
+            format!("/todo search {}", query.condition.trim())
+        }
+        "completed-time" if !query.condition.trim().is_empty() => {
+            format!("/todo {}", query.condition.trim())
+        }
+        _ => "/todo".to_owned(),
+    }
+}
+
+fn is_visible_todo_query_type(query_type: &str) -> bool {
+    matches!(
+        query_type,
+        "list" | "search" | "all" | "completed-list" | "completed-time" | "cancelled-list"
+    )
 }
 
 pub(super) fn is_completed_todo_cleanup_target(text: &str) -> bool {
@@ -235,6 +295,25 @@ pub(super) fn is_completed_todo_cleanup_target(text: &str) -> bool {
     matches!(
         compact.as_str(),
         "已完成" | "全部已完成" | "所有已完成" | "已完成任务" | "已完成待办"
+    )
+}
+
+pub(super) fn is_cancelled_todo_cleanup_target(text: &str) -> bool {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    match trimmed.to_ascii_lowercase().as_str() {
+        "cancelled" | "canceled" => return true,
+        _ => {}
+    }
+    let compact = trimmed
+        .chars()
+        .filter(|ch| !ch.is_whitespace())
+        .collect::<String>();
+    matches!(
+        compact.as_str(),
+        "已取消" | "全部已取消" | "所有已取消" | "已取消任务" | "已取消待办"
     )
 }
 

--- a/qq-maid-core/src/storage/session.rs
+++ b/qq-maid-core/src/storage/session.rs
@@ -983,6 +983,7 @@ mod tests {
         session.summary = "摘要".to_owned();
         session.append_message("user", "hi");
         session.pending_operation = Some(PendingOperation::MemoryCreate {
+            initiator_user_id: Some("u1".to_owned()),
             memory: PendingMemory {
                 content: "新记忆".to_owned(),
                 source_text: "/memory 新记忆".to_owned(),
@@ -1062,6 +1063,7 @@ mod tests {
         let store = SessionStore::new(SqliteDatabase::open(&path, SESSION_MIGRATIONS).unwrap());
         let mut session = store.create(&meta, "跨进程状态", true).unwrap();
         session.pending_operation = Some(PendingOperation::MemoryCreate {
+            initiator_user_id: Some("u1".to_owned()),
             memory: PendingMemory {
                 content: "需要确认的记忆".to_owned(),
                 source_text: "/memory 需要确认的记忆".to_owned(),

--- a/qq-maid-core/src/storage/todo.rs
+++ b/qq-maid-core/src/storage/todo.rs
@@ -171,6 +171,13 @@ pub struct TodoBulkRestoreOutcome {
     pub skipped_ids: Vec<String>,
 }
 
+/// 批量物理删除已取消待办事项的结果。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TodoBulkDeleteOutcome {
+    pub deleted_count: usize,
+    pub skipped_ids: Vec<String>,
+}
+
 /// Todo reminder 可安全使用的私聊 owner 候选。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TodoReminderOwnerCandidate {
@@ -352,6 +359,14 @@ impl TodoStore {
         Ok(items)
     }
 
+    /// 列出所有已取消的待办事项，按创建时间降序排列。
+    pub fn list_cancelled(&self, owner: &TodoOwner) -> Result<Vec<TodoItem>, TodoError> {
+        let conn = self.connection()?;
+        let mut items = query_items_by_status(&conn, owner, TodoStatus::Cancelled)?;
+        sort_todos_by_created_desc(&mut items);
+        Ok(items)
+    }
+
     /// 列出所有待办事项（不限状态），按创建时间降序排列。
     pub fn list_all(&self, owner: &TodoOwner) -> Result<Vec<TodoItem>, TodoError> {
         let conn = self.connection()?;
@@ -435,6 +450,32 @@ impl TodoStore {
             }
         }
         Ok(matched)
+    }
+
+    /// 根据 ID 列表查找指定状态的待办事项。
+    pub fn list_by_ids_with_status(
+        &self,
+        owner: &TodoOwner,
+        ids: &[String],
+        status: TodoStatus,
+    ) -> Result<Vec<TodoItem>, TodoError> {
+        let conn = self.connection()?;
+        let mut matched = Vec::new();
+        for id in ids.iter().filter_map(|id| parse_todo_db_id(id)) {
+            if let Some(item) = get_by_id_status_unlocked(&conn, owner, id, status.clone())? {
+                matched.push(item);
+            }
+        }
+        Ok(matched)
+    }
+
+    /// 根据内部 ID 获取当前 owner/scope 下任意状态的待办。
+    pub fn get_by_id(&self, owner: &TodoOwner, id: &str) -> Result<Option<TodoItem>, TodoError> {
+        let Some(id) = parse_todo_db_id(id) else {
+            return Ok(None);
+        };
+        let conn = self.connection()?;
+        get_by_id_unlocked(&conn, owner, id)
     }
 
     /// 将待办事项标记为已完成。
@@ -626,6 +667,55 @@ impl TodoStore {
         tx.commit().map_err(TodoError::from_sql)?;
         Ok(TodoBulkCancelOutcome {
             cancelled,
+            skipped_ids,
+        })
+    }
+
+    /// 物理删除已取消待办事项（按 ID 列表匹配）。
+    ///
+    /// 清理已取消项与普通删除不同：普通删除保持软删除语义，这里只允许删除
+    /// 已经处于 Cancelled 状态的记录，并在同一事务内校验 owner、scope 和 status。
+    pub fn delete_cancelled_by_ids(
+        &self,
+        owner: &TodoOwner,
+        ids: &[String],
+    ) -> Result<TodoBulkDeleteOutcome, TodoError> {
+        let mut conn = self.connection()?;
+        let tx = conn.transaction().map_err(TodoError::from_sql)?;
+        let mut deleted_count = 0usize;
+        let mut skipped_ids = Vec::new();
+
+        for id_text in ids.iter().map(|id| clean_todo_id(id)) {
+            let Some(id) = parse_todo_db_id(&id_text) else {
+                if !id_text.is_empty() {
+                    skipped_ids.push(id_text);
+                }
+                continue;
+            };
+            let affected = tx
+                .execute(
+                    "DELETE FROM todos
+                     WHERE id = ?1
+                       AND owner_key = ?2
+                       AND scope_key = ?3
+                       AND status = ?4",
+                    params![
+                        id,
+                        owner.key.as_str(),
+                        owner.scope_key.as_str(),
+                        TodoStatus::Cancelled.as_str(),
+                    ],
+                )
+                .map_err(TodoError::from_sql)?;
+            if affected == 0 {
+                skipped_ids.push(id_text);
+            } else {
+                deleted_count += affected;
+            }
+        }
+        tx.commit().map_err(TodoError::from_sql)?;
+        Ok(TodoBulkDeleteOutcome {
+            deleted_count,
             skipped_ids,
         })
     }
@@ -1914,6 +2004,107 @@ mod tests {
                 missing_completed_at.id.as_str(),
                 already_cancelled.id.as_str()
             ]
+        );
+    }
+
+    #[test]
+    fn delete_cancelled_by_ids_filters_owner_scope_and_status_in_transaction() {
+        let store = test_store();
+        let owner = TodoStore::owner(Some("u1"), "group:g1");
+        let other_owner = TodoStore::owner(Some("u2"), "group:g1");
+
+        let pending = store
+            .create(
+                &owner,
+                TodoItemDraft {
+                    title: "未完成".to_owned(),
+                    detail: None,
+                    raw_text: None,
+                    due_date: None,
+                    due_at: None,
+                    time_precision: TodoTimePrecision::None,
+                },
+            )
+            .unwrap();
+        let completed = store
+            .create(
+                &owner,
+                TodoItemDraft {
+                    title: "已完成".to_owned(),
+                    detail: None,
+                    raw_text: None,
+                    due_date: None,
+                    due_at: None,
+                    time_precision: TodoTimePrecision::None,
+                },
+            )
+            .unwrap();
+        let cancelled = store
+            .create(
+                &owner,
+                TodoItemDraft {
+                    title: "已取消".to_owned(),
+                    detail: None,
+                    raw_text: None,
+                    due_date: None,
+                    due_at: None,
+                    time_precision: TodoTimePrecision::None,
+                },
+            )
+            .unwrap();
+        let other_cancelled = store
+            .create(
+                &other_owner,
+                TodoItemDraft {
+                    title: "其他用户已取消".to_owned(),
+                    detail: None,
+                    raw_text: None,
+                    due_date: None,
+                    due_at: None,
+                    time_precision: TodoTimePrecision::None,
+                },
+            )
+            .unwrap();
+        store.complete(&owner, &completed.id).unwrap();
+        store.cancel(&owner, &cancelled.id).unwrap();
+        store.cancel(&other_owner, &other_cancelled.id).unwrap();
+
+        let outcome = store
+            .delete_cancelled_by_ids(
+                &owner,
+                &[
+                    pending.id.clone(),
+                    completed.id.clone(),
+                    cancelled.id.clone(),
+                    other_cancelled.id.clone(),
+                    "999".to_owned(),
+                ],
+            )
+            .unwrap();
+
+        assert_eq!(outcome.deleted_count, 1);
+        assert_eq!(outcome.skipped_ids.len(), 4);
+        let own_items = store.list_all(&owner).unwrap();
+        assert!(own_items.iter().all(|item| item.id != cancelled.id));
+        assert_eq!(
+            own_items
+                .iter()
+                .find(|item| item.id == pending.id)
+                .unwrap()
+                .status,
+            TodoStatus::Pending
+        );
+        assert_eq!(
+            own_items
+                .iter()
+                .find(|item| item.id == completed.id)
+                .unwrap()
+                .status,
+            TodoStatus::Completed
+        );
+        assert_eq!(
+            store.list_all(&other_owner).unwrap()[0].status,
+            TodoStatus::Cancelled
         );
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/event.rs
+++ b/qq-maid-gateway-rs/src/gateway/event.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
+use tracing::warn;
+
+use crate::gateway::logging::mask_openid;
 
 pub const EVENT_C2C_MESSAGE_CREATE: &str = "C2C_MESSAGE_CREATE";
 pub const EVENT_GROUP_AT_MESSAGE_CREATE: &str = "GROUP_AT_MESSAGE_CREATE";
@@ -109,8 +112,10 @@ struct RawGroupMessage {
     group_id: Option<String>,
     #[serde(default)]
     author: Option<RawAuthor>,
-    #[serde(default, alias = "member_openid")]
+    #[serde(default)]
     user_openid: Option<String>,
+    #[serde(default)]
+    member_openid: Option<String>,
     #[serde(default)]
     content: Option<String>,
     #[serde(default)]
@@ -182,19 +187,13 @@ pub fn parse_c2c_message(envelope: &GatewayEnvelope) -> Result<Option<C2cMessage
         .or(raw.event_id)
         .filter(|value| !value.trim().is_empty())
         .ok_or(EventError::MissingMessageId)?;
-    let user_openid = raw
-        .author
-        .and_then(|author| {
-            author
-                .user_openid
-                .or(author.openid)
-                .or(author.member_openid)
-                .or(author.id)
-        })
-        .or(raw.user_openid)
-        .or(raw.openid)
-        .filter(|value| !value.trim().is_empty())
-        .ok_or(EventError::MissingUserOpenid)?;
+    let user_openid = resolve_c2c_user_openid(
+        envelope.t.as_deref().unwrap_or(EVENT_C2C_MESSAGE_CREATE),
+        raw.author.as_ref(),
+        raw.user_openid.as_deref(),
+        raw.openid.as_deref(),
+    )
+    .ok_or(EventError::MissingUserOpenid)?;
     let base_content = raw.content.unwrap_or_default().trim().to_owned();
     let reply = extract_message_reply(&base_content, raw.reply.as_ref(), raw.quote.as_ref());
     Ok(Some(C2cMessage {
@@ -229,19 +228,12 @@ pub fn parse_group_message(envelope: &GatewayEnvelope) -> Result<Option<GroupMes
         .filter(|value| !value.trim().is_empty())
         .ok_or(EventError::MissingGroupOpenid)?;
     let author = raw.author;
-    let member_openid = author
-        .as_ref()
-        .and_then(|author| {
-            author
-                .member_openid
-                .as_ref()
-                .or(author.user_openid.as_ref())
-                .or(author.openid.as_ref())
-                .or(author.id.as_ref())
-                .cloned()
-        })
-        .or(raw.user_openid)
-        .filter(|value| !value.trim().is_empty());
+    let member_openid = resolve_group_member_openid(
+        envelope.t.as_deref().unwrap_or(EVENT_GROUP_MESSAGE_CREATE),
+        author.as_ref(),
+        raw.member_openid.as_deref(),
+        raw.user_openid.as_deref(),
+    );
     let author_is_bot = raw.bot.or(raw.is_bot).unwrap_or(false)
         || author
             .as_ref()
@@ -299,6 +291,61 @@ fn extract_cq_reply_message_id(content: &str) -> Option<&str> {
         }
     }
     None
+}
+
+fn resolve_c2c_user_openid(
+    event_type: &str,
+    author: Option<&RawAuthor>,
+    top_user_openid: Option<&str>,
+    top_openid: Option<&str>,
+) -> Option<String> {
+    first_non_empty([
+        author.and_then(|author| author.user_openid.as_deref()),
+        author.and_then(|author| author.openid.as_deref()),
+        author.and_then(|author| author.member_openid.as_deref()),
+        top_user_openid,
+        top_openid,
+    ])
+    .or_else(|| legacy_author_id_fallback(event_type, author))
+}
+
+fn resolve_group_member_openid(
+    event_type: &str,
+    author: Option<&RawAuthor>,
+    top_member_openid: Option<&str>,
+    top_user_openid: Option<&str>,
+) -> Option<String> {
+    first_non_empty([
+        author.and_then(|author| author.member_openid.as_deref()),
+        author.and_then(|author| author.user_openid.as_deref()),
+        author.and_then(|author| author.openid.as_deref()),
+        top_member_openid,
+        top_user_openid,
+    ])
+    .or_else(|| legacy_author_id_fallback(event_type, author))
+}
+
+fn first_non_empty<const N: usize>(values: [Option<&str>; N]) -> Option<String> {
+    values
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn legacy_author_id_fallback(event_type: &str, author: Option<&RawAuthor>) -> Option<String> {
+    let value = author
+        .and_then(|author| author.id.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    // author.id 仅作旧事件兼容兜底；没有证据保证它长期等价于 OpenID，日志必须脱敏。
+    warn!(
+        event_type = %event_type,
+        identity = %mask_openid(value),
+        "QQ identity resolved through untrusted author.id fallback"
+    );
+    Some(value.to_owned())
 }
 
 impl Attachment {
@@ -383,6 +430,108 @@ mod tests {
         assert_eq!(message.member_openid.as_deref(), Some("member-1"));
         assert_eq!(message.content, "/rss");
         assert_eq!(message.event_type, GroupEventType::GroupAtMessage);
+    }
+
+    #[test]
+    fn parses_group_message_member_openid_from_top_level() {
+        let envelope = GatewayEnvelope {
+            op: 0,
+            s: Some(42),
+            t: Some(EVENT_GROUP_MESSAGE_CREATE.to_owned()),
+            id: None,
+            d: json!({
+                "id": "msg-top-member",
+                "group_openid": "group-1",
+                "member_openid": "member-2",
+                "content": "hello"
+            }),
+        };
+
+        let message = parse_group_message(&envelope).unwrap().unwrap();
+
+        assert_eq!(message.member_openid.as_deref(), Some("member-2"));
+    }
+
+    #[test]
+    fn parses_group_message_with_top_member_and_user_openid() {
+        let envelope = GatewayEnvelope {
+            op: 0,
+            s: Some(42),
+            t: Some(EVENT_GROUP_MESSAGE_CREATE.to_owned()),
+            id: None,
+            d: json!({
+                "id": "msg-top-both",
+                "group_openid": "group-1",
+                "member_openid": "member-top",
+                "user_openid": "user-top",
+                "content": "hello"
+            }),
+        };
+
+        let message = parse_group_message(&envelope).unwrap().unwrap();
+
+        assert_eq!(message.member_openid.as_deref(), Some("member-top"));
+    }
+
+    #[test]
+    fn prefers_author_member_openid_over_top_level_group_identity() {
+        let envelope = GatewayEnvelope {
+            op: 0,
+            s: Some(42),
+            t: Some(EVENT_GROUP_MESSAGE_CREATE.to_owned()),
+            id: None,
+            d: json!({
+                "id": "msg-author-priority",
+                "group_openid": "group-1",
+                "member_openid": "member-top",
+                "user_openid": "user-top",
+                "author": {"member_openid": "member-author"},
+                "content": "hello"
+            }),
+        };
+
+        let message = parse_group_message(&envelope).unwrap().unwrap();
+
+        assert_eq!(message.member_openid.as_deref(), Some("member-author"));
+    }
+
+    #[test]
+    fn parses_group_message_with_legacy_author_id_fallback() {
+        let envelope = GatewayEnvelope {
+            op: 0,
+            s: Some(42),
+            t: Some(EVENT_GROUP_MESSAGE_CREATE.to_owned()),
+            id: None,
+            d: json!({
+                "id": "msg-legacy-author-id",
+                "group_openid": "group-1",
+                "author": {"id": "legacy-author-id"},
+                "content": "hello"
+            }),
+        };
+
+        let message = parse_group_message(&envelope).unwrap().unwrap();
+
+        assert_eq!(message.member_openid.as_deref(), Some("legacy-author-id"));
+    }
+
+    #[test]
+    fn group_message_allows_missing_member_identity() {
+        let envelope = GatewayEnvelope {
+            op: 0,
+            s: Some(42),
+            t: Some(EVENT_GROUP_MESSAGE_CREATE.to_owned()),
+            id: None,
+            d: json!({
+                "id": "msg-no-member",
+                "group_openid": "group-1",
+                "content": "hello"
+            }),
+        };
+
+        let message = parse_group_message(&envelope).unwrap().unwrap();
+
+        assert_eq!(message.member_openid, None);
     }
 
     #[test]


### PR DESCRIPTION
## 这次改了什么

这个 PR 主要修两类问题。

第一类是群聊里 pending 操作的发起人校验。群聊 session 是共享的，之前部分 pending 没有记录是谁发起的，其他群成员有机会用“确认 / 取消”消费掉别人的操作。现在 pending 会保存发起人，并在总分发入口统一校验。

第二类是 Todo 列表序号。以前 `/todo all` 展示出来的编号不能被后续 `/todo delete 3` 正确复用，删除逻辑会按固定的已完成列表快照去解析，所以会提示重新执行 `/todo done`。现在凡是会展示 Todo 编号的列表都会刷新最近列表快照，后续按编号操作时只使用用户最后看到的那份列表。

## Todo 相关变化

- `/todo`、`/todo done`、`/todo all`、搜索结果、完成时间查询都会写入最近列表快照。
- `/todo delete 3` 会先用最近快照把展示序号转成内部 Todo ID，再进入确认流程。
- 快照过期提示会按来源生成，比如 `/todo all` 过期时提示重新执行 `/todo all`。
- `done`、`undo/restore`、`edit`、`delete` 这些按序号定位的操作也统一走最近快照，再由具体操作校验状态。
- 新增 `/todo delete cancelled`，并兼容 `/todo delete canceled`、`/todo delete 已取消`。
- 清理已取消待办需要二次确认；Pending 保存发起时匹配到的 ID 集合，确认时不会重新查询当前所有已取消项。
- 已取消清理只删除当前 owner/scope 下仍处于 `cancelled` 状态的记录，不会影响未完成、已完成或其他用户的数据。

## QQ 身份解析相关变化

- 拆开 QQ 群消息顶层 `member_openid` 和 `user_openid` 的解析，避免两个语义不同的字段混在一起。
- `author.id` 只作为 legacy/untrusted fallback，在 OpenID 字段都缺失时才使用。
- 相关日志继续脱敏，不打印完整用户标识。

## 验证

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test -p qq-maid-core todo --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
