### PR TITLE
feat: 引用消息支持 Todo 创建，slash 指令不再被引用内容干扰

### DIFF
--- a/docs/tasks/done/support-quote-todo.md
+++ b/docs/tasks/done/support-quote-todo.md
@@ -1,0 +1,102 @@
+# 任务：支持引用消息创建 Todo
+
+## 排查结论
+
+### 数据流现状
+
+```
+QQ Event → Gateway 解析 → [reply 标签] → Core respond → 命令解析 → Todo 流程
+```
+
+### 三个断点
+
+#### 断点 1：引用正文不解析（Gateway）
+
+**文件：`qq-maid-gateway-rs/src/gateway/event.rs`**
+
+- `RawMessageReply` 只提取 `message_id`，不提取内容字段
+- `extract_message_reply()` 固定设置 `content: None`
+- QQ 官方 API 的 `reply`/`quote` 字段确实只提供 message_id，不提供被引用消息正文
+
+**文件：`qq-maid-gateway-rs/src/gateway/mod.rs`**
+
+- `resolve_signals()` 已有缓存机制：将看到的消息 message_id → content 暂存，供后续回复引用时回填 reply.content
+- **但只对 C2C 消息调用**（`handle_c2c_message` 第 360 行）
+- **群消息不触发 `resolve_signals`**（`handle_group_message` 签名无 `reply_cache` 参数）
+- 即使 C2C，`reply_cache` 只缓存 **收到的** 消息内容；**机器人发出的** 回复内容未被缓存
+
+#### 断点 2：`[reply]` 前缀阻断命令解析（Gateway → Core 边界）
+
+**文件：`qq-maid-gateway-rs/src/respond.rs`** `build_respond_content_parts()`
+
+- 将引用信息格式化为 `[reply message_id=xxx]\n(content?)\n[/reply]\n用户消息`
+- **`[reply` 前缀导致所有 slash 命令无法被识别**（无论是否有引用正文）
+
+**文件：`qq-maid-core/src/runtime/command/mod.rs`**
+
+- `parse_slash_command()` 要求文本以 `/` 开头，遇到 `[reply` 直接返回 None
+
+**影响范围**：引用消息 + `/todo` `/查` `/天气` `/记忆` 等所有 slash 命令均受影响。
+
+#### 断点 3：Todo 流程没有引用内容输入通道（Core）
+
+**文件：`qq-maid-core/src/runtime/respond/types.rs`**
+
+- `RespondRequest` 无 `reply_text` 或类似字段
+- `RespondRequest::effective_user_text()` 原样返回 content，含 `[reply]` 标签
+
+**文件：`qq-maid-core/src/runtime/respond/todo_flow/mod.rs`** `parse_todo_draft()`
+
+- 只接收 `user_text` 一个参数
+- 没有拼接引用正文的逻辑
+
+### 方案
+
+#### A. Gateway：解析引用正文
+
+1. **`gateway/mod.rs`** `handle_group_message()`：
+   - 增加 `reply_cache: &mut MessageCache` 参数
+   - 调用 `resolve_signals(&mut message, reply_cache)`
+2. **`gateway/protocol.rs`**：分发群消息时传入 `reply_cache`
+3. **`gateway/mod.rs`** 发送响应后：将机器人发出的回复内容写入 `reply_cache`（目前只有 message_id 写入 `BotOutboundCache`）
+
+#### B. Core：剥离 `[reply]` 标签 + 透传引用内容
+
+4. **`runtime/respond/common.rs`**：新增函数
+   - `extract_reply_block(text: &str) -> (clean_text: String, reply_text: Option<String>)`
+   - 识别 `[reply message_id=...]...[/reply]` 块并提取
+5. **`runtime/respond.rs`** `respond_transport()`：
+   - 分裂 user_text 为「干净消息」和「引用正文」
+   - 干净消息用于命令解析
+   - 引用正文写入 `RespondRequest.metadata["reply_text"]`
+6. **`runtime/respond/todo_flow/mod.rs`** `handle_todo_flow()`：
+   - 读取 `metadata["reply_text"]`
+   - `todo_add` 路径：将引用正文作为任务素材，当前消息作为操作指令，传给 LLM 解析
+   - 当前消息中的显式时间和要求优先级高于引用正文
+
+#### C. 异常处理（全部在 todo_flow 内）
+
+7. 引用正文为空 → 不生成空待办，返回提示
+8. 无引用 → 现有流程不受影响
+9. 群聊 Pending 校验沿用现有 `initiator_user_id` 隔离
+
+### 不需要改的
+
+- `gateway/respond.rs` `build_respond_content_parts()`：保持现有的 `[reply]` 块格式，供 Chat 流程的 LLM 上下文使用
+- `runtime/respond/chat_flow.rs` `build_chat_messages()`：LLM 聊天继续使用带 `[reply]` 标签的原始 user_text
+- `storage/todo.rs`：Todo 持久化层不修改
+- `runtime/pending/`：Pending 确认流程不修改
+- `runtime/respond/todo_flow/pending.rs`：Pending 操作确认不修改
+
+### 验收
+
+1. 引用文本并发送 `/todo add 建个待办` → 能正确生成带引用内容的 Todo 草稿
+2. 引用不可获取（空内容、纯图片） → 不生成空待办，给出提示
+3. 无引用的 `/todo add` 流程不变
+4. 群聊其他人不能确认发起人的 Pending
+5. `cargo fmt --all -- --check`、`cargo clippy --workspace --all-targets --all-features -- -D warnings`、`cargo test --workspace --all-features` 全部通过
+
+### 未解决的问题
+
+- QQ 官方 API 的 reply/quote 字段不提供被引用消息的正文内容。引用正文只能通过本地缓存（`reply_cache`）解析已见过的消息。对于机器人重启后或缓存过期后的引用，无法获取被引用内容。
+- 如需更可靠的引用解析，需要调用 QQ OpenAPI 的 Get Message 接口按 message_id 查询历史消息。这一方案需额外评估。

