### PR TITLE
refactor: 部署和知识同步脚本抽取共享远程配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,8 @@ runtime/qq-maid-llm
 runtime/botctl.sh
 runtime/validate-runtime.sh
 runtime/diagnose-network.sh
+
+# 本地同步/部署脚本配置文件（含个人路径和远端别名）
+scripts/deploy.conf
 runtime/llmctl.sh
 runtime/gatewayctl.sh

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -114,8 +114,8 @@ make clean
 - `scripts/validate-runtime.sh glm`：只验证 GLM / OpenAI 兼容 key 和模型调用。
 - `scripts/validate-runtime.sh console`：只验证 Web 控制台 `/console/`。
 - `scripts/validate-runtime.sh restart-source`：用 `target/debug/qq-maid-bot` 临时验证当前源码统一程序。
-- `bash scripts/sync_knowledge.sh`：将本地知识库 markdown 文件同步到 `scripts/deploy.conf` 配置的远端服务器。
-- `bash scripts/sync_knowledge.sh --dry-run`：仅预览同步差异，不实际传输。
+- `bash scripts/sync_knowledge.sh`：以镜像语义把本地知识库 Markdown 同步到 `scripts/deploy.conf` 配置的远端服务器。本地删除或重命名的 `.md` 会从对应远端子目录中删除，删除范围仅限该子目录内部；非 `.md` 文件不会被传输或删除。
+- `bash scripts/sync_knowledge.sh --dry-run`：仅预览同步差异（包含将被删除的远端 `.md`），不实际传输或删除。远端知识库根目录由 `deploy.conf` 的 `REMOTE_KNOWLEDGE_DIR` 控制，未设置时默认为 `${REMOTE_PROJECT_DIR}/runtime/config/knowledge`，便于兼容应用通过 `KNOWLEDGE_DIR` 读取外部知识目录的部署方式。
 - `make clean`：清理根目录 Cargo Workspace 的构建产物。
 
 ## HTTP 与命令入口

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -33,6 +33,8 @@ QQ 接入相关能力优先在 gateway 演进；模型协议和 provider fallbac
 ├── scripts/
 │   ├── deploy-remote.sh
 │   ├── deploy-local.sh
+│   ├── sync_knowledge.sh
+│   ├── deploy.conf.example
 │   ├── diagnose-network.sh
 │   └── botctl.sh
 ├── runtime/
@@ -106,12 +108,14 @@ make clean
 - `make test-gateway`：执行 Rust common 与 Rust gateway fmt check、测试和 `cargo check`。
 - `make build`：构建统一 `qq-maid-bot` release 二进制。
 - `make deploy-local`：执行 `scripts/deploy-local.sh`，构建并安装到本地 `runtime/`。
-- `make deploy-remote`：执行 `scripts/deploy-remote.sh`，构建并发布 release 二进制到脚本配置的远端运行目录。
+- `make deploy-remote`：执行 `scripts/deploy-remote.sh`，构建并发布 release 二进制到 `scripts/deploy.conf` 配置的远端运行目录。
 - `make diagnose`：运行 shell 网络诊断，检查配置文件存在性、代理、公网出口 IP 和 Core `/healthz`。
 - `scripts/validate-runtime.sh check`：检查运行中统一服务状态、GLM 上游、Web 控制台和最近日志。
 - `scripts/validate-runtime.sh glm`：只验证 GLM / OpenAI 兼容 key 和模型调用。
 - `scripts/validate-runtime.sh console`：只验证 Web 控制台 `/console/`。
 - `scripts/validate-runtime.sh restart-source`：用 `target/debug/qq-maid-bot` 临时验证当前源码统一程序。
+- `bash scripts/sync_knowledge.sh`：将本地知识库 markdown 文件同步到 `scripts/deploy.conf` 配置的远端服务器。
+- `bash scripts/sync_knowledge.sh --dry-run`：仅预览同步差异，不实际传输。
 - `make clean`：清理根目录 Cargo Workspace 的构建产物。
 
 ## HTTP 与命令入口

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -4,14 +4,31 @@ set -euo pipefail
 # ============================================================
 # deploy-remote.sh - 构建并部署 qq-maid 项目到远程服务器
 #
-# 远程主机: aliyun
-# 远程路径: /root/project/qqbot
+# 远程服务器信息从 scripts/deploy.conf 读取 (与 sync_knowledge.sh 共用)。
+# 首次使用请从 deploy.conf.example 复制并填入实际值。
 # 部署组件: qq-maid-bot、控制脚本与诊断工具
 # ============================================================
 
