### PR TITLE
refactor: 收敛文本脱敏和截断工具

### DIFF
--- a/qq-maid-common/src/lib.rs
+++ b/qq-maid-common/src/lib.rs
@@ -2,4 +2,6 @@
 //!
 //! 这里只放 gateway 和 LLM 都可能复用、且不依赖业务状态的通用逻辑。
 
+pub mod redaction;
+pub mod text;
 pub mod time_context;

--- a/qq-maid-common/src/redaction.rs
+++ b/qq-maid-common/src/redaction.rs
@@ -1,0 +1,115 @@
+//! 敏感信息脱敏工具。
+//!
+//! 这里只维护跨模块共享的文本级脱敏规则；正则集合保持私有，避免调用方依赖规则细节。
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// 敏感信息匹配模式列表，用于在写入持久化数据或日志前自动脱敏 API Key、Token 等凭证。
+static SENSITIVE_PATTERNS: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(|| {
+    vec![
+        (
+            Regex::new(r"(?i)(OPENAI_API_KEY\s*=\s*)\S+").unwrap(),
+            "$1<redacted>",
+        ),
+        (
+            Regex::new(r"(?i)(DEEPSEEK_API_KEY\s*=\s*)\S+").unwrap(),
+            "$1<redacted>",
+        ),
+        (
+            Regex::new(r"(?i)(QQ_SECRET\s*=\s*)\S+").unwrap(),
+            "$1<redacted>",
+        ),
+        (
+            Regex::new(r"(?i)(API[_ -]?KEY\s*[:=]\s*)\S+").unwrap(),
+            "$1<redacted>",
+        ),
+        (
+            Regex::new(r"(?i)(SECRET\s*[:=]\s*)\S+").unwrap(),
+            "$1<redacted>",
+        ),
+        (
+            Regex::new(r"(?i)(TOKEN\s*[:=]\s*)\S+").unwrap(),
+            "$1<redacted>",
+        ),
+        (
+            Regex::new(r"sk-[A-Za-z0-9_-]{20,}").unwrap(),
+            "<redacted:openai_api_key>",
+        ),
+        (
+            Regex::new(r"(?i)Bearer\s+[A-Za-z0-9._-]{20,}").unwrap(),
+            "Bearer <redacted>",
+        ),
+    ]
+});
+
+/// 脱敏文本中的敏感信息。
+pub fn redact_sensitive_text(text: impl AsRef<str>) -> String {
+    let mut redacted = text.as_ref().to_owned();
+    for (pattern, replacement) in SENSITIVE_PATTERNS.iter() {
+        redacted = pattern.replace_all(&redacted, *replacement).to_string();
+    }
+    redacted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_named_provider_keys_and_tokens() {
+        assert_eq!(
+            redact_sensitive_text("OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz123456"),
+            "OPENAI_API_KEY=<redacted>"
+        );
+        assert_eq!(
+            redact_sensitive_text("DEEPSEEK_API_KEY=deepseek-fake-token-value"),
+            "DEEPSEEK_API_KEY=<redacted>"
+        );
+        assert_eq!(
+            redact_sensitive_text("QQ_SECRET=qq-fake-secret-value"),
+            "QQ_SECRET=<redacted>"
+        );
+        assert_eq!(
+            redact_sensitive_text("TOKEN: abcdefghijklmnopqrstuvwxyz123456"),
+            "TOKEN: <redacted>"
+        );
+    }
+
+    #[test]
+    fn redacts_generic_sk_and_bearer_values() {
+        assert_eq!(
+            redact_sensitive_text("key sk-abcdefghijklmnopqrstuvwxyz123456"),
+            "key <redacted:openai_api_key>"
+        );
+        assert_eq!(
+            redact_sensitive_text("Authorization: Bearer abcdefghijklmnopqrstuvwxyz123456"),
+            "Authorization: Bearer <redacted>"
+        );
+    }
+
+    #[test]
+    fn redacts_multiple_sensitive_values_in_same_text() {
+        let text = "OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz123456\nBearer abcdefghijklmnopqrstuvwxyz123456";
+
+        assert_eq!(
+            redact_sensitive_text(text),
+            "OPENAI_API_KEY=<redacted>\nBearer <redacted>"
+        );
+    }
+
+    #[test]
+    fn keeps_normal_and_partial_similar_text_unchanged() {
+        assert_eq!(
+            redact_sensitive_text("普通文本没有凭证"),
+            "普通文本没有凭证"
+        );
+        assert_eq!(redact_sensitive_text("sk-short-token"), "sk-short-token");
+        assert_eq!(redact_sensitive_text("Bearer short"), "Bearer short");
+        assert_eq!(
+            redact_sensitive_text("API key maybe later"),
+            "API key maybe later"
+        );
+    }
+}

