### PR TITLE
[codex] 恢复普通聊天流式路由

### DIFF
--- a/qq-maid-core/src/runtime/respond.rs
+++ b/qq-maid-core/src/runtime/respond.rs
@@ -15,7 +15,7 @@ use crate::{
         prompt::PromptConfig,
         query::DynQueryExecutor,
         rss::{RssFetcher, RssStore},
-        session::{SessionMeta, SessionStore},
+        session::{SessionMeta, SessionRecord, SessionStore},
         todo::TodoStore,
         tools::{
             CancelTodoTool, CompleteTodoTool, CreateTodoTool, DeleteTodoTool, EditTodoTool,
@@ -47,11 +47,13 @@ mod session_flow;
 mod tests;
 mod title;
 mod todo_flow;
+mod tool_route;
 mod train_flow;
 mod translation_flow;
 mod weather_flow;
 
 use common::{clean_string, session_error};
+use tool_route::{ToolLoopRoute, ToolRouteContext};
 
 /// `RustRespondService` 需要的持久化存储集合。
 ///
@@ -103,6 +105,19 @@ pub struct RespondServiceOptions {
     pub tool_calling_enabled: bool,
     /// 单次 Tool Loop 最大工具调用轮数。
     pub tool_calling_max_rounds: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RespondPlan {
+    Immediate,
+    StreamingChat,
+    CompleteToolLoop,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChatToolPlan {
+    Plain,
+    ForceCompleteToolLoop,
 }
 
 /// Rust 原生实现的响应服务。
@@ -234,6 +249,65 @@ impl RustRespondService {
         }
     }
 
+    /// 为响应入口计算本轮响应计划。
+    ///
+    /// 这里是普通聊天是否走流式、是否因当前已接入的 Weather/Todo Tool
+    /// 进入 Complete Tool Loop 的唯一决策点。pending 和确定性命令仍优先
+    /// 走 `Immediate`，避免完整业务流程误入 stream。
+    pub(crate) fn plan_core_respond(&self, req: &RespondRequest) -> Result<RespondPlan, LlmError> {
+        let user_text = req.effective_user_text();
+        let trimmed = user_text.trim();
+        if trimmed.is_empty() {
+            return Ok(RespondPlan::Immediate);
+        }
+
+        let meta = respond_meta(req);
+        let active_session = self
+            .session_store
+            .get_active(&meta)
+            .map_err(session_error)?;
+        if pending_blocks_immediate(&user_text, active_session.as_ref()) {
+            return Ok(RespondPlan::Immediate);
+        }
+
+        if search_flow::parse_web_search_command(&user_text).is_some() {
+            return Ok(RespondPlan::StreamingChat);
+        }
+        if trimmed.starts_with('/') || trimmed.starts_with('／') {
+            return Ok(RespondPlan::Immediate);
+        }
+
+        let tool_route = self.route_tool_loop(req, active_session.as_ref());
+        if matches!(tool_route, ToolLoopRoute::CompleteToolLoop) {
+            return Ok(RespondPlan::CompleteToolLoop);
+        }
+
+        let classification = classify_inbound_with_active(&user_text, active_session.as_ref());
+        if matches!(classification.kind, CoreInboundKind::Immediate) {
+            Ok(RespondPlan::Immediate)
+        } else {
+            Ok(RespondPlan::StreamingChat)
+        }
+    }
+
+    fn route_tool_loop(
+        &self,
+        req: &RespondRequest,
+        active_session: Option<&SessionRecord>,
+    ) -> ToolLoopRoute {
+        tool_route::route_tool_loop(
+            req,
+            ToolRouteContext {
+                tool_calling_enabled: self.tool_calling_enabled,
+                provider_supports_tool_calling: self
+                    .provider
+                    .tool_calling_protocol(req.model.as_deref())
+                    .is_some(),
+                active_session,
+            },
+        )
+    }
+
     /// 统一的请求响应入口。
     ///
     /// 分派顺序：
@@ -247,15 +321,17 @@ impl RustRespondService {
     /// 8. 检查是否为**长期记忆操作**。
     /// 9. 兜底：进入**普通聊天**处理流程。
     pub async fn respond(&self, req: RespondRequest) -> Result<RespondResponse, LlmError> {
+        let plan = self.plan_core_respond(&req)?;
+        self.respond_with_plan(req, plan).await
+    }
+
+    pub(crate) async fn respond_with_plan(
+        &self,
+        req: RespondRequest,
+        plan: RespondPlan,
+    ) -> Result<RespondResponse, LlmError> {
         let user_text = req.effective_user_text();
-        let meta = SessionMeta::new(
-            req.scope_key.clone(),
-            req.user_id.clone(),
-            req.group_id.clone(),
-            req.guild_id.clone(),
-            req.channel_id.clone(),
-            clean_string(req.platform.clone()).unwrap_or_else(|| "qq".to_owned()),
-        );
+        let meta = respond_meta(&req);
 
         // 尝试获取当前会话的活跃记录
         let mut active_session = self
@@ -288,6 +364,7 @@ impl RustRespondService {
                 .get_or_create_active(&meta)
                 .map_err(session_error)?,
         };
+        let force_tool_loop = matches!(plan, RespondPlan::CompleteToolLoop);
 
         // 检查是否为翻译指令（如 "/翻译 文本"、"/翻译日语 文本"）
         if let Some(command) = translation_flow::parse_translation_command(&user_text) {
@@ -323,24 +400,34 @@ impl RustRespondService {
             return Ok(response);
         }
 
-        // 检查是否为待办相关操作（新增、查看、完成、编辑、删除等）
-        if let Some(response) = self
-            .handle_todo_flow(&user_text, &meta, &mut session)
-            .await?
-        {
-            return Ok(response);
+        // Core 计划已判定为 CompleteToolLoop 时，Todo 查询/续指等自然语言工具意图
+        // 交给 Tool Loop 处理；slash 命令和 pending 已在前面保持完整响应路径。
+        if !force_tool_loop {
+            // 检查是否为待办相关操作（新增、查看、完成、编辑、删除等）
+            if let Some(response) = self
+                .handle_todo_flow(&user_text, &meta, &mut session)
+                .await?
+            {
+                return Ok(response);
+            }
         }
 
         // 检查是否为长期记忆相关操作（记忆新增、查看、更新、删除等）
-        if let Some(response) = self
-            .handle_memory_flow(&user_text, &meta, &mut session)
-            .await?
+        if !force_tool_loop
+            && let Some(response) = self
+                .handle_memory_flow(&user_text, &meta, &mut session)
+                .await?
         {
             return Ok(response);
         }
 
         // 兜底：进入普通 LLM 聊天流程
-        self.handle_chat(req, user_text, meta, session).await
+        let chat_plan = match plan {
+            RespondPlan::CompleteToolLoop => ChatToolPlan::ForceCompleteToolLoop,
+            RespondPlan::Immediate | RespondPlan::StreamingChat => ChatToolPlan::Plain,
+        };
+        self.handle_chat(req, user_text, meta, session, chat_plan)
+            .await
     }
 
     /// 轻量判断物理入站消息是否可以进入短窗口聚合。
@@ -352,49 +439,22 @@ impl RustRespondService {
         req: RespondRequest,
     ) -> Result<CoreInboundClassification, LlmError> {
         let user_text = req.effective_user_text();
-        let meta = SessionMeta::new(
-            req.scope_key.clone(),
-            req.user_id.clone(),
-            req.group_id.clone(),
-            req.guild_id.clone(),
-            req.channel_id.clone(),
-            clean_string(req.platform.clone()).unwrap_or_else(|| "qq".to_owned()),
-        );
+        let meta = respond_meta(&req);
         let active_session = self
             .session_store
             .get_active(&meta)
             .map_err(session_error)?;
 
-        let bypass_pending_for_session_command =
-            session_flow::parse_pending_bypass_session_command(&user_text).is_some();
-        if !bypass_pending_for_session_command
-            && active_session
-                .as_ref()
-                .and_then(|session| session.pending_operation.as_ref())
-                .is_some()
-        {
+        if pending_blocks_immediate(&user_text, active_session.as_ref()) {
             return Ok(CoreInboundClassification {
                 kind: CoreInboundKind::Immediate,
             });
         }
 
-        let is_command = session_flow::parse_session_command(&user_text).is_some()
-            || translation_flow::parse_translation_command(&user_text).is_some()
-            || weather_flow::parse_weather_command(&user_text).is_some()
-            || train_flow::parse_train_command(&user_text).is_some()
-            || search_flow::parse_web_search_command(&user_text).is_some()
-            || rss_flow::parse_rss_command(&user_text).is_some()
-            || todo_flow::parse_todo_command(&user_text).is_some()
-            || todo_flow::is_natural_todo_query_text(&user_text)
-            || memory_flow::parse_memory_command(&user_text).is_some();
-
-        Ok(CoreInboundClassification {
-            kind: if is_command {
-                CoreInboundKind::Immediate
-            } else {
-                CoreInboundKind::NormalChat
-            },
-        })
+        Ok(classify_inbound_with_active(
+            &user_text,
+            active_session.as_ref(),
+        ))
     }
 
     /// 仅供 Core 进程内 stream 边界使用的真流式入口。
@@ -409,14 +469,7 @@ impl RustRespondService {
         F: FnMut(String) -> Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send>> + Send,
     {
         let user_text = req.effective_user_text();
-        let meta = SessionMeta::new(
-            req.scope_key.clone(),
-            req.user_id.clone(),
-            req.group_id.clone(),
-            req.guild_id.clone(),
-            req.channel_id.clone(),
-            clean_string(req.platform.clone()).unwrap_or_else(|| "qq".to_owned()),
-        );
+        let meta = respond_meta(&req);
         let mut active_session = self
             .session_store
             .get_active(&meta)
@@ -452,5 +505,54 @@ impl RustRespondService {
         }
 
         self.handle_chat_stream(req, on_delta).await
+    }
+}
+
+fn respond_meta(req: &RespondRequest) -> SessionMeta {
+    SessionMeta::new(
+        req.scope_key.clone(),
+        req.user_id.clone(),
+        req.group_id.clone(),
+        req.guild_id.clone(),
+        req.channel_id.clone(),
+        clean_string(req.platform.clone()).unwrap_or_else(|| "qq".to_owned()),
+    )
+}
+
+fn pending_blocks_immediate(user_text: &str, active_session: Option<&SessionRecord>) -> bool {
+    let bypass_pending_for_session_command =
+        session_flow::parse_pending_bypass_session_command(user_text).is_some();
+    !bypass_pending_for_session_command
+        && active_session
+            .and_then(|session| session.pending_operation.as_ref())
+            .is_some()
+}
+
+fn classify_inbound_with_active(
+    user_text: &str,
+    active_session: Option<&SessionRecord>,
+) -> CoreInboundClassification {
+    if pending_blocks_immediate(user_text, active_session) {
+        return CoreInboundClassification {
+            kind: CoreInboundKind::Immediate,
+        };
+    }
+
+    let is_command = session_flow::parse_session_command(user_text).is_some()
+        || translation_flow::parse_translation_command(user_text).is_some()
+        || weather_flow::parse_weather_command(user_text).is_some()
+        || train_flow::parse_train_command(user_text).is_some()
+        || search_flow::parse_web_search_command(user_text).is_some()
+        || rss_flow::parse_rss_command(user_text).is_some()
+        || todo_flow::parse_todo_command(user_text).is_some()
+        || todo_flow::is_natural_todo_query_text(user_text)
+        || memory_flow::parse_memory_command(user_text).is_some();
+
+    CoreInboundClassification {
+        kind: if is_command {
+            CoreInboundKind::Immediate
+        } else {
+            CoreInboundKind::NormalChat
+        },
     }
 }

--- a/qq-maid-core/src/runtime/respond.rs
+++ b/qq-maid-core/src/runtime/respond.rs
@@ -277,14 +277,16 @@ impl RustRespondService {
             return Ok(RespondPlan::Immediate);
         }
 
-        let tool_route = self.route_tool_loop(req, active_session.as_ref());
-        if matches!(tool_route, ToolLoopRoute::CompleteToolLoop) {
-            return Ok(RespondPlan::CompleteToolLoop);
-        }
-
+        // 先保护已有确定性命令和自然语言 Todo 查询，避免简单列表查询绕过
+        // `handle_todo_flow()` 进入模型 Tool Loop，回归同义词和默认过滤语义。
         let classification = classify_inbound_with_active(&user_text, active_session.as_ref());
         if matches!(classification.kind, CoreInboundKind::Immediate) {
-            Ok(RespondPlan::Immediate)
+            return Ok(RespondPlan::Immediate);
+        }
+
+        let tool_route = self.route_tool_loop(req, active_session.as_ref());
+        if matches!(tool_route, ToolLoopRoute::CompleteToolLoop) {
+            Ok(RespondPlan::CompleteToolLoop)
         } else {
             Ok(RespondPlan::StreamingChat)
         }

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -19,9 +19,9 @@ use crate::{
 use super::{
     RespondPurpose, RespondRequest, RespondResponse, RustRespondService,
     common::{
-        SESSION_HISTORY_MESSAGE_LIMIT, SESSION_STATE_SHORT_TEXT_LIMIT, command_response,
-        empty_respond_request, memory_error, merge_metadata, session_error, state_string,
-        truncate_chars,
+        SESSION_HISTORY_MESSAGE_LIMIT, SESSION_STATE_SHORT_TEXT_LIMIT, clean_string,
+        command_response, empty_respond_request, memory_error, merge_metadata, session_error,
+        state_string, truncate_chars,
     },
     llm_service::{ChatService, LlmChatService, response_from_output},
     session_flow::build_session_context,
@@ -31,6 +31,57 @@ use super::{
 mod todo_guard;
 
 impl RustRespondService {
+    /// 判断私聊普通聊天是否确实需要 Tool Loop 接管。
+    ///
+    /// Tool Calling 会走完整响应路径，无法把 provider token delta 直接交给
+    /// Gateway；因此只有天气和 Todo 这类明确工具意图才进入 Tool Loop，其它普通
+    /// 聊天保持 `stream_chat` 真流式输出。
+    pub(crate) fn should_use_tool_loop_for_chat(
+        &self,
+        req: &RespondRequest,
+    ) -> Result<bool, LlmError> {
+        if !self.tool_calling_enabled {
+            return Ok(false);
+        }
+        let service = LlmChatService::new(self.provider.clone());
+        if !service.supports_tool_calling(req.model.as_deref()) {
+            return Ok(false);
+        }
+        let user_text = req.effective_user_text();
+        let trimmed = user_text.trim();
+        if trimmed.is_empty()
+            || trimmed.starts_with('/')
+            || trimmed.starts_with('／')
+            || req
+                .group_id
+                .as_deref()
+                .is_some_and(|value| !value.is_empty())
+        {
+            return Ok(false);
+        }
+
+        let meta = SessionMeta::new(
+            req.scope_key.clone(),
+            req.user_id.clone(),
+            req.group_id.clone(),
+            req.guild_id.clone(),
+            req.channel_id.clone(),
+            clean_string(req.platform.clone()).unwrap_or_else(|| "qq".to_owned()),
+        );
+        let session = self
+            .session_store
+            .get_or_create_active(&meta)
+            .map_err(session_error)?;
+        let should_use = looks_like_weather_tool_request(trimmed)
+            || looks_like_todo_tool_request(trimmed, &session);
+        tracing::debug!(
+            scope_key = %req.scope_key,
+            tool_loop_intent = should_use,
+            "private chat tool loop intent classified"
+        );
+        Ok(should_use)
+    }
+
     /// 处理普通聊天请求。
     ///
     /// 1. 空消息直接返回提示。
@@ -131,8 +182,7 @@ impl RustRespondService {
             ..empty_respond_request()
         };
         let service = LlmChatService::new(self.provider.clone());
-        let use_tool_loop =
-            self.tool_calling_enabled && !is_group_chat && service.supports_tool_calling(None);
+        let use_tool_loop = self.should_use_tool_loop_for_chat(&chat_req)?;
         let todo_requirement = if use_tool_loop {
             todo_guard::required_todo_tool_kind(&user_text, &session)
         } else {
@@ -667,6 +717,64 @@ fn looks_like_correction(text: &str) -> bool {
 /// 检查文本是否包含关键字列表中的任意一个。
 fn contains_any(text: &str, needles: &[&str]) -> bool {
     needles.iter().any(|needle| text.contains(needle))
+}
+
+/// 判断普通私聊是否明显需要天气 Tool。
+///
+/// 这里不是替代模型决策，只是避免所有私聊都被 Tool Loop 抢走流式链路；
+/// 命中后仍由模型决定是否真正调用 `get_weather`。
+fn looks_like_weather_tool_request(text: &str) -> bool {
+    contains_any(
+        text,
+        &[
+            "天气",
+            "下雨",
+            "下雪",
+            "带伞",
+            "温度",
+            "气温",
+            "几度",
+            "降雨",
+            "降雪",
+            "空气质量",
+            "雾霾",
+            "预警",
+            "台风",
+            "风力",
+            "冷不冷",
+            "热不热",
+            "穿什么",
+        ],
+    )
+}
+
+/// 判断普通私聊是否明显需要 Todo Tool。
+///
+/// 写操作复用 `todo_guard` 的严格判定；查询类只覆盖现有 Tool Loop 语义中
+/// 需要模型绑定可见编号/最近对象的短句，避免“聊聊待办设计”这类普通聊天误入工具链路。
+fn looks_like_todo_tool_request(text: &str, session: &SessionRecord) -> bool {
+    if todo_guard::required_todo_tool_kind(text, session).is_some() {
+        return true;
+    }
+    if super::todo_flow::is_natural_todo_query_text(text) {
+        return true;
+    }
+    contains_any(
+        text,
+        &[
+            "看看已完成",
+            "查看已完成",
+            "列出已完成",
+            "看看已取消",
+            "查看已取消",
+            "列出已取消",
+            "看看待办",
+            "查看待办",
+            "列出待办",
+            "还有什么待办",
+            "有哪些待办",
+        ],
+    )
 }
 
 /// 判断是否为短接续句（字符数 <= 24）。

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -17,71 +17,20 @@ use crate::{
 };
 
 use super::{
-    RespondPurpose, RespondRequest, RespondResponse, RustRespondService,
+    ChatToolPlan, RespondPurpose, RespondRequest, RespondResponse, RustRespondService,
     common::{
-        SESSION_HISTORY_MESSAGE_LIMIT, SESSION_STATE_SHORT_TEXT_LIMIT, clean_string,
-        command_response, empty_respond_request, memory_error, merge_metadata, session_error,
-        state_string, truncate_chars,
+        SESSION_HISTORY_MESSAGE_LIMIT, SESSION_STATE_SHORT_TEXT_LIMIT, command_response,
+        empty_respond_request, memory_error, merge_metadata, session_error, state_string,
+        truncate_chars,
     },
     llm_service::{ChatService, LlmChatService, response_from_output},
     session_flow::build_session_context,
     title::{context_session_title, generate_session_title},
 };
 
-mod todo_guard;
+pub(super) mod todo_guard;
 
 impl RustRespondService {
-    /// 判断私聊普通聊天是否确实需要 Tool Loop 接管。
-    ///
-    /// Tool Calling 会走完整响应路径，无法把 provider token delta 直接交给
-    /// Gateway；因此只有天气和 Todo 这类明确工具意图才进入 Tool Loop，其它普通
-    /// 聊天保持 `stream_chat` 真流式输出。
-    pub(crate) fn should_use_tool_loop_for_chat(
-        &self,
-        req: &RespondRequest,
-    ) -> Result<bool, LlmError> {
-        if !self.tool_calling_enabled {
-            return Ok(false);
-        }
-        let service = LlmChatService::new(self.provider.clone());
-        if !service.supports_tool_calling(req.model.as_deref()) {
-            return Ok(false);
-        }
-        let user_text = req.effective_user_text();
-        let trimmed = user_text.trim();
-        if trimmed.is_empty()
-            || trimmed.starts_with('/')
-            || trimmed.starts_with('／')
-            || req
-                .group_id
-                .as_deref()
-                .is_some_and(|value| !value.is_empty())
-        {
-            return Ok(false);
-        }
-
-        let meta = SessionMeta::new(
-            req.scope_key.clone(),
-            req.user_id.clone(),
-            req.group_id.clone(),
-            req.guild_id.clone(),
-            req.channel_id.clone(),
-            clean_string(req.platform.clone()).unwrap_or_else(|| "qq".to_owned()),
-        );
-        let session = self
-            .session_store
-            .get_or_create_active(&meta)
-            .map_err(session_error)?;
-        let should_use = looks_like_weather_tool_request(trimmed)
-            || looks_like_todo_tool_request(trimmed, &session);
-        tracing::debug!(
-            scope_key = %req.scope_key,
-            tool_loop_intent = should_use,
-            "private chat tool loop intent classified"
-        );
-        Ok(should_use)
-    }
-
     /// 处理普通聊天请求。
     ///
     /// 1. 空消息直接返回提示。
@@ -97,6 +46,7 @@ impl RustRespondService {
         user_text: String,
         meta: SessionMeta,
         mut session: SessionRecord,
+        chat_tool_plan: ChatToolPlan,
     ) -> Result<RespondResponse, LlmError> {
         if user_text.trim().is_empty() {
             let reply = "唔，小女仆在。可以直接说要我看哪一块。";
@@ -182,7 +132,7 @@ impl RustRespondService {
             ..empty_respond_request()
         };
         let service = LlmChatService::new(self.provider.clone());
-        let use_tool_loop = self.should_use_tool_loop_for_chat(&chat_req)?;
+        let use_tool_loop = matches!(chat_tool_plan, ChatToolPlan::ForceCompleteToolLoop);
         let todo_requirement = if use_tool_loop {
             todo_guard::required_todo_tool_kind(&user_text, &session)
         } else {
@@ -342,7 +292,9 @@ impl RustRespondService {
             .get_or_create_active(&meta)
             .map_err(session_error)?;
         if user_text.trim().is_empty() {
-            return self.handle_chat(req, user_text, meta, session).await;
+            return self
+                .handle_chat(req, user_text, meta, session, ChatToolPlan::Plain)
+                .await;
         }
 
         update_session_state_from_user(&mut session, &user_text);
@@ -717,64 +669,6 @@ fn looks_like_correction(text: &str) -> bool {
 /// 检查文本是否包含关键字列表中的任意一个。
 fn contains_any(text: &str, needles: &[&str]) -> bool {
     needles.iter().any(|needle| text.contains(needle))
-}
-
-/// 判断普通私聊是否明显需要天气 Tool。
-///
-/// 这里不是替代模型决策，只是避免所有私聊都被 Tool Loop 抢走流式链路；
-/// 命中后仍由模型决定是否真正调用 `get_weather`。
-fn looks_like_weather_tool_request(text: &str) -> bool {
-    contains_any(
-        text,
-        &[
-            "天气",
-            "下雨",
-            "下雪",
-            "带伞",
-            "温度",
-            "气温",
-            "几度",
-            "降雨",
-            "降雪",
-            "空气质量",
-            "雾霾",
-            "预警",
-            "台风",
-            "风力",
-            "冷不冷",
-            "热不热",
-            "穿什么",
-        ],
-    )
-}
-
-/// 判断普通私聊是否明显需要 Todo Tool。
-///
-/// 写操作复用 `todo_guard` 的严格判定；查询类只覆盖现有 Tool Loop 语义中
-/// 需要模型绑定可见编号/最近对象的短句，避免“聊聊待办设计”这类普通聊天误入工具链路。
-fn looks_like_todo_tool_request(text: &str, session: &SessionRecord) -> bool {
-    if todo_guard::required_todo_tool_kind(text, session).is_some() {
-        return true;
-    }
-    if super::todo_flow::is_natural_todo_query_text(text) {
-        return true;
-    }
-    contains_any(
-        text,
-        &[
-            "看看已完成",
-            "查看已完成",
-            "列出已完成",
-            "看看已取消",
-            "查看已取消",
-            "列出已取消",
-            "看看待办",
-            "查看待办",
-            "列出待办",
-            "还有什么待办",
-            "有哪些待办",
-        ],
-    )
 }
 
 /// 判断是否为短接续句（字符数 <= 24）。

--- a/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
@@ -65,6 +65,18 @@ pub(super) fn required_todo_tool_kind(
     user_text: &str,
     session: &SessionRecord,
 ) -> Option<TodoMutationToolKind> {
+    required_todo_tool_kind_with_context(
+        user_text,
+        session.last_todo_query.is_some(),
+        session.last_todo_action.is_some(),
+    )
+}
+
+fn required_todo_tool_kind_with_context(
+    user_text: &str,
+    has_last_todo_query: bool,
+    has_last_todo_action: bool,
+) -> Option<TodoMutationToolKind> {
     let text = user_text.trim();
     if text.is_empty() {
         return None;
@@ -83,10 +95,8 @@ pub(super) fn required_todo_tool_kind(
     // 完成/取消/恢复/删除必须同时存在 Todo 目标上下文，否则普通聊天里的
     // “完成项目/取消会议/删除日志”会被误强制成 Todo Tool，甚至真的修改用户待办。
     let has_todo_noun = contains_any(text, &["待办", "任务", "todo"]);
-    let has_visible_reference =
-        contains_visible_number_reference(text) && session.last_todo_query.is_some();
-    let has_last_reference =
-        contains_last_todo_reference(text) && session.last_todo_action.is_some();
+    let has_visible_reference = contains_visible_number_reference(text) && has_last_todo_query;
+    let has_last_reference = contains_last_todo_reference(text) && has_last_todo_action;
     if !(has_todo_noun || has_visible_reference || has_last_reference) {
         return None;
     }
@@ -113,6 +123,15 @@ pub(super) fn required_todo_tool_kind(
         return Some(TodoMutationToolKind::Cancel);
     }
     None
+}
+
+pub(in crate::runtime::respond) fn requires_todo_tool_with_context(
+    user_text: &str,
+    has_last_todo_query: bool,
+    has_last_todo_action: bool,
+) -> bool {
+    required_todo_tool_kind_with_context(user_text, has_last_todo_query, has_last_todo_action)
+        .is_some()
 }
 
 /// 识别明确的待办创建意图。

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -667,7 +667,8 @@ async fn todo_create_intent_without_tool_call_does_not_leak_fake_success_reply()
 #[tokio::test]
 async fn natural_language_todo_query_prefers_listing_over_todo_parse_creation_chain() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
-    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    // Tool Calling 关闭时仍保留确定性 Todo 查询路径；开启时由前置路由交给 Tool Loop。
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), false);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
     service
         .todo_store
@@ -703,7 +704,8 @@ async fn natural_language_todo_query_prefers_listing_over_todo_parse_creation_ch
 #[tokio::test]
 async fn natural_language_todo_query_aliases_and_filters_stay_deterministic() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
-    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    // Tool Calling 关闭时仍保留确定性 Todo 查询路径；开启时由前置路由交给 Tool Loop。
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), false);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
     let pending = service
         .todo_store
@@ -800,7 +802,8 @@ async fn natural_language_todo_query_aliases_and_filters_stay_deterministic() {
 #[tokio::test]
 async fn natural_language_cancelled_todo_query_lists_cancelled_items() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
-    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    // Tool Calling 关闭时仍保留确定性 Todo 查询路径；开启时由前置路由交给 Tool Loop。
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), false);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
     let todo = service
         .todo_store

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -75,6 +75,31 @@ async fn private_chat_with_openai_responses_capability_enters_tool_loop() {
 }
 
 #[tokio::test]
+async fn private_general_chat_with_tool_capability_uses_plain_chat() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("聊聊 Rust 的所有权"))
+        .await
+        .unwrap();
+
+    assert!(
+        response
+            .text
+            .as_deref()
+            .unwrap()
+            .contains("回复：聊聊 Rust 的所有权")
+    );
+    assert_eq!(inspector.tool_call_count(), 0);
+    assert_eq!(inspector.requests().len(), 1);
+    assert_eq!(
+        response.diagnostics.unwrap()["tool_calling_enabled"],
+        serde_json::json!(false)
+    );
+}
+
+#[tokio::test]
 async fn private_tool_loop_registers_todo_tools_and_keeps_internal_ids_hidden() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
@@ -837,8 +862,9 @@ async fn non_todo_chat_phrase_does_not_force_required_tool() {
         diagnostics["tool_loop_executed_tools"],
         serde_json::json!([])
     );
-    // 没有 Todo 目标上下文时不触发受控重试，只走一次普通 tool loop 调用。
-    assert_eq!(inspector.tool_call_count(), 1);
+    // 没有 Todo 目标上下文时不触发受控重试，也不让 Tool Loop 抢走普通聊天流式链路。
+    assert_eq!(inspector.tool_call_count(), 0);
+    assert_eq!(inspector.requests().len(), 1);
     // 待办不应被误修改。
     assert_eq!(
         service.todo_store.list_pending(&owner).unwrap()[0].status,

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -329,16 +329,10 @@ async fn restore_then_cancel_last_reference_creates_pending_without_relisting() 
         .respond(private_message("看看已完成"))
         .await
         .unwrap();
-    let tool_request = inspector.tool_requests().remove(0);
-    tool_request
-        .tools
-        .execute_json(
-            &tool_request.tool_context,
-            "list_todos",
-            r#"{"status":"completed"}"#,
-        )
-        .await
-        .unwrap();
+    assert_eq!(inspector.tool_call_count(), 0);
+    let _ = service.respond(private_message("恢复第 1 个")).await;
+    let mut tool_requests = inspector.tool_requests();
+    let tool_request = tool_requests.pop().unwrap();
     tool_request
         .tools
         .execute_json(
@@ -402,16 +396,10 @@ async fn restore_then_reuse_stale_number_keeps_visible_number_error() {
         .respond(private_message("看看已完成"))
         .await
         .unwrap();
-    let tool_request = inspector.tool_requests().remove(0);
-    tool_request
-        .tools
-        .execute_json(
-            &tool_request.tool_context,
-            "list_todos",
-            r#"{"status":"completed"}"#,
-        )
-        .await
-        .unwrap();
+    assert_eq!(inspector.tool_call_count(), 0);
+    let _ = service.respond(private_message("恢复第 1 个")).await;
+    let mut tool_requests = inspector.tool_requests();
+    let tool_request = tool_requests.pop().unwrap();
     tool_request
         .tools
         .execute_json(

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -62,8 +62,10 @@ const TODO_QUERY_LIST_VERBS: &[&str] = &[
 ];
 const TODO_QUERY_ALL_MARKERS: &[&str] = &["全部", "所有", "包含已完成", "包含已取消"];
 const TODO_QUERY_PENDING_EXACT: &[&str] = &["我的待办", "待办列表"];
-const TODO_QUERY_COMPLETED_EXACT: &[&str] = &["已完成的待办"];
-const TODO_QUERY_CANCELLED_EXACT: &[&str] = &["已取消的待办"];
+const TODO_QUERY_COMPLETED_EXACT: &[&str] =
+    &["已完成的待办", "看看已完成", "查看已完成", "列出已完成"];
+const TODO_QUERY_CANCELLED_EXACT: &[&str] =
+    &["已取消的待办", "看看已取消", "查看已取消", "列出已取消"];
 
 impl RustRespondService {
     /// 处理待办指令的主入口。解析 `/todo` 子命令并分派到对应的处理逻辑。

--- a/qq-maid-core/src/runtime/respond/tool_route.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route.rs
@@ -1,0 +1,265 @@
+//! 普通私聊 Tool Loop 前置路由。
+//!
+//! 当前这里只覆盖已经接入 Tool Loop 的 Weather 和 Todo，用来决定本轮普通
+//! 私聊是否要走 Complete Tool Loop。它不是通用语义分类器，也不负责 Memory、
+//! RSS、MCP、Skills 等未来工具；完整通用 Tool Loop 流式能力留给 #83 处理。
+
+use crate::runtime::session::SessionRecord;
+
+use super::{RespondRequest, chat_flow::todo_guard, todo_flow};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ToolLoopRoute {
+    PlainChat,
+    CompleteToolLoop,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct ToolRouteContext<'a> {
+    pub tool_calling_enabled: bool,
+    pub provider_supports_tool_calling: bool,
+    pub active_session: Option<&'a SessionRecord>,
+}
+
+pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext<'_>) -> ToolLoopRoute {
+    if !ctx.tool_calling_enabled || !ctx.provider_supports_tool_calling {
+        return ToolLoopRoute::PlainChat;
+    }
+    let text = req.effective_user_text();
+    let trimmed = text.trim();
+    if trimmed.is_empty()
+        || trimmed.starts_with('/')
+        || trimmed.starts_with('／')
+        || req
+            .group_id
+            .as_deref()
+            .is_some_and(|value| !value.is_empty())
+    {
+        return ToolLoopRoute::PlainChat;
+    }
+
+    if looks_like_weather_tool_request(trimmed) || looks_like_todo_tool_request(trimmed, ctx) {
+        ToolLoopRoute::CompleteToolLoop
+    } else {
+        ToolLoopRoute::PlainChat
+    }
+}
+
+/// 判断普通私聊是否明显需要天气 Tool。
+///
+/// 这里只识别当前稳定接入的天气工具请求，不处理“天气 API 怎么设计”这类
+/// 元讨论，避免工具链路抢走本该流式输出的普通聊天。
+fn looks_like_weather_tool_request(text: &str) -> bool {
+    if looks_like_weather_meta_discussion(text) {
+        return false;
+    }
+    contains_any(
+        text,
+        &[
+            "下雨",
+            "下雪",
+            "带伞",
+            "温度",
+            "气温",
+            "几度",
+            "降雨",
+            "降雪",
+            "空气质量",
+            "雾霾",
+            "预警",
+            "台风",
+            "风力",
+            "冷不冷",
+            "热不热",
+            "穿什么",
+        ],
+    ) || (text.contains("天气")
+        && contains_any(text, &["今天", "明天", "后天", "现在", "本周", "周末"]))
+}
+
+fn looks_like_weather_meta_discussion(text: &str) -> bool {
+    text.contains("天气")
+        && contains_any(
+            text,
+            &[
+                "API",
+                "api",
+                "接口",
+                "设计",
+                "实现",
+                "架构",
+                "模块",
+                "代码",
+                "怎么做",
+                "怎么写",
+            ],
+        )
+}
+
+/// 判断普通私聊是否明显需要 Todo Tool。
+///
+/// 写操作复用 `todo_guard` 的严格判定；查询类只覆盖当前 Tool Loop 已承载的
+/// 可见编号/最近对象绑定场景，避免“聊聊待办设计”误入工具链路。
+fn looks_like_todo_tool_request(text: &str, ctx: ToolRouteContext<'_>) -> bool {
+    let has_last_query = ctx
+        .active_session
+        .and_then(|session| session.last_todo_query.as_ref())
+        .is_some();
+    let has_last_action = ctx
+        .active_session
+        .and_then(|session| session.last_todo_action.as_ref())
+        .is_some();
+    if todo_guard::requires_todo_tool_with_context(text, has_last_query, has_last_action) {
+        return true;
+    }
+    if todo_flow::is_natural_todo_query_text(text) {
+        return true;
+    }
+    contains_any(
+        text,
+        &[
+            "看看已完成",
+            "查看已完成",
+            "列出已完成",
+            "看看已取消",
+            "查看已取消",
+            "列出已取消",
+            "看看待办",
+            "查看待办",
+            "列出待办",
+            "还有什么待办",
+            "有哪些待办",
+        ],
+    )
+}
+
+fn contains_any(text: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| text.contains(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::runtime::{
+        session::{LastTodoAction, LastTodoQuery, SessionRecord},
+        todo::TodoStatus,
+    };
+
+    use super::*;
+
+    fn request(text: &str) -> RespondRequest {
+        RespondRequest {
+            content: text.to_owned(),
+            scope_key: "private:u1".to_owned(),
+            user_id: Some("u1".to_owned()),
+            platform: "qq_official".to_owned(),
+            ..Default::default()
+        }
+    }
+
+    fn context(active_session: Option<&SessionRecord>) -> ToolRouteContext<'_> {
+        ToolRouteContext {
+            tool_calling_enabled: true,
+            provider_supports_tool_calling: true,
+            active_session,
+        }
+    }
+
+    fn empty_session() -> SessionRecord {
+        serde_json::from_value(json!({})).unwrap()
+    }
+
+    fn session_with_last_query() -> SessionRecord {
+        let mut session = empty_session();
+        session.last_todo_query = Some(LastTodoQuery {
+            owner_key: "private:u1".to_owned(),
+            query_type: "list".to_owned(),
+            condition: String::new(),
+            result_ids: vec!["item-1".to_owned()],
+            created_at: "2026-06-30T00:00:00+08:00".to_owned(),
+        });
+        session
+    }
+
+    fn session_with_last_action() -> SessionRecord {
+        let mut session = empty_session();
+        session.last_todo_action = Some(LastTodoAction {
+            owner_key: "private:u1".to_owned(),
+            item_id: "item-1".to_owned(),
+            title: "示例待办".to_owned(),
+            action: "restored".to_owned(),
+            resulting_status: TodoStatus::Pending,
+            created_at: "2026-06-30T00:00:00+08:00".to_owned(),
+        });
+        session
+    }
+
+    #[test]
+    fn general_chat_keeps_plain_route_even_with_tool_calling_enabled() {
+        assert_eq!(
+            route_tool_loop(&request("聊聊 Rust 的所有权"), context(None)),
+            ToolLoopRoute::PlainChat
+        );
+    }
+
+    #[test]
+    fn weather_route_avoids_meta_discussion() {
+        assert_eq!(
+            route_tool_loop(&request("杭州明天要带伞吗"), context(None)),
+            ToolLoopRoute::CompleteToolLoop
+        );
+        assert_eq!(
+            route_tool_loop(&request("聊聊天气 API 怎么设计"), context(None)),
+            ToolLoopRoute::PlainChat
+        );
+        // 当前阶段只覆盖明确 Weather/Todo 工具意图；泛化外出建议留给 #83 的通用 Tool Loop。
+        assert_eq!(
+            route_tool_loop(&request("杭州明天适合出门吗"), context(None)),
+            ToolLoopRoute::PlainChat
+        );
+    }
+
+    #[test]
+    fn todo_mutations_and_queries_route_to_tool_loop() {
+        let with_query = session_with_last_query();
+        let with_action = session_with_last_action();
+        for (text, session) in [
+            ("提醒我明天下午三点开会", None),
+            ("完成第 1 个待办", None),
+            ("修改第 2 个待办", None),
+            ("取消第 2 个任务", None),
+            ("永久删除已完成待办第 3 个", None),
+            ("恢复第 1 个", Some(&with_query)),
+            ("取消它", Some(&with_action)),
+            ("看看已完成", None),
+        ] {
+            assert_eq!(
+                route_tool_loop(&request(text), context(session)),
+                ToolLoopRoute::CompleteToolLoop,
+                "{text}"
+            );
+        }
+    }
+
+    #[test]
+    fn disabled_or_group_request_keeps_plain_route() {
+        let mut group = request("杭州明天要带伞吗");
+        group.group_id = Some("g1".to_owned());
+        assert_eq!(
+            route_tool_loop(&group, context(None)),
+            ToolLoopRoute::PlainChat
+        );
+        assert_eq!(
+            route_tool_loop(
+                &request("杭州明天要带伞吗"),
+                ToolRouteContext {
+                    tool_calling_enabled: false,
+                    provider_supports_tool_calling: true,
+                    active_session: None,
+                },
+            ),
+            ToolLoopRoute::PlainChat
+        );
+    }
+}

--- a/qq-maid-core/src/runtime/respond/tool_route.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route.rs
@@ -6,7 +6,7 @@
 
 use crate::runtime::session::SessionRecord;
 
-use super::{RespondRequest, chat_flow::todo_guard, todo_flow};
+use super::{RespondRequest, chat_flow::todo_guard};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ToolLoopRoute {
@@ -98,8 +98,9 @@ fn looks_like_weather_meta_discussion(text: &str) -> bool {
 
 /// 判断普通私聊是否明显需要 Todo Tool。
 ///
-/// 写操作复用 `todo_guard` 的严格判定；查询类只覆盖当前 Tool Loop 已承载的
-/// 可见编号/最近对象绑定场景，避免“聊聊待办设计”误入工具链路。
+/// 这里只覆盖创建、修改、完成、取消、恢复、删除等写操作，以及依赖最近
+/// Todo 查询/操作上下文的续指。普通列表查询必须继续交给 `handle_todo_flow()`
+/// 的确定性流程，避免同义词和默认过滤语义回归。
 fn looks_like_todo_tool_request(text: &str, ctx: ToolRouteContext<'_>) -> bool {
     let has_last_query = ctx
         .active_session
@@ -109,28 +110,7 @@ fn looks_like_todo_tool_request(text: &str, ctx: ToolRouteContext<'_>) -> bool {
         .active_session
         .and_then(|session| session.last_todo_action.as_ref())
         .is_some();
-    if todo_guard::requires_todo_tool_with_context(text, has_last_query, has_last_action) {
-        return true;
-    }
-    if todo_flow::is_natural_todo_query_text(text) {
-        return true;
-    }
-    contains_any(
-        text,
-        &[
-            "看看已完成",
-            "查看已完成",
-            "列出已完成",
-            "看看已取消",
-            "查看已取消",
-            "列出已取消",
-            "看看待办",
-            "查看待办",
-            "列出待办",
-            "还有什么待办",
-            "有哪些待办",
-        ],
-    )
+    todo_guard::requires_todo_tool_with_context(text, has_last_query, has_last_action)
 }
 
 fn contains_any(text: &str, needles: &[&str]) -> bool {
@@ -227,16 +207,34 @@ mod tests {
         for (text, session) in [
             ("提醒我明天下午三点开会", None),
             ("完成第 1 个待办", None),
+            ("完成第一条", Some(&with_query)),
             ("修改第 2 个待办", None),
             ("取消第 2 个任务", None),
             ("永久删除已完成待办第 3 个", None),
             ("恢复第 1 个", Some(&with_query)),
             ("取消它", Some(&with_action)),
-            ("看看已完成", None),
         ] {
             assert_eq!(
                 route_tool_loop(&request(text), context(session)),
                 ToolLoopRoute::CompleteToolLoop,
+                "{text}"
+            );
+        }
+    }
+
+    #[test]
+    fn todo_list_queries_keep_plain_route_for_deterministic_flow() {
+        for text in [
+            "看看已完成",
+            "看看待办",
+            "查看待办",
+            "列出待办",
+            "还有什么待办",
+            "有哪些待办",
+        ] {
+            assert_eq!(
+                route_tool_loop(&request(text), context(None)),
+                ToolLoopRoute::PlainChat,
                 "{text}"
             );
         }

--- a/qq-maid-core/src/service.rs
+++ b/qq-maid-core/src/service.rs
@@ -15,7 +15,7 @@ use std::{
 
 use async_trait::async_trait;
 use tokio::{sync::mpsc, time::timeout};
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 
 use crate::{
     config::AppConfig,
@@ -190,7 +190,23 @@ impl CoreService for CoreHandle {
         let recorder = MetricsRecorder::start();
         let scope_key = req.scope_key.clone();
         let state = self.state.as_ref();
-        let should_stream = should_stream_respond(&req) && !should_use_tool_calling(state, &req);
+        let stream_candidate = should_stream_respond(&service, &req).map_err(CoreError::from)?;
+        let should_use_tool_loop = if stream_candidate {
+            service
+                .should_use_tool_loop_for_chat(&req)
+                .map_err(CoreError::from)?
+        } else {
+            false
+        };
+        if stream_candidate && should_use_tool_loop {
+            info!(
+                scope_key,
+                transport = "complete",
+                reason = "tool_loop_intent",
+                "core respond stream bypassed for tool loop"
+            );
+        }
+        let should_stream = stream_candidate && !should_use_tool_loop;
         if should_stream {
             let provider_stream_enabled = state.provider.stream_enabled();
             let result = timeout(
@@ -440,36 +456,26 @@ async fn send_core_delta(
         .map_err(|_| LlmError::new("cancelled", "stream receiver dropped", "stream"))
 }
 
-fn should_stream_respond(req: &RespondRequest) -> bool {
+fn should_stream_respond(
+    service: &RustRespondService,
+    req: &RespondRequest,
+) -> Result<bool, LlmError> {
     let text = req.effective_user_text();
     let trimmed = text.trim();
     if trimmed.is_empty() {
-        return false;
+        return Ok(false);
     }
     if is_web_search_command(trimmed) {
-        return true;
+        return Ok(true);
     }
     // 只有普通聊天默认流式化；短命令继续走 Complete，保留原有总超时语义。
-    !trimmed.starts_with('/') && !trimmed.starts_with('／')
-}
-
-fn should_use_tool_calling(state: &AppState, req: &RespondRequest) -> bool {
-    if !state.config.tool_calling_enabled {
-        return false;
+    if trimmed.starts_with('/') || trimmed.starts_with('／') {
+        return Ok(false);
     }
-    if state
-        .provider
-        .tool_calling_protocol(req.model.as_deref())
-        .is_none()
-    {
-        return false;
-    }
-    let text = req.effective_user_text();
-    let trimmed = text.trim();
-    !trimmed.is_empty()
-        && !trimmed.starts_with('/')
-        && !trimmed.starts_with('／')
-        && req.group_id.as_deref().is_none_or(str::is_empty)
+    // 非 slash 的待办查询、pending 确认等仍属于完整业务流程；这里复用
+    // RespondService 的轻量分类，避免 stream 入口复制第二套命令判断。
+    let classification = service.classify_inbound(req.clone())?;
+    Ok(matches!(classification.kind, CoreInboundKind::NormalChat))
 }
 
 impl CoreRequest {
@@ -898,13 +904,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn core_private_chat_with_tool_capability_uses_complete_tool_loop_path() {
+    async fn core_private_weather_chat_with_tool_capability_uses_complete_tool_loop_path() {
         let provider = TestProvider::replying("工具完整回复")
             .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
         let state = test_state_with_tool_calling(provider.clone(), 5, true);
         let service = CoreHandle::new(state);
 
-        let output = service.respond(private_request("hello")).await.unwrap();
+        let output = service
+            .respond(private_request("杭州明天要带伞吗"))
+            .await
+            .unwrap();
 
         let CoreRespondOutput::Complete(response) = output else {
             panic!("expected complete output for tool loop path");
@@ -912,6 +921,21 @@ mod tests {
         assert_eq!(response.text.as_deref(), Some("工具完整回复"));
         assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
         assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn core_private_general_chat_with_tool_capability_keeps_stream_path() {
+        let provider = TestProvider::replying("普通流式回复")
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+        let state = test_state_with_tool_calling(provider.clone(), 5, true);
+        let service = CoreHandle::new(state);
+
+        let response =
+            collect_stream_completed(service.respond(private_request("hello")).await).await;
+
+        assert_eq!(response.text.as_deref(), Some("普通流式回复"));
+        assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/qq-maid-core/src/service.rs
+++ b/qq-maid-core/src/service.rs
@@ -23,8 +23,8 @@ use crate::{
     http::routes::AppState,
     provider::types::{ChatMessage, ChatRequest, ChatRole},
     runtime::respond::{
-        RespondExecutors, RespondRequest, RespondResponse, RespondServiceOptions, RespondStores,
-        RustRespondService,
+        RespondExecutors, RespondPlan, RespondRequest, RespondResponse, RespondServiceOptions,
+        RespondStores, RustRespondService,
     },
     util::metrics::MetricsRecorder,
 };
@@ -190,15 +190,8 @@ impl CoreService for CoreHandle {
         let recorder = MetricsRecorder::start();
         let scope_key = req.scope_key.clone();
         let state = self.state.as_ref();
-        let stream_candidate = should_stream_respond(&service, &req).map_err(CoreError::from)?;
-        let should_use_tool_loop = if stream_candidate {
-            service
-                .should_use_tool_loop_for_chat(&req)
-                .map_err(CoreError::from)?
-        } else {
-            false
-        };
-        if stream_candidate && should_use_tool_loop {
+        let respond_plan = service.plan_core_respond(&req).map_err(CoreError::from)?;
+        if matches!(respond_plan, RespondPlan::CompleteToolLoop) {
             info!(
                 scope_key,
                 transport = "complete",
@@ -206,8 +199,7 @@ impl CoreService for CoreHandle {
                 "core respond stream bypassed for tool loop"
             );
         }
-        let should_stream = stream_candidate && !should_use_tool_loop;
-        if should_stream {
+        if matches!(respond_plan, RespondPlan::StreamingChat) {
             let provider_stream_enabled = state.provider.stream_enabled();
             let result = timeout(
                 Duration::from_secs(state.config.request_timeout_seconds),
@@ -240,7 +232,7 @@ impl CoreService for CoreHandle {
         }
         let result = timeout(
             Duration::from_secs(state.config.request_timeout_seconds),
-            service.respond(req),
+            service.respond_with_plan(req, respond_plan),
         )
         .await;
 
@@ -456,28 +448,6 @@ async fn send_core_delta(
         .map_err(|_| LlmError::new("cancelled", "stream receiver dropped", "stream"))
 }
 
-fn should_stream_respond(
-    service: &RustRespondService,
-    req: &RespondRequest,
-) -> Result<bool, LlmError> {
-    let text = req.effective_user_text();
-    let trimmed = text.trim();
-    if trimmed.is_empty() {
-        return Ok(false);
-    }
-    if is_web_search_command(trimmed) {
-        return Ok(true);
-    }
-    // 只有普通聊天默认流式化；短命令继续走 Complete，保留原有总超时语义。
-    if trimmed.starts_with('/') || trimmed.starts_with('／') {
-        return Ok(false);
-    }
-    // 非 slash 的待办查询、pending 确认等仍属于完整业务流程；这里复用
-    // RespondService 的轻量分类，避免 stream 入口复制第二套命令判断。
-    let classification = service.classify_inbound(req.clone())?;
-    Ok(matches!(classification.kind, CoreInboundKind::NormalChat))
-}
-
 impl CoreRequest {
     pub fn scope_key(&self) -> String {
         match &self.conversation {
@@ -623,14 +593,6 @@ fn user_visible_failure_message(kind: CoreFailureKind) -> String {
     .to_owned()
 }
 
-fn is_web_search_command(text: &str) -> bool {
-    let normalized = text.strip_prefix('／').unwrap_or(text);
-    normalized.starts_with("/查")
-        || normalized.starts_with("/查询")
-        || normalized.starts_with("/search ")
-        || normalized == "/search"
-}
-
 fn respond_options(config: &AppConfig) -> RespondServiceOptions {
     RespondServiceOptions {
         title_model: config.title_model.clone(),
@@ -695,11 +657,12 @@ mod tests {
         },
         runtime::{
             knowledge::KnowledgeIndex,
+            pending::PendingOperation,
             prompt::PromptConfig,
             query::{QueryExecutor, QueryOutcome, QueryRequest},
             rss::{RssFetchConfig, RssFetcher, RssStore},
-            session::SessionStore,
-            todo::TodoStore,
+            session::{SessionMeta, SessionStore},
+            todo::{TodoItemDraft, TodoStore, TodoTimePrecision},
             train::{TrainExecutor, TrainSchedule, TrainScheduleRequest},
             weather::{WeatherExecutor, WeatherOutcome, WeatherRequest},
         },
@@ -788,6 +751,123 @@ mod tests {
         assert_eq!(response.session_id.as_deref(), Some("session-1"));
         assert_eq!(response.command.as_deref(), Some("chat"));
         assert_eq!(response.diagnostics.unwrap()["k"], "v");
+    }
+
+    #[test]
+    fn core_plan_routes_general_private_chat_to_streaming() {
+        let provider = TestProvider::replying("普通回复")
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+        let state = test_state_with_tool_calling(provider, 5, true);
+        let service = CoreHandle::new(state).respond_service();
+        let req: RespondRequest = private_request("hello").into();
+
+        assert_eq!(
+            service.plan_core_respond(&req).unwrap(),
+            RespondPlan::StreamingChat
+        );
+    }
+
+    #[test]
+    fn core_plan_routes_weather_tool_intent_to_complete_tool_loop() {
+        let provider = TestProvider::replying("工具回复")
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+        let state = test_state_with_tool_calling(provider, 5, true);
+        let service = CoreHandle::new(state).respond_service();
+        let req: RespondRequest = private_request("杭州明天要带伞吗").into();
+
+        assert_eq!(
+            service.plan_core_respond(&req).unwrap(),
+            RespondPlan::CompleteToolLoop
+        );
+    }
+
+    #[test]
+    fn core_plan_routes_todo_query_and_followup_to_complete_tool_loop() {
+        let provider = TestProvider::replying("工具回复")
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+        let state = test_state_with_tool_calling(provider, 5, true);
+        let session_store = state.session_store.clone();
+        let meta = SessionMeta::new(
+            "private:u1",
+            Some("u1".to_owned()),
+            None,
+            None,
+            None,
+            "qq_official",
+        );
+        let mut session = session_store.get_or_create_active(&meta).unwrap();
+        session.last_todo_query = Some(crate::runtime::session::LastTodoQuery {
+            owner_key: "private:u1".to_owned(),
+            query_type: "list".to_owned(),
+            condition: String::new(),
+            result_ids: vec!["todo-1".to_owned()],
+            created_at: "2026-06-30T00:00:00+08:00".to_owned(),
+        });
+        session_store.save(&mut session).unwrap();
+
+        let service = CoreHandle::new(state).respond_service();
+        for input in ["看看已完成", "恢复第 1 个"] {
+            let req: RespondRequest = private_request(input).into();
+            assert_eq!(
+                service.plan_core_respond(&req).unwrap(),
+                RespondPlan::CompleteToolLoop,
+                "{input}"
+            );
+        }
+    }
+
+    #[test]
+    fn core_plan_keeps_pending_confirmation_immediate() {
+        let provider = TestProvider::replying("unused")
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+        let state = test_state_with_tool_calling(provider, 5, true);
+        let session_store = state.session_store.clone();
+        let meta = SessionMeta::new(
+            "private:u1",
+            Some("u1".to_owned()),
+            None,
+            None,
+            None,
+            "qq_official",
+        );
+        let mut session = session_store.get_or_create_active(&meta).unwrap();
+        session.pending_operation = Some(PendingOperation::TodoAdd {
+            initiator_user_id: Some("u1".to_owned()),
+            owner_key: "private:u1".to_owned(),
+            draft: TodoItemDraft {
+                title: "检查日志".to_owned(),
+                detail: None,
+                raw_text: Some("检查日志".to_owned()),
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+            allow_revision: true,
+            created_at: "2026-06-30T00:00:00+08:00".to_owned(),
+        });
+        session_store.save(&mut session).unwrap();
+
+        let service = CoreHandle::new(state).respond_service();
+        let req: RespondRequest = private_request("确认").into();
+
+        assert_eq!(
+            service.plan_core_respond(&req).unwrap(),
+            RespondPlan::Immediate
+        );
+    }
+
+    #[test]
+    fn core_plan_keeps_group_chat_streaming_even_when_tool_capable() {
+        let provider = TestProvider::replying("群聊回复")
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+        let state = test_state_with_tool_calling(provider, 5, true);
+        let service = CoreHandle::new(state).respond_service();
+        let req: RespondRequest = group_request("杭州明天要带伞吗").into();
+
+        assert_eq!(
+            service.plan_core_respond(&req).unwrap(),
+            RespondPlan::StreamingChat
+        );
     }
 
     #[tokio::test]
@@ -919,6 +999,26 @@ mod tests {
             panic!("expected complete output for tool loop path");
         };
         assert_eq!(response.text.as_deref(), Some("工具完整回复"));
+        assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn core_private_todo_query_uses_complete_tool_loop_path() {
+        let provider = TestProvider::replying("待办工具回复")
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+        let state = test_state_with_tool_calling(provider.clone(), 5, true);
+        let service = CoreHandle::new(state);
+
+        let output = service
+            .respond(private_request("看看已完成"))
+            .await
+            .unwrap();
+
+        let CoreRespondOutput::Complete(response) = output else {
+            panic!("expected complete output for todo tool loop path");
+        };
+        assert_eq!(response.text.as_deref(), Some("待办工具回复"));
         assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
         assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
     }

--- a/qq-maid-core/src/service.rs
+++ b/qq-maid-core/src/service.rs
@@ -661,8 +661,8 @@ mod tests {
             prompt::PromptConfig,
             query::{QueryExecutor, QueryOutcome, QueryRequest},
             rss::{RssFetchConfig, RssFetcher, RssStore},
-            session::{SessionMeta, SessionStore},
-            todo::{TodoItemDraft, TodoStore, TodoTimePrecision},
+            session::{LastTodoAction, SessionMeta, SessionStore},
+            todo::{TodoItemDraft, TodoStatus, TodoStore, TodoTimePrecision},
             train::{TrainExecutor, TrainSchedule, TrainScheduleRequest},
             weather::{WeatherExecutor, WeatherOutcome, WeatherRequest},
         },
@@ -782,7 +782,24 @@ mod tests {
     }
 
     #[test]
-    fn core_plan_routes_todo_query_and_followup_to_complete_tool_loop() {
+    fn core_plan_routes_simple_todo_queries_to_immediate() {
+        let provider = TestProvider::replying("工具回复")
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+        let state = test_state_with_tool_calling(provider, 5, true);
+        let service = CoreHandle::new(state).respond_service();
+
+        for input in ["看一下待办", "看一下代办", "看看已完成"] {
+            let req: RespondRequest = private_request(input).into();
+            assert_eq!(
+                service.plan_core_respond(&req).unwrap(),
+                RespondPlan::Immediate,
+                "{input}"
+            );
+        }
+    }
+
+    #[test]
+    fn core_plan_routes_todo_mutations_and_followups_to_complete_tool_loop() {
         let provider = TestProvider::replying("工具回复")
             .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
         let state = test_state_with_tool_calling(provider, 5, true);
@@ -803,10 +820,23 @@ mod tests {
             result_ids: vec!["todo-1".to_owned()],
             created_at: "2026-06-30T00:00:00+08:00".to_owned(),
         });
+        session.last_todo_action = Some(LastTodoAction {
+            owner_key: "private:u1".to_owned(),
+            item_id: "todo-1".to_owned(),
+            title: "检查日志".to_owned(),
+            action: "completed".to_owned(),
+            resulting_status: TodoStatus::Completed,
+            created_at: "2026-06-30T00:00:00+08:00".to_owned(),
+        });
         session_store.save(&mut session).unwrap();
 
         let service = CoreHandle::new(state).respond_service();
-        for input in ["看看已完成", "恢复第 1 个"] {
+        for input in [
+            "提醒我明天下午三点开会",
+            "完成第一条",
+            "恢复第 1 个",
+            "取消它",
+        ] {
             let req: RespondRequest = private_request(input).into();
             assert_eq!(
                 service.plan_core_respond(&req).unwrap(),
@@ -1004,22 +1034,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn core_private_todo_query_uses_complete_tool_loop_path() {
-        let provider = TestProvider::replying("待办工具回复")
+    async fn core_private_simple_todo_queries_use_deterministic_path() {
+        let provider = TestProvider::replying("不应调用模型")
             .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
         let state = test_state_with_tool_calling(provider.clone(), 5, true);
+        let owner = TodoStore::owner(Some("u1"), "private:u1");
+        let todo_store = state.todo_store.clone();
+        todo_store
+            .create(
+                &owner,
+                TodoItemDraft {
+                    title: "待查看项目".to_owned(),
+                    detail: None,
+                    raw_text: None,
+                    due_date: None,
+                    due_at: None,
+                    time_precision: TodoTimePrecision::None,
+                },
+            )
+            .unwrap();
         let service = CoreHandle::new(state);
 
-        let output = service
-            .respond(private_request("看看已完成"))
-            .await
-            .unwrap();
+        let mut responses = Vec::new();
+        for input in ["看一下待办", "看一下代办"] {
+            let output = service.respond(private_request(input)).await.unwrap();
+            let CoreRespondOutput::Complete(response) = output else {
+                panic!("expected complete output for deterministic todo query");
+            };
+            assert_eq!(response.command.as_deref(), Some("todo_list"), "{input}");
+            assert!(response.text.as_deref().unwrap().contains("待查看项目"));
+            responses.push(response.text);
+        }
 
-        let CoreRespondOutput::Complete(response) = output else {
-            panic!("expected complete output for todo tool loop path");
-        };
-        assert_eq!(response.text.as_deref(), Some("待办工具回复"));
-        assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(responses[0], responses[1]);
+        assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
         assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
     }
 


### PR DESCRIPTION
## 变更

修复 #96。

- Core 在决定返回 `CoreResponseStream` 前复用现有 `classify_inbound`，避免 pending、自然语言待办查询等完整业务流程被简单“非 slash”规则误送进 stream 入口。
- 私聊普通聊天的 Tool Loop 改为按明确工具意图接管：天气、Todo 写操作、现有 Todo 查询/续指短句继续走完整 Tool Loop；其它普通聊天恢复 `stream_chat` 真流式输出。
- 增加脱敏路由日志，用于区分“普通聊天进入 stream”和“因工具意图绕过 stream”。
- 补充 Core/RespondService 测试，覆盖 provider 支持 Tool Calling 时普通聊天仍走 stream、天气/Todo 场景仍保留 Tool Loop。

## 根因

默认配置开启 `TOOL_CALLING_ENABLED=true`，且 OpenAI Responses provider 支持 Tool Calling 时，原逻辑会让所有私聊普通聊天绕过 `CoreResponseStream`，直接走 `Complete` 的 Tool Loop 路径。Gateway 因此只看到完整响应，不会进入 C2C Markdown 流式发送状态机。

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`