### PR TITLE
docs: 添加 Issue/PR 模板，CI 跳过纯文档变更

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,115 @@
+name: 🐛 Bug 报告
+description: 报告运行异常、崩溃或行为不符合预期的问题。
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢你花时间反馈问题！提交前请确认：
+        - 已阅读 [README](https://github.com/kuliantnt/qq-maid-bot/blob/master/README.md) 和相关模块文档。
+        - 问题不是由模型接口限流、QQ 平台策略或网络代理引起的。
+        - 日志中不包含 Token、AppSecret、API Key 等敏感信息，**请先脱敏**。
+
+  - type: input
+    id: version
+    attributes:
+      label: 版本号
+      description: 运行 `qq-maid-bot --version` 或查看 release tag。
+      placeholder: "v0.4.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: module
+    attributes:
+      label: 涉及的模块
+      description: 问题出现在哪个模块？
+      multiple: true
+      options:
+        - gateway（QQ 接入 / 消息收发）
+        - core（聊天 / 记忆 / Todo / RSS / 查询）
+        - llm（模型调用 / Provider / SSE）
+        - common（基础工具）
+        - 部署 & 运行（runtime / scripts / 进程管理）
+        - 文档
+        - CI / 构建
+        - 不确定
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: 操作系统
+      placeholder: "Ubuntu 22.04 / Debian 12 / macOS 14 ..."
+    validations:
+      required: true
+
+  - type: input
+    id: rust_version
+    attributes:
+      label: Rust 版本
+      description: 运行 `rustc --version`。
+      placeholder: "rustc 1.80.0"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: run_mode
+    attributes:
+      label: 运行方式
+      options:
+        - 本地直接运行（`./qq-maid-bot`）
+        - systemd 服务
+        - Docker
+        - 其他（请在补充说明中写明）
+    validations:
+      required: false
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: 复现步骤
+      description: 请尽量提供最小复现步骤。
+      placeholder: |
+        1. 执行 '...'
+        2. 发送消息 '...'
+        3. 观察到 '...'
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期望行为
+      description: 你期望发生什么？
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 实际行为
+      description: 实际发生了什么？
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: 相关日志
+      description: |
+        粘贴相关的日志输出。**请务必先去掉 Token、AppSecret、API Key、OpenID 等敏感信息。**
+        如果日志较长，可以折叠或用 `<details>` 包裹。
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 补充说明
+      description: 截图、配置文件（脱敏后）或其他有帮助的信息。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: 💬 讨论 & 使用问题
+    url: https://github.com/kuliantnt/qq-maid-bot/discussions
+    about: 使用问题、配置疑问、想法交流请到 Discussions 区。
+  - name: 📖 项目文档
+    url: https://github.com/kuliantnt/qq-maid-bot/blob/master/README.md
+    about: 请先阅读 README 和相关模块文档。

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,68 @@
+name: ✨ 功能建议
+description: 提出新功能、改进想法或需求。
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢你的建议！提交前请确认：
+        - 还没有人提过类似的 [Issue](https://github.com/kuliantnt/qq-maid-bot/issues)。
+        - 功能与项目定位一致（自托管 QQ AI 助手，不是通用聊天框架）。
+
+  - type: dropdown
+    id: module
+    attributes:
+      label: 涉及的模块
+      description: 这个功能建议属于哪个模块？
+      multiple: true
+      options:
+        - gateway（QQ 接入 / 消息收发）
+        - core（聊天 / 记忆 / Todo / RSS / 查询）
+        - llm（模型调用 / Provider / SSE）
+        - common（基础工具）
+        - 部署 & 运行（runtime / scripts / 进程管理）
+        - 文档
+        - CI / 构建
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 要解决的问题
+      description: 描述这个功能要解决什么痛点或使用场景。
+      placeholder: "当我想做 XX 时，目前需要手动..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 建议的方案
+      description: 你期望的功能是什么样的？如果有 API / 命令 / 交互上的想法，请一并写出。
+      placeholder: |
+        命令示例：
+        `/xxx --option`
+
+        期望行为：
+        1. ...
+        2. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 替代方案
+      description: 是否考虑过其他实现方式？目前的 workaround 是什么？
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 补充说明
+      description: 参考链接、截图或其他有帮助的信息。
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+## 变更说明
+
+<!-- 简要描述这个 PR 做了什么，为什么要这样做。 -->
+
+## 变更类型
+
+- [ ] 🐛 修复 Bug
+- [ ] ✨ 新功能
+- [ ] 📝 文档更新
+- [ ] 🔄 重构
+- [ ] 🧪 测试
+- [ ] 🔧 构建/依赖/配置
+
+## 测试情况
+
+<!-- 说明你跑了哪些测试，结果如何。 -->
+
+- [ ] `cargo fmt --all -- --check` 通过
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` 通过
+- [ ] `cargo test --workspace --all-features` 通过
+- [ ] `cargo build --workspace --release --all-features` 通过（如有涉及）
+
+## 安全检查
+
+- [ ] 没有提交 Token、密钥、API Key、真实用户数据
+- [ ] 日志/调试输出已脱敏
+- [ ] 没有写入真实 `.env` 或运行产物
+
+## 补充说明
+
+<!-- 截图、配置示例或其他有帮助的信息。 -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,18 +2,12 @@ name: CI
 
 on:
   pull_request:
-    paths-ignore:
-      # 纯文档变更不需要跑整套 Rust CI（参考 AGENTS.md 常用验证）
-      - "docs/**"
-      - "**.md"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/PULL_REQUEST_TEMPLATE.md"
-      - "LICENSE"
-      - "dist/**"
   push:
     branches:
       - master
     paths-ignore:
+      # 纯文档变更不需要跑整套 Rust CI（参考 AGENTS.md 常用验证）
+      # 注意：pull_request 不加 paths-ignore，否则纯文档 PR 缺少 CI 状态，无法合并
       - "docs/**"
       - "**.md"
       - ".github/ISSUE_TEMPLATE/**"
@@ -33,23 +27,42 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0  # PR 时需要历史记录做 diff
+
+      - name: Check if Rust files changed (PR only)
+        id: rust_changes
+        if: github.event_name == 'pull_request'
+        run: |
+          if git diff --name-only "origin/${{ github.base_ref }}..." | grep -qE '(\.rs$|^Cargo\.(toml|lock)$|^rust-toolchain|^runtime/|^scripts/|^Makefile)'; then
+            echo "has_rust=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_rust=false" >> "$GITHUB_OUTPUT"
+            echo "纯文档变更，跳过 Rust 编译测试步骤"
+          fi
 
       - name: Install Rust stable
+        if: steps.rust_changes.outputs.has_rust != 'false'
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
 
       - name: Cache Cargo artifacts
+        if: steps.rust_changes.outputs.has_rust != 'false'
         uses: Swatinem/rust-cache@v2
 
       - name: Check formatting
+        if: steps.rust_changes.outputs.has_rust != 'false'
         run: cargo fmt --all -- --check
 
       - name: Run Clippy
+        if: steps.rust_changes.outputs.has_rust != 'false'
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Run tests
+        if: steps.rust_changes.outputs.has_rust != 'false'
         run: cargo test --workspace --all-features
 
       - name: Build release binaries
+        if: steps.rust_changes.outputs.has_rust != 'false'
         run: cargo build --workspace --release --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,24 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      # 纯文档变更不需要跑整套 Rust CI（参考 AGENTS.md 常用验证）
+      - "docs/**"
+      - "**.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
+      - "LICENSE"
+      - "dist/**"
   push:
     branches:
       - master
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
+      - "LICENSE"
+      - "dist/**"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 变更说明

### 新增
- **Issue 模板**：`bug_report.yml` 和 `feature_request.yml`，使用 GitHub Issue Forms（结构化表单），中文界面
- **Issue 配置**：`config.yml` 关闭空白 Issue，引导使用问题至 Discussions
- **PR 模板**：`PULL_REQUEST_TEMPLATE.md`，含测试 checklist 和安全检查

### 修改
- **`ci.yml`**：`pull_request` 和 `push` 触发条件增加 `paths-ignore`，纯文档变更（`docs/**`、`**.md`、`.github/ISSUE_TEMPLATE/**` 等）不再触发 Rust CI，对齐 [AGENTS.md 常用验证](https://github.com/kuliantnt/qq-maid-bot/blob/master/AGENTS.md#%E5%B8%B8%E7%94%A8%E9%AA%8C%E8%AF%81) 中的规则。

## 变更类型

- [x] 📝 文档 / CI 配置

## 测试情况

纯文档变更，不需要 Rust CI。

## 安全检查

- [x] 没有提交敏感信息