### PR TITLE
fix: release.yml 加 paths-ignore 和 master 祖先校验

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,14 @@ on:
   push:
     tags:
       - "v*"
+    paths-ignore:
+      # 纯文档 tag 不触发构建发布（参考 AGENTS.md 常用验证）
+      - "docs/**"
+      - "**.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
+      - "LICENSE"
+      - "dist/**"
   workflow_dispatch:
     inputs:
       version:
@@ -160,6 +168,20 @@ jobs:
       contents: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0  # 需要 master 历史做祖先校验
+
+      - name: Verify tag is on master
+        run: |
+          git fetch origin master
+          if ! git merge-base --is-ancestor "${{ github.ref_name }}" origin/master; then
+            echo "::error::Tag ${{ github.ref_name }} 不在 master 分支上，拒绝发布。请确认 tag 打在 master 上。"
+            exit 1
+          fi
+          echo "Tag ${{ github.ref_name }} 是 master 的祖先 ✓"
+
       - name: Download all package artifacts
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,13 +36,16 @@ jobs:
       - name: Preflight checks
         id: check
         shell: bash
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           # 默认拒绝，安全优先
           allow_build="false"
           allow_publish="false"
 
           # ---- workflow_dispatch：手动打包，不做 tag 校验 ----
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             allow_build="true"
             allow_publish="false"
             echo "allow_build=${allow_build}" >> "$GITHUB_OUTPUT"
@@ -56,17 +59,19 @@ jobs:
           # ================================================================
 
           # 1. 安全解析 tag 为 commit（兼容轻量 tag 和 annotated tag）
-          tag_commit=$(git rev-list -n 1 "${{ github.ref_name }}")
-          echo "Tag ${{ github.ref_name }} resolves to commit ${tag_commit}"
+          tag_commit=$(git rev-list -n 1 "${TAG_NAME}")
+          echo "Tag ${TAG_NAME} resolves to commit ${tag_commit}"
 
           # 2. 校验 tag commit 属于 master 祖先
-          git fetch origin master --depth=1
+          #    使用完整 refspec 强制更新 origin/master，避免 --depth=1 等浅拉取
+          #    截断历史，导致 git merge-base --is-ancestor 误判合法祖先 tag
+          git fetch --no-tags origin '+refs/heads/master:refs/remotes/origin/master'
           if ! git merge-base --is-ancestor "${tag_commit}" origin/master; then
-            echo "::error::Tag ${{ github.ref_name }} 不在 master 分支上，拒绝构建和发布"
-            echo "::error::请确认 tag 打在 master 上：git checkout master && git tag ${{ github.ref_name }}"
+            echo "::error::Tag ${TAG_NAME} 不在 master 分支上，拒绝构建和发布"
+            echo "::error::请确认 tag 打在 master 上：git checkout master && git tag ${TAG_NAME}"
             exit 1
           fi
-          echo "Tag ${{ github.ref_name }} is on master ✓"
+          echo "Tag ${TAG_NAME} is on master ✓"
 
           # 3. 获取第一父提交（用于 diff）
           #    对 merge commit，^1 是 master 在被合并前的 HEAD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,6 @@ on:
   push:
     tags:
       - "v*"
-    paths-ignore:
-      # 纯文档 tag 不触发构建发布（参考 AGENTS.md 常用验证）
-      - "docs/**"
-      - "**.md"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/PULL_REQUEST_TEMPLATE.md"
-      - "LICENSE"
-      - "dist/**"
   workflow_dispatch:
     inputs:
       version:
@@ -23,8 +15,112 @@ permissions:
   contents: read
 
 jobs:
