### PR TITLE
fix: 统一 Todo 查询最近可见列表快照读写

### DIFF
--- a/qq-maid-core/src/runtime/respond.rs
+++ b/qq-maid-core/src/runtime/respond.rs
@@ -15,7 +15,7 @@ use crate::{
         prompt::PromptConfig,
         query::DynQueryExecutor,
         rss::{RssFetcher, RssStore},
-        session::{SessionMeta, SessionStore},
+        session::{SessionMeta, SessionRecord, SessionStore},
         todo::TodoStore,
         tools::{
             CancelTodoTool, CompleteTodoTool, CreateTodoTool, DeleteTodoTool, EditTodoTool,
@@ -47,11 +47,13 @@ mod session_flow;
 mod tests;
 mod title;
 mod todo_flow;
+mod tool_route;
 mod train_flow;
 mod translation_flow;
 mod weather_flow;
 
 use common::{clean_string, session_error};
+use tool_route::{ToolLoopRoute, ToolRouteContext};
 
 /// `RustRespondService` 需要的持久化存储集合。
 ///
@@ -103,6 +105,19 @@ pub struct RespondServiceOptions {
     pub tool_calling_enabled: bool,
     /// 单次 Tool Loop 最大工具调用轮数。
     pub tool_calling_max_rounds: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RespondPlan {
+    Immediate,
+    StreamingChat,
+    CompleteToolLoop,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChatToolPlan {
+    Plain,
+    ForceCompleteToolLoop,
 }
 
 /// Rust 原生实现的响应服务。
@@ -234,6 +249,65 @@ impl RustRespondService {
         }
     }
 
+    /// 为响应入口计算本轮响应计划。
+    ///
+    /// 这里是普通聊天是否走流式、是否因当前已接入的 Weather/Todo Tool
+    /// 进入 Complete Tool Loop 的唯一决策点。pending 和确定性命令仍优先
+    /// 走 `Immediate`，避免完整业务流程误入 stream。
+    pub(crate) fn plan_core_respond(&self, req: &RespondRequest) -> Result<RespondPlan, LlmError> {
+        let user_text = req.effective_user_text();
+        let trimmed = user_text.trim();
+        if trimmed.is_empty() {
+            return Ok(RespondPlan::Immediate);
+        }
+
+        let meta = respond_meta(req);
+        let active_session = self
+            .session_store
+            .get_active(&meta)
+            .map_err(session_error)?;
+        if pending_blocks_immediate(&user_text, active_session.as_ref()) {
+            return Ok(RespondPlan::Immediate);
+        }
+
+        if search_flow::parse_web_search_command(&user_text).is_some() {
+            return Ok(RespondPlan::StreamingChat);
+        }
+        if trimmed.starts_with('/') || trimmed.starts_with('／') {
+            return Ok(RespondPlan::Immediate);
+        }
+
+        let tool_route = self.route_tool_loop(req, active_session.as_ref());
+        if matches!(tool_route, ToolLoopRoute::CompleteToolLoop) {
+            return Ok(RespondPlan::CompleteToolLoop);
+        }
+
+        let classification = classify_inbound_with_active(&user_text, active_session.as_ref());
+        if matches!(classification.kind, CoreInboundKind::Immediate) {
+            Ok(RespondPlan::Immediate)
+        } else {
+            Ok(RespondPlan::StreamingChat)
+        }
+    }
+
+    fn route_tool_loop(
+        &self,
+        req: &RespondRequest,
+        active_session: Option<&SessionRecord>,
+    ) -> ToolLoopRoute {
+        tool_route::route_tool_loop(
+            req,
+            ToolRouteContext {
+                tool_calling_enabled: self.tool_calling_enabled,
+                provider_supports_tool_calling: self
+                    .provider
+                    .tool_calling_protocol(req.model.as_deref())
+                    .is_some(),
+                active_session,
+            },
+        )
+    }
+
     /// 统一的请求响应入口。
     ///
     /// 分派顺序：
@@ -247,15 +321,17 @@ impl RustRespondService {
     /// 8. 检查是否为**长期记忆操作**。
     /// 9. 兜底：进入**普通聊天**处理流程。
     pub async fn respond(&self, req: RespondRequest) -> Result<RespondResponse, LlmError> {
+        let plan = self.plan_core_respond(&req)?;
+        self.respond_with_plan(req, plan).await
+    }
+
+    pub(crate) async fn respond_with_plan(
+        &self,
+        req: RespondRequest,
+        plan: RespondPlan,
+    ) -> Result<RespondResponse, LlmError> {
         let user_text = req.effective_user_text();
-        let meta = SessionMeta::new(
-            req.scope_key.clone(),
-            req.user_id.clone(),
-            req.group_id.clone(),
-            req.guild_id.clone(),
-            req.channel_id.clone(),
-            clean_string(req.platform.clone()).unwrap_or_else(|| "qq".to_owned()),
-        );
+        let meta = respond_meta(&req);
 
         // 尝试获取当前会话的活跃记录
         let mut active_session = self
@@ -288,6 +364,7 @@ impl RustRespondService {
                 .get_or_create_active(&meta)
                 .map_err(session_error)?,
         };
+        let force_tool_loop = matches!(plan, RespondPlan::CompleteToolLoop);
 
         // 检查是否为翻译指令（如 "/翻译 文本"、"/翻译日语 文本"）
         if let Some(command) = translation_flow::parse_translation_command(&user_text) {
@@ -323,24 +400,34 @@ impl RustRespondService {
             return Ok(response);
         }
 
-        // 检查是否为待办相关操作（新增、查看、完成、编辑、删除等）
-        if let Some(response) = self
-            .handle_todo_flow(&user_text, &meta, &mut session)
-            .await?
-        {
-            return Ok(response);
+        // Core 计划已判定为 CompleteToolLoop 时，Todo 查询/续指等自然语言工具意图
+        // 交给 Tool Loop 处理；slash 命令和 pending 已在前面保持完整响应路径。
+        if !force_tool_loop {
+            // 检查是否为待办相关操作（新增、查看、完成、编辑、删除等）
+            if let Some(response) = self
+                .handle_todo_flow(&user_text, &meta, &mut session)
+                .await?
+            {
+                return Ok(response);
+            }
         }
 
         // 检查是否为长期记忆相关操作（记忆新增、查看、更新、删除等）
-        if let Some(response) = self
-            .handle_memory_flow(&user_text, &meta, &mut session)
-            .await?
+        if !force_tool_loop
+            && let Some(response) = self
+                .handle_memory_flow(&user_text, &meta, &mut session)
+                .await?
         {
             return Ok(response);
         }
 
         // 兜底：进入普通 LLM 聊天流程
-        self.handle_chat(req, user_text, meta, session).await
+        let chat_plan = match plan {
+            RespondPlan::CompleteToolLoop => ChatToolPlan::ForceCompleteToolLoop,
+            RespondPlan::Immediate | RespondPlan::StreamingChat => ChatToolPlan::Plain,
+        };
+        self.handle_chat(req, user_text, meta, session, chat_plan)
+            .await
     }
 
     /// 轻量判断物理入站消息是否可以进入短窗口聚合。
@@ -352,49 +439,22 @@ impl RustRespondService {
         req: RespondRequest,
     ) -> Result<CoreInboundClassification, LlmError> {
         let user_text = req.effective_user_text();
-        let meta = SessionMeta::new(
-            req.scope_key.clone(),
-            req.user_id.clone(),
-            req.group_id.clone(),
-            req.guild_id.clone(),
-            req.channel_id.clone(),
-            clean_string(req.platform.clone()).unwrap_or_else(|| "qq".to_owned()),
-        );
+        let meta = respond_meta(&req);
         let active_session = self
             .session_store
             .get_active(&meta)
             .map_err(session_error)?;
 
-        let bypass_pending_for_session_command =
-            session_flow::parse_pending_bypass_session_command(&user_text).is_some();
-        if !bypass_pending_for_session_command
-            && active_session
-                .as_ref()
-                .and_then(|session| session.pending_operation.as_ref())
-                .is_some()
-        {
+        if pending_blocks_immediate(&user_text, active_session.as_ref()) {
             return Ok(CoreInboundClassification {
                 kind: CoreInboundKind::Immediate,
             });
         }
 
-        let is_command = session_flow::parse_session_command(&user_text).is_some()
-            || translation_flow::parse_translation_command(&user_text).is_some()
-            || weather_flow::parse_weather_command(&user_text).is_some()
-            || train_flow::parse_train_command(&user_text).is_some()
-            || search_flow::parse_web_search_command(&user_text).is_some()
-            || rss_flow::parse_rss_command(&user_text).is_some()
-            || todo_flow::parse_todo_command(&user_text).is_some()
-            || todo_flow::is_natural_todo_query_text(&user_text)
-            || memory_flow::parse_memory_command(&user_text).is_some();
-
-        Ok(CoreInboundClassification {
-            kind: if is_command {
-                CoreInboundKind::Immediate
-            } else {
-                CoreInboundKind::NormalChat
-            },
-        })
+        Ok(classify_inbound_with_active(
+            &user_text,
+            active_session.as_ref(),
+        ))
     }
 
     /// 仅供 Core 进程内 stream 边界使用的真流式入口。
@@ -409,14 +469,7 @@ impl RustRespondService {
         F: FnMut(String) -> Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send>> + Send,
     {
         let user_text = req.effective_user_text();
-        let meta = SessionMeta::new(
-            req.scope_key.clone(),
-            req.user_id.clone(),
-            req.group_id.clone(),
-            req.guild_id.clone(),
-            req.channel_id.clone(),
-            clean_string(req.platform.clone()).unwrap_or_else(|| "qq".to_owned()),
-        );
+        let meta = respond_meta(&req);
         let mut active_session = self
             .session_store
             .get_active(&meta)
@@ -452,5 +505,54 @@ impl RustRespondService {
         }
 
         self.handle_chat_stream(req, on_delta).await
+    }
+}
+
+fn respond_meta(req: &RespondRequest) -> SessionMeta {
+    SessionMeta::new(
+        req.scope_key.clone(),
+        req.user_id.clone(),
+        req.group_id.clone(),
+        req.guild_id.clone(),
+        req.channel_id.clone(),
+        clean_string(req.platform.clone()).unwrap_or_else(|| "qq".to_owned()),
+    )
+}
+
+fn pending_blocks_immediate(user_text: &str, active_session: Option<&SessionRecord>) -> bool {
+    let bypass_pending_for_session_command =
+        session_flow::parse_pending_bypass_session_command(user_text).is_some();
+    !bypass_pending_for_session_command
+        && active_session
+            .and_then(|session| session.pending_operation.as_ref())
+            .is_some()
+}
+
+fn classify_inbound_with_active(
+    user_text: &str,
+    active_session: Option<&SessionRecord>,
+) -> CoreInboundClassification {
+    if pending_blocks_immediate(user_text, active_session) {
+        return CoreInboundClassification {
+            kind: CoreInboundKind::Immediate,
+        };
+    }
+
+    let is_command = session_flow::parse_session_command(user_text).is_some()
+        || translation_flow::parse_translation_command(user_text).is_some()
+        || weather_flow::parse_weather_command(user_text).is_some()
+        || train_flow::parse_train_command(user_text).is_some()
+        || search_flow::parse_web_search_command(user_text).is_some()
+        || rss_flow::parse_rss_command(user_text).is_some()
+        || todo_flow::parse_todo_command(user_text).is_some()
+        || todo_flow::is_natural_todo_query_text(user_text)
+        || memory_flow::parse_memory_command(user_text).is_some();
+
+    CoreInboundClassification {
+        kind: if is_command {
+            CoreInboundKind::Immediate
+        } else {
+            CoreInboundKind::NormalChat
+        },
     }
 }

--- a/qq-maid-core/src/runtime/respond.rs
+++ b/qq-maid-core/src/runtime/respond.rs
@@ -277,14 +277,16 @@ impl RustRespondService {
             return Ok(RespondPlan::Immediate);
         }
 
-        let tool_route = self.route_tool_loop(req, active_session.as_ref());
-        if matches!(tool_route, ToolLoopRoute::CompleteToolLoop) {
-            return Ok(RespondPlan::CompleteToolLoop);
-        }
-
+        // 先保护已有确定性命令和自然语言 Todo 查询，避免简单列表查询绕过
+        // `handle_todo_flow()` 进入模型 Tool Loop，回归同义词和默认过滤语义。
         let classification = classify_inbound_with_active(&user_text, active_session.as_ref());
         if matches!(classification.kind, CoreInboundKind::Immediate) {
-            Ok(RespondPlan::Immediate)
+            return Ok(RespondPlan::Immediate);
+        }
+
+        let tool_route = self.route_tool_loop(req, active_session.as_ref());
+        if matches!(tool_route, ToolLoopRoute::CompleteToolLoop) {
+            Ok(RespondPlan::CompleteToolLoop)
         } else {
             Ok(RespondPlan::StreamingChat)
         }

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -19,9 +19,9 @@ use crate::{
 use super::{
     RespondPurpose, RespondRequest, RespondResponse, RustRespondService,
     common::{
-        SESSION_HISTORY_MESSAGE_LIMIT, SESSION_STATE_SHORT_TEXT_LIMIT, command_response,
-        empty_respond_request, memory_error, merge_metadata, session_error, state_string,
-        truncate_chars,
+        SESSION_HISTORY_MESSAGE_LIMIT, SESSION_STATE_SHORT_TEXT_LIMIT, clean_string,
+        command_response, empty_respond_request, memory_error, merge_metadata, session_error,
+        state_string, truncate_chars,
     },
     llm_service::{ChatService, LlmChatService, response_from_output},
     session_flow::build_session_context,
@@ -31,6 +31,57 @@ use super::{
 mod todo_guard;
 
 impl RustRespondService {
+    /// 判断私聊普通聊天是否确实需要 Tool Loop 接管。
+    ///
+    /// Tool Calling 会走完整响应路径，无法把 provider token delta 直接交给
+    /// Gateway；因此只有天气和 Todo 这类明确工具意图才进入 Tool Loop，其它普通
+    /// 聊天保持 `stream_chat` 真流式输出。
+    pub(crate) fn should_use_tool_loop_for_chat(
+        &self,
+        req: &RespondRequest,
+    ) -> Result<bool, LlmError> {
+        if !self.tool_calling_enabled {
+            return Ok(false);
+        }
+        let service = LlmChatService::new(self.provider.clone());
+        if !service.supports_tool_calling(req.model.as_deref()) {
+            return Ok(false);
+        }
+        let user_text = req.effective_user_text();
+        let trimmed = user_text.trim();
+        if trimmed.is_empty()
+            || trimmed.starts_with('/')
+            || trimmed.starts_with('／')
+            || req
+                .group_id
+                .as_deref()
+                .is_some_and(|value| !value.is_empty())
+        {
+            return Ok(false);
+        }
+
+        let meta = SessionMeta::new(
+            req.scope_key.clone(),
+            req.user_id.clone(),
+            req.group_id.clone(),
+            req.guild_id.clone(),
+            req.channel_id.clone(),
+            clean_string(req.platform.clone()).unwrap_or_else(|| "qq".to_owned()),
+        );
+        let session = self
+            .session_store
+            .get_or_create_active(&meta)
+            .map_err(session_error)?;
+        let should_use = looks_like_weather_tool_request(trimmed)
+            || looks_like_todo_tool_request(trimmed, &session);
+        tracing::debug!(
+            scope_key = %req.scope_key,
+            tool_loop_intent = should_use,
+            "private chat tool loop intent classified"
+        );
+        Ok(should_use)
+    }
+
     /// 处理普通聊天请求。
     ///
     /// 1. 空消息直接返回提示。
@@ -131,8 +182,7 @@ impl RustRespondService {
             ..empty_respond_request()
         };
         let service = LlmChatService::new(self.provider.clone());
-        let use_tool_loop =
-            self.tool_calling_enabled && !is_group_chat && service.supports_tool_calling(None);
+        let use_tool_loop = self.should_use_tool_loop_for_chat(&chat_req)?;
         let todo_requirement = if use_tool_loop {
             todo_guard::required_todo_tool_kind(&user_text, &session)
         } else {
@@ -667,6 +717,64 @@ fn looks_like_correction(text: &str) -> bool {
 /// 检查文本是否包含关键字列表中的任意一个。
 fn contains_any(text: &str, needles: &[&str]) -> bool {
     needles.iter().any(|needle| text.contains(needle))
+}
+
+/// 判断普通私聊是否明显需要天气 Tool。
+///
+/// 这里不是替代模型决策，只是避免所有私聊都被 Tool Loop 抢走流式链路；
+/// 命中后仍由模型决定是否真正调用 `get_weather`。
+fn looks_like_weather_tool_request(text: &str) -> bool {
+    contains_any(
+        text,
+        &[
+            "天气",
+            "下雨",
+            "下雪",
+            "带伞",
+            "温度",
+            "气温",
+            "几度",
+            "降雨",
+            "降雪",
+            "空气质量",
+            "雾霾",
+            "预警",
+            "台风",
+            "风力",
+            "冷不冷",
+            "热不热",
+            "穿什么",
+        ],
+    )
+}
+
+/// 判断普通私聊是否明显需要 Todo Tool。
+///
+/// 写操作复用 `todo_guard` 的严格判定；查询类只覆盖现有 Tool Loop 语义中
+/// 需要模型绑定可见编号/最近对象的短句，避免“聊聊待办设计”这类普通聊天误入工具链路。
+fn looks_like_todo_tool_request(text: &str, session: &SessionRecord) -> bool {
+    if todo_guard::required_todo_tool_kind(text, session).is_some() {
+        return true;
+    }
+    if super::todo_flow::is_natural_todo_query_text(text) {
+        return true;
+    }
+    contains_any(
+        text,
+        &[
+            "看看已完成",
+            "查看已完成",
+            "列出已完成",
+            "看看已取消",
+            "查看已取消",
+            "列出已取消",
+            "看看待办",
+            "查看待办",
+            "列出待办",
+            "还有什么待办",
+            "有哪些待办",
+        ],
+    )
 }
 
 /// 判断是否为短接续句（字符数 <= 24）。

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -17,71 +17,20 @@ use crate::{
 };
 
 use super::{
-    RespondPurpose, RespondRequest, RespondResponse, RustRespondService,
+    ChatToolPlan, RespondPurpose, RespondRequest, RespondResponse, RustRespondService,
     common::{
-        SESSION_HISTORY_MESSAGE_LIMIT, SESSION_STATE_SHORT_TEXT_LIMIT, clean_string,
-        command_response, empty_respond_request, memory_error, merge_metadata, session_error,
-        state_string, truncate_chars,
+        SESSION_HISTORY_MESSAGE_LIMIT, SESSION_STATE_SHORT_TEXT_LIMIT, command_response,
+        empty_respond_request, memory_error, merge_metadata, session_error, state_string,
+        truncate_chars,
     },
     llm_service::{ChatService, LlmChatService, response_from_output},
     session_flow::build_session_context,
     title::{context_session_title, generate_session_title},
 };
 
-mod todo_guard;
+pub(super) mod todo_guard;
 
 impl RustRespondService {
-    /// 判断私聊普通聊天是否确实需要 Tool Loop 接管。
-    ///
-    /// Tool Calling 会走完整响应路径，无法把 provider token delta 直接交给
-    /// Gateway；因此只有天气和 Todo 这类明确工具意图才进入 Tool Loop，其它普通
-    /// 聊天保持 `stream_chat` 真流式输出。
-    pub(crate) fn should_use_tool_loop_for_chat(
-        &self,
-        req: &RespondRequest,
-    ) -> Result<bool, LlmError> {
-        if !self.tool_calling_enabled {
-            return Ok(false);
-        }
-        let service = LlmChatService::new(self.provider.clone());
-        if !service.supports_tool_calling(req.model.as_deref()) {
-            return Ok(false);
-        }
-        let user_text = req.effective_user_text();
-        let trimmed = user_text.trim();
-        if trimmed.is_empty()
-            || trimmed.starts_with('/')
-            || trimmed.starts_with('／')
-            || req
-                .group_id
-                .as_deref()
-                .is_some_and(|value| !value.is_empty())
-        {
-            return Ok(false);
-        }
-
-        let meta = SessionMeta::new(
-            req.scope_key.clone(),
-            req.user_id.clone(),
-            req.group_id.clone(),
-            req.guild_id.clone(),
-            req.channel_id.clone(),
-            clean_string(req.platform.clone()).unwrap_or_else(|| "qq".to_owned()),
-        );
-        let session = self
-            .session_store
-            .get_or_create_active(&meta)
-            .map_err(session_error)?;
-        let should_use = looks_like_weather_tool_request(trimmed)
-            || looks_like_todo_tool_request(trimmed, &session);
-        tracing::debug!(
-            scope_key = %req.scope_key,
-            tool_loop_intent = should_use,
-            "private chat tool loop intent classified"
-        );
-        Ok(should_use)
-    }
-
     /// 处理普通聊天请求。
     ///
     /// 1. 空消息直接返回提示。
@@ -97,6 +46,7 @@ impl RustRespondService {
         user_text: String,
         meta: SessionMeta,
         mut session: SessionRecord,
+        chat_tool_plan: ChatToolPlan,
     ) -> Result<RespondResponse, LlmError> {
         if user_text.trim().is_empty() {
             let reply = "唔，小女仆在。可以直接说要我看哪一块。";
@@ -182,7 +132,7 @@ impl RustRespondService {
             ..empty_respond_request()
         };
         let service = LlmChatService::new(self.provider.clone());
-        let use_tool_loop = self.should_use_tool_loop_for_chat(&chat_req)?;
+        let use_tool_loop = matches!(chat_tool_plan, ChatToolPlan::ForceCompleteToolLoop);
         let todo_requirement = if use_tool_loop {
             todo_guard::required_todo_tool_kind(&user_text, &session)
         } else {
@@ -342,7 +292,9 @@ impl RustRespondService {
             .get_or_create_active(&meta)
             .map_err(session_error)?;
         if user_text.trim().is_empty() {
-            return self.handle_chat(req, user_text, meta, session).await;
+            return self
+                .handle_chat(req, user_text, meta, session, ChatToolPlan::Plain)
+                .await;
         }
 
         update_session_state_from_user(&mut session, &user_text);
@@ -717,64 +669,6 @@ fn looks_like_correction(text: &str) -> bool {
 /// 检查文本是否包含关键字列表中的任意一个。
 fn contains_any(text: &str, needles: &[&str]) -> bool {
     needles.iter().any(|needle| text.contains(needle))
-}
-
-/// 判断普通私聊是否明显需要天气 Tool。
-///
-/// 这里不是替代模型决策，只是避免所有私聊都被 Tool Loop 抢走流式链路；
-/// 命中后仍由模型决定是否真正调用 `get_weather`。
-fn looks_like_weather_tool_request(text: &str) -> bool {
-    contains_any(
-        text,
-        &[
-            "天气",
-            "下雨",
-            "下雪",
-            "带伞",
-            "温度",
-            "气温",
-            "几度",
-            "降雨",
-            "降雪",
-            "空气质量",
-            "雾霾",
-            "预警",
-            "台风",
-            "风力",
-            "冷不冷",
-            "热不热",
-            "穿什么",
-        ],
-    )
-}
-
-/// 判断普通私聊是否明显需要 Todo Tool。
-///
-/// 写操作复用 `todo_guard` 的严格判定；查询类只覆盖现有 Tool Loop 语义中
-/// 需要模型绑定可见编号/最近对象的短句，避免“聊聊待办设计”这类普通聊天误入工具链路。
-fn looks_like_todo_tool_request(text: &str, session: &SessionRecord) -> bool {
-    if todo_guard::required_todo_tool_kind(text, session).is_some() {
-        return true;
-    }
-    if super::todo_flow::is_natural_todo_query_text(text) {
-        return true;
-    }
-    contains_any(
-        text,
-        &[
-            "看看已完成",
-            "查看已完成",
-            "列出已完成",
-            "看看已取消",
-            "查看已取消",
-            "列出已取消",
-            "看看待办",
-            "查看待办",
-            "列出待办",
-            "还有什么待办",
-            "有哪些待办",
-        ],
-    )
 }
 
 /// 判断是否为短接续句（字符数 <= 24）。

--- a/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
@@ -65,6 +65,18 @@ pub(super) fn required_todo_tool_kind(
     user_text: &str,
     session: &SessionRecord,
 ) -> Option<TodoMutationToolKind> {
+    required_todo_tool_kind_with_context(
+        user_text,
+        session.last_todo_query.is_some(),
+        session.last_todo_action.is_some(),
+    )
+}
+
+fn required_todo_tool_kind_with_context(
+    user_text: &str,
+    has_last_todo_query: bool,
+    has_last_todo_action: bool,
+) -> Option<TodoMutationToolKind> {
     let text = user_text.trim();
     if text.is_empty() {
         return None;
@@ -83,10 +95,8 @@ pub(super) fn required_todo_tool_kind(
     // 完成/取消/恢复/删除必须同时存在 Todo 目标上下文，否则普通聊天里的
     // “完成项目/取消会议/删除日志”会被误强制成 Todo Tool，甚至真的修改用户待办。
     let has_todo_noun = contains_any(text, &["待办", "任务", "todo"]);
-    let has_visible_reference =
-        contains_visible_number_reference(text) && session.last_todo_query.is_some();
-    let has_last_reference =
-        contains_last_todo_reference(text) && session.last_todo_action.is_some();
+    let has_visible_reference = contains_visible_number_reference(text) && has_last_todo_query;
+    let has_last_reference = contains_last_todo_reference(text) && has_last_todo_action;
     if !(has_todo_noun || has_visible_reference || has_last_reference) {
         return None;
     }
@@ -113,6 +123,15 @@ pub(super) fn required_todo_tool_kind(
         return Some(TodoMutationToolKind::Cancel);
     }
     None
+}
+
+pub(in crate::runtime::respond) fn requires_todo_tool_with_context(
+    user_text: &str,
+    has_last_todo_query: bool,
+    has_last_todo_action: bool,
+) -> bool {
+    required_todo_tool_kind_with_context(user_text, has_last_todo_query, has_last_todo_action)
+        .is_some()
 }
 
 /// 识别明确的待办创建意图。

--- a/qq-maid-core/src/runtime/respond/common.rs
+++ b/qq-maid-core/src/runtime/respond/common.rs
@@ -5,18 +5,10 @@
 
 use std::collections::HashMap;
 
-use chrono::{DateTime, Duration};
 pub(super) use qq_maid_common::text::truncate_chars_with_ellipsis_trimmed as truncate_chars;
 use serde_json::{Value, json};
 
-use crate::{
-    error::LlmError,
-    runtime::session::SessionRecord,
-    util::{
-        metrics::LlmMetrics,
-        time_context::{now_iso_cn, shanghai_offset},
-    },
-};
+use crate::{error::LlmError, runtime::session::SessionRecord, util::metrics::LlmMetrics};
 
 use super::{RespondPurpose, RespondRequest, RespondResponse};
 
@@ -77,18 +69,11 @@ pub(super) const COMPACT_KEEP_MESSAGE_LIMIT: usize = 16;
 /// 写入会话状态的短文本最大长度
 pub(super) const SESSION_STATE_SHORT_TEXT_LIMIT: usize = 48;
 /// 最近查询结果的 TTL（秒）
-pub(super) const LAST_QUERY_TTL_SECONDS: i64 = 10 * 60;
+pub(super) const LAST_QUERY_TTL_SECONDS: i64 = crate::runtime::session::LAST_QUERY_TTL_SECONDS;
 
 /// 判断一条“最近查询”记录是否仍在有效期内（created_at 为 RFC3339，TTL 单位为秒）。
 pub(super) fn query_is_fresh(created_at: &str, ttl_seconds: i64) -> bool {
-    let Ok(created_at) = DateTime::parse_from_rfc3339(created_at.trim()) else {
-        return false;
-    };
-    let Ok(now) = DateTime::parse_from_rfc3339(&now_iso_cn()) else {
-        return false;
-    };
-    let age = now.signed_duration_since(created_at.with_timezone(&shanghai_offset()));
-    age >= Duration::zero() && age.num_seconds() <= ttl_seconds
+    crate::runtime::session::query_is_fresh(created_at, ttl_seconds)
 }
 
 /// 构造一个空的 `RespondRequest`，各字段均为默认值。

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -788,6 +788,470 @@ async fn natural_language_todo_query_aliases_and_filters_stay_deterministic() {
 }
 
 #[tokio::test]
+async fn deterministic_pending_query_then_tool_loop_complete_first_uses_latest_snapshot() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let first = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "测试代办".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    let second = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "明天晚上搬到16栋".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+
+    let listed = service
+        .respond(private_message("看一下待办"))
+        .await
+        .unwrap();
+    assert_eq!(listed.command.as_deref(), Some("todo_list"));
+    let listed_text = listed.text.unwrap();
+    assert!(listed_text.contains("1. 测试代办"));
+    assert!(listed_text.contains("2. 明天晚上搬到16栋"));
+    assert_eq!(inspector.tool_call_count(), 0);
+
+    let session = service
+        .session_store
+        .get_or_create_active(&private_test_meta())
+        .unwrap();
+    let snapshot = session.last_todo_query.expect("missing todo snapshot");
+    assert_eq!(snapshot.query_type, "list");
+    assert_eq!(
+        snapshot.result_ids,
+        vec![first.id.clone(), second.id.clone()]
+    );
+
+    let _ = service
+        .respond(private_message("完成第一条"))
+        .await
+        .unwrap();
+    assert!(inspector.tool_call_count() >= 1);
+    let mut tool_requests = inspector.tool_requests();
+    let tool_request = tool_requests.pop().expect("missing tool request");
+    let completed_output = tool_request
+        .tools
+        .execute_json(
+            &tool_request.tool_context,
+            "complete_todos",
+            r#"{"numbers":[1],"reference":null}"#,
+        )
+        .await
+        .unwrap();
+    let completed: Value = serde_json::from_str(&completed_output).unwrap();
+    assert_eq!(completed["ok"], true);
+    assert_eq!(completed["completed"][0]["visible_number"], 1);
+    assert_eq!(completed["completed"][0]["title"], "测试代办");
+
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &first.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Completed
+    );
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &second.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
+}
+
+#[tokio::test]
+async fn deterministic_todo_query_alias_then_tool_loop_complete_first_uses_latest_snapshot() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let first = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "代办 A".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "代办 B".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+
+    let listed = service
+        .respond(private_message("看一下代办"))
+        .await
+        .unwrap();
+    assert_eq!(listed.command.as_deref(), Some("todo_list"));
+    assert!(listed.text.as_deref().unwrap().contains("1. 代办 A"));
+
+    let _ = service
+        .respond(private_message("完成第一条"))
+        .await
+        .unwrap();
+    let tool_request = inspector
+        .tool_requests()
+        .pop()
+        .expect("missing tool request after alias query");
+    let completed_output = tool_request
+        .tools
+        .execute_json(
+            &tool_request.tool_context,
+            "complete_todos",
+            r#"{"numbers":[1],"reference":null}"#,
+        )
+        .await
+        .unwrap();
+    let completed: Value = serde_json::from_str(&completed_output).unwrap();
+    assert_eq!(completed["ok"], true);
+    assert_eq!(completed["completed"][0]["title"], "代办 A");
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &first.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Completed
+    );
+}
+
+#[tokio::test]
+async fn deterministic_completed_query_then_tool_loop_restore_first_uses_latest_snapshot() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let first = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "已完成 A".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    let second = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "已完成 B".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    service.todo_store.complete(&owner, &first.id).unwrap();
+    service.todo_store.complete(&owner, &second.id).unwrap();
+
+    let listed = service
+        .respond(private_message("看看已完成"))
+        .await
+        .unwrap();
+    assert_eq!(listed.command.as_deref(), Some("todo_done"));
+    let session = service
+        .session_store
+        .get_or_create_active(&private_test_meta())
+        .unwrap();
+    let snapshot = session.last_todo_query.expect("missing completed snapshot");
+    assert_eq!(snapshot.query_type, "completed-list");
+    let expected_first_id = snapshot
+        .result_ids
+        .first()
+        .cloned()
+        .expect("completed snapshot should contain first item");
+    let expected_first_title = service
+        .todo_store
+        .get_by_id(&owner, &expected_first_id)
+        .unwrap()
+        .unwrap()
+        .title;
+
+    let _ = service
+        .respond(private_message("恢复第一条"))
+        .await
+        .unwrap();
+    let tool_request = inspector
+        .tool_requests()
+        .pop()
+        .expect("missing restore tool request");
+    let restored_output = tool_request
+        .tools
+        .execute_json(
+            &tool_request.tool_context,
+            "restore_todos",
+            r#"{"numbers":[1],"reference":null}"#,
+        )
+        .await
+        .unwrap();
+    let restored: Value = serde_json::from_str(&restored_output).unwrap();
+    assert_eq!(restored["ok"], true);
+    assert_eq!(restored["restored"][0]["title"], expected_first_title);
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &expected_first_id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
+}
+
+#[tokio::test]
+async fn deterministic_cancelled_query_then_tool_loop_restore_first_uses_latest_snapshot() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let first = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "已取消 A".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    let second = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "已取消 B".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    service.todo_store.cancel(&owner, &first.id).unwrap();
+    service.todo_store.cancel(&owner, &second.id).unwrap();
+
+    let listed = service
+        .respond(private_message("看看已取消"))
+        .await
+        .unwrap();
+    assert_eq!(listed.command.as_deref(), Some("todo_cancelled_list"));
+    let session = service
+        .session_store
+        .get_or_create_active(&private_test_meta())
+        .unwrap();
+    let snapshot = session.last_todo_query.expect("missing cancelled snapshot");
+    let expected_first_id = snapshot
+        .result_ids
+        .first()
+        .cloned()
+        .expect("cancelled snapshot should contain first item");
+    let expected_first_title = service
+        .todo_store
+        .get_by_id(&owner, &expected_first_id)
+        .unwrap()
+        .unwrap()
+        .title;
+
+    let _ = service
+        .respond(private_message("恢复第一条"))
+        .await
+        .unwrap();
+    let tool_request = inspector
+        .tool_requests()
+        .pop()
+        .expect("missing cancelled restore tool request");
+    let restored_output = tool_request
+        .tools
+        .execute_json(
+            &tool_request.tool_context,
+            "restore_todos",
+            r#"{"numbers":[1],"reference":null}"#,
+        )
+        .await
+        .unwrap();
+    let restored: Value = serde_json::from_str(&restored_output).unwrap();
+    assert_eq!(restored["ok"], true);
+    assert_eq!(restored["restored"][0]["title"], expected_first_title);
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &expected_first_id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
+}
+
+#[tokio::test]
+async fn deterministic_empty_query_clears_old_snapshot_before_number_mutation() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let todo = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "旧快照条目".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+
+    service
+        .respond(private_message("看一下待办"))
+        .await
+        .unwrap();
+    service.todo_store.complete(&owner, &todo.id).unwrap();
+
+    let empty_list = service
+        .respond(private_message("看一下待办"))
+        .await
+        .unwrap();
+    assert!(
+        empty_list
+            .text
+            .as_deref()
+            .unwrap()
+            .contains("当前没有未完成待办")
+    );
+    let session = service
+        .session_store
+        .get_or_create_active(&private_test_meta())
+        .unwrap();
+    let snapshot = session.last_todo_query.expect("missing empty snapshot");
+    assert!(snapshot.result_ids.is_empty());
+
+    let _ = service
+        .respond(private_message("完成第一条"))
+        .await
+        .unwrap();
+    let tool_request = inspector
+        .tool_requests()
+        .pop()
+        .expect("missing tool request after empty query");
+    let completed_output = tool_request
+        .tools
+        .execute_json(
+            &tool_request.tool_context,
+            "complete_todos",
+            r#"{"numbers":[1],"reference":null}"#,
+        )
+        .await
+        .unwrap();
+    let completed: Value = serde_json::from_str(&completed_output).unwrap();
+    assert_eq!(completed["ok"], true);
+    assert_eq!(completed["completed"], serde_json::json!([]));
+    assert_eq!(completed["missing_numbers"], serde_json::json!([1]));
+}
+
+#[tokio::test]
+async fn deterministic_query_then_status_changes_returns_precise_missing_error() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let todo = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "状态先被改掉".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+
+    service
+        .respond(private_message("看一下待办"))
+        .await
+        .unwrap();
+    // 模拟用户看到列表后，条目已被其他操作提前完成。
+    service.todo_store.complete(&owner, &todo.id).unwrap();
+
+    let _ = service
+        .respond(private_message("完成第一条"))
+        .await
+        .unwrap();
+    let tool_request = inspector
+        .tool_requests()
+        .pop()
+        .expect("missing tool request after state change");
+    let completed_output = tool_request
+        .tools
+        .execute_json(
+            &tool_request.tool_context,
+            "complete_todos",
+            r#"{"numbers":[1],"reference":null}"#,
+        )
+        .await
+        .unwrap();
+    let completed: Value = serde_json::from_str(&completed_output).unwrap();
+    assert_eq!(completed["ok"], true);
+    assert_eq!(completed["completed"], serde_json::json!([]));
+    assert_eq!(completed["missing_numbers"], serde_json::json!([1]));
+}
+
+#[tokio::test]
 async fn natural_language_cancelled_todo_query_lists_cancelled_items() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     // Tool Calling 关闭时仍保留确定性 Todo 查询路径；开启时由前置路由交给 Tool Loop。

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -667,7 +667,8 @@ async fn todo_create_intent_without_tool_call_does_not_leak_fake_success_reply()
 #[tokio::test]
 async fn natural_language_todo_query_prefers_listing_over_todo_parse_creation_chain() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
-    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    // Tool Calling 关闭时仍保留确定性 Todo 查询路径；开启时由前置路由交给 Tool Loop。
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), false);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
     service
         .todo_store
@@ -703,7 +704,8 @@ async fn natural_language_todo_query_prefers_listing_over_todo_parse_creation_ch
 #[tokio::test]
 async fn natural_language_todo_query_aliases_and_filters_stay_deterministic() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
-    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    // Tool Calling 关闭时仍保留确定性 Todo 查询路径；开启时由前置路由交给 Tool Loop。
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), false);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
     let pending = service
         .todo_store
@@ -800,7 +802,8 @@ async fn natural_language_todo_query_aliases_and_filters_stay_deterministic() {
 #[tokio::test]
 async fn natural_language_cancelled_todo_query_lists_cancelled_items() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
-    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    // Tool Calling 关闭时仍保留确定性 Todo 查询路径；开启时由前置路由交给 Tool Loop。
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), false);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
     let todo = service
         .todo_store

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -75,6 +75,31 @@ async fn private_chat_with_openai_responses_capability_enters_tool_loop() {
 }
 
 #[tokio::test]
+async fn private_general_chat_with_tool_capability_uses_plain_chat() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("聊聊 Rust 的所有权"))
+        .await
+        .unwrap();
+
+    assert!(
+        response
+            .text
+            .as_deref()
+            .unwrap()
+            .contains("回复：聊聊 Rust 的所有权")
+    );
+    assert_eq!(inspector.tool_call_count(), 0);
+    assert_eq!(inspector.requests().len(), 1);
+    assert_eq!(
+        response.diagnostics.unwrap()["tool_calling_enabled"],
+        serde_json::json!(false)
+    );
+}
+
+#[tokio::test]
 async fn private_tool_loop_registers_todo_tools_and_keeps_internal_ids_hidden() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
@@ -837,8 +862,9 @@ async fn non_todo_chat_phrase_does_not_force_required_tool() {
         diagnostics["tool_loop_executed_tools"],
         serde_json::json!([])
     );
-    // 没有 Todo 目标上下文时不触发受控重试，只走一次普通 tool loop 调用。
-    assert_eq!(inspector.tool_call_count(), 1);
+    // 没有 Todo 目标上下文时不触发受控重试，也不让 Tool Loop 抢走普通聊天流式链路。
+    assert_eq!(inspector.tool_call_count(), 0);
+    assert_eq!(inspector.requests().len(), 1);
     // 待办不应被误修改。
     assert_eq!(
         service.todo_store.list_pending(&owner).unwrap()[0].status,

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -329,16 +329,10 @@ async fn restore_then_cancel_last_reference_creates_pending_without_relisting() 
         .respond(private_message("看看已完成"))
         .await
         .unwrap();
-    let tool_request = inspector.tool_requests().remove(0);
-    tool_request
-        .tools
-        .execute_json(
-            &tool_request.tool_context,
-            "list_todos",
-            r#"{"status":"completed"}"#,
-        )
-        .await
-        .unwrap();
+    assert_eq!(inspector.tool_call_count(), 0);
+    let _ = service.respond(private_message("恢复第 1 个")).await;
+    let mut tool_requests = inspector.tool_requests();
+    let tool_request = tool_requests.pop().unwrap();
     tool_request
         .tools
         .execute_json(
@@ -402,16 +396,10 @@ async fn restore_then_reuse_stale_number_keeps_visible_number_error() {
         .respond(private_message("看看已完成"))
         .await
         .unwrap();
-    let tool_request = inspector.tool_requests().remove(0);
-    tool_request
-        .tools
-        .execute_json(
-            &tool_request.tool_context,
-            "list_todos",
-            r#"{"status":"completed"}"#,
-        )
-        .await
-        .unwrap();
+    assert_eq!(inspector.tool_call_count(), 0);
+    let _ = service.respond(private_message("恢复第 1 个")).await;
+    let mut tool_requests = inspector.tool_requests();
+    let tool_request = tool_requests.pop().unwrap();
     tool_request
         .tools
         .execute_json(

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     error::LlmError,
     runtime::{
         pending::{PendingOperation, PendingTodoAction},
-        session::{LastTodoQuery, SessionMeta, SessionRecord, now_iso_cn},
+        session::{SessionMeta, SessionRecord, now_iso_cn, valid_last_visible_todo_query},
         todo::{
             TodoItem, TodoItemDraft, TodoOwner, TodoStatus, TodoStore, enrich_draft_time_from_text,
         },
@@ -46,7 +46,6 @@ use target::{
     TodoTarget, is_cancelled_todo_cleanup_target, is_completed_todo_cleanup_target,
     parse_todo_edit_argument, parse_todo_number_list, remember_todo_query,
     resolve_todo_numbers_from_snapshot, resolve_todo_target, todo_target_label,
-    valid_last_visible_todo_query,
 };
 
 const TODO_QUERY_NOUNS: &[&str] = &["待办", "代办", "任务"];
@@ -68,6 +67,30 @@ const TODO_QUERY_CANCELLED_EXACT: &[&str] =
     &["已取消的待办", "看看已取消", "查看已取消", "列出已取消"];
 
 impl RustRespondService {
+    fn append_todo_query_response(
+        &self,
+        session: &mut SessionRecord,
+        user_text: &str,
+        reply: impl Into<CommandBody>,
+        command: impl Into<String>,
+    ) -> Result<RespondResponse, LlmError> {
+        let reply = reply.into();
+        self.session_store
+            .append_exchange_with_latest(session, user_text, &reply.text, |latest, current| {
+                // 确定性 Todo 查询必须把“用户刚刚看到的列表快照”写入最新 session，
+                // 但不能用旧 SessionRecord 覆盖 Tool Loop 或其他路径刚写入的 pending、
+                // 最近操作对象、历史等状态。
+                latest.state = current.state.clone();
+                latest.last_todo_query = current.last_todo_query.clone();
+            })
+            .map_err(super::common::session_error)?;
+        Ok(super::common::command_response(
+            reply,
+            Some(session.session_id.clone()),
+            Some(command),
+        ))
+    }
+
     /// 处理待办指令的主入口。解析 `/todo` 子命令并分派到对应的处理逻辑。
     pub(super) async fn handle_todo_flow(
         &self,
@@ -82,7 +105,7 @@ impl RustRespondService {
         if let Some((reply, command_name)) =
             self.try_handle_natural_todo_query(user_text, &owner, session)?
         {
-            return Ok(Some(self.append_pending_response(
+            return Ok(Some(self.append_todo_query_response(
                 session,
                 user_text,
                 reply,
@@ -93,16 +116,16 @@ impl RustRespondService {
             return Ok(None);
         };
 
-        let (reply, command_name) = match command.action.as_str() {
+        let (reply, command_name, visible_query_shown) = match command.action.as_str() {
             "todo_list" => {
                 let items = self.todo_store.list_pending(&owner).map_err(todo_error)?;
                 remember_todo_query(session, &owner, "list", "", &items);
-                (format_todo_list_reply(&items), "todo_list".to_owned())
+                (format_todo_list_reply(&items), "todo_list".to_owned(), true)
             }
             "todo_all" => {
                 let items = self.todo_store.list_all(&owner).map_err(todo_error)?;
                 remember_todo_query(session, &owner, "all", "全部待办", &items);
-                (format_todo_all_reply(&items), "todo_all".to_owned())
+                (format_todo_all_reply(&items), "todo_all".to_owned(), true)
             }
             "todo_search" => {
                 let query = command.argument.trim();
@@ -111,19 +134,19 @@ impl RustRespondService {
                         .todo_store
                         .list_completed_before(&owner, completed_query.completed_before)
                         .map_err(todo_error)?;
-                    session.last_todo_query = Some(LastTodoQuery {
-                        owner_key: owner.key.clone(),
-                        query_type: "completed-time".to_owned(),
-                        condition: completed_query.source_condition.clone(),
-                        result_ids: items.iter().map(|item| item.id.clone()).collect(),
-                        created_at: now_iso_cn(),
-                    });
+                    session.remember_last_todo_query(
+                        &owner.key,
+                        "completed-time",
+                        completed_query.source_condition.clone(),
+                        items.iter().map(|item| item.id.clone()).collect(),
+                    );
                     (
                         format_completed_todo_time_query_reply(
                             &items,
                             &completed_query.source_condition,
                         ),
                         "todo_completed_search".to_owned(),
+                        true,
                     )
                 } else {
                     session.last_todo_query = None;
@@ -138,6 +161,7 @@ impl RustRespondService {
                     (
                         format_todo_search_reply(&items, query),
                         "todo_search".to_owned(),
+                        true,
                     )
                 }
             }
@@ -148,6 +172,7 @@ impl RustRespondService {
                     (
                         CommandBody::plain("用法：/todo add 待办内容"),
                         "todo_add".to_owned(),
+                        false,
                     )
                 } else {
                     // 先用本地保守规则判断是否明显像火车行程，避免普通 Todo
@@ -164,7 +189,7 @@ impl RustRespondService {
                                         created_at: pending_add.created_at,
                                     });
                                 }
-                                (reply, "todo_train_add".to_owned())
+                                (reply, "todo_train_add".to_owned(), false)
                             }
                             // 启发式只负责“是否值得尝试 train_add”；
                             // 只要 LLM 没有明确识别为火车行程，就回退普通 Todo，
@@ -180,10 +205,14 @@ impl RustRespondService {
                                                 allow_revision: true,
                                                 created_at: now_iso_cn(),
                                             });
-                                        (format_todo_add_confirm(&draft), "todo_add".to_owned())
+                                        (
+                                            format_todo_add_confirm(&draft),
+                                            "todo_add".to_owned(),
+                                            false,
+                                        )
                                     }
                                     Err(message) => {
-                                        (CommandBody::plain(message), "todo_add".to_owned())
+                                        (CommandBody::plain(message), "todo_add".to_owned(), false)
                                     }
                                 }
                             }
@@ -198,9 +227,15 @@ impl RustRespondService {
                                     allow_revision: true,
                                     created_at: now_iso_cn(),
                                 });
-                                (format_todo_add_confirm(&draft), "todo_add".to_owned())
+                                (
+                                    format_todo_add_confirm(&draft),
+                                    "todo_add".to_owned(),
+                                    false,
+                                )
                             }
-                            Err(message) => (CommandBody::plain(message), "todo_add".to_owned()),
+                            Err(message) => {
+                                (CommandBody::plain(message), "todo_add".to_owned(), false)
+                            }
                         }
                     }
                 }
@@ -210,9 +245,15 @@ impl RustRespondService {
                 if argument.is_empty() {
                     let items = self.todo_store.list_completed(&owner).map_err(todo_error)?;
                     remember_todo_query(session, &owner, "completed-list", "已完成列表", &items);
-                    (format_todo_done_list_reply(&items), "todo_done".to_owned())
+                    (
+                        format_todo_done_list_reply(&items),
+                        "todo_done".to_owned(),
+                        true,
+                    )
                 } else {
-                    self.complete_todo_list_numbers(session, &owner, argument)?
+                    let (reply, command_name) =
+                        self.complete_todo_list_numbers(session, &owner, argument)?;
+                    (reply, command_name, false)
                 }
             }
             "todo_undo" => {
@@ -220,25 +261,36 @@ impl RustRespondService {
                 if argument.is_empty() {
                     let items = self.todo_store.list_completed(&owner).map_err(todo_error)?;
                     remember_todo_query(session, &owner, "completed-list", "已完成列表", &items);
-                    (format_todo_done_list_reply(&items), "todo_undo".to_owned())
+                    (
+                        format_todo_done_list_reply(&items),
+                        "todo_undo".to_owned(),
+                        true,
+                    )
                 } else {
-                    self.restore_todo_list_numbers(session, &owner, argument)?
+                    let (reply, command_name) =
+                        self.restore_todo_list_numbers(session, &owner, argument)?;
+                    (reply, command_name, false)
                 }
             }
             "todo_delete" => {
                 let argument = command.argument.trim();
                 if argument.is_empty() {
                     if let Some(query) = valid_last_completed_todo_bulk_query(session, &owner) {
-                        self.prepare_todo_bulk_delete_from_ids(
+                        let (reply, command_name) = self.prepare_todo_bulk_delete_from_ids(
                             session,
                             &owner,
                             initiator_user_id.clone(),
                             query.result_ids,
                             query.condition,
                             TodoStatus::Completed,
-                        )?
+                        )?;
+                        (reply, command_name, false)
                     } else {
-                        (format_todo_delete_usage_reply(), "todo_delete".to_owned())
+                        (
+                            format_todo_delete_usage_reply(),
+                            "todo_delete".to_owned(),
+                            false,
+                        )
                     }
                 } else if is_completed_todo_cleanup_target(argument) {
                     let items = self.todo_store.list_completed(&owner).map_err(todo_error)?;
@@ -249,14 +301,15 @@ impl RustRespondService {
                         "全部已完成待办",
                         &items,
                     );
-                    self.prepare_todo_bulk_delete_from_items(
+                    let (reply, command_name) = self.prepare_todo_bulk_delete_from_items(
                         session,
                         &owner,
                         initiator_user_id.clone(),
                         items,
                         "全部已完成待办".to_owned(),
                         TodoStatus::Completed,
-                    )?
+                    )?;
+                    (reply, command_name, false)
                 } else if is_cancelled_todo_cleanup_target(argument) {
                     let items = self.todo_store.list_cancelled(&owner).map_err(todo_error)?;
                     remember_todo_query(
@@ -266,42 +319,44 @@ impl RustRespondService {
                         "全部已取消待办",
                         &items,
                     );
-                    self.prepare_todo_bulk_delete_from_items(
+                    let (reply, command_name) = self.prepare_todo_bulk_delete_from_items(
                         session,
                         &owner,
                         initiator_user_id.clone(),
                         items,
                         "全部已取消待办".to_owned(),
                         TodoStatus::Cancelled,
-                    )?
+                    )?;
+                    (reply, command_name, false)
                 } else if let Some(completed_query) = parse_completed_todo_time_query(argument) {
                     let items = self
                         .todo_store
                         .list_completed_before(&owner, completed_query.completed_before)
                         .map_err(todo_error)?;
-                    session.last_todo_query = Some(LastTodoQuery {
-                        owner_key: owner.key.clone(),
-                        query_type: "completed-time".to_owned(),
-                        condition: completed_query.source_condition.clone(),
-                        result_ids: items.iter().map(|item| item.id.clone()).collect(),
-                        created_at: now_iso_cn(),
-                    });
-                    self.prepare_todo_bulk_delete_from_items(
+                    session.remember_last_todo_query(
+                        &owner.key,
+                        "completed-time",
+                        completed_query.source_condition.clone(),
+                        items.iter().map(|item| item.id.clone()).collect(),
+                    );
+                    let (reply, command_name) = self.prepare_todo_bulk_delete_from_items(
                         session,
                         &owner,
                         initiator_user_id.clone(),
                         items,
                         completed_query.source_condition,
                         TodoStatus::Completed,
-                    )?
+                    )?;
+                    (reply, command_name, false)
                 } else {
-                    self.prepare_todo_match_operation(
+                    let (reply, command_name) = self.prepare_todo_match_operation(
                         session,
                         &owner,
                         initiator_user_id.clone(),
                         PendingTodoAction::Delete,
                         argument,
-                    )?
+                    )?;
+                    (reply, command_name, false)
                 }
             }
             "todo_edit" => {
@@ -354,6 +409,7 @@ impl RustRespondService {
                     [] => (
                         format_todo_no_match_reply(&target_label),
                         "todo_edit".to_owned(),
+                        false,
                     ),
                     [item] => match self.parse_todo_edit_draft(&edit_text, item).await? {
                         Ok(draft) => {
@@ -367,9 +423,12 @@ impl RustRespondService {
                             (
                                 format_todo_edit_confirm(item, &draft),
                                 "todo_edit".to_owned(),
+                                false,
                             )
                         }
-                        Err(message) => (CommandBody::plain(message), "todo_edit".to_owned()),
+                        Err(message) => {
+                            (CommandBody::plain(message), "todo_edit".to_owned(), false)
+                        }
                     },
                     _ => {
                         let candidates = candidates.into_iter().take(5).collect::<Vec<_>>();
@@ -384,6 +443,7 @@ impl RustRespondService {
                         (
                             format_todo_candidate_selection(&PendingTodoAction::Edit, &candidates),
                             "todo_select".to_owned(),
+                            false,
                         )
                     }
                 }
@@ -393,16 +453,17 @@ impl RustRespondService {
                 (
                     CommandBody::plain("用法：/todo [list|all|add|done|undo|edit|delete|search]"),
                     command.action,
+                    false,
                 )
             }
         };
 
-        Ok(Some(self.append_pending_response(
-            session,
-            user_text,
-            reply,
-            command_name,
-        )?))
+        let response = if visible_query_shown {
+            self.append_todo_query_response(session, user_text, reply, command_name)?
+        } else {
+            self.append_pending_response(session, user_text, reply, command_name)?
+        };
+        Ok(Some(response))
     }
 
     fn try_handle_natural_todo_query(
@@ -599,7 +660,7 @@ impl RustRespondService {
             Ok(numbers) => numbers,
             Err(message) => return Ok((CommandBody::plain(message), "todo_done".to_owned())),
         };
-        let Some(query) = valid_last_visible_todo_query(session, owner) else {
+        let Some(query) = valid_last_visible_todo_query(session, &owner.key) else {
             return Ok((
                 CommandBody::plain("请先发送 /todo 查看待办列表。"),
                 "todo_done".to_owned(),
@@ -660,7 +721,7 @@ impl RustRespondService {
             Ok(numbers) => numbers,
             Err(message) => return Ok((CommandBody::plain(message), "todo_undo".to_owned())),
         };
-        let Some(query) = valid_last_visible_todo_query(session, owner) else {
+        let Some(query) = valid_last_visible_todo_query(session, &owner.key) else {
             return Ok((
                 CommandBody::plain("请先发送 /todo done 查看已完成待办。"),
                 "todo_undo".to_owned(),

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -62,8 +62,10 @@ const TODO_QUERY_LIST_VERBS: &[&str] = &[
 ];
 const TODO_QUERY_ALL_MARKERS: &[&str] = &["全部", "所有", "包含已完成", "包含已取消"];
 const TODO_QUERY_PENDING_EXACT: &[&str] = &["我的待办", "待办列表"];
-const TODO_QUERY_COMPLETED_EXACT: &[&str] = &["已完成的待办"];
-const TODO_QUERY_CANCELLED_EXACT: &[&str] = &["已取消的待办"];
+const TODO_QUERY_COMPLETED_EXACT: &[&str] =
+    &["已完成的待办", "看看已完成", "查看已完成", "列出已完成"];
+const TODO_QUERY_CANCELLED_EXACT: &[&str] =
+    &["已取消的待办", "看看已取消", "查看已取消", "列出已取消"];
 
 impl RustRespondService {
     /// 处理待办指令的主入口。解析 `/todo` 子命令并分派到对应的处理逻辑。

--- a/qq-maid-core/src/runtime/respond/todo_flow/target.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/target.rs
@@ -7,11 +7,9 @@
 use std::collections::HashSet;
 
 use crate::runtime::{
-    session::{LastTodoQuery, SessionRecord, now_iso_cn},
+    session::{LastTodoQuery, SessionRecord, valid_last_todo_query},
     todo::{TodoItem, TodoOwner},
 };
-
-use crate::runtime::respond::common::{LAST_QUERY_TTL_SECONDS, query_is_fresh};
 
 use super::format::format_todo_number_usage_reply;
 
@@ -51,30 +49,9 @@ fn valid_last_pending_todo_query(
     session: &mut SessionRecord,
     owner: &TodoOwner,
 ) -> Option<LastTodoQuery> {
-    let query = session.last_todo_query.clone()?;
-    if query.owner_key != owner.key || !matches!(query.query_type.as_str(), "list" | "search") {
-        return None;
-    }
-    if !query_is_fresh(&query.created_at, LAST_QUERY_TTL_SECONDS) {
-        session.last_todo_query = None;
-        return None;
-    }
-    Some(query)
-}
-
-pub(super) fn valid_last_visible_todo_query(
-    session: &mut SessionRecord,
-    owner: &TodoOwner,
-) -> Option<LastTodoQuery> {
-    let query = session.last_todo_query.clone()?;
-    if query.owner_key != owner.key || !is_visible_todo_query_type(&query.query_type) {
-        return None;
-    }
-    if !query_is_fresh(&query.created_at, LAST_QUERY_TTL_SECONDS) {
-        session.last_todo_query = None;
-        return None;
-    }
-    Some(query)
+    valid_last_todo_query(session, &owner.key, |query_type| {
+        matches!(query_type, "list" | "search")
+    })
 }
 
 pub(super) fn remember_todo_query(
@@ -84,13 +61,12 @@ pub(super) fn remember_todo_query(
     condition: impl Into<String>,
     items: &[TodoItem],
 ) {
-    session.last_todo_query = Some(LastTodoQuery {
-        owner_key: owner.key.clone(),
-        query_type: query_type.into(),
-        condition: condition.into(),
-        result_ids: items.iter().map(|item| item.id.clone()).collect(),
-        created_at: now_iso_cn(),
-    });
+    session.remember_last_todo_query(
+        &owner.key,
+        query_type,
+        condition,
+        items.iter().map(|item| item.id.clone()).collect(),
+    );
 }
 
 pub(super) fn parse_todo_number_list(argument: &str) -> Result<Vec<usize>, String> {
@@ -175,9 +151,14 @@ pub(super) fn resolve_todo_target(
         return TodoTarget::Query(target.to_owned());
     };
     if use_latest_visible_snapshot {
-        let Some(query) = session.last_todo_query.clone().filter(|query| {
-            query.owner_key == owner.key && is_visible_todo_query_type(&query.query_type)
-        }) else {
+        let snapshot = session.last_todo_query.clone();
+        let Some(query) = super::valid_last_visible_todo_query(session, &owner.key) else {
+            if let Some(query) = snapshot.filter(|query| query.owner_key == owner.key) {
+                return TodoTarget::ListUnavailable {
+                    source_label: todo_query_source_label(&query),
+                    source_command: todo_query_source_command(&query),
+                };
+            }
             return TodoTarget::ListUnavailable {
                 source_label: "待办".to_owned(),
                 source_command: "/todo".to_owned(),
@@ -185,13 +166,6 @@ pub(super) fn resolve_todo_target(
         };
         let source_label = todo_query_source_label(&query);
         let source_command = todo_query_source_command(&query);
-        if !query_is_fresh(&query.created_at, LAST_QUERY_TTL_SECONDS) {
-            session.last_todo_query = None;
-            return TodoTarget::ListUnavailable {
-                source_label,
-                source_command,
-            };
-        }
         if let Some(id) = query
             .result_ids
             .get(index.saturating_sub(1))
@@ -270,13 +244,6 @@ pub(super) fn todo_query_source_command(query: &LastTodoQuery) -> String {
         }
         _ => "/todo".to_owned(),
     }
-}
-
-fn is_visible_todo_query_type(query_type: &str) -> bool {
-    matches!(
-        query_type,
-        "list" | "search" | "all" | "completed-list" | "completed-time" | "cancelled-list"
-    )
 }
 
 pub(super) fn is_completed_todo_cleanup_target(text: &str) -> bool {

--- a/qq-maid-core/src/runtime/respond/tool_route.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route.rs
@@ -1,0 +1,265 @@
+//! 普通私聊 Tool Loop 前置路由。
+//!
+//! 当前这里只覆盖已经接入 Tool Loop 的 Weather 和 Todo，用来决定本轮普通
+//! 私聊是否要走 Complete Tool Loop。它不是通用语义分类器，也不负责 Memory、
+//! RSS、MCP、Skills 等未来工具；完整通用 Tool Loop 流式能力留给 #83 处理。
+
+use crate::runtime::session::SessionRecord;
+
+use super::{RespondRequest, chat_flow::todo_guard, todo_flow};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ToolLoopRoute {
+    PlainChat,
+    CompleteToolLoop,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct ToolRouteContext<'a> {
+    pub tool_calling_enabled: bool,
+    pub provider_supports_tool_calling: bool,
+    pub active_session: Option<&'a SessionRecord>,
+}
+
+pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext<'_>) -> ToolLoopRoute {
+    if !ctx.tool_calling_enabled || !ctx.provider_supports_tool_calling {
+        return ToolLoopRoute::PlainChat;
+    }
+    let text = req.effective_user_text();
+    let trimmed = text.trim();
+    if trimmed.is_empty()
+        || trimmed.starts_with('/')
+        || trimmed.starts_with('／')
+        || req
+            .group_id
+            .as_deref()
+            .is_some_and(|value| !value.is_empty())
+    {
+        return ToolLoopRoute::PlainChat;
+    }
+
+    if looks_like_weather_tool_request(trimmed) || looks_like_todo_tool_request(trimmed, ctx) {
+        ToolLoopRoute::CompleteToolLoop
+    } else {
+        ToolLoopRoute::PlainChat
+    }
+}
+
+/// 判断普通私聊是否明显需要天气 Tool。
+///
+/// 这里只识别当前稳定接入的天气工具请求，不处理“天气 API 怎么设计”这类
+/// 元讨论，避免工具链路抢走本该流式输出的普通聊天。
+fn looks_like_weather_tool_request(text: &str) -> bool {
+    if looks_like_weather_meta_discussion(text) {
+        return false;
+    }
+    contains_any(
+        text,
+        &[
+            "下雨",
+            "下雪",
+            "带伞",
+            "温度",
+            "气温",
+            "几度",
+            "降雨",
+            "降雪",
+            "空气质量",
+            "雾霾",
+            "预警",
+            "台风",
+            "风力",
+            "冷不冷",
+            "热不热",
+            "穿什么",
+        ],
+    ) || (text.contains("天气")
+        && contains_any(text, &["今天", "明天", "后天", "现在", "本周", "周末"]))
+}
+
+fn looks_like_weather_meta_discussion(text: &str) -> bool {
+    text.contains("天气")
+        && contains_any(
+            text,
+            &[
+                "API",
+                "api",
+                "接口",
+                "设计",
+                "实现",
+                "架构",
+                "模块",
+                "代码",
+                "怎么做",
+                "怎么写",
+            ],
+        )
+}
+
+/// 判断普通私聊是否明显需要 Todo Tool。
+///
+/// 写操作复用 `todo_guard` 的严格判定；查询类只覆盖当前 Tool Loop 已承载的
+/// 可见编号/最近对象绑定场景，避免“聊聊待办设计”误入工具链路。
+fn looks_like_todo_tool_request(text: &str, ctx: ToolRouteContext<'_>) -> bool {
+    let has_last_query = ctx
+        .active_session
+        .and_then(|session| session.last_todo_query.as_ref())
+        .is_some();
+    let has_last_action = ctx
+        .active_session
+        .and_then(|session| session.last_todo_action.as_ref())
+        .is_some();
+    if todo_guard::requires_todo_tool_with_context(text, has_last_query, has_last_action) {
+        return true;
+    }
+    if todo_flow::is_natural_todo_query_text(text) {
+        return true;
+    }
+    contains_any(
+        text,
+        &[
+            "看看已完成",
+            "查看已完成",
+            "列出已完成",
+            "看看已取消",
+            "查看已取消",
+            "列出已取消",
+            "看看待办",
+            "查看待办",
+            "列出待办",
+            "还有什么待办",
+            "有哪些待办",
+        ],
+    )
+}
+
+fn contains_any(text: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| text.contains(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::runtime::{
+        session::{LastTodoAction, LastTodoQuery, SessionRecord},
+        todo::TodoStatus,
+    };
+
+    use super::*;
+
+    fn request(text: &str) -> RespondRequest {
+        RespondRequest {
+            content: text.to_owned(),
+            scope_key: "private:u1".to_owned(),
+            user_id: Some("u1".to_owned()),
+            platform: "qq_official".to_owned(),
+            ..Default::default()
+        }
+    }
+
+    fn context(active_session: Option<&SessionRecord>) -> ToolRouteContext<'_> {
+        ToolRouteContext {
+            tool_calling_enabled: true,
+            provider_supports_tool_calling: true,
+            active_session,
+        }
+    }
+
+    fn empty_session() -> SessionRecord {
+        serde_json::from_value(json!({})).unwrap()
+    }
+
+    fn session_with_last_query() -> SessionRecord {
+        let mut session = empty_session();
+        session.last_todo_query = Some(LastTodoQuery {
+            owner_key: "private:u1".to_owned(),
+            query_type: "list".to_owned(),
+            condition: String::new(),
+            result_ids: vec!["item-1".to_owned()],
+            created_at: "2026-06-30T00:00:00+08:00".to_owned(),
+        });
+        session
+    }
+
+    fn session_with_last_action() -> SessionRecord {
+        let mut session = empty_session();
+        session.last_todo_action = Some(LastTodoAction {
+            owner_key: "private:u1".to_owned(),
+            item_id: "item-1".to_owned(),
+            title: "示例待办".to_owned(),
+            action: "restored".to_owned(),
+            resulting_status: TodoStatus::Pending,
+            created_at: "2026-06-30T00:00:00+08:00".to_owned(),
+        });
+        session
+    }
+
+    #[test]
+    fn general_chat_keeps_plain_route_even_with_tool_calling_enabled() {
+        assert_eq!(
+            route_tool_loop(&request("聊聊 Rust 的所有权"), context(None)),
+            ToolLoopRoute::PlainChat
+        );
+    }
+
+    #[test]
+    fn weather_route_avoids_meta_discussion() {
+        assert_eq!(
+            route_tool_loop(&request("杭州明天要带伞吗"), context(None)),
+            ToolLoopRoute::CompleteToolLoop
+        );
+        assert_eq!(
+            route_tool_loop(&request("聊聊天气 API 怎么设计"), context(None)),
+            ToolLoopRoute::PlainChat
+        );
+        // 当前阶段只覆盖明确 Weather/Todo 工具意图；泛化外出建议留给 #83 的通用 Tool Loop。
+        assert_eq!(
+            route_tool_loop(&request("杭州明天适合出门吗"), context(None)),
+            ToolLoopRoute::PlainChat
+        );
+    }
+
+    #[test]
+    fn todo_mutations_and_queries_route_to_tool_loop() {
+        let with_query = session_with_last_query();
+        let with_action = session_with_last_action();
+        for (text, session) in [
+            ("提醒我明天下午三点开会", None),
+            ("完成第 1 个待办", None),
+            ("修改第 2 个待办", None),
+            ("取消第 2 个任务", None),
+            ("永久删除已完成待办第 3 个", None),
+            ("恢复第 1 个", Some(&with_query)),
+            ("取消它", Some(&with_action)),
+            ("看看已完成", None),
+        ] {
+            assert_eq!(
+                route_tool_loop(&request(text), context(session)),
+                ToolLoopRoute::CompleteToolLoop,
+                "{text}"
+            );
+        }
+    }
+
+    #[test]
+    fn disabled_or_group_request_keeps_plain_route() {
+        let mut group = request("杭州明天要带伞吗");
+        group.group_id = Some("g1".to_owned());
+        assert_eq!(
+            route_tool_loop(&group, context(None)),
+            ToolLoopRoute::PlainChat
+        );
+        assert_eq!(
+            route_tool_loop(
+                &request("杭州明天要带伞吗"),
+                ToolRouteContext {
+                    tool_calling_enabled: false,
+                    provider_supports_tool_calling: true,
+                    active_session: None,
+                },
+            ),
+            ToolLoopRoute::PlainChat
+        );
+    }
+}

--- a/qq-maid-core/src/runtime/respond/tool_route.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route.rs
@@ -6,7 +6,7 @@
 
 use crate::runtime::session::SessionRecord;
 
-use super::{RespondRequest, chat_flow::todo_guard, todo_flow};
+use super::{RespondRequest, chat_flow::todo_guard};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ToolLoopRoute {
@@ -98,8 +98,9 @@ fn looks_like_weather_meta_discussion(text: &str) -> bool {
 
 /// 判断普通私聊是否明显需要 Todo Tool。
 ///
-/// 写操作复用 `todo_guard` 的严格判定；查询类只覆盖当前 Tool Loop 已承载的
-/// 可见编号/最近对象绑定场景，避免“聊聊待办设计”误入工具链路。
+/// 这里只覆盖创建、修改、完成、取消、恢复、删除等写操作，以及依赖最近
+/// Todo 查询/操作上下文的续指。普通列表查询必须继续交给 `handle_todo_flow()`
+/// 的确定性流程，避免同义词和默认过滤语义回归。
 fn looks_like_todo_tool_request(text: &str, ctx: ToolRouteContext<'_>) -> bool {
     let has_last_query = ctx
         .active_session
@@ -109,28 +110,7 @@ fn looks_like_todo_tool_request(text: &str, ctx: ToolRouteContext<'_>) -> bool {
         .active_session
         .and_then(|session| session.last_todo_action.as_ref())
         .is_some();
-    if todo_guard::requires_todo_tool_with_context(text, has_last_query, has_last_action) {
-        return true;
-    }
-    if todo_flow::is_natural_todo_query_text(text) {
-        return true;
-    }
-    contains_any(
-        text,
-        &[
-            "看看已完成",
-            "查看已完成",
-            "列出已完成",
-            "看看已取消",
-            "查看已取消",
-            "列出已取消",
-            "看看待办",
-            "查看待办",
-            "列出待办",
-            "还有什么待办",
-            "有哪些待办",
-        ],
-    )
+    todo_guard::requires_todo_tool_with_context(text, has_last_query, has_last_action)
 }
 
 fn contains_any(text: &str, needles: &[&str]) -> bool {
@@ -227,16 +207,34 @@ mod tests {
         for (text, session) in [
             ("提醒我明天下午三点开会", None),
             ("完成第 1 个待办", None),
+            ("完成第一条", Some(&with_query)),
             ("修改第 2 个待办", None),
             ("取消第 2 个任务", None),
             ("永久删除已完成待办第 3 个", None),
             ("恢复第 1 个", Some(&with_query)),
             ("取消它", Some(&with_action)),
-            ("看看已完成", None),
         ] {
             assert_eq!(
                 route_tool_loop(&request(text), context(session)),
                 ToolLoopRoute::CompleteToolLoop,
+                "{text}"
+            );
+        }
+    }
+
+    #[test]
+    fn todo_list_queries_keep_plain_route_for_deterministic_flow() {
+        for text in [
+            "看看已完成",
+            "看看待办",
+            "查看待办",
+            "列出待办",
+            "还有什么待办",
+            "有哪些待办",
+        ] {
+            assert_eq!(
+                route_tool_loop(&request(text), context(None)),
+                ToolLoopRoute::PlainChat,
                 "{text}"
             );
         }

--- a/qq-maid-core/src/runtime/tools/todo.rs
+++ b/qq-maid-core/src/runtime/tools/todo.rs
@@ -17,7 +17,7 @@ use crate::{
     error::LlmError,
     runtime::{
         pending::PendingOperation,
-        session::{LastTodoQuery, SessionMeta, SessionStore, now_iso_cn},
+        session::{SessionMeta, SessionStore, now_iso_cn, valid_last_visible_todo_query},
         todo::{
             TodoItem, TodoItemDraft, TodoOwner, TodoStatus, TodoStore, TodoTimePrecision,
             display_draft_time, display_todo_time, enrich_draft_time_from_text,
@@ -874,13 +874,12 @@ impl TodoToolScope {
     }
 
     fn remember(&mut self, query_type: &str, condition: &str, items: &[TodoItem]) {
-        self.session.last_todo_query = Some(LastTodoQuery {
-            owner_key: self.owner.key.clone(),
-            query_type: query_type.to_owned(),
-            condition: condition.to_owned(),
-            result_ids: items.iter().map(|item| item.id.clone()).collect(),
-            created_at: now_iso_cn(),
-        });
+        self.session.remember_last_todo_query(
+            &self.owner.key,
+            query_type,
+            condition,
+            items.iter().map(|item| item.id.clone()).collect(),
+        );
     }
 
     fn resolve_selection(
@@ -900,12 +899,8 @@ impl TodoToolScope {
         }
     }
 
-    fn resolve_numbers(&self, numbers: &[usize]) -> Result<ResolvedTodoSelection, LlmError> {
-        let query = self
-            .session
-            .last_todo_query
-            .clone()
-            .filter(|query| query.owner_key == self.owner.key);
+    fn resolve_numbers(&mut self, numbers: &[usize]) -> Result<ResolvedTodoSelection, LlmError> {
+        let query = valid_last_visible_todo_query(&mut self.session, &self.owner.key);
         let Some(query) = query else {
             return Ok(ResolvedTodoSelection::error(
                 TODO_VISIBLE_NUMBERS_UNAVAILABLE_CODE,

--- a/qq-maid-core/src/service.rs
+++ b/qq-maid-core/src/service.rs
@@ -15,7 +15,7 @@ use std::{
 
 use async_trait::async_trait;
 use tokio::{sync::mpsc, time::timeout};
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 
 use crate::{
     config::AppConfig,
@@ -190,7 +190,23 @@ impl CoreService for CoreHandle {
         let recorder = MetricsRecorder::start();
         let scope_key = req.scope_key.clone();
         let state = self.state.as_ref();
-        let should_stream = should_stream_respond(&req) && !should_use_tool_calling(state, &req);
+        let stream_candidate = should_stream_respond(&service, &req).map_err(CoreError::from)?;
+        let should_use_tool_loop = if stream_candidate {
+            service
+                .should_use_tool_loop_for_chat(&req)
+                .map_err(CoreError::from)?
+        } else {
+            false
+        };
+        if stream_candidate && should_use_tool_loop {
+            info!(
+                scope_key,
+                transport = "complete",
+                reason = "tool_loop_intent",
+                "core respond stream bypassed for tool loop"
+            );
+        }
+        let should_stream = stream_candidate && !should_use_tool_loop;
         if should_stream {
             let provider_stream_enabled = state.provider.stream_enabled();
             let result = timeout(
@@ -440,36 +456,26 @@ async fn send_core_delta(
         .map_err(|_| LlmError::new("cancelled", "stream receiver dropped", "stream"))
 }
 
-fn should_stream_respond(req: &RespondRequest) -> bool {
+fn should_stream_respond(
+    service: &RustRespondService,
+    req: &RespondRequest,
+) -> Result<bool, LlmError> {
     let text = req.effective_user_text();
     let trimmed = text.trim();
     if trimmed.is_empty() {
-        return false;
+        return Ok(false);
     }
     if is_web_search_command(trimmed) {
-        return true;
+        return Ok(true);
     }
     // 只有普通聊天默认流式化；短命令继续走 Complete，保留原有总超时语义。
-    !trimmed.starts_with('/') && !trimmed.starts_with('／')
-}
-
-fn should_use_tool_calling(state: &AppState, req: &RespondRequest) -> bool {
-    if !state.config.tool_calling_enabled {
-        return false;
+    if trimmed.starts_with('/') || trimmed.starts_with('／') {
+        return Ok(false);
     }
-    if state
-        .provider
-        .tool_calling_protocol(req.model.as_deref())
-        .is_none()
-    {
-        return false;
-    }
-    let text = req.effective_user_text();
-    let trimmed = text.trim();
-    !trimmed.is_empty()
-        && !trimmed.starts_with('/')
-        && !trimmed.starts_with('／')
-        && req.group_id.as_deref().is_none_or(str::is_empty)
+    // 非 slash 的待办查询、pending 确认等仍属于完整业务流程；这里复用
+    // RespondService 的轻量分类，避免 stream 入口复制第二套命令判断。
+    let classification = service.classify_inbound(req.clone())?;
+    Ok(matches!(classification.kind, CoreInboundKind::NormalChat))
 }
 
 impl CoreRequest {
@@ -898,13 +904,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn core_private_chat_with_tool_capability_uses_complete_tool_loop_path() {
+    async fn core_private_weather_chat_with_tool_capability_uses_complete_tool_loop_path() {
         let provider = TestProvider::replying("工具完整回复")
             .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
         let state = test_state_with_tool_calling(provider.clone(), 5, true);
         let service = CoreHandle::new(state);
 
-        let output = service.respond(private_request("hello")).await.unwrap();
+        let output = service
+            .respond(private_request("杭州明天要带伞吗"))
+            .await
+            .unwrap();
 
         let CoreRespondOutput::Complete(response) = output else {
             panic!("expected complete output for tool loop path");
@@ -912,6 +921,21 @@ mod tests {
         assert_eq!(response.text.as_deref(), Some("工具完整回复"));
         assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
         assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn core_private_general_chat_with_tool_capability_keeps_stream_path() {
+        let provider = TestProvider::replying("普通流式回复")
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+        let state = test_state_with_tool_calling(provider.clone(), 5, true);
+        let service = CoreHandle::new(state);
+
+        let response =
+            collect_stream_completed(service.respond(private_request("hello")).await).await;
+
+        assert_eq!(response.text.as_deref(), Some("普通流式回复"));
+        assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/qq-maid-core/src/service.rs
+++ b/qq-maid-core/src/service.rs
@@ -23,8 +23,8 @@ use crate::{
     http::routes::AppState,
     provider::types::{ChatMessage, ChatRequest, ChatRole},
     runtime::respond::{
-        RespondExecutors, RespondRequest, RespondResponse, RespondServiceOptions, RespondStores,
-        RustRespondService,
+        RespondExecutors, RespondPlan, RespondRequest, RespondResponse, RespondServiceOptions,
+        RespondStores, RustRespondService,
     },
     util::metrics::MetricsRecorder,
 };
@@ -190,15 +190,8 @@ impl CoreService for CoreHandle {
         let recorder = MetricsRecorder::start();
         let scope_key = req.scope_key.clone();
         let state = self.state.as_ref();
-        let stream_candidate = should_stream_respond(&service, &req).map_err(CoreError::from)?;
-        let should_use_tool_loop = if stream_candidate {
-            service
-                .should_use_tool_loop_for_chat(&req)
-                .map_err(CoreError::from)?
-        } else {
-            false
-        };
-        if stream_candidate && should_use_tool_loop {
+        let respond_plan = service.plan_core_respond(&req).map_err(CoreError::from)?;
+        if matches!(respond_plan, RespondPlan::CompleteToolLoop) {
             info!(
                 scope_key,
                 transport = "complete",
@@ -206,8 +199,7 @@ impl CoreService for CoreHandle {
                 "core respond stream bypassed for tool loop"
             );
         }
-        let should_stream = stream_candidate && !should_use_tool_loop;
-        if should_stream {
+        if matches!(respond_plan, RespondPlan::StreamingChat) {
             let provider_stream_enabled = state.provider.stream_enabled();
             let result = timeout(
                 Duration::from_secs(state.config.request_timeout_seconds),
@@ -240,7 +232,7 @@ impl CoreService for CoreHandle {
         }
         let result = timeout(
             Duration::from_secs(state.config.request_timeout_seconds),
-            service.respond(req),
+            service.respond_with_plan(req, respond_plan),
         )
         .await;
 
@@ -456,28 +448,6 @@ async fn send_core_delta(
         .map_err(|_| LlmError::new("cancelled", "stream receiver dropped", "stream"))
 }
 
-fn should_stream_respond(
-    service: &RustRespondService,
-    req: &RespondRequest,
-) -> Result<bool, LlmError> {
-    let text = req.effective_user_text();
-    let trimmed = text.trim();
-    if trimmed.is_empty() {
-        return Ok(false);
-    }
-    if is_web_search_command(trimmed) {
-        return Ok(true);
-    }
-    // 只有普通聊天默认流式化；短命令继续走 Complete，保留原有总超时语义。
-    if trimmed.starts_with('/') || trimmed.starts_with('／') {
-        return Ok(false);
-    }
-    // 非 slash 的待办查询、pending 确认等仍属于完整业务流程；这里复用
-    // RespondService 的轻量分类，避免 stream 入口复制第二套命令判断。
-    let classification = service.classify_inbound(req.clone())?;
-    Ok(matches!(classification.kind, CoreInboundKind::NormalChat))
-}
-
 impl CoreRequest {
     pub fn scope_key(&self) -> String {
         match &self.conversation {
@@ -623,14 +593,6 @@ fn user_visible_failure_message(kind: CoreFailureKind) -> String {
     .to_owned()
 }
 
-fn is_web_search_command(text: &str) -> bool {
-    let normalized = text.strip_prefix('／').unwrap_or(text);
-    normalized.starts_with("/查")
-        || normalized.starts_with("/查询")
-        || normalized.starts_with("/search ")
-        || normalized == "/search"
-}
-
 fn respond_options(config: &AppConfig) -> RespondServiceOptions {
     RespondServiceOptions {
         title_model: config.title_model.clone(),
@@ -695,11 +657,12 @@ mod tests {
         },
         runtime::{
             knowledge::KnowledgeIndex,
+            pending::PendingOperation,
             prompt::PromptConfig,
             query::{QueryExecutor, QueryOutcome, QueryRequest},
             rss::{RssFetchConfig, RssFetcher, RssStore},
-            session::SessionStore,
-            todo::TodoStore,
+            session::{SessionMeta, SessionStore},
+            todo::{TodoItemDraft, TodoStore, TodoTimePrecision},
             train::{TrainExecutor, TrainSchedule, TrainScheduleRequest},
             weather::{WeatherExecutor, WeatherOutcome, WeatherRequest},
         },
@@ -788,6 +751,123 @@ mod tests {
         assert_eq!(response.session_id.as_deref(), Some("session-1"));
         assert_eq!(response.command.as_deref(), Some("chat"));
         assert_eq!(response.diagnostics.unwrap()["k"], "v");
+    }
+
+    #[test]
+    fn core_plan_routes_general_private_chat_to_streaming() {
+        let provider = TestProvider::replying("普通回复")
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+        let state = test_state_with_tool_calling(provider, 5, true);
+        let service = CoreHandle::new(state).respond_service();
+        let req: RespondRequest = private_request("hello").into();
+
+        assert_eq!(
+            service.plan_core_respond(&req).unwrap(),
+            RespondPlan::StreamingChat
+        );
+    }
+
+    #[test]
+    fn core_plan_routes_weather_tool_intent_to_complete_tool_loop() {
+        let provider = TestProvider::replying("工具回复")
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+        let state = test_state_with_tool_calling(provider, 5, true);
+        let service = CoreHandle::new(state).respond_service();
+        let req: RespondRequest = private_request("杭州明天要带伞吗").into();
+
+        assert_eq!(
+            service.plan_core_respond(&req).unwrap(),
+            RespondPlan::CompleteToolLoop
+        );
+    }
+
+    #[test]
+    fn core_plan_routes_todo_query_and_followup_to_complete_tool_loop() {
+        let provider = TestProvider::replying("工具回复")
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+        let state = test_state_with_tool_calling(provider, 5, true);
+        let session_store = state.session_store.clone();
+        let meta = SessionMeta::new(
+            "private:u1",
+            Some("u1".to_owned()),
+            None,
+            None,
+            None,
+            "qq_official",
+        );
+        let mut session = session_store.get_or_create_active(&meta).unwrap();
+        session.last_todo_query = Some(crate::runtime::session::LastTodoQuery {
+            owner_key: "private:u1".to_owned(),
+            query_type: "list".to_owned(),
+            condition: String::new(),
+            result_ids: vec!["todo-1".to_owned()],
+            created_at: "2026-06-30T00:00:00+08:00".to_owned(),
+        });
+        session_store.save(&mut session).unwrap();
+
+        let service = CoreHandle::new(state).respond_service();
+        for input in ["看看已完成", "恢复第 1 个"] {
+            let req: RespondRequest = private_request(input).into();
+            assert_eq!(
+                service.plan_core_respond(&req).unwrap(),
+                RespondPlan::CompleteToolLoop,
+                "{input}"
+            );
+        }
+    }
+
+    #[test]
+    fn core_plan_keeps_pending_confirmation_immediate() {
+        let provider = TestProvider::replying("unused")
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+        let state = test_state_with_tool_calling(provider, 5, true);
+        let session_store = state.session_store.clone();
+        let meta = SessionMeta::new(
+            "private:u1",
+            Some("u1".to_owned()),
+            None,
+            None,
+            None,
+            "qq_official",
+        );
+        let mut session = session_store.get_or_create_active(&meta).unwrap();
+        session.pending_operation = Some(PendingOperation::TodoAdd {
+            initiator_user_id: Some("u1".to_owned()),
+            owner_key: "private:u1".to_owned(),
+            draft: TodoItemDraft {
+                title: "检查日志".to_owned(),
+                detail: None,
+                raw_text: Some("检查日志".to_owned()),
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+            allow_revision: true,
+            created_at: "2026-06-30T00:00:00+08:00".to_owned(),
+        });
+        session_store.save(&mut session).unwrap();
+
+        let service = CoreHandle::new(state).respond_service();
+        let req: RespondRequest = private_request("确认").into();
+
+        assert_eq!(
+            service.plan_core_respond(&req).unwrap(),
+            RespondPlan::Immediate
+        );
+    }
+
+    #[test]
+    fn core_plan_keeps_group_chat_streaming_even_when_tool_capable() {
+        let provider = TestProvider::replying("群聊回复")
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+        let state = test_state_with_tool_calling(provider, 5, true);
+        let service = CoreHandle::new(state).respond_service();
+        let req: RespondRequest = group_request("杭州明天要带伞吗").into();
+
+        assert_eq!(
+            service.plan_core_respond(&req).unwrap(),
+            RespondPlan::StreamingChat
+        );
     }
 
     #[tokio::test]
@@ -919,6 +999,26 @@ mod tests {
             panic!("expected complete output for tool loop path");
         };
         assert_eq!(response.text.as_deref(), Some("工具完整回复"));
+        assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn core_private_todo_query_uses_complete_tool_loop_path() {
+        let provider = TestProvider::replying("待办工具回复")
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+        let state = test_state_with_tool_calling(provider.clone(), 5, true);
+        let service = CoreHandle::new(state);
+
+        let output = service
+            .respond(private_request("看看已完成"))
+            .await
+            .unwrap();
+
+        let CoreRespondOutput::Complete(response) = output else {
+            panic!("expected complete output for todo tool loop path");
+        };
+        assert_eq!(response.text.as_deref(), Some("待办工具回复"));
         assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
         assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
     }

--- a/qq-maid-core/src/service.rs
+++ b/qq-maid-core/src/service.rs
@@ -661,8 +661,8 @@ mod tests {
             prompt::PromptConfig,
             query::{QueryExecutor, QueryOutcome, QueryRequest},
             rss::{RssFetchConfig, RssFetcher, RssStore},
-            session::{SessionMeta, SessionStore},
-            todo::{TodoItemDraft, TodoStore, TodoTimePrecision},
+            session::{LastTodoAction, SessionMeta, SessionStore},
+            todo::{TodoItemDraft, TodoStatus, TodoStore, TodoTimePrecision},
             train::{TrainExecutor, TrainSchedule, TrainScheduleRequest},
             weather::{WeatherExecutor, WeatherOutcome, WeatherRequest},
         },
@@ -782,7 +782,24 @@ mod tests {
     }
 
     #[test]
-    fn core_plan_routes_todo_query_and_followup_to_complete_tool_loop() {
+    fn core_plan_routes_simple_todo_queries_to_immediate() {
+        let provider = TestProvider::replying("工具回复")
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+        let state = test_state_with_tool_calling(provider, 5, true);
+        let service = CoreHandle::new(state).respond_service();
+
+        for input in ["看一下待办", "看一下代办", "看看已完成"] {
+            let req: RespondRequest = private_request(input).into();
+            assert_eq!(
+                service.plan_core_respond(&req).unwrap(),
+                RespondPlan::Immediate,
+                "{input}"
+            );
+        }
+    }
+
+    #[test]
+    fn core_plan_routes_todo_mutations_and_followups_to_complete_tool_loop() {
         let provider = TestProvider::replying("工具回复")
             .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
         let state = test_state_with_tool_calling(provider, 5, true);
@@ -803,10 +820,23 @@ mod tests {
             result_ids: vec!["todo-1".to_owned()],
             created_at: "2026-06-30T00:00:00+08:00".to_owned(),
         });
+        session.last_todo_action = Some(LastTodoAction {
+            owner_key: "private:u1".to_owned(),
+            item_id: "todo-1".to_owned(),
+            title: "检查日志".to_owned(),
+            action: "completed".to_owned(),
+            resulting_status: TodoStatus::Completed,
+            created_at: "2026-06-30T00:00:00+08:00".to_owned(),
+        });
         session_store.save(&mut session).unwrap();
 
         let service = CoreHandle::new(state).respond_service();
-        for input in ["看看已完成", "恢复第 1 个"] {
+        for input in [
+            "提醒我明天下午三点开会",
+            "完成第一条",
+            "恢复第 1 个",
+            "取消它",
+        ] {
             let req: RespondRequest = private_request(input).into();
             assert_eq!(
                 service.plan_core_respond(&req).unwrap(),
@@ -1004,22 +1034,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn core_private_todo_query_uses_complete_tool_loop_path() {
-        let provider = TestProvider::replying("待办工具回复")
+    async fn core_private_simple_todo_queries_use_deterministic_path() {
+        let provider = TestProvider::replying("不应调用模型")
             .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
         let state = test_state_with_tool_calling(provider.clone(), 5, true);
+        let owner = TodoStore::owner(Some("u1"), "private:u1");
+        let todo_store = state.todo_store.clone();
+        todo_store
+            .create(
+                &owner,
+                TodoItemDraft {
+                    title: "待查看项目".to_owned(),
+                    detail: None,
+                    raw_text: None,
+                    due_date: None,
+                    due_at: None,
+                    time_precision: TodoTimePrecision::None,
+                },
+            )
+            .unwrap();
         let service = CoreHandle::new(state);
 
-        let output = service
-            .respond(private_request("看看已完成"))
-            .await
-            .unwrap();
+        let mut responses = Vec::new();
+        for input in ["看一下待办", "看一下代办"] {
+            let output = service.respond(private_request(input)).await.unwrap();
+            let CoreRespondOutput::Complete(response) = output else {
+                panic!("expected complete output for deterministic todo query");
+            };
+            assert_eq!(response.command.as_deref(), Some("todo_list"), "{input}");
+            assert!(response.text.as_deref().unwrap().contains("待查看项目"));
+            responses.push(response.text);
+        }
 
-        let CoreRespondOutput::Complete(response) = output else {
-            panic!("expected complete output for todo tool loop path");
-        };
-        assert_eq!(response.text.as_deref(), Some("待办工具回复"));
-        assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(responses[0], responses[1]);
+        assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
         assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
     }
 

--- a/qq-maid-core/src/storage/session.rs
+++ b/qq-maid-core/src/storage/session.rs
@@ -6,6 +6,8 @@
 
 use std::fmt;
 
+use chrono::{DateTime, Duration};
+
 pub use qq_maid_common::redaction::redact_sensitive_text;
 use rusqlite::{Connection, OptionalExtension, Row, Transaction, params};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
@@ -81,6 +83,8 @@ pub const SESSION_MIGRATIONS: &[SqliteMigration] = &[SESSION_SCHEMA_V1, SESSION_
 
 /// 默认会话标题，当用户未指定标题时使用。
 pub const DEFAULT_SESSION_TITLE: &str = "未命名会话";
+/// 最近列表/查询快照的统一有效期（秒）。
+pub const LAST_QUERY_TTL_SECONDS: i64 = 10 * 60;
 
 /// 会话记录，包含完整的会话状态和历史。
 ///
@@ -359,6 +363,33 @@ impl SessionStore {
         self.save(session)
     }
 
+    /// 先按 session_id 重新读取最新记录，再合并当前调用方显式变更的字段并追加本轮对话。
+    ///
+    /// 这类“先重读再合并”的写法主要用于会话中途可能已有其他路径落库的场景，
+    /// 例如 Tool Loop 已经写入 pending / 最近查询 / 最近操作对象后，
+    /// 旧 `SessionRecord` 不能再整行覆盖最新记录。
+    pub fn append_exchange_with_latest<F>(
+        &self,
+        session: &mut SessionRecord,
+        user_text: &str,
+        reply: &str,
+        merge_latest: F,
+    ) -> Result<(), SessionError>
+    where
+        F: FnOnce(&mut SessionRecord, &SessionRecord),
+    {
+        let mut latest = if session.session_id.trim().is_empty() {
+            session.clone()
+        } else {
+            self.get(&session.session_id)?
+                .unwrap_or_else(|| session.clone())
+        };
+        merge_latest(&mut latest, session);
+        self.append_exchange(&mut latest, user_text, reply)?;
+        *session = latest;
+        Ok(())
+    }
+
     /// 压缩会话历史：保留最近的 N 条消息，将更早的消息归档到 extra 中，
     /// 并更新会话摘要。
     pub fn compact_history(
@@ -502,6 +533,26 @@ impl SessionRecord {
         self.last_memory_query = None;
     }
 
+    /// 记录最近一次真正展示给用户的 Todo 列表快照。
+    ///
+    /// `result_ids` 必须与最终展示顺序完全一致；后续“第一条 / 第二条 / 它”
+    /// 等续指只允许按这份快照映射，不能回退数据库默认顺序。
+    pub fn remember_last_todo_query(
+        &mut self,
+        owner_key: &str,
+        query_type: impl Into<String>,
+        condition: impl Into<String>,
+        result_ids: Vec<String>,
+    ) {
+        self.last_todo_query = Some(LastTodoQuery {
+            owner_key: owner_key.to_owned(),
+            query_type: query_type.into(),
+            condition: condition.into(),
+            result_ids,
+            created_at: now_iso_cn(),
+        });
+    }
+
     /// 记录最近一次成功操作的单条 Todo。
     ///
     /// 这里只保存自然语言续指所需的最小快照；下次真正执行时仍需重新读取当前 Todo。
@@ -548,6 +599,51 @@ impl SessionRecord {
             self.last_todo_action = None;
         }
     }
+}
+
+/// 判断一条“最近查询”记录是否仍在有效期内（created_at 为 RFC3339，TTL 单位为秒）。
+pub fn query_is_fresh(created_at: &str, ttl_seconds: i64) -> bool {
+    let Ok(created_at) = DateTime::parse_from_rfc3339(created_at.trim()) else {
+        return false;
+    };
+    let Ok(now) = DateTime::parse_from_rfc3339(&now_iso_cn()) else {
+        return false;
+    };
+    let age = now.signed_duration_since(created_at.with_timezone(&time_context::shanghai_offset()));
+    age >= Duration::zero() && age.num_seconds() <= ttl_seconds
+}
+
+/// 当前快照是否属于用户可见 Todo 列表。
+pub fn is_visible_todo_query_type(query_type: &str) -> bool {
+    matches!(
+        query_type,
+        "list" | "search" | "all" | "completed-list" | "completed-time" | "cancelled-list"
+    )
+}
+
+/// 按 owner 和 query_type 条件读取最近 Todo 查询快照；过期时顺手清理旧值。
+pub fn valid_last_todo_query(
+    session: &mut SessionRecord,
+    owner_key: &str,
+    query_type_matches: impl Fn(&str) -> bool,
+) -> Option<LastTodoQuery> {
+    let query = session.last_todo_query.clone()?;
+    if query.owner_key != owner_key || !query_type_matches(&query.query_type) {
+        return None;
+    }
+    if !query_is_fresh(&query.created_at, LAST_QUERY_TTL_SECONDS) {
+        session.last_todo_query = None;
+        return None;
+    }
+    Some(query)
+}
+
+/// 读取最近一次仍可供用户按编号续指的 Todo 列表快照。
+pub fn valid_last_visible_todo_query(
+    session: &mut SessionRecord,
+    owner_key: &str,
+) -> Option<LastTodoQuery> {
+    valid_last_todo_query(session, owner_key, is_visible_todo_query_type)
 }
 
 impl SessionMeta {
@@ -1237,6 +1333,82 @@ mod tests {
         assert_eq!(restored.last_todo_query, session.last_todo_query);
         assert_eq!(restored.last_todo_action, session.last_todo_action);
         assert_eq!(restored.last_memory_query, session.last_memory_query);
+    }
+
+    #[test]
+    fn append_exchange_with_latest_merges_query_snapshot_without_overwriting_newer_fields() {
+        let store = test_store();
+        let meta = test_meta();
+        let mut stale = store.create(&meta, "合并测试", true).unwrap();
+        stale.append_message("user", "旧问题");
+        store.save(&mut stale).unwrap();
+
+        let mut latest = store.get_or_create_active(&meta).unwrap();
+        latest.pending_operation = Some(PendingOperation::MemoryCreate {
+            initiator_user_id: Some("u1".to_owned()),
+            memory: PendingMemory {
+                content: "较新的 pending".to_owned(),
+                source_text: "/memory 较新的 pending".to_owned(),
+                memory_type: "note".to_owned(),
+                scope: "general".to_owned(),
+                created_at: now_iso_cn(),
+                target_scope_type: Some("personal".to_owned()),
+                target_scope_id: Some("u1".to_owned()),
+            },
+        });
+        latest.last_todo_action = Some(LastTodoAction {
+            owner_key: "group:g1".to_owned(),
+            item_id: "todo-new".to_owned(),
+            title: "较新的最近对象".to_owned(),
+            action: "completed".to_owned(),
+            resulting_status: TodoStatus::Completed,
+            created_at: now_iso_cn(),
+        });
+        latest.append_message("assistant", "较新的回复");
+        store.save(&mut latest).unwrap();
+
+        stale.remember_last_todo_query(
+            "group:g1",
+            "list",
+            "",
+            vec!["todo-a".to_owned(), "todo-b".to_owned()],
+        );
+        store
+            .append_exchange_with_latest(
+                &mut stale,
+                "看一下待办",
+                "1. A\n2. B",
+                |current, stale| {
+                    current.state = stale.state.clone();
+                    current.last_todo_query = stale.last_todo_query.clone();
+                },
+            )
+            .unwrap();
+
+        let merged = store.get_or_create_active(&meta).unwrap();
+        assert!(merged.pending_operation.is_some());
+        assert_eq!(
+            merged
+                .last_todo_action
+                .as_ref()
+                .map(|item| item.item_id.as_str()),
+            Some("todo-new")
+        );
+        assert_eq!(
+            merged
+                .last_todo_query
+                .as_ref()
+                .map(|query| query.result_ids.clone()),
+            Some(vec!["todo-a".to_owned(), "todo-b".to_owned()])
+        );
+        assert_eq!(
+            merged
+                .history
+                .iter()
+                .map(|message| message.content.as_str())
+                .collect::<Vec<_>>(),
+            vec!["旧问题", "较新的回复", "看一下待办", "1. A\n2. B"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 背景

确定性 Todo 查询、Todo Tool Loop、编号解析之前没有共用同一套“最近可见列表”读写 helper，写入点和校验逻辑分散。更关键的是确定性查询展示列表后落库时没有走“先重读最新 session 再合并”的安全模式，存在旧 SessionRecord 把较新的最近列表快照覆盖回去的风险，导致用户刚看到 A、B，后续“第一条”有机会读到旧快照，误报“已经不在未完成列表里”。

## 改动

- 统一写入 helper：`SessionRecord::remember_last_todo_query(...)`，位于 `qq-maid-core/src/storage/session.rs`
- 统一读取 helper：`valid_last_todo_query(...)` / `valid_last_visible_todo_query(...)`，同文件
- 确定性查询展示前统一经 `runtime/respond/todo_flow/mod.rs` 的 `append_todo_query_response(...)` 保存
- Tool Loop 列表查询通过 `runtime/tools/todo.rs` 的 `TodoToolScope::remember(...)` 调同一 helper 保存
- 落库走 `append_exchange_with_latest` 安全模式，避免旧 session 覆盖 `last_todo_query` 等较新更新字段

## 编号绑定与展示顺序

- 快照 `result_ids` 只按“最终展示给用户的顺序”写入，不回退数据库默认顺序
- 确定性查询与 Tool Loop 编号解析统一走 `valid_last_visible_todo_query(...)`
- 空列表保存空快照，不再沿用旧编号
- 条目状态在展示后被其他操作改掉时，后续编号操作先按快照绑定内部 ID，再按当前状态执行，返回“编号存在但当前状态已不匹配”的准确结果

## 变更文件

- qq-maid-core/src/storage/session.rs
- qq-maid-core/src/runtime/respond/todo_flow/mod.rs
- qq-maid-core/src/runtime/respond/todo_flow/target.rs
- qq-maid-core/src/runtime/tools/todo.rs
- qq-maid-core/src/runtime/respond/common.rs
- qq-maid-core/src/runtime/respond/tests/chat.rs

## 验证

- \`cargo fmt --all -- --check\`：通过
- \`cargo clippy --workspace --all-targets --all-features -- -D warnings\`：通过
- \`cargo test -p qq-maid-core\`：通过（477 个测试）
- \`cargo test --workspace --all-features\`：通过
- 新增回归测试覆盖：看一下待办/看一下代办/看看已完成/看看已取消 后编号操作、空列表后编号操作、查询后状态变化、`append_exchange_with_latest` 不覆盖更新字段
- 未修改 Gateway 流式协议或 QQ 发送逻辑

## 其他

- 复用现有 TodoStore、快照结构、Tool Loop / 确定性 Todo 流程，未把普通 Todo 查询改回 Tool Loop
- 补充必要中文注释，未删除已有有效注释
- 未写入敏感信息