### PR TITLE
fix: 仅在官方群 at 事件回复中 @ 发起人

### DIFF
--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -151,6 +151,16 @@ fn prefix_group_reply_outbound(
     };
     outbound.prefix_text(&prefix)
 }
+
+fn group_respond_error_texts(
+    message: &GroupMessage,
+    err: &crate::respond::RespondError,
+) -> (String, String) {
+    let log_text = respond_error_to_qq_text(err);
+    // 群 at fallback 的实际 QQ 文本需要保留 <@openid>，但日志字段只能使用未加前缀的安全文案。
+    let qq_text = prefix_group_reply_text(message, &log_text);
+    (qq_text, log_text)
+}
 /// QQ 网关主循环：初始化所有共享组件后，反复获取网关地址并建立 WebSocket 连接。
 /// 连接断开或失败后会等待 `RECONNECT_DELAY` 后重连，从而保证长期在线。
 pub async fn run(
@@ -312,14 +322,14 @@ pub(super) async fn handle_group_message(
         }
         Err(err) => {
             runtime.record_respond_failure(err.log_summary());
-            let qq_text = prefix_group_reply_text(&message, &respond_error_to_qq_text(&err));
+            let (qq_text, log_text) = group_respond_error_texts(&message, &err);
             warn!(
                 message_id = %message.message_id,
                 group = %masked_group,
                 error = %err.log_summary(),
                 local_fallback = true,
                 fallback_reason = "respond_error",
-                qq_error_text = %qq_text,
+                qq_error_text = %log_text,
                 "respond backend call failed; sending local group fallback"
             );
             let sent_message_id = send_group_text_with_status(
@@ -713,6 +723,22 @@ mod tests {
             prefix_group_reply_text(&message, "回复正文"),
             "<@member-1>\n回复正文"
         );
+    }
+
+    #[test]
+    fn group_at_respond_error_log_text_keeps_member_openid_out() {
+        let message = group_message("hello", GroupEventType::GroupAtMessage);
+        let error = crate::respond::RespondError::Core(qq_maid_core::service::CoreError::new(
+            "internal_error",
+            "respond",
+            "backend down",
+        ));
+
+        let (qq_text, log_text) = group_respond_error_texts(&message, &error);
+
+        assert!(qq_text.starts_with("<@member-1>\n"));
+        assert!(!log_text.contains("member-1"));
+        assert!(!log_text.contains("<@"));
     }
 
     #[test]

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -116,6 +116,41 @@ fn resolve_signals(message: &mut C2cMessage, cache: &ReplyCache) {
         reply.content = Some(content);
     }
 }
+
+fn group_reply_mention_prefix(message: &GroupMessage) -> Option<String> {
+    // 只有用户显式 @ 机器人触发的官方群 at 事件，才在回复正文里 @ 回发起人；
+    // 普通群命令、关键词触发和回复机器人消息继续只挂原消息 msg_id，避免额外打扰。
+    if message.event_type != GroupEventType::GroupAtMessage {
+        return None;
+    }
+    message
+        .member_openid
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|member_openid| format!("<@{member_openid}>"))
+}
+
+fn prefix_group_reply_text(message: &GroupMessage, text: &str) -> String {
+    let Some(prefix) = group_reply_mention_prefix(message) else {
+        return text.to_owned();
+    };
+    if text.trim().is_empty() {
+        prefix
+    } else {
+        format!("{prefix}\n{text}")
+    }
+}
+
+fn prefix_group_reply_outbound(
+    message: &GroupMessage,
+    outbound: OutboundMessage,
+) -> OutboundMessage {
+    let Some(prefix) = group_reply_mention_prefix(message) else {
+        return outbound;
+    };
+    outbound.prefix_text(&prefix)
+}
 /// QQ 网关主循环：初始化所有共享组件后，反复获取网关地址并建立 WebSocket 连接。
 /// 连接断开或失败后会等待 `RECONNECT_DELAY` 后重连，从而保证长期在线。
 pub async fn run(
@@ -277,7 +312,7 @@ pub(super) async fn handle_group_message(
         }
         Err(err) => {
             runtime.record_respond_failure(err.log_summary());
-            let qq_text = respond_error_to_qq_text(&err);
+            let qq_text = prefix_group_reply_text(&message, &respond_error_to_qq_text(&err));
             warn!(
                 message_id = %message.message_id,
                 group = %masked_group,
@@ -347,6 +382,7 @@ pub(super) async fn send_group_respond_response(
         );
         return Ok(());
     };
+    let outbound = prefix_group_reply_outbound(message, outbound);
     let sender = RuntimeRecordingGroupSender {
         inner: api,
         runtime,
@@ -667,6 +703,46 @@ mod tests {
             author_is_bot: false,
             author_is_self: false,
         }
+    }
+
+    #[test]
+    fn group_at_reply_text_mentions_sender_when_member_openid_exists() {
+        let message = group_message("hello", GroupEventType::GroupAtMessage);
+
+        assert_eq!(
+            prefix_group_reply_text(&message, "回复正文"),
+            "<@member-1>\n回复正文"
+        );
+    }
+
+    #[test]
+    fn group_reply_text_skips_mention_for_plain_group_message() {
+        let message = group_message("hello", GroupEventType::GroupMessage);
+
+        assert_eq!(prefix_group_reply_text(&message, "回复正文"), "回复正文");
+    }
+
+    #[test]
+    fn group_at_reply_text_skips_mention_without_member_openid() {
+        let mut message = group_message("hello", GroupEventType::GroupAtMessage);
+        message.member_openid = None;
+
+        assert_eq!(prefix_group_reply_text(&message, "回复正文"), "回复正文");
+    }
+
+    #[test]
+    fn group_at_reply_outbound_mentions_sender() {
+        let message = group_message("hello", GroupEventType::GroupAtMessage);
+        let outbound = OutboundMessage::Text {
+            text: "回复正文".to_owned(),
+        };
+
+        assert_eq!(
+            prefix_group_reply_outbound(&message, outbound),
+            OutboundMessage::Text {
+                text: "<@member-1>\n回复正文".to_owned(),
+            }
+        );
     }
 
     #[test]

--- a/qq-maid-gateway-rs/src/render.rs
+++ b/qq-maid-gateway-rs/src/render.rs
@@ -24,6 +24,37 @@ impl OutboundMessage {
             }
         }
     }