-REMOTE="aliyun"
-REMOTE_DIR="/root/project/qqbot"
-REMOTE_RUNTIME_DIR="${REMOTE_DIR}/runtime"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPLOY_CONF="${SCRIPT_DIR}/deploy.conf"
+
+if [[ ! -f "$DEPLOY_CONF" ]]; then
+  echo "[错误] 远程服务器配置不存在: $DEPLOY_CONF"
+  echo "  请从 deploy.conf.example 复制并填入实际值。"
+  exit 1
+fi
+source "$DEPLOY_CONF"
+
+if [[ -z "${REMOTE_HOST:-}" ]]; then
+  echo "[错误] deploy.conf 缺少 REMOTE_HOST"
+  exit 1
+fi
+if [[ -z "${REMOTE_PROJECT_DIR:-}" ]]; then
+  echo "[错误] deploy.conf 缺少 REMOTE_PROJECT_DIR"
+  exit 1
+fi
+
+REMOTE_RUNTIME_DIR="${REMOTE_PROJECT_DIR}/runtime"
 LOCAL_VALIDATE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/qqbot-deploy-validate.XXXXXX")"
 
 cleanup_local_validate_dir() {
@@ -44,30 +61,30 @@ bash scripts/validate-release-runtime.sh "${LOCAL_VALIDATE_DIR}"
 
 echo "==> Uploading artifacts..."
 # runtime 是远端运行目录，专门放二进制、控制脚本、配置模板和运行期文件。
-ssh "${REMOTE}" "mkdir -p '${REMOTE_RUNTIME_DIR}'"
+ssh "${REMOTE_HOST}" "mkdir -p '${REMOTE_RUNTIME_DIR}'"
 
 # 将编译产物、脚本和配置模板上传为 .new 临时文件，避免覆盖正在运行的服务
-scp target/release/qq-maid-bot "${REMOTE}:${REMOTE_RUNTIME_DIR}/.qq-maid-bot.new"
-scp scripts/botctl.sh "${REMOTE}:${REMOTE_RUNTIME_DIR}/.botctl.sh.new"
-scp scripts/diagnose-network.sh "${REMOTE}:${REMOTE_RUNTIME_DIR}/.diagnose-network.sh.new"
-scp scripts/validate-runtime.sh "${REMOTE}:${REMOTE_RUNTIME_DIR}/.validate-runtime.sh.new"
-scp runtime/config/.env.example "${REMOTE}:${REMOTE_RUNTIME_DIR}/.env.example"
-scp runtime/README.md "${REMOTE}:${REMOTE_RUNTIME_DIR}/README.md"
-scp -r runtime/static "${REMOTE}:${REMOTE_RUNTIME_DIR}/.static.new"
+scp target/release/qq-maid-bot "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.qq-maid-bot.new"
+scp scripts/botctl.sh "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.botctl.sh.new"
+scp scripts/diagnose-network.sh "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.diagnose-network.sh.new"
+scp scripts/validate-runtime.sh "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.validate-runtime.sh.new"
+scp runtime/config/.env.example "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.env.example"
+scp runtime/README.md "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/README.md"
+scp -r runtime/static "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.static.new"
 
 echo "==> Installing artifacts..."
 # 设置可执行权限后，将临时文件原子地替换为目标文件
-ssh "${REMOTE}" "cd '${REMOTE_RUNTIME_DIR}' && rm -rf static.old && chmod 0755 .qq-maid-bot.new .botctl.sh.new .diagnose-network.sh.new .validate-runtime.sh.new && mv -f .qq-maid-bot.new qq-maid-bot && mv -f .botctl.sh.new botctl.sh && mv -f .diagnose-network.sh.new diagnose-network.sh && mv -f .validate-runtime.sh.new validate-runtime.sh && find . -maxdepth 1 -type f -name 'qq-maid-*' ! -name 'qq-maid-bot' -delete && find . -maxdepth 1 -type f -name '*ctl.sh' ! -name 'botctl.sh' -delete && { test ! -d static || mv static static.old; } && mv .static.new static && rm -rf static.old"
+ssh "${REMOTE_HOST}" "cd '${REMOTE_RUNTIME_DIR}' && rm -rf static.old && chmod 0755 .qq-maid-bot.new .botctl.sh.new .diagnose-network.sh.new .validate-runtime.sh.new && mv -f .qq-maid-bot.new qq-maid-bot && mv -f .botctl.sh.new botctl.sh && mv -f .diagnose-network.sh.new diagnose-network.sh && mv -f .validate-runtime.sh.new validate-runtime.sh && find . -maxdepth 1 -type f -name 'qq-maid-*' ! -name 'qq-maid-bot' -delete && find . -maxdepth 1 -type f -name '*ctl.sh' ! -name 'botctl.sh' -delete && { test ! -d static || mv static static.old; } && mv .static.new static && rm -rf static.old"
 
 echo "==> Restarting remote services..."
 # 重启统一服务。旧双进程文件在安装阶段清理，避免同机残留旧入口。
 SECONDS=0
-ssh "${REMOTE}" "cd '${REMOTE_DIR}' && ./runtime/botctl.sh restart"
+ssh "${REMOTE_HOST}" "cd '${REMOTE_PROJECT_DIR}' && ./runtime/botctl.sh restart"
 RESTART_ELAPSED="${SECONDS}"
 
 echo "==> Checking processes..."
 # 检查服务是否已重新拉起
-ssh "${REMOTE}" "ps aux | grep -E 'qq-maid-bot' | grep -v grep || true"
+ssh "${REMOTE_HOST}" "ps aux | grep -E 'qq-maid-bot' | grep -v grep || true"
 
 echo "==> Done."
 printf '  构建 %ds | 重启 %ds | 总计 %ds\n' \

--- a/scripts/deploy.conf.example
+++ b/scripts/deploy.conf.example
@@ -10,9 +10,20 @@ REMOTE_HOST="your-server"
 # 远程项目根目录
 REMOTE_PROJECT_DIR="/root/project/qqbot"
 
+# 知识库在远端的根目录 (可选, 仅 sync_knowledge.sh 使用, deploy-remote.sh 忽略)
+# 应用可通过 KNOWLEDGE_DIR 指向项目目录之外的外部知识目录 (见
+# runtime/config/.env.example)。如果远端用这种方式把知识库放在项目目录外，
+# 请在这里设置 REMOTE_KNOWLEDGE_DIR 指向同一目录。
+# 留空或未设置: 使用 ${REMOTE_PROJECT_DIR}/runtime/config/knowledge
+# 示例: REMOTE_KNOWLEDGE_DIR="/opt/qqbot/private/config/knowledge"
+REMOTE_KNOWLEDGE_DIR=""
+
 # 知识库同步映射 (sync_knowledge.sh 使用, deploy-remote.sh 忽略)
-# 格式: "本地目录|远程子目录"
-# 远程目标 = ${REMOTE_PROJECT_DIR}/runtime/config/knowledge/<子目录>/
+# 格式: "本地目录|远端子目录"
+# 远端子目录必须是相对路径, 不允许绝对路径或 .. 穿越路径。
+# 远端目标 = ${REMOTE_KNOWLEDGE_DIR (或默认路径)}/<子目录>/
+# 同步为镜像语义: 本地删除的 .md 会从远端对应子目录中被删除,
+# 删除范围严格限定在该子目录内部; 非 .md 文件不会被传输或删除。
 SYNC_MAP=(
   # "/home/you/wiki/entries|wiki"
   # "/home/you/docs/project|docs"

--- a/scripts/deploy.conf.example
+++ b/scripts/deploy.conf.example
@@ -1,0 +1,19 @@
+# deploy-remote.sh / sync_knowledge.sh 共用远程服务器配置
+# 复制为 deploy.conf 并填入实际值:
+#   cp scripts/deploy.conf.example scripts/deploy.conf
+#
+# deploy.conf 已在 .gitignore 中，不会被提交。
+
+# SSH 别名或 user@host
+REMOTE_HOST="your-server"
+
+# 远程项目根目录
+REMOTE_PROJECT_DIR="/root/project/qqbot"
+
+# 知识库同步映射 (sync_knowledge.sh 使用, deploy-remote.sh 忽略)
+# 格式: "本地目录|远程子目录"
+# 远程目标 = ${REMOTE_PROJECT_DIR}/runtime/config/knowledge/<子目录>/
+SYNC_MAP=(
+  # "/home/you/wiki/entries|wiki"
+  # "/home/you/docs/project|docs"
+)

--- a/scripts/sync_knowledge.sh
+++ b/scripts/sync_knowledge.sh
@@ -88,16 +88,32 @@ if [[ ${#SYNC_MAP[@]} -eq 0 ]]; then
   exit 1
 fi
 
-# 校验每个映射条目，提前拦截非法配置，避免拼出越界或绝对路径。
-# 约束: 必须为 "本地目录|远端子目录"；两侧非空；远端子目录必须是
-# 相对路径，禁止绝对路径或 .. 路径穿越，确保 --delete 只在受控子目录内执行。
+# --- 预解析全部 SYNC_MAP，并在执行任何 rsync 前完成完整校验 ---
+# 先解析再校验，是因为 --delete 具有删除能力：若部分条目合法、部分非法，
+# 边执行边报错会让合法条目先同步，产生“只同步了一部分”的中间结果，
+# 甚至让一条映射把另一条映射刚同步的内容删掉。全部预校验可避免部分同步。
+#
+# 解析约束：条目必须“恰好包含一个 |”。用 ${ENTRY%%|*}/${ENTRY##*|} 会在
+# 含多个 | 时静默丢弃中间段，因此这里先计算分隔符数量再判定。
+#
+# 每条映射拆成两个并行数组：
+#   MAP_LOCALS[i] / MAP_SUBS[i] / MAP_RAW[i] (原始条目，用于错误提示)
+MAP_LOCALS=()
+MAP_SUBS=()
+MAP_RAW=()
 for ENTRY in "${SYNC_MAP[@]}"; do
-  if [[ "$ENTRY" != *"|"* ]]; then
-    echo "[错误] SYNC_MAP 条目缺少分隔符 |: '$ENTRY'，应为 '本地目录|远端子目录'"
+  # 条目必须恰好包含一个 |：
+  # 先把非 | 字符全部删掉，只剩 | 序列，其长度即 | 的个数。
+  # 注意 bash 不支持 ${#VAR//PAT/} (长度与替换不能嵌套)，因此先赋中间变量。
+  # 这里拒绝 0 个 | (缺分隔符) 和 ≥2 个 | (中间段会被 ${ENTRY%%|*} 静默丢弃)。
+  BARS_ONLY=${ENTRY//[!|]/}
+  BAR_COUNT=${#BARS_ONLY}
+  if [[ "$BAR_COUNT" -ne 1 ]]; then
+    echo "[错误] SYNC_MAP 条目必须包含且仅包含一个分隔符 |: '$ENTRY'，应为 '本地目录|远端子目录'"
     exit 1
   fi
   MAP_LOCAL="${ENTRY%%|*}"
-  MAP_SUB="${ENTRY##*|}"
+  MAP_SUB="${ENTRY#*|}"
   if [[ -z "$MAP_LOCAL" ]]; then
     echo "[错误] SYNC_MAP 条目本地目录为空: '$ENTRY'"
     exit 1
@@ -106,15 +122,94 @@ for ENTRY in "${SYNC_MAP[@]}"; do
     echo "[错误] SYNC_MAP 条目远端子目录为空: '$ENTRY'"
     exit 1
   fi
-  # 禁止绝对路径 (/开头) 和 .. 路径穿越，限制删除范围在受控子目录内
-  if [[ "$MAP_SUB" == /* ]]; then
-    echo "[错误] SYNC_MAP 远端子目录必须是相对路径，禁止绝对路径: '$ENTRY'"
+  MAP_LOCALS+=("$MAP_LOCAL")
+  MAP_SUBS+=("$MAP_SUB")
+  MAP_RAW+=("$ENTRY")
+done
+
+# 严格校验每个远端子目录并规范化为唯一形式。规范化后才用于冲突判断，
+# 避免不同写法 (如 wiki 与 wiki/) 被误判为不同目标后又互相删除文件。
+# 规范化结果存入 MAP_SUBS_NORM，后续 rsync 也用规范形式作为实际目标，
+# 保证冲突检查所见即 rsync 所写。
+MAP_SUBS_NORM=()
+for i in "${!MAP_SUBS[@]}"; do
+  SUB="${MAP_SUBS[$i]}"
+  RAW="${MAP_RAW[$i]}"
+  # 禁止绝对路径：/ 开头会跳出 REMOTE_KBASE 划定的受控子目录范围
+  if [[ "$SUB" == /* ]]; then
+    echo "[错误] SYNC_MAP 远端子目录必须是相对路径，禁止绝对路径: '$RAW'"
     exit 1
   fi
-  if [[ "$MAP_SUB" == *..* ]]; then
-    echo "[错误] SYNC_MAP 远端子目录不允许包含 .. 以防止路径穿越: '$ENTRY'"
+  # 逐段拆解并规范化：折结空段、. 与 ..。
+  # 为检测“根目标”与越界，保留一个隐含的根标记逻辑：
+  #   - 任一段为空 (重复斜杠 wiki//a) → 拒绝；
+  #   - 任一段为 .  → 拒绝，含 ./ 、 wiki/. 、 a/./b 等；
+  #   - 任一段为 .. → 拒绝，含 ../ 、wiki/.. 、 wiki/../a 等。
+  # 拒绝 . 能避免“wiki|.”这类指向知识库根的映射与其他映射 (或全库) 互删。
+  NORM=""
+  SEG_IDX=0
+  # 在两端补 / 以保证首尾段不会被漏掉，例如 . 、 foo/ 同时可被按段检查。
+  REMAINDER="${SUB}/"
+  while [[ -n "$REMAINDER" ]]; do
+    SEG="${REMAINDER%%/*}"
+    REST="${REMAINDER#*/}"
+    REMAINDER="$REST"
+    if [[ -z "$SEG" ]]; then
+      # 首空段 = 绝对路径 (已拦)，中间/末尾空段 = 重复斜杠 (wiki//a) 或尾随斜杠 (wiki/)
+      echo "[错误] SYNC_MAP 远端子目录包含空路径段或重复斜杠: '$RAW'"
+      exit 1
+    fi
+    if [[ "$SEG" == "." ]]; then
+      echo "[错误] SYNC_MAP 远端子目录不允许使用 '.' 段: '$RAW'"
+      exit 1
+    fi
+    if [[ "$SEG" == ".." ]]; then
+      echo "[错误] SYNC_MAP 远端子目录不允许包含 '..' 以防止路径穿越: '$RAW'"
+      exit 1
+    fi
+    if [[ $SEG_IDX -eq 0 ]]; then
+      NORM="$SEG"
+    else
+      NORM="${NORM}/${SEG}"
+    fi
+    SEG_IDX=$((SEG_IDX + 1))
+  done
+  if [[ -z "$NORM" ]]; then
+    # 例如原始为空 (已在上面拦) 或被上面的逻辑推到，这里二次防御
+    echo "[错误] SYNC_MAP 远端子目录规范化后为空: '$RAW'"
     exit 1
   fi
+  MAP_SUBS_NORM+=("$NORM")
+done
+
+# 检查所有远端子目录目标之间是否存在重复或父子重叠冲突。
+# 因为 --delete 会在各自子目录内删除本地不存在的 .md，若两个映射指向
+# 同一目标或一个是另一个的父目录，后者会删掉前者刚写的内容，或在
+# 重复目标上发生互相覆盖。以规范后的段序列比较，避免写法不同被漏掉。
+# 同时将上一轮已见到的目标计入冲突信息，让错误能展示两个冲突目标。
+# 冲突检查发生在任何 rsync 之前，保证不存在部分同步结果。
+SEEN_NORM=()        # 已见到的规范路径
+SEEN_RAW=()         # 对应原始条目，用于冲突报错可读
+for i in "${!MAP_SUBS_NORM[@]}"; do
+  CUR="${MAP_SUBS_NORM[$i]}"
+  CUR_RAW="${MAP_RAW[$i]}"
+  for j in "${!SEEN_NORM[@]}"; do
+    PREV="${SEEN_NORM[$j]}"
+    PREV_RAW="${SEEN_RAW[$j]}"
+    if [[ "$CUR" == "$PREV" ]]; then
+      echo "[错误] SYNC_MAP 发现重复远端目标: '$CUR_RAW' 与 '$PREV_RAW' 均指向 '$CUR'"
+      exit 1
+    fi
+    # 父子重叠：以“段级前缀”判定。CUR 与 PREV 并存时，均是以 / 划分后的序段序列。
+    # 若 A 子目录是 B 的父目录，则 B 序列 = A 序列 + "/...". 例子：wiki vs wiki/private。
+    # 这里用 “A / ”前缀比较避免 wiki 与 wiki2 被误判 (段级而非字符串级)。
+    if [[ "$CUR" == "${PREV}/"* || "$PREV" == "${CUR}/"* ]]; then
+      echo "[错误] SYNC_MAP 发现父子重叠远端目标: '$CUR_RAW' 与 '$PREV_RAW' (路径 $CUR / $PREV)"
+      exit 1
+    fi
+  done
+  SEEN_NORM+=("$CUR")
+  SEEN_RAW+=("$CUR_RAW")
 done
 
 # 远端知识库根目录: 优先 REMOTE_KNOWLEDGE_DIR (兼容应用用 KNOWLEDGE_DIR
@@ -134,19 +229,23 @@ if [[ -n "$DRY_RUN" ]]; then
 fi
 
 OK=0
-SKIP=0
 FAIL=0
 
-for ENTRY in "${SYNC_MAP[@]}"; do
-  LOCAL_DIR="${ENTRY%%|*}"
-  SUB_DIR="${ENTRY##*|}"
+# 同步循环使用预解析后的 MAP_LOCALS / MAP_SUBS。原始 SUB_SPACE 写法用于日志输出，
+# 实际远端路径拼接用规范后的 MAP_SUBS_NORM 以保证冲突检查与实际目标一致。
+for i in "${!MAP_LOCALS[@]}"; do
+  LOCAL_DIR="${MAP_LOCALS[$i]}"
+  SUB_DIR="${MAP_SUBS_NORM[$i]}"
 
   echo ""
   echo ">>> 同步: ${LOCAL_DIR}/ -> ${REMOTE_HOST}:${REMOTE_KBASE}/${SUB_DIR}/"
 
+  # 本地源目录不存在不再是可忽略的 SKIP：--delete 镜像语义下，
+  # 如果当作成功跳过，会在远端残留旧 .md 而脚本仍返回 0，与镜像语义矛盾。
+  # 参与计入失败计数，由文末汇总判定整体退出码，避免“返回成功但远端末干净”。
   if [[ ! -d "$LOCAL_DIR" ]]; then
-    echo "  [跳过] 本地目录不存在: $LOCAL_DIR"
-    SKIP=$((SKIP + 1))
+    echo "  [失败] 本地源目录不存在: $LOCAL_DIR"
+    FAIL=$((FAIL + 1))
     continue
   fi
 
@@ -163,7 +262,7 @@ for ENTRY in "${SYNC_MAP[@]}"; do
 done
 
 echo ""
-echo "=== 同步完成: 成功 ${OK}, 跳过 ${SKIP}, 失败 ${FAIL} ==="
+echo "=== 同步完成: 成功 ${OK}, 失败 ${FAIL} ==="
 
 # 任意 rsync 失败时整体以非零退出，供 CI / 自动化判定结果。
 # 不能只在日志里打印失败计数后仍返回成功 (修前 bug)。

--- a/scripts/sync_knowledge.sh
+++ b/scripts/sync_knowledge.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# 同步本地知识库 markdown 文件到远程服务器
+# 同步本地知识库 markdown 文件到远程服务器 (镜像语义)
 #
 # 用法:
 #   bash scripts/sync_knowledge.sh          # 执行同步
@@ -7,6 +7,21 @@
 #
 # 配置文件: scripts/deploy.conf (与 deploy-remote.sh 共用)
 #   首次使用请从 deploy.conf.example 复制并修改。
+#
+# 同步语义:
+#   对每个 SYNC_MAP 条目，把本地目录下的 Markdown (.md) 镜像同步到
+#   远端对应子目录。所谓“镜像”指：本地已删除或重命名的 .md 文件会
+#   在本次同步中被从远端对应子目录里删除。
+#   删除范围严格限定在每个映射条目对应的远端子目录内部，绝不会影响
+#   该子目录之外的任何文件。
+#   非 .md 文件不在传输/删除范围内：本地上传不含非 md 文件，远端非
+#   md 文件也不会被删除 (rsync --delete 不会触及被 exclude 的文件)。
+#
+# 远端知识库根目录:
+#   优先使用 deploy.conf 中的 REMOTE_KNOWLEDGE_DIR (用于支持应用通过
+#   KNOWLEDGE_DIR 读取外部知识目录的部署方式)。
+#   未设置或为空时默认使用: ${REMOTE_PROJECT_DIR}/runtime/config/knowledge
+#   每个 SYNC_MAP 条目的远端目标为: ${REMOTE_KNOWLEDGE_DIR 或默认路径}/${子目录}/
 
 set -euo pipefail
 
@@ -24,9 +39,14 @@ while [[ $# -gt 0 ]]; do
     -h|--help)
       echo "用法: bash scripts/sync_knowledge.sh [--dry-run]"
       echo ""
-      echo "  同步本地知识库 markdown 文件到远程服务器。"
-      echo "  配置文件: scripts/deploy.conf (与 deploy-remote.sh 共用)"
-      echo "  首次使用请从 deploy.conf.example 复制并修改。"
+      echo "  镜像同步本地知识库 Markdown 到远端 (与 deploy-remote.sh 共用 deploy.conf)。"
+      echo "  本地删除的 .md 会在对应远端子目录中被删除，删除范围仅限该子目录内部。"
+      echo "  非 .md 文件不会被传输或删除。"
+      echo ""
+      echo "  远端知识库根目录由 deploy.conf 的 REMOTE_KNOWLEDGE_DIR 控制，"
+      echo '  未设置时默认使用 ${REMOTE_PROJECT_DIR}/runtime/config/knowledge。'
+      echo ""
+      echo "  --dry-run 仅预览差异，不实际传输或删除。"
       exit 0
       ;;
     *)
@@ -53,19 +73,64 @@ if [[ -z "${REMOTE_PROJECT_DIR:-}" ]]; then
   echo "[错误] deploy.conf 缺少 REMOTE_PROJECT_DIR"
   exit 1
 fi
+# set -u 下直接访问未声明的数组会触发 unbound variable。
+# Bash 5.2 中 ${SYNC_MAP+x} 对 \"声明但为空数组\" 与 \"完全未声明\" 均返回空，
+# 无法区分，因此改用 declare -p 探测变量是否被声明：
+#   未声明 → declare -p 失败 (rc=1)，输出“未声明”友好错误；
+#   声明为空 SYNC_MAP=() → declare -p 成功，再由 ${#SYNC_MAP[@]} 判空，
+#   输出“缺少条目”错误。两种情况都以非零退出，且不暴露 unbound 错误。
+if ! declare -p SYNC_MAP >/dev/null 2>&1; then
+  echo "[错误] deploy.conf 未声明 SYNC_MAP，请按 \"本地目录|远端子目录\" 格式定义至少一条映射"
+  exit 1
+fi
 if [[ ${#SYNC_MAP[@]} -eq 0 ]]; then
-  echo "[错误] deploy.conf 缺少 SYNC_MAP 条目"
+  echo "[错误] deploy.conf 缺少 SYNC_MAP 条目，请至少配置一条 \"本地目录|远端子目录\" 映射"
   exit 1
 fi
 
-# 知识库在远程项目目录下的固定位置
-REMOTE_KBASE="${REMOTE_PROJECT_DIR}/runtime/config/knowledge"
+# 校验每个映射条目，提前拦截非法配置，避免拼出越界或绝对路径。
+# 约束: 必须为 "本地目录|远端子目录"；两侧非空；远端子目录必须是
+# 相对路径，禁止绝对路径或 .. 路径穿越，确保 --delete 只在受控子目录内执行。
+for ENTRY in "${SYNC_MAP[@]}"; do
+  if [[ "$ENTRY" != *"|"* ]]; then
+    echo "[错误] SYNC_MAP 条目缺少分隔符 |: '$ENTRY'，应为 '本地目录|远端子目录'"
+    exit 1
+  fi
+  MAP_LOCAL="${ENTRY%%|*}"
+  MAP_SUB="${ENTRY##*|}"
+  if [[ -z "$MAP_LOCAL" ]]; then
+    echo "[错误] SYNC_MAP 条目本地目录为空: '$ENTRY'"
+    exit 1
+  fi
+  if [[ -z "$MAP_SUB" ]]; then
+    echo "[错误] SYNC_MAP 条目远端子目录为空: '$ENTRY'"
+    exit 1
+  fi
+  # 禁止绝对路径 (/开头) 和 .. 路径穿越，限制删除范围在受控子目录内
+  if [[ "$MAP_SUB" == /* ]]; then
+    echo "[错误] SYNC_MAP 远端子目录必须是相对路径，禁止绝对路径: '$ENTRY'"
+    exit 1
+  fi
+  if [[ "$MAP_SUB" == *..* ]]; then
+    echo "[错误] SYNC_MAP 远端子目录不允许包含 .. 以防止路径穿越: '$ENTRY'"
+    exit 1
+  fi
+done
+
+# 远端知识库根目录: 优先 REMOTE_KNOWLEDGE_DIR (兼容应用用 KNOWLEDGE_DIR
+# 读取外部目录的部署方式)，未设置或为空时回退到默认项目内路径。
+# 注意 ${REMOTE_KNOWLEDGE_DIR:-} 在 set -u 下安全: 未声明时展开为空。
+REMOTE_KBASE="${REMOTE_KNOWLEDGE_DIR:-${REMOTE_PROJECT_DIR}/runtime/config/knowledge}"
 
 # --- 执行同步 ---
-RSYNC_FLAGS="-avz --progress"
+# --delete 实现“镜像”语义：远端对应子目录中本地不存在的 .md 会被删除。
+# 由于 include/exclude 规则把非 .md 文件置于 *,exclude，--delete 不会触及
+# 这些被排除的文件，因此远端非 .md 文件保持原样，不会被误删。
+# 删除范围被 rsync 自动限定在本次传输的远端目标子目录内部，绝不外溢。
+RSYNC_FLAGS="-avz --progress --delete"
 if [[ -n "$DRY_RUN" ]]; then
   RSYNC_FLAGS="$RSYNC_FLAGS --dry-run"
-  echo "=== 预览模式 (--dry-run) ==="
+  echo "=== 预览模式 (--dry-run)，不会实际传输或删除 ==="
 fi
 
 OK=0
@@ -85,6 +150,8 @@ for ENTRY in "${SYNC_MAP[@]}"; do
     continue
   fi
 
+  # 失败用 if 判定收集计数，不能让 set -e 直接退出，否则无法输出汇总。
+  # 本次同步的状态由循环结束后的汇总决定 (见文末)。
   if rsync ${RSYNC_FLAGS} \
     --include='*/' --include='*.md' --exclude='*' \
     "${LOCAL_DIR}/" "${REMOTE_HOST}:${REMOTE_KBASE}/${SUB_DIR}/"; then
@@ -97,3 +164,10 @@ done
 
 echo ""
 echo "=== 同步完成: 成功 ${OK}, 跳过 ${SKIP}, 失败 ${FAIL} ==="
+
+# 任意 rsync 失败时整体以非零退出，供 CI / 自动化判定结果。
+# 不能只在日志里打印失败计数后仍返回成功 (修前 bug)。
+if [[ "$FAIL" -ne 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/scripts/sync_knowledge.sh
+++ b/scripts/sync_knowledge.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# 同步本地知识库 markdown 文件到远程服务器
+#
+# 用法:
+#   bash scripts/sync_knowledge.sh          # 执行同步
+#   bash scripts/sync_knowledge.sh --dry-run # 仅预览差异
+#
+# 配置文件: scripts/deploy.conf (与 deploy-remote.sh 共用)
+#   首次使用请从 deploy.conf.example 复制并修改。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPLOY_CONF="${SCRIPT_DIR}/deploy.conf"
+DRY_RUN=""
+
+# --- 参数解析 ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN="--dry-run"
+      shift
+      ;;
+    -h|--help)
+      echo "用法: bash scripts/sync_knowledge.sh [--dry-run]"
+      echo ""
+      echo "  同步本地知识库 markdown 文件到远程服务器。"
+      echo "  配置文件: scripts/deploy.conf (与 deploy-remote.sh 共用)"
+      echo "  首次使用请从 deploy.conf.example 复制并修改。"
+      exit 0
+      ;;
+    *)
+      echo "未知参数: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# --- 加载配置 ---
+if [[ ! -f "$DEPLOY_CONF" ]]; then
+  echo "[错误] 配置文件不存在: $DEPLOY_CONF"
+  echo "  请从 deploy.conf.example 复制并填入实际值。"
+  exit 1
+fi
+source "$DEPLOY_CONF"
+
+# --- 校验 ---
+if [[ -z "${REMOTE_HOST:-}" ]]; then
+  echo "[错误] deploy.conf 缺少 REMOTE_HOST"
+  exit 1
+fi
+if [[ -z "${REMOTE_PROJECT_DIR:-}" ]]; then
+  echo "[错误] deploy.conf 缺少 REMOTE_PROJECT_DIR"
+  exit 1
+fi
+if [[ ${#SYNC_MAP[@]} -eq 0 ]]; then
+  echo "[错误] deploy.conf 缺少 SYNC_MAP 条目"
+  exit 1
+fi
+
+# 知识库在远程项目目录下的固定位置
+REMOTE_KBASE="${REMOTE_PROJECT_DIR}/runtime/config/knowledge"
+
+# --- 执行同步 ---
+RSYNC_FLAGS="-avz --progress"
+if [[ -n "$DRY_RUN" ]]; then
+  RSYNC_FLAGS="$RSYNC_FLAGS --dry-run"
+  echo "=== 预览模式 (--dry-run) ==="
+fi
+
+OK=0
+SKIP=0
+FAIL=0
+
+for ENTRY in "${SYNC_MAP[@]}"; do
+  LOCAL_DIR="${ENTRY%%|*}"
+  SUB_DIR="${ENTRY##*|}"
+
+  echo ""
+  echo ">>> 同步: ${LOCAL_DIR}/ -> ${REMOTE_HOST}:${REMOTE_KBASE}/${SUB_DIR}/"
+
+  if [[ ! -d "$LOCAL_DIR" ]]; then
+    echo "  [跳过] 本地目录不存在: $LOCAL_DIR"
+    SKIP=$((SKIP + 1))
+    continue
+  fi
+
+  if rsync ${RSYNC_FLAGS} \
+    --include='*/' --include='*.md' --exclude='*' \
+    "${LOCAL_DIR}/" "${REMOTE_HOST}:${REMOTE_KBASE}/${SUB_DIR}/"; then
+    OK=$((OK + 1))
+  else
+    echo "  [失败] rsync 返回非零: ${LOCAL_DIR}"
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+echo ""
+echo "=== 同步完成: 成功 ${OK}, 跳过 ${SKIP}, 失败 ${FAIL} ==="

--- a/scripts/tests/test-sync-knowledge.sh
+++ b/scripts/tests/test-sync-knowledge.sh
@@ -1,0 +1,389 @@
+#!/usr/bin/env bash
+# sync_knowledge.sh 回归测试。
+#
+# 思路: 用一个 fake rsync 把 sync_knowledge.sh 调用中的最后一个 host:path
+# 形参改写成本地临时目录，复用真实 /usr/bin/rsync 完成实际镜像动作，
+# 从而在不需要真实服务器的情况下验证退出码、镜像删除、删除范围限定、
+# 配置校验、目标冲突等行为。
+#
+# 用法:
+#   bash scripts/tests/test-sync-knowledge.sh
+#
+# 退出码: 全部通过返回 0，任一失败返回 1。临时目录在退出前清理。
+
+set -uo pipefail
+
+# 仓库根目录: 本脚本位于 <repo>/scripts/tests/，向上两级即仓库根。
+TEST_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/sync_knowledge.sh"
+
+# 同步脚本固定读取 scripts/deploy.conf，测试期间向其写入临时配置并清理。
+DEPLOY_CONF="$REPO_ROOT/scripts/deploy.conf"
+
+PASS=0
+FAIL=0
+TMPROOT=""
+
+ok() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+ko() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+cleanup() {
+  rm -rf "$TMPROOT"
+  rm -f "$DEPLOY_CONF"
+}
+trap cleanup EXIT
+
+# 准备一个 fake rsync + fake ssh 的临时环境到一个独立的 case 根目录。
+# 返回的 TROOT 变量供单个用例使用。fake rsync 会把 host:path 改写到
+# $FAKE_REMOTE_ROOT/path 之下，并按需预创建目标目录。
+setup_fake() {
+  TROOT="$1"
+  rm -rf "$TROOT"
+  mkdir -p "$TROOT/bin" "$TROOT/local" "$TROOT/remote"
+  cat > "$TROOT/bin/rsync" <<'RSYNC'
+#!/usr/bin/env bash
+# 拦截并把最后一个 host:path 形参改写为本地方向，再调用真实 rsync。
+real=/usr/bin/rsync
+args=()
+for a in "$@"; do
+  # 仅匹配形如 host:path 的远端目标 (不以 - 开头、含冒号、非绝对路径)。
+  if [[ "$a" == *":"* && "$a" != /* && "$a" != -* ]]; then
+    path="${a#*:}"
+    dest="${FAKE_REMOTE_ROOT}/${path}"
+    mkdir -p "$dest"
+    args+=("$dest")
+  else
+    args+=("$a")
+  fi
+done
+# 可选: 命中关键字时模拟 rsync 失败，用于验证失败退出码。
+if [[ -n "${FAKE_RSYNC_FAIL_ON:-}" ]]; then
+  for a in "${args[@]}"; do
+    if [[ "$a" == *"$FAKE_RSYNC_FAIL_ON"* ]]; then
+      echo "fake-rsync: simulated failure for $a" >&2
+      exit 1
+    fi
+  done
+fi
+exec "$real" "${args[@]}"
+RSYNC
+  chmod +x "$TROOT/bin/rsync"
+  cat > "$TROOT/bin/ssh" <<'SSH'
+#!/usr/bin/env bash
+exit 0
+SSH
+  chmod +x "$TROOT/bin/ssh"
+}
+
+# 把给定 stdin 写入 $DEPLOY_CONF (供 source)。
+putconf() { cat > "$DEPLOY_CONF"; }
+
+# 运行被测脚本时注入 fake PATH 与 FAKE_REMOTE_ROOT。
+run() {
+  PATH="$TROOT/bin:$PATH" FAKE_REMOTE_ROOT="$TROOT/remote" bash "$SCRIPT" "$@"
+}
+
+COUNTER=0
+newcase() {
+  COUNTER=$((COUNTER + 1))
+  TROOT="$TMPROOT/c${COUNTER}"
+  setup_fake "$TROOT"
+}
+
+# ---------------------------------------------------------------------------
+TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/sync-knowledge-tests.XXXXXX")"
+
+# --- 1. 缺失 SYNC_MAP (完全不声明) ---
+newcase
+putconf <<'CONF'
+REMOTE_HOST="srv"
+REMOTE_PROJECT_DIR="/srv/qqbot"
+CONF
+out=$(run 2>&1); rc=$?
+if echo "$out" | grep -q '未声明 SYNC_MAP' && [[ $rc -ne 0 ]] && ! echo "$out" | grep -qi 'unbound'; then
+  ok "缺失 SYNC_MAP → 友好错误 + 非零 + 无 unbound"
+else
+  ko "缺失SYNC_MAP: rc=$rc out=$out"
+fi
+
+# --- 2. 空 SYNC_MAP=() ---
+newcase
+putconf <<'CONF'
+REMOTE_HOST="srv"
+REMOTE_PROJECT_DIR="/srv/qqbot"
+SYNC_MAP=()
+CONF
+out=$(run 2>&1); rc=$?
+if echo "$out" | grep -q '缺少 SYNC_MAP 条目' && [[ $rc -ne 0 ]]; then
+  ok "空 SYNC_MAP → 拒绝 + 非零"
+else
+  ko "空SYNC_MAP: rc=$rc out=$out"
+fi
+
+# --- 3. 缺少分隔符 ---
+newcase
+putconf <<'CONF'
+REMOTE_HOST="srv"
+REMOTE_PROJECT_DIR="/srv/qqbot"
+SYNC_MAP=("wikinocthing")
+CONF
+out=$(run 2>&1); rc=$?
+if [[ $rc -ne 0 ]] && echo "$out" | grep -q '且仅包含一个分隔符'; then
+  ok "缺少分隔符被拒绝"
+else
+  ko "缺少分隔符: rc=$rc out=$out"
+fi
+
+# --- 4. 多个分隔符 ---
+newcase
+putconf <<'CONF'
+REMOTE_HOST="srv"
+REMOTE_PROJECT_DIR="/srv/qqbot"
+SYNC_MAP=("/home/x/wiki|wiki|extra")
+CONF
+out=$(run 2>&1); rc=$?
+if [[ $rc -ne 0 ]] && echo "$out" | grep -q '且仅包含一个分隔符'; then
+  ok "多个分隔符被拒绝 (中间段不被静默丢弃)"
+else
+  ko "多分隔符: rc=$rc out=$out"
+fi
+
+# --- 5. 本地目录为空 / 远端子目录为空 ---
+newcase
+putconf <<'CONF'
+REMOTE_HOST="srv"
+REMOTE_PROJECT_DIR="/srv/qqbot"
+SYNC_MAP=("|wiki")
+CONF
+out=$(run 2>&1); rc=$?
+[[ $rc -ne 0 ]] && echo "$out" | grep -q '本地目录为空' && ok "本地目录空被拒" || ko "本地空: rc=$rc out=$out"
+
+newcase
+putconf <<'CONF'
+REMOTE_HOST="srv"
+REMOTE_PROJECT_DIR="/srv/qqbot"
+SYNC_MAP=("/home/x/wiki|")
+CONF
+out=$(run 2>&1); rc=$?
+[[ $rc -ne 0 ]] && echo "$out" | grep -q '远端子目录为空' && ok "远端子目录空被拒" || ko "远端空: rc=$rc out=$out"
+
+# --- 6. 非法子目录路径 (绝对 / 空段重复斜杠 / . / ..) ---
+bad_cases=(
+  "wiki|/abs"          # 绝对路径
+  "wiki|wiki//a"       # 重复斜杠
+  "wiki|wiki/"         # 尾随斜杠 → 末尾空段
+  "wiki|."             # 根目录别名
+  "wiki|./"            # 根目录别名变体
+  "wiki|./wiki"        # 前导 ./
+  "wiki|wiki/."        # 末尾 .
+  "wiki|wiki/../a"     # .. 穿越
+  "wiki|a/../b"        # .. 归一后段
+)
+for bad in "${bad_cases[@]}"; do
+  newcase
+  putconf <<CONF
+REMOTE_HOST="srv"
+REMOTE_PROJECT_DIR="/srv/qqbot"
+SYNC_MAP=("$bad")
+CONF
+  out=$(run 2>&1); rc=$?
+  if [[ $rc -ne 0 ]] && echo "$out" | grep -q '\[错误\]'; then
+    ok "拒绝非法子目录 [$bad]"
+  else
+    ko "非法子目录未拒 [$bad] rc=$rc out=$out"
+  fi
+done
+
+# --- 7. 重复目标: wiki 与 wiki ---
+newcase
+mkdir -p "$TROOT/local/a" "$TROOT/local/b"
+echo "a" > "$TROOT/local/a/a.md"
+echo "b" > "$TROOT/local/b/b.md"
+putconf <<CONF
+REMOTE_HOST="srv"
+REMOTE_PROJECT_DIR="/srv/qqbot"
+SYNC_MAP=("$TROOT/local/a|wiki" "$TROOT/local/b|wiki")
+CONF
+out=$(run 2>&1); rc=$?
+# 重复目标必须发生在任何 rsync 之前，所以远端不应被写入。
+if [[ $rc -ne 0 ]] && echo "$out" | grep -q '重复远端目标' && [ -z "$(ls -A "$TROOT/remote" 2>/dev/null)" ]; then
+  ok "重复目标 wiki|wiki 冲突报错且未触发同步"
+else
+  ko "重复目标: rc=$rc out=$out remote=$(ls -A "$TROOT/remote" 2>/dev/null)"
+fi
+
+# --- 8. 父子重叠: wiki 与 wiki/private ---
+newcase
+mkdir -p "$TROOT/local/a" "$TROOT/local/b"
+echo "a" > "$TROOT/local/a/a.md"
+echo "b" > "$TROOT/local/b/b.md"
+putconf <<CONF
+REMOTE_HOST="srv"
+REMOTE_PROJECT_DIR="/srv/qqbot"
+SYNC_MAP=("$TROOT/local/a|wiki" "$TROOT/local/b|wiki/private")
+CONF
+out=$(run 2>&1); rc=$?
+if [[ $rc -ne 0 ]] && echo "$out" | grep -q '父子重叠' && [ -z "$(ls -A "$TROOT/remote" 2>/dev/null)" ]; then
+  ok "父子重叠 wiki / wiki/private 冲突且未同步"
+else
+  ko "父子重叠: rc=$rc out=$out"
+fi
+
+# --- 9. 父子字母相邻但不应误判: wiki 与 wiki2 ---
+newcase
+mkdir -p "$TROOT/local/a" "$TROOT/local/b"
+echo "a" > "$TROOT/local/a/a.md"
+echo "b" > "$TROOT/local/b/b.md"
+putconf <<CONF
+REMOTE_HOST="srv"
+REMOTE_PROJECT_DIR="/srv/qqbot"
+SYNC_MAP=("$TROOT/local/a|wiki" "$TROOT/local/b|wiki2")
+CONF
+out=$(run 2>&1); rc=$?
+# wiki 与 wiki2 是同级、段级前缀不重叠，应允许通过且成功同步两个目录。
+if [[ $rc -eq 0 ]] && echo "$out" | grep -q '成功 2'; then
+  ok "wiki 与 wiki2 不被误判为父子重叠"
+else
+  ko "wiki/wiki2 误判: rc=$rc out=$out"
+fi
+
+# --- 10. 本地源目录不存在 → 非零 ---
+newcase
+putconf <<'CONF'
+REMOTE_HOST="srv"
+REMOTE_PROJECT_DIR="/srv/qqbot"
+SYNC_MAP=("/nonexistent/path/here|wiki")
+CONF
+out=$(run 2>&1); rc=$?
+if [[ $rc -ne 0 ]] && echo "$out" | grep -q '本地源目录不存在'; then
+  ok "源目录不存在 → 失败 + 非零"
+else
+  ko "源目录不存在: rc=$rc out=$out"
+fi
+
+# --- 11. 正常多映射同步成功 + 默认目标 ---
+newcase
+mkdir -p "$TROOT/local/wiki" "$TROOT/local/docs"
+echo "w" > "$TROOT/local/wiki/w.md"
+echo "d" > "$TROOT/local/docs/d.md"
+putconf <<CONF
+REMOTE_HOST="srv"
+REMOTE_PROJECT_DIR="/srv/qqbot"
+SYNC_MAP=("$TROOT/local/wiki|wiki" "$TROOT/local/docs|docs")
+CONF
+out=$(run 2>&1); rc=$?
+base="$TROOT/remote/srv/qqbot/runtime/config/knowledge"
+if [[ $rc -eq 0 ]] && echo "$out" | grep -q '成功 2' \
+  && [ -f "$base/wiki/w.md" ] && [ -f "$base/docs/d.md" ]; then
+  ok "正常多映射成功且默认目标正确"
+else
+  ko "正常多映射: rc=$rc out=$out"
+fi
+
+# --- 12. 自定义 REMOTE_KNOWLEDGE_DIR ---
+newcase
+mkdir -p "$TROOT/local/wiki"; echo "b" > "$TROOT/local/wiki/b.md"
+putconf <<CONF
+REMOTE_HOST="srv"
+REMOTE_PROJECT_DIR="/srv/qqbot"
+REMOTE_KNOWLEDGE_DIR="/opt/qqbot/private/config/knowledge"
+SYNC_MAP=("$TROOT/local/wiki|wiki")
+CONF
+out=$(run 2>&1); rc=$?
+tgt="$TROOT/remote/opt/qqbot/private/config/knowledge/wiki/b.md"
+if [[ $rc -eq 0 ]] && [ -f "$tgt" ]; then
+  ok "REMOTE_KNOWLEDGE_DIR 覆盖目标"
+else
+  ko "覆盖失败: rc=$rc out=$out"
+fi
+
+# --- 13. dry-run 删除预览 + 非实际删除 + 非md保留 ---
+newcase
+mkdir -p "$TROOT/local/wiki"; echo "keep" > "$TROOT/local/wiki/keep.md"
+R="$TROOT/remote/srv/qqbot/runtime/config/knowledge/wiki"
+mkdir -p "$R"
+echo "old" > "$R/stale.md"
+echo "txt"  > "$R/note.txt"
+echo "remote-keep" > "$R/keep.md"
+putconf <<CONF
+REMOTE_HOST="srv"
+REMOTE_PROJECT_DIR="/srv/qqbot"
+SYNC_MAP=("$TROOT/local/wiki|wiki")
+CONF
+out=$(run --dry-run 2>&1); rc=$?
+if echo "$out" | grep -q 'deleting' && echo "$out" | grep -q 'stale.md' && [ -f "$R/stale.md" ]; then
+  dry_ok=1
+else
+  dry_ok=0
+fi
+out=$(run 2>&1); rc=$?
+if [[ $dry_ok -eq 1 && $rc -eq 0 ]] && [ ! -f "$R/stale.md" ] && [ -f "$R/note.txt" ] && [ -f "$R/keep.md" ]; then
+  ok "dry-run 预览删除 + 正式同步删除 stale.md 且保留 note.txt/keep.md"
+else
+  ko "dry-run/镜像删除: rc=$rc out=$out ls=$(ls "$R")"
+fi
+
+# --- 14. 删除范围限定在子目录内 ---
+newcase
+mkdir -p "$TROOT/local/wiki"; echo "x" > "$TROOT/local/wiki/x.md"
+mkdir -p "$TROOT/remote/srv/qqbot/runtime/config/knowledge/wiki"
+mkdir -p "$TROOT/remote/srv/qqbot/runtime/config/knowledge/other"
+echo "other-md" > "$TROOT/remote/srv/qqbot/runtime/config/knowledge/other/only.md"
+putconf <<CONF
+REMOTE_HOST="srv"
+REMOTE_PROJECT_DIR="/srv/qqbot"
+SYNC_MAP=("$TROOT/local/wiki|wiki")
+CONF
+out=$(run 2>&1); rc=$?
+if [[ $rc -eq 0 ]] && [ -f "$TROOT/remote/srv/qqbot/runtime/config/knowledge/other/only.md" ]; then
+  ok "删除范围限定 wiki，other/only.md 保留"
+else
+  ko "越界删除: rc=$rc out=$out"
+fi
+
+# --- 15. rsync 一成一败 → 整体非零 + 汇总正确 ---
+newcase
+mkdir -p "$TROOT/local/a" "$TROOT/local/b"
+echo "1" > "$TROOT/local/a/a.md"
+echo "2" > "$TROOT/local/b/b.md"
+putconf <<CONF
+REMOTE_HOST="srv"
+REMOTE_PROJECT_DIR="/srv/qqbot"
+SYNC_MAP=("$TROOT/local/a|grp/a" "$TROOT/local/b|grp/b")
+CONF
+out=$(PATH="$TROOT/bin:$PATH" FAKE_REMOTE_ROOT="$TROOT/remote" FAKE_RSYNC_FAIL_ON="/grp/b" bash "$SCRIPT" 2>&1); rc=$?
+if [[ $rc -ne 0 ]] && echo "$out" | grep -q '成功 1' && echo "$out" | grep -q '失败 1'; then
+  ok "一成一败 → 整体非零且汇总显示成功 1 失败 1"
+else
+  ko "一成一败: rc=$rc out=$out"
+fi
+
+# --- 16. 所有校验失败时零次 rsync (用 fake rsync 计数) ---
+newcase
+# 在 fake rsync 内加一个计数文件，验证冲突报错分支没调用 rsync。
+cat > "$TROOT/bin/rsync" <<'RSYNC'
+#!/usr/bin/env bash
+echo "1" >> "${RSYNC_HIT_FILE}"
+exit 99
+RSYNC
+chmod +x "$TROOT/bin/rsync"
+mkdir -p "$TROOT/local/a" "$TROOT/local/b"
+echo "a" > "$TROOT/local/a/a.md"
+echo "b" > "$TROOT/local/b/b.md"
+putconf <<CONF
+REMOTE_HOST="srv"
+REMOTE_PROJECT_DIR="/srv/qqbot"
+SYNC_MAP=("$TROOT/local/a|wiki" "$TROOT/local/b|wiki")
+CONF
+hit="$TROOT/rsync_hits"
+out=$(PATH="$TROOT/bin:$PATH" RSYNC_HIT_FILE="$hit" bash "$SCRIPT" 2>&1); rc=$?
+if [[ $rc -ne 0 ]] && echo "$out" | grep -q '重复远端目标' && [ ! -f "$hit" ]; then
+  ok "冲突校验阶段未触发任何 rsync"
+else
+  ko "冲突期误调 rsync: rc=$rc hits=$([ -f "$hit" ] && cat "$hit" || echo none) out=$out"
+fi
+
+echo ""
+echo "==== 总结: PASS=$PASS FAIL=$FAIL ===="
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## 概述

将 `deploy-remote.sh` 中硬编码的远程服务器信息 (`aliyun` / `/root/project/qqbot`) 抽取为共享配置文件，同时新增通用知识库同步脚本 `sync_knowledge.sh`。

## 改动

### 新增

- `scripts/deploy.conf.example` — 共享远程配置模板，包含 `REMOTE_HOST`、`REMOTE_PROJECT_DIR` 和 `SYNC_MAP`
- `scripts/sync_knowledge.sh` — 知识库 markdown 同步脚本，支持 `--dry-run` 预览

### 修改

- `scripts/deploy-remote.sh` — 去掉硬编码，改为 `source deploy.conf` 读取远程信息
- `.gitignore` — 忽略 `scripts/deploy.conf`（含个人路径和远端别名）
- `docs/DEVELOPMENT.md` — 补充新脚本和配置说明

### 配置层次

一份 `deploy.conf` 两份脚本共用：

```
deploy.conf
  ├── REMOTE_HOST        → deploy-remote.sh + sync_knowledge.sh
  ├── REMOTE_PROJECT_DIR → deploy-remote.sh + sync_knowledge.sh
  └── SYNC_MAP           → sync_knowledge.sh 专用
```

### 使用方式

```bash
# 首次
cp scripts/deploy.conf.example scripts/deploy.conf
# 编辑 .conf 填入实际值

# 日常
bash scripts/deploy-remote.sh
bash scripts/sync_knowledge.sh
bash scripts/sync_knowledge.sh --dry-run
```

## CI

- [x] cargo fmt / clippy / test 全 workspace 通过
- [x] bash -n 所有脚本语法正确