### PR TITLE
fix: /ping 异常摘要同时呈现多条 note，修复漏报 LLM 降级与 Gateway 重连 (Closes #68)

### DIFF
--- a/qq-maid-gateway-rs/src/gateway/ping/assess.rs
+++ b/qq-maid-gateway-rs/src/gateway/ping/assess.rs
@@ -422,20 +422,30 @@ fn summary_text(overall: PingSeverity, notes: &[String]) -> String {
             "Gateway、QQ WebSocket、LLM 服务和上游模型均正常，未发现未恢复异常。".to_owned()
         }
         PingSeverity::Warning => {
-            let detail = notes
-                .first()
-                .cloned()
-                .unwrap_or_else(|| "存在需要关注的状态".to_owned());
+            // 顶部异常摘要需呈现同一严重度下的全部 note，避免漏报并发的 LLM 降级、
+            // Gateway 重连/invalid session、发送失败等条目（见 Issue #68）。
+            // 使用中文分号内联拼接，避免在 Markdown 引用块内产生多段 `>`，
+            // 以保证现有 `/ping` 回复结构对 QQ 富文本渲染的兼容性。
+            let detail = join_summary_notes(notes, "存在需要关注的状态");
             format!("服务当前可用，但需要关注：{detail}。")
         }
         PingSeverity::Error => {
-            let detail = notes
-                .first()
-                .cloned()
-                .unwrap_or_else(|| "存在影响服务的异常".to_owned());
+            let detail = join_summary_notes(notes, "存在影响服务的异常");
             format!("检测到影响服务的异常：{detail}。")
         }
     }