+
+    /// 群 at 回复需要在 QQ 出站边界补充平台提及语法；富媒体和 fallback 文本保持一致。
+    pub fn prefix_text(self, prefix: &str) -> Self {
+        fn join(prefix: &str, text: String) -> String {
+            if text.trim().is_empty() {
+                prefix.to_owned()
+            } else {
+                format!("{prefix}\n{text}")
+            }
+        }
+
+        match self {
+            Self::Text { text } => Self::Text {
+                text: join(prefix, text),
+            },
+            Self::Markdown {
+                markdown,
+                fallback_text,
+            } => Self::Markdown {
+                markdown: MarkdownPayload::new(join(prefix, markdown.content)),
+                fallback_text: join(prefix, fallback_text),
+            },
+            Self::Image {
+                image,
+                fallback_text,
+            } => Self::Image {
+                image,
+                fallback_text: join(prefix, fallback_text),
+            },
+        }
+    }
 }
 
 pub fn render_respond_response(
@@ -134,6 +165,23 @@ mod tests {
         assert_eq!(
             render_respond_response(&response_with_body(None, Some("# hi")), true, true),
             None
+        );
+    }
+
+    #[test]
+    fn prefix_text_updates_markdown_and_fallback() {
+        let outbound = OutboundMessage::Markdown {
+            markdown: MarkdownPayload::new("**正文**"),
+            fallback_text: "正文".to_owned(),
+        }
+        .prefix_text("<@member-1>");
+
+        assert_eq!(
+            outbound,
+            OutboundMessage::Markdown {
+                markdown: MarkdownPayload::new("<@member-1>\n**正文**"),
+                fallback_text: "<@member-1>\n正文".to_owned(),
+            }
         );
     }
 }


### PR DESCRIPTION


**变更内容：**
- `render.rs`：`OutboundMessage` 增加 `prefix_text` 方法，方便在出站边界统一给文本、Markdown 和 fallback 加前缀。
- `gateway/mod.rs`：新增 `group_reply_mention_prefix` 等三个 helper，只在 `GROUP_AT_MESSAGE_CREATE` 且存在 `member_openid` 时，回复正文才带 `<@member_openid>` 前缀；普通群消息、命令、关键词触发和回复机器人仍只引用原 `msg_id`。
- error fallback 文本也统一受 @ 前缀保护。

**验证：**
- `make test-gateway`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`（407+82+98 tests passed）