--- a/qq-maid-common/src/text.rs
+++ b/qq-maid-common/src/text.rs
@@ -1,0 +1,87 @@
+//! 共享文本截断工具。
+//!
+//! 现有调用点存在展示文本、RSS 摘要和 Todo 持久化三种边界语义，统一放在这里维护，
+//! 但不强行合并为同一种输出，避免改变用户可见文本或已保存数据。
+
+/// 将字符串截断到指定字符数，超出时末尾追加"…"，并沿用 respond 展示层的 trim 语义。
+pub fn truncate_chars_with_ellipsis_trimmed(text: &str, limit: usize) -> String {
+    if text.chars().count() <= limit {
+        return text.trim().to_owned();
+    }
+    let keep = limit.saturating_sub(1);
+    format!(
+        "{}…",
+        text.chars().take(keep).collect::<String>().trim_end()
+    )
+}
+
+/// 将字符串截断到指定字符数，超出时末尾追加"…"，不额外清理首尾空白。
+pub fn truncate_chars_with_ellipsis(text: &str, limit: usize) -> String {
+    if text.chars().count() <= limit {
+        return text.to_owned();
+    }
+    let keep = limit.saturating_sub(1);
+    format!("{}…", text.chars().take(keep).collect::<String>())
+}
+
+/// 将字符串截断到指定字符数并清理首尾空白，不追加省略号。
+pub fn truncate_chars_trimmed(text: &str, limit: usize) -> String {
+    if text.chars().count() <= limit {
+        return text.trim().to_owned();
+    }
+    text.chars()
+        .take(limit)
+        .collect::<String>()
+        .trim()
+        .to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ellipsis_trimmed_keeps_short_and_exact_limit_text() {
+        assert_eq!(truncate_chars_with_ellipsis_trimmed("短文本", 10), "短文本");
+        assert_eq!(truncate_chars_with_ellipsis_trimmed("abcd", 4), "abcd");
+        assert_eq!(truncate_chars_with_ellipsis_trimmed("  ab  ", 6), "ab");
+    }
+
+    #[test]
+    fn ellipsis_trimmed_truncates_unicode_text() {
+        assert_eq!(
+            truncate_chars_with_ellipsis_trimmed("中文天气预警说明", 6),
+            "中文天气预…"
+        );
+        assert_eq!(
+            truncate_chars_with_ellipsis_trimmed("你好世界🙂再见", 6),
+            "你好世界🙂…"
+        );
+    }
+
+    #[test]
+    fn ellipsis_trimmed_handles_empty_and_zero_limit() {
+        assert_eq!(truncate_chars_with_ellipsis_trimmed("", 6), "");
+        assert_eq!(truncate_chars_with_ellipsis_trimmed("abc", 0), "…");
+    }
+
+    #[test]
+    fn ellipsis_without_trim_preserves_rss_boundary_semantics() {
+        assert_eq!(truncate_chars_with_ellipsis("  ab  ", 6), "  ab  ");
+        assert_eq!(truncate_chars_with_ellipsis("  abcd  ", 6), "  abc…");
+        assert_eq!(truncate_chars_with_ellipsis("abc", 0), "…");
+    }
+
+    #[test]
+    fn trimmed_without_ellipsis_preserves_todo_storage_semantics() {
+        assert_eq!(truncate_chars_trimmed("短文本", 10), "短文本");
+        assert_eq!(truncate_chars_trimmed("abcd", 4), "abcd");
+        assert_eq!(
+            truncate_chars_trimmed("中文天气预警说明", 6),
+            "中文天气预警"
+        );
+        assert_eq!(truncate_chars_trimmed("你好世界🙂再见", 6), "你好世界🙂再");
+        assert_eq!(truncate_chars_trimmed("", 6), "");
+        assert_eq!(truncate_chars_trimmed("abc", 0), "");
+    }
+}

--- a/qq-maid-core/src/runtime/respond/common.rs
+++ b/qq-maid-core/src/runtime/respond/common.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 
 use chrono::{DateTime, Duration};