+}
+
+/// 将多条 note 拼接为顶部摘要正文。
+///
+/// 约束：摘要行嵌入在 Markdown 引用块 `> {summary}` 中，因此只使用内联分隔符
+/// 「；」，不引入换行或多段 `>`。条目顺序沿用 notes 原序。空列表时回退到
+/// `fallback` 文案，保持单 note 场景与历史行为一致。
+fn join_summary_notes(notes: &[String], fallback: &str) -> String {
+    if notes.is_empty() {
+        return fallback.to_owned();
+    }
+    notes.join("；")
 }
 
 fn recent_events(

--- a/qq-maid-gateway-rs/src/gateway/ping/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/ping/tests.rs
@@ -346,6 +346,85 @@ fn renders_fallback_success_as_available_but_degraded() {
     assert!(reply.contains("发生模型降级"));
 }
 
+#[test]
+fn renders_summary_with_both_llm_degradation_and_recovered_reconnect() {
+    // Issue #68：LLM fallback 降级与 Gateway 重连已恢复同时出现时，顶部异常摘要
+    // 必须同时呈现两条 note，不再只保留首条。
+    let runtime = GatewayRuntimeStatus::new_for_test();
+    runtime.update_state(|state| {
+        state.last_gateway_connected_at = Some("unix:1000".to_owned());
+        state.last_ready_at = Some("unix:1001".to_owned());
+        state.last_heartbeat_ack_at = Some("unix:1190".to_owned());
+        // 重连发生在 1100，随后 READY/RESUMED 在 1105 恢复，构成「已恢复」note。
+        state.last_reconnect_at = Some("unix:1100".to_owned());
+        state.last_resumed_at = Some("unix:1105".to_owned());
+        state.last_c2c_received_at = Some("unix:1200".to_owned());
+    });
+
+    let reply = render_c2c_ping_reply_at(
+        &message(),
+        &config(),
+        &runtime,
+        &token_snapshot(),
+        &health(
+            "ok(in-process)",
+            LlmUpstreamSnapshot::Available {
+                last_success_at: Some("unix:1195".to_owned()),
+                provider: Some("deepseek".to_owned()),
+                model: Some("deepseek-chat".to_owned()),
+                fallback_used: true,
+            },
+        ),
+        PingMode::Summary,
+        1200,
+    );
+
+    assert!(reply.contains("# 🟡 服务可用，但存在警告"));
+    // 顶部引用摘要行同时包含 LLM 降级与重连恢复两条信息。
+    assert!(reply.contains("LLM 上游最近一次调用发生过降级"));
+    assert!(reply.contains("最近发生过重连并已恢复"));
+    // 两条 note 必须出现在同一行（引用块内），不引入多段 `>`。
+    assert!(!reply.contains("\n> 最近发生过重连并已恢复"));
+}
+
+#[test]
+fn renders_summary_with_llm_degradation_and_unrecovered_reconnect() {
+    // LLM fallback 降级 + 重连尚未恢复：overall 应为 Error，且摘要同时体现两条。
+    let runtime = GatewayRuntimeStatus::new_for_test();
+    runtime.update_state(|state| {
+        state.last_gateway_connected_at = Some("unix:1000".to_owned());
+        state.last_ready_at = Some("unix:1001".to_owned());
+        state.last_heartbeat_ack_at = Some("unix:1190".to_owned());
+        // 重连发生但无后续恢复记录（last_ready_at 先于重连，不计为恢复）。
+        state.last_reconnect_at = Some("unix:1150".to_owned());
+        state.last_c2c_received_at = Some("unix:1200".to_owned());
+    });
+
+    let reply = render_c2c_ping_reply_at(
+        &message(),
+        &config(),
+        &runtime,
+        &token_snapshot(),
+        &health(
+            "ok(in-process)",
+            LlmUpstreamSnapshot::Available {
+                last_success_at: Some("unix:1195".to_owned()),
+                provider: Some("deepseek".to_owned()),
+                model: Some("deepseek-chat".to_owned()),
+                fallback_used: true,
+            },
+        ),
+        PingMode::Summary,
+        1200,
+    );
+
+    assert!(reply.contains("# 🔴 服务异常"));
+    assert!(reply.contains("检测到影响服务的异常"));
+    assert!(reply.contains("LLM 上游最近一次调用发生过降级"));
+    assert!(reply.contains("最近重连尚未发现恢复记录"));
+    assert!(!reply.contains("\n> 最近重连尚未发现恢复记录"));
+}
+
 #[tokio::test]
 async fn ping_check_direct_failure_overrides_stale_healthz_status() {
     let config = config();


### PR DESCRIPTION
## 背景

来自 Issue #68：`/ping` 异常摘要（顶部 `> {summary}` 行）在 Warning / Error 只取 `notes.first()`，导致同一严重度下并发的多条 note 被漏报。最常见的就是「LLM fallback 已降级」与「Gateway 重连已恢复/未恢复」同时出现时，重连条目必然被丢弃，与下方 `## 最近事件` 区块的完整信息不一致，给运维造成「似乎只有一个问题」的误导。

## 改动

### \`qq-maid-gateway-rs/src/gateway/ping/assess.rs\`
- \`summary_text\` 的 Warning / Error 分支改为遍历 \`notes\` 全部条目，新增 \`join_summary_notes\` 用中文分号「；」内联拼接。
- Normal 分支保持固定文案不变；\`overall\` 严重度聚合逻辑不变。
- 内联拼接而非换行/多段 \`>\`，保持现有 Markdown 引用块 \`> {summary}\` 单行结构，兼容 QQ 富文本渲染。
- 补充说明「为什么这样做」的中文注释（Issue #68 漏报背景 + 引用块渲染约束）。

### \`qq-maid-gateway-rs/src/gateway/ping/tests.rs\`
- 新增 \`renders_summary_with_both_llm_degradation_and_recovered_reconnect\`：构造 LLM 上游 Available + fallback_used=true 与 \`last_reconnect_at\` + 之后 \`last_resumed_at\` 并发，断言 Warning 下摘要同时包含两条 note，且不在引用块内产生多段 \`>\`。
- 新增 \`renders_summary_with_llm_degradation_and_unrecovered_reconnect\`：构造 LLM 降级 + 重连后无恢复记录，断言 Error 标题、摘要同时呈现两条 note。

## 边界

- 完全复用现有 notes 来源（\`assess_ping_status\` 推入顺序、\`collect_reconnect_note\`、LLM 上游分支等），未改动 \`status.rs\` 写入语义、\`protocol.rs\` 重连点、\`healthz.rs\` / \`render.rs\` 脱敏、\`recent_events\` 结构。
- 无新增依赖、无新 HTTP 入口。
- 既有单 note 测试全部回归未受影响。

## 验证

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --workspace --all-features\`（含两个新增 ping 单测及既有 ping 测试均通过）
- [x] \`cargo build --workspace --release --all-features\`

## 安全

摘要行只复用已有 \`notes\` 文本，未引入任何 raw 时间戳、openid、凭据；\`unix:\` / \`Authorization\` / \`Bearer\` / \`sk-\` 等敏感标记不会出现在摘要行（既有脱敏测试继续覆盖）。

Closes #68