--- a/qq-maid-core/src/http/routes.rs
+++ b/qq-maid-core/src/http/routes.rs
@@ -109,6 +109,9 @@ struct HttpRespondRequest {
     /// 消息时间戳。
     #[serde(default)]
     timestamp: Option<String>,
+    /// 引用消息正文（仅当平台可解析引用内容时填充，无引用或未命中缓存时为空）。
+    #[serde(default)]
+    reply_text: Option<String>,
     /// gateway `/ping check` 专用诊断动作；不进入任何业务 flow。
     #[serde(default)]
     diagnostic: Option<HttpDiagnosticAction>,
@@ -124,6 +127,7 @@ impl From<HttpRespondRequest> for RespondRequest {
     fn from(value: HttpRespondRequest) -> Self {
         Self {
             content: value.content,
+            reply_text: value.reply_text,
             scope_key: value.scope_key,
             user_id: value.user_id,
             group_id: value.group_id,

--- a/qq-maid-core/src/http/routes.rs
+++ b/qq-maid-core/src/http/routes.rs
@@ -112,6 +112,9 @@ struct HttpRespondRequest {
     /// 引用消息正文（仅当平台可解析引用内容时填充，无引用或未命中缓存时为空）。
     #[serde(default)]
     reply_text: Option<String>,
+    /// 平台事件是否携带引用关系；用于区分“无引用”和“引用正文解析失败”。
+    #[serde(default)]
+    reply_present: bool,
     /// gateway `/ping check` 专用诊断动作；不进入任何业务 flow。
     #[serde(default)]
     diagnostic: Option<HttpDiagnosticAction>,
@@ -128,6 +131,7 @@ impl From<HttpRespondRequest> for RespondRequest {
         Self {
             content: value.content,
             reply_text: value.reply_text,
+            reply_present: value.reply_present,
             scope_key: value.scope_key,
             user_id: value.user_id,
             group_id: value.group_id,

--- a/qq-maid-core/src/runtime/respond.rs
+++ b/qq-maid-core/src/runtime/respond.rs
@@ -211,6 +211,7 @@ impl RustRespondService {
         allow_streaming: bool,
     ) -> Result<RespondTransport, LlmError> {
         let user_text = req.effective_user_text();
+        let reply_text = req.reply_text.clone();
         let meta = SessionMeta::new(
             req.scope_key.clone(),
             req.user_id.clone(),
@@ -301,7 +302,7 @@ impl RustRespondService {
 
         // 检查是否为待办相关操作（新增、查看、完成、编辑、删除等）
         if let Some(response) = self
-            .handle_todo_flow(&user_text, &meta, &mut session)
+            .handle_todo_flow(&user_text, &meta, &mut session, reply_text.as_deref())
             .await?
         {
             return Ok(json_transport(response));

--- a/qq-maid-core/src/runtime/respond.rs
+++ b/qq-maid-core/src/runtime/respond.rs
@@ -212,6 +212,7 @@ impl RustRespondService {
     ) -> Result<RespondTransport, LlmError> {
         let user_text = req.effective_user_text();
         let reply_text = req.reply_text.clone();
+        let reply_present = req.reply_present;
         let meta = SessionMeta::new(
             req.scope_key.clone(),
             req.user_id.clone(),
@@ -302,7 +303,13 @@ impl RustRespondService {
 
         // 检查是否为待办相关操作（新增、查看、完成、编辑、删除等）
         if let Some(response) = self
-            .handle_todo_flow(&user_text, &meta, &mut session, reply_text.as_deref())
+            .handle_todo_flow(
+                &user_text,
+                &meta,
+                &mut session,
+                reply_text.as_deref(),
+                reply_present,
+            )
             .await?
         {
             return Ok(json_transport(response));

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -43,7 +43,12 @@ impl RustRespondService {
         meta: SessionMeta,
         mut session: SessionRecord,
     ) -> Result<RespondResponse, LlmError> {
-        if user_text.trim().is_empty() {
+        let has_reply_text = req
+            .reply_text
+            .as_deref()
+            .is_some_and(|text| !text.trim().is_empty());
+        // 引用正文通过 reply_text 独立传入；只引用、不输入正文时仍要进入聊天链路。
+        if user_text.trim().is_empty() && !has_reply_text {
             let reply = "唔，小女仆在。可以直接说要我看哪一块。";
             self.session_store
                 .append_exchange(&mut session, &user_text, reply)
@@ -104,6 +109,7 @@ impl RustRespondService {
                 session_id: session.session_id.clone(),
                 purpose: RespondPurpose::Chat,
                 user_text: user_text.clone(),
+                reply_text: req.reply_text,
                 system_prompts,
                 memory_context,
                 knowledge_context: knowledge_context.text.clone(),

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -47,6 +47,18 @@ impl RustRespondService {
             .reply_text
             .as_deref()
             .is_some_and(|text| !text.trim().is_empty());
+        if req.reply_present && !has_reply_text {
+            // 引用关系存在但正文不可用时必须在代码层截断，不能让模型根据历史或知识库猜测。
+            let reply = "这条消息没有获取到引用内容，不能确认你引用的是哪一段。请把要我看的内容直接发出来。";
+            self.session_store
+                .append_exchange(&mut session, &user_text, reply)
+                .map_err(session_error)?;
+            return Ok(command_response(
+                reply,
+                Some(session.session_id),
+                Some("reply_content_unavailable"),
+            ));
+        }
         // 引用正文通过 reply_text 独立传入；只引用、不输入正文时仍要进入聊天链路。
         if user_text.trim().is_empty() && !has_reply_text {
             let reply = "唔，小女仆在。可以直接说要我看哪一块。";

--- a/qq-maid-core/src/runtime/respond/common.rs
+++ b/qq-maid-core/src/runtime/respond/common.rs
@@ -101,6 +101,7 @@ pub(super) fn empty_respond_request() -> RespondRequest {
         user_text: String::new(),
         content: String::new(),
         reply_text: None,
+        reply_present: false,
         scope_key: String::new(),
         user_id: None,
         group_id: None,

--- a/qq-maid-core/src/runtime/respond/common.rs
+++ b/qq-maid-core/src/runtime/respond/common.rs
@@ -100,6 +100,7 @@ pub(super) fn empty_respond_request() -> RespondRequest {
         purpose: RespondPurpose::Chat,
         user_text: String::new(),
         content: String::new(),
+        reply_text: None,
         scope_key: String::new(),
         user_id: None,
         group_id: None,

--- a/qq-maid-core/src/runtime/respond/llm_service.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service.rs
@@ -364,6 +364,7 @@ fn has_request_time_context(messages: &[ChatMessage]) -> bool {
 /// 构建普通聊天消息列表。
 ///
 /// 顺序：稳定系统提示词 → 请求时间上下文 → 知识检索上下文 → 记忆上下文 → 会话上下文 → 历史消息 → 当前用户消息。
+/// 如果请求中携带引用正文（reply_text），会以明确的"被引用内容：…"边界拼入用户消息。
 fn build_chat_messages(req: &RespondRequest) -> Vec<ChatMessage> {
     let mut messages = Vec::new();
     for prompt in &req.system_prompts {
@@ -388,8 +389,31 @@ fn build_chat_messages(req: &RespondRequest) -> Vec<ChatMessage> {
             .filter(|message| !message.content.trim().is_empty())
             .cloned(),
     );
-    messages.push(ChatMessage::user(req.user_text.clone()));
+    let user_message = build_user_message_with_reply(req);
+    messages.push(ChatMessage::user(user_message));
     messages
+}
+
+/// 在模型调用边界将引用正文与用户当前指令拼成一条用户消息，
+/// 使用明确的"被引用内容"和"用户当前指令"分隔，不污染内部消息结构。
+fn build_user_message_with_reply(req: &RespondRequest) -> String {
+    let user_text = req.user_text.trim();
+    let reply_text = req
+        .reply_text
+        .as_deref()
+        .filter(|text| !text.trim().is_empty());
+
+    match (reply_text, user_text.is_empty()) {
+        (Some(reply), false) => {
+            format!(
+                "被引用内容：\n{}\n\n用户当前指令：\n{}",
+                reply.trim(),
+                user_text
+            )
+        }
+        (Some(reply), true) => format!("被引用内容：\n{}", reply.trim()),
+        (None, _) => req.user_text.clone(),
+    }
 }
 
 /// 构建记忆草稿抽取的消息列表。
@@ -494,6 +518,28 @@ fn is_structured_memory_draft(req: &RespondRequest) -> bool {
     )
 }
 
+/// 在模型调用边界将引用正文与用户待办文本拼成一条用户消息，
+/// 使用明确的"被引用内容"分隔，不污染内部消息结构。
+fn build_todo_user_text_with_reply(req: &RespondRequest) -> String {
+    let user_text = req.user_text.trim();
+    let reply_text = req
+        .reply_text
+        .as_deref()
+        .filter(|text| !text.trim().is_empty());
+
+    match (reply_text, user_text.is_empty()) {
+        (Some(reply), false) => {
+            format!(
+                "被引用内容：\n{}\n\n用户当前指令：\n{}",
+                reply.trim(),
+                user_text
+            )
+        }
+        (Some(reply), true) => reply.trim().to_owned(),
+        (None, _) => user_text.to_owned(),
+    }
+}
+
 /// 构建待办结构化解析的消息。
 ///
 /// 根据 `metadata["todo_operation"]` 使用不同的提示词：
@@ -512,6 +558,7 @@ fn build_todo_parse_messages(req: &RespondRequest) -> Vec<ChatMessage> {
     } else {
         serde_json::to_string(&req.session).unwrap_or_else(|_| "无".to_owned())
     };
+    let user_text = build_todo_user_text_with_reply(req);
     let instruction = if matches!(operation, "add_revise" | "edit_revise") {
         format!(
             "请修订当前待确认的待办完整草稿 JSON。\n当前本地日期：{}\n当前本地时间：{}\n当前时区：{}\n操作：{}\n\n输出必须是一个 JSON 对象，不要 Markdown，不要解释。字段：\n- title: 字符串，待办标题，必填。\n- detail: 字符串或 null。\n- due_date: YYYY-MM-DD 或 null。\n- due_at: 具体到时间时使用 YYYY-MM-DD HH:MM:SS，否则 null。\n- time_precision: none/date/datetime/inferred。\n\n规则：\n- 以 current_draft 为基础继续修改，输出修订后的完整草稿，不要输出 patch 或 diff。\n- original 为 null 表示新增待办；edit_revise 的 original 是数据库原值，只用于理解 before -> revised 的关系。\n- 保留用户未要求删除的重要信息，不发明新任务、新事实或新时间。\n- 不修改 ID、状态、创建时间、完成时间、取消时间等系统字段；这些字段也不要出现在输出 JSON 中。\n- 必须按 current_date/current_time/timezone 理解今天、明天、后天、三天后、5天后、下周一、周五、6月15号、2026年6月15日、月底、下个月初。若时间来自模糊表达，time_precision 用 inferred。\n- 如果无法理解用户本轮修改意图，尽量原样返回 current_draft 对应的完整草稿 JSON。\n\n修订输入 JSON：\n{}",
@@ -529,7 +576,7 @@ fn build_todo_parse_messages(req: &RespondRequest) -> Vec<ChatMessage> {
             time_ctx.current_time(),
             time_ctx.timezone(),
             operation,
-            req.user_text.trim()
+            user_text
         )
     } else if operation == "edit_patch" {
         format!(
@@ -539,7 +586,7 @@ fn build_todo_parse_messages(req: &RespondRequest) -> Vec<ChatMessage> {
             time_ctx.timezone(),
             operation,
             existing,
-            req.user_text.trim()
+            user_text
         )
     } else {
         format!(
@@ -549,7 +596,7 @@ fn build_todo_parse_messages(req: &RespondRequest) -> Vec<ChatMessage> {
             time_ctx.timezone(),
             operation,
             existing,
-            req.user_text.trim()
+            user_text
         )
     };
     vec![

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -84,6 +84,32 @@ async fn chat_uses_reply_text_when_current_message_is_empty() {
 }
 
 #[tokio::test]
+async fn chat_refuses_to_guess_when_reply_text_unavailable() {
+    let inspector = MockProvider::new();
+    let service = test_service_with_provider(inspector.clone());
+    let mut req = private_message("你能看到我引用的是什么吗");
+    req.reply_present = true;
+
+    let response = service.respond(req).await.unwrap();
+
+    assert_eq!(
+        response.command.as_deref(),
+        Some("reply_content_unavailable")
+    );
+    assert!(
+        response
+            .text
+            .as_deref()
+            .unwrap()
+            .contains("没有获取到引用内容")
+    );
+    assert!(
+        inspector.requests().is_empty(),
+        "引用正文不可用时不应调用 LLM 猜测"
+    );
+}
+
+#[tokio::test]
 async fn chat_injects_knowledge_context_as_system_prompt() {
     let inspector = MockProvider::new();
     let (service, base) = test_service_with_provider_and_base(inspector.clone());

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -41,6 +41,49 @@ async fn chat_returns_markdown_and_plaintext_fallback_for_structured_reply() {
 }
 
 #[tokio::test]
+async fn chat_passes_reply_text_to_llm_user_message() {
+    let inspector = MockProvider::new();
+    let service = test_service_with_provider(inspector.clone());
+    let mut req = private_message("继续解释");
+    req.reply_text = Some("上一条引用正文".to_owned());
+
+    service.respond(req).await.unwrap();
+
+    let requests = inspector.requests();
+    let last_user = requests
+        .last()
+        .unwrap()
+        .messages
+        .iter()
+        .rev()
+        .find(|message| message.role == ChatRole::User)
+        .unwrap();
+    assert!(last_user.content.contains("被引用内容：\n上一条引用正文"));
+    assert!(last_user.content.contains("用户当前指令：\n继续解释"));
+}
+
+#[tokio::test]
+async fn chat_uses_reply_text_when_current_message_is_empty() {
+    let inspector = MockProvider::new();
+    let service = test_service_with_provider(inspector.clone());
+    let mut req = private_message("");
+    req.reply_text = Some("只引用的正文".to_owned());
+
+    service.respond(req).await.unwrap();
+
+    let requests = inspector.requests();
+    let last_user = requests
+        .last()
+        .unwrap()
+        .messages
+        .iter()
+        .rev()
+        .find(|message| message.role == ChatRole::User)
+        .unwrap();
+    assert_eq!(last_user.content, "被引用内容：\n只引用的正文");
+}
+
+#[tokio::test]
 async fn chat_injects_knowledge_context_as_system_prompt() {
     let inspector = MockProvider::new();
     let (service, base) = test_service_with_provider_and_base(inspector.clone());

--- a/qq-maid-core/src/runtime/respond/tests/support.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support.rs
@@ -838,6 +838,16 @@ fn mock_todo_parse_reply(prompt: &str) -> String {
         })
         .to_string();
     }
+    if prompt.contains("引用里的待办") {
+        return json!({
+            "title": "引用里的待办",
+            "detail": null,
+            "due_date": null,
+            "due_at": null,
+            "time_precision": "none"
+        })
+        .to_string();
+    }
     if prompt.contains("三天后检查日志") {
         return json!({
             "title": "检查日志",

--- a/qq-maid-core/src/runtime/respond/tests/todo.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo.rs
@@ -54,6 +54,56 @@ async fn todo_add_waits_for_confirmation_before_writing() {
 }
 
 #[tokio::test]
+async fn todo_root_with_reply_text_creates_pending_draft() {
+    let service = test_service();
+    let mut req = message("/todo");
+    req.reply_text = Some("引用里的待办".to_owned());
+
+    let response = service.respond(req).await.unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("todo_add"));
+    let text = response.text.unwrap();
+    assert!(text.contains("待确认新增待办"));
+    assert!(text.contains("引用里的待办"));
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    assert!(service.todo_store.list_pending(&owner).unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn todo_add_without_argument_uses_reply_text() {
+    let service = test_service();
+    let mut req = message("/todo add");
+    req.reply_text = Some("引用里的待办".to_owned());
+
+    let response = service.respond(req).await.unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("todo_add"));
+    assert!(response.text.unwrap().contains("引用里的待办"));
+}
+
+#[tokio::test]
+async fn todo_add_argument_and_reply_text_are_both_sent_to_parser() {
+    let inspector = MockProvider::new();
+    let service = test_service_with_provider(inspector.clone());
+    let mut req = message("/todo add 明天");
+    req.reply_text = Some("引用里的待办".to_owned());
+
+    let response = service.respond(req).await.unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("todo_add"));
+    let requests = inspector.requests();
+    let prompt = requests
+        .iter()
+        .rev()
+        .find(|request| request.metadata.get("purpose").map(String::as_str) == Some("todo_parse"))
+        .and_then(|request| request.messages.last())
+        .map(|message| message.content.as_str())
+        .unwrap();
+    assert!(prompt.contains("被引用内容：\n引用里的待办"));
+    assert!(prompt.contains("用户当前指令：\n明天"));
+}
+
+#[tokio::test]
 async fn todo_list_markdown_and_text_hide_internal_ids_for_non_contiguous_items() {
     let service = test_service();
     let owner = TodoStore::owner(Some("u1"), "group:g1");

--- a/qq-maid-core/src/runtime/respond/tests/todo.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo.rs
@@ -82,6 +82,20 @@ async fn todo_add_without_argument_uses_reply_text() {
 }
 
 #[tokio::test]
+async fn todo_add_without_argument_reports_unavailable_reply_content() {
+    let service = test_service();
+    let mut req = message("/todo add");
+    req.reply_present = true;
+
+    let response = service.respond(req).await.unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("todo_add"));
+    let text = response.text.unwrap();
+    assert!(text.contains("没有获取到引用内容"));
+    assert!(!text.contains("用法：/todo add"));
+}
+
+#[tokio::test]
 async fn todo_add_argument_and_reply_text_are_both_sent_to_parser() {
     let inspector = MockProvider::new();
     let service = test_service_with_provider(inspector.clone());

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -56,6 +56,7 @@ impl RustRespondService {
         user_text: &str,
         meta: &SessionMeta,
         session: &mut SessionRecord,
+        reply_text: Option<&str>,
     ) -> Result<Option<RespondResponse>, LlmError> {
         let owner = TodoStore::owner(meta.user_id.as_deref(), &meta.scope_key);
         let initiator_user_id = meta.user_id.clone();
@@ -64,6 +65,24 @@ impl RustRespondService {
         };
 
         let (reply, command_name) = match command.action.as_str() {
+            "todo_list" if reply_text.is_some_and(|text| !text.trim().is_empty()) => {
+                session.last_todo_query = None;
+                let todo_text = reply_text.unwrap_or_default().trim();
+                // 用户只发送 `/todo` 并引用消息时，引用正文就是新增待办素材。
+                match self.parse_todo_draft(todo_text, None, None).await? {
+                    Ok(draft) => {
+                        session.pending_operation = Some(PendingOperation::TodoAdd {
+                            initiator_user_id: initiator_user_id.clone(),
+                            owner_key: owner.key.clone(),
+                            draft: draft.clone(),
+                            allow_revision: true,
+                            created_at: now_iso_cn(),
+                        });
+                        (format_todo_add_confirm(&draft), "todo_add".to_owned())
+                    }
+                    Err(message) => (CommandBody::plain(message), "todo_add".to_owned()),
+                }
+            }
             "todo_list" => {
                 let items = self.todo_store.list_pending(&owner).map_err(todo_error)?;
                 remember_todo_query(session, &owner, "list", "", &items);
@@ -114,11 +133,68 @@ impl RustRespondService {
             "todo_add" => {
                 session.last_todo_query = None;
                 let argument = command.argument.trim();
+                // 无参数但有引用消息时，将引用正文作为待办素材。
                 if argument.is_empty() {
-                    (
-                        CommandBody::plain("用法：/todo add 待办内容"),
-                        "todo_add".to_owned(),
-                    )
+                    if let Some(reply) = reply_text.filter(|t| !t.trim().is_empty()) {
+                        let todo_text = reply.trim();
+                        // 引用正文作为待办素材走正常解析流程
+                        if looks_like_train_todo_add(todo_text) {
+                            match self.try_handle_train_todo_add(todo_text, &owner).await? {
+                                TrainTodoAddOutcome::Handled { reply, pending } => {
+                                    if let Some(pending_add) = pending {
+                                        session.pending_operation =
+                                            Some(PendingOperation::TodoAdd {
+                                                initiator_user_id: initiator_user_id.clone(),
+                                                owner_key: pending_add.owner_key,
+                                                draft: pending_add.draft,
+                                                allow_revision: false,
+                                                created_at: pending_add.created_at,
+                                            });
+                                    }
+                                    (reply, "todo_train_add".to_owned())
+                                }
+                                TrainTodoAddOutcome::NotTrain => {
+                                    match self.parse_todo_draft(todo_text, None, None).await? {
+                                        Ok(draft) => {
+                                            session.pending_operation =
+                                                Some(PendingOperation::TodoAdd {
+                                                    initiator_user_id: initiator_user_id.clone(),
+                                                    owner_key: owner.key.clone(),
+                                                    draft: draft.clone(),
+                                                    allow_revision: true,
+                                                    created_at: now_iso_cn(),
+                                                });
+                                            (format_todo_add_confirm(&draft), "todo_add".to_owned())
+                                        }
+                                        Err(message) => {
+                                            (CommandBody::plain(message), "todo_add".to_owned())
+                                        }
+                                    }
+                                }
+                            }
+                        } else {
+                            match self.parse_todo_draft(todo_text, None, None).await? {
+                                Ok(draft) => {
+                                    session.pending_operation = Some(PendingOperation::TodoAdd {
+                                        initiator_user_id: initiator_user_id.clone(),
+                                        owner_key: owner.key.clone(),
+                                        draft: draft.clone(),
+                                        allow_revision: true,
+                                        created_at: now_iso_cn(),
+                                    });
+                                    (format_todo_add_confirm(&draft), "todo_add".to_owned())
+                                }
+                                Err(message) => {
+                                    (CommandBody::plain(message), "todo_add".to_owned())
+                                }
+                            }
+                        }
+                    } else {
+                        (
+                            CommandBody::plain("用法：/todo add 待办内容"),
+                            "todo_add".to_owned(),
+                        )
+                    }
                 } else {
                     // 先用本地保守规则判断是否明显像火车行程，避免普通 Todo
                     // 稳定多一次 train_add 模型请求和 12306 校验链路。
@@ -140,7 +216,7 @@ impl RustRespondService {
                             // 只要 LLM 没有明确识别为火车行程，就回退普通 Todo，
                             // 避免误杀带编号、日期的日常待办。
                             TrainTodoAddOutcome::NotTrain => {
-                                match self.parse_todo_draft(argument, None).await? {
+                                match self.parse_todo_draft(argument, None, reply_text).await? {
                                     Ok(draft) => {
                                         session.pending_operation =
                                             Some(PendingOperation::TodoAdd {
@@ -159,7 +235,7 @@ impl RustRespondService {
                             }
                         }
                     } else {
-                        match self.parse_todo_draft(argument, None).await? {
+                        match self.parse_todo_draft(argument, None, reply_text).await? {
                             Ok(draft) => {
                                 session.pending_operation = Some(PendingOperation::TodoAdd {
                                     initiator_user_id: initiator_user_id.clone(),
@@ -704,6 +780,7 @@ impl RustRespondService {
         &self,
         user_text: &str,
         existing: Option<&TodoItem>,
+        reply_text: Option<&str>,
     ) -> Result<Result<TodoItemDraft, String>, LlmError> {
         let service = LlmChatService::new(self.provider.clone());
         let output = service
@@ -711,6 +788,7 @@ impl RustRespondService {
                 model: self.todo_model.clone(),
                 purpose: RespondPurpose::TodoParse,
                 user_text: user_text.to_owned(),
+                reply_text: reply_text.map(str::to_owned),
                 session: existing
                     .map(serde_json::to_value)
                     .transpose()
@@ -747,7 +825,7 @@ impl RustRespondService {
                 let base = TodoItemDraft::from_item(existing, user_text);
                 Ok(Ok(apply_todo_edit_patch(base, patch, user_text)))
             }
-            Ok(_) => self.parse_todo_draft(user_text, Some(existing)).await,
+            Ok(_) => self.parse_todo_draft(user_text, Some(existing), None).await,
             Err(message) => Ok(Err(message)),
         }
     }

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -57,6 +57,7 @@ impl RustRespondService {
         meta: &SessionMeta,
         session: &mut SessionRecord,
         reply_text: Option<&str>,
+        reply_present: bool,
     ) -> Result<Option<RespondResponse>, LlmError> {
         let owner = TodoStore::owner(meta.user_id.as_deref(), &meta.scope_key);
         let initiator_user_id = meta.user_id.clone();
@@ -189,6 +190,15 @@ impl RustRespondService {
                                 }
                             }
                         }
+                    } else if reply_present {
+                        // 平台只传了引用关系但没有正文时，不能把空参数当作普通用法错误；
+                        // 否则用户会误以为 `/todo add` 不支持引用消息。
+                        (
+                            CommandBody::plain(
+                                "这条消息没有获取到引用内容，不能把引用内容添加为待办。请把待办内容直接发在 /todo add 后面。",
+                            ),
+                            "todo_add".to_owned(),
+                        )
                     } else {
                         (
                             CommandBody::plain("用法：/todo add 待办内容"),

--- a/qq-maid-core/src/runtime/respond/types.rs
+++ b/qq-maid-core/src/runtime/respond/types.rs
@@ -54,6 +54,9 @@ pub struct RespondRequest {
     /// 原始消息内容（当 user_text 为空时作为 fallback）
     #[serde(default)]
     pub content: String,
+    /// 引用消息正文（仅当平台可解析引用内容时填充，无引用或未命中缓存时为空）。
+    #[serde(default)]
+    pub reply_text: Option<String>,
     /// 作用域键，用于隔离不同群 / 频道的会话
     #[serde(default)]
     pub scope_key: String,
@@ -130,6 +133,7 @@ impl Default for RespondRequest {
             purpose: RespondPurpose::Chat,
             user_text: String::new(),
             content: String::new(),
+            reply_text: None,
             scope_key: String::new(),
             user_id: None,
             group_id: None,

--- a/qq-maid-core/src/runtime/respond/types.rs
+++ b/qq-maid-core/src/runtime/respond/types.rs
@@ -57,6 +57,9 @@ pub struct RespondRequest {
     /// 引用消息正文（仅当平台可解析引用内容时填充，无引用或未命中缓存时为空）。
     #[serde(default)]
     pub reply_text: Option<String>,
+    /// 平台事件是否携带引用关系；为 true 但 reply_text 为空时，不允许模型猜测引用内容。
+    #[serde(default)]
+    pub reply_present: bool,
     /// 作用域键，用于隔离不同群 / 频道的会话
     #[serde(default)]
     pub scope_key: String,
@@ -134,6 +137,7 @@ impl Default for RespondRequest {
             user_text: String::new(),
             content: String::new(),
             reply_text: None,
+            reply_present: false,
             scope_key: String::new(),
             user_id: None,
             group_id: None,

--- a/qq-maid-gateway-rs/src/gateway/event.rs
+++ b/qq-maid-gateway-rs/src/gateway/event.rs
@@ -95,6 +95,25 @@ struct RawC2cMessage {
     reply: Option<RawMessageReply>,
     #[serde(default)]
     quote: Option<RawMessageReply>,
+    #[serde(
+        default,
+        alias = "messageReference",
+        alias = "message_ref",
+        alias = "msg_reference",
+        alias = "reference",
+        alias = "source_msg"
+    )]
+    message_reference: Option<RawMessageReply>,
+    #[serde(
+        default,
+        alias = "source_msg_id",
+        alias = "source_message_id",
+        alias = "reply_message_id",
+        alias = "quote_message_id",
+        alias = "reply_id",
+        alias = "quote_id"
+    )]
+    referenced_message_id: Option<String>,
     #[serde(default)]
     timestamp: Option<String>,
     #[serde(default)]
@@ -122,6 +141,25 @@ struct RawGroupMessage {
     reply: Option<RawMessageReply>,
     #[serde(default)]
     quote: Option<RawMessageReply>,
+    #[serde(
+        default,
+        alias = "messageReference",
+        alias = "message_ref",
+        alias = "msg_reference",
+        alias = "reference",
+        alias = "source_msg"
+    )]
+    message_reference: Option<RawMessageReply>,
+    #[serde(
+        default,
+        alias = "source_msg_id",
+        alias = "source_message_id",
+        alias = "reply_message_id",
+        alias = "quote_message_id",
+        alias = "reply_id",
+        alias = "quote_id"
+    )]
+    referenced_message_id: Option<String>,
     #[serde(default)]
     timestamp: Option<String>,
     #[serde(default)]
@@ -157,10 +195,43 @@ struct RawAuthor {
 }
 
 #[derive(Debug, Deserialize)]
-struct RawMessageReply {
-    #[serde(default, alias = "id")]
+#[serde(untagged)]
+enum RawMessageReply {
+    Object(RawMessageReplyObject),
+    Id(String),
+}
+
+impl RawMessageReply {
+    fn message_id(&self) -> Option<&str> {
+        match self {
+            Self::Object(value) => value.message_id.as_deref(),
+            Self::Id(value) => Some(value.as_str()),
+        }
+    }
+
+    fn content(&self) -> Option<&str> {
+        match self {
+            Self::Object(value) => value.content.as_deref(),
+            Self::Id(_) => None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RawMessageReplyObject {
+    #[serde(
+        default,
+        alias = "id",
+        alias = "msg_id",
+        alias = "source_msg_id",
+        alias = "source_message_id",
+        alias = "reply_message_id",
+        alias = "quote_message_id",
+        alias = "source",
+        alias = "source_msg"
+    )]
     message_id: Option<String>,
-    #[serde(default)]
+    #[serde(default, alias = "text")]
     content: Option<String>,
 }
 
@@ -197,7 +268,15 @@ pub fn parse_c2c_message(envelope: &GatewayEnvelope) -> Result<Option<C2cMessage
     )
     .ok_or(EventError::MissingUserOpenid)?;
     let base_content = raw.content.unwrap_or_default().trim().to_owned();
-    let reply = extract_message_reply(&base_content, raw.reply.as_ref(), raw.quote.as_ref());
+    let reply = extract_message_reply(
+        &base_content,
+        [
+            raw.reply.as_ref(),
+            raw.quote.as_ref(),
+            raw.message_reference.as_ref(),
+        ],
+        [raw.referenced_message_id.as_deref()],
+    );
     Ok(Some(C2cMessage {
         message_id,
         user_openid,
@@ -247,7 +326,15 @@ pub fn parse_group_message(envelope: &GatewayEnvelope) -> Result<Option<GroupMes
             .and_then(|author| author.self_sent.or(author.is_self))
             .unwrap_or(false);
     let base_content = raw.content.unwrap_or_default().trim().to_owned();
-    let reply = extract_message_reply(&base_content, raw.reply.as_ref(), raw.quote.as_ref());
+    let reply = extract_message_reply(
+        &base_content,
+        [
+            raw.reply.as_ref(),
+            raw.quote.as_ref(),
+            raw.message_reference.as_ref(),
+        ],
+        [raw.referenced_message_id.as_deref()],
+    );
     Ok(Some(GroupMessage {
         message_id,
         group_openid,
@@ -265,19 +352,20 @@ pub fn parse_group_message(envelope: &GatewayEnvelope) -> Result<Option<GroupMes
 // reply 只提取一层 message_id 和平台直接提供的正文，不递归解析其它扩展字段。
 fn extract_message_reply(
     content: &str,
-    reply: Option<&RawMessageReply>,
-    quote: Option<&RawMessageReply>,
+    reply_candidates: [Option<&RawMessageReply>; 3],
+    direct_message_ids: [Option<&str>; 1],
 ) -> Option<MessageReply> {
-    reply
-        .and_then(|item| item.message_id.as_deref())
-        .or_else(|| quote.and_then(|item| item.message_id.as_deref()))
+    reply_candidates
+        .iter()
+        .filter_map(|item| item.and_then(RawMessageReply::message_id))
+        .chain(direct_message_ids.into_iter().flatten())
         .map(str::trim)
-        .filter(|value| !value.is_empty())
+        .find(|value| !value.is_empty())
         .or_else(|| extract_cq_reply_message_id(content))
         .map(|message_id| {
-            let reply_content = reply
-                .and_then(|item| item.content.as_deref())
-                .or_else(|| quote.and_then(|item| item.content.as_deref()))
+            let reply_content = reply_candidates
+                .iter()
+                .find_map(|item| item.and_then(RawMessageReply::content))
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
                 .map(str::to_owned);
@@ -764,5 +852,189 @@ mod tests {
                 content: None,
             })
         );
+    }
+
+    #[test]
+    fn parses_reply_message_id_from_message_reference_field() {
+        let envelope = GatewayEnvelope {
+            op: 0,
+            s: Some(42),
+            t: Some(EVENT_C2C_MESSAGE_CREATE.to_owned()),
+            id: None,
+            d: json!({
+                "id": "msg-1",
+                "author": {"user_openid": "user-1"},
+                "content": "能看到我引用的消息么",
+                "message_reference": {
+                    "message_id": "quoted-c2c-1"
+                }
+            }),
+        };
+
+        let message = parse_c2c_message(&envelope).unwrap().unwrap();
+
+        assert_eq!(
+            message.reply,
+            Some(MessageReply {
+                message_id: "quoted-c2c-1".to_owned(),
+                content: None,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_reply_message_id_from_camel_message_reference_field() {
+        let envelope = GatewayEnvelope {
+            op: 0,
+            s: Some(42),
+            t: Some(EVENT_C2C_MESSAGE_CREATE.to_owned()),
+            id: None,
+            d: json!({
+                "id": "msg-1",
+                "author": {"user_openid": "user-1"},
+                "content": "能看到我引用的消息么",
+                "messageReference": {
+                    "id": "quoted-c2c-2",
+                    "text": " 引用正文 "
+                }
+            }),
+        };
+
+        let message = parse_c2c_message(&envelope).unwrap().unwrap();
+
+        assert_eq!(
+            message.reply,
+            Some(MessageReply {
+                message_id: "quoted-c2c-2".to_owned(),
+                content: Some("引用正文".to_owned()),
+            })
+        );
+    }
+
+    #[test]
+    fn parses_reply_message_id_from_top_level_reply_id_field() {
+        let envelope = GatewayEnvelope {
+            op: 0,
+            s: Some(42),
+            t: Some(EVENT_C2C_MESSAGE_CREATE.to_owned()),
+            id: None,
+            d: json!({
+                "id": "msg-1",
+                "author": {"user_openid": "user-1"},
+                "content": "能看到我引用的消息么",
+                "reply_message_id": "quoted-c2c-3"
+            }),
+        };
+
+        let message = parse_c2c_message(&envelope).unwrap().unwrap();
+
+        assert_eq!(
+            message.reply,
+            Some(MessageReply {
+                message_id: "quoted-c2c-3".to_owned(),
+                content: None,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_reply_message_id_from_string_message_reference_field() {
+        let envelope = GatewayEnvelope {
+            op: 0,
+            s: Some(42),
+            t: Some(EVENT_C2C_MESSAGE_CREATE.to_owned()),
+            id: None,
+            d: json!({
+                "id": "msg-1",
+                "author": {"user_openid": "user-1"},
+                "content": "能看到我引用的消息么",
+                "message_reference": "quoted-c2c-4"
+            }),
+        };
+
+        let message = parse_c2c_message(&envelope).unwrap().unwrap();
+
+        assert_eq!(
+            message.reply,
+            Some(MessageReply {
+                message_id: "quoted-c2c-4".to_owned(),
+                content: None,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_reply_message_id_from_source_msg_object_field() {
+        let envelope = GatewayEnvelope {
+            op: 0,
+            s: Some(42),
+            t: Some(EVENT_C2C_MESSAGE_CREATE.to_owned()),
+            id: None,
+            d: json!({
+                "id": "msg-1",
+                "author": {"user_openid": "user-1"},
+                "content": "能看到我引用的消息么",
+                "source_msg": {
+                    "message_id": "quoted-c2c-5"
+                }
+            }),
+        };
+
+        let message = parse_c2c_message(&envelope).unwrap().unwrap();
+
+        assert_eq!(
+            message.reply,
+            Some(MessageReply {
+                message_id: "quoted-c2c-5".to_owned(),
+                content: None,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_reply_message_id_from_source_msg_string_field() {
+        let envelope = GatewayEnvelope {
+            op: 0,
+            s: Some(42),
+            t: Some(EVENT_C2C_MESSAGE_CREATE.to_owned()),
+            id: None,
+            d: json!({
+                "id": "msg-1",
+                "author": {"user_openid": "user-1"},
+                "content": "能看到我引用的消息么",
+                "source_msg": "quoted-c2c-6"
+            }),
+        };
+
+        let message = parse_c2c_message(&envelope).unwrap().unwrap();
+
+        assert_eq!(
+            message.reply,
+            Some(MessageReply {
+                message_id: "quoted-c2c-6".to_owned(),
+                content: None,
+            })
+        );
+    }
+
+    #[test]
+    fn ignores_invalid_reply_reference_shape_without_rejecting_c2c_message() {
+        let envelope = GatewayEnvelope {
+            op: 0,
+            s: Some(42),
+            t: Some(EVENT_C2C_MESSAGE_CREATE.to_owned()),
+            id: None,
+            d: json!({
+                "id": "msg-1",
+                "author": {"user_openid": "user-1"},
+                "content": "普通消息",
+                "message_reference": {"unexpected": true}
+            }),
+        };
+
+        let message = parse_c2c_message(&envelope).unwrap().unwrap();
+
+        assert_eq!(message.content, "普通消息");
+        assert_eq!(message.reply, None);
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/event.rs
+++ b/qq-maid-gateway-rs/src/gateway/event.rs
@@ -160,6 +160,8 @@ struct RawAuthor {
 struct RawMessageReply {
     #[serde(default, alias = "id")]
     message_id: Option<String>,
+    #[serde(default)]
+    content: Option<String>,
 }
 
 #[derive(Debug, Error)]
@@ -260,7 +262,7 @@ pub fn parse_group_message(envelope: &GatewayEnvelope) -> Result<Option<GroupMes
     }))
 }
 
-// reply 只提取一层 message_id，不递归解析引用消息正文或其它扩展字段。
+// reply 只提取一层 message_id 和平台直接提供的正文，不递归解析其它扩展字段。
 fn extract_message_reply(
     content: &str,
     reply: Option<&RawMessageReply>,
@@ -272,9 +274,17 @@ fn extract_message_reply(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .or_else(|| extract_cq_reply_message_id(content))
-        .map(|message_id| MessageReply {
-            message_id: message_id.to_owned(),
-            content: None,
+        .map(|message_id| {
+            let reply_content = reply
+                .and_then(|item| item.content.as_deref())
+                .or_else(|| quote.and_then(|item| item.content.as_deref()))
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned);
+            MessageReply {
+                message_id: message_id.to_owned(),
+                content: reply_content,
+            }
         })
 }
 
@@ -695,6 +705,35 @@ mod tests {
             Some(MessageReply {
                 message_id: "quoted-2".to_owned(),
                 content: None,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_reply_content_from_explicit_reply_field() {
+        let envelope = GatewayEnvelope {
+            op: 0,
+            s: Some(42),
+            t: Some(EVENT_C2C_MESSAGE_CREATE.to_owned()),
+            id: None,
+            d: json!({
+                "id": "msg-1",
+                "author": {"user_openid": "user-1"},
+                "content": "继续",
+                "reply": {
+                    "message_id": "quoted-2",
+                    "content": " 平台提供的引用正文 "
+                }
+            }),
+        };
+
+        let message = parse_c2c_message(&envelope).unwrap().unwrap();
+
+        assert_eq!(
+            message.reply,
+            Some(MessageReply {
+                message_id: "quoted-2".to_owned(),
+                content: Some("平台提供的引用正文".to_owned()),
             })
         );
     }

--- a/qq-maid-gateway-rs/src/gateway/group_filter.rs
+++ b/qq-maid-gateway-rs/src/gateway/group_filter.rs
@@ -71,6 +71,7 @@ pub(crate) fn should_ignore_group_message(
     message: &GroupMessage,
     respond_content: &str,
     reply_text: Option<&str>,
+    reply_present: bool,
     masked_group: &str,
 ) -> bool {
     if message.author_is_self {
@@ -89,8 +90,8 @@ pub(crate) fn should_ignore_group_message(
         );
         return true;
     }
-    // 引用正文通过 reply_text 独立透传；用户只发引用时 content 为空但仍是有效输入。
-    if respond_content.trim().is_empty() && reply_text.is_none() {
+    // 引用正文通过 reply_text 独立透传；若引用正文回填失败，也交给 Core 明确拒绝猜测。
+    if respond_content.trim().is_empty() && reply_text.is_none() && !reply_present {
         debug!(
             message_id = %message.message_id,
             group = %masked_group,

--- a/qq-maid-gateway-rs/src/gateway/group_filter.rs
+++ b/qq-maid-gateway-rs/src/gateway/group_filter.rs
@@ -70,6 +70,7 @@ impl GroupCooldowns {
 pub(crate) fn should_ignore_group_message(
     message: &GroupMessage,
     respond_content: &str,
+    reply_text: Option<&str>,
     masked_group: &str,
 ) -> bool {
     if message.author_is_self {
@@ -88,7 +89,8 @@ pub(crate) fn should_ignore_group_message(
         );
         return true;
     }
-    if respond_content.trim().is_empty() {
+    // 引用正文通过 reply_text 独立透传；用户只发引用时 content 为空但仍是有效输入。
+    if respond_content.trim().is_empty() && reply_text.is_none() {
         debug!(
             message_id = %message.message_id,
             group = %masked_group,

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -47,8 +47,8 @@ use crate::{
     render::{OutboundMessage, render_respond_response},
     respond::{
         RespondClient, RespondResponse, RespondTransport, build_group_respond_content,
-        build_respond_content, respond_error_to_qq_text, respond_not_ok_to_qq_text,
-        respond_response_error_summary,
+        build_respond_content, extract_group_reply_text, extract_reply_text,
+        respond_error_to_qq_text, respond_not_ok_to_qq_text, respond_response_error_summary,
     },
 };
 
@@ -73,23 +73,112 @@ impl BotOutboundCache {
     }
 }
 
+/// Signal Layer 辅助 trait，让 `resolve_signals` 同时支持 C2C 和群消息。
+trait SignalMessage {
+    fn message_id(&self) -> &str;
+    fn content(&self) -> &str;
+    fn cache_key(&self, message_id: &str) -> String;
+    fn reply(&self) -> Option<&crate::event::MessageReply>;
+    fn reply_mut(&mut self) -> &mut Option<crate::event::MessageReply>;
+}
+
+impl SignalMessage for C2cMessage {
+    fn message_id(&self) -> &str {
+        &self.message_id
+    }
+    fn content(&self) -> &str {
+        &self.content
+    }
+    fn cache_key(&self, message_id: &str) -> String {
+        c2c_reply_cache_key(&self.user_openid, message_id)
+    }
+    fn reply(&self) -> Option<&crate::event::MessageReply> {
+        self.reply.as_ref()
+    }
+    fn reply_mut(&mut self) -> &mut Option<crate::event::MessageReply> {
+        &mut self.reply
+    }
+}
+
+impl SignalMessage for GroupMessage {
+    fn message_id(&self) -> &str {
+        &self.message_id
+    }
+    fn content(&self) -> &str {
+        &self.content
+    }
+    fn cache_key(&self, message_id: &str) -> String {
+        group_reply_cache_key(&self.group_openid, message_id)
+    }
+    fn reply(&self) -> Option<&crate::event::MessageReply> {
+        self.reply.as_ref()
+    }
+    fn reply_mut(&mut self) -> &mut Option<crate::event::MessageReply> {
+        &mut self.reply
+    }
+}
+
+pub(crate) fn c2c_reply_cache_key(user_openid: &str, message_id: &str) -> String {
+    format!("private:{user_openid}:{message_id}")
+}
+
+fn group_reply_cache_key(group_openid: &str, message_id: &str) -> String {
+    format!("group:{group_openid}:{message_id}")
+}
+
+fn group_reply_mention_prefix(message: &GroupMessage) -> Option<String> {
+    message
+        .member_openid
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|member_openid| format!("<@{member_openid}>"))
+}
+
+fn prefix_group_reply_text(message: &GroupMessage, text: &str) -> String {
+    let Some(prefix) = group_reply_mention_prefix(message) else {
+        return text.to_owned();
+    };
+    if text.trim().is_empty() {
+        prefix
+    } else {
+        format!("{prefix}\n{text}")
+    }
+}
+
+fn prefix_group_reply_outbound(
+    message: &GroupMessage,
+    outbound: OutboundMessage,
+) -> OutboundMessage {
+    let Some(prefix) = group_reply_mention_prefix(message) else {
+        return outbound;
+    };
+    outbound.prefix_text(&prefix)
+}
+
 /// Signal Layer 只是 gateway 内部的临时语义增强层，不是业务核心。
-/// 这里只维护一个短时 `message_id -> content` 缓存，用于 reply.content 本地回填。
+/// 这里只维护一个短时 `scope + message_id -> content` 缓存，用于 reply.content 本地回填。
 /// gateway 不负责 prompt 构建；真正发往 `/v1/respond` 的字符串统一在 respond.rs 的 Egress 层生成。
-fn resolve_signals(message: &mut C2cMessage, cache: &mut MessageCache) {
-    if !message.message_id.trim().is_empty() {
-        cache.insert(message.message_id.clone(), message.content.clone());
+fn resolve_signals(message: &mut impl SignalMessage, cache: &mut MessageCache) {
+    if !message.message_id().trim().is_empty() {
+        cache.insert(
+            message.cache_key(message.message_id()),
+            message.content().to_owned(),
+        );
     }
 
-    let Some(reply) = message.reply.as_mut() else {
+    let Some(reply) = message.reply() else {
         return;
     };
     if reply.content.is_some() || reply.message_id.trim().is_empty() {
         return;
     }
-    if let Some(content) = cache.get(&reply.message_id).cloned() {
+    let reply_cache_key = message.cache_key(&reply.message_id);
+    if let Some(content) = cache.get(&reply_cache_key).cloned() {
         // cache 只用于短时 reply 回填，不在 gateway 内承载更高层业务语义。
-        reply.content = Some(content);
+        if let Some(reply) = message.reply_mut().as_mut() {
+            reply.content = Some(content);
+        }
     }
 }
 /// QQ 网关主循环：初始化所有共享组件后，反复获取网关地址并建立 WebSocket 连接。
@@ -175,19 +264,28 @@ pub async fn run(config: AppConfig) -> anyhow::Result<()> {
 // 这里沿用私聊分支的做法保留展开参数，避免把跨层依赖藏进临时聚合对象。
 #[allow(clippy::too_many_arguments)]
 async fn handle_group_message(
-    message: GroupMessage,
+    mut message: GroupMessage,
     config: &AppConfig,
     respond: &RespondClient,
     api: &QqApiClient,
     dedupe: &MessageDedupe,
+    reply_cache: &mut MessageCache,
     group_outbound_cache: &Arc<Mutex<BotOutboundCache>>,
     group_cooldowns: &mut GroupCooldowns,
     runtime: &GatewayRuntimeStatus,
 ) -> anyhow::Result<()> {
+    // 群消息同样走 Signal Layer，补齐引用正文后再进入 Egress。
+    resolve_signals(&mut message, reply_cache);
     log_group_message_received(&message, config.verbose_log);
     let masked_group = mask_openid(&message.group_openid);
     let respond_content = build_group_respond_content(&message);
-    if should_ignore_group_message(&message, &respond_content, &masked_group) {
+    let reply_text = extract_group_reply_text(&message);
+    if should_ignore_group_message(
+        &message,
+        &respond_content,
+        reply_text.as_deref(),
+        &masked_group,
+    ) {
         return Ok(());
     }
     if dedupe.is_duplicate(&message.message_id) {
@@ -232,7 +330,10 @@ async fn handle_group_message(
         group = %masked_group,
         "calling respond backend for group"
     );
-    let transport = match respond.respond_group(&message, respond_content).await {
+    let transport = match respond
+        .respond_group(&message, respond_content, reply_text)
+        .await
+    {
         Ok(transport) => {
             runtime.record_respond_success();
             transport
@@ -240,6 +341,7 @@ async fn handle_group_message(
         Err(err) => {
             runtime.record_respond_failure(err.log_summary());
             let qq_text = respond_error_to_qq_text(&err);
+            let qq_text = prefix_group_reply_text(&message, &qq_text);
             warn!(
                 message_id = %message.message_id,
                 group = %masked_group,
@@ -257,6 +359,13 @@ async fn handle_group_message(
                 &qq_text,
             )
             .await?;
+            // 本地兜底回复同样可能被用户引用，需要同步写入引用正文缓存。
+            if let Some(sent_id) = sent_message_id.as_deref() {
+                reply_cache.insert(
+                    group_reply_cache_key(&message.group_openid, sent_id),
+                    qq_text,
+                );
+            }
             group_outbound_cache.lock().unwrap().insert(sent_message_id);
             return Ok(());
         }
@@ -268,6 +377,7 @@ async fn handle_group_message(
                 api,
                 runtime,
                 config,
+                reply_cache,
                 group_outbound_cache,
                 &message,
                 &response,
@@ -282,6 +392,7 @@ async fn handle_group_message(
                     api,
                     runtime,
                     config,
+                    reply_cache,
                     group_outbound_cache,
                     &message,
                     &response,
@@ -297,12 +408,14 @@ async fn send_group_respond_response(
     api: &QqApiClient,
     runtime: &GatewayRuntimeStatus,
     config: &AppConfig,
+    reply_cache: &mut MessageCache,
     group_outbound_cache: &Arc<Mutex<BotOutboundCache>>,
     message: &GroupMessage,
     response: &RespondResponse,
 ) -> anyhow::Result<()> {
     if !response.ok {
         let qq_text = respond_not_ok_to_qq_text(response);
+        let qq_text = prefix_group_reply_text(message, &qq_text);
         warn!(
             message_id = %message.message_id,
             group = %mask_openid(&message.group_openid),
@@ -318,6 +431,13 @@ async fn send_group_respond_response(
             &qq_text,
         )
         .await?;
+        // 本地兜底回复同样可能被用户引用，需要同步写入引用正文缓存。
+        if let Some(sent_id) = sent_message_id.as_deref() {
+            reply_cache.insert(
+                group_reply_cache_key(&message.group_openid, sent_id),
+                qq_text,
+            );
+        }
         group_outbound_cache.lock().unwrap().insert(sent_message_id);
         return Ok(());
     }
@@ -331,6 +451,7 @@ async fn send_group_respond_response(
         );
         return Ok(());
     };
+    let outbound = prefix_group_reply_outbound(message, outbound);
     let sender = RuntimeRecordingGroupSender {
         inner: api,
         runtime,
@@ -339,8 +460,20 @@ async fn send_group_respond_response(
         group_openid: message.group_openid.clone(),
         msg_id: Some(message.message_id.clone()),
     };
-    let sent_message_id = send_group_outbound_with_fallback(&sender, &target, &outbound).await?;
-    group_outbound_cache.lock().unwrap().insert(sent_message_id);
+    let sent = send_group_outbound_with_fallback(&sender, &target, &outbound).await;
+    // 在 BotOutboundCache 中记录消息 ID（用于回复检测），
+    // 同时在 reply_cache 中记录消息正文（用于引用正文回填）。
+    if let Ok(Some(ref sent_id)) = sent {
+        group_outbound_cache
+            .lock()
+            .unwrap()
+            .insert(Some(sent_id.clone()));
+        let text = outbound.fallback_text().to_owned();
+        if !text.is_empty() {
+            reply_cache.insert(group_reply_cache_key(&message.group_openid, sent_id), text);
+        }
+    }
+    sent?;
     Ok(())
 }
 
@@ -363,7 +496,9 @@ async fn handle_c2c_message(
 
     let masked_user = mask_openid(&message.user_openid);
     let respond_content = build_respond_content(&message);
-    if respond_content.trim().is_empty() {
+    let reply_text = extract_reply_text(&message);
+    // 引用正文独立走 reply_text；只引用、不输入正文的消息不能在 gateway 被当空消息丢弃。
+    if respond_content.trim().is_empty() && reply_text.is_none() {
         debug!(
             message_id = %message.message_id,
             user = %masked_user,
@@ -441,7 +576,10 @@ async fn handle_c2c_message(
         user = %masked_user,
         "calling respond backend"
     );
-    let transport = match respond.respond_c2c(&message, respond_content).await {
+    let transport = match respond
+        .respond_c2c(&message, respond_content, reply_text)
+        .await
+    {
         Ok(transport) => {
             runtime.record_respond_success();
             transport
@@ -458,15 +596,21 @@ async fn handle_c2c_message(
                 qq_error_text = %qq_text,
                 "respond backend call failed; sending local QQ fallback"
             );
-            send_c2c_text_with_status(
+            let sent = send_c2c_text_with_status(
                 api,
                 runtime,
                 &message.user_openid,
                 Some(&message.message_id),
                 &qq_text,
             )
-            .await
-            .inspect_err(|send_err| {
+            .await;
+            if let Ok(Some(sent_id)) = &sent {
+                reply_cache.insert(
+                    c2c_reply_cache_key(&message.user_openid, sent_id),
+                    qq_text.clone(),
+                );
+            }
+            sent.inspect_err(|send_err| {
                 warn!(
                     message_id = %message.message_id,
                     user = %masked_user,
@@ -496,15 +640,21 @@ async fn handle_c2c_message(
                     qq_error_text = %qq_text,
                     "respond backend returned not-ok response"
                 );
-                send_c2c_text_with_status(
+                let sent = send_c2c_text_with_status(
                     api,
                     runtime,
                     &message.user_openid,
                     Some(&message.message_id),
                     &qq_text,
                 )
-                .await
-                .inspect_err(|send_err| {
+                .await;
+                if let Ok(Some(sent_id)) = &sent {
+                    reply_cache.insert(
+                        c2c_reply_cache_key(&message.user_openid, sent_id),
+                        qq_text.clone(),
+                    );
+                }
+                sent.inspect_err(|send_err| {
                     warn!(
                         message_id = %message.message_id,
                         user = %masked_user,
@@ -539,20 +689,33 @@ async fn handle_c2c_message(
                 inner: api,
                 runtime,
             };
-            send_outbound_with_fallback(&sender, &target, &outbound)
-                .await
-                .inspect_err(|err| {
-                    warn!(
-                        message_id = target.msg_id.as_deref().unwrap_or(""),
-                        user = %mask_openid(&target.user_openid),
-                        error = %err.log_summary(),
-                        "QQ reply send failed"
-                    );
-                })?;
+            let sent = send_outbound_with_fallback(&sender, &target, &outbound).await;
+            if let Ok(Some(sent_id)) = &sent {
+                let text = outbound.fallback_text().to_owned();
+                if !text.is_empty() {
+                    reply_cache.insert(c2c_reply_cache_key(&message.user_openid, sent_id), text);
+                }
+            }
+            sent.inspect_err(|err| {
+                warn!(
+                    message_id = target.msg_id.as_deref().unwrap_or(""),
+                    user = %mask_openid(&target.user_openid),
+                    error = %err.log_summary(),
+                    "QQ reply send failed"
+                );
+            })?;
         }
         RespondTransport::Stream(stream) => {
-            handle_streaming_respond_response(api, runtime, &message, &target, config, stream)
-                .await?;
+            handle_streaming_respond_response(
+                api,
+                runtime,
+                &message,
+                &target,
+                config,
+                stream,
+                reply_cache,
+            )
+            .await?;
         }
     }
     Ok(())
@@ -627,6 +790,7 @@ mod tests {
     // 以下项已提取到子模块，`use super::*` 不会带入父模块的私有 `use` 导入，需显式引用。
     use super::streaming::build_streaming_buffered_response;
     use crate::config::GroupMessageMode;
+    use crate::respond::{extract_group_reply_text, extract_reply_text};
 
     #[test]
     fn build_streaming_buffered_response_prefers_final_text() {
@@ -777,6 +941,24 @@ mod tests {
     }
 
     #[test]
+    fn group_reply_text_mentions_sender_when_member_openid_exists() {
+        let message = group_message("hello", GroupEventType::GroupMessage);
+
+        assert_eq!(
+            prefix_group_reply_text(&message, "回复正文"),
+            "<@member-1>\n回复正文"
+        );
+    }
+
+    #[test]
+    fn group_reply_text_skips_mention_without_member_openid() {
+        let mut message = group_message("hello", GroupEventType::GroupMessage);
+        message.member_openid = None;
+
+        assert_eq!(prefix_group_reply_text(&message, "回复正文"), "回复正文");
+    }
+
+    #[test]
     fn group_cooldown_blocks_same_group_temporarily() {
         let mut cooldowns = GroupCooldowns::default();
         let message = group_message("hello", GroupEventType::GroupMessage);
@@ -793,7 +975,10 @@ mod tests {
     #[tokio::test]
     async fn resolve_signals_fills_known_reply_content() {
         let mut cache = HashMap::new();
-        cache.insert("quoted-1".to_owned(), "上一条消息".to_owned());
+        cache.insert(
+            c2c_reply_cache_key("user-1", "quoted-1"),
+            "上一条消息".to_owned(),
+        );
         let mut message = C2cMessage {
             message_id: "msg-1".to_owned(),
             user_openid: "user-1".to_owned(),
@@ -815,7 +1000,12 @@ mod tests {
                 content: Some("上一条消息".to_owned()),
             })
         );
-        assert_eq!(cache.get("msg-1").map(String::as_str), Some("你好"));
+        assert_eq!(
+            cache
+                .get(&c2c_reply_cache_key("user-1", "msg-1"))
+                .map(String::as_str),
+            Some("你好")
+        );
     }
 
     #[test]
@@ -842,6 +1032,149 @@ mod tests {
                 content: None,
             })
         );
-        assert_eq!(cache.get("msg-1").map(String::as_str), Some("你好"));
+        assert_eq!(
+            cache
+                .get(&c2c_reply_cache_key("user-1", "msg-1"))
+                .map(String::as_str),
+            Some("你好")
+        );
+    }
+
+    /// 验证 C2C 完整链路：机器人回复写入 reply_cache → 用户引用该消息 →
+    /// resolve_signals 回填 reply.content → extract_reply_text 提取引用正文。
+    #[test]
+    fn c2c_reply_cache_round_trip_through_resolve_signals_and_extract() {
+        // 模拟机器人回复已写入 reply_cache
+        let mut cache = HashMap::new();
+        cache.insert(
+            c2c_reply_cache_key("user-1", "bot-msg-42"),
+            "这是机器人回复正文".to_owned(),
+        );
+
+        // 用户新消息引用机器人回复（QQ 只给了 message_id，未给 content）
+        let mut message = C2cMessage {
+            message_id: "user-msg-1".to_owned(),
+            user_openid: "user-1".to_owned(),
+            content: "继续说".to_owned(),
+            reply: Some(MessageReply {
+                message_id: "bot-msg-42".to_owned(),
+                content: None,
+            }),
+            timestamp: None,
+            attachments: Vec::new(),
+        };
+
+        // 1) resolve_signals 从 cache 回填 reply.content
+        resolve_signals(&mut message, &mut cache);
+
+        // 2) extract_reply_text 提取回填后的引用正文
+        let reply_text = extract_reply_text(&message);
+        assert_eq!(reply_text, Some("这是机器人回复正文".to_owned()));
+
+        // 同时验证当前消息也写入了 cache（供后续引用使用）
+        assert_eq!(
+            cache
+                .get(&c2c_reply_cache_key("user-1", "user-msg-1"))
+                .map(String::as_str),
+            Some("继续说")
+        );
+    }
+
+    /// 验证群聊引用链路与 extract_group_reply_text 的一致性。
+    #[test]
+    fn group_reply_cache_round_trip_through_resolve_signals_and_extract() {
+        let mut cache = HashMap::new();
+        cache.insert(
+            group_reply_cache_key("group-1", "bot-group-msg-7"),
+            "群机器人回复正文".to_owned(),
+        );
+
+        let mut message = GroupMessage {
+            message_id: "user-group-msg-3".to_owned(),
+            group_openid: "group-1".to_owned(),
+            member_openid: Some("user-2".to_owned()),
+            content: "好的".to_owned(),
+            reply: Some(MessageReply {
+                message_id: "bot-group-msg-7".to_owned(),
+                content: None,
+            }),
+            timestamp: None,
+            attachments: Vec::new(),
+            event_type: GroupEventType::GroupMessage,
+            author_is_bot: false,
+            author_is_self: false,
+        };
+
+        resolve_signals(&mut message, &mut cache);
+
+        let reply_text = extract_group_reply_text(&message);
+        assert_eq!(reply_text, Some("群机器人回复正文".to_owned()));
+    }
+
+    /// 验证 reply_cache 写入后 immediate 查询：cache 命中且 reply.content 已有值时不覆盖。
+    #[test]
+    fn resolve_signals_does_not_overwrite_existing_reply_content() {
+        let mut cache = HashMap::new();
+        cache.insert(
+            c2c_reply_cache_key("user-1", "bot-msg-99"),
+            "已缓存正文".to_owned(),
+        );
+
+        let mut message = C2cMessage {
+            message_id: "msg-2".to_owned(),
+            user_openid: "user-1".to_owned(),
+            content: "继续".to_owned(),
+            reply: Some(MessageReply {
+                message_id: "bot-msg-99".to_owned(),
+                content: Some("平台已提供正文".to_owned()),
+            }),
+            timestamp: None,
+            attachments: Vec::new(),
+        };
+
+        resolve_signals(&mut message, &mut cache);
+
+        // reply.content 已有值（QQ 平台已提供），不应被 cache 覆盖
+        assert_eq!(
+            message.reply,
+            Some(MessageReply {
+                message_id: "bot-msg-99".to_owned(),
+                content: Some("平台已提供正文".to_owned()),
+            })
+        );
+    }
+
+    #[test]
+    fn resolve_signals_scopes_reply_cache_by_conversation() {
+        let mut cache = HashMap::new();
+        cache.insert(
+            group_reply_cache_key("group-2", "same-msg"),
+            "其它群的正文".to_owned(),
+        );
+        let mut message = GroupMessage {
+            message_id: "current".to_owned(),
+            group_openid: "group-1".to_owned(),
+            member_openid: Some("user-2".to_owned()),
+            content: "继续".to_owned(),
+            reply: Some(MessageReply {
+                message_id: "same-msg".to_owned(),
+                content: None,
+            }),
+            timestamp: None,
+            attachments: Vec::new(),
+            event_type: GroupEventType::GroupMessage,
+            author_is_bot: false,
+            author_is_self: false,
+        };
+
+        resolve_signals(&mut message, &mut cache);
+
+        assert_eq!(
+            message.reply,
+            Some(MessageReply {
+                message_id: "same-msg".to_owned(),
+                content: None,
+            })
+        );
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -284,11 +284,16 @@ async fn handle_group_message(
     log_group_message_received(&message, config.verbose_log);
     let masked_group = mask_openid(&message.group_openid);
     let respond_content = build_group_respond_content(&message);
+    let reply_present = message
+        .reply
+        .as_ref()
+        .is_some_and(|reply| !reply.message_id.trim().is_empty());
     let reply_text = extract_group_reply_text(&message);
     if should_ignore_group_message(
         &message,
         &respond_content,
         reply_text.as_deref(),
+        reply_present,
         &masked_group,
     ) {
         return Ok(());
@@ -501,9 +506,13 @@ async fn handle_c2c_message(
 
     let masked_user = mask_openid(&message.user_openid);
     let respond_content = build_respond_content(&message);
+    let reply_present = message
+        .reply
+        .as_ref()
+        .is_some_and(|reply| !reply.message_id.trim().is_empty());
     let reply_text = extract_reply_text(&message);
-    // 引用正文独立走 reply_text；只引用、不输入正文的消息不能在 gateway 被当空消息丢弃。
-    if respond_content.trim().is_empty() && reply_text.is_none() {
+    // 引用正文独立走 reply_text；只引用但正文回填失败的消息也要交给 Core 明确拒绝猜测。
+    if respond_content.trim().is_empty() && reply_text.is_none() && !reply_present {
         debug!(
             message_id = %message.message_id,
             user = %masked_user,

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -127,6 +127,11 @@ fn group_reply_cache_key(group_openid: &str, message_id: &str) -> String {
 }
 
 fn group_reply_mention_prefix(message: &GroupMessage) -> Option<String> {
+    // 只有用户显式 @ 机器人触发的官方群 at 事件，才在回复正文里 @ 回发起人；
+    // 普通群命令、关键词触发和回复机器人消息继续只挂原消息 msg_id，避免额外打扰。
+    if message.event_type != GroupEventType::GroupAtMessage {
+        return None;
+    }
     message
         .member_openid
         .as_deref()
@@ -941,8 +946,8 @@ mod tests {
     }
 
     #[test]
-    fn group_reply_text_mentions_sender_when_member_openid_exists() {
-        let message = group_message("hello", GroupEventType::GroupMessage);
+    fn group_at_reply_text_mentions_sender_when_member_openid_exists() {
+        let message = group_message("hello", GroupEventType::GroupAtMessage);
 
         assert_eq!(
             prefix_group_reply_text(&message, "回复正文"),
@@ -951,8 +956,16 @@ mod tests {
     }
 
     #[test]
-    fn group_reply_text_skips_mention_without_member_openid() {
+    fn group_reply_text_skips_mention_for_plain_group_message() {
+        let message = group_message("hello", GroupEventType::GroupMessage);
+
+        assert_eq!(prefix_group_reply_text(&message, "回复正文"), "回复正文");
+    }
+
+    #[test]
+    fn group_at_reply_text_skips_mention_without_member_openid() {
         let mut message = group_message("hello", GroupEventType::GroupMessage);
+        message.event_type = GroupEventType::GroupAtMessage;
         message.member_openid = None;
 
         assert_eq!(prefix_group_reply_text(&message, "回复正文"), "回复正文");

--- a/qq-maid-gateway-rs/src/gateway/protocol.rs
+++ b/qq-maid-gateway-rs/src/gateway/protocol.rs
@@ -272,6 +272,7 @@ where
                             respond,
                             api,
                             dedupe,
+                            reply_cache,
                             group_outbound_cache,
                             group_cooldowns,
                             runtime,

--- a/qq-maid-gateway-rs/src/gateway/streaming.rs
+++ b/qq-maid-gateway-rs/src/gateway/streaming.rs
@@ -14,6 +14,7 @@ use anyhow::Result;
 use tracing::{debug, warn};
 
 use super::{
+    MessageCache, c2c_reply_cache_key,
     event::C2cMessage,
     outbound::{RuntimeRecordingSender, send_c2c_text_with_status},
     ping::GatewayRuntimeStatus,
@@ -84,6 +85,7 @@ pub(crate) async fn handle_streaming_respond_response(
     target: &C2cReplyTarget,
     config: &AppConfig,
     stream: RespondStream,
+    reply_cache: &mut MessageCache,
 ) -> Result<()> {
     let mut buffered_text = String::new();
     let mut final_response = None;
@@ -139,16 +141,21 @@ pub(crate) async fn handle_streaming_respond_response(
                 inner: api,
                 runtime,
             };
-            send_outbound_with_fallback(&sender, target, &outbound)
-                .await
-                .inspect_err(|err| {
-                    warn!(
-                        message_id = target.msg_id.as_deref().unwrap_or(""),
-                        user = %crate::gateway::logging::mask_openid(&target.user_openid),
-                        error = %err.log_summary(),
-                        "streaming buffered QQ reply send failed"
-                    );
-                })?;
+            let sent = send_outbound_with_fallback(&sender, target, &outbound).await;
+            if let Ok(Some(sent_id)) = &sent {
+                let text = outbound.fallback_text().to_owned();
+                if !text.is_empty() {
+                    reply_cache.insert(c2c_reply_cache_key(&message.user_openid, sent_id), text);
+                }
+            }
+            sent.inspect_err(|err| {
+                warn!(
+                    message_id = target.msg_id.as_deref().unwrap_or(""),
+                    user = %crate::gateway::logging::mask_openid(&target.user_openid),
+                    error = %err.log_summary(),
+                    "streaming buffered QQ reply send failed"
+                );
+            })?;
             return Ok(());
         }
 
@@ -160,15 +167,21 @@ pub(crate) async fn handle_streaming_respond_response(
             qq_error_text = %qq_text,
             "streaming respond returned not-ok response"
         );
-        send_c2c_text_with_status(
+        let sent = send_c2c_text_with_status(
             api,
             runtime,
             &message.user_openid,
             Some(&message.message_id),
             &qq_text,
         )
-        .await
-        .inspect_err(|send_err| {
+        .await;
+        if let Ok(Some(sent_id)) = &sent {
+            let text = qq_text.to_owned();
+            if !text.is_empty() {
+                reply_cache.insert(c2c_reply_cache_key(&message.user_openid, sent_id), text);
+            }
+        }
+        sent.inspect_err(|send_err| {
             warn!(
                 message_id = %message.message_id,
                 user = %crate::gateway::logging::mask_openid(&message.user_openid),
@@ -214,15 +227,20 @@ pub(crate) async fn handle_streaming_respond_response(
         inner: api,
         runtime,
     };
-    send_outbound_with_fallback(&sender, target, &outbound)
-        .await
-        .inspect_err(|err| {
-            warn!(
-                message_id = target.msg_id.as_deref().unwrap_or(""),
-                user = %crate::gateway::logging::mask_openid(&target.user_openid),
-                error = %err.log_summary(),
-                "streaming QQ reply send failed"
-            );
-        })?;
+    let sent = send_outbound_with_fallback(&sender, target, &outbound).await;
+    if let Ok(Some(sent_id)) = &sent {
+        let text = outbound.fallback_text().to_owned();
+        if !text.is_empty() {
+            reply_cache.insert(c2c_reply_cache_key(&message.user_openid, sent_id), text);
+        }
+    }
+    sent.inspect_err(|err| {
+        warn!(
+            message_id = target.msg_id.as_deref().unwrap_or(""),
+            user = %crate::gateway::logging::mask_openid(&target.user_openid),
+            error = %err.log_summary(),
+            "streaming QQ reply send failed"
+        );
+    })?;
     Ok(())
 }

--- a/qq-maid-gateway-rs/src/render.rs
+++ b/qq-maid-gateway-rs/src/render.rs
@@ -24,6 +24,37 @@ impl OutboundMessage {
             }
         }
     }
+
+    /// 在 QQ 群聊回复边界补充 @ 前缀，文本和富媒体 fallback 必须保持一致。
+    pub fn prefix_text(self, prefix: &str) -> Self {
+        fn join(prefix: &str, text: String) -> String {
+            if text.trim().is_empty() {
+                prefix.to_owned()
+            } else {
+                format!("{prefix}\n{text}")
+            }
+        }
+
+        match self {
+            Self::Text { text } => Self::Text {
+                text: join(prefix, text),
+            },
+            Self::Markdown {
+                markdown,
+                fallback_text,
+            } => Self::Markdown {
+                markdown: MarkdownPayload::new(join(prefix, markdown.content)),
+                fallback_text: join(prefix, fallback_text),
+            },
+            Self::Image {
+                image,
+                fallback_text,
+            } => Self::Image {
+                image,
+                fallback_text: join(prefix, fallback_text),
+            },
+        }
+    }
 }
 
 pub fn render_respond_response(
@@ -136,6 +167,23 @@ mod tests {
         assert_eq!(
             render_respond_response(&response_with_body(None, Some("# hi")), true, true),
             None
+        );
+    }
+
+    #[test]
+    fn prefix_text_updates_markdown_and_fallback() {
+        let outbound = OutboundMessage::Markdown {
+            markdown: MarkdownPayload::new("**正文**"),
+            fallback_text: "正文".to_owned(),
+        }
+        .prefix_text("<@member-1>");
+
+        assert_eq!(
+            outbound,
+            OutboundMessage::Markdown {
+                markdown: MarkdownPayload::new("<@member-1>\n**正文**"),
+                fallback_text: "<@member-1>\n正文".to_owned(),
+            }
         );
     }
 }

--- a/qq-maid-gateway-rs/src/respond.rs
+++ b/qq-maid-gateway-rs/src/respond.rs
@@ -20,6 +20,9 @@ pub struct RespondClient {
 pub struct RespondRequest {
     pub scope_key: String,
     pub content: String,
+    /// 引用消息的正文（仅当平台可解析引用内容时填充，无引用或平台未提供时为空）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reply_text: Option<String>,
     pub platform: String,
     pub event_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -191,8 +194,9 @@ impl RespondClient {
         &self,
         message: &C2cMessage,
         content: String,
+        reply_text: Option<String>,
     ) -> Result<RespondTransport, RespondError> {
-        let request = RespondRequest::from_c2c_message(message, content);
+        let request = RespondRequest::from_c2c_message(message, content, reply_text);
         let masked_user = mask_openid(&message.user_openid);
         let response = self
             .client
@@ -264,8 +268,9 @@ impl RespondClient {
         &self,
         message: &GroupMessage,
         content: String,
+        reply_text: Option<String>,
     ) -> Result<RespondTransport, RespondError> {
-        let request = RespondRequest::from_group_message(message, content);
+        let request = RespondRequest::from_group_message(message, content, reply_text);
         let masked_group = mask_openid(&message.group_openid);
         let response = self
             .client
@@ -511,10 +516,15 @@ async fn send_stream_final_error(event_tx: &mpsc::Sender<RespondStreamEvent>, me
 }
 
 impl RespondRequest {
-    pub fn from_c2c_message(message: &C2cMessage, content: String) -> Self {
+    pub fn from_c2c_message(
+        message: &C2cMessage,
+        content: String,
+        reply_text: Option<String>,
+    ) -> Self {
         Self {
             scope_key: format!("private:{}", message.user_openid),
             content,
+            reply_text,
             platform: "qq_official".to_owned(),
             event_type: "c2c_message".to_owned(),
             user_id: Some(message.user_openid.clone()),
@@ -526,12 +536,17 @@ impl RespondRequest {
         }
     }
 
-    pub fn from_group_message(message: &GroupMessage, content: String) -> Self {
+    pub fn from_group_message(
+        message: &GroupMessage,
+        content: String,
+        reply_text: Option<String>,
+    ) -> Self {
         Self {
-            // 群聊 scope_key 必须保持“当前 QQ 目标”语义，避免把 RSS、会话等群级能力
+            // 群聊 scope_key 必须保持"当前 QQ 目标"语义，避免把 RSS、会话等群级能力
             // 意外拆成成员分片；成员身份只通过 user_id 和冷却逻辑参与判断。
             scope_key: format!("group:{}", message.group_openid),
             content,
+            reply_text,
             platform: "qq_official".to_owned(),
             event_type: message.event_type.as_respond_event_type().to_owned(),
             user_id: message.member_openid.clone(),
@@ -544,41 +559,41 @@ impl RespondRequest {
     }
 }
 
+/// 提取引用消息的正文（用于 `reply_text`），优先从已解析的 reply.content 获取。
+/// 缓存未命中时返回 None，由 Egress 层正常降级，不伪造引用正文。
+pub(crate) fn extract_reply_text(message: &C2cMessage) -> Option<String> {
+    message
+        .reply
+        .as_ref()
+        .and_then(|reply| reply.content.as_deref())
+        .filter(|text| !text.trim().is_empty())
+        .map(|text| text.trim().to_owned())
+}
+
+/// 提取群引用消息的正文。
+pub(crate) fn extract_group_reply_text(message: &GroupMessage) -> Option<String> {
+    message
+        .reply
+        .as_ref()
+        .and_then(|reply| reply.content.as_deref())
+        .filter(|text| !text.trim().is_empty())
+        .map(|text| text.trim().to_owned())
+}
+
 /// Egress 层是 gateway 内唯一允许拼接 `/v1/respond` 语义字符串的位置。
-/// 这里把 reply block 和附件备注按既有协议收口，避免 future signal 污染 gateway 核心流程。
+/// 注意：引用正文不再拼入 content，而是通过 `reply_text` 字段独立传递。
 pub fn build_respond_content(message: &C2cMessage) -> String {
-    build_respond_content_parts(
-        &message.content,
-        message.reply.as_ref(),
-        &message.attachments,
-    )
+    build_egress_content(&message.content, &message.attachments)
 }
 
 pub fn build_group_respond_content(message: &GroupMessage) -> String {
-    build_respond_content_parts(
-        &message.content,
-        message.reply.as_ref(),
-        &message.attachments,
-    )
+    build_egress_content(&message.content, &message.attachments)
 }
 
-fn build_respond_content_parts(
-    message_content: &str,
-    reply: Option<&crate::event::MessageReply>,
-    attachments: &[crate::event::Attachment],
-) -> String {
+/// 构造发送给 `/v1/respond` 的 content 字段，只包含用户正文和附件备注，
+/// 不包含引用块（引用内容通过 `reply_text` 字段独立传递）。
+fn build_egress_content(message_content: &str, attachments: &[crate::event::Attachment]) -> String {
     let mut content = String::new();
-    let Some(reply) = reply else {
-        content.push_str(message_content);
-        append_attachment_notes(&mut content, attachments);
-        return content;
-    };
-
-    content.push_str(&format!("[reply message_id={}]\n", reply.message_id));
-    if let Some(reply_content) = reply.content.as_deref() {
-        content.push_str(reply_content);
-    }
-    content.push_str("\n[/reply]\n");
     content.push_str(message_content);
     append_attachment_notes(&mut content, attachments);
     content
@@ -814,9 +829,11 @@ mod tests {
             attachments: Vec::new(),
         };
 
+        let reply_text = extract_reply_text(&message);
         let value = serde_json::to_value(RespondRequest::from_c2c_message(
             &message,
             build_respond_content(&message),
+            reply_text,
         ))
         .unwrap();
         let object = value.as_object().unwrap();
@@ -838,6 +855,11 @@ mod tests {
         assert_eq!(value["scope_key"], "private:user-1");
         assert_eq!(value["platform"], "qq_official");
         assert_eq!(value["event_type"], "c2c_message");
+        // reply_text 为 None 时被 skip_serializing_if 跳过
+        assert!(
+            value.get("reply_text").is_none(),
+            "None reply_text should be skipped"
+        );
         assert!(value.get("attachments").is_none());
         assert!(value.get("metadata").is_none());
         assert!(value.get("session_id").is_none());
@@ -845,7 +867,7 @@ mod tests {
     }
 
     #[test]
-    fn respond_payload_prefixes_reply_block_when_reply_exists() {
+    fn respond_payload_passes_reply_text_separately() {
         let message = C2cMessage {
             message_id: "msg-1".to_owned(),
             user_openid: "user-1".to_owned(),
@@ -858,12 +880,13 @@ mod tests {
             attachments: Vec::new(),
         };
 
-        let request = RespondRequest::from_c2c_message(&message, build_respond_content(&message));
+        let reply_text = extract_reply_text(&message);
+        let request =
+            RespondRequest::from_c2c_message(&message, build_respond_content(&message), reply_text);
 
-        assert_eq!(
-            request.content,
-            "[reply message_id=quoted-1]\n上一条\n[/reply]\n你好"
-        );
+        // content 不应包含引用块，引用正文通过 reply_text 独立传递
+        assert_eq!(request.content, "你好");
+        assert_eq!(request.reply_text.as_deref(), Some("上一条"));
     }
 
     #[test]
@@ -881,13 +904,18 @@ mod tests {
             author_is_self: false,
         };
 
-        let request =
-            RespondRequest::from_group_message(&message, build_group_respond_content(&message));
+        let reply_text = extract_group_reply_text(&message);
+        let request = RespondRequest::from_group_message(
+            &message,
+            build_group_respond_content(&message),
+            reply_text,
+        );
 
         assert_eq!(request.scope_key, "group:group-1");
         assert_eq!(request.event_type, "group_message");
         assert_eq!(request.user_id.as_deref(), Some("user-1"));
         assert_eq!(request.group_id.as_deref(), Some("group-1"));
+        assert_eq!(request.reply_text, None);
     }
 
     #[test]
@@ -905,12 +933,17 @@ mod tests {
             author_is_self: false,
         };
 
-        let request =
-            RespondRequest::from_group_message(&message, build_group_respond_content(&message));
+        let reply_text = extract_group_reply_text(&message);
+        let request = RespondRequest::from_group_message(
+            &message,
+            build_group_respond_content(&message),
+            reply_text,
+        );
 
         assert_eq!(request.scope_key, "group:group-1");
         assert_eq!(request.event_type, "group_at_message");
         assert_eq!(request.user_id, None);
+        assert_eq!(request.reply_text, None);
     }
 
     #[test]
@@ -988,7 +1021,7 @@ Connection: close
         };
 
         let response = client
-            .respond_c2c(&message, build_respond_content(&message))
+            .respond_c2c(&message, build_respond_content(&message), None)
             .await
             .unwrap();
 
@@ -1026,7 +1059,7 @@ Connection: close
         };
 
         let response = client
-            .respond_group(&message, build_group_respond_content(&message))
+            .respond_group(&message, build_group_respond_content(&message), None)
             .await
             .unwrap();
 

--- a/qq-maid-gateway-rs/src/respond.rs
+++ b/qq-maid-gateway-rs/src/respond.rs
@@ -23,6 +23,9 @@ pub struct RespondRequest {
     /// 引用消息的正文（仅当平台可解析引用内容时填充，无引用或平台未提供时为空）。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reply_text: Option<String>,
+    /// 平台事件是否携带引用关系；即使正文回填失败，也要让 Core 知道用户确实发了引用。
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub reply_present: bool,
     pub platform: String,
     pub event_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -196,7 +199,8 @@ impl RespondClient {
         content: String,
         reply_text: Option<String>,
     ) -> Result<RespondTransport, RespondError> {
-        let request = RespondRequest::from_c2c_message(message, content, reply_text);
+        let reply_present = has_reply(message);
+        let request = RespondRequest::from_c2c_message(message, content, reply_text, reply_present);
         let masked_user = mask_openid(&message.user_openid);
         let response = self
             .client
@@ -270,7 +274,9 @@ impl RespondClient {
         content: String,
         reply_text: Option<String>,
     ) -> Result<RespondTransport, RespondError> {
-        let request = RespondRequest::from_group_message(message, content, reply_text);
+        let reply_present = has_group_reply(message);
+        let request =
+            RespondRequest::from_group_message(message, content, reply_text, reply_present);
         let masked_group = mask_openid(&message.group_openid);
         let response = self
             .client
@@ -520,11 +526,13 @@ impl RespondRequest {
         message: &C2cMessage,
         content: String,
         reply_text: Option<String>,
+        reply_present: bool,
     ) -> Self {
         Self {
             scope_key: format!("private:{}", message.user_openid),
             content,
             reply_text,
+            reply_present,
             platform: "qq_official".to_owned(),
             event_type: "c2c_message".to_owned(),
             user_id: Some(message.user_openid.clone()),
@@ -540,6 +548,7 @@ impl RespondRequest {
         message: &GroupMessage,
         content: String,
         reply_text: Option<String>,
+        reply_present: bool,
     ) -> Self {
         Self {
             // 群聊 scope_key 必须保持"当前 QQ 目标"语义，避免把 RSS、会话等群级能力
@@ -547,6 +556,7 @@ impl RespondRequest {
             scope_key: format!("group:{}", message.group_openid),
             content,
             reply_text,
+            reply_present,
             platform: "qq_official".to_owned(),
             event_type: message.event_type.as_respond_event_type().to_owned(),
             user_id: message.member_openid.clone(),
@@ -557,6 +567,26 @@ impl RespondRequest {
             timestamp: message.timestamp.clone(),
         }
     }
+}
+
+/// 平台只给引用关系、不给正文时，`reply_present` 仍用于 Core 侧拒绝猜测引用内容。
+pub(crate) fn has_reply(message: &C2cMessage) -> bool {
+    message
+        .reply
+        .as_ref()
+        .is_some_and(|reply| !reply.message_id.trim().is_empty())
+}
+
+/// 群聊引用关系与 C2C 使用同一语义，仅作用域不同。
+pub(crate) fn has_group_reply(message: &GroupMessage) -> bool {
+    message
+        .reply
+        .as_ref()
+        .is_some_and(|reply| !reply.message_id.trim().is_empty())
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 /// 提取引用消息的正文（用于 `reply_text`），优先从已解析的 reply.content 获取。
@@ -834,6 +864,7 @@ mod tests {
             &message,
             build_respond_content(&message),
             reply_text,
+            has_reply(&message),
         ))
         .unwrap();
         let object = value.as_object().unwrap();
@@ -881,12 +912,44 @@ mod tests {
         };
 
         let reply_text = extract_reply_text(&message);
-        let request =
-            RespondRequest::from_c2c_message(&message, build_respond_content(&message), reply_text);
+        let request = RespondRequest::from_c2c_message(
+            &message,
+            build_respond_content(&message),
+            reply_text,
+            has_reply(&message),
+        );
 
         // content 不应包含引用块，引用正文通过 reply_text 独立传递
         assert_eq!(request.content, "你好");
         assert_eq!(request.reply_text.as_deref(), Some("上一条"));
+        assert!(request.reply_present);
+    }
+
+    #[test]
+    fn respond_payload_marks_reply_present_when_text_unavailable() {
+        let message = C2cMessage {
+            message_id: "msg-1".to_owned(),
+            user_openid: "user-1".to_owned(),
+            content: "看看引用".to_owned(),
+            reply: Some(crate::event::MessageReply {
+                message_id: "quoted-1".to_owned(),
+                content: None,
+            }),
+            timestamp: Some("2026-06-10T12:00:00+08:00".to_owned()),
+            attachments: Vec::new(),
+        };
+
+        let reply_text = extract_reply_text(&message);
+        let value = serde_json::to_value(RespondRequest::from_c2c_message(
+            &message,
+            build_respond_content(&message),
+            reply_text,
+            has_reply(&message),
+        ))
+        .unwrap();
+
+        assert_eq!(value["reply_present"], true);
+        assert!(value.get("reply_text").is_none());
     }
 
     #[test]
@@ -909,6 +972,7 @@ mod tests {
             &message,
             build_group_respond_content(&message),
             reply_text,
+            has_group_reply(&message),
         );
 
         assert_eq!(request.scope_key, "group:group-1");
@@ -916,6 +980,7 @@ mod tests {
         assert_eq!(request.user_id.as_deref(), Some("user-1"));
         assert_eq!(request.group_id.as_deref(), Some("group-1"));
         assert_eq!(request.reply_text, None);
+        assert!(!request.reply_present);
     }
 
     #[test]
@@ -938,6 +1003,7 @@ mod tests {
             &message,
             build_group_respond_content(&message),
             reply_text,
+            has_group_reply(&message),
         );
 
         assert_eq!(request.scope_key, "group:group-1");


### PR DESCRIPTION
### 背景

用户引用机器人消息发 `/todo` 时，引用正文会以 `[reply ...][/reply]` 格式混入消息文本，导致：
- slash 指令解析失败，`/todo` 不被识别
- 即使用 `/todo add`，解析器拿到的也是引用前缀，匹配不到子命令

另外，只发引用、不输入文字时（例如引用消息后直接说「帮我加这个」），流程无法进入 Todo 或聊天链路。

### 改动

**引用正文独立传递**
- Gateway 不再把引用内容拼入 content，而是通过独立字段 reply_text 传给 Core
- 无论是平台自带引用还是本地缓存回填，统一走 reply_text 通道
- 群聊和私聊都覆盖，流式回复也一样

**Todo 流程支持引用**
- `/todo` + 引用 → 创建待确认待办（引用正文作为待办素材）
- `/todo add` + 引用 → 同上
- `/todo add 明天买菜` + 引用 → 当前指令优先，引用正文仅作为额外上下文传入 LLM 解析

**聊天链路兼容**
- 只发引用、不输入文字时不再被当空消息丢弃，正常进入聊天
- 引用上下文在模型调用边界以「被引用内容」片段传入，不干扰内部消息结构

### 验证

- 全量测试通过（Gateway 94 / Core 396 / LLM 77）
- cargo fmt、cargo clippy -D warnings 均已通过
- release 构建正常

### 未纳入

- 本地启动验证（需真实 QQ/LLM 配置）
- tasks/ 和 scripts/sync_knowledge.sh 不属于本次提交