+pub(super) use qq_maid_common::text::truncate_chars_with_ellipsis_trimmed as truncate_chars;
 use serde_json::{Value, json};
 
 use crate::{
@@ -229,18 +230,6 @@ pub(super) fn state_string(session: &SessionRecord, key: &str) -> Option<String>
 pub(super) fn clean_string(value: String) -> Option<String> {
     let value = value.trim().to_owned();
     if value.is_empty() { None } else { Some(value) }
-}
-
-/// 将字符串截断到指定字符数，超出时末尾追加"…"。
-pub(super) fn truncate_chars(text: &str, limit: usize) -> String {
-    if text.chars().count() <= limit {
-        return text.trim().to_owned();
-    }
-    let keep = limit.saturating_sub(1);
-    format!(
-        "{}…",
-        text.chars().take(keep).collect::<String>().trim_end()
-    )
 }
 
 /// 从模型输出中尽力抽取一个 JSON 对象：

--- a/qq-maid-core/src/runtime/rss/feed.rs
+++ b/qq-maid-core/src/runtime/rss/feed.rs
@@ -7,6 +7,7 @@
 use std::{net::IpAddr, time::Duration};
 
 use feed_rs::{model, parser};
+use qq_maid_common::text::truncate_chars_with_ellipsis as truncate_chars;
 use regex::Regex;
 use reqwest::{StatusCode, redirect::Policy};
 use sha2::{Digest, Sha256};
@@ -436,14 +437,6 @@ fn is_placeholder_null(value: &str) -> bool {
 
 fn strip_markdown_emphasis(raw: &str) -> String {
     raw.replace("**", "").replace("__", "").replace('`', "")
-}
-
-fn truncate_chars(text: &str, limit: usize) -> String {
-    if text.chars().count() <= limit {
-        return text.to_owned();
-    }
-    let keep = limit.saturating_sub(1);
-    format!("{}…", text.chars().take(keep).collect::<String>())
 }
 
 fn sha256_hex(value: &str) -> String {

--- a/qq-maid-core/src/storage/memory.rs
+++ b/qq-maid-core/src/storage/memory.rs
@@ -4,9 +4,7 @@
 //! 已经初始化并执行 migration 的 [`SqliteDatabase`] 句柄，不自行读取数据库路径，
 //! 也不保留 JSONL 回退，避免写入失败时出现“表面成功、实际未保存”的状态。
 
-use std::sync::LazyLock;
-
-use regex::Regex;
+use qq_maid_common::redaction::redact_sensitive_text;
 use rusqlite::{
     Connection, OptionalExtension, Row, params, params_from_iter, types::Value as SqlValue,
 };
@@ -76,44 +74,6 @@ pub const MEMORY_SCOPE_SCHEMA_V2: SqliteMigration = SqliteMigration {
 };
 
 pub const MEMORY_MIGRATIONS: &[SqliteMigration] = &[MEMORY_SCHEMA_V1, MEMORY_SCOPE_SCHEMA_V2];
-
-/// 敏感信息匹配模式列表，用于在存储时自动脱敏 API Key、Token 等凭证。
-static SENSITIVE_PATTERNS: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(|| {
-    vec![
-        (
-            Regex::new(r"(?i)(OPENAI_API_KEY\s*=\s*)\S+").unwrap(),
-            "$1<redacted>",
-        ),
-        (
-            Regex::new(r"(?i)(DEEPSEEK_API_KEY\s*=\s*)\S+").unwrap(),
-            "$1<redacted>",
-        ),
-        (
-            Regex::new(r"(?i)(QQ_SECRET\s*=\s*)\S+").unwrap(),
-            "$1<redacted>",
-        ),
-        (
-            Regex::new(r"(?i)(API[_ -]?KEY\s*[:=]\s*)\S+").unwrap(),
-            "$1<redacted>",
-        ),
-        (
-            Regex::new(r"(?i)(SECRET\s*[:=]\s*)\S+").unwrap(),
-            "$1<redacted>",
-        ),
-        (
-            Regex::new(r"(?i)(TOKEN\s*[:=]\s*)\S+").unwrap(),
-            "$1<redacted>",
-        ),
-        (
-            Regex::new(r"sk-[A-Za-z0-9_-]{20,}").unwrap(),
-            "<redacted:openai_api_key>",
-        ),
-        (
-            Regex::new(r"(?i)Bearer\s+[A-Za-z0-9._-]{20,}").unwrap(),
-            "Bearer <redacted>",
-        ),
-    ]
-});
 
 /// 记忆记录，表示一条持久化存储的长期记忆。
 ///
@@ -1105,15 +1065,6 @@ fn clean_optional_str(value: &str) -> Option<String> {
 /// 清理可选 Option 字段：内层值空则返回 None。
 fn clean_optional_option(value: Option<String>) -> Option<String> {
     value.and_then(clean_optional)
-}
-
-/// 脱敏文本中的敏感信息（API Key、Secret、Token 等）。
-fn redact_sensitive_text(text: &str) -> String {
-    let mut redacted = text.to_owned();
-    for (pattern, replacement) in SENSITIVE_PATTERNS.iter() {
-        redacted = pattern.replace_all(&redacted, *replacement).to_string();
-    }
-    redacted
 }
 
 /// 默认记忆类型。

--- a/qq-maid-core/src/storage/session.rs
+++ b/qq-maid-core/src/storage/session.rs
@@ -6,7 +6,7 @@
 
 use std::fmt;
 
-use regex::Regex;
+pub use qq_maid_common::redaction::redact_sensitive_text;
 use rusqlite::{Connection, OptionalExtension, Row, Transaction, params};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::{Map, Value};
@@ -71,45 +71,6 @@ pub const SESSION_MIGRATIONS: &[SqliteMigration] = &[SESSION_SCHEMA_V1];
 
 /// 默认会话标题，当用户未指定标题时使用。
 pub const DEFAULT_SESSION_TITLE: &str = "未命名会话";
-
-/// 敏感信息匹配模式列表，存储会话时自动脱敏。
-static SENSITIVE_PATTERNS: std::sync::LazyLock<Vec<(Regex, &'static str)>> =
-    std::sync::LazyLock::new(|| {
-        vec![
-            (
-                Regex::new(r"(?i)(OPENAI_API_KEY\s*=\s*)\S+").unwrap(),
-                "$1<redacted>",
-            ),
-            (
-                Regex::new(r"(?i)(DEEPSEEK_API_KEY\s*=\s*)\S+").unwrap(),
-                "$1<redacted>",
-            ),
-            (
-                Regex::new(r"(?i)(QQ_SECRET\s*=\s*)\S+").unwrap(),
-                "$1<redacted>",
-            ),
-            (
-                Regex::new(r"(?i)(API[_ -]?KEY\s*[:=]\s*)\S+").unwrap(),
-                "$1<redacted>",
-            ),
-            (
-                Regex::new(r"(?i)(SECRET\s*[:=]\s*)\S+").unwrap(),
-                "$1<redacted>",
-            ),
-            (
-                Regex::new(r"(?i)(TOKEN\s*[:=]\s*)\S+").unwrap(),
-                "$1<redacted>",
-            ),
-            (
-                Regex::new(r"sk-[A-Za-z0-9_-]{20,}").unwrap(),
-                "<redacted:openai_api_key>",
-            ),
-            (
-                Regex::new(r"(?i)Bearer\s+[A-Za-z0-9._-]{20,}").unwrap(),
-                "Bearer <redacted>",
-            ),
-        ]
-    });
 
 /// 会话记录，包含完整的会话状态和历史。
 ///
@@ -952,15 +913,6 @@ where
 /// 获取当前北京时间 ISO8601 字符串。
 pub fn now_iso_cn() -> String {
     time_context::now_iso_cn()
-}
-
-/// 脱敏文本中的敏感信息。
-pub fn redact_sensitive_text(text: impl AsRef<str>) -> String {
-    let mut redacted = text.as_ref().to_owned();
-    for (pattern, replacement) in SENSITIVE_PATTERNS.iter() {
-        redacted = pattern.replace_all(&redacted, *replacement).to_string();
-    }
-    redacted
 }
 
 #[cfg(test)]

--- a/qq-maid-core/src/storage/todo.rs
+++ b/qq-maid-core/src/storage/todo.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use chrono::NaiveDate;
+use qq_maid_common::text::truncate_chars_trimmed as truncate_chars;
 use rusqlite::{Connection, OptionalExtension, params, types::Type};
 use serde::{Deserialize, Serialize};
 
@@ -1397,18 +1398,6 @@ fn clean_optional(value: &str) -> Option<String> {
 
 fn private_target_from_scope_key(value: &str) -> Option<String> {
     value.strip_prefix("private:").and_then(clean_optional)
-}
-
-/// 截断字符串到指定字符数（基于 Unicode 字符，非字节）。
-fn truncate_chars(text: &str, limit: usize) -> String {
-    if text.chars().count() <= limit {
-        return text.trim().to_owned();
-    }
-    text.chars()
-        .take(limit)
-        .collect::<String>()
-        .trim()
-        .to_owned()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 变更
- 在 qq-maid-common 新增 redaction 模块，集中维护敏感信息脱敏规则和 redact_sensitive_text。
- 在 qq-maid-common 新增 text 模块，集中维护现有三类字符截断语义。
- session/memory 改为复用 common 脱敏实现，respond/RSS/todo 改为复用 common 截断实现。

## 语义说明
- session 与 memory 原脱敏规则完全一致，本次保持规则顺序和替换文本不变。
- truncate_chars 原有三处存在语义差异：respond 会 trim 并追加省略号，RSS 追加省略号但不 trim，todo trim 但不追加省略号。本次在 common 中保留三种命名函数，避免改变用户可见输出和持久化内容。

## 验证
- cargo fmt --all -- --check
- cargo test -p qq-maid-common
- cargo test -p qq-maid-core
- cargo check -p qq-maid-common
- cargo check -p qq-maid-core
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features
- cargo build --workspace --release --all-features