### PR TITLE
feat: 新增 qq-maid-healthcheck.sh 进程级健康诊断脚本

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 target/
 dist/
+# 本地部署配置，可能包含远端路径或账号信息，不进入 Git。
+scripts/deploy.conf
 # 根级历史残留，防止误建。
 data/
 
@@ -74,8 +76,6 @@ runtime/qq-maid-llm
 runtime/botctl.sh
 runtime/validate-runtime.sh
 runtime/diagnose-network.sh
-
-# 本地同步/部署脚本配置文件（含个人路径和远端别名）
-scripts/deploy.conf
+runtime/qq-maid-healthcheck.sh
 runtime/llmctl.sh
 runtime/gatewayctl.sh

--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,11 @@ install:
 	cp -f scripts/botctl.sh runtime/botctl.sh
 	cp -f scripts/diagnose-network.sh runtime/diagnose-network.sh
 	cp -f scripts/validate-runtime.sh runtime/validate-runtime.sh
+	cp -f scripts/qq-maid-healthcheck.sh runtime/qq-maid-healthcheck.sh
 	mkdir -p runtime/static
-	find runtime -maxdepth 1 -type f -name 'qq-maid-*' ! -name 'qq-maid-bot' -delete
+	find runtime -maxdepth 1 -type f -name 'qq-maid-*' ! -name 'qq-maid-bot' ! -name 'qq-maid-healthcheck.sh' -delete
 	find runtime -maxdepth 1 -type f -name '*ctl.sh' ! -name 'botctl.sh' -delete
-	chmod +x runtime/$(BOT_BIN) runtime/botctl.sh runtime/diagnose-network.sh runtime/validate-runtime.sh
+	chmod +x runtime/$(BOT_BIN) runtime/botctl.sh runtime/diagnose-network.sh runtime/validate-runtime.sh runtime/qq-maid-healthcheck.sh
 	@printf '安装完成：runtime/ 目录已包含 release 二进制和控制脚本\n'
 
 deploy: deploy-remote

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 #
 # 远程服务器信息从 scripts/deploy.conf 读取 (与 sync_knowledge.sh 共用)。
 # 首次使用请从 deploy.conf.example 复制并填入实际值。
