### PR TITLE
chore: 发布 v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 本文档基于 [keep a changelog](https://keepachangelog.com/zh-CN/1.0.0/) 格式，记录每个已发布版本的变更。
 
+## [v0.7.0] - 2026-06-28
+
+### Added
+
+- 长期记忆增加个人/群聊作用域，修复跨用户记忆泄露
+- 接入 BigModel（大模型 API）provider，扩展 LLM 供应商支持
+
+### Fixed
+
+- 修复知识库 frontmatter 检索污染：frontmatter 属性值被 BM25 误命中问题
+- 修复群聊 pending 操作发起人校验：防止跨用户操作待办和记忆
+- 修复已完成待办删除语义：改为永久删除（原软删除导致残留）
+- 修复已取消待办删除确认文案区分
+- 修复待办序号快照逻辑和已取消待办清理
+- 修复记忆管理改用列表序号显示
+- 修复记忆目标解析 Clippy 告警
+
+### Internal
+
+- `qq-maid-core` 0.1.8 → 0.1.9（长期记忆作用域隔离、待办/记忆多项修复）
+- `qq-maid-gateway-rs` 0.1.2 → 0.1.3（群聊 pending 校验修复）
+- `qq-maid-llm` 0.1.1 → 0.1.2（接入 BigModel provider）
+
+### Documentation
+
+- 更新 README Rust 行数描述
+
 ## [v0.6.2] - 2026-06-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,7 +1429,7 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "qq-maid-bot"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "qq-maid-core",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-core"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-gateway-rs"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-llm"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-bot"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2024"
 publish = false
 

--- a/qq-maid-core/Cargo.toml
+++ b/qq-maid-core/Cargo.toml
@@ -1,7 +1,7 @@
 # qq-maid-core 项目清单 —— 定义包元信息和依赖项。
 [package]
 name = "qq-maid-core"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 
 # 主运行依赖

--- a/qq-maid-gateway-rs/Cargo.toml
+++ b/qq-maid-gateway-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-gateway-rs"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 publish = false
 

--- a/qq-maid-llm/Cargo.toml
+++ b/qq-maid-llm/Cargo.toml
@@ -1,7 +1,7 @@
 # qq-maid-llm 项目清单 —— 只承载模型调用、Provider 路由和 Web Search 协议能力。
 [package]
 name = "qq-maid-llm"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
## 变更

### Added
- 长期记忆增加个人/群聊作用域，修复跨用户记忆泄露
- 接入 BigModel（大模型 API）provider

### Fixed
- 知识库 frontmatter 检索污染
- 群聊 pending 操作发起人校验
- 已完成待办删除改为永久删除
- 已取消待办删除确认文案区分
- 待办序号快照逻辑和已取消待办清理
- 记忆管理改用列表序号显示

详见 CHANGELOG.md