+  # ==========================================================================
+  # preflight：在矩阵构建前完成所有 tag 合法性检查
+  #   - workflow_dispatch：直接放行构建，但不发布
+  #   - tag push：校验 master 祖先 + 非纯文档，任一不通过则拒绝
+  # ==========================================================================
+  preflight:
+    name: Preflight check
+    runs-on: ubuntu-latest
+    outputs:
+      allow_build: ${{ steps.check.outputs.allow_build }}
+      allow_publish: ${{ steps.check.outputs.allow_publish }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0  # 需要完整历史以解析 tag 和 diff
+
+      - name: Preflight checks
+        id: check
+        shell: bash
+        run: |
+          # 默认拒绝，安全优先
+          allow_build="false"
+          allow_publish="false"
+
+          # ---- workflow_dispatch：手动打包，不做 tag 校验 ----
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            allow_build="true"
+            allow_publish="false"
+            echo "allow_build=${allow_build}" >> "$GITHUB_OUTPUT"
+            echo "allow_publish=${allow_publish}" >> "$GITHUB_OUTPUT"
+            echo "Manual workflow_dispatch — skipping tag preflight checks"
+            exit 0
+          fi
+
+          # ================================================================
+          # 以下是 tag push 的校验逻辑
+          # ================================================================
+
+          # 1. 安全解析 tag 为 commit（兼容轻量 tag 和 annotated tag）
+          tag_commit=$(git rev-list -n 1 "${{ github.ref_name }}")
+          echo "Tag ${{ github.ref_name }} resolves to commit ${tag_commit}"
+
+          # 2. 校验 tag commit 属于 master 祖先
+          git fetch origin master --depth=1
+          if ! git merge-base --is-ancestor "${tag_commit}" origin/master; then
+            echo "::error::Tag ${{ github.ref_name }} 不在 master 分支上，拒绝构建和发布"
+            echo "::error::请确认 tag 打在 master 上：git checkout master && git tag ${{ github.ref_name }}"
+            exit 1
+          fi
+          echo "Tag ${{ github.ref_name }} is on master ✓"
+
+          # 3. 获取第一父提交（用于 diff）
+          #    对 merge commit，^1 是 master 在被合并前的 HEAD
+          #    对普通 commit，^1 是上一个 commit
+          parent=$(git rev-parse "${tag_commit}^1" 2>/dev/null) || true
+          if [[ -z "${parent}" ]]; then
+            echo "::error::无法获取 tag commit 的父提交（可能是 root commit），拒绝构建"
+            exit 1
+          fi
+          echo "Parent commit: ${parent}"
+
+          # 4. diff 第一父提交 .. tag commit
+          changed_files=$(git diff --name-only "${parent}" "${tag_commit}")
+          if [[ -z "${changed_files}" ]]; then
+            echo "::error::tag commit 相对父提交无变更文件，拒绝构建"
+            exit 1
+          fi
+          echo "Changed files:"
+          echo "${changed_files}"
+
+          # 5. 判断是否存在非文档/非忽略路径的变更
+          #    忽略列表：docs/、.md、ISSUE_TEMPLATE、PULL_REQUEST_TEMPLATE、LICENSE、dist/
+          ignore_pattern='^docs/|\.md$|^\.github/ISSUE_TEMPLATE/|^\.github/PULL_REQUEST_TEMPLATE\.md$|^LICENSE$|^dist/'
+          has_code_changes=false
+
+          while IFS= read -r file; do
+            if ! echo "${file}" | grep -qE "${ignore_pattern}"; then
+              has_code_changes=true
+              echo "Non-doc change detected: ${file}"
+              break
+            fi
+          done <<< "${changed_files}"
+
+          if [[ "${has_code_changes}" == "true" ]]; then
+            allow_build="true"
+            allow_publish="true"
+            echo "Valid release tag — allowing build and publish"
+          else
+            allow_build="false"
+            allow_publish="false"
+            echo "Pure doc tag — skipping build and release"
+          fi
+
+          echo "allow_build=${allow_build}" >> "$GITHUB_OUTPUT"
+          echo "allow_publish=${allow_publish}" >> "$GITHUB_OUTPUT"
+
+  # ==========================================================================
+  # build-package：5 平台矩阵构建
+  #   仅当 preflight 输出 allow_build == 'true' 时执行
+  # ==========================================================================
   build-package:
     name: Build ${{ matrix.target_triple }}
+    needs: preflight
+    if: needs.preflight.outputs.allow_build == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -159,29 +255,23 @@ jobs:
             dist/qq-maid-bot-${{ steps.package.outputs.version }}-${{ matrix.target_triple }}.${{ matrix.archive_format }}.sha256
           if-no-files-found: error
 
+  # ==========================================================================
+  # publish-release：创建 GitHub Release
+  #   仅当是 tag push 且 preflight 允许发布时执行
+  #   needs build-package 保证 artifact 准备就绪；若 build-package 被跳过
+  #   （纯文档 tag），publish-release 也会被自动跳过
+  # ==========================================================================
   publish-release:
     name: Publish GitHub Release
-    needs: build-package
-    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [preflight, build-package]
+    if: |
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.preflight.outputs.allow_publish == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0  # 需要 master 历史做祖先校验
-
-      - name: Verify tag is on master
-        run: |
-          git fetch origin master
-          if ! git merge-base --is-ancestor "${{ github.ref_name }}" origin/master; then
-            echo "::error::Tag ${{ github.ref_name }} 不在 master 分支上，拒绝发布。请确认 tag 打在 master 上。"
-            exit 1
-          fi
-          echo "Tag ${{ github.ref_name }} 是 master 的祖先 ✓"
-
       - name: Download all package artifacts
         uses: actions/download-artifact@v8
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,7 @@ cargo build --workspace --release --all-features
 
 * 代码变更提交前至少跑完 1–3 步。
 * 纯文档变更（仅 `docs/`、`README.md`、`AGENTS.md` 等说明文档）不需要走一遍整套 CI；按影响范围做必要的文本自检即可。
+  * CI 行为：`ci.yml` 在 PR 阶段永远触发（保证状态检查不缺失），job 内通过 `git diff` 检测变更文件，纯文档则自动跳过 Rust 步骤。push 到 master 时通过 `paths-ignore` 从源头跳过纯文档推送。
 * 改动涉及启动、配置、依赖或发布时，再跑第 4 步。
 * 修改 `scripts/*.sh`：至少执行 `bash -n` 对应脚本。
 * 涉及诊断入口时执行 `make diagnose`。
@@ -286,8 +287,11 @@ commit message 使用简洁中文：
 注意：
 
 * tag 必须打在对应版本的 commit 上，不要漏打或打错版本号。
+* tag 必须打在 master 分支上。`release.yml` 的 `publish-release` job 会校验 tag 是否为 master 的祖先，不在 master 上则拒绝发布。
+  * 发版本前确保版本 commit 已合并到 master，再打 tag 推送。
 * 发版本前先跑完"常用验证"里的 CI 四步。
 * 不要把未发布的版本号写进 README 或文档里提前预告。
+* `release.yml` 的 `push: tags:` 也配置了 `paths-ignore`，纯文档变更打 tag 不会触发构建发布。发版本时因为一定会改 `Cargo.toml`（不在忽略列表），所以正常触发。
 
 ## 修改前后检查
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,11 +287,12 @@ commit message 使用简洁中文：
 注意：
 
 * tag 必须打在对应版本的 commit 上，不要漏打或打错版本号。
-* tag 必须打在 master 分支上。`release.yml` 的 `publish-release` job 会校验 tag 是否为 master 的祖先，不在 master 上则拒绝发布。
-  * 发版本前确保版本 commit 已合并到 master，再打 tag 推送。
+* tag 必须打在 master 分支上。`release.yml` 的 `preflight` job 会在矩阵构建前校验：
+  * tag commit 是否为 master 的祖先（`git merge-base --is-ancestor`），不在 master 上则立即失败，不启动 5 平台构建。
+  * tag commit 相对第一父提交是否包含有效代码变更（通过 `git diff` 检查变更文件），纯文档 tag 会跳过构建和发布。
+* 发版本前确保版本 commit 已合并到 master，再打 tag 推送。
 * 发版本前先跑完"常用验证"里的 CI 四步。
 * 不要把未发布的版本号写进 README 或文档里提前预告。
-* `release.yml` 的 `push: tags:` 也配置了 `paths-ignore`，纯文档变更打 tag 不会触发构建发布。发版本时因为一定会改 `Cargo.toml`（不在忽略列表），所以正常触发。
 
 ## 修改前后检查
 


### PR DESCRIPTION
## 变更说明

release.yml 加上两道防线，防止 tag 误打在非 master 分支或纯文档 commit 上触发发布。

### 防线 1：paths-ignore
`push: tags:` 触发条件加上 `paths-ignore`，纯文档 tag 从源头不触发 5 架构构建。

### 防线 2：master 祖先校验
`publish-release` job 新增 `git merge-base --is-ancestor` 检查，tag 不在 master 上直接报错拒绝发布。

## 相关
续 PR #63，那个 PR 合并后还差 release.yml 的改动未带上。