### PR TITLE
feat: Tool Loop 支持同轮多调用串行执行与 Todo 编号预绑定 (issue #97)

### DIFF
--- a/qq-maid-core/src/runtime/respond.rs
+++ b/qq-maid-core/src/runtime/respond.rs
@@ -18,8 +18,8 @@ use crate::{
         session::{SessionMeta, SessionStore},
         todo::TodoStore,
         tools::{
-            CancelTodoTool, CompleteTodoTool, CreateTodoTool, DeleteTodoTool, ListTodoTool,
-            RestoreTodoTool, WeatherTool,
+            CancelTodoTool, CompleteTodoTool, CreateTodoTool, DeleteTodoTool, EditTodoTool,
+            ListTodoTool, RestoreTodoTool, WeatherTool,
         },
         train::DynTrainExecutor,
         translation::TranslationService,
@@ -181,6 +181,10 @@ impl RustRespondService {
             )),
             std::sync::Arc::new(CreateTodoTool::new(stores.session_store.clone())),
             std::sync::Arc::new(CompleteTodoTool::new(
+                stores.todo_store.clone(),
+                stores.session_store.clone(),
+            )),
+            std::sync::Arc::new(EditTodoTool::new(
                 stores.todo_store.clone(),
                 stores.session_store.clone(),
             )),

--- a/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
@@ -14,6 +14,7 @@ use crate::runtime::session::SessionRecord;
 pub(super) enum TodoMutationToolKind {
     Create,
     Complete,
+    Edit,
     Cancel,
     Restore,
     Delete,
@@ -24,6 +25,7 @@ impl TodoMutationToolKind {
         match self {
             Self::Create => "create",
             Self::Complete => "complete",
+            Self::Edit => "edit",
             Self::Cancel => "cancel",
             Self::Restore => "restore",
             Self::Delete => "delete",
@@ -34,6 +36,7 @@ impl TodoMutationToolKind {
         match self {
             Self::Create => "create_todo",
             Self::Complete => "complete_todos",
+            Self::Edit => "edit_todo",
             Self::Cancel => "cancel_todo",
             Self::Restore => "restore_todos",
             Self::Delete => "delete_todos",
@@ -96,6 +99,12 @@ pub(super) fn required_todo_tool_kind(
     }
     if contains_any(&operative, &["恢复", "撤销完成", "恢复完成", "取消完成"]) {
         return Some(TodoMutationToolKind::Restore);
+    }
+    if contains_any(
+        &operative,
+        &["修改", "改成", "改为", "更新", "改一下", "改下"],
+    ) {
+        return Some(TodoMutationToolKind::Edit);
     }
     if contains_any(&operative, &["完成", "做完", "标记完成", "搞定"]) {
         return Some(TodoMutationToolKind::Complete);
@@ -226,6 +235,7 @@ pub(super) fn todo_required_tool_not_called_reply(
     let action = match required_tool_kind {
         Some(TodoMutationToolKind::Create) => "新增待办",
         Some(TodoMutationToolKind::Complete) => "完成待办",
+        Some(TodoMutationToolKind::Edit) => "修改待办",
         Some(TodoMutationToolKind::Cancel) => "取消待办",
         Some(TodoMutationToolKind::Restore) => "恢复待办",
         Some(TodoMutationToolKind::Delete) => "删除待办",
@@ -333,6 +343,11 @@ mod tests {
             "完成第 1 个待办",
             &session,
             Some(TodoMutationToolKind::Complete),
+        );
+        assert_kind(
+            "修改第 2 个待办",
+            &session,
+            Some(TodoMutationToolKind::Edit),
         );
         assert_kind(
             "取消第 2 个任务",

--- a/qq-maid-core/src/runtime/respond/llm_service.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service.rs
@@ -205,6 +205,7 @@ fn tool_context_from_request(req: &RespondRequest) -> ToolContext {
             .unwrap_or_else(|| Uuid::new_v4().to_string()),
         user_id: req.user_id.clone(),
         scope_id: req.scope_key.clone(),
+        tool_call_id: None,
     }
 }
 

--- a/qq-maid-core/src/runtime/tools/mod.rs
+++ b/qq-maid-core/src/runtime/tools/mod.rs
@@ -7,6 +7,7 @@ mod todo;
 mod weather;
 
 pub use todo::{
-    CancelTodoTool, CompleteTodoTool, CreateTodoTool, DeleteTodoTool, ListTodoTool, RestoreTodoTool,
+    CancelTodoTool, CompleteTodoTool, CreateTodoTool, DeleteTodoTool, EditTodoTool, ListTodoTool,
+    RestoreTodoTool,
 };
 pub use weather::WeatherTool;

--- a/qq-maid-core/src/runtime/tools/todo.rs
+++ b/qq-maid-core/src/runtime/tools/todo.rs
@@ -6,9 +6,12 @@
 use std::collections::HashSet;
 
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 
-use qq_maid_llm::tool::{Tool, ToolContext, ToolMetadata, ToolOutput};
+use qq_maid_llm::tool::{
+    Tool, ToolCallDependency, ToolContext, ToolMetadata, ToolOutput, ToolPreparation,
+};
 
 use crate::{
     error::LlmError,
@@ -26,6 +29,7 @@ use crate::{
 const LIST_TODOS_TOOL_NAME: &str = "list_todos";
 const CREATE_TODO_TOOL_NAME: &str = "create_todo";
 const COMPLETE_TODOS_TOOL_NAME: &str = "complete_todos";
+const EDIT_TODO_TOOL_NAME: &str = "edit_todo";
 const CANCEL_TODO_TOOL_NAME: &str = "cancel_todo";
 const RESTORE_TODOS_TOOL_NAME: &str = "restore_todos";
 const DELETE_TODOS_TOOL_NAME: &str = "delete_todos";
@@ -38,8 +42,14 @@ const TODO_REFERENCE_INVALID_STATE_CODE: &str = "todo_reference_invalid_state";
 const TODO_SELECTION_NOT_FOUND_CODE: &str = "todo_selection_not_found";
 const TODO_DELETE_INVALID_STATE_CODE: &str = "todo_delete_invalid_state";
 const TODO_DELETE_MIXED_STATUS_CODE: &str = "todo_delete_mixed_status";
+const TODO_DEDUP_HISTORY_KEY: &str = "tool_todo_dedup_history";
+const TODO_DEDUP_HISTORY_LIMIT: usize = 32;
+const PREBOUND_SELECTION_KEY: &str = "_resolved_selection";
+const PREBOUND_SINGLE_ID_KEY: &str = "_resolved_todo_id";
+const PREBOUND_SINGLE_LABEL_KEY: &str = "_resolved_label";
+const PREBOUND_EDIT_DRAFT_KEY: &str = "_resolved_edit_draft";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 enum TodoReference {
     Last,
 }
@@ -58,10 +68,39 @@ enum TodoSelectionRequest {
     Reference(TodoReference),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 enum TodoSelectionLabel {
     Number(usize),
     Reference(TodoReference),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PreparedSelectionMatch {
+    label: TodoSelectionLabel,
+    id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct PreparedResolvedSelection {
+    labels: Vec<TodoSelectionLabel>,
+    matched: Vec<PreparedSelectionMatch>,
+    missing: Vec<TodoSelectionLabel>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct TodoToolDedupEntry {
+    call_id: String,
+    arguments: Value,
+    output: Value,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct TodoEditPatch {
+    title: Option<String>,
+    detail: Option<String>,
+    due_date: Option<String>,
+    due_at: Option<String>,
+    time_precision: Option<TodoTimePrecision>,
 }
 
 /// 查询当前私聊用户的 Todo，并刷新用户可见编号快照。
@@ -97,6 +136,22 @@ impl CreateTodoTool {
 pub struct CompleteTodoTool {
     todo_store: TodoStore,
     session_store: SessionStore,
+}
+
+/// 按最近可见编号编辑未完成 Todo；内部复用现有 `/todo edit` 的草稿语义。
+#[derive(Clone)]
+pub struct EditTodoTool {
+    todo_store: TodoStore,
+    session_store: SessionStore,
+}
+
+impl EditTodoTool {
+    pub fn new(todo_store: TodoStore, session_store: SessionStore) -> Self {
+        Self {
+            todo_store,
+            session_store,
+        }
+    }
 }
 
 impl CompleteTodoTool {
@@ -192,7 +247,7 @@ impl Tool for ListTodoTool {
         }
         .map_err(todo_tool_error)?;
         scope.remember(status.query_type(), status.condition(), &items);
-        scope.save(&self.session_store)?;
+        scope.save()?;
 
         Ok(ToolOutput::json(json!({
             "status": status.as_str(),
@@ -250,6 +305,9 @@ impl Tool for CreateTodoTool {
         arguments: Value,
     ) -> Result<ToolOutput, LlmError> {
         let mut scope = TodoToolScope::load(&self.session_store, &context)?;
+        if let Some(output) = scope.take_dedup_output(&context, &arguments)? {
+            return Ok(output);
+        }
         let content = required_non_empty_text(&arguments, "content")?;
         let title = optional_text(&arguments, "title")?.unwrap_or_else(|| content.clone());
         let detail = optional_text(&arguments, "detail")?;
@@ -276,14 +334,16 @@ impl Tool for CreateTodoTool {
             allow_revision: true,
             created_at: now_iso_cn(),
         });
-        scope.save(&self.session_store)?;
+        scope.save()?;
 
-        Ok(ToolOutput::json(json!({
+        let output = ToolOutput::json(json!({
             "requires_confirmation": true,
             "pending_action": "create",
             "message": "已生成待确认待办草稿；必须等待用户确认后才会写入。",
             "draft": todo_draft_json(&draft),
-        })))
+        }));
+        scope.remember_dedup_output(&context, &arguments, &output)?;
+        Ok(output)
     }
 }
 
@@ -297,18 +357,32 @@ impl Tool for CompleteTodoTool {
         }
     }
 
+    fn prepare(
+        &self,
+        context: &ToolContext,
+        arguments: Value,
+    ) -> Result<ToolPreparation, LlmError> {
+        prepare_selection_arguments(
+            &self.session_store,
+            &self.todo_store,
+            context,
+            arguments,
+            true,
+        )
+    }
+
     async fn execute(
         &self,
         context: ToolContext,
         arguments: Value,
     ) -> Result<ToolOutput, LlmError> {
         let mut scope = TodoToolScope::load(&self.session_store, &context)?;
-        let selection = todo_selection_request(&arguments, true)?;
-        let resolved = match scope.resolve_selection(&selection, &self.todo_store)? {
-            TodoToolSelectionResolution::Resolved(resolved) => resolved,
-            TodoToolSelectionResolution::Output(output) => return Ok(output),
-        };
-        let ids = resolved.ids();
+        if let Some(output) = scope.take_dedup_output(&context, &arguments)? {
+            return Ok(output);
+        }
+        let resolved =
+            resolved_selection_from_arguments(&mut scope, &self.todo_store, &arguments, true)?;
+        let ids = prepared_selection_ids(&resolved);
         let outcome = self
             .todo_store
             .complete_by_ids(&scope.owner, &ids)
@@ -323,15 +397,162 @@ impl Tool for CompleteTodoTool {
                 "completed",
                 &outcome.completed,
             );
-            scope.save(&self.session_store)?;
+            scope.save()?;
         }
 
-        Ok(ToolOutput::json(json!({
+        let output = ToolOutput::json(json!({
             "ok": true,
             "completed": todo_selected_items_json(&completed),
             "missing_numbers": missing_numbers_json(&missing),
             "message": "已完成的条目已变更为 completed；missing_numbers 表示编号不存在、状态不是未完成或条目已变化。"
-        })))
+        }));
+        scope.remember_dedup_output(&context, &arguments, &output)?;
+        Ok(output)
+    }
+}
+
+#[async_trait]
+impl Tool for EditTodoTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            name: EDIT_TODO_TOOL_NAME.to_owned(),
+            description: "编辑未完成待办的标题、详情和时间。用户明确说“第 N 个”时只能传 number 并依赖最近一次 list_todos 的 visible_number；用户说“刚才那个 / 它”时传 reference=\"last\"。不会接受数据库内部 ID，也不会修改已完成/已取消待办。".to_owned(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "number": {
+                        "type": ["integer", "null"],
+                        "minimum": 1,
+                        "description": "要编辑的 visible_number"
+                    },
+                    "reference": {
+                        "type": ["string", "null"],
+                        "enum": [TODO_REFERENCE_LAST, null],
+                        "description": "当用户说“刚才那个 / 它 / 刚恢复的那个 / 刚创建的那个”时传 \"last\"；与 number 二选一。"
+                    },
+                    "raw_text": {
+                        "type": "string",
+                        "description": "用户原始修改内容，例如“改为除了搬家还有宽带要迁移”"
+                    },
+                    "title": {
+                        "type": ["string", "null"],
+                        "description": "新的标题；仅在用户明确修改标题时传值"
+                    },
+                    "detail": {
+                        "type": ["string", "null"],
+                        "description": "新的详情/内容/备注；仅在用户明确修改详情时传值"
+                    },
+                    "due_date": {
+                        "type": ["string", "null"],
+                        "description": "新的 YYYY-MM-DD 截止日期；没有则传 null"
+                    },
+                    "due_at": {
+                        "type": ["string", "null"],
+                        "description": "新的 YYYY-MM-DD HH:MM:SS 截止时间；没有则传 null"
+                    },
+                    "time_precision": {
+                        "type": ["string", "null"],
+                        "enum": ["none", "date", "date_time", "inferred", null],
+                        "description": "新的时间精度；未明确修改时传 null"
+                    }
+                },
+                "required": ["number", "reference", "raw_text", "title", "detail", "due_date", "due_at", "time_precision"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn prepare(
+        &self,
+        context: &ToolContext,
+        arguments: Value,
+    ) -> Result<ToolPreparation, LlmError> {
+        let mut scope = TodoToolScope::load(&self.session_store, context)?;
+        let selection = single_todo_selection_request(&arguments)?;
+        let patch = todo_edit_patch(&arguments)?;
+        let raw_text = required_non_empty_text(&arguments, "raw_text")?;
+        let prepared = match selection {
+            TodoSelectionRequest::Numbers(_) => {
+                let resolved =
+                    resolve_prepared_selection(&mut scope, &selection, &self.todo_store)?;
+                let id = resolved
+                    .matched
+                    .first()
+                    .map(|item| item.id.clone())
+                    .ok_or_else(|| bad_tool_arguments("number did not match any visible todo"))?;
+                let label = serde_json::to_value(
+                    resolved
+                        .labels
+                        .first()
+                        .cloned()
+                        .unwrap_or(TodoSelectionLabel::Number(1)),
+                )
+                .map_err(|err| {
+                    LlmError::new(
+                        "bad_tool_arguments",
+                        format!("failed to encode selection label: {err}"),
+                        "tool",
+                    )
+                })?;
+                json!({
+                    PREBOUND_SINGLE_ID_KEY: id,
+                    PREBOUND_SINGLE_LABEL_KEY: label,
+                    PREBOUND_EDIT_DRAFT_KEY: serde_json::to_value(patch).map_err(|err| LlmError::new("bad_tool_arguments", format!("failed to encode edit patch: {err}"), "tool"))?,
+                    "raw_text": raw_text,
+                })
+            }
+            TodoSelectionRequest::Reference(_) => {
+                let mut prepared = arguments.clone();
+                if let Some(object) = prepared.as_object_mut() {
+                    object.insert("raw_text".to_owned(), json!(raw_text));
+                }
+                prepared
+            }
+        };
+        let dependency = match selection {
+            TodoSelectionRequest::Reference(_) => ToolCallDependency::PreviousCallSuccess,
+            TodoSelectionRequest::Numbers(_) => ToolCallDependency::None,
+        };
+        Ok(ToolPreparation::ready(prepared).with_dependency(dependency))
+    }
+
+    async fn execute(
+        &self,
+        context: ToolContext,
+        arguments: Value,
+    ) -> Result<ToolOutput, LlmError> {
+        let mut scope = TodoToolScope::load(&self.session_store, &context)?;
+        if let Some(output) = scope.take_dedup_output(&context, &arguments)? {
+            return Ok(output);
+        }
+        let (item, label, patch, raw_text) =
+            prepared_edit_target(&mut scope, &self.todo_store, &arguments)?;
+        if item.status != TodoStatus::Pending {
+            return Ok(todo_tool_error_output(
+                TODO_REFERENCE_INVALID_STATE_CODE,
+                "edit_todo only accepts pending todos",
+            ));
+        }
+        let draft = apply_tool_edit_patch(
+            TodoItemDraft::from_item(&item, raw_text.clone()),
+            patch,
+            &raw_text,
+        );
+        let updated = self
+            .todo_store
+            .edit(&scope.owner, &item.id, draft)
+            .map_err(todo_tool_error)?;
+        scope.session.last_todo_query = None;
+        scope
+            .session
+            .remember_last_todo_action(&scope.owner.key, &updated, "edited");
+        let output = ToolOutput::json(json!({
+            "ok": true,
+            "updated": todo_selected_item_json(label, &updated),
+            "message": "待办已更新；执行前已把用户可见编号绑定到稳定内部 ID。"
+        }));
+        scope.remember_dedup_output(&context, &arguments, &output)?;
+        Ok(output)
     }
 }
 
@@ -345,17 +566,31 @@ impl Tool for CancelTodoTool {
         }
     }
 
+    fn prepare(
+        &self,
+        context: &ToolContext,
+        arguments: Value,
+    ) -> Result<ToolPreparation, LlmError> {
+        prepare_selection_arguments(
+            &self.session_store,
+            &self.todo_store,
+            context,
+            arguments,
+            false,
+        )
+    }
+
     async fn execute(
         &self,
         context: ToolContext,
         arguments: Value,
     ) -> Result<ToolOutput, LlmError> {
         let mut scope = TodoToolScope::load(&self.session_store, &context)?;
-        let selection = single_todo_selection_request(&arguments)?;
-        let resolved = match scope.resolve_selection(&selection, &self.todo_store)? {
-            TodoToolSelectionResolution::Resolved(resolved) => resolved,
-            TodoToolSelectionResolution::Output(output) => return Ok(output),
-        };
+        if let Some(output) = scope.take_dedup_output(&context, &arguments)? {
+            return Ok(output);
+        }
+        let resolved =
+            resolved_selection_from_arguments(&mut scope, &self.todo_store, &arguments, false)?;
         let item = match resolved.single_item(&self.todo_store, &scope.owner)? {
             TodoToolSingleItemResolution::Item(item) => *item,
             TodoToolSingleItemResolution::Output(output) => return Ok(output),
@@ -374,15 +609,17 @@ impl Tool for CancelTodoTool {
             item: item.clone(),
             created_at: now_iso_cn(),
         });
-        scope.save(&self.session_store)?;
+        scope.save()?;
 
-        Ok(ToolOutput::json(json!({
+        let output = ToolOutput::json(json!({
             "ok": true,
             "requires_confirmation": true,
             "pending_action": "cancel",
             "message": "已发起取消待办确认；用户确认后只会标记为已取消，不会永久删除。",
             "item": todo_selected_item_json(resolved.single_label(), &item),
-        })))
+        }));
+        scope.remember_dedup_output(&context, &arguments, &output)?;
+        Ok(output)
     }
 }
 
@@ -396,18 +633,32 @@ impl Tool for RestoreTodoTool {
         }
     }
 
+    fn prepare(
+        &self,
+        context: &ToolContext,
+        arguments: Value,
+    ) -> Result<ToolPreparation, LlmError> {
+        prepare_selection_arguments(
+            &self.session_store,
+            &self.todo_store,
+            context,
+            arguments,
+            true,
+        )
+    }
+
     async fn execute(
         &self,
         context: ToolContext,
         arguments: Value,
     ) -> Result<ToolOutput, LlmError> {
         let mut scope = TodoToolScope::load(&self.session_store, &context)?;
-        let selection = todo_selection_request(&arguments, true)?;
-        let resolved = match scope.resolve_selection(&selection, &self.todo_store)? {
-            TodoToolSelectionResolution::Resolved(resolved) => resolved,
-            TodoToolSelectionResolution::Output(output) => return Ok(output),
-        };
-        let ids = resolved.ids();
+        if let Some(output) = scope.take_dedup_output(&context, &arguments)? {
+            return Ok(output);
+        }
+        let resolved =
+            resolved_selection_from_arguments(&mut scope, &self.todo_store, &arguments, true)?;
+        let ids = prepared_selection_ids(&resolved);
         let completed_outcome = self
             .todo_store
             .restore_completed_by_ids(&scope.owner, &ids)
@@ -431,15 +682,17 @@ impl Tool for RestoreTodoTool {
                 "restored",
                 &combined,
             );
-            scope.save(&self.session_store)?;
+            scope.save()?;
         }
 
-        Ok(ToolOutput::json(json!({
+        let output = ToolOutput::json(json!({
             "ok": true,
             "restored": todo_selected_items_json(&restored),
             "missing_numbers": missing_numbers_json(&missing),
             "message": "已恢复的条目已变更为 pending；missing_numbers 表示编号不存在、状态不是已完成/已取消或条目已变化。"
-        })))
+        }));
+        scope.remember_dedup_output(&context, &arguments, &output)?;
+        Ok(output)
     }
 }
 
@@ -453,18 +706,32 @@ impl Tool for DeleteTodoTool {
         }
     }
 
+    fn prepare(
+        &self,
+        context: &ToolContext,
+        arguments: Value,
+    ) -> Result<ToolPreparation, LlmError> {
+        prepare_selection_arguments(
+            &self.session_store,
+            &self.todo_store,
+            context,
+            arguments,
+            true,
+        )
+    }
+
     async fn execute(
         &self,
         context: ToolContext,
         arguments: Value,
     ) -> Result<ToolOutput, LlmError> {
         let mut scope = TodoToolScope::load(&self.session_store, &context)?;
-        let selection = todo_selection_request(&arguments, true)?;
-        let resolved = match scope.resolve_selection(&selection, &self.todo_store)? {
-            TodoToolSelectionResolution::Resolved(resolved) => resolved,
-            TodoToolSelectionResolution::Output(output) => return Ok(output),
-        };
-        let ids = resolved.ids();
+        if let Some(output) = scope.take_dedup_output(&context, &arguments)? {
+            return Ok(output);
+        }
+        let resolved =
+            resolved_selection_from_arguments(&mut scope, &self.todo_store, &arguments, true)?;
+        let ids = prepared_selection_ids(&resolved);
         if ids.is_empty() {
             return Ok(todo_tool_error_output(
                 TODO_SELECTION_NOT_FOUND_CODE,
@@ -529,22 +796,25 @@ impl Tool for DeleteTodoTool {
             source_condition: source_condition.clone(),
             created_at: now_iso_cn(),
         });
-        scope.save(&self.session_store)?;
+        scope.save()?;
 
-        Ok(ToolOutput::json(json!({
+        let output = ToolOutput::json(json!({
             "ok": true,
             "requires_confirmation": true,
             "pending_action": "delete",
             "message": "已发起永久删除确认；只针对已完成或已取消待办，用户确认后才会删除记录。",
             "source_condition": source_condition,
             "items": todo_items_json(&items),
-        })))
+        }));
+        scope.remember_dedup_output(&context, &arguments, &output)?;
+        Ok(output)
     }
 }
 
 struct TodoToolScope {
     owner: TodoOwner,
     session: crate::runtime::session::SessionRecord,
+    session_store: SessionStore,
 }
 
 impl TodoToolScope {
@@ -580,7 +850,11 @@ impl TodoToolScope {
             .get_or_create_active(&meta)
             .map_err(session_tool_error)?;
         let owner = TodoStore::owner(Some(user_id), &context.scope_id);
-        Ok(Self { owner, session })
+        Ok(Self {
+            owner,
+            session,
+            session_store: session_store.clone(),
+        })
     }
 
     fn remember(&mut self, query_type: &str, condition: &str, items: &[TodoItem]) {
@@ -675,10 +949,86 @@ impl TodoToolScope {
         ))
     }
 
-    fn save(&mut self, session_store: &SessionStore) -> Result<(), LlmError> {
-        session_store
+    fn save(&mut self) -> Result<(), LlmError> {
+        self.session_store
             .save(&mut self.session)
             .map_err(session_tool_error)
+    }
+
+    fn take_dedup_output(
+        &self,
+        context: &ToolContext,
+        arguments: &Value,
+    ) -> Result<Option<ToolOutput>, LlmError> {
+        let Some(call_id) = dedup_call_key(context) else {
+            return Ok(None);
+        };
+        let Some(entries_value) = self.session.extra.get(TODO_DEDUP_HISTORY_KEY) else {
+            return Ok(None);
+        };
+        let entries = serde_json::from_value::<Vec<TodoToolDedupEntry>>(entries_value.clone())
+            .map_err(|err| {
+                LlmError::new(
+                    "session_decode_error",
+                    format!("failed to decode todo dedup history: {err}"),
+                    "todo_tool",
+                )
+            })?;
+        let Some(entry) = entries.into_iter().find(|entry| entry.call_id == call_id) else {
+            return Ok(None);
+        };
+        if entry.arguments == *arguments {
+            return Ok(Some(ToolOutput::json(entry.output)));
+        }
+        Ok(None)
+    }
+
+    fn remember_dedup_output(
+        &mut self,
+        context: &ToolContext,
+        arguments: &Value,
+        output: &ToolOutput,
+    ) -> Result<(), LlmError> {
+        let Some(call_id) = dedup_call_key(context) else {
+            return Ok(());
+        };
+        let mut entries = self
+            .session
+            .extra
+            .get(TODO_DEDUP_HISTORY_KEY)
+            .cloned()
+            .map(|value| serde_json::from_value::<Vec<TodoToolDedupEntry>>(value))
+            .transpose()
+            .map_err(|err| {
+                LlmError::new(
+                    "session_decode_error",
+                    format!("failed to decode todo dedup history: {err}"),
+                    "todo_tool",
+                )
+            })?
+            .unwrap_or_default();
+        entries.retain(|entry| entry.call_id != call_id);
+        entries.push(TodoToolDedupEntry {
+            call_id,
+            arguments: arguments.clone(),
+            output: output.value.clone(),
+        });
+        if entries.len() > TODO_DEDUP_HISTORY_LIMIT {
+            let keep_from = entries.len() - TODO_DEDUP_HISTORY_LIMIT;
+            entries.drain(..keep_from);
+        }
+        self.session.extra.insert(
+            TODO_DEDUP_HISTORY_KEY.to_owned(),
+            serde_json::to_value(entries).map_err(|err| {
+                LlmError::new(
+                    "session_encode_error",
+                    format!("failed to encode todo dedup history: {err}"),
+                    "todo_tool",
+                )
+            })?,
+        );
+        self.save()?;
+        Ok(())
     }
 
     fn ensure_no_pending(&self) -> Result<(), LlmError> {
@@ -733,10 +1083,6 @@ impl ResolvedTodoSelection {
             missing: Vec::new(),
             error_output: Some(todo_tool_error_output(error_code, message)),
         }
-    }
-
-    fn ids(&self) -> Vec<String> {
-        self.matched.iter().map(|(_, id)| id.clone()).collect()
     }
 
     fn single_label(&self) -> TodoSelectionLabel {
@@ -1011,6 +1357,59 @@ fn optional_time_precision(arguments: &Value, key: &str) -> Result<TodoTimePreci
     }
 }
 
+fn optional_edit_time_precision(
+    arguments: &Value,
+    key: &str,
+) -> Result<Option<TodoTimePrecision>, LlmError> {
+    match arguments.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => match value.as_str() {
+            "none" => Ok(Some(TodoTimePrecision::None)),
+            "date" => Ok(Some(TodoTimePrecision::Date)),
+            "date_time" => Ok(Some(TodoTimePrecision::DateTime)),
+            "inferred" => Ok(Some(TodoTimePrecision::Inferred)),
+            _ => Err(bad_tool_arguments("invalid time_precision")),
+        },
+        _ => Err(bad_tool_arguments(format!("{key} must be string or null"))),
+    }
+}
+
+fn todo_edit_patch(arguments: &Value) -> Result<TodoEditPatch, LlmError> {
+    Ok(TodoEditPatch {
+        title: optional_text(arguments, "title")?,
+        detail: optional_text(arguments, "detail")?,
+        due_date: optional_text(arguments, "due_date")?,
+        due_at: optional_text(arguments, "due_at")?,
+        time_precision: optional_edit_time_precision(arguments, "time_precision")?,
+    })
+}
+
+fn apply_tool_edit_patch(
+    mut draft: TodoItemDraft,
+    patch: TodoEditPatch,
+    raw_text: &str,
+) -> TodoItemDraft {
+    if let Some(title) = patch.title {
+        draft.title = title;
+    }
+    if let Some(detail) = patch.detail {
+        draft.detail = Some(detail);
+    }
+    if let Some(due_at) = patch.due_at {
+        draft.due_at = Some(due_at);
+        draft.due_date = patch.due_date;
+        draft.time_precision = patch.time_precision.unwrap_or(TodoTimePrecision::DateTime);
+    } else if let Some(due_date) = patch.due_date {
+        draft.due_date = Some(due_date);
+        draft.due_at = None;
+        draft.time_precision = patch.time_precision.unwrap_or(TodoTimePrecision::Date);
+    } else if let Some(precision) = patch.time_precision {
+        draft.time_precision = precision;
+    }
+    draft.raw_text = Some(raw_text.to_owned());
+    draft
+}
+
 fn todo_items_json(items: &[TodoItem]) -> Vec<Value> {
     items
         .iter()
@@ -1154,6 +1553,218 @@ fn todo_selection_label_text(label: &TodoSelectionLabel) -> String {
     }
 }
 
+fn dedup_call_key(context: &ToolContext) -> Option<String> {
+    let tool_call_id = context
+        .tool_call_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    Some(format!("{}:{tool_call_id}", context.task_id))
+}
+
+fn resolve_prepared_selection(
+    scope: &mut TodoToolScope,
+    selection: &TodoSelectionRequest,
+    todo_store: &TodoStore,
+) -> Result<PreparedResolvedSelection, LlmError> {
+    let resolved = match scope.resolve_selection(selection, todo_store)? {
+        TodoToolSelectionResolution::Resolved(resolved) => resolved,
+        TodoToolSelectionResolution::Output(output) => {
+            return Err(LlmError::new(
+                output.value["error_code"]
+                    .as_str()
+                    .unwrap_or("bad_tool_arguments")
+                    .to_owned(),
+                output.value["message"]
+                    .as_str()
+                    .unwrap_or("todo selection unavailable")
+                    .to_owned(),
+                "tool",
+            ));
+        }
+    };
+    Ok(PreparedResolvedSelection {
+        labels: resolved.labels.clone(),
+        matched: resolved
+            .matched
+            .iter()
+            .map(|(label, id)| PreparedSelectionMatch {
+                label: label.clone(),
+                id: id.clone(),
+            })
+            .collect(),
+        missing: resolved.missing.clone(),
+    })
+}
+
+fn prepared_selection_argument(
+    arguments: &Value,
+) -> Result<Option<PreparedResolvedSelection>, LlmError> {
+    arguments
+        .get(PREBOUND_SELECTION_KEY)
+        .cloned()
+        .map(|value| {
+            serde_json::from_value::<PreparedResolvedSelection>(value).map_err(|err| {
+                LlmError::new(
+                    "bad_tool_arguments",
+                    format!("invalid prepared selection payload: {err}"),
+                    "tool",
+                )
+            })
+        })
+        .transpose()
+}
+
+fn prepared_edit_target(
+    scope: &mut TodoToolScope,
+    todo_store: &TodoStore,
+    arguments: &Value,
+) -> Result<(TodoItem, TodoSelectionLabel, TodoEditPatch, String), LlmError> {
+    if let Some(id) = arguments
+        .get(PREBOUND_SINGLE_ID_KEY)
+        .and_then(Value::as_str)
+    {
+        let label_value = arguments
+            .get(PREBOUND_SINGLE_LABEL_KEY)
+            .cloned()
+            .ok_or_else(|| bad_tool_arguments("missing prepared edit label"))?;
+        let label = serde_json::from_value::<TodoSelectionLabel>(label_value)
+            .map_err(|err| bad_tool_arguments(format!("invalid prepared edit label: {err}")))?;
+        let patch_value = arguments
+            .get(PREBOUND_EDIT_DRAFT_KEY)
+            .cloned()
+            .ok_or_else(|| bad_tool_arguments("missing prepared edit patch"))?;
+        let patch = serde_json::from_value::<TodoEditPatch>(patch_value)
+            .map_err(|err| bad_tool_arguments(format!("invalid prepared edit patch: {err}")))?;
+        let raw_text = required_non_empty_text(arguments, "raw_text")?;
+        let item = todo_store
+            .get_by_id(&scope.owner, id)
+            .map_err(todo_tool_error)?
+            .ok_or_else(|| {
+                LlmError::new(
+                    TODO_SELECTION_NOT_FOUND_CODE,
+                    "selected todo no longer exists",
+                    "tool",
+                )
+            })?;
+        return Ok((item, label, patch, raw_text));
+    }
+
+    let selection = single_todo_selection_request(arguments)?;
+    let resolved = match scope.resolve_selection(&selection, todo_store)? {
+        TodoToolSelectionResolution::Resolved(resolved) => resolved,
+        TodoToolSelectionResolution::Output(output) => {
+            return Err(LlmError::new(
+                output.value["error_code"]
+                    .as_str()
+                    .unwrap_or("bad_tool_arguments"),
+                output.value["message"]
+                    .as_str()
+                    .unwrap_or("todo selection unavailable"),
+                "tool",
+            ));
+        }
+    };
+    let item = match resolved.single_item(todo_store, &scope.owner)? {
+        TodoToolSingleItemResolution::Item(item) => *item,
+        TodoToolSingleItemResolution::Output(output) => {
+            return Err(LlmError::new(
+                output.value["error_code"]
+                    .as_str()
+                    .unwrap_or("bad_tool_arguments"),
+                output.value["message"]
+                    .as_str()
+                    .unwrap_or("selected todo is unavailable"),
+                "tool",
+            ));
+        }
+    };
+    Ok((
+        item,
+        resolved.single_label(),
+        todo_edit_patch(arguments)?,
+        required_non_empty_text(arguments, "raw_text")?,
+    ))
+}
+
+fn prepare_selection_arguments(
+    session_store: &SessionStore,
+    todo_store: &TodoStore,
+    context: &ToolContext,
+    arguments: Value,
+    allow_many: bool,
+) -> Result<ToolPreparation, LlmError> {
+    let mut scope = TodoToolScope::load(session_store, context)?;
+    let selection = if allow_many {
+        todo_selection_request(&arguments, true)?
+    } else {
+        single_todo_selection_request(&arguments)?
+    };
+    let dependency = match selection {
+        TodoSelectionRequest::Reference(_) => ToolCallDependency::PreviousCallSuccess,
+        TodoSelectionRequest::Numbers(_) => ToolCallDependency::None,
+    };
+    let prepared_arguments = match selection {
+        TodoSelectionRequest::Numbers(_) => {
+            let resolved = resolve_prepared_selection(&mut scope, &selection, todo_store)?;
+            let mut prepared = arguments.clone();
+            let object = prepared
+                .as_object_mut()
+                .ok_or_else(|| bad_tool_arguments("tool arguments must be a JSON object"))?;
+            object.insert(
+                PREBOUND_SELECTION_KEY.to_owned(),
+                serde_json::to_value(resolved).map_err(|err| {
+                    bad_tool_arguments(format!("failed to encode prepared selection: {err}"))
+                })?,
+            );
+            prepared
+        }
+        TodoSelectionRequest::Reference(_) => arguments,
+    };
+    Ok(ToolPreparation::ready(prepared_arguments).with_dependency(dependency))
+}
+
+fn resolved_selection_from_arguments(
+    scope: &mut TodoToolScope,
+    todo_store: &TodoStore,
+    arguments: &Value,
+    allow_many: bool,
+) -> Result<ResolvedTodoSelection, LlmError> {
+    if let Some(prepared) = prepared_selection_argument(arguments)? {
+        return Ok(ResolvedTodoSelection {
+            labels: prepared.labels,
+            matched: prepared
+                .matched
+                .into_iter()
+                .map(|item| (item.label, item.id))
+                .collect(),
+            missing: prepared.missing,
+            error_output: None,
+        });
+    }
+    let selection = if allow_many {
+        todo_selection_request(arguments, true)?
+    } else {
+        single_todo_selection_request(arguments)?
+    };
+    match scope.resolve_selection(&selection, todo_store)? {
+        TodoToolSelectionResolution::Resolved(resolved) => Ok(resolved),
+        TodoToolSelectionResolution::Output(output) => Err(LlmError::new(
+            output.value["error_code"]
+                .as_str()
+                .unwrap_or("bad_tool_arguments"),
+            output.value["message"]
+                .as_str()
+                .unwrap_or("todo selection unavailable"),
+            "tool",
+        )),
+    }
+}
+
+fn prepared_selection_ids(resolved: &ResolvedTodoSelection) -> Vec<String> {
+    resolved.matched.iter().map(|(_, id)| id.clone()).collect()
+}
+
 fn todo_tool_error(err: crate::runtime::todo::TodoError) -> LlmError {
     LlmError::new(err.code().to_owned(), err.message().to_owned(), "todo_tool")
 }
@@ -1172,4 +1783,151 @@ fn todo_tool_error_output(error_code: &str, message: &str) -> ToolOutput {
         "error_code": error_code,
         "message": message,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{APP_MIGRATIONS, database::SqliteDatabase};
+
+    fn test_context() -> ToolContext {
+        ToolContext {
+            task_id: "msg-1".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_id: "private:u1".to_owned(),
+            tool_call_id: Some("call-1".to_owned()),
+        }
+    }
+
+    fn test_stores() -> (TodoStore, SessionStore, TodoOwner) {
+        let database = SqliteDatabase::open_temp("todo-tool-tests", APP_MIGRATIONS).unwrap();
+        let todo_store = TodoStore::new(database.clone());
+        let session_store = SessionStore::new(database);
+        let owner = TodoStore::owner(Some("u1"), "private:u1");
+        (todo_store, session_store, owner)
+    }
+
+    #[tokio::test]
+    async fn prepared_number_binding_survives_previous_completion() {
+        let (todo_store, session_store, owner) = test_stores();
+        let first = todo_store
+            .create(
+                &owner,
+                TodoItemDraft {
+                    title: "搬家".to_owned(),
+                    detail: None,
+                    raw_text: None,
+                    due_date: None,
+                    due_at: None,
+                    time_precision: TodoTimePrecision::None,
+                },
+            )
+            .unwrap();
+        let second = todo_store
+            .create(
+                &owner,
+                TodoItemDraft {
+                    title: "宽带迁移".to_owned(),
+                    detail: None,
+                    raw_text: None,
+                    due_date: None,
+                    due_at: None,
+                    time_precision: TodoTimePrecision::None,
+                },
+            )
+            .unwrap();
+
+        let list_tool = ListTodoTool::new(todo_store.clone(), session_store.clone());
+        let complete_tool = CompleteTodoTool::new(todo_store.clone(), session_store.clone());
+        let edit_tool = EditTodoTool::new(todo_store.clone(), session_store.clone());
+        let context = test_context();
+
+        list_tool
+            .execute(context.clone(), json!({"status":"pending"}))
+            .await
+            .unwrap();
+
+        let complete_prepared = complete_tool
+            .prepare(&context, json!({"numbers":[1], "reference": null}))
+            .unwrap();
+        let mut edit_context = context.clone();
+        edit_context.tool_call_id = Some("call-2".to_owned());
+        let edit_prepared = edit_tool
+            .prepare(
+                &edit_context,
+                json!({
+                    "number": 2,
+                    "reference": null,
+                    "raw_text": "改为除了搬家还有宽带要迁移",
+                    "title": null,
+                    "detail": "除了搬家还有宽带要迁移",
+                    "due_date": null,
+                    "due_at": null,
+                    "time_precision": null
+                }),
+            )
+            .unwrap();
+
+        complete_tool
+            .execute(context.clone(), complete_prepared.arguments)
+            .await
+            .unwrap();
+        let edited = edit_tool
+            .execute(edit_context.clone(), edit_prepared.arguments)
+            .await
+            .unwrap();
+
+        let edited_value = edited.value;
+        assert_eq!(edited_value["ok"], true);
+        assert_eq!(
+            todo_store
+                .get_by_id(&owner, &first.id)
+                .unwrap()
+                .unwrap()
+                .status,
+            TodoStatus::Completed
+        );
+        let second_item = todo_store.get_by_id(&owner, &second.id).unwrap().unwrap();
+        assert_eq!(
+            second_item.detail.as_deref(),
+            Some("除了搬家还有宽带要迁移")
+        );
+    }
+
+    #[tokio::test]
+    async fn create_tool_replay_with_same_call_id_does_not_duplicate_pending() {
+        let (_todo_store, session_store, _owner) = test_stores();
+        let create_tool = CreateTodoTool::new(session_store.clone());
+        let context = test_context();
+        let arguments = json!({
+            "content":"今晚检查机器人日志",
+            "title":null,
+            "detail":null,
+            "due_date":null,
+            "due_at":null,
+            "time_precision":null
+        });
+
+        let first = create_tool
+            .execute(context.clone(), arguments.clone())
+            .await
+            .unwrap();
+        let second = create_tool.execute(context, arguments).await.unwrap();
+
+        assert_eq!(first.value, second.value);
+        let session = session_store
+            .get_or_create_active(&SessionMeta::new(
+                "private:u1",
+                Some("u1".to_owned()),
+                None,
+                None,
+                None,
+                "qq_official",
+            ))
+            .unwrap();
+        assert!(matches!(
+            session.pending_operation,
+            Some(PendingOperation::TodoAdd { .. })
+        ));
+    }
 }

--- a/qq-maid-core/src/runtime/tools/todo.rs
+++ b/qq-maid-core/src/runtime/tools/todo.rs
@@ -48,6 +48,7 @@ const PREBOUND_SELECTION_KEY: &str = "_resolved_selection";
 const PREBOUND_SINGLE_ID_KEY: &str = "_resolved_todo_id";
 const PREBOUND_SINGLE_LABEL_KEY: &str = "_resolved_label";
 const PREBOUND_EDIT_DRAFT_KEY: &str = "_resolved_edit_draft";
+const PREBOUND_ERROR_OUTPUT_KEY: &str = "_error_output";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 enum TodoReference {
@@ -85,6 +86,7 @@ struct PreparedResolvedSelection {
     labels: Vec<TodoSelectionLabel>,
     matched: Vec<PreparedSelectionMatch>,
     missing: Vec<TodoSelectionLabel>,
+    error_output: Option<Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -475,6 +477,12 @@ impl Tool for EditTodoTool {
             TodoSelectionRequest::Numbers(_) => {
                 let resolved =
                     resolve_prepared_selection(&mut scope, &selection, &self.todo_store)?;
+                if let Some(error_output) = resolved.error_output {
+                    return Ok(ToolPreparation::ready(json!({
+                        PREBOUND_ERROR_OUTPUT_KEY: error_output,
+                        "raw_text": raw_text,
+                    })));
+                }
                 let id = resolved
                     .matched
                     .first()
@@ -526,7 +534,15 @@ impl Tool for EditTodoTool {
             return Ok(output);
         }
         let (item, label, patch, raw_text) =
-            prepared_edit_target(&mut scope, &self.todo_store, &arguments)?;
+            match prepared_edit_target(&mut scope, &self.todo_store, &arguments)? {
+                TodoToolSingleItemResolutionWithDraft::Item {
+                    item,
+                    label,
+                    patch,
+                    raw_text,
+                } => (item, label, patch, raw_text),
+                TodoToolSingleItemResolutionWithDraft::Output(output) => return Ok(output),
+            };
         if item.status != TodoStatus::Pending {
             return Ok(todo_tool_error_output(
                 TODO_REFERENCE_INVALID_STATE_CODE,
@@ -1569,18 +1585,15 @@ fn resolve_prepared_selection(
 ) -> Result<PreparedResolvedSelection, LlmError> {
     let resolved = match scope.resolve_selection(selection, todo_store)? {
         TodoToolSelectionResolution::Resolved(resolved) => resolved,
+        // 这里保留业务错误输出，不在 prepare 阶段抛异常，避免直接调用 execute_json
+        // 时把原本应返回给模型/测试的结构化失败升级成 Err。
         TodoToolSelectionResolution::Output(output) => {
-            return Err(LlmError::new(
-                output.value["error_code"]
-                    .as_str()
-                    .unwrap_or("bad_tool_arguments")
-                    .to_owned(),
-                output.value["message"]
-                    .as_str()
-                    .unwrap_or("todo selection unavailable")
-                    .to_owned(),
-                "tool",
-            ));
+            return Ok(PreparedResolvedSelection {
+                labels: Vec::new(),
+                matched: Vec::new(),
+                missing: Vec::new(),
+                error_output: Some(output.value),
+            });
         }
     };
     Ok(PreparedResolvedSelection {
@@ -1594,6 +1607,7 @@ fn resolve_prepared_selection(
             })
             .collect(),
         missing: resolved.missing.clone(),
+        error_output: resolved.error_output.map(|output| output.value),
     })
 }
 
@@ -1619,7 +1633,7 @@ fn prepared_edit_target(
     scope: &mut TodoToolScope,
     todo_store: &TodoStore,
     arguments: &Value,
-) -> Result<(TodoItem, TodoSelectionLabel, TodoEditPatch, String), LlmError> {
+) -> Result<TodoToolSingleItemResolutionWithDraft, LlmError> {
     if let Some(id) = arguments
         .get(PREBOUND_SINGLE_ID_KEY)
         .and_then(Value::as_str)
@@ -1647,44 +1661,39 @@ fn prepared_edit_target(
                     "tool",
                 )
             })?;
-        return Ok((item, label, patch, raw_text));
+        return Ok(TodoToolSingleItemResolutionWithDraft::Item {
+            item: Box::new(item),
+            label,
+            patch,
+            raw_text,
+        });
+    }
+
+    if let Some(output) = arguments.get(PREBOUND_ERROR_OUTPUT_KEY).cloned() {
+        return Ok(TodoToolSingleItemResolutionWithDraft::Output(
+            ToolOutput::json(output),
+        ));
     }
 
     let selection = single_todo_selection_request(arguments)?;
     let resolved = match scope.resolve_selection(&selection, todo_store)? {
         TodoToolSelectionResolution::Resolved(resolved) => resolved,
         TodoToolSelectionResolution::Output(output) => {
-            return Err(LlmError::new(
-                output.value["error_code"]
-                    .as_str()
-                    .unwrap_or("bad_tool_arguments"),
-                output.value["message"]
-                    .as_str()
-                    .unwrap_or("todo selection unavailable"),
-                "tool",
-            ));
+            return Ok(TodoToolSingleItemResolutionWithDraft::Output(output));
         }
     };
     let item = match resolved.single_item(todo_store, &scope.owner)? {
         TodoToolSingleItemResolution::Item(item) => *item,
         TodoToolSingleItemResolution::Output(output) => {
-            return Err(LlmError::new(
-                output.value["error_code"]
-                    .as_str()
-                    .unwrap_or("bad_tool_arguments"),
-                output.value["message"]
-                    .as_str()
-                    .unwrap_or("selected todo is unavailable"),
-                "tool",
-            ));
+            return Ok(TodoToolSingleItemResolutionWithDraft::Output(output));
         }
     };
-    Ok((
-        item,
-        resolved.single_label(),
-        todo_edit_patch(arguments)?,
-        required_non_empty_text(arguments, "raw_text")?,
-    ))
+    Ok(TodoToolSingleItemResolutionWithDraft::Item {
+        item: Box::new(item),
+        label: resolved.single_label(),
+        patch: todo_edit_patch(arguments)?,
+        raw_text: required_non_empty_text(arguments, "raw_text")?,
+    })
 }
 
 fn prepare_selection_arguments(
@@ -1739,7 +1748,7 @@ fn resolved_selection_from_arguments(
                 .map(|item| (item.label, item.id))
                 .collect(),
             missing: prepared.missing,
-            error_output: None,
+            error_output: prepared.error_output.map(ToolOutput::json),
         });
     }
     let selection = if allow_many {
@@ -1749,16 +1758,24 @@ fn resolved_selection_from_arguments(
     };
     match scope.resolve_selection(&selection, todo_store)? {
         TodoToolSelectionResolution::Resolved(resolved) => Ok(resolved),
-        TodoToolSelectionResolution::Output(output) => Err(LlmError::new(
-            output.value["error_code"]
-                .as_str()
-                .unwrap_or("bad_tool_arguments"),
-            output.value["message"]
-                .as_str()
-                .unwrap_or("todo selection unavailable"),
-            "tool",
-        )),
+        TodoToolSelectionResolution::Output(output) => Ok(ResolvedTodoSelection {
+            labels: Vec::new(),
+            matched: Vec::new(),
+            missing: Vec::new(),
+            error_output: Some(output),
+        }),
     }
+}
+
+enum TodoToolSingleItemResolutionWithDraft {
+    Item {
+        // 编辑目标沿用装箱，避免带草稿的枚举触发 large_enum_variant。
+        item: Box<TodoItem>,
+        label: TodoSelectionLabel,
+        patch: TodoEditPatch,
+        raw_text: String,
+    },
+    Output(ToolOutput),
 }
 
 fn prepared_selection_ids(resolved: &ResolvedTodoSelection) -> Vec<String> {

--- a/qq-maid-core/src/runtime/tools/todo.rs
+++ b/qq-maid-core/src/runtime/tools/todo.rs
@@ -997,7 +997,7 @@ impl TodoToolScope {
             .extra
             .get(TODO_DEDUP_HISTORY_KEY)
             .cloned()
-            .map(|value| serde_json::from_value::<Vec<TodoToolDedupEntry>>(value))
+            .map(serde_json::from_value::<Vec<TodoToolDedupEntry>>)
             .transpose()
             .map_err(|err| {
                 LlmError::new(

--- a/qq-maid-core/src/runtime/tools/weather.rs
+++ b/qq-maid-core/src/runtime/tools/weather.rs
@@ -231,6 +231,7 @@ mod tests {
             task_id: "task-1".to_owned(),
             user_id: Some("u1".to_owned()),
             scope_id: "private:u1".to_owned(),
+            tool_call_id: None,
         }
     }
 

--- a/qq-maid-llm/src/provider/mod.rs
+++ b/qq-maid-llm/src/provider/mod.rs
@@ -1047,6 +1047,7 @@ mod tests {
                 task_id: "task-1".to_owned(),
                 user_id: Some("u1".to_owned()),
                 scope_id: "private:u1".to_owned(),
+                tool_call_id: None,
             },
             max_rounds: 3,
         }

--- a/qq-maid-llm/src/provider/openai/tool_loop.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop.rs
@@ -13,7 +13,7 @@ use crate::{
         ChatOutcome,
         types::{ChatMessage, TokenUsage},
     },
-    tool::{ToolContext, ToolMetadata, ToolRegistry},
+    tool::{PreparedToolCall, ToolCallDependency, ToolContext, ToolMetadata, ToolRegistry},
 };
 
 use super::{
@@ -41,6 +41,11 @@ struct FunctionCall {
     name: String,
     call_id: String,
     arguments: String,
+}
+
+struct PreparedFunctionCall {
+    call_id: String,
+    prepared: PreparedToolCall,
 }
 
 pub(crate) async fn openai_responses_tool_loop(
@@ -120,29 +125,23 @@ pub(crate) async fn openai_responses_tool_loop(
                 "tool_loop",
             ));
         }
-        if calls.len() > 1 {
-            warn!(
-                provider = req.provider,
-                model = req.model,
-                tool_loop_used = true,
-                tool_loop_rounds = round,
-                parallel_calls = calls.len(),
-                "openai tool loop rejected parallel tool calls"
-            );
-            return Err(LlmError::new(
-                "unsupported_tool_calling",
-                "parallel tool calls are not supported",
-                "tool_loop",
-            ));
-        }
-
         append_response_output_items(&mut input, &body)?;
-        for call in calls {
-            executed_tools.push(call.name.clone());
-            let output = req
-                .tools
-                .execute_json(&req.tool_context, &call.name, &call.arguments)
-                .await?;
+        let prepared_calls = prepare_function_calls(&req, &calls, round)?;
+        let mut previous_call_succeeded = true;
+        for call in prepared_calls {
+            executed_tools.push(call.prepared.name.clone());
+            let (output, succeeded) = if call.prepared.dependency
+                == ToolCallDependency::PreviousCallSuccess
+                && !previous_call_succeeded
+            {
+                (tool_skip_output("dependency_previous_call_failed"), false)
+            } else {
+                match req.tools.execute_prepared(call.prepared).await {
+                    Ok(output) => (output, true),
+                    Err(err) => (tool_error_output(&err), false),
+                }
+            };
+            previous_call_succeeded = succeeded;
             input.push(json!({
                 "type": "function_call_output",
                 "call_id": call.call_id,
@@ -156,6 +155,64 @@ pub(crate) async fn openai_responses_tool_loop(
         "tool loop exceeded maximum rounds",
         "tool_loop",
     ))
+}
+
+fn prepare_function_calls(
+    req: &OpenAiToolLoopRequest<'_>,
+    calls: &[FunctionCall],
+    round: usize,
+) -> Result<Vec<PreparedFunctionCall>, LlmError> {
+    let mut prepared_calls = Vec::with_capacity(calls.len());
+    for (index, call) in calls.iter().enumerate() {
+        let mut context = req.tool_context.clone();
+        context.tool_call_id = Some(stable_tool_call_id(
+            &context.task_id,
+            &call.call_id,
+            round,
+            index,
+        ));
+        let prepared = req
+            .tools
+            .prepare_json(&context, &call.name, &call.arguments)?;
+        prepared_calls.push(PreparedFunctionCall {
+            call_id: call.call_id.clone(),
+            prepared,
+        });
+    }
+    Ok(prepared_calls)
+}
+
+fn stable_tool_call_id(task_id: &str, call_id: &str, round: usize, index: usize) -> String {
+    let call_id = call_id.trim();
+    if !call_id.is_empty() {
+        format!("{task_id}:{call_id}")
+    } else {
+        // 兼容上游未返回稳定 call_id 的场景，回退到 request + round + index。
+        format!("{task_id}:round-{round}:call-{index}")
+    }
+}
+
+fn tool_error_output(err: &LlmError) -> String {
+    serde_json::to_string(&json!({
+        "ok": false,
+        "error": {
+            "code": err.code,
+            "message": err.message,
+            "stage": err.stage,
+        }
+    }))
+    .unwrap_or_else(|_| r#"{"ok":false,"error":{"code":"tool_output_error","message":"failed to serialize tool error","stage":"tool_loop"}}"#.to_owned())
+}
+
+fn tool_skip_output(reason: &str) -> String {
+    serde_json::to_string(&json!({
+        "ok": false,
+        "skipped": true,
+        "reason": reason,
+    }))
+    .unwrap_or_else(|_| {
+        r#"{"ok":false,"skipped":true,"reason":"dependency_previous_call_failed"}"#.to_owned()
+    })
 }
 
 fn openai_tool_loop_input(messages: &[ChatMessage]) -> Result<Vec<Value>, LlmError> {
@@ -284,7 +341,10 @@ mod tests {
     use async_trait::async_trait;
     use axum::{Json, Router, extract::State, routing::post};
     use serde_json::json;
-    use std::sync::Arc;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
     use tokio::{net::TcpListener, sync::Mutex};
 
     struct WeatherToolStub;
@@ -323,6 +383,61 @@ mod tests {
             task_id: "task-1".to_owned(),
             user_id: Some("u1".to_owned()),
             scope_id: "private:u1".to_owned(),
+            tool_call_id: None,
+        }
+    }
+
+    struct SequenceToolStub {
+        fail: bool,
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Tool for SequenceToolStub {
+        fn metadata(&self) -> ToolMetadata {
+            ToolMetadata {
+                name: if self.fail {
+                    "fail_tool".to_owned()
+                } else {
+                    "ok_tool".to_owned()
+                },
+                description: "sequence test".to_owned(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "string"}
+                    },
+                    "required": ["value"],
+                    "additionalProperties": false
+                }),
+            }
+        }
+
+        fn prepare(
+            &self,
+            _context: &ToolContext,
+            arguments: Value,
+        ) -> Result<crate::tool::ToolPreparation, LlmError> {
+            let mut prepared = crate::tool::ToolPreparation::ready(arguments);
+            if !self.fail {
+                prepared = prepared.with_dependency(ToolCallDependency::PreviousCallSuccess);
+            }
+            Ok(prepared)
+        }
+
+        async fn execute(
+            &self,
+            _context: ToolContext,
+            arguments: Value,
+        ) -> Result<ToolOutput, LlmError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail {
+                return Err(LlmError::new("tool_failed", "simulated failure", "tool"));
+            }
+            Ok(ToolOutput::json(json!({
+                "ok": true,
+                "value": arguments["value"],
+            })))
         }
     }
 
@@ -356,12 +471,60 @@ mod tests {
         }))
     }
 
+    async fn mock_multi_tool_handler(
+        State(state): State<Arc<Mutex<ToolLoopMockState>>>,
+        Json(body): Json<Value>,
+    ) -> Json<Value> {
+        let mut state = state.lock().await;
+        state.requests.push(body);
+        if state.requests.len() == 1 {
+            return Json(json!({
+                "output": [
+                    {
+                        "type": "function_call",
+                        "name": "fail_tool",
+                        "call_id": "call_fail_1",
+                        "arguments": "{\"value\":\"first\"}"
+                    },
+                    {
+                        "type": "function_call",
+                        "name": "ok_tool",
+                        "call_id": "call_ok_1",
+                        "arguments": "{\"value\":\"second\"}"
+                    }
+                ]
+            }));
+        }
+        Json(json!({
+            "output_text": "已经汇总结果。",
+            "output": [{
+                "type": "message",
+                "content": [{"type": "output_text", "text": "已经汇总结果。"}]
+            }]
+        }))
+    }
+
     async fn spawn_tool_loop_mock() -> (String, Arc<Mutex<ToolLoopMockState>>) {
         let state = Arc::new(Mutex::new(ToolLoopMockState {
             requests: Vec::new(),
         }));
         let app = Router::new()
             .route("/v1/responses", post(mock_tool_loop_handler))
+            .with_state(state.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{addr}/v1"), state)
+    }
+
+    async fn spawn_multi_tool_mock() -> (String, Arc<Mutex<ToolLoopMockState>>) {
+        let state = Arc::new(Mutex::new(ToolLoopMockState {
+            requests: Vec::new(),
+        }));
+        let app = Router::new()
+            .route("/v1/responses", post(mock_multi_tool_handler))
             .with_state(state.clone());
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -441,6 +604,61 @@ mod tests {
                 && item["output"]
                     .as_str()
                     .is_some_and(|output| output.contains("\"weather\":\"小雨\""))
+        }));
+    }
+
+    #[tokio::test]
+    async fn tool_loop_serializes_multiple_calls_and_skips_dependent_call_after_failure() {
+        let (base_url, state) = spawn_multi_tool_mock().await;
+        let fail_calls = Arc::new(AtomicUsize::new(0));
+        let ok_calls = Arc::new(AtomicUsize::new(0));
+        let registry = ToolRegistry::new()
+            .register(SequenceToolStub {
+                fail: true,
+                calls: fail_calls.clone(),
+            })
+            .unwrap()
+            .register(SequenceToolStub {
+                fail: false,
+                calls: ok_calls.clone(),
+            })
+            .unwrap();
+        let client = reqwest::Client::new();
+
+        let outcome = openai_responses_tool_loop(OpenAiToolLoopRequest {
+            client: &client,
+            api_key: "test-key",
+            base_url: Some(&base_url),
+            provider: "openai",
+            model: "gpt-test",
+            max_output_tokens: 1200,
+            messages: &[ChatMessage::user("连续执行两个工具")],
+            tools: registry,
+            tool_context: test_context(),
+            max_rounds: 3,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.reply, "已经汇总结果。");
+        assert_eq!(fail_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(ok_calls.load(Ordering::SeqCst), 0);
+        let state = state.lock().await;
+        assert_eq!(state.requests.len(), 2);
+        let second_input = state.requests[1]["input"].as_array().unwrap();
+        assert!(second_input.iter().any(|item| {
+            item["type"] == "function_call_output"
+                && item["call_id"] == "call_fail_1"
+                && item["output"]
+                    .as_str()
+                    .is_some_and(|output| output.contains("\"tool_failed\""))
+        }));
+        assert!(second_input.iter().any(|item| {
+            item["type"] == "function_call_output"
+                && item["call_id"] == "call_ok_1"
+                && item["output"]
+                    .as_str()
+                    .is_some_and(|output| output.contains("\"skipped\":true"))
         }));
     }
 }

--- a/qq-maid-llm/src/provider/openai/tool_loop.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop.rs
@@ -138,7 +138,10 @@ pub(crate) async fn openai_responses_tool_loop(
                         (tool_skip_output("dependency_previous_call_failed"), false)
                     } else {
                         match req.tools.execute_prepared(prepared).await {
-                            Ok(output) => (output, true),
+                            Ok(output) => {
+                                let succeeded = tool_output_indicates_success(&output);
+                                (output, succeeded)
+                            }
                             Err(err) => (tool_error_output(&err), false),
                         }
                     }
@@ -216,6 +219,15 @@ fn tool_skip_output(reason: &str) -> String {
     .unwrap_or_else(|_| {
         r#"{"ok":false,"skipped":true,"reason":"dependency_previous_call_failed"}"#.to_owned()
     })
+}
+
+fn tool_output_indicates_success(output: &str) -> bool {
+    // 约定俗成的业务工具失败通常会返回 {"ok":false,...}，这里把它视为失败，
+    // 这样同轮里依赖前一项成功的调用不会在业务失败后继续误执行。
+    serde_json::from_str::<Value>(output)
+        .ok()
+        .and_then(|value| value.get("ok").and_then(Value::as_bool))
+        .unwrap_or(true)
 }
 
 fn openai_tool_loop_input(messages: &[ChatMessage]) -> Result<Vec<Value>, LlmError> {
@@ -484,6 +496,41 @@ mod tests {
         }
     }
 
+    struct SoftFailToolStub {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Tool for SoftFailToolStub {
+        fn metadata(&self) -> ToolMetadata {
+            ToolMetadata {
+                name: "soft_fail_tool".to_owned(),
+                description: "returns structured failure".to_owned(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "string"}
+                    },
+                    "required": ["value"],
+                    "additionalProperties": false
+                }),
+            }
+        }
+
+        async fn execute(
+            &self,
+            _context: ToolContext,
+            arguments: Value,
+        ) -> Result<ToolOutput, LlmError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(ToolOutput::json(json!({
+                "ok": false,
+                "error_code": "soft_failure",
+                "value": arguments["value"],
+            })))
+        }
+    }
+
     #[derive(Debug)]
     struct ToolLoopMockState {
         requests: Vec<Value>,
@@ -580,6 +627,39 @@ mod tests {
         }))
     }
 
+    async fn mock_soft_failure_handler(
+        State(state): State<Arc<Mutex<ToolLoopMockState>>>,
+        Json(body): Json<Value>,
+    ) -> Json<Value> {
+        let mut state = state.lock().await;
+        state.requests.push(body);
+        if state.requests.len() == 1 {
+            return Json(json!({
+                "output": [
+                    {
+                        "type": "function_call",
+                        "name": "soft_fail_tool",
+                        "call_id": "call_soft_fail_1",
+                        "arguments": "{\"value\":\"first\"}"
+                    },
+                    {
+                        "type": "function_call",
+                        "name": "ok_tool",
+                        "call_id": "call_ok_2",
+                        "arguments": "{\"value\":\"second\"}"
+                    }
+                ]
+            }));
+        }
+        Json(json!({
+            "output_text": "业务失败已汇总。",
+            "output": [{
+                "type": "message",
+                "content": [{"type": "output_text", "text": "业务失败已汇总。"}]
+            }]
+        }))
+    }
+
     async fn spawn_tool_loop_mock() -> (String, Arc<Mutex<ToolLoopMockState>>) {
         let state = Arc::new(Mutex::new(ToolLoopMockState {
             requests: Vec::new(),
@@ -616,6 +696,21 @@ mod tests {
         }));
         let app = Router::new()
             .route("/v1/responses", post(mock_prepare_failure_handler))
+            .with_state(state.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{addr}/v1"), state)
+    }
+
+    async fn spawn_soft_failure_mock() -> (String, Arc<Mutex<ToolLoopMockState>>) {
+        let state = Arc::new(Mutex::new(ToolLoopMockState {
+            requests: Vec::new(),
+        }));
+        let app = Router::new()
+            .route("/v1/responses", post(mock_soft_failure_handler))
             .with_state(state.clone());
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -795,6 +890,60 @@ mod tests {
                 && item["output"]
                     .as_str()
                     .is_some_and(|output| output.contains("\"weather\":\"小雨\""))
+        }));
+    }
+
+    #[tokio::test]
+    async fn tool_loop_skips_dependent_call_after_structured_tool_failure() {
+        let (base_url, state) = spawn_soft_failure_mock().await;
+        let soft_fail_calls = Arc::new(AtomicUsize::new(0));
+        let ok_calls = Arc::new(AtomicUsize::new(0));
+        let registry = ToolRegistry::new()
+            .register(SoftFailToolStub {
+                calls: soft_fail_calls.clone(),
+            })
+            .unwrap()
+            .register(SequenceToolStub {
+                fail: false,
+                calls: ok_calls.clone(),
+            })
+            .unwrap();
+        let client = reqwest::Client::new();
+
+        let outcome = openai_responses_tool_loop(OpenAiToolLoopRequest {
+            client: &client,
+            api_key: "test-key",
+            base_url: Some(&base_url),
+            provider: "openai",
+            model: "gpt-test",
+            max_output_tokens: 1200,
+            messages: &[ChatMessage::user("先返回业务失败，再尝试依赖调用")],
+            tools: registry,
+            tool_context: test_context(),
+            max_rounds: 3,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.reply, "业务失败已汇总。");
+        assert_eq!(soft_fail_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(ok_calls.load(Ordering::SeqCst), 0);
+        let state = state.lock().await;
+        assert_eq!(state.requests.len(), 2);
+        let second_input = state.requests[1]["input"].as_array().unwrap();
+        assert!(second_input.iter().any(|item| {
+            item["type"] == "function_call_output"
+                && item["call_id"] == "call_soft_fail_1"
+                && item["output"]
+                    .as_str()
+                    .is_some_and(|output| output.contains("\"soft_failure\""))
+        }));
+        assert!(second_input.iter().any(|item| {
+            item["type"] == "function_call_output"
+                && item["call_id"] == "call_ok_2"
+                && item["output"]
+                    .as_str()
+                    .is_some_and(|output| output.contains("\"skipped\":true"))
         }));
     }
 }

--- a/qq-maid-llm/src/provider/openai/tool_loop.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop.rs
@@ -45,7 +45,7 @@ struct FunctionCall {
 
 struct PreparedFunctionCall {
     call_id: String,
-    prepared: PreparedToolCall,
+    prepared: Result<PreparedToolCall, LlmError>,
 }
 
 pub(crate) async fn openai_responses_tool_loop(
@@ -129,17 +129,21 @@ pub(crate) async fn openai_responses_tool_loop(
         let prepared_calls = prepare_function_calls(&req, &calls, round)?;
         let mut previous_call_succeeded = true;
         for call in prepared_calls {
-            executed_tools.push(call.prepared.name.clone());
-            let (output, succeeded) = if call.prepared.dependency
-                == ToolCallDependency::PreviousCallSuccess
-                && !previous_call_succeeded
-            {
-                (tool_skip_output("dependency_previous_call_failed"), false)
-            } else {
-                match req.tools.execute_prepared(call.prepared).await {
-                    Ok(output) => (output, true),
-                    Err(err) => (tool_error_output(&err), false),
+            let (output, succeeded) = match call.prepared {
+                Ok(prepared) => {
+                    executed_tools.push(prepared.name.clone());
+                    if prepared.dependency == ToolCallDependency::PreviousCallSuccess
+                        && !previous_call_succeeded
+                    {
+                        (tool_skip_output("dependency_previous_call_failed"), false)
+                    } else {
+                        match req.tools.execute_prepared(prepared).await {
+                            Ok(output) => (output, true),
+                            Err(err) => (tool_error_output(&err), false),
+                        }
+                    }
                 }
+                Err(err) => (tool_error_output(&err), false),
             };
             previous_call_succeeded = succeeded;
             input.push(json!({
@@ -171,12 +175,11 @@ fn prepare_function_calls(
             round,
             index,
         ));
-        let prepared = req
-            .tools
-            .prepare_json(&context, &call.name, &call.arguments)?;
         prepared_calls.push(PreparedFunctionCall {
             call_id: call.call_id.clone(),
-            prepared,
+            prepared: req
+                .tools
+                .prepare_json(&context, &call.name, &call.arguments),
         });
     }
     Ok(prepared_calls)
@@ -441,6 +444,46 @@ mod tests {
         }
     }
 
+    struct PrepareFailToolStub;
+
+    #[async_trait]
+    impl Tool for PrepareFailToolStub {
+        fn metadata(&self) -> ToolMetadata {
+            ToolMetadata {
+                name: "prepare_fail_tool".to_owned(),
+                description: "prepare failure test".to_owned(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "string"}
+                    },
+                    "required": ["value"],
+                    "additionalProperties": false
+                }),
+            }
+        }
+
+        fn prepare(
+            &self,
+            _context: &ToolContext,
+            _arguments: Value,
+        ) -> Result<crate::tool::ToolPreparation, LlmError> {
+            Err(LlmError::new(
+                "bad_tool_arguments",
+                "prepare failed",
+                "tool",
+            ))
+        }
+
+        async fn execute(
+            &self,
+            _context: ToolContext,
+            _arguments: Value,
+        ) -> Result<ToolOutput, LlmError> {
+            panic!("prepare failure tool should never execute");
+        }
+    }
+
     #[derive(Debug)]
     struct ToolLoopMockState {
         requests: Vec<Value>,
@@ -504,6 +547,39 @@ mod tests {
         }))
     }
 
+    async fn mock_prepare_failure_handler(
+        State(state): State<Arc<Mutex<ToolLoopMockState>>>,
+        Json(body): Json<Value>,
+    ) -> Json<Value> {
+        let mut state = state.lock().await;
+        state.requests.push(body);
+        if state.requests.len() == 1 {
+            return Json(json!({
+                "output": [
+                    {
+                        "type": "function_call",
+                        "name": "prepare_fail_tool",
+                        "call_id": "call_prepare_fail_1",
+                        "arguments": "{\"value\":\"bad\"}"
+                    },
+                    {
+                        "type": "function_call",
+                        "name": "get_weather",
+                        "call_id": "call_weather_2",
+                        "arguments": "{\"city\":\"杭州\"}"
+                    }
+                ]
+            }));
+        }
+        Json(json!({
+            "output_text": "准备失败已汇总。",
+            "output": [{
+                "type": "message",
+                "content": [{"type": "output_text", "text": "准备失败已汇总。"}]
+            }]
+        }))
+    }
+
     async fn spawn_tool_loop_mock() -> (String, Arc<Mutex<ToolLoopMockState>>) {
         let state = Arc::new(Mutex::new(ToolLoopMockState {
             requests: Vec::new(),
@@ -525,6 +601,21 @@ mod tests {
         }));
         let app = Router::new()
             .route("/v1/responses", post(mock_multi_tool_handler))
+            .with_state(state.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{addr}/v1"), state)
+    }
+
+    async fn spawn_prepare_failure_mock() -> (String, Arc<Mutex<ToolLoopMockState>>) {
+        let state = Arc::new(Mutex::new(ToolLoopMockState {
+            requests: Vec::new(),
+        }));
+        let app = Router::new()
+            .route("/v1/responses", post(mock_prepare_failure_handler))
             .with_state(state.clone());
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -659,6 +750,51 @@ mod tests {
                 && item["output"]
                     .as_str()
                     .is_some_and(|output| output.contains("\"skipped\":true"))
+        }));
+    }
+
+    #[tokio::test]
+    async fn tool_loop_keeps_independent_calls_after_prepare_failure() {
+        let (base_url, state) = spawn_prepare_failure_mock().await;
+        let registry = ToolRegistry::new()
+            .register(PrepareFailToolStub)
+            .unwrap()
+            .register(WeatherToolStub)
+            .unwrap();
+        let client = reqwest::Client::new();
+
+        let outcome = openai_responses_tool_loop(OpenAiToolLoopRequest {
+            client: &client,
+            api_key: "test-key",
+            base_url: Some(&base_url),
+            provider: "openai",
+            model: "gpt-test",
+            max_output_tokens: 1200,
+            messages: &[ChatMessage::user("先失败再查天气")],
+            tools: registry,
+            tool_context: test_context(),
+            max_rounds: 3,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.reply, "准备失败已汇总。");
+        let state = state.lock().await;
+        assert_eq!(state.requests.len(), 2);
+        let second_input = state.requests[1]["input"].as_array().unwrap();
+        assert!(second_input.iter().any(|item| {
+            item["type"] == "function_call_output"
+                && item["call_id"] == "call_prepare_fail_1"
+                && item["output"]
+                    .as_str()
+                    .is_some_and(|output| output.contains("\"prepare failed\""))
+        }));
+        assert!(second_input.iter().any(|item| {
+            item["type"] == "function_call_output"
+                && item["call_id"] == "call_weather_2"
+                && item["output"]
+                    .as_str()
+                    .is_some_and(|output| output.contains("\"weather\":\"小雨\""))
         }));
     }
 }

--- a/qq-maid-llm/src/tool.rs
+++ b/qq-maid-llm/src/tool.rs
@@ -39,6 +39,8 @@ pub struct ToolContext {
     pub user_id: Option<String>,
     /// 当前请求的会话/业务作用域 ID。
     pub scope_id: String,
+    /// 当前工具调用的稳定标识；由上游 Tool Loop 生成，用于幂等去重与审计关联。
+    pub tool_call_id: Option<String>,
 }
 
 /// Tool 执行输出。
@@ -54,11 +56,54 @@ impl ToolOutput {
     }
 }
 
+/// 预处理后的工具调用依赖关系。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolCallDependency {
+    /// 与同轮其他工具调用无显式依赖，可直接串行执行。
+    None,
+    /// 依赖前一个工具调用成功；若前一项失败，本项应跳过。
+    PreviousCallSuccess,
+}
+
+/// Tool 在真正执行前返回的预处理结果。
+#[derive(Debug, Clone, PartialEq)]
+pub struct ToolPreparation {
+    /// 预处理后的参数。可用于把用户侧编号绑定成稳定内部 ID。
+    pub arguments: Value,
+    /// 与同轮其他工具调用的依赖信息。
+    pub dependency: ToolCallDependency,
+}
+
+impl ToolPreparation {
+    pub fn ready(arguments: Value) -> Self {
+        Self {
+            arguments,
+            dependency: ToolCallDependency::None,
+        }
+    }
+
+    pub fn with_dependency(mut self, dependency: ToolCallDependency) -> Self {
+        self.dependency = dependency;
+        self
+    }
+}
+
 /// 可执行 Tool。
 #[async_trait]
 pub trait Tool: Send + Sync {
     /// 返回工具元数据。
     fn metadata(&self) -> ToolMetadata;
+    /// 执行前的本地预处理。
+    ///
+    /// 默认直接沿用模型参数；有状态工具可在这里把用户可见编号预绑定成稳定内部 ID，
+    /// 避免同轮前序写操作改变后续编号语义。
+    fn prepare(
+        &self,
+        _context: &ToolContext,
+        arguments: Value,
+    ) -> Result<ToolPreparation, LlmError> {
+        Ok(ToolPreparation::ready(arguments))
+    }
     /// 执行工具。上下文来自服务端，参数已经由 Tool Loop 按 JSON 解析完成。
     async fn execute(&self, context: ToolContext, arguments: Value)
     -> Result<ToolOutput, LlmError>;
@@ -66,6 +111,20 @@ pub trait Tool: Send + Sync {
 
 /// 动态 Tool 指针。
 pub type DynTool = Arc<dyn Tool>;
+
+/// 已完成参数校验/预处理的工具调用。
+#[derive(Clone)]
+pub struct PreparedToolCall {
+    tool: DynTool,
+    /// 工具名，仅用于日志、测试和结果聚合。
+    pub name: String,
+    /// 当前调用上下文。
+    pub context: ToolContext,
+    /// 预处理后的参数。
+    pub arguments: Value,
+    /// 与同轮前一项调用的依赖关系。
+    pub dependency: ToolCallDependency,
+}
 
 /// Tool 注册表，只允许模型调用显式注册的工具。
 #[derive(Clone)]
@@ -138,6 +197,16 @@ impl ToolRegistry {
         name: &str,
         arguments: &str,
     ) -> Result<String, LlmError> {
+        let prepared = self.prepare_json(context, name, arguments)?;
+        self.execute_prepared(prepared).await
+    }
+
+    pub fn prepare_json(
+        &self,
+        context: &ToolContext,
+        name: &str,
+        arguments: &str,
+    ) -> Result<PreparedToolCall, LlmError> {
         let Some(tool) = self.tools.get(name).cloned() else {
             return Err(LlmError::new(
                 "tool_not_found",
@@ -152,13 +221,29 @@ impl ToolRegistry {
                 "tool",
             )
         })?;
-        let output = timeout(self.timeout, tool.execute(context.clone(), arguments))
-            .await
-            .map_err(|_| LlmError::new("timeout", "tool execution timed out", "tool"))??;
+        let preparation = tool.prepare(context, arguments)?;
+        Ok(PreparedToolCall {
+            tool,
+            name: name.to_owned(),
+            context: context.clone(),
+            arguments: preparation.arguments,
+            dependency: preparation.dependency,
+        })
+    }
+
+    pub async fn execute_prepared(&self, prepared: PreparedToolCall) -> Result<String, LlmError> {
+        let output = timeout(
+            self.timeout,
+            prepared
+                .tool
+                .execute(prepared.context.clone(), prepared.arguments),
+        )
+        .await
+        .map_err(|_| LlmError::new("timeout", "tool execution timed out", "tool"))??;
         let serialized = serde_json::to_string(&output.value).map_err(|err| {
             LlmError::new(
                 "tool_output_error",
-                format!("failed to serialize tool `{name}` output: {err}"),
+                format!("failed to serialize tool `{}` output: {err}", prepared.name),
                 "tool",
             )
         })?;
@@ -271,6 +356,7 @@ mod tests {
             task_id: "task-1".to_owned(),
             user_id: Some("u1".to_owned()),
             scope_id: "private:u1".to_owned(),
+            tool_call_id: None,
         }
     }
 


### PR DESCRIPTION
## 背景

Issue #97：模型在同轮返回多个 function_call 时，原有实现直接拒绝并返回 "parallel tool calls are not supported"。

## 核心改动

### 1. Tool 抽象层 (`qq-maid-llm/src/tool.rs`)
- 新增 `ToolPreparation` / `PreparedToolCall` / `ToolCallDependency` 类型
- `Tool` trait 新增 `prepare()` 方法，用于执行前的本地预处理
- `ToolContext` 新增 `tool_call_id` 字段，用于幂等去重与审计关联

### 2. Tool Loop (`qq-maid-llm/src/provider/openai/tool_loop.rs`)
- 同一轮多个 `function_call` 先统一 `prepare`，再按模型返回顺序串行执行
- 不再返回 "parallel tool calls are not supported"
- 单项失败转成结构化 `function_call_output` 回给模型
- `reference=last` 依赖前项成功的调用，在前项失败时跳过

### 3. Todo Tool (`qq-maid-core/src/runtime/tools/todo.rs`)
- 新增原生 `edit_todo` Tool，复用现有 `TodoStore`/`SessionStore`/`PendingOperation`
- `complete`/`cancel`/`restore`/`delete`/`edit` 编号选择改为 `prepare()` 阶段预绑定内部 ID
- 避免"先完成第一条再修改第二条"时编号漂移
- 基于 `task_id + tool_call_id` 的最小去重，防止同一写工具重放

## 已验证

```bash
cargo fmt --all -- --check   ✓
cargo check -p qq-maid-llm -p qq-maid-core   ✓
cargo test -p qq-maid-llm tool_loop -- --nocapture   ✓
cargo test -p qq-maid-core runtime::tools::todo::tests -- --nocapture   ✓
cargo test -p qq-maid-core mutation_with_todo_noun_recognized_without_session_state   ✓
```

## 待补跑

- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo build --workspace --release --all-features`