### PR TITLE
feat: 贯通 provider 真实增量流

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 本文档基于 [keep a changelog](https://keepachangelog.com/zh-CN/1.0.0/) 格式，记录每个已发布版本的变更。
 
+## [v0.8.0] - 2026-06-28
+
+### Added
+
+- Provider 真实增量流贯通：OpenAI Responses、Chat Completions、DeepSeek、BigModel 全部支持真实 SSE delta 向上传递到 Core 和 Gateway
+- `/查` 改为使用 `query_stream()` 真实流式搜索，不再人工切片伪装流式
+- 后台异步自动标题，不再阻塞主聊天回复
+- `SessionStore::update_title_if_current()` 条件更新接口，防止后台标题覆盖会话数据
+
+### Changed
+
+- 普通聊天改走 `LlmChatService::stream_respond()` 真实 Provider 流，不再等待完整结果后才返回
+- ModelRoute 流式候选链：首个非空 delta 后不再静默切换候选模型
+- 异常 EOF 正确识别为流失败，不再被吞为成功完成
+- 自动标题异步化：生成不阻塞 Completed，失败不影响本轮聊天，通过 `health_observation=ignore` 避免覆盖主模型健康状态
+
+### Fixed
+
+- 修复后台标题旧 SessionRecord 快照覆盖新会话数据的并发问题：后台标题改为条件 SQL 更新，仅当前标题仍为默认值时才写入
+
+### Internal
+
+- `qq-maid-llm` 0.1.2 → 0.1.3（Provider 流式改造、SSE 跨 chunk 拼接修复、Web Search 真实流）
+- `qq-maid-core` 0.1.9 → 0.1.10（CoreResponseStream TextDelta 真实传递、chat 流式路径、异步标题、会话条件更新）
+- `qq-maid-gateway-rs` 0.1.3 → 0.1.4（持续消费 TextDelta，仍只发送最终 Completed）
+- LlmStreamEvent / CoreResponseEvent 统一标准流事件
+- ObservedProvider 接入真实流式 metrics 和健康观测
+- stream=false 兼容：非流请求包装为单 TextDelta + Completed，维持进程内流边界一致
+- 取消传播改进：receiver 关闭后 producer 及早停止转发，释放 Provider 流
+
 ## [v0.7.0] - 2026-06-28
 
 ### Added
@@ -377,6 +407,9 @@ bash scripts/deploy-local.sh
 - 移除已废弃的 Python 接入层和旧 Provider
 - rig-core 升级至 0.38.2
 
+[v0.8.0]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.7.0...v0.8.0
+[v0.7.0]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.6.2...v0.7.0
+[v0.6.2]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.6.1...v0.6.2
 [v0.6.1]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.6.0...v0.6.1
 [v0.6.0]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.5.0...v0.6.0
 [v0.5.0]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.4.5...v0.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,7 +1429,7 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "qq-maid-bot"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "qq-maid-core",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-core"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-gateway-rs"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-llm"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-bot"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 publish = false
 

--- a/qq-maid-core/Cargo.toml
+++ b/qq-maid-core/Cargo.toml
@@ -1,7 +1,7 @@
 # qq-maid-core 项目清单 —— 定义包元信息和依赖项。
 [package]
 name = "qq-maid-core"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 
 # 主运行依赖

--- a/qq-maid-core/src/runtime/respond.rs
+++ b/qq-maid-core/src/runtime/respond.rs
@@ -4,6 +4,8 @@
 //! 发来的 `RespondRequest`，根据请求类型和会话状态将其分派到对应的子处理
 //! 模块（聊天、翻译、待办、记忆、天气、搜索、会话管理），最终返回 `RespondResponse`。
 
+use std::{future::Future, pin::Pin};
+
 use crate::{
     error::LlmError,
     provider::DynLlmProvider,
@@ -281,5 +283,62 @@ impl RustRespondService {
 
         // 兜底：进入普通 LLM 聊天流程
         self.handle_chat(req, user_text, meta, session).await
+    }
+
+    /// 仅供 Core 进程内 stream 边界使用的真流式入口。
+    ///
+    /// 本阶段只接通 `/查` 和普通聊天；短命令仍走完整响应路径，避免改变用户可见语义。
+    pub async fn respond_stream<F>(
+        &self,
+        req: RespondRequest,
+        on_delta: F,
+    ) -> Result<RespondResponse, LlmError>
+    where
+        F: FnMut(String) -> Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send>> + Send,
+    {
+        let user_text = req.effective_user_text();
+        let meta = SessionMeta::new(
+            req.scope_key.clone(),
+            req.user_id.clone(),
+            req.group_id.clone(),
+            req.guild_id.clone(),
+            req.channel_id.clone(),
+            clean_string(req.platform.clone()).unwrap_or_else(|| "qq".to_owned()),
+        );
+        let mut active_session = self
+            .session_store
+            .get_active(&meta)
+            .map_err(session_error)?;
+
+        let bypass_pending_for_session_command =
+            session_flow::parse_pending_bypass_session_command(&user_text).is_some();
+        if !bypass_pending_for_session_command
+            && let Some(session) = active_session.as_mut()
+            && let Some(response) = self
+                .handle_pending_operation(&user_text, &meta, session)
+                .await?
+        {
+            return Ok(response);
+        }
+
+        if let Some(command) = session_flow::parse_session_command(&user_text) {
+            return self.handle_session_command(command, &meta).await;
+        }
+
+        let mut session = match active_session {
+            Some(session) => session,
+            None => self
+                .session_store
+                .get_or_create_active(&meta)
+                .map_err(session_error)?,
+        };
+
+        if let Some(command) = search_flow::parse_web_search_command(&user_text) {
+            return self
+                .handle_web_search_command_stream(command, &mut session, on_delta)
+                .await;
+        }
+
+        self.handle_chat_stream(req, on_delta).await
     }
 }

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -127,7 +127,7 @@ impl RustRespondService {
         self.session_store
             .append_exchange(&mut session, &user_text, &reply)
             .map_err(session_error)?;
-        self.maybe_generate_auto_title(&mut session).await;
+        self.schedule_auto_title(session.clone());
 
         let mut response = response_from_output(output);
         response.session_id = Some(session.session_id);
@@ -244,7 +244,7 @@ impl RustRespondService {
         self.session_store
             .append_exchange(&mut session, &user_text, &reply)
             .map_err(session_error)?;
-        self.maybe_generate_auto_title(&mut session).await;
+        self.schedule_auto_title(session.clone());
 
         let mut response = response_from_output(output);
         response.session_id = Some(session.session_id);
@@ -295,10 +295,12 @@ impl RustRespondService {
         }
     }
 
-    /// 如果会话标题还是默认值，且用户消息轮数在 2~4 之间，
-    /// 则调用标题生成模型自动生成标题。
-    async fn maybe_generate_auto_title(&self, session: &mut SessionRecord) {
-        let Some(title_model) = self.title_model.as_deref() else {
+    /// 如果会话标题还是默认值，且用户消息轮数在 2~4 之间，则后台尝试生成标题。
+    ///
+    /// 主聊天回复已经完成落库，标题只是展示增强；不能让标题模型的慢响应、
+    /// 失败或取消影响本轮 `Completed`。
+    fn schedule_auto_title(&self, mut session: SessionRecord) {
+        let Some(title_model) = self.title_model.clone() else {
             return;
         };
         if session.title != DEFAULT_SESSION_TITLE {
@@ -313,27 +315,31 @@ impl RustRespondService {
             return;
         }
 
-        match generate_session_title(self.provider.as_ref(), title_model, &session.history, false)
-            .await
-        {
-            Ok(title) => {
-                session.title = title;
-                if let Err(err) = self.session_store.save(session) {
-                    tracing::warn!(
-                        error = %err.message(),
+        let provider = self.provider.clone();
+        let session_store = self.session_store.clone();
+        tokio::spawn(async move {
+            match generate_session_title(provider.as_ref(), &title_model, &session.history, false)
+                .await
+            {
+                Ok(title) => {
+                    session.title = title;
+                    if let Err(err) = session_store.save(&mut session) {
+                        tracing::warn!(
+                            error = %err.message(),
+                            session_id = %session.session_id,
+                            "failed to save generated session title"
+                        );
+                    }
+                }
+                Err(err) => {
+                    tracing::debug!(
+                        error = %err,
                         session_id = %session.session_id,
-                        "failed to save generated session title"
+                        "session auto title generation failed"
                     );
                 }
             }
-            Err(err) => {
-                tracing::debug!(
-                    error = %err,
-                    session_id = %session.session_id,
-                    "session auto title generation failed"
-                );
-            }
-        }
+        });
     }
 }
 

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -3,6 +3,8 @@
 //! 承担 `RustRespondService` 中"兜底聊天"路径的实现：
 //! 组装 LLM 请求、发起调用、保存对话记录、自动生成会话标题等。
 
+use std::{future::Future, pin::Pin};
+
 use serde_json::{Value, json};
 
 use crate::{
@@ -119,6 +121,123 @@ impl RustRespondService {
                 ),
                 ..empty_respond_request()
             })
+            .await?;
+
+        let reply = output.reply.clone();
+        self.session_store
+            .append_exchange(&mut session, &user_text, &reply)
+            .map_err(session_error)?;
+        self.maybe_generate_auto_title(&mut session).await;
+
+        let mut response = response_from_output(output);
+        response.session_id = Some(session.session_id);
+        response.command = None;
+        response.handled = Some(true);
+        response.diagnostics = Some(json!({
+            "backend": "rust",
+            "session_backend": "rust",
+            "used_memory": used_memory,
+            "used_knowledge": used_knowledge,
+            "knowledge_hit_count": knowledge_context.hit_count,
+            "used_search": false,
+        }));
+        Ok(response)
+    }
+
+    /// 普通聊天真流式路径：复用非流式聊天的上下文构造和后处理，只替换 LLM 调用方式。
+    pub async fn handle_chat_stream<F>(
+        &self,
+        req: RespondRequest,
+        on_delta: F,
+    ) -> Result<RespondResponse, LlmError>
+    where
+        F: FnMut(String) -> Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send>> + Send,
+    {
+        let user_text = req.effective_user_text();
+        let meta = SessionMeta::new(
+            req.scope_key.clone(),
+            req.user_id.clone(),
+            req.group_id.clone(),
+            req.guild_id.clone(),
+            req.channel_id.clone(),
+            req.platform.clone(),
+        );
+        let mut session = self
+            .session_store
+            .get_or_create_active(&meta)
+            .map_err(session_error)?;
+        if user_text.trim().is_empty() {
+            return self.handle_chat(req, user_text, meta, session).await;
+        }
+
+        update_session_state_from_user(&mut session, &user_text);
+        let is_group_chat = meta
+            .group_id
+            .as_deref()
+            .is_some_and(|value| !value.is_empty());
+        let member_matches = if is_group_chat {
+            Vec::new()
+        } else {
+            self.prompt_config.find_member_id_mentions(&user_text)?
+        };
+        if !is_group_chat
+            && let Some(unknown) = member_matches.iter().find(|item| item.name.is_none())
+        {
+            let mapping = self.prompt_config.load_member_id_mapping()?;
+            let reply = unknown_member_id_reply(&unknown.member_id, &mapping);
+            self.session_store
+                .append_exchange(&mut session, &user_text, &reply)
+                .map_err(session_error)?;
+            return Ok(command_response(
+                reply,
+                Some(session.session_id),
+                Some("member_id_unknown"),
+            ));
+        }
+        update_session_speaker_hint(&mut session, &member_matches);
+
+        let mut session_context = build_session_context(&session);
+        if let Some(identity_context) = build_member_identity_context(&member_matches) {
+            session_context.push_str("\n\n");
+            session_context.push_str(&identity_context);
+        }
+
+        let knowledge_context = self.knowledge_index.search_context(&user_text)?;
+        let used_knowledge = !knowledge_context.text.trim().is_empty();
+        let memory_context = self.build_memory_context(&meta)?;
+        let used_memory = !memory_context.trim().is_empty();
+        let system_prompts = if is_group_chat {
+            self.prompt_config.load_static_prompts_only()?
+        } else {
+            self.prompt_config.load_system_prompts()?
+        };
+        let service = LlmChatService::new(self.provider.clone());
+        let output = service
+            .stream_respond(
+                RespondRequest {
+                    session_id: session.session_id.clone(),
+                    purpose: RespondPurpose::Chat,
+                    user_text: user_text.clone(),
+                    system_prompts,
+                    memory_context,
+                    knowledge_context: knowledge_context.text.clone(),
+                    session_context,
+                    history_messages: recent_session_messages(
+                        &session,
+                        SESSION_HISTORY_MESSAGE_LIMIT,
+                    ),
+                    metadata: merge_metadata(
+                        req.metadata,
+                        &[
+                            ("purpose", "chat"),
+                            ("platform", meta.platform.as_str()),
+                            ("scope_key", meta.scope_key.as_str()),
+                        ],
+                    ),
+                    ..empty_respond_request()
+                },
+                on_delta,
+            )
             .await?;
 
         let reply = output.reply.clone();

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -298,8 +298,9 @@ impl RustRespondService {
     /// 如果会话标题还是默认值，且用户消息轮数在 2~4 之间，则后台尝试生成标题。
     ///
     /// 主聊天回复已经完成落库，标题只是展示增强；不能让标题模型的慢响应、
-    /// 失败或取消影响本轮 `Completed`。
-    fn schedule_auto_title(&self, mut session: SessionRecord) {
+    /// 失败或取消影响本轮 `Completed`。后台任务只允许条件更新标题，不能保存
+    /// 旧的完整会话快照，否则会覆盖期间继续写入的历史、pending 或手工重命名。
+    fn schedule_auto_title(&self, session: SessionRecord) {
         let Some(title_model) = self.title_model.clone() else {
             return;
         };
@@ -317,24 +318,36 @@ impl RustRespondService {
 
         let provider = self.provider.clone();
         let session_store = self.session_store.clone();
+        let session_id = session.session_id.clone();
+        let history = session.history.clone();
         tokio::spawn(async move {
-            match generate_session_title(provider.as_ref(), &title_model, &session.history, false)
-                .await
-            {
+            match generate_session_title(provider.as_ref(), &title_model, &history, false).await {
                 Ok(title) => {
-                    session.title = title;
-                    if let Err(err) = session_store.save(&mut session) {
-                        tracing::warn!(
-                            error = %err.message(),
-                            session_id = %session.session_id,
-                            "failed to save generated session title"
-                        );
+                    match session_store.update_title_if_current(
+                        &session_id,
+                        DEFAULT_SESSION_TITLE,
+                        &title,
+                    ) {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            tracing::debug!(
+                                session_id = %session_id,
+                                "generated session title ignored because current title changed"
+                            );
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                error = %err.message(),
+                                session_id = %session_id,
+                                "failed to save generated session title"
+                            );
+                        }
                     }
                 }
                 Err(err) => {
                     tracing::debug!(
                         error = %err,
-                        session_id = %session.session_id,
+                        session_id = %session_id,
                         "session auto title generation failed"
                     );
                 }
@@ -369,7 +382,6 @@ pub(super) fn recent_session_messages(session: &SessionRecord, limit: usize) -> 
         .rev()
         .collect()
 }
-
 /// 根据用户输入更新会话状态（话题、场景、模式、焦点等）。
 fn update_session_state_from_user(session: &mut SessionRecord, user_text: &str) {
     let text = user_text.trim();

--- a/qq-maid-core/src/runtime/respond/llm_service.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service.rs
@@ -12,10 +12,12 @@ use std::env;
 use async_trait::async_trait;
 use regex::Regex;
 
+use futures::StreamExt;
+
 use crate::{
     error::LlmError,
     provider::{
-        ChatOutcome, DynLlmProvider,
+        ChatOutcome, DynLlmProvider, LlmStreamEvent,
         types::{ChatMessage, ChatRequest, ChatRole},
     },
     runtime::session::redact_sensitive_text,
@@ -67,6 +69,77 @@ impl LlmChatService {
     pub fn new(provider: DynLlmProvider) -> Self {
         Self { provider }
     }
+
+    /// 消费 provider 真流式输出，并把同一条流的非空 delta 交给上层转发。
+    ///
+    /// 最终正文只由本次 stream 的 delta 聚合得到；这里不做任何二次模型调用。
+    pub async fn stream_respond<F, Fut>(
+        &self,
+        req: RespondRequest,
+        mut on_delta: F,
+    ) -> Result<RespondOutput, LlmError>
+    where
+        F: FnMut(String) -> Fut + Send,
+        Fut: std::future::Future<Output = Result<(), LlmError>> + Send,
+    {
+        let messages = build_respond_messages(&req);
+        trace_chat_messages(&req, &messages);
+        let chat_req = ChatRequest {
+            session_id: req.session_id.clone(),
+            model: req.model.clone(),
+            messages,
+            metadata: req.metadata.clone(),
+        };
+        let mut stream = self.provider.stream_chat(chat_req).await?;
+        let mut raw_reply = String::new();
+        let mut usage = None;
+        let mut completed = false;
+        while let Some(event) = stream.next().await {
+            match event? {
+                LlmStreamEvent::TextDelta(delta) => {
+                    if delta.is_empty() {
+                        continue;
+                    }
+                    raw_reply.push_str(&delta);
+                    on_delta(delta).await?;
+                }
+                LlmStreamEvent::Completed {
+                    usage: event_usage, ..
+                } => {
+                    if completed {
+                        return Err(LlmError::provider(
+                            "LLM stream produced multiple completion events",
+                            "stream",
+                        ));
+                    }
+                    completed = true;
+                    usage = event_usage;
+                }
+            }
+        }
+        if !completed {
+            return Err(LlmError::provider(
+                "LLM stream ended without completion event",
+                "stream",
+            ));
+        }
+        let raw_reply = raw_reply.trim().to_owned();
+        let outcome = ChatOutcome {
+            reply: raw_reply.clone(),
+            metrics: crate::util::metrics::LlmMetrics {
+                provider: self.provider.name().to_owned(),
+                model: self.provider.model().to_owned(),
+                stream: true,
+                ttfe_ms: None,
+                ttft_ms: None,
+                total_latency_ms: 0,
+            },
+            usage,
+            fallback_used: false,
+        };
+        log_llm_request_completed(&req, &outcome);
+        output_from_raw_reply(&req, raw_reply, outcome)
+    }
 }
 
 #[async_trait]
@@ -83,48 +156,56 @@ impl ChatService for LlmChatService {
         let outcome = self.provider.chat(chat_req).await?;
         log_llm_request_completed(&req, &outcome);
         let raw_reply = outcome.reply.trim().to_owned();
-        trace_chat_raw_reply(&req, &raw_reply);
-        let (reply, text, markdown) = match req.purpose {
-            RespondPurpose::Chat => {
-                if raw_reply.is_empty() {
-                    (
-                        "唔，小女仆刚刚没整理出可用回复。可以再戳我一次。".to_owned(),
-                        "唔，小女仆刚刚没整理出可用回复。可以再戳我一次。".to_owned(),
-                        None,
-                    )
-                } else {
-                    let (text, markdown) = format_chat_reply_channels(&raw_reply);
-                    let reply = markdown.clone().unwrap_or_else(|| text.clone());
-                    (reply, text, markdown)
-                }
-            }
-            RespondPurpose::MemoryDraft if is_structured_memory_draft(&req) => {
-                let reply = raw_reply.clone();
-                (reply.clone(), reply, None)
-            }
-            RespondPurpose::MemoryDraft => {
-                let reply = clean_memory_draft_output(&raw_reply);
-                (reply.clone(), reply, None)
-            }
-            RespondPurpose::TodoParse => {
-                let reply = raw_reply.clone();
-                (reply.clone(), reply, None)
-            }
-            RespondPurpose::Compact => {
-                let reply = raw_reply.clone();
-                (reply.clone(), reply, None)
-            }
-        };
-        trace_chat_final_reply(&req, &text);
-        let chat = ChatResponse::ok(raw_reply.clone(), outcome.metrics, outcome.usage);
-
-        Ok(RespondOutput {
-            reply,
-            text,
-            markdown,
-            chat,
-        })
+        output_from_raw_reply(&req, raw_reply, outcome)
     }
+}
+
+fn output_from_raw_reply(
+    req: &RespondRequest,
+    raw_reply: String,
+    outcome: ChatOutcome,
+) -> Result<RespondOutput, LlmError> {
+    trace_chat_raw_reply(req, &raw_reply);
+    let (reply, text, markdown) = match req.purpose {
+        RespondPurpose::Chat => {
+            if raw_reply.is_empty() {
+                (
+                    "唔，小女仆刚刚没整理出可用回复。可以再戳我一次。".to_owned(),
+                    "唔，小女仆刚刚没整理出可用回复。可以再戳我一次。".to_owned(),
+                    None,
+                )
+            } else {
+                let (text, markdown) = format_chat_reply_channels(&raw_reply);
+                let reply = markdown.clone().unwrap_or_else(|| text.clone());
+                (reply, text, markdown)
+            }
+        }
+        RespondPurpose::MemoryDraft if is_structured_memory_draft(req) => {
+            let reply = raw_reply.clone();
+            (reply.clone(), reply, None)
+        }
+        RespondPurpose::MemoryDraft => {
+            let reply = clean_memory_draft_output(&raw_reply);
+            (reply.clone(), reply, None)
+        }
+        RespondPurpose::TodoParse => {
+            let reply = raw_reply.clone();
+            (reply.clone(), reply, None)
+        }
+        RespondPurpose::Compact => {
+            let reply = raw_reply.clone();
+            (reply.clone(), reply, None)
+        }
+    };
+    trace_chat_final_reply(req, &text);
+    let chat = ChatResponse::ok(raw_reply.clone(), outcome.metrics, outcome.usage);
+
+    Ok(RespondOutput {
+        reply,
+        text,
+        markdown,
+        chat,
+    })
 }
 
 /// 在请求完成后记录统一的脱敏结构化摘要，便于观察真实 token usage 与缓存命中。

--- a/qq-maid-core/src/runtime/respond/llm_service.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service.rs
@@ -21,7 +21,10 @@ use crate::{
         types::{ChatMessage, ChatRequest, ChatRole},
     },
     runtime::session::redact_sensitive_text,
-    util::time_context::{RequestTimeContext, request_time_context},
+    util::{
+        metrics::MetricsRecorder,
+        time_context::{RequestTimeContext, request_time_context},
+    },
 };
 
 use super::{
@@ -91,20 +94,26 @@ impl LlmChatService {
             metadata: req.metadata.clone(),
         };
         let mut stream = self.provider.stream_chat(chat_req).await?;
+        let mut recorder = MetricsRecorder::start();
         let mut raw_reply = String::new();
         let mut usage = None;
         let mut completed = false;
+        let mut fallback_used = false;
         while let Some(event) = stream.next().await {
             match event? {
                 LlmStreamEvent::TextDelta(delta) => {
+                    recorder.mark_event();
                     if delta.is_empty() {
                         continue;
                     }
+                    recorder.mark_token();
                     raw_reply.push_str(&delta);
                     on_delta(delta).await?;
                 }
                 LlmStreamEvent::Completed {
-                    usage: event_usage, ..
+                    usage: event_usage,
+                    fallback_used: event_fallback_used,
+                    ..
                 } => {
                     if completed {
                         return Err(LlmError::provider(
@@ -114,6 +123,7 @@ impl LlmChatService {
                     }
                     completed = true;
                     usage = event_usage;
+                    fallback_used |= event_fallback_used;
                 }
             }
         }
@@ -126,16 +136,9 @@ impl LlmChatService {
         let raw_reply = raw_reply.trim().to_owned();
         let outcome = ChatOutcome {
             reply: raw_reply.clone(),
-            metrics: crate::util::metrics::LlmMetrics {
-                provider: self.provider.name().to_owned(),
-                model: self.provider.model().to_owned(),
-                stream: true,
-                ttfe_ms: None,
-                ttft_ms: None,
-                total_latency_ms: 0,
-            },
+            metrics: recorder.finish(self.provider.name(), self.provider.model(), true),
             usage,
-            fallback_used: false,
+            fallback_used,
         };
         log_llm_request_completed(&req, &outcome);
         output_from_raw_reply(&req, raw_reply, outcome)

--- a/qq-maid-core/src/runtime/respond/search_flow.rs
+++ b/qq-maid-core/src/runtime/respond/search_flow.rs
@@ -2,7 +2,10 @@
 //! 负责解析 `/查` `/查询` `/search` 等指令，调用查询执行器进行联网搜索，
 //! 并格式化搜索结果回复。同时处理超时、配置缺失、上游异常等错误场景。
 
+use std::{future::Future, pin::Pin};
+
 use serde_json::json;
+use tokio::sync::mpsc;
 
 use crate::{
     error::LlmError,
@@ -122,6 +125,99 @@ impl RustRespondService {
             false,
         );
         Ok(response)
+    }
+
+    /// `/查` 真流式路径：只消费执行器的 `query_stream`，不退回完整 `query()` 伪增量。
+    pub async fn handle_web_search_command_stream<F>(
+        &self,
+        command: ParsedCommand,
+        session: &mut SessionRecord,
+        mut on_delta: F,
+    ) -> Result<RespondResponse, LlmError>
+    where
+        F: FnMut(String) -> Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send>> + Send,
+    {
+        let query = command.argument.trim();
+        if query.is_empty() {
+            return Ok(command_response(
+                WEB_SEARCH_USAGE_REPLY,
+                Some(session.session_id.clone()),
+                Some(command.action),
+            ));
+        }
+        if query.chars().count() > WEB_SEARCH_QUERY_MAX_LENGTH {
+            return Ok(command_response(
+                WEB_SEARCH_TOO_LONG_REPLY,
+                Some(session.session_id.clone()),
+                Some(command.action),
+            ));
+        }
+
+        let command_text = format!("/{} {}", command.raw_command, command.argument);
+        let (delta_tx, mut delta_rx) = mpsc::channel(16);
+        let query_executor = self.query_executor.clone();
+        let query_req = QueryRequest {
+            query: query.to_owned(),
+            raw_question: Some(command_text.clone()),
+            max_results: None,
+            context_size: None,
+        };
+        let query_task =
+            tokio::spawn(async move { query_executor.query_stream(query_req, delta_tx).await });
+        while let Some(delta) = delta_rx.recv().await {
+            if !delta.is_empty()
+                && let Err(err) = on_delta(delta).await
+            {
+                // 接收方取消时必须停止继续 poll provider stream，而不是只停止转发。
+                query_task.abort();
+                return Err(err);
+            }
+        }
+        let outcome = match query_task.await.map_err(|err| {
+            LlmError::provider(format!("web search stream task failed: {err}"), "internal")
+        })? {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                tracing::warn!(
+                    error_code = err.code,
+                    error_stage = err.stage,
+                    query_provider = self.query_executor.provider_name(),
+                    "web search stream command failed"
+                );
+                let reply = format_web_search_error_reply(&err);
+                self.session_store
+                    .append_exchange(session, &command_text, &reply)
+                    .map_err(session_error)?;
+
+                let response = build_web_search_response(
+                    session.session_id.clone(),
+                    command.action.clone(),
+                    reply,
+                    self.query_executor.provider_name().to_owned(),
+                    Some(err.code.clone()),
+                    Some(err.stage.clone()),
+                    true,
+                );
+                return Ok(response);
+            }
+        };
+        let reply = if outcome.answer.trim().is_empty() {
+            WEB_SEARCH_EMPTY_RESULT_REPLY.to_owned()
+        } else {
+            format_web_search_command_reply(&outcome.answer)
+        };
+        self.session_store
+            .append_exchange(session, &command_text, &reply)
+            .map_err(session_error)?;
+
+        Ok(build_web_search_success_response(
+            session.session_id.clone(),
+            command.action,
+            reply,
+            outcome.provider,
+            outcome.elapsed_ms,
+            true,
+        ))
     }
 }
 

--- a/qq-maid-core/src/runtime/respond/tests/search.rs
+++ b/qq-maid-core/src/runtime/respond/tests/search.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 
 use super::support::*;
 use crate::error::LlmError;
@@ -25,6 +28,39 @@ async fn web_search_command_uses_query_executor() {
     );
     assert_eq!(response.diagnostics.unwrap()["used_search"], true);
     assert_eq!(response.command.as_deref(), Some("web_search"));
+}
+
+#[tokio::test]
+async fn web_search_stream_uses_query_stream_and_forwards_deltas() {
+    let query_calls = Arc::new(AtomicUsize::new(0));
+    let stream_calls = Arc::new(AtomicUsize::new(0));
+    let (service, _base) = test_service_with_provider_base_title_and_query(
+        MockProvider::new(),
+        None,
+        Arc::new(StreamOnlyQueryExecutor {
+            deltas: vec!["你".to_owned(), "好".to_owned()],
+            query_calls: query_calls.clone(),
+            stream_calls: stream_calls.clone(),
+        }),
+    );
+    let deltas = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let collected = deltas.clone();
+
+    let response = service
+        .respond_stream(message("/查 keyword"), move |delta| {
+            let collected = collected.clone();
+            Box::pin(async move {
+                collected.lock().unwrap().push(delta);
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(deltas.lock().unwrap().as_slice(), ["你", "好"]);
+    assert_eq!(response.text.as_deref(), Some("【联网查询】\n\n你好"));
+    assert_eq!(query_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(stream_calls.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tests/session.rs
+++ b/qq-maid-core/src/runtime/respond/tests/session.rs
@@ -4,12 +4,54 @@ use std::sync::{
 };
 
 use serde_json::Value;
+use tokio::time::{Duration, sleep};
 
 use super::support::*;
 use crate::{
     error::LlmError,
     runtime::session::{DEFAULT_SESSION_TITLE, SessionMeta},
 };
+
+async fn wait_for_session_title(
+    service: &crate::runtime::respond::RustRespondService,
+    title: &str,
+) {
+    for _ in 0..50 {
+        let session = service
+            .session_store
+            .get_or_create_active(&test_meta())
+            .unwrap();
+        if session.title == title {
+            return;
+        }
+        sleep(Duration::from_millis(10)).await;
+    }
+    let session = service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap();
+    assert_eq!(session.title, title);
+}
+
+async fn wait_for_title_request_count(inspector: &MockProvider, expected: usize) {
+    for _ in 0..50 {
+        let count = inspector
+            .requests()
+            .iter()
+            .filter(|req| req.metadata.get("purpose").map(String::as_str) == Some("session_title"))
+            .count();
+        if count == expected {
+            return;
+        }
+        sleep(Duration::from_millis(10)).await;
+    }
+    let count = inspector
+        .requests()
+        .iter()
+        .filter(|req| req.metadata.get("purpose").map(String::as_str) == Some("session_title"))
+        .count();
+    assert_eq!(count, expected);
+}
 
 #[tokio::test]
 async fn help_without_argument_returns_concise_overview() {
@@ -311,6 +353,7 @@ async fn auto_title_retries_after_failure_and_uses_per_call_model() {
     );
 
     service.respond(message("第三条确认方案")).await.unwrap();
+    wait_for_session_title(&service, "部署排障").await;
     let session = service
         .session_store
         .get_or_create_active(&test_meta())
@@ -338,6 +381,57 @@ async fn auto_title_retries_after_failure_and_uses_per_call_model() {
             .iter()
             .filter(|req| req.metadata.get("purpose").map(String::as_str) == Some("chat"))
             .all(|req| req.model.is_none())
+    );
+}
+
+#[tokio::test]
+async fn auto_title_delay_does_not_block_chat_response() {
+    let provider = MockProvider::with_title_replies(vec![Ok("后台标题")])
+        .with_title_delay(Duration::from_millis(300));
+    let (service, _) = test_service_with_title_provider(provider);
+
+    service.respond(message("第一条")).await.unwrap();
+    let response = tokio::time::timeout(
+        Duration::from_millis(100),
+        service.respond(message("第二条触发标题")),
+    )
+    .await
+    .expect("chat response should not wait for auto title")
+    .unwrap();
+
+    assert_eq!(response.text.as_deref(), Some("回复：第二条触发标题"));
+    assert_eq!(
+        service
+            .session_store
+            .get_or_create_active(&test_meta())
+            .unwrap()
+            .title,
+        DEFAULT_SESSION_TITLE
+    );
+    wait_for_session_title(&service, "后台标题").await;
+}
+
+#[tokio::test]
+async fn auto_title_failure_does_not_fail_chat_response() {
+    let provider = MockProvider::with_title_replies(vec![Err(LlmError::provider(
+        "title blocked",
+        "provider",
+    ))]);
+    let inspector = provider.clone();
+    let (service, _) = test_service_with_title_provider(provider);
+
+    service.respond(message("第一条")).await.unwrap();
+    let response = service.respond(message("第二条")).await.unwrap();
+
+    assert_eq!(response.text.as_deref(), Some("回复：第二条"));
+    wait_for_title_request_count(&inspector, 1).await;
+    assert_eq!(
+        service
+            .session_store
+            .get_or_create_active(&test_meta())
+            .unwrap()
+            .title,
+        DEFAULT_SESSION_TITLE
     );
 }
 
@@ -413,6 +507,7 @@ async fn auto_title_stops_after_fourth_user_message() {
     for text in ["第一条", "第二条", "第三条", "第四条", "第五条"] {
         service.respond(message(text)).await.unwrap();
     }
+    wait_for_title_request_count(&inspector, 3).await;
 
     let session = service
         .session_store

--- a/qq-maid-core/src/runtime/respond/tests/session.rs
+++ b/qq-maid-core/src/runtime/respond/tests/session.rs
@@ -412,6 +412,66 @@ async fn auto_title_delay_does_not_block_chat_response() {
 }
 
 #[tokio::test]
+async fn delayed_auto_title_preserves_messages_saved_after_snapshot() {
+    let provider =
+        MockProvider::with_title_replies(vec![Ok("后台标题"), Ok("后台标题"), Ok("后台标题")])
+            .with_title_delay(Duration::from_millis(250));
+    let (service, _) = test_service_with_title_provider(provider);
+
+    service.respond(message("第一条")).await.unwrap();
+    service.respond(message("第二条触发标题")).await.unwrap();
+    service.respond(message("第三条继续聊天")).await.unwrap();
+    service.respond(message("第四条继续聊天")).await.unwrap();
+
+    wait_for_session_title(&service, "后台标题").await;
+    sleep(Duration::from_millis(300)).await;
+    let session = service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap();
+
+    assert_eq!(session.title, "后台标题");
+    assert_eq!(
+        session
+            .history
+            .iter()
+            .map(|message| message.content.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "第一条",
+            "回复：第一条",
+            "第二条触发标题",
+            "回复：第二条触发标题",
+            "第三条继续聊天",
+            "回复：第三条继续聊天",
+            "第四条继续聊天",
+            "回复：第四条继续聊天",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn delayed_auto_title_does_not_overwrite_manual_rename() {
+    let provider = MockProvider::with_title_replies(vec![Ok("后台标题")])
+        .with_title_delay(Duration::from_millis(250));
+    let inspector = provider.clone();
+    let (service, _) = test_service_with_title_provider(provider);
+
+    service.respond(message("第一条")).await.unwrap();
+    service.respond(message("第二条触发标题")).await.unwrap();
+    wait_for_title_request_count(&inspector, 1).await;
+    service.respond(message("/rename 手工标题")).await.unwrap();
+
+    sleep(Duration::from_millis(350)).await;
+    let session = service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap();
+
+    assert_eq!(session.title, "手工标题");
+}
+
+#[tokio::test]
 async fn auto_title_failure_does_not_fail_chat_response() {
     let provider = MockProvider::with_title_replies(vec![Err(LlmError::provider(
         "title blocked",

--- a/qq-maid-core/src/runtime/respond/tests/support.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support.rs
@@ -47,6 +47,7 @@ pub(super) struct MockProvider {
     calls: Arc<AtomicUsize>,
     requests: Arc<Mutex<Vec<ChatRequest>>>,
     title_replies: Arc<Mutex<Vec<Result<String, LlmError>>>>,
+    title_delay: Option<std::time::Duration>,
 }
 
 pub(super) struct MockQueryExecutor;
@@ -110,6 +111,7 @@ impl MockProvider {
             calls: Arc::new(AtomicUsize::new(0)),
             requests: Arc::new(Mutex::new(Vec::new())),
             title_replies: Arc::new(Mutex::new(Vec::new())),
+            title_delay: None,
         }
     }
 
@@ -118,6 +120,7 @@ impl MockProvider {
             calls,
             requests: Arc::new(Mutex::new(Vec::new())),
             title_replies: Arc::new(Mutex::new(Vec::new())),
+            title_delay: None,
         }
     }
 
@@ -129,8 +132,14 @@ impl MockProvider {
                     .map(|result| result.map(str::to_owned))
                     .collect(),
             )),
+            title_delay: None,
             ..Self::new()
         }
+    }
+
+    pub(super) fn with_title_delay(mut self, delay: std::time::Duration) -> Self {
+        self.title_delay = Some(delay);
+        self
     }
 
     pub(super) fn requests(&self) -> Vec<ChatRequest> {
@@ -259,6 +268,9 @@ impl LlmProvider for MockProvider {
         self.calls.fetch_add(1, Ordering::SeqCst);
         self.requests.lock().unwrap().push(req.clone());
         if req.metadata.get("purpose").map(String::as_str) == Some("session_title") {
+            if let Some(delay) = self.title_delay {
+                tokio::time::sleep(delay).await;
+            }
             let reply = self.title_replies.lock().unwrap().remove(0)?;
             return Ok(ChatOutcome {
                 reply,

--- a/qq-maid-core/src/runtime/respond/tests/support.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support.rs
@@ -10,6 +10,7 @@ use std::{
 use async_trait::async_trait;
 use chrono::{Duration, NaiveDate};
 use serde_json::{Value, json};
+use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use super::super::{
@@ -68,6 +69,12 @@ pub(super) struct SupplementWeatherExecutor {
 
 pub(super) struct FailingQueryExecutor {
     pub(super) err: LlmError,
+}
+
+pub(super) struct StreamOnlyQueryExecutor {
+    pub(super) deltas: Vec<String>,
+    pub(super) query_calls: Arc<AtomicUsize>,
+    pub(super) stream_calls: Arc<AtomicUsize>,
 }
 
 #[derive(Clone)]
@@ -497,6 +504,38 @@ impl QueryExecutor for FailingQueryExecutor {
 
     fn provider_name(&self) -> &'static str {
         "mock-query"
+    }
+}
+
+#[async_trait]
+impl QueryExecutor for StreamOnlyQueryExecutor {
+    async fn query(&self, _req: QueryRequest) -> Result<QueryOutcome, LlmError> {
+        self.query_calls.fetch_add(1, Ordering::SeqCst);
+        Err(LlmError::provider("query must not be called", "test"))
+    }
+
+    async fn query_stream(
+        &self,
+        _req: QueryRequest,
+        delta_tx: mpsc::Sender<String>,
+    ) -> Result<QueryOutcome, LlmError> {
+        self.stream_calls.fetch_add(1, Ordering::SeqCst);
+        for delta in &self.deltas {
+            delta_tx
+                .send(delta.clone())
+                .await
+                .map_err(|_| LlmError::new("cancelled", "receiver dropped", "test"))?;
+        }
+        Ok(QueryOutcome {
+            answer: self.deltas.join(""),
+            sources: Vec::new(),
+            provider: "stream-query".to_owned(),
+            elapsed_ms: 11,
+        })
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "stream-query"
     }
 }
 

--- a/qq-maid-core/src/service.rs
+++ b/qq-maid-core/src/service.rs
@@ -173,9 +173,16 @@ impl CoreService for CoreHandle {
         let scope_key = req.scope_key.clone();
         let state = self.state.as_ref();
         if should_stream {
+            let provider_stream_enabled = state.provider.stream_enabled();
             let result = timeout(
                 Duration::from_secs(state.config.request_timeout_seconds),
-                async { Ok::<_, LlmError>(start_core_response_stream(service, req)) },
+                async {
+                    Ok::<_, LlmError>(start_core_response_stream(
+                        service,
+                        req,
+                        provider_stream_enabled,
+                    ))
+                },
             )
             .await;
             return match result {
@@ -307,6 +314,7 @@ impl Drop for CoreResponseStream {
 fn start_core_response_stream(
     service: RustRespondService,
     req: RespondRequest,
+    provider_stream_enabled: bool,
 ) -> CoreResponseStream {
     let (tx, receiver) = mpsc::channel(16);
     let cancelled = Arc::new(AtomicBool::new(false));
@@ -319,8 +327,14 @@ fn start_core_response_stream(
                 .await;
             return;
         }
-        let result =
-            run_streaming_respond(&service, req, tx.clone(), producer_cancelled.clone()).await;
+        let result = run_streaming_respond(
+            &service,
+            req,
+            tx.clone(),
+            producer_cancelled.clone(),
+            provider_stream_enabled,
+        )
+        .await;
         if producer_cancelled.load(Ordering::SeqCst) {
             return;
         }
@@ -358,7 +372,24 @@ async fn run_streaming_respond(
     req: RespondRequest,
     tx: mpsc::Sender<CoreResponseEvent>,
     cancelled: Arc<AtomicBool>,
+    provider_stream_enabled: bool,
 ) -> Result<RespondResponse, LlmError> {
+    if !provider_stream_enabled {
+        let response = service.respond(req).await?;
+        // provider 流式关闭时仍维持 Core/Gateway 的进程内流契约；
+        // 这里合成单个 delta，但上游请求保持原有非 SSE 行为。
+        if response.ok
+            && let Some(delta) = response
+                .markdown
+                .as_deref()
+                .or(response.text.as_deref())
+                .map(str::to_owned)
+                .filter(|value| !value.trim().is_empty())
+        {
+            send_core_delta(&tx, &cancelled, delta).await?;
+        }
+        return Ok(response);
+    }
     service
         .respond_stream(req, |delta| {
             let tx = tx.clone();
@@ -769,6 +800,33 @@ mod tests {
         assert_eq!(sessions[0].history.last().unwrap().content, "你好");
     }
 
+    #[tokio::test]
+    async fn stream_disabled_chat_is_wrapped_as_process_stream() {
+        let provider = TestProvider::replying("非流完整回复");
+        let state = test_state(provider.clone(), 5);
+        let service = CoreHandle::new(state);
+        let CoreRespondOutput::Stream(mut stream) =
+            service.respond(private_request("hello")).await.unwrap()
+        else {
+            panic!("expected stream output");
+        };
+
+        assert_eq!(
+            stream.recv().await,
+            Some(CoreResponseEvent::TextDelta("非流完整回复".to_owned()))
+        );
+        let Some(CoreResponseEvent::Completed(response)) = stream.recv().await else {
+            panic!("expected completed response");
+        };
+
+        assert_eq!(response.text.as_deref(), Some("非流完整回复"));
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            provider.requests()[0].metadata.get("purpose").unwrap(),
+            "chat"
+        );
+    }
+
     async fn collect_stream_failure(
         output: Result<CoreRespondOutput, CoreError>,
     ) -> CoreRespondFailure {
@@ -810,6 +868,7 @@ mod tests {
         behavior: ProviderBehavior,
         requests: Arc<Mutex<Vec<ChatRequest>>>,
         calls: Arc<AtomicUsize>,
+        stream_enabled: bool,
     }
 
     impl TestProvider {
@@ -822,7 +881,7 @@ mod tests {
         }
 
         fn streaming(events: Vec<Result<LlmStreamEvent, LlmError>>) -> Self {
-            Self::new(ProviderBehavior::Stream(events))
+            Self::new(ProviderBehavior::Stream(events)).with_stream_enabled(true)
         }
 
         fn delayed(reply: &str, delay: Duration) -> Self {
@@ -837,7 +896,13 @@ mod tests {
                 behavior,
                 requests: Arc::new(Mutex::new(Vec::new())),
                 calls: Arc::new(AtomicUsize::new(0)),
+                stream_enabled: false,
             }
+        }
+
+        fn with_stream_enabled(mut self, enabled: bool) -> Self {
+            self.stream_enabled = enabled;
+            self
         }
 
         fn requests(&self) -> Vec<ChatRequest> {
@@ -925,7 +990,7 @@ mod tests {
         }
 
         fn stream_enabled(&self) -> bool {
-            false
+            self.stream_enabled
         }
     }
 

--- a/qq-maid-core/src/service.rs
+++ b/qq-maid-core/src/service.rs
@@ -319,7 +319,8 @@ fn start_core_response_stream(
                 .await;
             return;
         }
-        let result = service.respond(req).await;
+        let result =
+            run_streaming_respond(&service, req, tx.clone(), producer_cancelled.clone()).await;
         if producer_cancelled.load(Ordering::SeqCst) {
             return;
         }
@@ -350,6 +351,34 @@ fn start_core_response_stream(
         receiver,
         cancelled,
     }
+}
+
+async fn run_streaming_respond(
+    service: &RustRespondService,
+    req: RespondRequest,
+    tx: mpsc::Sender<CoreResponseEvent>,
+    cancelled: Arc<AtomicBool>,
+) -> Result<RespondResponse, LlmError> {
+    service
+        .respond_stream(req, |delta| {
+            let tx = tx.clone();
+            let cancelled = cancelled.clone();
+            Box::pin(async move { send_core_delta(&tx, &cancelled, delta).await })
+        })
+        .await
+}
+
+async fn send_core_delta(
+    tx: &mpsc::Sender<CoreResponseEvent>,
+    cancelled: &Arc<AtomicBool>,
+    delta: String,
+) -> Result<(), LlmError> {
+    if cancelled.load(Ordering::SeqCst) {
+        return Err(LlmError::new("cancelled", "stream cancelled", "stream"));
+    }
+    tx.send(CoreResponseEvent::TextDelta(delta))
+        .await
+        .map_err(|_| LlmError::new("cancelled", "stream receiver dropped", "stream"))
 }
 
 fn should_stream_respond(req: &RespondRequest) -> bool {
@@ -566,7 +595,7 @@ mod tests {
             DailyReminderTime, OpenAiApiMode, ProviderMode,
         },
         provider::{
-            ChatOutcome, LlmProvider,
+            ChatOutcome, LlmProvider, LlmStream, LlmStreamEvent,
             status::{UpstreamStatus, observe_provider},
             types::{ModelRoute, TokenUsage},
         },
@@ -702,6 +731,44 @@ mod tests {
         assert_eq!(response.text.as_deref(), Some("late"));
     }
 
+    #[tokio::test]
+    async fn chat_stream_forwards_text_delta_and_completed_from_same_stream() {
+        let provider = TestProvider::streaming(vec![
+            Ok(LlmStreamEvent::TextDelta("你".to_owned())),
+            Ok(LlmStreamEvent::TextDelta("好".to_owned())),
+            Ok(LlmStreamEvent::Completed {
+                usage: None,
+                finish_reason: None,
+                fallback_used: false,
+            }),
+        ]);
+        let state = test_state(provider.clone(), 5);
+        let session_store = state.session_store.clone();
+        let service = CoreHandle::new(state);
+        let CoreRespondOutput::Stream(mut stream) =
+            service.respond(private_request("hello")).await.unwrap()
+        else {
+            panic!("expected stream output");
+        };
+
+        assert_eq!(
+            stream.recv().await,
+            Some(CoreResponseEvent::TextDelta("你".to_owned()))
+        );
+        assert_eq!(
+            stream.recv().await,
+            Some(CoreResponseEvent::TextDelta("好".to_owned()))
+        );
+        let Some(CoreResponseEvent::Completed(response)) = stream.recv().await else {
+            panic!("expected completed response");
+        };
+
+        assert_eq!(response.text.as_deref(), Some("你好"));
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+        let sessions = session_store.list_for_scope("private:u1", None).unwrap();
+        assert_eq!(sessions[0].history.last().unwrap().content, "你好");
+    }
+
     async fn collect_stream_failure(
         output: Result<CoreRespondOutput, CoreError>,
     ) -> CoreRespondFailure {
@@ -733,6 +800,7 @@ mod tests {
     #[derive(Clone)]
     enum ProviderBehavior {
         Reply(String),
+        Stream(Vec<Result<LlmStreamEvent, LlmError>>),
         Error(LlmError),
         Delayed { reply: String, delay: Duration },
     }
@@ -751,6 +819,10 @@ mod tests {
 
         fn failing(error: LlmError) -> Self {
             Self::new(ProviderBehavior::Error(error))
+        }
+
+        fn streaming(events: Vec<Result<LlmStreamEvent, LlmError>>) -> Self {
+            Self::new(ProviderBehavior::Stream(events))
         }
 
         fn delayed(reply: &str, delay: Duration) -> Self {
@@ -780,10 +852,66 @@ mod tests {
             self.requests.lock().unwrap().push(req);
             match &self.behavior {
                 ProviderBehavior::Reply(reply) => Ok(chat_outcome(reply)),
+                ProviderBehavior::Stream(events) => {
+                    let reply = events
+                        .iter()
+                        .filter_map(|event| match event {
+                            Ok(LlmStreamEvent::TextDelta(delta)) => Some(delta.as_str()),
+                            _ => None,
+                        })
+                        .collect::<String>();
+                    Ok(chat_outcome(&reply))
+                }
                 ProviderBehavior::Error(error) => Err(error.clone()),
                 ProviderBehavior::Delayed { reply, delay } => {
                     tokio::time::sleep(*delay).await;
                     Ok(chat_outcome(reply))
+                }
+            }
+        }
+
+        async fn stream_chat(&self, req: ChatRequest) -> Result<LlmStream, LlmError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.requests.lock().unwrap().push(req);
+            match &self.behavior {
+                ProviderBehavior::Reply(reply) => Ok(Box::pin(futures::stream::iter(vec![
+                    Ok(LlmStreamEvent::TextDelta(reply.clone())),
+                    Ok(LlmStreamEvent::Completed {
+                        usage: None,
+                        finish_reason: None,
+                        fallback_used: false,
+                    }),
+                ]))),
+                ProviderBehavior::Stream(events) => {
+                    Ok(Box::pin(futures::stream::iter(events.to_vec())))
+                }
+                ProviderBehavior::Error(error) => Err(error.clone()),
+                ProviderBehavior::Delayed { reply, delay } => {
+                    let reply = reply.clone();
+                    let delay = *delay;
+                    Ok(Box::pin(futures::stream::unfold(
+                        (0_u8, reply, delay),
+                        |(state, reply, delay)| async move {
+                            if state == 0 {
+                                tokio::time::sleep(delay).await;
+                                return Some((
+                                    Ok(LlmStreamEvent::TextDelta(reply)),
+                                    (1, String::new(), delay),
+                                ));
+                            }
+                            if state == 1 {
+                                return Some((
+                                    Ok(LlmStreamEvent::Completed {
+                                        usage: None,
+                                        finish_reason: None,
+                                        fallback_used: false,
+                                    }),
+                                    (2, String::new(), delay),
+                                ));
+                            }
+                            None
+                        },
+                    )))
                 }
             }
         }

--- a/qq-maid-core/src/storage/session.rs
+++ b/qq-maid-core/src/storage/session.rs
@@ -279,6 +279,32 @@ impl SessionStore {
         self.save_unlocked(&mut conn, session, true)
     }
 
+    /// 仅当当前标题仍为预期旧标题时更新标题，不回写会话历史或其他状态。
+    ///
+    /// 后台自动标题会基于某一时刻的会话快照生成结果；这里必须用条件更新，
+    /// 避免旧快照通过 `save` 覆盖后续聊天写入的消息、pending 或手工重命名。
+    pub fn update_title_if_current(
+        &self,
+        session_id: &str,
+        expected_title: &str,
+        new_title: &str,
+    ) -> Result<bool, SessionError> {
+        let title = normalize_session_title(new_title);
+        let now = now_iso_cn();
+        let conn = self.connection()?;
+        let changed = conn
+            .execute(
+                "UPDATE sessions
+                 SET title = ?1,
+                     updated_at = ?2
+                 WHERE session_id = ?3
+                   AND title = ?4",
+                params![title, now, session_id, expected_title],
+            )
+            .map_err(SessionError::from_sql)?;
+        Ok(changed > 0)
+    }
+
     /// 将指定会话设为某个作用域的活跃会话。
     pub fn set_active_session_id(
         &self,
@@ -1060,6 +1086,57 @@ mod tests {
                 .and_then(Value::as_array)
                 .is_some_and(|items| items.len() == 1)
         );
+    }
+
+    #[test]
+    fn update_title_if_current_preserves_newer_session_data() {
+        let store = test_store();
+        let meta = test_meta();
+        let mut snapshot = store.create(&meta, "", true).unwrap();
+        snapshot.append_message("user", "第二轮问题");
+        snapshot.append_message("assistant", "第二轮回复");
+        store.save(&mut snapshot).unwrap();
+
+        let mut current = store.get_or_create_active(&meta).unwrap();
+        current.append_message("user", "第三轮问题");
+        current.summary = "后续摘要".to_owned();
+        store.save(&mut current).unwrap();
+
+        let updated = store
+            .update_title_if_current(&snapshot.session_id, DEFAULT_SESSION_TITLE, "后台标题")
+            .unwrap();
+        let reloaded = store.get_or_create_active(&meta).unwrap();
+
+        assert!(updated);
+        assert_eq!(reloaded.title, "后台标题");
+        assert_eq!(reloaded.summary, "后续摘要");
+        assert_eq!(
+            reloaded
+                .history
+                .iter()
+                .map(|message| message.content.as_str())
+                .collect::<Vec<_>>(),
+            vec!["第二轮问题", "第二轮回复", "第三轮问题"]
+        );
+    }
+
+    #[test]
+    fn update_title_if_current_skips_after_manual_rename() {
+        let store = test_store();
+        let meta = test_meta();
+        let session = store.create(&meta, "", true).unwrap();
+
+        let mut renamed = store.get_or_create_active(&meta).unwrap();
+        renamed.title = "手工标题".to_owned();
+        store.save(&mut renamed).unwrap();
+
+        let updated = store
+            .update_title_if_current(&session.session_id, DEFAULT_SESSION_TITLE, "后台标题")
+            .unwrap();
+        let reloaded = store.get_or_create_active(&meta).unwrap();
+
+        assert!(!updated);
+        assert_eq!(reloaded.title, "手工标题");
     }
 
     #[test]

--- a/qq-maid-gateway-rs/Cargo.toml
+++ b/qq-maid-gateway-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-gateway-rs"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 publish = false
 

--- a/qq-maid-llm/Cargo.toml
+++ b/qq-maid-llm/Cargo.toml
@@ -1,7 +1,7 @@
 # qq-maid-llm 项目清单 —— 只承载模型调用、Provider 路由和 Web Search 协议能力。
 [package]
 name = "qq-maid-llm"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 publish = false
 

--- a/qq-maid-llm/src/provider/bigmodel.rs
+++ b/qq-maid-llm/src/provider/bigmodel.rs
@@ -12,10 +12,11 @@ use crate::{
     config::LlmConfig,
     error::LlmError,
     provider::{
-        ChatOutcome, LlmProvider, LlmStream, collect_llm_stream,
+        ChatOutcome, LlmProvider, LlmStream,
         openai::{
             ChatCompletionsClient, chat_completions_stream, chat_completions_with_stream_fallback,
         },
+        outcome_to_stream,
         types::{ChatRequest, ModelId, ModelProvider},
     },
 };
@@ -64,10 +65,6 @@ impl BigModelProvider {
 impl LlmProvider for BigModelProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatOutcome, LlmError> {
         let effective_model = effective_bigmodel_model(req.model.as_deref(), &self.model)?;
-        if self.stream {
-            let stream = self.stream_chat(req).await?;
-            return collect_llm_stream(stream, self.name(), &effective_model).await;
-        }
         chat_completions_with_stream_fallback(
             self.stream,
             &self.client,
@@ -81,6 +78,18 @@ impl LlmProvider for BigModelProvider {
 
     async fn stream_chat(&self, req: ChatRequest) -> Result<LlmStream, LlmError> {
         let effective_model = effective_bigmodel_model(req.model.as_deref(), &self.model)?;
+        if !self.stream {
+            let outcome = chat_completions_with_stream_fallback(
+                false,
+                &self.client,
+                self.name(),
+                &effective_model,
+                self.max_output_tokens,
+                &req.messages,
+            )
+            .await?;
+            return Ok(outcome_to_stream(outcome));
+        }
         chat_completions_stream(
             &self.client,
             self.name(),
@@ -138,6 +147,55 @@ fn effective_bigmodel_model(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::{
+        Router,
+        body::Body,
+        extract::State,
+        http::{StatusCode, header},
+        response::IntoResponse,
+        routing::post,
+    };
+    use serde_json::{Value, json};
+    use std::sync::Arc;
+    use tokio::{net::TcpListener, sync::Mutex};
+
+    #[derive(Debug)]
+    struct MockChatState {
+        bodies: Vec<String>,
+        requests: Vec<Value>,
+    }
+
+    async fn mock_chat_handler(
+        State(state): State<Arc<Mutex<MockChatState>>>,
+        body: Body,
+    ) -> impl IntoResponse {
+        let bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+        let request: Value = serde_json::from_slice(&bytes).unwrap();
+        let mut state = state.lock().await;
+        state.requests.push(request);
+        let body = state.bodies.remove(0);
+        (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "text/event-stream")],
+            body,
+        )
+    }
+
+    async fn spawn_mock_chat(bodies: Vec<String>) -> (String, Arc<Mutex<MockChatState>>) {
+        let state = Arc::new(Mutex::new(MockChatState {
+            bodies,
+            requests: Vec::new(),
+        }));
+        let app = Router::new()
+            .route("/chat/completions", post(mock_chat_handler))
+            .with_state(state.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{addr}"), state)
+    }
 
     #[test]
     fn effective_bigmodel_model_strips_bigmodel_prefix() {
@@ -166,5 +224,36 @@ mod tests {
 
         let err = bigmodel_config_model("deepseek:deepseek-chat").unwrap_err();
         assert_eq!(err.code, "config");
+    }
+
+    #[tokio::test]
+    async fn chat_retries_non_stream_after_empty_sse_when_stream_enabled() {
+        let (base_url, state) = spawn_mock_chat(vec![
+            "data: [DONE]\n\n".to_owned(),
+            json!({"choices": [{"message": {"content": "bigmodel non-stream"}}]}).to_string(),
+        ])
+        .await;
+        let provider = BigModelProvider {
+            client: ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new()),
+            model: "glm-5.2".to_owned(),
+            stream: true,
+            max_output_tokens: 1200,
+        };
+
+        let outcome = provider
+            .chat(ChatRequest {
+                session_id: "s".to_owned(),
+                model: None,
+                messages: vec![crate::provider::types::ChatMessage::user("hi")],
+                metadata: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.reply, "bigmodel non-stream");
+        let requests = &state.lock().await.requests;
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0]["stream"], true);
+        assert!(requests[1].get("stream").is_none());
     }
 }

--- a/qq-maid-llm/src/provider/bigmodel.rs
+++ b/qq-maid-llm/src/provider/bigmodel.rs
@@ -12,8 +12,10 @@ use crate::{
     config::LlmConfig,
     error::LlmError,
     provider::{
-        ChatOutcome, LlmProvider,
-        openai::{ChatCompletionsClient, chat_completions_with_stream_fallback},
+        ChatOutcome, LlmProvider, LlmStream, collect_llm_stream,
+        openai::{
+            ChatCompletionsClient, chat_completions_stream, chat_completions_with_stream_fallback,
+        },
         types::{ChatRequest, ModelId, ModelProvider},
     },
 };
@@ -62,6 +64,10 @@ impl BigModelProvider {
 impl LlmProvider for BigModelProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatOutcome, LlmError> {
         let effective_model = effective_bigmodel_model(req.model.as_deref(), &self.model)?;
+        if self.stream {
+            let stream = self.stream_chat(req).await?;
+            return collect_llm_stream(stream, self.name(), &effective_model).await;
+        }
         chat_completions_with_stream_fallback(
             self.stream,
             &self.client,
@@ -69,6 +75,19 @@ impl LlmProvider for BigModelProvider {
             &effective_model,
             self.max_output_tokens,
             &req.messages,
+        )
+        .await
+    }
+
+    async fn stream_chat(&self, req: ChatRequest) -> Result<LlmStream, LlmError> {
+        let effective_model = effective_bigmodel_model(req.model.as_deref(), &self.model)?;
+        chat_completions_stream(
+            &self.client,
+            self.name(),
+            &effective_model,
+            self.max_output_tokens,
+            &req.messages,
+            true,
         )
         .await
     }

--- a/qq-maid-llm/src/provider/deepseek.rs
+++ b/qq-maid-llm/src/provider/deepseek.rs
@@ -11,8 +11,10 @@ use crate::{
     config::LlmConfig,
     error::LlmError,
     provider::{
-        ChatOutcome, LlmProvider,
-        openai::{ChatCompletionsClient, chat_completions_with_stream_fallback},
+        ChatOutcome, LlmProvider, LlmStream, collect_llm_stream,
+        openai::{
+            ChatCompletionsClient, chat_completions_stream, chat_completions_with_stream_fallback,
+        },
         types::{ChatRequest, ModelId, ModelProvider},
     },
 };
@@ -61,6 +63,10 @@ impl DeepSeekProvider {
 impl LlmProvider for DeepSeekProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatOutcome, LlmError> {
         let effective_model = effective_deepseek_model(req.model.as_deref(), &self.model)?;
+        if self.stream {
+            let stream = self.stream_chat(req).await?;
+            return collect_llm_stream(stream, self.name(), &effective_model).await;
+        }
         chat_completions_with_stream_fallback(
             self.stream,
             &self.client,
@@ -68,6 +74,19 @@ impl LlmProvider for DeepSeekProvider {
             &effective_model,
             self.max_output_tokens,
             &req.messages,
+        )
+        .await
+    }
+
+    async fn stream_chat(&self, req: ChatRequest) -> Result<LlmStream, LlmError> {
+        let effective_model = effective_deepseek_model(req.model.as_deref(), &self.model)?;
+        chat_completions_stream(
+            &self.client,
+            self.name(),
+            &effective_model,
+            self.max_output_tokens,
+            &req.messages,
+            true,
         )
         .await
     }

--- a/qq-maid-llm/src/provider/deepseek.rs
+++ b/qq-maid-llm/src/provider/deepseek.rs
@@ -11,10 +11,11 @@ use crate::{
     config::LlmConfig,
     error::LlmError,
     provider::{
-        ChatOutcome, LlmProvider, LlmStream, collect_llm_stream,
+        ChatOutcome, LlmProvider, LlmStream,
         openai::{
             ChatCompletionsClient, chat_completions_stream, chat_completions_with_stream_fallback,
         },
+        outcome_to_stream,
         types::{ChatRequest, ModelId, ModelProvider},
     },
 };
@@ -63,10 +64,6 @@ impl DeepSeekProvider {
 impl LlmProvider for DeepSeekProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatOutcome, LlmError> {
         let effective_model = effective_deepseek_model(req.model.as_deref(), &self.model)?;
-        if self.stream {
-            let stream = self.stream_chat(req).await?;
-            return collect_llm_stream(stream, self.name(), &effective_model).await;
-        }
         chat_completions_with_stream_fallback(
             self.stream,
             &self.client,
@@ -80,6 +77,18 @@ impl LlmProvider for DeepSeekProvider {
 
     async fn stream_chat(&self, req: ChatRequest) -> Result<LlmStream, LlmError> {
         let effective_model = effective_deepseek_model(req.model.as_deref(), &self.model)?;
+        if !self.stream {
+            let outcome = chat_completions_with_stream_fallback(
+                false,
+                &self.client,
+                self.name(),
+                &effective_model,
+                self.max_output_tokens,
+                &req.messages,
+            )
+            .await?;
+            return Ok(outcome_to_stream(outcome));
+        }
         chat_completions_stream(
             &self.client,
             self.name(),
@@ -137,6 +146,56 @@ fn effective_deepseek_model(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::{
+        Router,
+        body::Body,
+        extract::State,
+        http::{StatusCode, header},
+        response::IntoResponse,
+        routing::post,
+    };
+    use futures::StreamExt;
+    use serde_json::{Value, json};
+    use std::sync::Arc;
+    use tokio::{net::TcpListener, sync::Mutex};
+
+    #[derive(Debug)]
+    struct MockChatState {
+        bodies: Vec<String>,
+        requests: Vec<Value>,
+    }
+
+    async fn mock_chat_handler(
+        State(state): State<Arc<Mutex<MockChatState>>>,
+        body: Body,
+    ) -> impl IntoResponse {
+        let bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+        let request: Value = serde_json::from_slice(&bytes).unwrap();
+        let mut state = state.lock().await;
+        state.requests.push(request);
+        let body = state.bodies.remove(0);
+        (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "text/event-stream")],
+            body,
+        )
+    }
+
+    async fn spawn_mock_chat(bodies: Vec<String>) -> (String, Arc<Mutex<MockChatState>>) {
+        let state = Arc::new(Mutex::new(MockChatState {
+            bodies,
+            requests: Vec::new(),
+        }));
+        let app = Router::new()
+            .route("/chat/completions", post(mock_chat_handler))
+            .with_state(state.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{addr}"), state)
+    }
 
     #[test]
     fn effective_deepseek_model_strips_deepseek_prefix() {
@@ -158,5 +217,67 @@ mod tests {
     fn effective_deepseek_model_rejects_openai_prefix() {
         let err = effective_deepseek_model(Some("openai:gpt-5-mini"), "default").unwrap_err();
         assert_eq!(err.code, "bad_request");
+    }
+
+    #[tokio::test]
+    async fn chat_retries_non_stream_after_empty_sse_when_stream_enabled() {
+        let (base_url, state) = spawn_mock_chat(vec![
+            "data: [DONE]\n\n".to_owned(),
+            json!({"choices": [{"message": {"content": "deepseek non-stream"}}]}).to_string(),
+        ])
+        .await;
+        let provider = DeepSeekProvider {
+            client: ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new()),
+            model: "deepseek-chat".to_owned(),
+            stream: true,
+            max_output_tokens: 1200,
+        };
+
+        let outcome = provider
+            .chat(ChatRequest {
+                session_id: "s".to_owned(),
+                model: None,
+                messages: vec![crate::provider::types::ChatMessage::user("hi")],
+                metadata: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.reply, "deepseek non-stream");
+        let requests = &state.lock().await.requests;
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0]["stream"], true);
+        assert!(requests[1].get("stream").is_none());
+    }
+
+    #[tokio::test]
+    async fn stream_chat_after_delta_error_does_not_retry_non_stream() {
+        let (base_url, state) = spawn_mock_chat(vec![
+            "data: {\"choices\":[{\"delta\":{\"content\":\"半截\"}}]}\n\ndata: {not-json}\n\n"
+                .to_owned(),
+        ])
+        .await;
+        let provider = DeepSeekProvider {
+            client: ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new()),
+            model: "deepseek-chat".to_owned(),
+            stream: true,
+            max_output_tokens: 1200,
+        };
+
+        let mut stream = provider
+            .stream_chat(ChatRequest {
+                session_id: "s".to_owned(),
+                model: None,
+                messages: vec![crate::provider::types::ChatMessage::user("hi")],
+                metadata: Default::default(),
+            })
+            .await
+            .unwrap();
+        assert!(matches!(
+            stream.next().await,
+            Some(Ok(crate::provider::LlmStreamEvent::TextDelta(_)))
+        ));
+        assert!(stream.next().await.unwrap().is_err());
+        assert_eq!(state.lock().await.requests.len(), 1);
     }
 }

--- a/qq-maid-llm/src/provider/mod.rs
+++ b/qq-maid-llm/src/provider/mod.rs
@@ -46,6 +46,7 @@ pub enum LlmStreamEvent {
     Completed {
         usage: Option<TokenUsage>,
         finish_reason: Option<String>,
+        fallback_used: bool,
     },
 }
 
@@ -84,6 +85,7 @@ pub async fn collect_llm_stream(
     let mut reply = String::new();
     let mut usage = None;
     let mut completed = false;
+    let mut fallback_used = false;
     while let Some(event) = stream.next().await {
         match event? {
             LlmStreamEvent::TextDelta(delta) => {
@@ -94,7 +96,9 @@ pub async fn collect_llm_stream(
                 reply.push_str(&delta);
             }
             LlmStreamEvent::Completed {
-                usage: event_usage, ..
+                usage: event_usage,
+                fallback_used: event_fallback_used,
+                ..
             } => {
                 if completed {
                     return Err(LlmError::provider(
@@ -104,6 +108,7 @@ pub async fn collect_llm_stream(
                 }
                 completed = true;
                 usage = event_usage;
+                fallback_used |= event_fallback_used;
             }
         }
     }
@@ -123,7 +128,7 @@ pub async fn collect_llm_stream(
         reply,
         metrics: recorder.finish(provider, model, true),
         usage,
-        fallback_used: false,
+        fallback_used,
     })
 }
 
@@ -135,6 +140,7 @@ pub(crate) fn outcome_to_stream(outcome: ChatOutcome) -> LlmStream {
         Ok(LlmStreamEvent::Completed {
             usage,
             finish_reason: None,
+            fallback_used: outcome.fallback_used,
         }),
     ]))
 }
@@ -347,6 +353,37 @@ impl LlmProvider for ModelRouteProvider {
         Err(aggregate_route_error(task, failures))
     }
 
+    async fn stream_chat(&self, req: ChatRequest) -> Result<LlmStream, LlmError> {
+        let route = match req.model.as_deref() {
+            Some(value) => ModelRoute::parse(value, "request")?,
+            None => self.default_route.clone(),
+        };
+        let task = model_task_name(&req).to_owned();
+        let candidates = route.candidates().to_vec();
+        let providers = self.providers.clone();
+        let default_provider = self.default_provider;
+
+        Ok(Box::pin(stream::unfold(
+            RouteStreamState {
+                req,
+                task,
+                candidates,
+                providers,
+                default_provider,
+                candidate_index: 0,
+                current_stream: None,
+                current_attempt: None,
+                failures: Vec::new(),
+                emitted_non_empty_delta: false,
+                done: false,
+            },
+            |mut state| async move {
+                let event = next_route_stream_event(&mut state).await;
+                event.map(|event| (event, state))
+            },
+        )))
+    }
+
     fn name(&self) -> &'static str {
         self.name
     }
@@ -360,6 +397,207 @@ impl LlmProvider for ModelRouteProvider {
             .first()
             .map(|(_, provider)| provider.stream_enabled())
             .unwrap_or(false)
+    }
+}
+
+struct RouteStreamState {
+    req: ChatRequest,
+    task: String,
+    candidates: Vec<ModelId>,
+    providers: Vec<(ModelProvider, DynLlmProvider)>,
+    default_provider: ModelProvider,
+    candidate_index: usize,
+    current_stream: Option<LlmStream>,
+    current_attempt: Option<(usize, ModelProvider, ModelId)>,
+    failures: Vec<ModelAttemptFailure>,
+    emitted_non_empty_delta: bool,
+    done: bool,
+}
+
+async fn next_route_stream_event(
+    state: &mut RouteStreamState,
+) -> Option<Result<LlmStreamEvent, LlmError>> {
+    loop {
+        if state.done {
+            return None;
+        }
+        if state.current_stream.is_none() {
+            match start_next_route_candidate(state).await {
+                Ok(true) => {}
+                Ok(false) => {
+                    state.done = true;
+                    return Some(Err(aggregate_route_error(
+                        &state.task,
+                        std::mem::take(&mut state.failures),
+                    )));
+                }
+                Err(err) => {
+                    state.done = true;
+                    return Some(Err(err));
+                }
+            }
+        }
+
+        let Some(stream) = state.current_stream.as_mut() else {
+            continue;
+        };
+        match stream.next().await {
+            Some(Ok(LlmStreamEvent::TextDelta(delta))) => {
+                if !delta.is_empty() {
+                    state.emitted_non_empty_delta = true;
+                }
+                return Some(Ok(LlmStreamEvent::TextDelta(delta)));
+            }
+            Some(Ok(LlmStreamEvent::Completed {
+                usage,
+                finish_reason,
+                fallback_used,
+            })) => {
+                if !state.emitted_non_empty_delta {
+                    let err =
+                        LlmError::provider("LLM stream returned empty text output", "provider");
+                    record_current_route_failure(state, err);
+                    state.current_stream = None;
+                    state.current_attempt = None;
+                    continue;
+                }
+                let fallback_used = fallback_used
+                    || state
+                        .current_attempt
+                        .as_ref()
+                        .is_some_and(|(index, _, _)| *index > 0);
+                state.done = true;
+                return Some(Ok(LlmStreamEvent::Completed {
+                    usage,
+                    finish_reason,
+                    fallback_used,
+                }));
+            }
+            Some(Err(err)) => {
+                if state.emitted_non_empty_delta {
+                    state.done = true;
+                    return Some(Err(LlmError::new(
+                        err.code,
+                        err.message,
+                        "stream_after_delta",
+                    )));
+                }
+                record_current_route_failure(state, err);
+                state.current_stream = None;
+                state.current_attempt = None;
+            }
+            None => {
+                if state.emitted_non_empty_delta {
+                    state.done = true;
+                    return Some(Err(LlmError::provider(
+                        "LLM stream ended before completion after emitting text",
+                        "stream_after_delta",
+                    )));
+                }
+                let err = LlmError::provider("LLM stream ended without completion event", "stream");
+                record_current_route_failure(state, err);
+                state.current_stream = None;
+                state.current_attempt = None;
+            }
+        }
+    }
+}
+
+async fn start_next_route_candidate(state: &mut RouteStreamState) -> Result<bool, LlmError> {
+    while state.candidate_index < state.candidates.len() {
+        let index = state.candidate_index;
+        state.candidate_index += 1;
+        let candidate = state.candidates[index].clone();
+        let provider_kind = candidate.provider.unwrap_or(state.default_provider);
+        let provider = state
+            .providers
+            .iter()
+            .find(|(kind, _)| *kind == provider_kind)
+            .map(|(_, provider)| provider.clone())
+            .ok_or_else(|| {
+                LlmError::config(format!(
+                    "provider `{}` is not available for model candidate `{}`",
+                    provider_kind.as_str(),
+                    candidate.to_request_model()
+                ))
+            })?;
+        let mut candidate_req = state.req.clone();
+        candidate_req.model = Some(candidate.to_request_model());
+        match provider.stream_chat(candidate_req).await {
+            Ok(stream) => {
+                tracing::info!(
+                    task = state.task.as_str(),
+                    candidate_index = index,
+                    provider = provider_kind.as_str(),
+                    model = %candidate.name,
+                    result = "stream_started",
+                    "model candidate stream started"
+                );
+                state.current_stream = Some(stream);
+                state.current_attempt = Some((index, provider_kind, candidate));
+                return Ok(true);
+            }
+            Err(err) => {
+                let fallback =
+                    state.candidate_index < state.candidates.len() && should_try_next_model(&err);
+                tracing::warn!(
+                    task = state.task.as_str(),
+                    candidate_index = index,
+                    provider = provider_kind.as_str(),
+                    model = %candidate.name,
+                    result = "failed",
+                    error_code = err.code.as_str(),
+                    error_stage = err.stage.as_str(),
+                    error_kind = model_error_kind(&err),
+                    fallback,
+                    "model candidate stream init failed"
+                );
+                if !fallback {
+                    return Err(err);
+                }
+                state.failures.push(ModelAttemptFailure::new(
+                    index,
+                    provider_kind,
+                    &candidate,
+                    err,
+                ));
+            }
+        }
+    }
+    Ok(false)
+}
+
+fn record_current_route_failure(state: &mut RouteStreamState, err: LlmError) {
+    let Some((index, provider_kind, candidate)) = state.current_attempt.take() else {
+        state.failures.push(ModelAttemptFailure {
+            index: state.candidate_index,
+            provider: state.default_provider,
+            model: "<unknown>".to_owned(),
+            error: err,
+        });
+        return;
+    };
+    let fallback = state.candidate_index < state.candidates.len() && should_try_next_model(&err);
+    tracing::warn!(
+        task = state.task.as_str(),
+        candidate_index = index,
+        provider = provider_kind.as_str(),
+        model = %candidate.name,
+        result = "failed",
+        error_code = err.code.as_str(),
+        error_stage = err.stage.as_str(),
+        error_kind = model_error_kind(&err),
+        fallback,
+        "model candidate stream failed before text delta"
+    );
+    state.failures.push(ModelAttemptFailure::new(
+        index,
+        provider_kind,
+        &candidate,
+        err,
+    ));
+    if !fallback {
+        state.candidate_index = state.candidates.len();
     }
 }
 
@@ -601,6 +839,7 @@ mod tests {
         model: &'static str,
         stream: bool,
         results: Arc<Mutex<Vec<Result<ChatOutcome, LlmError>>>>,
+        stream_results: Arc<Mutex<Vec<Result<LlmStream, LlmError>>>>,
         calls: Arc<Mutex<usize>>,
         requests: Arc<Mutex<Vec<ChatRequest>>>,
     }
@@ -612,6 +851,19 @@ mod tests {
                 model: "mock-model",
                 stream: false,
                 results: Arc::new(Mutex::new(results)),
+                stream_results: Arc::new(Mutex::new(Vec::new())),
+                calls: Arc::new(Mutex::new(0)),
+                requests: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn with_streams(name: &'static str, results: Vec<Result<LlmStream, LlmError>>) -> Self {
+            Self {
+                name,
+                model: "mock-model",
+                stream: true,
+                results: Arc::new(Mutex::new(Vec::new())),
+                stream_results: Arc::new(Mutex::new(results)),
                 calls: Arc::new(Mutex::new(0)),
                 requests: Arc::new(Mutex::new(Vec::new())),
             }
@@ -632,6 +884,12 @@ mod tests {
             *self.calls.lock().unwrap() += 1;
             self.requests.lock().unwrap().push(req);
             self.results.lock().unwrap().remove(0)
+        }
+
+        async fn stream_chat(&self, req: ChatRequest) -> Result<LlmStream, LlmError> {
+            *self.calls.lock().unwrap() += 1;
+            self.requests.lock().unwrap().push(req);
+            self.stream_results.lock().unwrap().remove(0)
         }
 
         fn name(&self) -> &'static str {
@@ -670,6 +928,10 @@ mod tests {
             usage: None,
             fallback_used: false,
         }
+    }
+
+    fn stream_events(events: Vec<Result<LlmStreamEvent, LlmError>>) -> LlmStream {
+        Box::pin(stream::iter(events))
     }
 
     fn app_config(provider: ProviderMode, model: &str) -> LlmConfig {
@@ -993,6 +1255,96 @@ mod tests {
             deepseek.requests()[0].model.as_deref(),
             Some("deepseek:deepseek-chat")
         );
+    }
+
+    #[tokio::test]
+    async fn model_route_stream_falls_back_before_delta_only() {
+        let openai = Arc::new(MockProvider::with_streams(
+            "openai",
+            vec![Ok(stream_events(vec![Ok(LlmStreamEvent::Completed {
+                usage: None,
+                finish_reason: None,
+                fallback_used: false,
+            })]))],
+        ));
+        let deepseek = Arc::new(MockProvider::with_streams(
+            "deepseek",
+            vec![Ok(stream_events(vec![
+                Ok(LlmStreamEvent::TextDelta("fallback".to_owned())),
+                Ok(LlmStreamEvent::Completed {
+                    usage: None,
+                    finish_reason: None,
+                    fallback_used: false,
+                }),
+            ]))],
+        ));
+        let provider = ModelRouteProvider::new(
+            "auto",
+            ModelProvider::OpenAi,
+            ModelRoute::parse_config("openai:gpt-a,deepseek:deepseek-chat", "LLM_MODEL").unwrap(),
+            vec![
+                (ModelProvider::OpenAi, openai.clone()),
+                (ModelProvider::DeepSeek, deepseek.clone()),
+            ],
+        )
+        .unwrap();
+
+        let outcome = collect_llm_stream(
+            provider.stream_chat(request()).await.unwrap(),
+            provider.name(),
+            provider.model(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.reply, "fallback");
+        assert!(outcome.fallback_used);
+        assert_eq!(openai.calls(), 1);
+        assert_eq!(deepseek.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn model_route_stream_error_after_delta_does_not_fallback() {
+        let openai = Arc::new(MockProvider::with_streams(
+            "openai",
+            vec![Ok(stream_events(vec![
+                Ok(LlmStreamEvent::TextDelta("partial".to_owned())),
+                Err(LlmError::provider("broken", "stream")),
+            ]))],
+        ));
+        let deepseek = Arc::new(MockProvider::with_streams(
+            "deepseek",
+            vec![Ok(stream_events(vec![
+                Ok(LlmStreamEvent::TextDelta("fallback".to_owned())),
+                Ok(LlmStreamEvent::Completed {
+                    usage: None,
+                    finish_reason: None,
+                    fallback_used: false,
+                }),
+            ]))],
+        ));
+        let provider = ModelRouteProvider::new(
+            "auto",
+            ModelProvider::OpenAi,
+            ModelRoute::parse_config("openai:gpt-a,deepseek:deepseek-chat", "LLM_MODEL").unwrap(),
+            vec![
+                (ModelProvider::OpenAi, openai.clone()),
+                (ModelProvider::DeepSeek, deepseek.clone()),
+            ],
+        )
+        .unwrap();
+
+        let err = collect_llm_stream(
+            provider.stream_chat(request()).await.unwrap(),
+            provider.name(),
+            provider.model(),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.stage, "stream_after_delta");
+        assert_eq!(openai.calls(), 1);
+        assert_eq!(deepseek.calls(), 0);
     }
 
     #[tokio::test]

--- a/qq-maid-llm/src/provider/openai/chat.rs
+++ b/qq-maid-llm/src/provider/openai/chat.rs
@@ -21,6 +21,7 @@ use crate::{
 use super::fallback::{
     should_retry_non_stream_after_empty_stream, should_retry_non_stream_after_stream_error,
 };
+use super::responses::{incomplete_stream_eof_error, stream_transport_error};
 
 const OPENAI_DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
 
@@ -292,6 +293,8 @@ pub(crate) async fn chat_completions_stream(
             usage,
             pending_events: VecDeque::new(),
             allow_completed_message_fallback,
+            saw_done: false,
+            finish_reason: None,
             finished: false,
         },
         |mut state| async move {
@@ -307,7 +310,7 @@ fn handle_chat_stream_event(
     answer: &mut String,
     final_message: &mut String,
     usage: &mut Option<TokenUsage>,
-) -> Result<Vec<LlmStreamEvent>, LlmError> {
+) -> Result<(Vec<LlmStreamEvent>, Option<String>), LlmError> {
     let value = serde_json::from_str::<Value>(data).map_err(|err| {
         LlmError::provider(
             format!("invalid Chat Completions stream JSON: {err}"),
@@ -319,8 +322,9 @@ fn handle_chat_stream_event(
     }
     let mut events = Vec::new();
     let Some(choices) = value.get("choices").and_then(Value::as_array) else {
-        return Ok(events);
+        return Ok((events, None));
     };
+    let mut finish_reason = None;
     for choice in choices {
         if let Some(delta) = choice
             .get("delta")
@@ -338,8 +342,13 @@ fn handle_chat_stream_event(
         {
             final_message.push_str(&message);
         }
+        if let Some(reason) = choice.get("finish_reason").and_then(Value::as_str)
+            && !reason.trim().is_empty()
+        {
+            finish_reason = Some(reason.to_owned());
+        }
     }
-    Ok(events)
+    Ok((events, finish_reason))
 }
 
 struct ChatStreamState {
@@ -351,6 +360,8 @@ struct ChatStreamState {
     usage: Option<TokenUsage>,
     pending_events: VecDeque<LlmStreamEvent>,
     allow_completed_message_fallback: bool,
+    saw_done: bool,
+    finish_reason: Option<String>,
     finished: bool,
 }
 
@@ -368,6 +379,10 @@ async fn next_chat_stream_event(
             }) else {
                 continue;
             };
+            if event.data.trim() == "[DONE]" {
+                state.saw_done = true;
+                continue;
+            }
             state.recorder.mark_event();
             match handle_chat_stream_event(
                 &event.data,
@@ -376,7 +391,12 @@ async fn next_chat_stream_event(
                 &mut state.final_message,
                 &mut state.usage,
             ) {
-                Ok(events) => state.pending_events.extend(events),
+                Ok((events, finish_reason)) => {
+                    if finish_reason.is_some() {
+                        state.finish_reason = finish_reason;
+                    }
+                    state.pending_events.extend(events);
+                }
                 Err(err) => return Some(Err(err)),
             }
             continue;
@@ -400,20 +420,30 @@ async fn next_chat_stream_event(
                         continue;
                     };
                     state.frame_buffer.clear();
-                    state.recorder.mark_event();
-                    match handle_chat_stream_event(
-                        &event.data,
-                        &mut state.recorder,
-                        &mut state.answer,
-                        &mut state.final_message,
-                        &mut state.usage,
-                    ) {
-                        Ok(events) => state.pending_events.extend(events),
-                        Err(err) => return Some(Err(err)),
+                    if event.data.trim() == "[DONE]" {
+                        state.saw_done = true;
+                    } else {
+                        state.recorder.mark_event();
+                        match handle_chat_stream_event(
+                            &event.data,
+                            &mut state.recorder,
+                            &mut state.answer,
+                            &mut state.final_message,
+                            &mut state.usage,
+                        ) {
+                            Ok((events, finish_reason)) => {
+                                if finish_reason.is_some() {
+                                    state.finish_reason = finish_reason;
+                                }
+                                state.pending_events.extend(events);
+                            }
+                            Err(err) => return Some(Err(err)),
+                        }
                     }
                 }
                 if state.answer.trim().is_empty()
                     && state.allow_completed_message_fallback
+                    && (state.saw_done || state.finish_reason.is_some())
                     && !state.final_message.trim().is_empty()
                 {
                     // 仅在没有真实 delta 时回补 completed message，避免把两套正文拼接。
@@ -421,17 +451,25 @@ async fn next_chat_stream_event(
                     state.recorder.mark_token();
                     return Some(Ok(LlmStreamEvent::TextDelta(state.final_message.clone())));
                 }
+                if !state.saw_done && state.finish_reason.is_none() {
+                    state.finished = true;
+                    return Some(Err(incomplete_stream_eof_error(
+                        "Chat Completions stream ended before [DONE] or finish_reason",
+                        &state.answer,
+                    )));
+                }
                 state.finished = true;
                 return Some(Ok(LlmStreamEvent::Completed {
                     usage: state.usage.clone(),
-                    finish_reason: None,
+                    finish_reason: state.finish_reason.clone(),
                     fallback_used: false,
                 }));
             }
             Err(err) => {
-                return Some(Err(LlmError::http(format!(
-                    "Chat Completions stream failed: {err}"
-                ))));
+                return Some(Err(stream_transport_error(
+                    format!("Chat Completions stream failed: {err}"),
+                    &state.answer,
+                )));
             }
         }
     }
@@ -639,6 +677,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stream_chat_completion_requires_done_after_delta() {
+        let body = "data: {\"choices\":[{\"delta\":{\"content\":\"半截\"}}]}\n\n".to_owned();
+        let (base_url, _state) = spawn_mock_chat(vec![body], StatusCode::OK).await;
+        let client =
+            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+
+        let err = stream_completion(
+            &client,
+            "openai",
+            "gpt-test",
+            1200,
+            &[ChatMessage::user("hi")],
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.stage, "stream_after_delta");
+        assert!(err.message.contains("[DONE]"));
+    }
+
+    #[tokio::test]
+    async fn stream_chat_completion_accepts_finish_reason_without_done() {
+        let body = concat!(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"你\"}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"content\":\"好\"},\"finish_reason\":\"stop\"}]}\n\n",
+        )
+        .to_owned();
+        let (base_url, _state) = spawn_mock_chat(vec![body], StatusCode::OK).await;
+        let client =
+            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+
+        let outcome = stream_completion(
+            &client,
+            "openai",
+            "gpt-test",
+            1200,
+            &[ChatMessage::user("hi")],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.reply, "你好");
+    }
+
+    #[tokio::test]
     async fn empty_stream_retries_non_stream() {
         let (base_url, state) = spawn_mock_chat(
             vec![
@@ -664,6 +747,71 @@ mod tests {
 
         assert_eq!(outcome.reply, "retry ok");
         assert_eq!(state.lock().await.requests.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn chat_with_stream_fallback_retries_non_stream_after_stream_parse_error() {
+        let (base_url, state) = spawn_mock_chat(
+            vec![
+                concat!(
+                    "data: {\"choices\":[{\"delta\":{\"content\":\"半截\"}}]}\n\n",
+                    "data: {not-json}\n\n",
+                )
+                .to_owned(),
+                json!({"choices": [{"message": {"content": "non stream ok"}}]}).to_string(),
+            ],
+            StatusCode::OK,
+        )
+        .await;
+        let client =
+            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+
+        let outcome = chat_completions_with_stream_fallback(
+            true,
+            &client,
+            "openai",
+            "gpt-test",
+            1200,
+            &[ChatMessage::user("hi")],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.reply, "non stream ok");
+        let requests = &state.lock().await.requests;
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0]["stream"], true);
+        assert!(requests[1].get("stream").is_none());
+    }
+
+    #[tokio::test]
+    async fn raw_stream_chat_does_not_retry_non_stream_after_delta_error() {
+        let (base_url, state) = spawn_mock_chat(
+            vec![
+                concat!(
+                    "data: {\"choices\":[{\"delta\":{\"content\":\"半截\"}}]}\n\n",
+                    "data: {not-json}\n\n",
+                )
+                .to_owned(),
+            ],
+            StatusCode::OK,
+        )
+        .await;
+        let client =
+            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+
+        let err = stream_completion(
+            &client,
+            "openai",
+            "gpt-test",
+            1200,
+            &[ChatMessage::user("hi")],
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.stage, "sse");
+        assert_eq!(state.lock().await.requests.len(), 1);
     }
 
     #[tokio::test]

--- a/qq-maid-llm/src/provider/openai/chat.rs
+++ b/qq-maid-llm/src/provider/openai/chat.rs
@@ -3,14 +3,16 @@
 //! OpenAI fallback 和 DeepSeek 都复用同一套 `/chat/completions` HTTP/SSE 实现，
 //! 只在 base URL、API key 和模型规则上区分。
 
+use futures::stream;
 use reqwest::{StatusCode, header};
 use serde_json::{Value, json};
+use std::collections::VecDeque;
 
 use crate::{
     error::LlmError,
     metrics::MetricsRecorder,
     provider::{
-        ChatOutcome,
+        ChatOutcome, LlmStream, LlmStreamEvent, collect_llm_stream,
         types::{ChatMessage, ChatRole, TokenUsage},
     },
     sse::{parse_sse_frame, take_sse_frame},
@@ -259,65 +261,44 @@ pub(crate) async fn stream_completion(
     max_output_tokens: u64,
     messages: &[ChatMessage],
 ) -> Result<ChatOutcome, LlmError> {
-    let mut recorder = MetricsRecorder::start();
-    let payload = chat_completions_payload(messages, model, max_output_tokens, true)?;
-    let mut response = send_chat_completions_request(client, &payload, true).await?;
-    let mut frame_buffer = Vec::new();
-    let mut answer = String::new();
-    let mut final_message = String::new();
-    let mut usage = None;
+    let stream =
+        chat_completions_stream(client, provider, model, max_output_tokens, messages, true).await?;
+    collect_llm_stream(stream, provider, model).await
+}
 
-    while let Some(chunk) = response
-        .chunk()
-        .await
-        .map_err(|err| LlmError::http(format!("Chat Completions stream failed: {err}")))?
-    {
-        frame_buffer.extend_from_slice(&chunk);
-        while let Some(frame) = take_sse_frame(&mut frame_buffer) {
-            let Some(event) = parse_sse_frame(&frame)? else {
-                continue;
-            };
-            recorder.mark_event();
-            handle_chat_stream_event(
-                &event.data,
-                &mut recorder,
-                &mut answer,
-                &mut final_message,
-                &mut usage,
-            )?;
-        }
-    }
-    if !frame_buffer.is_empty()
-        && let Some(event) = parse_sse_frame(&frame_buffer)?
-    {
-        recorder.mark_event();
-        handle_chat_stream_event(
-            &event.data,
-            &mut recorder,
-            &mut answer,
-            &mut final_message,
-            &mut usage,
-        )?;
-    }
+pub(crate) async fn chat_completions_stream(
+    client: &ChatCompletionsClient,
+    _provider: &str,
+    _model: &str,
+    max_output_tokens: u64,
+    messages: &[ChatMessage],
+    allow_completed_message_fallback: bool,
+) -> Result<LlmStream, LlmError> {
+    let recorder = MetricsRecorder::start();
+    let payload = chat_completions_payload(messages, _model, max_output_tokens, true)?;
+    let response = send_chat_completions_request(client, &payload, true).await?;
+    let frame_buffer = Vec::new();
+    let answer = String::new();
+    let final_message = String::new();
+    let usage = None;
 
-    if answer.trim().is_empty() {
-        answer = final_message;
-    }
-    let reply = answer.trim().to_owned();
-    if reply.is_empty() {
-        return Err(LlmError::provider(
-            "Chat Completions returned empty text output",
-            "provider",
-        ));
-    }
-    let metrics = recorder.finish(provider, model, true);
-
-    Ok(ChatOutcome {
-        reply,
-        metrics,
-        usage,
-        fallback_used: false,
-    })
+    Ok(Box::pin(stream::unfold(
+        ChatStreamState {
+            response,
+            frame_buffer,
+            recorder,
+            answer,
+            final_message,
+            usage,
+            pending_events: VecDeque::new(),
+            allow_completed_message_fallback,
+            finished: false,
+        },
+        |mut state| async move {
+            let event = next_chat_stream_event(&mut state).await;
+            event.map(|event| (event, state))
+        },
+    )))
 }
 
 fn handle_chat_stream_event(
@@ -326,7 +307,7 @@ fn handle_chat_stream_event(
     answer: &mut String,
     final_message: &mut String,
     usage: &mut Option<TokenUsage>,
-) -> Result<(), LlmError> {
+) -> Result<Vec<LlmStreamEvent>, LlmError> {
     let value = serde_json::from_str::<Value>(data).map_err(|err| {
         LlmError::provider(
             format!("invalid Chat Completions stream JSON: {err}"),
@@ -336,8 +317,9 @@ fn handle_chat_stream_event(
     if let Some(event_usage) = extract_chat_completion_usage(&value) {
         *usage = Some(event_usage);
     }
+    let mut events = Vec::new();
     let Some(choices) = value.get("choices").and_then(Value::as_array) else {
-        return Ok(());
+        return Ok(events);
     };
     for choice in choices {
         if let Some(delta) = choice
@@ -347,6 +329,7 @@ fn handle_chat_stream_event(
         {
             recorder.mark_token();
             answer.push_str(&delta);
+            events.push(LlmStreamEvent::TextDelta(delta));
         }
         if let Some(message) = choice
             .get("message")
@@ -356,7 +339,102 @@ fn handle_chat_stream_event(
             final_message.push_str(&message);
         }
     }
-    Ok(())
+    Ok(events)
+}
+
+struct ChatStreamState {
+    response: reqwest::Response,
+    frame_buffer: Vec<u8>,
+    recorder: MetricsRecorder,
+    answer: String,
+    final_message: String,
+    usage: Option<TokenUsage>,
+    pending_events: VecDeque<LlmStreamEvent>,
+    allow_completed_message_fallback: bool,
+    finished: bool,
+}
+
+async fn next_chat_stream_event(
+    state: &mut ChatStreamState,
+) -> Option<Result<LlmStreamEvent, LlmError>> {
+    loop {
+        if let Some(event) = state.pending_events.pop_front() {
+            return Some(Ok(event));
+        }
+        if let Some(frame) = take_sse_frame(&mut state.frame_buffer) {
+            let Some(event) = (match parse_sse_frame(&frame) {
+                Ok(event) => event,
+                Err(err) => return Some(Err(err)),
+            }) else {
+                continue;
+            };
+            state.recorder.mark_event();
+            match handle_chat_stream_event(
+                &event.data,
+                &mut state.recorder,
+                &mut state.answer,
+                &mut state.final_message,
+                &mut state.usage,
+            ) {
+                Ok(events) => state.pending_events.extend(events),
+                Err(err) => return Some(Err(err)),
+            }
+            continue;
+        }
+
+        if state.finished {
+            return None;
+        }
+
+        match state.response.chunk().await {
+            Ok(Some(chunk)) => {
+                state.frame_buffer.extend_from_slice(&chunk);
+            }
+            Ok(None) => {
+                if !state.frame_buffer.is_empty() {
+                    let Some(event) = (match parse_sse_frame(&state.frame_buffer) {
+                        Ok(event) => event,
+                        Err(err) => return Some(Err(err)),
+                    }) else {
+                        state.frame_buffer.clear();
+                        continue;
+                    };
+                    state.frame_buffer.clear();
+                    state.recorder.mark_event();
+                    match handle_chat_stream_event(
+                        &event.data,
+                        &mut state.recorder,
+                        &mut state.answer,
+                        &mut state.final_message,
+                        &mut state.usage,
+                    ) {
+                        Ok(events) => state.pending_events.extend(events),
+                        Err(err) => return Some(Err(err)),
+                    }
+                }
+                if state.answer.trim().is_empty()
+                    && state.allow_completed_message_fallback
+                    && !state.final_message.trim().is_empty()
+                {
+                    // 仅在没有真实 delta 时回补 completed message，避免把两套正文拼接。
+                    state.answer = state.final_message.clone();
+                    state.recorder.mark_token();
+                    return Some(Ok(LlmStreamEvent::TextDelta(state.final_message.clone())));
+                }
+                state.finished = true;
+                return Some(Ok(LlmStreamEvent::Completed {
+                    usage: state.usage.clone(),
+                    finish_reason: None,
+                    fallback_used: false,
+                }));
+            }
+            Err(err) => {
+                return Some(Err(LlmError::http(format!(
+                    "Chat Completions stream failed: {err}"
+                ))));
+            }
+        }
+    }
 }
 
 fn extract_chat_completion_text(body: &Value) -> Option<String> {

--- a/qq-maid-llm/src/provider/openai/fallback.rs
+++ b/qq-maid-llm/src/provider/openai/fallback.rs
@@ -15,8 +15,10 @@ pub(crate) fn should_retry_non_stream_after_stream_error(err: &LlmError) -> bool
     matches!(
         err.code.as_str(),
         "provider_error" | "http_error" | "timeout"
-    ) && matches!(err.stage.as_str(), "provider" | "stream" | "http")
-        && err.stage != "stream_after_delta"
+    ) && matches!(
+        err.stage.as_str(),
+        "provider" | "stream" | "http" | "sse" | "stream_after_delta"
+    )
 }
 
 /// 当 Responses 主链路失败时，是否允许降级到 Chat Completions。
@@ -24,7 +26,7 @@ pub(crate) fn should_fallback_to_chat_after_responses_error(err: &LlmError) -> b
     matches!(
         err.code.as_str(),
         "provider_error" | "http_error" | "timeout"
-    )
+    ) && err.stage != "stream_after_delta"
 }
 
 #[cfg(test)]

--- a/qq-maid-llm/src/provider/openai/fallback.rs
+++ b/qq-maid-llm/src/provider/openai/fallback.rs
@@ -16,6 +16,7 @@ pub(crate) fn should_retry_non_stream_after_stream_error(err: &LlmError) -> bool
         err.code.as_str(),
         "provider_error" | "http_error" | "timeout"
     ) && matches!(err.stage.as_str(), "provider" | "stream" | "http")
+        && err.stage != "stream_after_delta"
 }
 
 /// 当 Responses 主链路失败时，是否允许降级到 Chat Completions。

--- a/qq-maid-llm/src/provider/openai/mod.rs
+++ b/qq-maid-llm/src/provider/openai/mod.rs
@@ -19,12 +19,14 @@ use crate::{
     config::{LlmConfig, OpenAiApiMode},
     error::LlmError,
     provider::{
-        ChatOutcome, LlmProvider,
+        ChatOutcome, LlmProvider, LlmStream, collect_llm_stream,
         types::{ChatMessage, ChatRequest, ModelProvider, ModelRoute},
     },
 };
 
-pub(crate) use chat::{ChatCompletionsClient, chat_completions_with_stream_fallback};
+pub(crate) use chat::{
+    ChatCompletionsClient, chat_completions_stream, chat_completions_with_stream_fallback,
+};
 
 struct OpenAiChatFallbackRequest<'a> {
     api_mode: OpenAiApiMode,
@@ -95,9 +97,42 @@ impl LlmProvider for OpenAiProvider {
     /// 执行聊天补全，根据配置选择 Responses 或 Chat Completions。`model` 支持 `"openai:"` 前缀。
     async fn chat(&self, req: ChatRequest) -> Result<ChatOutcome, LlmError> {
         let effective_model = effective_openai_model(req.model.as_deref(), &self.model)?;
+        if self.stream {
+            let stream = openai_stream_with_chat_fallback(OpenAiChatFallbackRequest {
+                api_mode: self.api_mode,
+                stream: true,
+                responses_client: &self.responses_client,
+                chat_client: &self.chat_client,
+                api_key: &self.api_key,
+                base_url: self.base_url.as_deref(),
+                provider: self.name(),
+                model: &effective_model,
+                max_output_tokens: self.max_output_tokens,
+                messages: &req.messages,
+            })
+            .await?;
+            return collect_llm_stream(stream, self.name(), &effective_model).await;
+        }
         openai_chat_with_chat_fallback(OpenAiChatFallbackRequest {
             api_mode: self.api_mode,
             stream: self.stream,
+            responses_client: &self.responses_client,
+            chat_client: &self.chat_client,
+            api_key: &self.api_key,
+            base_url: self.base_url.as_deref(),
+            provider: self.name(),
+            model: &effective_model,
+            max_output_tokens: self.max_output_tokens,
+            messages: &req.messages,
+        })
+        .await
+    }
+
+    async fn stream_chat(&self, req: ChatRequest) -> Result<LlmStream, LlmError> {
+        let effective_model = effective_openai_model(req.model.as_deref(), &self.model)?;
+        openai_stream_with_chat_fallback(OpenAiChatFallbackRequest {
+            api_mode: self.api_mode,
+            stream: true,
             responses_client: &self.responses_client,
             chat_client: &self.chat_client,
             api_key: &self.api_key,
@@ -123,6 +158,25 @@ impl LlmProvider for OpenAiProvider {
     }
 }
 
+async fn openai_stream_with_chat_fallback(
+    req: OpenAiChatFallbackRequest<'_>,
+) -> Result<LlmStream, LlmError> {
+    match req.api_mode {
+        OpenAiApiMode::Auto => openai_auto_stream_with_chat_fallback(req).await,
+        OpenAiApiMode::ChatOnly => {
+            chat::chat_completions_stream(
+                req.chat_client,
+                req.provider,
+                req.model,
+                req.max_output_tokens,
+                req.messages,
+                true,
+            )
+            .await
+        }
+    }
+}
+
 async fn openai_chat_with_chat_fallback(
     req: OpenAiChatFallbackRequest<'_>,
 ) -> Result<ChatOutcome, LlmError> {
@@ -142,6 +196,45 @@ async fn openai_chat_with_chat_fallback(
     }
 }
 
+async fn openai_auto_stream_with_chat_fallback(
+    req: OpenAiChatFallbackRequest<'_>,
+) -> Result<LlmStream, LlmError> {
+    match responses::openai_responses_chat_stream(responses::OpenAiResponsesChatRequest {
+        stream: true,
+        client: req.responses_client,
+        api_key: req.api_key,
+        base_url: req.base_url,
+        provider: req.provider,
+        model: req.model,
+        max_output_tokens: req.max_output_tokens,
+        messages: req.messages,
+        allow_completed_response_fallback: true,
+    })
+    .await
+    {
+        Ok(stream) => Ok(stream),
+        Err(err) if fallback::should_fallback_to_chat_after_responses_error(&err) => {
+            tracing::warn!(
+                provider = req.provider,
+                model = %req.model,
+                error_code = err.code.as_str(),
+                error_stage = err.stage.as_str(),
+                "OpenAI Responses stream init failed; falling back to Chat Completions stream"
+            );
+            chat::chat_completions_stream(
+                req.chat_client,
+                req.provider,
+                req.model,
+                req.max_output_tokens,
+                req.messages,
+                true,
+            )
+            .await
+        }
+        Err(err) => Err(err),
+    }
+}
+
 async fn openai_auto_chat_with_chat_fallback(
     req: OpenAiChatFallbackRequest<'_>,
 ) -> Result<ChatOutcome, LlmError> {
@@ -155,6 +248,7 @@ async fn openai_auto_chat_with_chat_fallback(
             model: req.model,
             max_output_tokens: req.max_output_tokens,
             messages: req.messages,
+            allow_completed_response_fallback: true,
         },
     )
     .await

--- a/qq-maid-llm/src/provider/openai/mod.rs
+++ b/qq-maid-llm/src/provider/openai/mod.rs
@@ -14,12 +14,13 @@ mod transport;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use futures::{StreamExt, stream as futures_stream};
 
 use crate::{
     config::{LlmConfig, OpenAiApiMode},
     error::LlmError,
     provider::{
-        ChatOutcome, LlmProvider, LlmStream, collect_llm_stream,
+        ChatOutcome, LlmProvider, LlmStream, LlmStreamEvent, outcome_to_stream,
         types::{ChatMessage, ChatRequest, ModelProvider, ModelRoute},
     },
 };
@@ -97,22 +98,6 @@ impl LlmProvider for OpenAiProvider {
     /// 执行聊天补全，根据配置选择 Responses 或 Chat Completions。`model` 支持 `"openai:"` 前缀。
     async fn chat(&self, req: ChatRequest) -> Result<ChatOutcome, LlmError> {
         let effective_model = effective_openai_model(req.model.as_deref(), &self.model)?;
-        if self.stream {
-            let stream = openai_stream_with_chat_fallback(OpenAiChatFallbackRequest {
-                api_mode: self.api_mode,
-                stream: true,
-                responses_client: &self.responses_client,
-                chat_client: &self.chat_client,
-                api_key: &self.api_key,
-                base_url: self.base_url.as_deref(),
-                provider: self.name(),
-                model: &effective_model,
-                max_output_tokens: self.max_output_tokens,
-                messages: &req.messages,
-            })
-            .await?;
-            return collect_llm_stream(stream, self.name(), &effective_model).await;
-        }
         openai_chat_with_chat_fallback(OpenAiChatFallbackRequest {
             api_mode: self.api_mode,
             stream: self.stream,
@@ -130,9 +115,25 @@ impl LlmProvider for OpenAiProvider {
 
     async fn stream_chat(&self, req: ChatRequest) -> Result<LlmStream, LlmError> {
         let effective_model = effective_openai_model(req.model.as_deref(), &self.model)?;
+        if !self.stream {
+            let outcome = openai_chat_with_chat_fallback(OpenAiChatFallbackRequest {
+                api_mode: self.api_mode,
+                stream: false,
+                responses_client: &self.responses_client,
+                chat_client: &self.chat_client,
+                api_key: &self.api_key,
+                base_url: self.base_url.as_deref(),
+                provider: self.name(),
+                model: &effective_model,
+                max_output_tokens: self.max_output_tokens,
+                messages: &req.messages,
+            })
+            .await?;
+            return Ok(outcome_to_stream(outcome));
+        }
         openai_stream_with_chat_fallback(OpenAiChatFallbackRequest {
             api_mode: self.api_mode,
-            stream: true,
+            stream: self.stream,
             responses_client: &self.responses_client,
             chat_client: &self.chat_client,
             api_key: &self.api_key,
@@ -161,6 +162,10 @@ impl LlmProvider for OpenAiProvider {
 async fn openai_stream_with_chat_fallback(
     req: OpenAiChatFallbackRequest<'_>,
 ) -> Result<LlmStream, LlmError> {
+    if !req.stream {
+        let outcome = openai_chat_with_chat_fallback(req).await?;
+        return Ok(outcome_to_stream(outcome));
+    }
     match req.api_mode {
         OpenAiApiMode::Auto => openai_auto_stream_with_chat_fallback(req).await,
         OpenAiApiMode::ChatOnly => {
@@ -212,7 +217,7 @@ async fn openai_auto_stream_with_chat_fallback(
     })
     .await
     {
-        Ok(stream) => Ok(stream),
+        Ok(stream) => Ok(openai_responses_runtime_fallback_stream(stream, req)),
         Err(err) if fallback::should_fallback_to_chat_after_responses_error(&err) => {
             tracing::warn!(
                 provider = req.provider,
@@ -232,6 +237,154 @@ async fn openai_auto_stream_with_chat_fallback(
             .await
         }
         Err(err) => Err(err),
+    }
+}
+
+fn openai_responses_runtime_fallback_stream(
+    responses_stream: LlmStream,
+    req: OpenAiChatFallbackRequest<'_>,
+) -> LlmStream {
+    Box::pin(futures_stream::unfold(
+        OpenAiRuntimeFallbackStreamState {
+            responses_stream: Some(responses_stream),
+            chat_stream: None,
+            chat_client: req.chat_client.clone(),
+            provider: req.provider.to_owned(),
+            model: req.model.to_owned(),
+            max_output_tokens: req.max_output_tokens,
+            messages: req.messages.to_vec(),
+            emitted_non_empty_delta: false,
+            fallback_used: false,
+            done: false,
+        },
+        |mut state| async move {
+            let event = next_openai_runtime_fallback_event(&mut state).await;
+            event.map(|event| (event, state))
+        },
+    ))
+}
+
+struct OpenAiRuntimeFallbackStreamState {
+    responses_stream: Option<LlmStream>,
+    chat_stream: Option<LlmStream>,
+    chat_client: ChatCompletionsClient,
+    provider: String,
+    model: String,
+    max_output_tokens: u64,
+    messages: Vec<ChatMessage>,
+    emitted_non_empty_delta: bool,
+    fallback_used: bool,
+    done: bool,
+}
+
+async fn next_openai_runtime_fallback_event(
+    state: &mut OpenAiRuntimeFallbackStreamState,
+) -> Option<Result<LlmStreamEvent, LlmError>> {
+    loop {
+        if state.done {
+            return None;
+        }
+        if let Some(stream) = state.responses_stream.as_mut() {
+            match stream.next().await {
+                Some(Ok(LlmStreamEvent::TextDelta(delta))) => {
+                    if !delta.is_empty() {
+                        state.emitted_non_empty_delta = true;
+                    }
+                    return Some(Ok(LlmStreamEvent::TextDelta(delta)));
+                }
+                Some(Ok(LlmStreamEvent::Completed {
+                    usage,
+                    finish_reason,
+                    fallback_used,
+                })) => {
+                    state.done = true;
+                    return Some(Ok(LlmStreamEvent::Completed {
+                        usage,
+                        finish_reason,
+                        fallback_used: fallback_used || state.fallback_used,
+                    }));
+                }
+                Some(Err(err)) => {
+                    if state.emitted_non_empty_delta
+                        || !fallback::should_fallback_to_chat_after_responses_error(&err)
+                    {
+                        state.done = true;
+                        return Some(Err(err));
+                    }
+                    tracing::warn!(
+                        provider = state.provider.as_str(),
+                        model = %state.model,
+                        error_code = err.code.as_str(),
+                        error_stage = err.stage.as_str(),
+                        "OpenAI Responses stream failed before first delta; falling back to Chat Completions stream"
+                    );
+                    state.responses_stream = None;
+                    match chat::chat_completions_stream(
+                        &state.chat_client,
+                        &state.provider,
+                        &state.model,
+                        state.max_output_tokens,
+                        &state.messages,
+                        true,
+                    )
+                    .await
+                    {
+                        Ok(stream) => {
+                            state.chat_stream = Some(stream);
+                            state.fallback_used = true;
+                        }
+                        Err(err) => {
+                            state.done = true;
+                            return Some(Err(err));
+                        }
+                    }
+                    continue;
+                }
+                None => {
+                    state.done = true;
+                    return Some(Err(LlmError::provider(
+                        "OpenAI Responses stream ended without completion event",
+                        "stream",
+                    )));
+                }
+            }
+        }
+
+        let Some(stream) = state.chat_stream.as_mut() else {
+            state.done = true;
+            return None;
+        };
+        match stream.next().await {
+            Some(Ok(LlmStreamEvent::TextDelta(delta))) => {
+                if !delta.is_empty() {
+                    state.emitted_non_empty_delta = true;
+                }
+                return Some(Ok(LlmStreamEvent::TextDelta(delta)));
+            }
+            Some(Ok(LlmStreamEvent::Completed {
+                usage,
+                finish_reason,
+                fallback_used,
+            })) => {
+                state.done = true;
+                return Some(Ok(LlmStreamEvent::Completed {
+                    usage,
+                    finish_reason,
+                    fallback_used: fallback_used || state.fallback_used,
+                }));
+            }
+            Some(Err(err)) => {
+                state.done = true;
+                return Some(Err(err));
+            }
+            None => {
+                state.done = true;
+                return Some(Err(LlmError::provider(
+                    "Chat Completions fallback stream ended without completion event",
+                    "stream",
+                )));
+            }
+        }
     }
 }
 
@@ -315,7 +468,11 @@ fn effective_openai_model(
 mod tests {
     use super::*;
     use axum::{
-        Json, Router, extract::State, http::StatusCode as AxumStatusCode, response::IntoResponse,
+        Json, Router,
+        body::Body,
+        extract::State,
+        http::{StatusCode as AxumStatusCode, header},
+        response::IntoResponse,
         routing::post,
     };
     use serde_json::Value;
@@ -356,6 +513,62 @@ mod tests {
         let app = Router::new()
             .route("/v1/responses", post(mock_responses_handler))
             .route("/v1/chat/completions", post(mock_chat_completions_handler))
+            .with_state(state.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{addr}/v1"), state)
+    }
+
+    #[derive(Debug)]
+    struct MockOpenAiStreamState {
+        responses_body: String,
+        chat_body: String,
+        responses_calls: usize,
+        chat_calls: usize,
+    }
+
+    async fn mock_stream_responses_handler(
+        State(state): State<Arc<Mutex<MockOpenAiStreamState>>>,
+        _body: Body,
+    ) -> impl IntoResponse {
+        let mut state = state.lock().await;
+        state.responses_calls += 1;
+        (
+            AxumStatusCode::OK,
+            [(header::CONTENT_TYPE, "text/event-stream")],
+            state.responses_body.clone(),
+        )
+    }
+
+    async fn mock_stream_chat_handler(
+        State(state): State<Arc<Mutex<MockOpenAiStreamState>>>,
+        _body: Body,
+    ) -> impl IntoResponse {
+        let mut state = state.lock().await;
+        state.chat_calls += 1;
+        (
+            AxumStatusCode::OK,
+            [(header::CONTENT_TYPE, "text/event-stream")],
+            state.chat_body.clone(),
+        )
+    }
+
+    async fn spawn_mock_openai_stream(
+        responses_body: String,
+        chat_body: String,
+    ) -> (String, Arc<Mutex<MockOpenAiStreamState>>) {
+        let state = Arc::new(Mutex::new(MockOpenAiStreamState {
+            responses_body,
+            chat_body,
+            responses_calls: 0,
+            chat_calls: 0,
+        }));
+        let app = Router::new()
+            .route("/v1/responses", post(mock_stream_responses_handler))
+            .route("/v1/chat/completions", post(mock_stream_chat_handler))
             .with_state(state.clone());
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -501,6 +714,90 @@ mod tests {
         let state = state.lock().await;
         assert_eq!(state.responses_calls, 0);
         assert_eq!(state.chat_calls, 1);
+    }
+
+    #[tokio::test]
+    async fn openai_responses_stream_falls_back_before_first_delta() {
+        let (base_url, state) = spawn_mock_openai_stream(
+            "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"error\":{\"message\":\"responses unavailable\"}}}\n\n"
+                .to_owned(),
+            concat!(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"chat fallback\"}}]}\n\n",
+                "data: [DONE]\n\n",
+            )
+            .to_owned(),
+        )
+        .await;
+        let http_client = reqwest::Client::new();
+        let chat_client =
+            ChatCompletionsClient::new("test-key", Some(&base_url), http_client.clone());
+
+        let stream = openai_auto_stream_with_chat_fallback(OpenAiChatFallbackRequest {
+            api_mode: OpenAiApiMode::Auto,
+            stream: true,
+            responses_client: &http_client,
+            chat_client: &chat_client,
+            api_key: "test-key",
+            base_url: Some(&base_url),
+            provider: "openai",
+            model: "gpt-5.5",
+            max_output_tokens: 1200,
+            messages: &[ChatMessage::user("hi")],
+        })
+        .await
+        .unwrap();
+        let outcome = crate::provider::collect_llm_stream(stream, "openai", "gpt-5.5")
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.reply, "chat fallback");
+        assert!(outcome.fallback_used);
+        let state = state.lock().await;
+        assert_eq!(state.responses_calls, 1);
+        assert_eq!(state.chat_calls, 1);
+    }
+
+    #[tokio::test]
+    async fn openai_responses_stream_does_not_fallback_after_delta() {
+        let (base_url, state) = spawn_mock_openai_stream(
+            concat!(
+                "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n",
+                "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"error\":{\"message\":\"broken\"}}}\n\n",
+            )
+            .to_owned(),
+            concat!(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"must not append\"}}]}\n\n",
+                "data: [DONE]\n\n",
+            )
+            .to_owned(),
+        )
+        .await;
+        let http_client = reqwest::Client::new();
+        let chat_client =
+            ChatCompletionsClient::new("test-key", Some(&base_url), http_client.clone());
+
+        let stream = openai_auto_stream_with_chat_fallback(OpenAiChatFallbackRequest {
+            api_mode: OpenAiApiMode::Auto,
+            stream: true,
+            responses_client: &http_client,
+            chat_client: &chat_client,
+            api_key: "test-key",
+            base_url: Some(&base_url),
+            provider: "openai",
+            model: "gpt-5.5",
+            max_output_tokens: 1200,
+            messages: &[ChatMessage::user("hi")],
+        })
+        .await
+        .unwrap();
+        let err = crate::provider::collect_llm_stream(stream, "openai", "gpt-5.5")
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.stage, "sse");
+        let state = state.lock().await;
+        assert_eq!(state.responses_calls, 1);
+        assert_eq!(state.chat_calls, 0);
     }
 
     #[test]

--- a/qq-maid-llm/src/provider/openai/responses.rs
+++ b/qq-maid-llm/src/provider/openai/responses.rs
@@ -3,12 +3,13 @@
 //! 这里仅负责 Responses API 的流式/非流式聊天执行，以及在需要时回退到同 provider
 //! 的非流式请求；不直接接触 Chat Completions，以保证 Responses 与 fallback provider 解耦。
 
+use futures::stream;
 use serde_json::Value;
 
 use crate::{
     error::LlmError,
     metrics::MetricsRecorder,
-    provider::{ChatOutcome, types::ChatMessage},
+    provider::{ChatOutcome, LlmStream, LlmStreamEvent, collect_llm_stream, types::ChatMessage},
     sse::{parse_sse_frame, take_sse_frame},
 };
 
@@ -34,6 +35,7 @@ pub(crate) struct OpenAiResponsesChatRequest<'a> {
     pub(crate) model: &'a str,
     pub(crate) max_output_tokens: u64,
     pub(crate) messages: &'a [ChatMessage],
+    pub(crate) allow_completed_response_fallback: bool,
 }
 
 /// 执行 OpenAI Responses API 聊天补全，并在流式异常时补一次非流式请求。
@@ -131,67 +133,143 @@ pub(crate) async fn openai_responses_stream_chat(
     max_output_tokens: u64,
     messages: &[ChatMessage],
 ) -> Result<ChatOutcome, LlmError> {
-    let mut recorder = MetricsRecorder::start();
-    let payload = openai_responses_payload(messages, model, max_output_tokens, true)?;
-    let mut response =
-        send_openai_responses_request(client, api_key, base_url, &payload, true).await?;
+    let stream = openai_responses_chat_stream(OpenAiResponsesChatRequest {
+        stream: true,
+        client,
+        api_key,
+        base_url,
+        provider,
+        model,
+        max_output_tokens,
+        messages,
+        allow_completed_response_fallback: true,
+    })
+    .await?;
+    collect_llm_stream(stream, provider, model).await
+}
 
-    let mut frame_buffer = Vec::new();
-    let mut answer = String::new();
-    let mut completed_response: Option<Value> = None;
-    while let Some(chunk) = response
-        .chunk()
-        .await
-        .map_err(|err| LlmError::http(format!("OpenAI chat stream failed: {err}")))?
-    {
-        frame_buffer.extend_from_slice(&chunk);
-        while let Some(frame) = take_sse_frame(&mut frame_buffer) {
-            let Some(event) = parse_sse_frame(&frame)? else {
+pub(crate) async fn openai_responses_chat_stream(
+    req: OpenAiResponsesChatRequest<'_>,
+) -> Result<LlmStream, LlmError> {
+    let recorder = MetricsRecorder::start();
+    let payload = openai_responses_payload(req.messages, req.model, req.max_output_tokens, true)?;
+    let response =
+        send_openai_responses_request(req.client, req.api_key, req.base_url, &payload, true)
+            .await?;
+
+    let frame_buffer = Vec::new();
+    let answer = String::new();
+    let completed_response: Option<Value> = None;
+    Ok(Box::pin(stream::unfold(
+        ResponsesStreamState {
+            response,
+            frame_buffer,
+            recorder,
+            answer,
+            completed_response,
+            allow_completed_response_fallback: req.allow_completed_response_fallback,
+            finished: false,
+        },
+        |mut state| async move {
+            let event = next_responses_stream_event(&mut state).await;
+            event.map(|event| (event, state))
+        },
+    )))
+}
+
+struct ResponsesStreamState {
+    response: reqwest::Response,
+    frame_buffer: Vec<u8>,
+    recorder: MetricsRecorder,
+    answer: String,
+    completed_response: Option<Value>,
+    allow_completed_response_fallback: bool,
+    finished: bool,
+}
+
+async fn next_responses_stream_event(
+    state: &mut ResponsesStreamState,
+) -> Option<Result<LlmStreamEvent, LlmError>> {
+    loop {
+        if let Some(frame) = take_sse_frame(&mut state.frame_buffer) {
+            let Some(event) = (match parse_sse_frame(&frame) {
+                Ok(event) => event,
+                Err(err) => return Some(Err(err)),
+            }) else {
                 continue;
             };
-            recorder.mark_event();
-            handle_openai_chat_stream_event(
+            state.recorder.mark_event();
+            match handle_openai_chat_stream_event(
                 event,
-                &mut recorder,
-                &mut answer,
-                &mut completed_response,
-            )?;
+                &mut state.recorder,
+                &mut state.answer,
+                &mut state.completed_response,
+            ) {
+                Ok(Some(delta)) => return Some(Ok(LlmStreamEvent::TextDelta(delta))),
+                Ok(None) => continue,
+                Err(err) => return Some(Err(err)),
+            }
+        }
+
+        if state.finished {
+            return None;
+        }
+
+        match state.response.chunk().await {
+            Ok(Some(chunk)) => {
+                state.frame_buffer.extend_from_slice(&chunk);
+            }
+            Ok(None) => {
+                if !state.frame_buffer.is_empty() {
+                    let Some(event) = (match parse_sse_frame(&state.frame_buffer) {
+                        Ok(event) => event,
+                        Err(err) => return Some(Err(err)),
+                    }) else {
+                        state.frame_buffer.clear();
+                        continue;
+                    };
+                    state.frame_buffer.clear();
+                    state.recorder.mark_event();
+                    match handle_openai_chat_stream_event(
+                        event,
+                        &mut state.recorder,
+                        &mut state.answer,
+                        &mut state.completed_response,
+                    ) {
+                        Ok(Some(delta)) => return Some(Ok(LlmStreamEvent::TextDelta(delta))),
+                        Ok(None) => {}
+                        Err(err) => return Some(Err(err)),
+                    }
+                }
+                if state.answer.trim().is_empty()
+                    && state.allow_completed_response_fallback
+                    && let Some(response) = state.completed_response.as_ref()
+                    && let Some(answer) = extract_response_output_text(response)
+                    && !answer.trim().is_empty()
+                {
+                    // 只在没有真实 delta 时从 completed response 回补，保证最终正文来源单一。
+                    state.answer = answer.clone();
+                    state.recorder.mark_token();
+                    return Some(Ok(LlmStreamEvent::TextDelta(answer)));
+                }
+                let usage = state
+                    .completed_response
+                    .as_ref()
+                    .and_then(extract_response_usage);
+                state.finished = true;
+                return Some(Ok(LlmStreamEvent::Completed {
+                    usage,
+                    finish_reason: None,
+                    fallback_used: false,
+                }));
+            }
+            Err(err) => {
+                return Some(Err(LlmError::http(format!(
+                    "OpenAI chat stream failed: {err}"
+                ))));
+            }
         }
     }
-    if !frame_buffer.is_empty()
-        && let Some(event) = parse_sse_frame(&frame_buffer)?
-    {
-        recorder.mark_event();
-        handle_openai_chat_stream_event(
-            event,
-            &mut recorder,
-            &mut answer,
-            &mut completed_response,
-        )?;
-    }
-
-    // 某些兼容层不会把完整正文持续写成 delta，而是只在 completed 事件中附带最终响应。
-    if answer.trim().is_empty()
-        && let Some(response) = completed_response.as_ref()
-    {
-        answer = extract_response_output_text(response).unwrap_or_default();
-    }
-    let reply = answer.trim().to_owned();
-    if reply.is_empty() {
-        return Err(LlmError::provider(
-            "OpenAI chat returned empty text output",
-            "provider",
-        ));
-    }
-    let usage = completed_response.as_ref().and_then(extract_response_usage);
-    let metrics = recorder.finish(provider, model, true);
-
-    Ok(ChatOutcome {
-        reply,
-        metrics,
-        usage,
-        fallback_used: false,
-    })
 }
 
 #[cfg(test)]

--- a/qq-maid-llm/src/provider/openai/responses.rs
+++ b/qq-maid-llm/src/provider/openai/responses.rs
@@ -160,6 +160,7 @@ pub(crate) async fn openai_responses_chat_stream(
     let frame_buffer = Vec::new();
     let answer = String::new();
     let completed_response: Option<Value> = None;
+    let saw_completed = false;
     Ok(Box::pin(stream::unfold(
         ResponsesStreamState {
             response,
@@ -167,6 +168,7 @@ pub(crate) async fn openai_responses_chat_stream(
             recorder,
             answer,
             completed_response,
+            saw_completed,
             allow_completed_response_fallback: req.allow_completed_response_fallback,
             finished: false,
         },
@@ -183,6 +185,7 @@ struct ResponsesStreamState {
     recorder: MetricsRecorder,
     answer: String,
     completed_response: Option<Value>,
+    saw_completed: bool,
     allow_completed_response_fallback: bool,
     finished: bool,
 }
@@ -204,6 +207,7 @@ async fn next_responses_stream_event(
                 &mut state.recorder,
                 &mut state.answer,
                 &mut state.completed_response,
+                &mut state.saw_completed,
             ) {
                 Ok(Some(delta)) => return Some(Ok(LlmStreamEvent::TextDelta(delta))),
                 Ok(None) => continue,
@@ -235,6 +239,7 @@ async fn next_responses_stream_event(
                         &mut state.recorder,
                         &mut state.answer,
                         &mut state.completed_response,
+                        &mut state.saw_completed,
                     ) {
                         Ok(Some(delta)) => return Some(Ok(LlmStreamEvent::TextDelta(delta))),
                         Ok(None) => {}
@@ -252,6 +257,13 @@ async fn next_responses_stream_event(
                     state.recorder.mark_token();
                     return Some(Ok(LlmStreamEvent::TextDelta(answer)));
                 }
+                if !state.saw_completed {
+                    state.finished = true;
+                    return Some(Err(incomplete_stream_eof_error(
+                        "OpenAI Responses chat stream ended before response.completed",
+                        &state.answer,
+                    )));
+                }
                 let usage = state
                     .completed_response
                     .as_ref()
@@ -264,12 +276,31 @@ async fn next_responses_stream_event(
                 }));
             }
             Err(err) => {
-                return Some(Err(LlmError::http(format!(
-                    "OpenAI chat stream failed: {err}"
-                ))));
+                return Some(Err(stream_transport_error(
+                    format!("OpenAI chat stream failed: {err}"),
+                    &state.answer,
+                )));
             }
         }
     }
+}
+
+pub(crate) fn incomplete_stream_eof_error(message: &str, answer: &str) -> LlmError {
+    let stage = if answer.trim().is_empty() {
+        "stream"
+    } else {
+        "stream_after_delta"
+    };
+    LlmError::provider(message, stage)
+}
+
+pub(crate) fn stream_transport_error(message: String, answer: &str) -> LlmError {
+    let stage = if answer.trim().is_empty() {
+        "http"
+    } else {
+        "stream_after_delta"
+    };
+    LlmError::new("http_error", message, stage)
 }
 
 #[cfg(test)]
@@ -350,5 +381,60 @@ mod tests {
         assert_eq!(outcome.reply, "stream fallback");
         let state = state.lock().await;
         assert_eq!(state.calls, 1);
+    }
+
+    #[tokio::test]
+    async fn openai_responses_stream_requires_completed_after_delta() {
+        let (base_url, _state) = spawn_mock_responses(
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"半截\"}\n\n"
+                .to_owned(),
+            StatusCode::OK,
+        )
+        .await;
+        let client = reqwest::Client::new();
+
+        let err = openai_responses_stream_chat(
+            &client,
+            "test-key",
+            Some(&base_url),
+            "openai",
+            "gpt-5.5",
+            1200,
+            &[crate::provider::types::ChatMessage::user("hi")],
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.stage, "stream_after_delta");
+        assert!(err.message.contains("response.completed"));
+    }
+
+    #[tokio::test]
+    async fn openai_responses_stream_accepts_delta_then_completed() {
+        let (base_url, _state) = spawn_mock_responses(
+            concat!(
+                "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"你\"}\n\n",
+                "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"好\"}\n\n",
+                "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"output_text\":\"你好\"}}\n\n",
+            )
+            .to_owned(),
+            StatusCode::OK,
+        )
+        .await;
+        let client = reqwest::Client::new();
+
+        let outcome = openai_responses_stream_chat(
+            &client,
+            "test-key",
+            Some(&base_url),
+            "openai",
+            "gpt-5.5",
+            1200,
+            &[crate::provider::types::ChatMessage::user("hi")],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.reply, "你好");
     }
 }

--- a/qq-maid-llm/src/provider/openai/stream.rs
+++ b/qq-maid-llm/src/provider/openai/stream.rs
@@ -16,7 +16,7 @@ pub(crate) fn handle_openai_chat_stream_event(
     recorder: &mut MetricsRecorder,
     answer: &mut String,
     completed_response: &mut Option<Value>,
-) -> Result<(), LlmError> {
+) -> Result<Option<String>, LlmError> {
     let value = serde_json::from_str::<Value>(&event.data).map_err(|err| {
         LlmError::provider(format!("invalid OpenAI chat stream JSON: {err}"), "sse")
     })?;
@@ -33,6 +33,7 @@ pub(crate) fn handle_openai_chat_stream_event(
             {
                 recorder.mark_token();
                 answer.push_str(delta);
+                return Ok(Some(delta.to_owned()));
             }
         }
         "response.completed" => {
@@ -46,7 +47,7 @@ pub(crate) fn handle_openai_chat_stream_event(
         _ => {}
     }
 
-    Ok(())
+    Ok(None)
 }
 
 fn stream_error_message(value: &Value) -> Option<String> {

--- a/qq-maid-llm/src/provider/openai/stream.rs
+++ b/qq-maid-llm/src/provider/openai/stream.rs
@@ -16,6 +16,7 @@ pub(crate) fn handle_openai_chat_stream_event(
     recorder: &mut MetricsRecorder,
     answer: &mut String,
     completed_response: &mut Option<Value>,
+    saw_completed: &mut bool,
 ) -> Result<Option<String>, LlmError> {
     let value = serde_json::from_str::<Value>(&event.data).map_err(|err| {
         LlmError::provider(format!("invalid OpenAI chat stream JSON: {err}"), "sse")
@@ -37,6 +38,7 @@ pub(crate) fn handle_openai_chat_stream_event(
             }
         }
         "response.completed" => {
+            *saw_completed = true;
             *completed_response = extract_completed_response(&value);
         }
         "response.failed" | "response.incomplete" | "error" => {
@@ -99,6 +101,7 @@ mod tests {
         let mut recorder = MetricsRecorder::start();
         let mut answer = String::new();
         let mut completed_response = None;
+        let mut saw_completed = false;
 
         handle_openai_chat_stream_event(
             SseFrame {
@@ -108,6 +111,7 @@ mod tests {
             &mut recorder,
             &mut answer,
             &mut completed_response,
+            &mut saw_completed,
         )
         .unwrap();
         handle_openai_chat_stream_event(
@@ -119,10 +123,12 @@ mod tests {
             &mut recorder,
             &mut answer,
             &mut completed_response,
+            &mut saw_completed,
         )
         .unwrap();
 
         assert_eq!(answer, "你");
+        assert!(saw_completed);
         assert_eq!(
             completed_response.as_ref().and_then(|value| {
                 value

--- a/qq-maid-llm/src/provider/status.rs
+++ b/qq-maid-llm/src/provider/status.rs
@@ -11,6 +11,7 @@ use qq_maid_common::time_context::now_unix_seconds_marker;
 use serde::Serialize;
 
 use crate::error::LlmError;
+use crate::metrics::MetricsRecorder;
 
 use super::{
     ChatOutcome, DynLlmProvider, LlmProvider, LlmStream, LlmStreamEvent, types::ChatRequest,
@@ -194,6 +195,7 @@ impl LlmProvider for ObservedProvider {
                 reply: String::new(),
                 usage: None,
                 fallback_used: false,
+                recorder: MetricsRecorder::start(),
                 completed: false,
                 done: false,
             },
@@ -226,6 +228,7 @@ struct ObservedStreamState {
     reply: String,
     usage: Option<super::types::TokenUsage>,
     fallback_used: bool,
+    recorder: MetricsRecorder,
     completed: bool,
     done: bool,
 }
@@ -238,6 +241,10 @@ async fn next_observed_stream_event(
     }
     match state.inner.next().await {
         Some(Ok(LlmStreamEvent::TextDelta(delta))) => {
+            state.recorder.mark_event();
+            if !delta.is_empty() {
+                state.recorder.mark_token();
+            }
             state.reply.push_str(&delta);
             Some(Ok(LlmStreamEvent::TextDelta(delta)))
         }
@@ -249,16 +256,10 @@ async fn next_observed_stream_event(
             state.usage = usage.clone();
             state.fallback_used |= fallback_used;
             state.completed = true;
+            let recorder = std::mem::replace(&mut state.recorder, MetricsRecorder::start());
             let outcome = ChatOutcome {
                 reply: state.reply.clone(),
-                metrics: crate::metrics::LlmMetrics {
-                    provider: state.provider_name.clone(),
-                    model: state.model.clone(),
-                    stream: true,
-                    ttfe_ms: None,
-                    ttft_ms: None,
-                    total_latency_ms: 0,
-                },
+                metrics: recorder.finish(&state.provider_name, &state.model, true),
                 usage: state.usage.clone(),
                 fallback_used: state.fallback_used,
             };

--- a/qq-maid-llm/src/provider/status.rs
+++ b/qq-maid-llm/src/provider/status.rs
@@ -6,12 +6,15 @@
 use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
+use futures::{StreamExt, stream};
 use qq_maid_common::time_context::now_unix_seconds_marker;
 use serde::Serialize;
 
 use crate::error::LlmError;
 
-use super::{ChatOutcome, DynLlmProvider, LlmProvider, types::ChatRequest};
+use super::{
+    ChatOutcome, DynLlmProvider, LlmProvider, LlmStream, LlmStreamEvent, types::ChatRequest,
+};
 
 /// 最近一次真实 provider 调用状态。
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -164,6 +167,43 @@ impl LlmProvider for ObservedProvider {
         result
     }
 
+    async fn stream_chat(&self, req: ChatRequest) -> Result<LlmStream, LlmError> {
+        // 自动标题等旁路任务不应覆盖主聊天健康状态；stream_chat 也保持同一约束。
+        if req.metadata.get("health_observation").map(String::as_str) == Some("ignore") {
+            return self.provider.stream_chat(req).await;
+        }
+        let provider_name = self.provider.name().to_owned();
+        let model = self.provider.model().to_owned();
+        let status = self.status.clone();
+        let attempt = status.begin_attempt();
+        let stream = match self.provider.stream_chat(req).await {
+            Ok(stream) => stream,
+            Err(err) => {
+                status.record_failure(&err);
+                attempt.complete();
+                return Err(err);
+            }
+        };
+        Ok(Box::pin(stream::unfold(
+            ObservedStreamState {
+                inner: stream,
+                status,
+                provider_name,
+                model,
+                attempt: Some(attempt),
+                reply: String::new(),
+                usage: None,
+                fallback_used: false,
+                completed: false,
+                done: false,
+            },
+            |mut state| async move {
+                let event = next_observed_stream_event(&mut state).await;
+                event.map(|event| (event, state))
+            },
+        )))
+    }
+
     fn name(&self) -> &'static str {
         self.provider.name()
     }
@@ -174,6 +214,86 @@ impl LlmProvider for ObservedProvider {
 
     fn stream_enabled(&self) -> bool {
         self.provider.stream_enabled()
+    }
+}
+
+struct ObservedStreamState {
+    inner: LlmStream,
+    status: UpstreamStatus,
+    provider_name: String,
+    model: String,
+    attempt: Option<UpstreamAttemptGuard>,
+    reply: String,
+    usage: Option<super::types::TokenUsage>,
+    fallback_used: bool,
+    completed: bool,
+    done: bool,
+}
+
+async fn next_observed_stream_event(
+    state: &mut ObservedStreamState,
+) -> Option<Result<LlmStreamEvent, LlmError>> {
+    if state.done {
+        return None;
+    }
+    match state.inner.next().await {
+        Some(Ok(LlmStreamEvent::TextDelta(delta))) => {
+            state.reply.push_str(&delta);
+            Some(Ok(LlmStreamEvent::TextDelta(delta)))
+        }
+        Some(Ok(LlmStreamEvent::Completed {
+            usage,
+            finish_reason,
+            fallback_used,
+        })) => {
+            state.usage = usage.clone();
+            state.fallback_used |= fallback_used;
+            state.completed = true;
+            let outcome = ChatOutcome {
+                reply: state.reply.clone(),
+                metrics: crate::metrics::LlmMetrics {
+                    provider: state.provider_name.clone(),
+                    model: state.model.clone(),
+                    stream: true,
+                    ttfe_ms: None,
+                    ttft_ms: None,
+                    total_latency_ms: 0,
+                },
+                usage: state.usage.clone(),
+                fallback_used: state.fallback_used,
+            };
+            state.status.record_success(&outcome);
+            if let Some(attempt) = state.attempt.take() {
+                attempt.complete();
+            }
+            state.done = true;
+            Some(Ok(LlmStreamEvent::Completed {
+                usage,
+                finish_reason,
+                fallback_used,
+            }))
+        }
+        Some(Err(err)) => {
+            state.status.record_failure(&err);
+            if let Some(attempt) = state.attempt.take() {
+                attempt.complete();
+            }
+            state.done = true;
+            Some(Err(err))
+        }
+        None => {
+            if !state.completed {
+                state.status.record_failure(&LlmError::provider(
+                    "LLM stream ended before completion",
+                    "stream",
+                ));
+            }
+            if let Some(attempt) = state.attempt.take() {
+                attempt.complete();
+            }
+            state.done = true;
+            None
+        }
     }
 }
 

--- a/qq-maid-llm/src/service.rs
+++ b/qq-maid-llm/src/service.rs
@@ -9,7 +9,7 @@ use crate::{
     config::LlmConfig,
     error::LlmError,
     provider::{
-        ChatOutcome, DynLlmProvider, build_provider,
+        ChatOutcome, DynLlmProvider, LlmStream, build_provider,
         status::{UpstreamStatus, observe_provider},
         types::ChatRequest,
     },
@@ -39,6 +39,10 @@ impl LlmService {
 
     pub async fn chat(&self, req: ChatRequest) -> Result<ChatOutcome, LlmError> {
         self.provider.chat(req).await
+    }
+
+    pub async fn stream_chat(&self, req: ChatRequest) -> Result<LlmStream, LlmError> {
+        self.provider.stream_chat(req).await
     }
 
     pub async fn web_search(&self, req: WebSearchRequest) -> Result<WebSearchOutcome, LlmError> {

--- a/qq-maid-llm/src/sse.rs
+++ b/qq-maid-llm/src/sse.rs
@@ -53,9 +53,6 @@ pub fn parse_sse_frame(frame: &[u8]) -> Result<Option<SseFrame>, LlmError> {
         return Ok(None);
     }
     let data = data_lines.join("\n");
-    if data.trim() == "[DONE]" {
-        return Ok(None);
-    }
     Ok(Some(SseFrame { event, data }))
 }
 
@@ -87,5 +84,12 @@ mod tests {
         assert_eq!(parsed.event.as_deref(), Some("done"));
         assert_eq!(parsed.data, "{\"ok\":true}");
         assert!(buffer.is_empty());
+    }
+
+    #[test]
+    fn keeps_done_frame_visible_to_stream_state_machine() {
+        let parsed = parse_sse_frame(b"data: [DONE]").unwrap().unwrap();
+
+        assert_eq!(parsed.data, "[DONE]");
     }
 }

--- a/qq-maid-llm/src/web_search.rs
+++ b/qq-maid-llm/src/web_search.rs
@@ -301,10 +301,11 @@ impl WebSearchExecutor for OpenAiWebSearchExecutor {
         let mut frame_buffer = Vec::new();
         let mut answer = String::new();
         let mut completed_response: Option<Value> = None;
+        let mut saw_completed = false;
         while let Some(chunk) = response
             .chunk()
             .await
-            .map_err(|err| LlmError::http(format!("OpenAI web query stream failed: {err}")))?
+            .map_err(|err| web_search_stream_transport_error(err, &answer))?
         {
             frame_buffer.extend_from_slice(&chunk);
             while let Some(frame) = take_sse_frame(&mut frame_buffer) {
@@ -315,6 +316,7 @@ impl WebSearchExecutor for OpenAiWebSearchExecutor {
                     event,
                     &mut answer,
                     &mut completed_response,
+                    &mut saw_completed,
                     &delta_tx,
                 )
                 .await?;
@@ -327,9 +329,14 @@ impl WebSearchExecutor for OpenAiWebSearchExecutor {
                 event,
                 &mut answer,
                 &mut completed_response,
+                &mut saw_completed,
                 &delta_tx,
             )
             .await?;
+        }
+
+        if !saw_completed {
+            return Err(web_search_incomplete_eof_error(&answer));
         }
 
         if answer.trim().is_empty()
@@ -470,6 +477,7 @@ async fn handle_openai_web_search_stream_event(
     event: SseFrame,
     answer: &mut String,
     completed_response: &mut Option<Value>,
+    saw_completed: &mut bool,
     delta_tx: &mpsc::Sender<String>,
 ) -> Result<(), LlmError> {
     let value = serde_json::from_str::<Value>(&event.data)
@@ -490,6 +498,7 @@ async fn handle_openai_web_search_stream_event(
             }
         }
         "response.completed" => {
+            *saw_completed = true;
             *completed_response = value
                 .get("response")
                 .cloned()
@@ -504,6 +513,31 @@ async fn handle_openai_web_search_stream_event(
     }
 
     Ok(())
+}
+
+fn web_search_incomplete_eof_error(answer: &str) -> LlmError {
+    let stage = if answer.trim().is_empty() {
+        "stream"
+    } else {
+        "stream_after_delta"
+    };
+    LlmError::provider(
+        "OpenAI web query stream ended before response.completed",
+        stage,
+    )
+}
+
+fn web_search_stream_transport_error(err: reqwest::Error, answer: &str) -> LlmError {
+    let stage = if answer.trim().is_empty() {
+        "http"
+    } else {
+        "stream_after_delta"
+    };
+    LlmError::new(
+        "http_error",
+        format!("OpenAI web query stream failed: {err}"),
+        stage,
+    )
 }
 
 fn stream_error_message(value: &Value) -> Option<String> {
@@ -835,6 +869,36 @@ mod tests {
         assert!(delta_rx.recv().await.is_none());
         assert_eq!(outcome.answer, "你好");
         assert_eq!(state.lock().await.requests[0]["stream"], true);
+    }
+
+    #[tokio::test]
+    async fn query_stream_rejects_partial_delta_without_completed() {
+        let body = "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"半截\"}\n\n"
+            .to_owned();
+        let (base_url, _state) = spawn_mock_search(body).await;
+        let executor = OpenAiWebSearchExecutor {
+            client: reqwest::Client::new(),
+            api_key: "test-key".to_owned(),
+            base_url: Some(base_url),
+            search_model: "gpt-search".to_owned(),
+        };
+        let (delta_tx, _delta_rx) = mpsc::channel(4);
+
+        let err = executor
+            .query_stream(
+                WebSearchRequest {
+                    query: "测试".to_owned(),
+                    raw_question: Some("/查 测试".to_owned()),
+                    max_results: None,
+                    context_size: None,
+                },
+                delta_tx,
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.stage, "stream_after_delta");
+        assert!(err.message.contains("response.completed"));
     }
 
     #[test]

--- a/qq-maid-llm/src/web_search.rs
+++ b/qq-maid-llm/src/web_search.rs
@@ -677,7 +677,17 @@ fn collect_sources(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::{
+        Router,
+        body::Body,
+        extract::State,
+        http::{StatusCode, header},
+        response::IntoResponse,
+        routing::post,
+    };
     use chrono::{FixedOffset, TimeZone};
+    use std::sync::Arc;
+    use tokio::{net::TcpListener, sync::Mutex};
 
     fn fixed_time_context() -> RequestTimeContext {
         let offset = FixedOffset::east_opt(8 * 60 * 60).unwrap();
@@ -751,6 +761,80 @@ mod tests {
 
         assert_eq!(parsed.event.as_deref(), Some("response.output_text.delta"));
         assert!(parsed.data.contains("你好"));
+    }
+
+    #[derive(Debug)]
+    struct MockSearchState {
+        body: String,
+        requests: Vec<Value>,
+    }
+
+    async fn mock_search_handler(
+        State(state): State<Arc<Mutex<MockSearchState>>>,
+        body: Body,
+    ) -> impl IntoResponse {
+        let bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+        let request: Value = serde_json::from_slice(&bytes).unwrap();
+        let mut state = state.lock().await;
+        state.requests.push(request);
+        (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "text/event-stream")],
+            state.body.clone(),
+        )
+    }
+
+    async fn spawn_mock_search(body: String) -> (String, Arc<Mutex<MockSearchState>>) {
+        let state = Arc::new(Mutex::new(MockSearchState {
+            body,
+            requests: Vec::new(),
+        }));
+        let app = Router::new()
+            .route("/v1/responses", post(mock_search_handler))
+            .with_state(state.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{addr}/v1"), state)
+    }
+
+    #[tokio::test]
+    async fn query_stream_emits_real_sse_deltas_before_completion() {
+        let body = concat!(
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"你\"}\n\n",
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"好\"}\n\n",
+            "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"output_text\":\"你好\",\"output\":[]}}\n\n",
+        )
+        .to_owned();
+        let (base_url, state) = spawn_mock_search(body).await;
+        let executor = OpenAiWebSearchExecutor {
+            client: reqwest::Client::new(),
+            api_key: "test-key".to_owned(),
+            base_url: Some(base_url),
+            search_model: "gpt-search".to_owned(),
+        };
+        let (delta_tx, mut delta_rx) = mpsc::channel(4);
+
+        let outcome = executor
+            .query_stream(
+                WebSearchRequest {
+                    query: "测试".to_owned(),
+                    raw_question: Some("/查 测试".to_owned()),
+                    max_results: None,
+                    context_size: None,
+                },
+                delta_tx,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(delta_rx.recv().await.as_deref(), Some("你"));
+        assert_eq!(delta_rx.recv().await.as_deref(), Some("好"));
+        assert!(delta_rx.recv().await.is_none());
+        assert_eq!(outcome.answer, "你好");
+        assert_eq!(state.lock().await.requests[0]["stream"], true);
     }
 
     #[test]


### PR DESCRIPTION
# Provider 真实增量流内部贯通完成报告

## 一、基本信息

* PR：#47
* 分支：`feat/provider-delta-stream`
* 任务阶段：LLM 流式改造第二阶段
* 改造范围：Provider → LLM → Core → Gateway 的进程内真实增量流
* 用户可见行为：QQ 侧仍只在最终 `Completed(CoreResponse)` 后发送一次完整消息

本阶段没有实现 QQ 消息逐段刷新，也没有恢复 Gateway → Core 的 HTTP/SSE 通讯。

---

## 二、改造背景

第一阶段已经完成 Gateway → Core 的进程内调用和 `CoreRespondOutput::Complete` / `CoreRespondOutput::Stream` 业务响应边界。

但第一阶段中的 Stream 主要还是一个异步业务通道——Core 立即返回 Stream 后 producer 执行原有完整业务流程，等待 LLM 生成完整结果，再发送 `Completed(CoreResponse)` 给 Gateway 最终发送一次。虽然它解决了普通聊天和 `/查` 被旧完整请求总超时中断的问题，但 Provider 的真实 token/text delta 尚未向上传递。

第二阶段的目标是打通真正的内部增量链路：

```text
Provider SSE / delta
→ LlmStreamEvent::TextDelta
→ CoreResponseEvent::TextDelta
→ Gateway 持续消费
→ Completed(CoreResponse)
→ QQ 最终发送一次
```

---

## 三、主要变更

### LLM 层

- 统一标准流事件：`LlmStreamEvent::TextDelta` / `LlmStreamEvent::Completed`
- OpenAI Responses 真实流：解析 `response.output_text.delta`、拒绝文本 delta、`response.completed`/`failed`/`incomplete`、usage 提取、无正文 delta 时从 completed response 回补
- Chat Completions 标准流：`choices[].delta.content`、completed message 回补、usage 提取、`[DONE]`、`finish_reason`、中文 UTF-8 跨 chunk 拼接、SSE frame 跨网络 chunk 解析
- DeepSeek / BigModel 复用 OpenAI 兼容 Chat Completions 流实现
- 异常 EOF 正确识别为失败，不再被吞为成功完成
- 候选模型流式 fallback：首非空 delta 前允许降级，已产生 delta 后禁止切换
- OpenAI Responses → Chat Completions 协议 fallback（`OPENAI_API_MODE=auto`）
- `stream=false` 兼容：非流请求包装为单 `TextDelta` + `Completed`
- ObservedProvider 接入真实流式 metrics 和健康观测

### Core 层

- `LlmChatService::stream_respond()`：消费 Provider 真流式输出，转发 delta 同时聚合完整正文
- 普通聊天走真实 Provider 流，不再等待完整结果
- `/查` 改用 `query_stream()` 真实流式搜索，不再人工切片伪装
- `CoreResponseStream` 支持 `TextDelta` 事件真实向上传递
- 自动标题异步化：不阻塞主聊天 `Completed`，生成失败不影响本轮对话
- 后台标题并发覆盖修复：`SessionStore::update_title_if_current()` 条件 SQL 更新

### Gateway 层

- 持续消费 `TextDelta`，仅以最终 `Completed(CoreResponse)` 作为 QQ 发送依据
- 行为不变：Markdown/text 发送、C2C/群聊、reply cache、outbound cache 保持不变
- 不做 QQ 消息逐段刷新

---

## 四、验证

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --all-features
cargo build --workspace --release --all-features
git diff --check
```

全部通过。

---

## 五、未改变的行为

本次没有修改：
- QQ 用户可见逐段输出
- QQ 消息更新 / Markdown 分片
- text fallback / reply cache / group outbound cache
- 短命令的 Complete 路径
- Todo / Memory / RSS / 天气 / 火车 / 翻译的完整结果语义
- Gateway → Core 进程内调用结构
- Gateway → Core localhost HTTP / 内部 SSE 传输 / JSON chunk 协议

---

## 六、已知限制

1. **QQ 侧仍不可见增量**——Gateway 忽略 `TextDelta`，只发送最终 `Completed`
2. **尚未增加流空闲超时**——建连/首 token/流空闲/整体最大时长未细分
3. **取消传播仍是 best-effort**——后续可引入统一 cancellation token
4. **Provider HTTP 总超时仍然存在**——reqwest client 使用现有超时配置
5. **主动取消可能影响健康状态**——后续可区分调用方主动取消和真正 Provider 故障

---

## 七、完成结论

Provider 到 Gateway 的内部真实增量流已经贯通。Gateway 当前持续消费增量，但 QQ 侧仍只在 `Completed(CoreResponse)` 后发送一次最终消息。

后续若继续实施用户可见流式，只需要在 Gateway/平台发送层设计合理的缓冲、分段或消息更新策略，不再需要重新拆改 Provider、LLM 和 Core 的流式底座。