### PR TITLE
[codex] 修复待办查询同义词路由漂移

### DIFF
--- a/qq-maid-core/src/runtime/command/mod.rs
+++ b/qq-maid-core/src/runtime/command/mod.rs
@@ -50,7 +50,7 @@ fn normalize_command(command: &str) -> Option<String> {
         "compact" | "压缩" | "整理" => "compact",
         "help" | "帮助" => "help",
         "memory" | "记忆" | "记" | "zy" => "memory",
-        "todo" | "待办" | "任务" => "todo",
+        "todo" | "待办" | "代办" | "任务" => "todo",
         "rss" | "订阅" => "rss",
         "查" | "查询" | "search" => "web_search",
         "train" | "火车" => "train",

--- a/qq-maid-core/src/runtime/respond.rs
+++ b/qq-maid-core/src/runtime/respond.rs
@@ -385,6 +385,7 @@ impl RustRespondService {
             || search_flow::parse_web_search_command(&user_text).is_some()
             || rss_flow::parse_rss_command(&user_text).is_some()
             || todo_flow::parse_todo_command(&user_text).is_some()
+            || todo_flow::is_natural_todo_query_text(&user_text)
             || memory_flow::parse_memory_command(&user_text).is_some();
 
         Ok(CoreInboundClassification {

--- a/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
@@ -8,7 +8,7 @@ use std::sync::OnceLock;
 use regex::Regex;
 
 use super::contains_any;
-use crate::runtime::session::SessionRecord;
+use crate::runtime::{respond::todo_flow::is_natural_todo_query_text, session::SessionRecord};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum TodoMutationToolKind {
@@ -213,20 +213,7 @@ fn strip_todo_reference_and_status(text: &str) -> String {
 }
 
 fn looks_like_todo_query_text(text: &str) -> bool {
-    let compact = text.trim();
-    let mentions_todo = contains_any(compact, &["待办", "任务"]);
-    let asks_list = contains_any(
-        compact,
-        &["看看", "看下", "看一下", "列出", "有哪些", "查看"],
-    );
-    mentions_todo
-        && (asks_list
-            || compact == "我的待办"
-            || compact == "待办列表"
-            || compact == "已完成的待办"
-            || compact == "已取消的待办"
-            || compact == "看看已完成"
-            || compact == "看看已取消")
+    is_natural_todo_query_text(text)
 }
 
 pub(super) fn todo_required_tool_not_called_reply(

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -676,6 +676,103 @@ async fn natural_language_todo_query_prefers_listing_over_todo_parse_creation_ch
 }
 
 #[tokio::test]
+async fn natural_language_todo_query_aliases_and_filters_stay_deterministic() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let pending = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "未完成条目".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    let completed = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "已完成条目".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    service.todo_store.complete(&owner, &completed.id).unwrap();
+    let cancelled = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "已取消条目".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    service.todo_store.cancel(&owner, &cancelled.id).unwrap();
+
+    for input in ["看一下待办", "看一下代办", "查询待办", "查询代办"] {
+        let response = service.respond(private_message(input)).await.unwrap();
+        let text = response.text.unwrap();
+        assert_eq!(response.command.as_deref(), Some("todo_list"), "{input}");
+        assert!(text.contains("未完成条目"), "{input}");
+        assert!(!text.contains("已完成条目"), "{input}");
+        assert!(!text.contains("已取消条目"), "{input}");
+    }
+
+    let all = service
+        .respond(private_message("查看所有待办"))
+        .await
+        .unwrap();
+    let all_text = all.text.unwrap();
+    assert_eq!(all.command.as_deref(), Some("todo_all"));
+    assert!(all_text.contains("未完成条目"));
+    assert!(all_text.contains("已完成条目"));
+    assert!(all_text.contains("已取消条目"));
+
+    let completed_only = service
+        .respond(private_message("查看已完成待办"))
+        .await
+        .unwrap();
+    let completed_text = completed_only.text.unwrap();
+    assert_eq!(completed_only.command.as_deref(), Some("todo_done"));
+    assert!(!completed_text.contains("未完成条目"));
+    assert!(completed_text.contains("已完成条目"));
+    assert!(!completed_text.contains("已取消条目"));
+
+    let cancelled_only = service
+        .respond(private_message("查看已取消待办"))
+        .await
+        .unwrap();
+    let cancelled_text = cancelled_only.text.unwrap();
+    assert_eq!(
+        cancelled_only.command.as_deref(),
+        Some("todo_cancelled_list")
+    );
+    assert!(!cancelled_text.contains("未完成条目"));
+    assert!(!cancelled_text.contains("已完成条目"));
+    assert!(cancelled_text.contains("已取消条目"));
+
+    assert_eq!(pending.status, TodoStatus::Pending);
+    assert!(inspector.requests().is_empty());
+    assert_eq!(inspector.tool_call_count(), 0);
+}
+
+#[tokio::test]
 async fn natural_language_cancelled_todo_query_lists_cancelled_items() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);

--- a/qq-maid-core/src/runtime/respond/tests/pending.rs
+++ b/qq-maid-core/src/runtime/respond/tests/pending.rs
@@ -28,7 +28,32 @@ async fn inbound_classification_marks_pending_input_immediate() {
 fn inbound_classification_marks_business_commands_immediate() {
     let service = test_service();
 
-    for input in ["/todo", "/memory", "/查 Rust", "/天气杭州", "/翻译 hello"] {
+    for input in [
+        "/todo",
+        "/代办",
+        "/memory",
+        "/查 Rust",
+        "/天气杭州",
+        "/翻译 hello",
+    ] {
+        let classification = service.classify_inbound(message(input)).unwrap();
+        assert_eq!(classification.kind, CoreInboundKind::Immediate, "{input}");
+    }
+}
+
+#[test]
+fn inbound_classification_marks_natural_todo_queries_immediate() {
+    let service = test_service();
+
+    for input in [
+        "看一下待办",
+        "看一下代办",
+        "查询待办",
+        "查询代办",
+        "查看所有待办",
+        "查看已完成待办",
+        "查看已取消待办",
+    ] {
         let classification = service.classify_inbound(message(input)).unwrap();
         assert_eq!(classification.kind, CoreInboundKind::Immediate, "{input}");
     }

--- a/qq-maid-core/src/runtime/respond/tests/todo.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo.rs
@@ -14,7 +14,7 @@ use crate::runtime::{
 async fn todo_root_aliases_list_pending_items() {
     let service = test_service();
 
-    for command in ["/todo", "/待办", "/任务"] {
+    for command in ["/todo", "/待办", "/代办", "/任务"] {
         let response = service.respond(message(command)).await.unwrap();
         assert_eq!(response.command.as_deref(), Some("todo_list"));
         let text = response.text.unwrap();

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -49,6 +49,22 @@ use target::{
     valid_last_visible_todo_query,
 };
 
+const TODO_QUERY_NOUNS: &[&str] = &["待办", "代办", "任务"];
+const TODO_QUERY_LIST_VERBS: &[&str] = &[
+    "看一下",
+    "看下",
+    "看看",
+    "查询",
+    "查看",
+    "列出",
+    "有哪些",
+    "我的",
+];
+const TODO_QUERY_ALL_MARKERS: &[&str] = &["全部", "所有", "包含已完成", "包含已取消"];
+const TODO_QUERY_PENDING_EXACT: &[&str] = &["我的待办", "待办列表"];
+const TODO_QUERY_COMPLETED_EXACT: &[&str] = &["已完成的待办"];
+const TODO_QUERY_CANCELLED_EXACT: &[&str] = &["已取消的待办"];
+
 impl RustRespondService {
     /// 处理待办指令的主入口。解析 `/todo` 子命令并分派到对应的处理逻辑。
     pub(super) async fn handle_todo_flow(
@@ -401,6 +417,11 @@ impl RustRespondService {
                 let items = self.todo_store.list_pending(owner).map_err(todo_error)?;
                 remember_todo_query(session, owner, "list", "", &items);
                 (format_todo_list_reply(&items), "todo_list".to_owned())
+            }
+            NaturalTodoQueryKind::All => {
+                let items = self.todo_store.list_all(owner).map_err(todo_error)?;
+                remember_todo_query(session, owner, "all", "全部待办", &items);
+                (format_todo_all_reply(&items), "todo_all".to_owned())
             }
             NaturalTodoQueryKind::Completed => {
                 let items = self.todo_store.list_completed(owner).map_err(todo_error)?;
@@ -912,21 +933,41 @@ impl RustRespondService {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum NaturalTodoQueryKind {
     Pending,
+    All,
     Completed,
     Cancelled,
 }
 
 fn detect_natural_todo_query_kind(user_text: &str) -> Option<NaturalTodoQueryKind> {
-    let text = user_text.trim();
+    let text = normalize_natural_todo_text(user_text);
     if text.is_empty() {
         return None;
     }
-    let mentions_todo = text.contains("待办") || text.contains("任务");
-    let asks_list = ["看看", "看下", "看一下", "查看", "列出", "有哪些", "我的"]
+    // slash `/todo ...` 继续走显式命令解析，避免自然语言词表误抢 `/任务 搜 查询` 之类分支。
+    if text.starts_with('/') {
+        return None;
+    }
+    if TODO_QUERY_PENDING_EXACT.contains(&text.as_str()) {
+        return Some(NaturalTodoQueryKind::Pending);
+    }
+    if TODO_QUERY_COMPLETED_EXACT.contains(&text.as_str()) {
+        return Some(NaturalTodoQueryKind::Completed);
+    }
+    if TODO_QUERY_CANCELLED_EXACT.contains(&text.as_str()) {
+        return Some(NaturalTodoQueryKind::Cancelled);
+    }
+    let mentions_todo = TODO_QUERY_NOUNS.iter().any(|needle| text.contains(needle));
+    let asks_list = TODO_QUERY_LIST_VERBS
         .iter()
         .any(|needle| text.contains(needle));
     if !mentions_todo || !asks_list {
         return None;
+    }
+    if TODO_QUERY_ALL_MARKERS
+        .iter()
+        .any(|needle| text.contains(needle))
+    {
+        return Some(NaturalTodoQueryKind::All);
     }
     if text.contains("已取消") {
         return Some(NaturalTodoQueryKind::Cancelled);
@@ -935,6 +976,18 @@ fn detect_natural_todo_query_kind(user_text: &str) -> Option<NaturalTodoQueryKin
         return Some(NaturalTodoQueryKind::Completed);
     }
     Some(NaturalTodoQueryKind::Pending)
+}
+
+/// 自然语言待办查询入口统一做别字归一化，避免“代办/待办”落到不同链路。
+pub(super) fn normalize_natural_todo_text(text: &str) -> String {
+    text.trim().replace("代办", "待办")
+}
+
+/// 判断一段自然语言是否应走确定性的待办查询分支。
+///
+/// 这里与 Tool Loop 守卫、入站分类共享同一套词表，避免简单查询重新漂回 LLM 自由决策。
+pub(super) fn is_natural_todo_query_text(text: &str) -> bool {
+    detect_natural_todo_query_kind(text).is_some()
 }
 
 fn todo_delete_source_condition(target: &TodoTarget) -> String {


### PR DESCRIPTION
## 变更说明

修复待办自然语言查询的同义词路由漂移，统一 `待办` / `代办` 以及 `看一下` / `查询` / `查看` / `列出` 等表达在 Todo 查询链路中的确定性分流。

## 原因

当前链路里：

- `看一下待办` 会命中确定性 `todo_list`，默认只查未完成；
- `看一下代办` 没命中命令，落入 LLM Tool Calling，模型把查询解释成了全部状态。

问题不在 Todo 存储，而在同义词路由没有统一，导致简单查询被交给模型自由决定过滤条件。

## 实现

- 将自然语言查询中的 `代办` 统一归一化为 `待办`
- 将 `看一下 / 查询 / 查看 / 列出 / 我的` + `待办 / 代办 / 任务` 统一命中确定性 Todo 列表路由
- 默认固定只返回未完成待办
- 只有用户明确表达 `查看所有待办`、`查看已完成待办`、`查看已取消待办` 时，才切换状态过滤
- 让入站分类和 Todo Tool Loop 守卫复用同一套查询识别 helper，避免不同链路再次漂移
- 补充 `/代办` slash alias，保证 slash 与自然语言入口一致

## 影响

- `看一下待办`
- `看一下代办`
- `查询待办`
- `查询代办`

以上输入都会稳定返回未完成待办，不再交给 LLM 自由决定过滤条件。

- `查看所有待办` 返回全部状态
- `查看已完成待办` 仅返回已完成
- `查看已取消待办` 仅返回已取消

## 验证

已执行：

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test -p qq-maid-core runtime::respond::tests::chat`
- `cargo test -p qq-maid-core runtime::respond::tests::todo`
- `cargo test -p qq-maid-core runtime::respond::tests::pending`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