-# 部署组件: qq-maid-bot、控制脚本与诊断工具
+# 部署组件: qq-maid-bot、控制脚本、健康检查脚本与诊断工具
 # ============================================================
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -41,6 +41,7 @@ prepare_validate_runtime() {
     install -m 0755 scripts/botctl.sh "${LOCAL_VALIDATE_DIR}/botctl.sh"
     install -m 0755 scripts/diagnose-network.sh "${LOCAL_VALIDATE_DIR}/diagnose-network.sh"
     install -m 0755 scripts/validate-runtime.sh "${LOCAL_VALIDATE_DIR}/validate-runtime.sh"
+    install -m 0755 scripts/qq-maid-healthcheck.sh "${LOCAL_VALIDATE_DIR}/qq-maid-healthcheck.sh"
     install -m 0644 runtime/config/.env.example "${LOCAL_VALIDATE_DIR}/.env.example"
     install -m 0644 runtime/README.md "${LOCAL_VALIDATE_DIR}/README.md"
     cp -R runtime/static/. "${LOCAL_VALIDATE_DIR}/static/"
@@ -63,18 +64,20 @@ echo "==> Uploading artifacts..."
 # runtime 是远端运行目录，专门放二进制、控制脚本、配置模板和运行期文件。
 ssh "${REMOTE_HOST}" "mkdir -p '${REMOTE_RUNTIME_DIR}'"
 
-# 将编译产物、脚本和配置模板上传为 .new 临时文件，避免覆盖正在运行的服务
+# 将编译产物、脚本和配置模板上传为 .new 临时文件，避免覆盖正在运行的服务。
 scp target/release/qq-maid-bot "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.qq-maid-bot.new"
 scp scripts/botctl.sh "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.botctl.sh.new"
 scp scripts/diagnose-network.sh "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.diagnose-network.sh.new"
 scp scripts/validate-runtime.sh "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.validate-runtime.sh.new"
+scp scripts/qq-maid-healthcheck.sh "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.qq-maid-healthcheck.sh.new"
 scp runtime/config/.env.example "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.env.example"
 scp runtime/README.md "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/README.md"
 scp -r runtime/static "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.static.new"
 
 echo "==> Installing artifacts..."
-# 设置可执行权限后，将临时文件原子地替换为目标文件
-ssh "${REMOTE_HOST}" "cd '${REMOTE_RUNTIME_DIR}' && rm -rf static.old && chmod 0755 .qq-maid-bot.new .botctl.sh.new .diagnose-network.sh.new .validate-runtime.sh.new && mv -f .qq-maid-bot.new qq-maid-bot && mv -f .botctl.sh.new botctl.sh && mv -f .diagnose-network.sh.new diagnose-network.sh && mv -f .validate-runtime.sh.new validate-runtime.sh && find . -maxdepth 1 -type f -name 'qq-maid-*' ! -name 'qq-maid-bot' -delete && find . -maxdepth 1 -type f -name '*ctl.sh' ! -name 'botctl.sh' -delete && { test ! -d static || mv static static.old; } && mv .static.new static && rm -rf static.old"
+# 设置可执行权限后，将临时文件原子地替换为目标文件；清理旧 qq-maid-* 时需保留
+# 当前二进制和健康检查脚本，避免远端巡检入口在部署后被误删。
+ssh "${REMOTE_HOST}" "cd '${REMOTE_RUNTIME_DIR}' && rm -rf static.old && chmod 0755 .qq-maid-bot.new .botctl.sh.new .diagnose-network.sh.new .validate-runtime.sh.new .qq-maid-healthcheck.sh.new && mv -f .qq-maid-bot.new qq-maid-bot && mv -f .botctl.sh.new botctl.sh && mv -f .diagnose-network.sh.new diagnose-network.sh && mv -f .validate-runtime.sh.new validate-runtime.sh && mv -f .qq-maid-healthcheck.sh.new qq-maid-healthcheck.sh && find . -maxdepth 1 -type f -name 'qq-maid-*' ! -name 'qq-maid-bot' ! -name 'qq-maid-healthcheck.sh' -delete && find . -maxdepth 1 -type f -name '*ctl.sh' ! -name 'botctl.sh' -delete && { test ! -d static || mv static static.old; } && mv .static.new static && rm -rf static.old"
 
 echo "==> Restarting remote services..."
 # 重启统一服务。旧双进程文件在安装阶段清理，避免同机残留旧入口。

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -78,7 +78,9 @@ check_archive_contents() {
         "${PACKAGE_NAME}/.env.example" \
         "${PACKAGE_NAME}/static/index.html" \
         "${PACKAGE_NAME}/botctl.sh" \
-        "${PACKAGE_NAME}/validate-runtime.sh"
+        "${PACKAGE_NAME}/diagnose-network.sh" \
+        "${PACKAGE_NAME}/validate-runtime.sh" \
+        "${PACKAGE_NAME}/qq-maid-healthcheck.sh"
     do
         if ! printf '%s\n' "${listing}" | grep -Fx "${required}" >/dev/null; then
             die "archive missing ${required#${PACKAGE_NAME}/}"
@@ -98,6 +100,7 @@ main() {
     copy_executable scripts/botctl.sh "${STAGING_DIR}/botctl.sh"
     copy_executable scripts/diagnose-network.sh "${STAGING_DIR}/diagnose-network.sh"
     copy_executable scripts/validate-runtime.sh "${STAGING_DIR}/validate-runtime.sh"
+    copy_executable scripts/qq-maid-healthcheck.sh "${STAGING_DIR}/qq-maid-healthcheck.sh"
     copy_file runtime/README.md "${STAGING_DIR}/README.md"
     copy_file runtime/config/.env.example "${STAGING_DIR}/.env.example"
     copy_file runtime/static/index.html "${STAGING_DIR}/static/index.html"
@@ -134,7 +137,7 @@ main() {
             if printf '%s\n' "${zip_listing}" | grep -E '(^|[ /])\.env$|(^|[ /])app\.db$|(^|[ /])[^/]*\.db$|(^|[ /])logs/|(^|[ /])run/.*\.pid$' >/dev/null; then
                 die "archive contains forbidden runtime files"
             fi
-            for required in ".env.example" "static/index.html" "botctl.sh" "validate-runtime.sh"; do
+            for required in ".env.example" "static/index.html" "botctl.sh" "diagnose-network.sh" "validate-runtime.sh" "qq-maid-healthcheck.sh"; do
                 if ! printf '%s\n' "${zip_listing}" | grep -F "${PACKAGE_NAME}/${required}" >/dev/null; then
                     die "archive missing ${required}"
                 fi
@@ -155,6 +158,7 @@ main() {
     test -x "${STAGING_DIR}/botctl.sh"
     test -x "${STAGING_DIR}/diagnose-network.sh"
     test -x "${STAGING_DIR}/validate-runtime.sh"
+    test -x "${STAGING_DIR}/qq-maid-healthcheck.sh"
     test -f "${STAGING_DIR}/static/index.html"
 
     printf 'created %s\n' "${ARCHIVE_PATH}"

--- a/scripts/qq-maid-healthcheck.sh
+++ b/scripts/qq-maid-healthcheck.sh
@@ -9,19 +9,25 @@
 #   * 源码仓库中脚本位于 scripts/，默认运行目录为仓库下的 runtime/；
 #   * release 包中脚本位于运行目录根部，默认运行目录即为脚本所在目录。
 #
-# 不会读取或打印真实 .env 内容、QQ 事件、openid、Authorization 等敏感信息；
-# 连接信息仅展示本地/远端地址与端口、协议方向。
+# 仅按白名单读取健康端点所需的 LLM_SERVER_* 配置，不会打印真实 .env、
+# QQ 事件、openid、Authorization 等敏感信息；连接信息仅展示协议/状态和本地/远端地址。
 
 set -euo pipefail
 
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_NAME="$(basename -- "${BASH_SOURCE[0]}")"
 
-# 反射式运行目录解析：脚本被改名安装到运行目录根部时，优先认定该目录为运行目录。
-if [[ "${SCRIPT_NAME}" == "qq-maid-healthcheck.sh" && -f "${SCRIPT_DIR}/qq-maid-bot" ]]; then
+# 反射式运行目录解析：脚本安装到运行目录根部时，优先认定该目录为运行目录。
+# 判断 release 布局只依赖 config/ 目录，不依赖 qq-maid-bot 一定存在，便于二进制缺失时诊断。
+if [[ "${SCRIPT_NAME}" == "qq-maid-healthcheck.sh" && -d "${SCRIPT_DIR}/config" ]]; then
     DEFAULT_RUNTIME_DIR="${SCRIPT_DIR}"
 else
-    DEFAULT_RUNTIME_DIR="$(CDPATH= cd -- "${SCRIPT_DIR}/../runtime" && pwd)"
+    if resolved_runtime="$(CDPATH= cd -- "${SCRIPT_DIR}/../runtime" 2>/dev/null && pwd)"; then
+        DEFAULT_RUNTIME_DIR="${resolved_runtime}"
+    else
+        # 不在参数解析或 --help 前强制要求 runtime/ 存在，保留源码树外临时执行的可诊断性。
+        DEFAULT_RUNTIME_DIR="${SCRIPT_DIR}/../runtime"
+    fi
 fi
 RUNTIME_DIR="${QQ_MAID_RUNTIME_DIR:-${DEFAULT_RUNTIME_DIR}}"
 
@@ -34,10 +40,104 @@ PROC_MATCH="${HEALTHCHECK_PROC_MATCH:-$(basename -- "${BINARY}")}"
 # PID 文件：优先复用 botctl.sh 写入的 PID 文件，缺失时回退到 pgrep 查找。
 PID_FILE="${BOT_PID_FILE:-${RUNTIME_DIR}/run/qq-maid-bot.pid}"
 
-# 健康端点：与 botctl.sh 一致，兼容 LLM_SERVER_URL / HOST / PORT 三个变量。
-SERVER_HOST="${LLM_SERVER_HOST:-127.0.0.1}"
-SERVER_PORT="${LLM_SERVER_PORT:-8787}"
-SERVER_URL="${LLM_SERVER_URL:-http://${SERVER_HOST}:${SERVER_PORT}}"
+# 健康端点配置文件候选：只读取 LLM_SERVER_* 三个键，不 source 整个 .env，避免泄露或执行配置内容。
+HEALTH_ENV_FILES=()
+if [[ -n "${BOT_ENV_FILE:-}" ]]; then
+    HEALTH_ENV_FILES+=("${BOT_ENV_FILE}")
+else
+    HEALTH_ENV_FILES+=("${RUNTIME_DIR}/config/.env" "${RUNTIME_DIR}/.env")
+fi
+
+env_file_value() {
+    local file="$1"
+    local key="$2"
+    local line name value
+
+    [[ -f "${file}" ]] || return 1
+
+    while IFS= read -r line || [[ -n "${line}" ]]; do
+        line="${line%$'\r'}"
+        [[ "${line}" =~ ^[[:space:]]*$ ]] && continue
+        [[ "${line}" =~ ^[[:space:]]*# ]] && continue
+
+        if [[ "${line}" =~ ^[[:space:]]*export[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=[[:space:]]*(.*)$ ]]; then
+            name="${BASH_REMATCH[1]}"
+            value="${BASH_REMATCH[2]}"
+        elif [[ "${line}" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=[[:space:]]*(.*)$ ]]; then
+            name="${BASH_REMATCH[1]}"
+            value="${BASH_REMATCH[2]}"
+        else
+            continue
+        fi
+
+        [[ "${name}" == "${key}" ]] || continue
+        value="${value%"${value##*[![:space:]]}"}"
+
+        if [[ "${value}" == \"*\" && "${value}" == *\" ]]; then
+            value="${value#\"}"
+            value="${value%\"}"
+        elif [[ "${value}" == \'*\' && "${value}" == *\' ]]; then
+            value="${value#\'}"
+            value="${value%\'}"
+        fi
+
+        printf '%s\n' "${value}"
+        return 0
+    done < "${file}"
+
+    return 1
+}
+
+lookup_config_value() {
+    local key="$1"
+    local file value
+
+    for file in "${HEALTH_ENV_FILES[@]}"; do
+        if value="$(env_file_value "${file}" "${key}")" && [[ -n "${value}" ]]; then
+            printf '%s\n' "${value}"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+resolve_server_url() {
+    local host port url
+
+    # 优先级：显式 LLM_SERVER_URL > 显式 HOST/PORT > runtime 配置文件 > 默认值。
+    if [[ -n "${LLM_SERVER_URL:-}" ]]; then
+        printf '%s\n' "${LLM_SERVER_URL}"
+        return 0
+    fi
+
+    if [[ -n "${LLM_SERVER_HOST:-}" || -n "${LLM_SERVER_PORT:-}" ]]; then
+        printf 'http://%s:%s\n' "${LLM_SERVER_HOST:-127.0.0.1}" "${LLM_SERVER_PORT:-8787}"
+        return 0
+    fi
+
+    if url="$(lookup_config_value LLM_SERVER_URL)"; then
+        printf '%s\n' "${url}"
+        return 0
+    fi
+
+    host="$(lookup_config_value LLM_SERVER_HOST || printf '127.0.0.1')"
+    port="$(lookup_config_value LLM_SERVER_PORT || printf '8787')"
+    printf 'http://%s:%s\n' "${host}" "${port}"
+}
+
+mask_url() {
+    local value="${1:-}"
+
+    if [[ -z "${value}" ]]; then
+        printf '<missing>'
+        return
+    fi
+
+    # 输出 URL 时隐藏 userinfo 和常见敏感查询参数；实际请求仍使用未脱敏 URL。
+    printf '%s' "${value}" \
+        | sed -E 's#(://)[^/@]+@#\1***@#; s#([?&][^=&]*(token|Token|TOKEN|secret|Secret|SECRET|key|Key|KEY|authorization|Authorization|AUTHORIZATION|openid|Openid|OPENID)[^=&]*=)[^&#]*#\1***#g'
+}
 
 # 连接查看命令：root 直接 ss，非 root 优先尝试 sudo ss，再降级普通 ss / netstat。
 USE_SUDO_FOR_SS=0
@@ -59,6 +159,7 @@ Usage: qq-maid-healthcheck.sh [options]
 
 环境变量覆盖：
   BOT_BINARY          二进制路径（默认 runtime/qq-maid-bot）
+  BOT_ENV_FILE        指定读取健康端点配置的 env 文件
   BOT_PID_FILE        PID 文件路径（默认 runtime/run/qq-maid-bot.pid）
   HEALTHCHECK_PROC_MATCH  pgrep 进程匹配模式（默认二进制名）
   QQ_MAID_RUNTIME_DIR 运行目录
@@ -98,6 +199,8 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
+SERVER_URL="$(resolve_server_url)"
+
 # 解析目标 PID：显式指定 > PID 文件 > pgrep 匹配。
 # PID 文件可能存在残留（进程已退出），需配合存活校验。
 resolve_pid() {
@@ -131,62 +234,115 @@ resolve_pid() {
     return 1
 }
 
-# 健康端点查询：复用 curl，缺失时回退 wget，均无则跳过。
+# 健康端点查询：HTTP 200 才成功；请求失败、非 200、工具缺失均返回非 0。
 check_health() {
-    local url status
+    local url display_url status tmp rc
     url="${SERVER_URL%/}/healthz"
+    display_url="$(mask_url "${url}")"
 
     if command -v curl >/dev/null 2>&1; then
-        status="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 8 "${url}" 2>/dev/null || printf 'ERR')"
-        printf '  %s -> HTTP %s\n' "${url}" "${status}"
-        if [[ "${status}" == "200" ]]; then
-            return 0
+        if status="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 8 "${url}" 2>/dev/null)"; then
+            printf '  %s -> HTTP %s\n' "${display_url}" "${status}"
+            if [[ "${status}" == "200" ]]; then
+                return 0
+            fi
+            return 1
         fi
+        printf '  %s -> REQUEST FAILED\n' "${display_url}"
         return 1
     fi
 
     if command -v wget >/dev/null 2>&1; then
-        if wget -qO- --timeout=8 --tries=1 "${url}" >/dev/null 2>&1; then
-            printf '  %s -> HTTP 200\n' "${url}"
-            return 0
+        tmp="$(mktemp "${TMPDIR:-/tmp}/qq-maid-health.XXXXXX")"
+        if wget -qO- --server-response --timeout=8 --tries=1 "${url}" >/dev/null 2>"${tmp}"; then
+            rc=0
+        else
+            rc=$?
         fi
-        printf '  %s -> HTTP ERR\n' "${url}"
+        status="$(awk '/^[[:space:]]*HTTP\// { code=$2 } END { print code }' "${tmp}")"
+        rm -f "${tmp}"
+
+        if [[ -n "${status}" ]]; then
+            printf '  %s -> HTTP %s\n' "${display_url}" "${status}"
+            if [[ "${status}" == "200" ]]; then
+                return 0
+            fi
+            return 1
+        fi
+
+        printf '  %s -> REQUEST FAILED (wget exit %s)\n' "${display_url}" "${rc}"
         return 1
     fi
 
-    printf '  %s -> SKIPPED (curl/wget 均不可用)\n' "${url}"
+    printf '  %s -> ERROR (curl/wget 均不可用)\n' "${display_url}"
     return 1
 }
 
 # 连接查看：root 用 ss，非 root 在能免密 sudo 时用 sudo ss，否则降级 ss / netstat。
 list_connections() {
     local pid="$1"
-    local out
+    local out raw
 
     if command -v ss >/dev/null 2>&1; then
         if (( USE_SUDO_FOR_SS == 1 )); then
-            out="$(sudo -n ss -tpn 2>/dev/null | grep "pid=${pid}," || true)"
+            out="$(sudo -n ss -H -tunap 2>/dev/null | awk -v pid="${pid}" 'index($0, "pid=" pid ",") { print }' || true)"
         else
-            out="$(ss -tpn 2>/dev/null | grep "pid=${pid}," || true)"
+            out="$(ss -H -tunap 2>/dev/null | awk -v pid="${pid}" 'index($0, "pid=" pid ",") { print }' || true)"
         fi
-    elif command -v netstat >/dev/null 2>&1; then
-        # netstat 无进程列，只能按进程已建立的 fd-inode 粗略对应，这里仅展示监听与已建立。
-        out="$(netstat -tpn 2>/dev/null | grep -E "(ESTABLISHED|LISTEN)" || true)"
+
+        if [[ -z "${out}" ]]; then
+            printf '  (无连接记录，或当前权限无法关联目标进程)\n'
+            return
+        fi
+
+        # ss 已按 pid 精确过滤；仅输出协议/状态/本地地址/远端地址，不打印进程名或 PID。
+        printf '%s\n' "${out}" | awk '{ printf "  %s %s %s %s\n", $1, $2, $5, $6 }'
+        return
+    fi
+
+    if command -v netstat >/dev/null 2>&1; then
+        raw="$(netstat -tunap 2>/dev/null || true)"
+        # netstat 只有在 -p 能显示 PID/Program name 时才可安全过滤；否则绝不退化输出整机连接。
+        out="$(printf '%s\n' "${raw}" | awk -v pid="${pid}" '$1 ~ /^(tcp|udp)/ && $NF ~ "^" pid "/" { print }')"
+
+        if [[ -z "${out}" ]]; then
+            if printf '%s\n' "${raw}" | awk '$1 ~ /^(tcp|udp)/ && ($NF == "-" || $NF !~ /^[0-9]+\//) { found=1 } END { exit(found ? 0 : 1) }'; then
+                printf '  (权限不足或无法关联目标进程，netstat 未显示目标 PID)\n'
+            else
+                printf '  (无连接记录)\n'
+            fi
+            return
+        fi
+
+        # netstat 已按目标 pid 过滤；统一输出协议/状态/本地地址/远端地址。
+        printf '%s\n' "${out}" | awk '
+            $1 ~ /^tcp/ { printf "  %s %s %s %s\n", $1, $6, $4, $5; next }
+            $1 ~ /^udp/ {
+                state="-"
+                if ($6 !~ /^[0-9]+\// && $6 != "-") { state=$6 }
+                printf "  %s %s %s %s\n", $1, state, $4, $5
+            }
+        '
+        return
+    fi
+
+    printf '  (ss/netstat 均不可用)\n'
+}
+
+print_binary_status() {
+    if [[ -f "${BINARY}" ]]; then
+        printf 'binary present: %s\n' "${BINARY}"
     else
-        printf '  (ss/netstat 均不可用)\n'
-        return
+        printf 'binary missing (可能使用其它路径启动或发布包不完整): %s\n' "${BINARY}" >&2
     fi
-
-    if [[ -z "${out}" ]]; then
-        printf '  (无连接记录)\n'
-        return
-    fi
-
-    # 只输出关键列，避免打印完整 raw（netstat 仍含部分字段，但不涉及 QQ 事件/openid）。
-    printf '%s\n' "${out}" | awk '{ printf "  %s %s %s\n", $1, $5, $6 }'
 }
 
 main() {
+    if (( OPT_HEALTH_ONLY == 1 )); then
+        check_health
+        exit $?
+    fi
+
     printf 'QQ Maid healthcheck\n'
     printf '  runtime_dir: %s\n' "${RUNTIME_DIR}"
     printf '  binary:      %s\n' "${BINARY}"
@@ -195,6 +351,7 @@ main() {
     local pid
     if ! pid="$(resolve_pid)"; then
         printf '===== STATUS =====\n'
+        print_binary_status
         printf 'qq-maid-bot 未运行（无 PID 文件或匹配进程）\n\n'
         printf '===== HEALTH =====\n'
         check_health || true
@@ -203,18 +360,14 @@ main() {
 
     printf '===== STATUS =====\n'
     printf 'qq-maid-bot is running, pid=%s\n' "${pid}"
-    if [[ -f "${BINARY}" ]]; then
-        printf 'binary present: %s\n' "${BINARY}"
-    else
-        printf 'binary missing (可能使用其它路径启动): %s\n' "${BINARY}" >&2
-    fi
+    print_binary_status
     printf '\n'
 
     printf '===== HEALTH =====\n'
     check_health || true
     printf '\n'
 
-    if (( OPT_HEALTH_ONLY == 1 )) || (( OPT_NO_PROC == 1 )); then
+    if (( OPT_NO_PROC == 1 )); then
         exit 0
     fi
 

--- a/scripts/qq-maid-healthcheck.sh
+++ b/scripts/qq-maid-healthcheck.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# qq-maid-healthcheck.sh —— qq-maid-bot 进程级健康与资源占用诊断脚本
+#
+# 用途：
+#   定位正在运行的 qq-maid-bot 进程，输出其基本信息、内存、状态、IO、
+#   文件描述符、连接情况和资源上限，便于上线巡检和排障。
+#
+# 与 botctl.sh / diagnose-network.sh 共用运行目录语义：
+#   * 源码仓库中脚本位于 scripts/，默认运行目录为仓库下的 runtime/；
+#   * release 包中脚本位于运行目录根部，默认运行目录即为脚本所在目录。
+#
+# 不会读取或打印真实 .env 内容、QQ 事件、openid、Authorization 等敏感信息；
+# 连接信息仅展示本地/远端地址与端口、协议方向。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename -- "${BASH_SOURCE[0]}")"
+
+# 反射式运行目录解析：脚本被改名安装到运行目录根部时，优先认定该目录为运行目录。
+if [[ "${SCRIPT_NAME}" == "qq-maid-healthcheck.sh" && -f "${SCRIPT_DIR}/qq-maid-bot" ]]; then
+    DEFAULT_RUNTIME_DIR="${SCRIPT_DIR}"
+else
+    DEFAULT_RUNTIME_DIR="$(CDPATH= cd -- "${SCRIPT_DIR}/../runtime" && pwd)"
+fi
+RUNTIME_DIR="${QQ_MAID_RUNTIME_DIR:-${DEFAULT_RUNTIME_DIR}}"
+
+# 二进制名：用于 PID 文件回退与进程匹配。允许通过 BOT_BINARY 覆盖完整路径。
+DEFAULT_BINARY="${RUNTIME_DIR}/qq-maid-bot"
+BINARY="${BOT_BINARY:-${DEFAULT_BINARY}}"
+# 进程匹配模式：默认按二进制名匹配，避免误伤其它同名进程时可改成完整命令行片段。
+PROC_MATCH="${HEALTHCHECK_PROC_MATCH:-$(basename -- "${BINARY}")}"
+
+# PID 文件：优先复用 botctl.sh 写入的 PID 文件，缺失时回退到 pgrep 查找。
+PID_FILE="${BOT_PID_FILE:-${RUNTIME_DIR}/run/qq-maid-bot.pid}"
+
+# 健康端点：与 botctl.sh 一致，兼容 LLM_SERVER_URL / HOST / PORT 三个变量。
+SERVER_HOST="${LLM_SERVER_HOST:-127.0.0.1}"
+SERVER_PORT="${LLM_SERVER_PORT:-8787}"
+SERVER_URL="${LLM_SERVER_URL:-http://${SERVER_HOST}:${SERVER_PORT}}"
+
+# 连接查看命令：root 直接 ss，非 root 优先尝试 sudo ss，再降级普通 ss / netstat。
+USE_SUDO_FOR_SS=0
+if [[ "$(id -u)" -ne 0 ]]; then
+    if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+        USE_SUDO_FOR_SS=1
+    fi
+fi
+
+usage() {
+    cat <<'EOF'
+Usage: qq-maid-healthcheck.sh [options]
+
+选项：
+  -h, --help         显示帮助
+  --health           仅查询 HTTP 健康端点 (/healthz) 并打印状态码
+  --no-proc          跳过进程资源采集，仅做基础进程定位与健康检查
+  --pid <PID>        显式指定目标进程 PID，绕过 PID 文件与 pgrep 查找
+
+环境变量覆盖：
+  BOT_BINARY          二进制路径（默认 runtime/qq-maid-bot）
+  BOT_PID_FILE        PID 文件路径（默认 runtime/run/qq-maid-bot.pid）
+  HEALTHCHECK_PROC_MATCH  pgrep 进程匹配模式（默认二进制名）
+  QQ_MAID_RUNTIME_DIR 运行目录
+  LLM_SERVER_URL      健康端点基址
+  LLM_SERVER_HOST     健康端点主机（默认 127.0.0.1）
+  LLM_SERVER_PORT     健康端点端口（默认 8787）
+EOF
+}
+
+# 参数解析
+OPT_HEALTH_ONLY=0
+OPT_NO_PROC=0
+OPT_PID=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --health)
+            OPT_HEALTH_ONLY=1
+            ;;
+        --no-proc)
+            OPT_NO_PROC=1
+            ;;
+        --pid)
+            shift
+            [[ $# -gt 0 ]] || { echo "error: --pid 需要参数" >&2; exit 2; }
+            OPT_PID="$1"
+            ;;
+        *)
+            echo "error: 未知参数: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+# 解析目标 PID：显式指定 > PID 文件 > pgrep 匹配。
+# PID 文件可能存在残留（进程已退出），需配合存活校验。
+resolve_pid() {
+    local pid
+
+    if [[ -n "${OPT_PID}" ]]; then
+        if [[ "${OPT_PID}" =~ ^[0-9]+$ ]] && kill -0 "${OPT_PID}" 2>/dev/null; then
+            printf '%s\n' "${OPT_PID}"
+            return 0
+        fi
+        echo "warning: --pid ${OPT_PID} 对应进程不存在" >&2
+        return 1
+    fi
+
+    if [[ -f "${PID_FILE}" ]]; then
+        pid="$(tr -d '[:space:]' < "${PID_FILE}")"
+        if [[ "${pid}" =~ ^[0-9]+$ ]] && kill -0 "${pid}" 2>/dev/null; then
+            printf '%s\n' "${pid}"
+            return 0
+        fi
+        # PID 文件残留但进程不在，继续回退到 pgrep，而不是直接判定未运行。
+        echo "warning: PID 文件 ${PID_FILE} 残留(PID=${pid:-空})但进程不存在，回退到 pgrep" >&2
+    fi
+
+    # pgrep 匹配进程可执行名；-n 取最新启动的一个，避免多实例时输出不确定。
+    if pid="$(pgrep -n -f "${PROC_MATCH}" 2>/dev/null)" && [[ -n "${pid}" ]]; then
+        printf '%s\n' "${pid}"
+        return 0
+    fi
+
+    return 1
+}
+
+# 健康端点查询：复用 curl，缺失时回退 wget，均无则跳过。
+check_health() {
+    local url status
+    url="${SERVER_URL%/}/healthz"
+
+    if command -v curl >/dev/null 2>&1; then
+        status="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 8 "${url}" 2>/dev/null || printf 'ERR')"
+        printf '  %s -> HTTP %s\n' "${url}" "${status}"
+        if [[ "${status}" == "200" ]]; then
+            return 0
+        fi
+        return 1
+    fi
+
+    if command -v wget >/dev/null 2>&1; then
+        if wget -qO- --timeout=8 --tries=1 "${url}" >/dev/null 2>&1; then
+            printf '  %s -> HTTP 200\n' "${url}"
+            return 0
+        fi
+        printf '  %s -> HTTP ERR\n' "${url}"
+        return 1
+    fi
+
+    printf '  %s -> SKIPPED (curl/wget 均不可用)\n' "${url}"
+    return 1
+}
+
+# 连接查看：root 用 ss，非 root 在能免密 sudo 时用 sudo ss，否则降级 ss / netstat。
+list_connections() {
+    local pid="$1"
+    local out
+
+    if command -v ss >/dev/null 2>&1; then
+        if (( USE_SUDO_FOR_SS == 1 )); then
+            out="$(sudo -n ss -tpn 2>/dev/null | grep "pid=${pid}," || true)"
+        else
+            out="$(ss -tpn 2>/dev/null | grep "pid=${pid}," || true)"
+        fi
+    elif command -v netstat >/dev/null 2>&1; then
+        # netstat 无进程列，只能按进程已建立的 fd-inode 粗略对应，这里仅展示监听与已建立。
+        out="$(netstat -tpn 2>/dev/null | grep -E "(ESTABLISHED|LISTEN)" || true)"
+    else
+        printf '  (ss/netstat 均不可用)\n'
+        return
+    fi
+
+    if [[ -z "${out}" ]]; then
+        printf '  (无连接记录)\n'
+        return
+    fi
+
+    # 只输出关键列，避免打印完整 raw（netstat 仍含部分字段，但不涉及 QQ 事件/openid）。
+    printf '%s\n' "${out}" | awk '{ printf "  %s %s %s\n", $1, $5, $6 }'
+}
+
+main() {
+    printf 'QQ Maid healthcheck\n'
+    printf '  runtime_dir: %s\n' "${RUNTIME_DIR}"
+    printf '  binary:      %s\n' "${BINARY}"
+    printf '  pid_file:    %s\n\n' "${PID_FILE}"
+
+    local pid
+    if ! pid="$(resolve_pid)"; then
+        printf '===== STATUS =====\n'
+        printf 'qq-maid-bot 未运行（无 PID 文件或匹配进程）\n\n'
+        printf '===== HEALTH =====\n'
+        check_health || true
+        exit 0
+    fi
+
+    printf '===== STATUS =====\n'
+    printf 'qq-maid-bot is running, pid=%s\n' "${pid}"
+    if [[ -f "${BINARY}" ]]; then
+        printf 'binary present: %s\n' "${BINARY}"
+    else
+        printf 'binary missing (可能使用其它路径启动): %s\n' "${BINARY}" >&2
+    fi
+    printf '\n'
+
+    printf '===== HEALTH =====\n'
+    check_health || true
+    printf '\n'
+
+    if (( OPT_HEALTH_ONLY == 1 )) || (( OPT_NO_PROC == 1 )); then
+        exit 0
+    fi
+
+    # 以下为进程级资源采集，依赖 /proc，仅适用于 Linux。
+    if [[ ! -d "/proc/${pid}" ]]; then
+        printf '进程 /proc/%s 不可读（非 Linux 或权限不足），跳过资源采集\n' "${pid}"
+        exit 0
+    fi
+
+    printf '===== BASIC =====\n'
+    ps -p "${pid}" -o pid,ppid,user,stat,lstart,etime,%cpu,%mem,rss,vsz,nlwp,cmd || true
+    printf '\n'
+
+    printf '===== MEMORY =====\n'
+    cat "/proc/${pid}/smaps_rollup" 2>/dev/null \
+        | grep -E 'Rss:|Pss:|Private_|Anonymous:|Swap:' || true
+    printf '\n'
+
+    printf '===== STATUS =====\n'
+    grep -E 'State|Threads|VmPeak|VmSize|VmRSS|RssAnon|RssFile|VmSwap' "/proc/${pid}/status" 2>/dev/null || true
+    printf '\n'
+
+    printf '===== IO =====\n'
+    cat "/proc/${pid}/io" 2>/dev/null || true
+    printf '\n'
+
+    printf '===== FILE DESCRIPTORS =====\n'
+    printf 'FD count: %s\n' "$(find "/proc/${pid}/fd" -maxdepth 1 -type l 2>/dev/null | wc -l)"
+    printf '\n'
+
+    printf '===== CONNECTIONS =====\n'
+    list_connections "${pid}"
+    printf '\n'
+
+    printf '===== LIMITS =====\n'
+    grep -E 'Max open files|Max processes|Max address space' "/proc/${pid}/limits" 2>/dev/null || true
+}
+
+main

--- a/scripts/validate-release-runtime.sh
+++ b/scripts/validate-release-runtime.sh
@@ -17,12 +17,23 @@ require_executable() {
     [[ -x "${RUNTIME_DIR}/$1" ]] || die "$1 is not executable"
 }
 
+require_any_executable() {
+    local candidate
+    for candidate in "$@"; do
+        if [[ -f "${RUNTIME_DIR}/${candidate}" && -x "${RUNTIME_DIR}/${candidate}" ]]; then
+            return 0
+        fi
+    done
+    die "missing executable: $*"
+}
+
 # 这里只校验待发布 runtime 目录的离线结构是否完整，以及是否混入敏感/运行产物。
 # 服务状态、/healthz、上游调用和 /console 等在线检查由 scripts/validate-runtime.sh 负责。
-require_executable qq-maid-bot
+require_any_executable qq-maid-bot qq-maid-bot.exe
 require_executable botctl.sh
 require_executable validate-runtime.sh
 require_executable diagnose-network.sh
+require_executable qq-maid-healthcheck.sh
 require_file .env.example
 require_file README.md
 require_file static/index.html


### PR DESCRIPTION
## 背景

本 PR 在 `qq-maid-bot` 进程级健康诊断脚本的基础上，继续打通安装、打包、离线校验与远程部署链路。当前已不再只是新增一个脚本，而是确保健康检查脚本可以随本地安装、release 包和远端部署一起交付。

本分支已在 PR #66 合并后的最新 `master` 上 rebase，保留 PR #66 的通用部署配置语义：远端主机读取 `REMOTE_HOST`，项目目录读取 `REMOTE_PROJECT_DIR`，运行目录由 `${REMOTE_PROJECT_DIR}/runtime` 推导，不恢复硬编码远端主机或固定项目路径。

## 改动

- 新增 `scripts/qq-maid-healthcheck.sh`：用于 `qq-maid-bot` 进程级健康与资源占用诊断。
- 更新 `Makefile install`：安装 `runtime/qq-maid-healthcheck.sh`，设置可执行权限，并在清理旧 `qq-maid-*` 文件时保留健康检查脚本。
- 更新 `scripts/package-release.sh`：将健康检查脚本纳入 staging、`tar.gz` / `zip` 归档和归档内容校验。
- 更新 `scripts/validate-release-runtime.sh`：离线 runtime 校验要求包含可执行的 `qq-maid-healthcheck.sh`。
- 更新 `scripts/deploy-remote.sh`：在 PR #66 的 `scripts/deploy.conf` 通用配置基础上，部署健康检查脚本：
  - 本地离线校验目录包含 `qq-maid-healthcheck.sh`；
  - 上传 `.qq-maid-healthcheck.sh.new`；
  - 设置 `0755` 权限；
  - 原子替换为 `qq-maid-healthcheck.sh`；
  - 清理旧 `qq-maid-*` 时保留 `qq-maid-bot` 和 `qq-maid-healthcheck.sh`。
- 更新 `.gitignore`：保留 `scripts/deploy.conf` 单条忽略规则，并忽略安装到 `runtime/` 的健康检查脚本副本。

## 健康检查语义

- `--health` 是严格探活模式：HTTP 200 返回 0；非 200、请求失败、`curl`/`wget` 均不可用时返回非 0。
- 完整诊断模式仍保持 best-effort 输出：进程不存在、`/proc` 不可读、连接查看工具受限或健康端点失败时尽量输出可用诊断信息，不因单项失败中断整体诊断。
- 运行目录、PID 文件、健康端点配置与既有 `botctl.sh` / `diagnose-network.sh` 语义保持一致。
- 仅按白名单读取健康端点所需配置，并对 URL 输出做脱敏处理。

## 与 PR #66 的兼容性

- `scripts/deploy-remote.sh` 保留 `scripts/deploy.conf` 配置入口。
- SSH/SCP 均使用 `REMOTE_HOST`。
- 项目目录使用 `REMOTE_PROJECT_DIR`。
- runtime 目录使用 `${REMOTE_PROJECT_DIR}/runtime`。
- 未恢复 `aliyun` 或 `/root/project/qqbot` 等硬编码值。

## 验证

已执行：

- `bash -n scripts/deploy-remote.sh scripts/package-release.sh scripts/qq-maid-healthcheck.sh scripts/validate-release-runtime.sh`
- `scripts/qq-maid-healthcheck.sh --help`
- `scripts/qq-maid-healthcheck.sh --health` 的 HTTP 200、HTTP 503、连接失败路径，确认退出码符合预期。
- `make diagnose`
- `make install`，并检查 `runtime/qq-maid-healthcheck.sh` 存在且可执行。
- `scripts/package-release.sh` 的 `tar.gz` staging / 归档校验。
- `scripts/package-release.sh` 的 `zip` staging / 归档校验。
- 检查 `scripts/deploy-remote.sh` 不再包含硬编码远端主机和项目路径。
- 检查健康脚本上传、安装、权限设置和清理保留逻辑完整。
- 检查 diff 不包含 `runtime/config/knowledge/example.example.md` 删除或其它无关文件。

## 安全

未提交真实 `.env`、token、secret、QQ 事件、openid、群 ID 或运行数据。诊断输出保持脱敏。