### PR TITLE
feat: 为 DeepSeek 和 BigModel 接入工具调用

### DIFF
--- a/qq-maid-llm/src/provider/bigmodel.rs
+++ b/qq-maid-llm/src/provider/bigmodel.rs
@@ -12,9 +12,10 @@ use crate::{
     config::LlmConfig,
     error::LlmError,
     provider::{
-        ChatOutcome, LlmProvider, LlmStream,
+        ChatOutcome, LlmProvider, LlmStream, ToolCallingProtocol, ToolChatRequest,
         openai::{
-            ChatCompletionsClient, chat_completions_stream, chat_completions_with_stream_fallback,
+            ChatCompletionsClient, ChatCompletionsToolLoopRequest, chat_completions_stream,
+            chat_completions_tool_loop, chat_completions_with_stream_fallback,
         },
         outcome_to_stream,
         types::{ChatRequest, ModelId, ModelProvider},
@@ -101,6 +102,32 @@ impl LlmProvider for BigModelProvider {
         .await
     }
 
+    async fn chat_with_tools(&self, req: ToolChatRequest) -> Result<ChatOutcome, LlmError> {
+        if self.tool_calling_protocol(req.chat.model.as_deref())
+            != Some(ToolCallingProtocol::ChatCompletionsToolCalls)
+        {
+            return self.chat(req.chat).await;
+        }
+        let effective_model = effective_bigmodel_model(req.chat.model.as_deref(), &self.model)?;
+        chat_completions_tool_loop(ChatCompletionsToolLoopRequest {
+            client: &self.client,
+            provider: self.name(),
+            model: &effective_model,
+            max_output_tokens: self.max_output_tokens,
+            messages: &req.chat.messages,
+            tools: req.tools,
+            tool_context: req.tool_context,
+            max_rounds: req.max_rounds,
+        })
+        .await
+    }
+
+    fn tool_calling_protocol(&self, model: Option<&str>) -> Option<ToolCallingProtocol> {
+        effective_bigmodel_model(model, &self.model)
+            .ok()
+            .map(|_| ToolCallingProtocol::ChatCompletionsToolCalls)
+    }
+
     fn name(&self) -> &'static str {
         "bigmodel"
     }
@@ -147,6 +174,8 @@ fn effective_bigmodel_model(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tool::{Tool, ToolContext, ToolMetadata, ToolOutput, ToolRegistry};
+    use async_trait::async_trait;
     use axum::{
         Router,
         body::Body,
@@ -197,6 +226,47 @@ mod tests {
         (format!("http://{addr}"), state)
     }
 
+    struct WeatherToolStub;
+
+    #[async_trait]
+    impl Tool for WeatherToolStub {
+        fn metadata(&self) -> ToolMetadata {
+            ToolMetadata {
+                name: "get_weather".to_owned(),
+                description: "get weather".to_owned(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string"}
+                    },
+                    "required": ["city"],
+                    "additionalProperties": false
+                }),
+            }
+        }
+
+        async fn execute(
+            &self,
+            _context: ToolContext,
+            arguments: Value,
+        ) -> Result<ToolOutput, LlmError> {
+            Ok(ToolOutput::json(json!({
+                "ok": true,
+                "city": arguments["city"],
+                "weather": "晴"
+            })))
+        }
+    }
+
+    fn test_context() -> ToolContext {
+        ToolContext {
+            task_id: "task-1".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_id: "private:u1".to_owned(),
+            tool_call_id: None,
+        }
+    }
+
     #[test]
     fn effective_bigmodel_model_strips_bigmodel_prefix() {
         assert_eq!(
@@ -224,6 +294,22 @@ mod tests {
 
         let err = bigmodel_config_model("deepseek:deepseek-chat").unwrap_err();
         assert_eq!(err.code, "config");
+    }
+
+    #[test]
+    fn bigmodel_tool_calling_protocol_uses_chat_completions() {
+        let provider = BigModelProvider {
+            client: ChatCompletionsClient::new("test-key", None, reqwest::Client::new()),
+            model: "glm-5.2".to_owned(),
+            stream: true,
+            max_output_tokens: 1200,
+        };
+
+        assert_eq!(
+            provider.tool_calling_protocol(Some("bigmodel:glm-5.2")),
+            Some(ToolCallingProtocol::ChatCompletionsToolCalls)
+        );
+        assert_eq!(provider.tool_calling_protocol(Some("openai:gpt-5")), None);
     }
 
     #[tokio::test]
@@ -255,5 +341,67 @@ mod tests {
         assert_eq!(requests.len(), 2);
         assert_eq!(requests[0]["stream"], true);
         assert!(requests[1].get("stream").is_none());
+    }
+
+    #[tokio::test]
+    async fn chat_with_tools_runs_chat_completions_tool_loop() {
+        let (base_url, state) = spawn_mock_chat(vec![
+            json!({
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": null,
+                        "tool_calls": [{
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": r#"{"city":"北京"}"#
+                            }
+                        }]
+                    }
+                }]
+            })
+            .to_string(),
+            json!({
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": "北京今天晴。"
+                    }
+                }]
+            })
+            .to_string(),
+        ])
+        .await;
+        let provider = BigModelProvider {
+            client: ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new()),
+            model: "glm-5.2".to_owned(),
+            stream: true,
+            max_output_tokens: 1200,
+        };
+        let tools = ToolRegistry::new().register(WeatherToolStub).unwrap();
+
+        let outcome = provider
+            .chat_with_tools(ToolChatRequest {
+                chat: ChatRequest {
+                    session_id: "s".to_owned(),
+                    model: None,
+                    messages: vec![crate::provider::types::ChatMessage::user("北京天气怎么样")],
+                    metadata: Default::default(),
+                },
+                tools,
+                tool_context: test_context(),
+                max_rounds: 2,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.reply, "北京今天晴。");
+        assert_eq!(outcome.executed_tools, vec!["get_weather"]);
+        let requests = &state.lock().await.requests;
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0]["tool_choice"], "auto");
+        assert_eq!(requests[1]["messages"][2]["role"], "tool");
     }
 }

--- a/qq-maid-llm/src/provider/bigmodel.rs
+++ b/qq-maid-llm/src/provider/bigmodel.rs
@@ -14,8 +14,9 @@ use crate::{
     provider::{
         ChatOutcome, LlmProvider, LlmStream, ToolCallingProtocol, ToolChatRequest,
         openai::{
-            ChatCompletionsClient, ChatCompletionsToolLoopRequest, chat_completions_stream,
-            chat_completions_tool_loop, chat_completions_with_stream_fallback,
+            ChatCompletionsClient, chat_completions_stream, chat_completions_with_stream_fallback,
+            provider_chat_completions_tool_calling_protocol,
+            provider_chat_with_chat_completions_tools,
         },
         outcome_to_stream,
         types::{ChatRequest, ModelId, ModelProvider},
@@ -108,24 +109,23 @@ impl LlmProvider for BigModelProvider {
         {
             return self.chat(req.chat).await;
         }
-        let effective_model = effective_bigmodel_model(req.chat.model.as_deref(), &self.model)?;
-        chat_completions_tool_loop(ChatCompletionsToolLoopRequest {
-            client: &self.client,
-            provider: self.name(),
-            model: &effective_model,
-            max_output_tokens: self.max_output_tokens,
-            messages: &req.chat.messages,
-            tools: req.tools,
-            tool_context: req.tool_context,
-            max_rounds: req.max_rounds,
-        })
+        provider_chat_with_chat_completions_tools(
+            &self.client,
+            self.name(),
+            &self.model,
+            self.max_output_tokens,
+            req,
+            effective_bigmodel_model,
+        )
         .await
     }
 
     fn tool_calling_protocol(&self, model: Option<&str>) -> Option<ToolCallingProtocol> {
-        effective_bigmodel_model(model, &self.model)
-            .ok()
-            .map(|_| ToolCallingProtocol::ChatCompletionsToolCalls)
+        provider_chat_completions_tool_calling_protocol(
+            model,
+            &self.model,
+            effective_bigmodel_model,
+        )
     }
 
     fn name(&self) -> &'static str {
@@ -174,8 +174,10 @@ fn effective_bigmodel_model(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tool::{Tool, ToolContext, ToolMetadata, ToolOutput, ToolRegistry};
-    use async_trait::async_trait;
+    use crate::{
+        provider::test_support::{WeatherToolStub, test_tool_context},
+        tool::ToolRegistry,
+    };
     use axum::{
         Router,
         body::Body,
@@ -224,47 +226,6 @@ mod tests {
             axum::serve(listener, app).await.unwrap();
         });
         (format!("http://{addr}"), state)
-    }
-
-    struct WeatherToolStub;
-
-    #[async_trait]
-    impl Tool for WeatherToolStub {
-        fn metadata(&self) -> ToolMetadata {
-            ToolMetadata {
-                name: "get_weather".to_owned(),
-                description: "get weather".to_owned(),
-                parameters: json!({
-                    "type": "object",
-                    "properties": {
-                        "city": {"type": "string"}
-                    },
-                    "required": ["city"],
-                    "additionalProperties": false
-                }),
-            }
-        }
-
-        async fn execute(
-            &self,
-            _context: ToolContext,
-            arguments: Value,
-        ) -> Result<ToolOutput, LlmError> {
-            Ok(ToolOutput::json(json!({
-                "ok": true,
-                "city": arguments["city"],
-                "weather": "晴"
-            })))
-        }
-    }
-
-    fn test_context() -> ToolContext {
-        ToolContext {
-            task_id: "task-1".to_owned(),
-            user_id: Some("u1".to_owned()),
-            scope_id: "private:u1".to_owned(),
-            tool_call_id: None,
-        }
     }
 
     #[test]
@@ -380,7 +341,9 @@ mod tests {
             stream: true,
             max_output_tokens: 1200,
         };
-        let tools = ToolRegistry::new().register(WeatherToolStub).unwrap();
+        let tools = ToolRegistry::new()
+            .register(WeatherToolStub::new("晴"))
+            .unwrap();
 
         let outcome = provider
             .chat_with_tools(ToolChatRequest {
@@ -391,7 +354,7 @@ mod tests {
                     metadata: Default::default(),
                 },
                 tools,
-                tool_context: test_context(),
+                tool_context: test_tool_context(),
                 max_rounds: 2,
             })
             .await

--- a/qq-maid-llm/src/provider/deepseek.rs
+++ b/qq-maid-llm/src/provider/deepseek.rs
@@ -11,9 +11,10 @@ use crate::{
     config::LlmConfig,
     error::LlmError,
     provider::{
-        ChatOutcome, LlmProvider, LlmStream,
+        ChatOutcome, LlmProvider, LlmStream, ToolCallingProtocol, ToolChatRequest,
         openai::{
-            ChatCompletionsClient, chat_completions_stream, chat_completions_with_stream_fallback,
+            ChatCompletionsClient, ChatCompletionsToolLoopRequest, chat_completions_stream,
+            chat_completions_tool_loop, chat_completions_with_stream_fallback,
         },
         outcome_to_stream,
         types::{ChatRequest, ModelId, ModelProvider},
@@ -100,6 +101,32 @@ impl LlmProvider for DeepSeekProvider {
         .await
     }
 
+    async fn chat_with_tools(&self, req: ToolChatRequest) -> Result<ChatOutcome, LlmError> {
+        if self.tool_calling_protocol(req.chat.model.as_deref())
+            != Some(ToolCallingProtocol::ChatCompletionsToolCalls)
+        {
+            return self.chat(req.chat).await;
+        }
+        let effective_model = effective_deepseek_model(req.chat.model.as_deref(), &self.model)?;
+        chat_completions_tool_loop(ChatCompletionsToolLoopRequest {
+            client: &self.client,
+            provider: self.name(),
+            model: &effective_model,
+            max_output_tokens: self.max_output_tokens,
+            messages: &req.chat.messages,
+            tools: req.tools,
+            tool_context: req.tool_context,
+            max_rounds: req.max_rounds,
+        })
+        .await
+    }
+
+    fn tool_calling_protocol(&self, model: Option<&str>) -> Option<ToolCallingProtocol> {
+        effective_deepseek_model(model, &self.model)
+            .ok()
+            .map(|_| ToolCallingProtocol::ChatCompletionsToolCalls)
+    }
+
     fn name(&self) -> &'static str {
         "deepseek"
     }
@@ -146,6 +173,8 @@ fn effective_deepseek_model(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tool::{Tool, ToolContext, ToolMetadata, ToolOutput, ToolRegistry};
+    use async_trait::async_trait;
     use axum::{
         Router,
         body::Body,
@@ -197,6 +226,47 @@ mod tests {
         (format!("http://{addr}"), state)
     }
 
+    struct WeatherToolStub;
+
+    #[async_trait]
+    impl Tool for WeatherToolStub {
+        fn metadata(&self) -> ToolMetadata {
+            ToolMetadata {
+                name: "get_weather".to_owned(),
+                description: "get weather".to_owned(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string"}
+                    },
+                    "required": ["city"],
+                    "additionalProperties": false
+                }),
+            }
+        }
+
+        async fn execute(
+            &self,
+            _context: ToolContext,
+            arguments: Value,
+        ) -> Result<ToolOutput, LlmError> {
+            Ok(ToolOutput::json(json!({
+                "ok": true,
+                "city": arguments["city"],
+                "weather": "阵雨"
+            })))
+        }
+    }
+
+    fn test_context() -> ToolContext {
+        ToolContext {
+            task_id: "task-1".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_id: "private:u1".to_owned(),
+            tool_call_id: None,
+        }
+    }
+
     #[test]
     fn effective_deepseek_model_strips_deepseek_prefix() {
         assert_eq!(
@@ -217,6 +287,22 @@ mod tests {
     fn effective_deepseek_model_rejects_openai_prefix() {
         let err = effective_deepseek_model(Some("openai:gpt-5-mini"), "default").unwrap_err();
         assert_eq!(err.code, "bad_request");
+    }
+
+    #[test]
+    fn deepseek_tool_calling_protocol_uses_chat_completions() {
+        let provider = DeepSeekProvider {
+            client: ChatCompletionsClient::new("test-key", None, reqwest::Client::new()),
+            model: "deepseek-chat".to_owned(),
+            stream: true,
+            max_output_tokens: 1200,
+        };
+
+        assert_eq!(
+            provider.tool_calling_protocol(Some("deepseek:deepseek-chat")),
+            Some(ToolCallingProtocol::ChatCompletionsToolCalls)
+        );
+        assert_eq!(provider.tool_calling_protocol(Some("openai:gpt-5")), None);
     }
 
     #[tokio::test]
@@ -279,5 +365,67 @@ mod tests {
         ));
         assert!(stream.next().await.unwrap().is_err());
         assert_eq!(state.lock().await.requests.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn chat_with_tools_runs_chat_completions_tool_loop() {
+        let (base_url, state) = spawn_mock_chat(vec![
+            json!({
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": null,
+                        "tool_calls": [{
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": r#"{"city":"杭州"}"#
+                            }
+                        }]
+                    }
+                }]
+            })
+            .to_string(),
+            json!({
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": "杭州有阵雨，记得带伞。"
+                    }
+                }]
+            })
+            .to_string(),
+        ])
+        .await;
+        let provider = DeepSeekProvider {
+            client: ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new()),
+            model: "deepseek-chat".to_owned(),
+            stream: true,
+            max_output_tokens: 1200,
+        };
+        let tools = ToolRegistry::new().register(WeatherToolStub).unwrap();
+
+        let outcome = provider
+            .chat_with_tools(ToolChatRequest {
+                chat: ChatRequest {
+                    session_id: "s".to_owned(),
+                    model: None,
+                    messages: vec![crate::provider::types::ChatMessage::user("杭州天气怎么样")],
+                    metadata: Default::default(),
+                },
+                tools,
+                tool_context: test_context(),
+                max_rounds: 2,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.reply, "杭州有阵雨，记得带伞。");
+        assert_eq!(outcome.executed_tools, vec!["get_weather"]);
+        let requests = &state.lock().await.requests;
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0]["tool_choice"], "auto");
+        assert_eq!(requests[1]["messages"][2]["role"], "tool");
     }
 }

--- a/qq-maid-llm/src/provider/deepseek.rs
+++ b/qq-maid-llm/src/provider/deepseek.rs
@@ -13,8 +13,9 @@ use crate::{
     provider::{
         ChatOutcome, LlmProvider, LlmStream, ToolCallingProtocol, ToolChatRequest,
         openai::{
-            ChatCompletionsClient, ChatCompletionsToolLoopRequest, chat_completions_stream,
-            chat_completions_tool_loop, chat_completions_with_stream_fallback,
+            ChatCompletionsClient, chat_completions_stream, chat_completions_with_stream_fallback,
+            provider_chat_completions_tool_calling_protocol,
+            provider_chat_with_chat_completions_tools,
         },
         outcome_to_stream,
         types::{ChatRequest, ModelId, ModelProvider},
@@ -107,24 +108,23 @@ impl LlmProvider for DeepSeekProvider {
         {
             return self.chat(req.chat).await;
         }
-        let effective_model = effective_deepseek_model(req.chat.model.as_deref(), &self.model)?;
-        chat_completions_tool_loop(ChatCompletionsToolLoopRequest {
-            client: &self.client,
-            provider: self.name(),
-            model: &effective_model,
-            max_output_tokens: self.max_output_tokens,
-            messages: &req.chat.messages,
-            tools: req.tools,
-            tool_context: req.tool_context,
-            max_rounds: req.max_rounds,
-        })
+        provider_chat_with_chat_completions_tools(
+            &self.client,
+            self.name(),
+            &self.model,
+            self.max_output_tokens,
+            req,
+            effective_deepseek_model,
+        )
         .await
     }
 
     fn tool_calling_protocol(&self, model: Option<&str>) -> Option<ToolCallingProtocol> {
-        effective_deepseek_model(model, &self.model)
-            .ok()
-            .map(|_| ToolCallingProtocol::ChatCompletionsToolCalls)
+        provider_chat_completions_tool_calling_protocol(
+            model,
+            &self.model,
+            effective_deepseek_model,
+        )
     }
 
     fn name(&self) -> &'static str {
@@ -173,8 +173,10 @@ fn effective_deepseek_model(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tool::{Tool, ToolContext, ToolMetadata, ToolOutput, ToolRegistry};
-    use async_trait::async_trait;
+    use crate::{
+        provider::test_support::{WeatherToolStub, test_tool_context},
+        tool::ToolRegistry,
+    };
     use axum::{
         Router,
         body::Body,
@@ -224,47 +226,6 @@ mod tests {
             axum::serve(listener, app).await.unwrap();
         });
         (format!("http://{addr}"), state)
-    }
-
-    struct WeatherToolStub;
-
-    #[async_trait]
-    impl Tool for WeatherToolStub {
-        fn metadata(&self) -> ToolMetadata {
-            ToolMetadata {
-                name: "get_weather".to_owned(),
-                description: "get weather".to_owned(),
-                parameters: json!({
-                    "type": "object",
-                    "properties": {
-                        "city": {"type": "string"}
-                    },
-                    "required": ["city"],
-                    "additionalProperties": false
-                }),
-            }
-        }
-
-        async fn execute(
-            &self,
-            _context: ToolContext,
-            arguments: Value,
-        ) -> Result<ToolOutput, LlmError> {
-            Ok(ToolOutput::json(json!({
-                "ok": true,
-                "city": arguments["city"],
-                "weather": "阵雨"
-            })))
-        }
-    }
-
-    fn test_context() -> ToolContext {
-        ToolContext {
-            task_id: "task-1".to_owned(),
-            user_id: Some("u1".to_owned()),
-            scope_id: "private:u1".to_owned(),
-            tool_call_id: None,
-        }
     }
 
     #[test]
@@ -404,7 +365,9 @@ mod tests {
             stream: true,
             max_output_tokens: 1200,
         };
-        let tools = ToolRegistry::new().register(WeatherToolStub).unwrap();
+        let tools = ToolRegistry::new()
+            .register(WeatherToolStub::new("阵雨"))
+            .unwrap();
 
         let outcome = provider
             .chat_with_tools(ToolChatRequest {
@@ -415,7 +378,7 @@ mod tests {
                     metadata: Default::default(),
                 },
                 tools,
-                tool_context: test_context(),
+                tool_context: test_tool_context(),
                 max_rounds: 2,
             })
             .await

--- a/qq-maid-llm/src/provider/mod.rs
+++ b/qq-maid-llm/src/provider/mod.rs
@@ -56,6 +56,8 @@ pub struct ToolChatRequest {
 pub enum ToolCallingProtocol {
     /// OpenAI Responses `function_call` / `function_call_output` 协议。
     OpenAiResponses,
+    /// OpenAI 兼容 Chat Completions `tools` / `tool_calls` 协议。
+    ChatCompletionsToolCalls,
 }
 
 /// LLM 标准聊天流事件。

--- a/qq-maid-llm/src/provider/mod.rs
+++ b/qq-maid-llm/src/provider/mod.rs
@@ -8,6 +8,8 @@ pub mod deepseek;
 pub mod limiter;
 pub mod openai;
 pub mod status;
+#[cfg(test)]
+pub(crate) mod test_support;
 pub mod types;
 
 use std::{pin::Pin, sync::Arc};

--- a/qq-maid-llm/src/provider/openai/chat.rs
+++ b/qq-maid-llm/src/provider/openai/chat.rs
@@ -119,7 +119,7 @@ fn chat_completions_payload(
     Ok(payload)
 }
 
-fn chat_completions_messages(messages: &[ChatMessage]) -> Result<Vec<Value>, LlmError> {
+pub(super) fn chat_completions_messages(messages: &[ChatMessage]) -> Result<Vec<Value>, LlmError> {
     if messages.is_empty() {
         return Err(LlmError::new(
             "bad_request",
@@ -154,7 +154,7 @@ fn chat_completions_message(message: &ChatMessage) -> Value {
     })
 }
 
-async fn send_chat_completions_request(
+pub(super) async fn send_chat_completions_request(
     client: &ChatCompletionsClient,
     payload: &Value,
     stream: bool,
@@ -476,7 +476,7 @@ async fn next_chat_stream_event(
     }
 }
 
-fn extract_chat_completion_text(body: &Value) -> Option<String> {
+pub(super) fn extract_chat_completion_text(body: &Value) -> Option<String> {
     let choices = body.get("choices").and_then(Value::as_array)?;
     let mut parts = Vec::new();
     for choice in choices {
@@ -520,7 +520,7 @@ fn extract_content_value(value: Option<&Value>) -> Option<String> {
     }
 }
 
-fn extract_chat_completion_usage(body: &Value) -> Option<TokenUsage> {
+pub(super) fn extract_chat_completion_usage(body: &Value) -> Option<TokenUsage> {
     let usage = body.get("usage")?;
     let input_tokens = usage
         .get("prompt_tokens")

--- a/qq-maid-llm/src/provider/openai/chat_tool_loop.rs
+++ b/qq-maid-llm/src/provider/openai/chat_tool_loop.rs
@@ -1,0 +1,573 @@
+//! OpenAI 兼容 Chat Completions Tool Loop。
+//!
+//! DeepSeek 和 BigModel 都通过 `/chat/completions` 暴露 `tools` / `tool_calls`
+//! 协议，这里统一处理协议层的多轮往返，避免 provider 侧重复维护同一套工具循环。
+
+use serde_json::{Value, json};
+use tracing::{debug, warn};
+
+use crate::{
+    error::LlmError,
+    metrics::MetricsRecorder,
+    provider::{
+        ChatOutcome,
+        types::{ChatMessage, TokenUsage},
+    },
+    tool::{PreparedToolCall, ToolCallDependency, ToolContext, ToolMetadata, ToolRegistry},
+};
+
+use super::chat::{
+    ChatCompletionsClient, chat_completions_messages, extract_chat_completion_text,
+    extract_chat_completion_usage, send_chat_completions_request,
+};
+
+/// Chat Completions Tool Loop 请求上下文。
+pub(crate) struct ChatCompletionsToolLoopRequest<'a> {
+    pub(crate) client: &'a ChatCompletionsClient,
+    pub(crate) provider: &'a str,
+    pub(crate) model: &'a str,
+    pub(crate) max_output_tokens: u64,
+    pub(crate) messages: &'a [ChatMessage],
+    pub(crate) tools: ToolRegistry,
+    pub(crate) tool_context: ToolContext,
+    pub(crate) max_rounds: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FunctionCall {
+    name: String,
+    call_id: String,
+    arguments: String,
+}
+
+struct ToolCallRound {
+    assistant_message: Value,
+    calls: Vec<FunctionCall>,
+}
+
+struct PreparedFunctionCall {
+    call_id: String,
+    prepared: Result<PreparedToolCall, LlmError>,
+}
+
+pub(crate) async fn chat_completions_tool_loop(
+    req: ChatCompletionsToolLoopRequest<'_>,
+) -> Result<ChatOutcome, LlmError> {
+    if req.tools.is_empty() {
+        return Err(LlmError::new(
+            "bad_request",
+            "tool loop requires at least one registered tool",
+            "tool_loop",
+        ));
+    }
+    if req.max_rounds == 0 {
+        return Err(LlmError::new(
+            "bad_request",
+            "tool loop max_rounds must be positive",
+            "tool_loop",
+        ));
+    }
+
+    let recorder = MetricsRecorder::start();
+    let mut messages = chat_completions_messages(req.messages)?;
+    let tools = chat_completions_tool_defs(req.tools.metadata());
+    let mut usage = None;
+    let mut executed_tools = Vec::new();
+
+    for round in 0..=req.max_rounds {
+        let payload =
+            chat_completions_tool_loop_payload(&messages, &tools, req.model, req.max_output_tokens);
+        let response = send_chat_completions_request(req.client, &payload, false).await?;
+        let body: Value = response.json().await.map_err(|err| {
+            LlmError::provider(
+                format!("invalid Chat Completions tool loop JSON: {err}"),
+                "json",
+            )
+        })?;
+        usage = merge_usage(usage, extract_chat_completion_usage(&body));
+        let tool_rounds = extract_tool_call_rounds(&body)?;
+        if tool_rounds.is_empty() {
+            let reply = extract_chat_completion_text(&body).ok_or_else(|| {
+                LlmError::provider(
+                    "Chat Completions tool loop returned empty final text output",
+                    "provider",
+                )
+            })?;
+            debug!(
+                provider = req.provider,
+                model = req.model,
+                tool_loop_used = true,
+                tool_loop_rounds = round,
+                "chat completions tool loop completed with final reply"
+            );
+            return Ok(ChatOutcome {
+                reply,
+                metrics: recorder.finish(req.provider, req.model, false),
+                usage,
+                fallback_used: false,
+                executed_tools,
+            });
+        }
+        if round >= req.max_rounds {
+            warn!(
+                provider = req.provider,
+                model = req.model,
+                tool_loop_used = true,
+                tool_loop_rounds = round,
+                max_rounds = req.max_rounds,
+                "chat completions tool loop exceeded maximum rounds"
+            );
+            return Err(LlmError::new(
+                "tool_loop_limit",
+                "tool loop exceeded maximum rounds",
+                "tool_loop",
+            ));
+        }
+
+        let mut previous_call_succeeded = true;
+        for tool_round in tool_rounds {
+            messages.push(tool_round.assistant_message);
+            let prepared_calls = prepare_function_calls(&req, &tool_round.calls, round)?;
+            for call in prepared_calls {
+                let (output, succeeded) = match call.prepared {
+                    Ok(prepared) => {
+                        executed_tools.push(prepared.name.clone());
+                        if prepared.dependency == ToolCallDependency::PreviousCallSuccess
+                            && !previous_call_succeeded
+                        {
+                            (tool_skip_output("dependency_previous_call_failed"), false)
+                        } else {
+                            match req.tools.execute_prepared(prepared).await {
+                                Ok(output) => {
+                                    let succeeded = tool_output_indicates_success(&output);
+                                    (output, succeeded)
+                                }
+                                Err(err) => (tool_error_output(&err), false),
+                            }
+                        }
+                    }
+                    Err(err) => (tool_error_output(&err), false),
+                };
+                previous_call_succeeded = succeeded;
+                messages.push(json!({
+                    "role": "tool",
+                    "tool_call_id": call.call_id,
+                    "content": output,
+                }));
+            }
+        }
+    }
+
+    Err(LlmError::new(
+        "tool_loop_limit",
+        "tool loop exceeded maximum rounds",
+        "tool_loop",
+    ))
+}
+
+fn chat_completions_tool_defs(metadata: Vec<ToolMetadata>) -> Vec<Value> {
+    metadata
+        .into_iter()
+        .map(|item| {
+            json!({
+                "type": "function",
+                "function": {
+                    "name": item.name,
+                    "description": item.description,
+                    "parameters": item.parameters,
+                }
+            })
+        })
+        .collect()
+}
+
+fn chat_completions_tool_loop_payload(
+    messages: &[Value],
+    tools: &[Value],
+    model: &str,
+    max_output_tokens: u64,
+) -> Value {
+    json!({
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_output_tokens,
+        "tools": tools,
+        // BigModel 文档当前写明仅支持 auto，这里统一固定成兼容交集。
+        "tool_choice": "auto",
+    })
+}
+
+fn extract_tool_call_rounds(body: &Value) -> Result<Vec<ToolCallRound>, LlmError> {
+    let Some(choices) = body.get("choices").and_then(Value::as_array) else {
+        return Ok(Vec::new());
+    };
+    let mut rounds = Vec::new();
+    for choice in choices {
+        let Some(message) = choice.get("message") else {
+            continue;
+        };
+        let Some(tool_calls) = message.get("tool_calls").and_then(Value::as_array) else {
+            continue;
+        };
+        if tool_calls.is_empty() {
+            continue;
+        }
+        let mut calls = Vec::new();
+        for call in tool_calls {
+            let call_type = call
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or("function");
+            if call_type != "function" {
+                continue;
+            }
+            let function = call.get("function").ok_or_else(|| {
+                LlmError::provider(
+                    "Chat Completions tool call item missing `function`",
+                    "provider",
+                )
+            })?;
+            calls.push(FunctionCall {
+                name: required_string(function, "name", "Chat Completions function")?,
+                call_id: call
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .or_else(|| call.get("call_id").and_then(Value::as_str))
+                    .map(str::to_owned)
+                    .ok_or_else(|| {
+                        LlmError::provider(
+                            "Chat Completions tool call item missing `id`",
+                            "provider",
+                        )
+                    })?,
+                arguments: required_string(function, "arguments", "Chat Completions function")?,
+            });
+        }
+        if calls.is_empty() {
+            continue;
+        }
+        let mut assistant_message = message.clone();
+        if assistant_message
+            .get("role")
+            .and_then(Value::as_str)
+            .is_none()
+        {
+            assistant_message["role"] = json!("assistant");
+        }
+        rounds.push(ToolCallRound {
+            assistant_message,
+            calls,
+        });
+    }
+    Ok(rounds)
+}
+
+fn prepare_function_calls(
+    req: &ChatCompletionsToolLoopRequest<'_>,
+    calls: &[FunctionCall],
+    round: usize,
+) -> Result<Vec<PreparedFunctionCall>, LlmError> {
+    let mut prepared_calls = Vec::with_capacity(calls.len());
+    for (index, call) in calls.iter().enumerate() {
+        let mut context = req.tool_context.clone();
+        context.tool_call_id = Some(stable_tool_call_id(
+            &context.task_id,
+            &call.call_id,
+            round,
+            index,
+        ));
+        prepared_calls.push(PreparedFunctionCall {
+            call_id: call.call_id.clone(),
+            prepared: req
+                .tools
+                .prepare_json(&context, &call.name, &call.arguments),
+        });
+    }
+    Ok(prepared_calls)
+}
+
+fn stable_tool_call_id(task_id: &str, call_id: &str, round: usize, index: usize) -> String {
+    let call_id = call_id.trim();
+    if !call_id.is_empty() {
+        format!("{task_id}:{call_id}")
+    } else {
+        // 兼容上游未返回稳定 call_id 的场景，回退到 request + round + index。
+        format!("{task_id}:round-{round}:call-{index}")
+    }
+}
+
+fn tool_error_output(err: &LlmError) -> String {
+    serde_json::to_string(&json!({
+        "ok": false,
+        "error": {
+            "code": err.code,
+            "message": err.message,
+            "stage": err.stage,
+        }
+    }))
+    .unwrap_or_else(|_| r#"{"ok":false,"error":{"code":"tool_output_error","message":"failed to serialize tool error","stage":"tool_loop"}}"#.to_owned())
+}
+
+fn tool_skip_output(reason: &str) -> String {
+    serde_json::to_string(&json!({
+        "ok": false,
+        "skipped": true,
+        "reason": reason,
+    }))
+    .unwrap_or_else(|_| {
+        r#"{"ok":false,"skipped":true,"reason":"dependency_previous_call_failed"}"#.to_owned()
+    })
+}
+
+fn tool_output_indicates_success(output: &str) -> bool {
+    // 约定俗成的业务工具失败通常会返回 {"ok":false,...}，这里把它视为失败，
+    // 这样同轮里依赖前一项成功的调用不会在业务失败后继续误执行。
+    serde_json::from_str::<Value>(output)
+        .ok()
+        .and_then(|value| value.get("ok").and_then(Value::as_bool))
+        .unwrap_or(true)
+}
+
+fn required_string(item: &Value, key: &str, label: &str) -> Result<String, LlmError> {
+    item.get(key)
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| LlmError::provider(format!("{label} missing `{key}`"), "provider"))
+}
+
+fn merge_usage(current: Option<TokenUsage>, next: Option<TokenUsage>) -> Option<TokenUsage> {
+    match (current, next) {
+        (None, next) => next,
+        (current, None) => current,
+        (Some(left), Some(right)) => Some(TokenUsage {
+            input_tokens: add_optional(left.input_tokens, right.input_tokens),
+            cached_input_tokens: add_optional(left.cached_input_tokens, right.cached_input_tokens),
+            output_tokens: add_optional(left.output_tokens, right.output_tokens),
+            total_tokens: add_optional(left.total_tokens, right.total_tokens),
+        }),
+    }
+}
+
+fn add_optional(left: Option<u64>, right: Option<u64>) -> Option<u64> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left + right),
+        (Some(value), None) | (None, Some(value)) => Some(value),
+        (None, None) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tool::{Tool, ToolOutput};
+    use async_trait::async_trait;
+    use axum::{
+        Json, Router,
+        body::Body,
+        extract::State,
+        http::{StatusCode, header},
+        response::IntoResponse,
+        routing::post,
+    };
+    use serde_json::json;
+    use std::sync::Arc;
+    use tokio::{net::TcpListener, sync::Mutex};
+
+    #[derive(Debug)]
+    struct MockToolLoopState {
+        bodies: Vec<Value>,
+        requests: Vec<Value>,
+    }
+
+    async fn mock_tool_loop_handler(
+        State(state): State<Arc<Mutex<MockToolLoopState>>>,
+        body: Body,
+    ) -> impl IntoResponse {
+        let bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+        let request: Value = serde_json::from_slice(&bytes).unwrap();
+        let mut state = state.lock().await;
+        state.requests.push(request);
+        let body = state.bodies.remove(0);
+        (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "application/json")],
+            Json(body),
+        )
+    }
+
+    async fn spawn_mock_tool_loop(bodies: Vec<Value>) -> (String, Arc<Mutex<MockToolLoopState>>) {
+        let state = Arc::new(Mutex::new(MockToolLoopState {
+            bodies,
+            requests: Vec::new(),
+        }));
+        let app = Router::new()
+            .route("/v1/chat/completions", post(mock_tool_loop_handler))
+            .with_state(state.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{addr}/v1"), state)
+    }
+
+    struct WeatherToolStub;
+
+    #[async_trait]
+    impl Tool for WeatherToolStub {
+        fn metadata(&self) -> ToolMetadata {
+            ToolMetadata {
+                name: "get_weather".to_owned(),
+                description: "get weather".to_owned(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string"}
+                    },
+                    "required": ["city"],
+                    "additionalProperties": false
+                }),
+            }
+        }
+
+        async fn execute(
+            &self,
+            _context: ToolContext,
+            arguments: Value,
+        ) -> Result<ToolOutput, LlmError> {
+            Ok(ToolOutput::json(json!({
+                "ok": true,
+                "city": arguments["city"],
+                "weather": "小雨"
+            })))
+        }
+    }
+
+    fn test_context() -> ToolContext {
+        ToolContext {
+            task_id: "task-1".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_id: "private:u1".to_owned(),
+            tool_call_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_loop_executes_function_call_and_returns_output_to_model() {
+        let (base_url, state) = spawn_mock_tool_loop(vec![
+            json!({
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": null,
+                        "tool_calls": [{
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": r#"{"city":"杭州"}"#
+                            }
+                        }]
+                    }
+                }],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 3, "total_tokens": 13}
+            }),
+            json!({
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": "杭州今天小雨。"
+                    }
+                }],
+                "usage": {"prompt_tokens": 8, "completion_tokens": 4, "total_tokens": 12}
+            }),
+        ])
+        .await;
+        let client =
+            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+        let tools = ToolRegistry::new().register(WeatherToolStub).unwrap();
+
+        let outcome = chat_completions_tool_loop(ChatCompletionsToolLoopRequest {
+            client: &client,
+            provider: "deepseek",
+            model: "deepseek-chat",
+            max_output_tokens: 1200,
+            messages: &[ChatMessage::user("杭州天气怎么样")],
+            tools,
+            tool_context: test_context(),
+            max_rounds: 2,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.reply, "杭州今天小雨。");
+        assert_eq!(outcome.executed_tools, vec!["get_weather"]);
+        assert_eq!(outcome.usage.unwrap().total_tokens, Some(25));
+
+        let requests = &state.lock().await.requests;
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0]["tool_choice"], "auto");
+        assert_eq!(requests[0]["tools"][0]["function"]["name"], "get_weather");
+        assert_eq!(requests[1]["messages"][1]["tool_calls"][0]["id"], "call_1");
+        assert_eq!(requests[1]["messages"][2]["role"], "tool");
+        assert_eq!(requests[1]["messages"][2]["tool_call_id"], "call_1");
+    }
+
+    #[tokio::test]
+    async fn tool_loop_returns_limit_error_after_exceeding_max_rounds() {
+        let (base_url, _state) = spawn_mock_tool_loop(vec![
+            json!({
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": null,
+                        "tool_calls": [{
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": r#"{"city":"杭州"}"#
+                            }
+                        }]
+                    }
+                }]
+            }),
+            json!({
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": null,
+                        "tool_calls": [{
+                            "id": "call_2",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": r#"{"city":"杭州"}"#
+                            }
+                        }]
+                    }
+                }]
+            }),
+        ])
+        .await;
+        let client =
+            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+        let tools = ToolRegistry::new().register(WeatherToolStub).unwrap();
+
+        let err = chat_completions_tool_loop(ChatCompletionsToolLoopRequest {
+            client: &client,
+            provider: "bigmodel",
+            model: "glm-5.2",
+            max_output_tokens: 1200,
+            messages: &[ChatMessage::user("杭州天气怎么样")],
+            tools,
+            tool_context: test_context(),
+            max_rounds: 1,
+        })
+        .await
+        .unwrap_err();
+
+        assert_eq!(err.code, "tool_loop_limit");
+        assert_eq!(err.stage, "tool_loop");
+    }
+}

--- a/qq-maid-llm/src/provider/openai/chat_tool_loop.rs
+++ b/qq-maid-llm/src/provider/openai/chat_tool_loop.rs
@@ -10,7 +10,7 @@ use crate::{
     error::LlmError,
     metrics::MetricsRecorder,
     provider::{
-        ChatOutcome,
+        ChatOutcome, ToolCallingProtocol, ToolChatRequest,
         types::{ChatMessage, TokenUsage},
     },
     tool::{PreparedToolCall, ToolCallDependency, ToolContext, ToolMetadata, ToolRegistry},
@@ -163,6 +163,48 @@ pub(crate) async fn chat_completions_tool_loop(
         "tool loop exceeded maximum rounds",
         "tool_loop",
     ))
+}
+
+/// 把“OpenAI 兼容 Chat Completions provider 的工具调用接线”收敛成公共 helper。
+///
+/// DeepSeek / BigModel 的差异主要在模型前缀校验和默认 base URL，不值得各自复制
+/// 一整段 tool loop 入口逻辑。
+pub(crate) async fn provider_chat_with_chat_completions_tools<F>(
+    client: &ChatCompletionsClient,
+    provider: &'static str,
+    default_model: &str,
+    max_output_tokens: u64,
+    req: ToolChatRequest,
+    resolve_model: F,
+) -> Result<ChatOutcome, LlmError>
+where
+    F: FnOnce(Option<&str>, &str) -> Result<String, LlmError>,
+{
+    let effective_model = resolve_model(req.chat.model.as_deref(), default_model)?;
+    chat_completions_tool_loop(ChatCompletionsToolLoopRequest {
+        client,
+        provider,
+        model: &effective_model,
+        max_output_tokens,
+        messages: &req.chat.messages,
+        tools: req.tools,
+        tool_context: req.tool_context,
+        max_rounds: req.max_rounds,
+    })
+    .await
+}
+
+pub(crate) fn provider_chat_completions_tool_calling_protocol<F>(
+    model: Option<&str>,
+    default_model: &str,
+    resolve_model: F,
+) -> Option<ToolCallingProtocol>
+where
+    F: FnOnce(Option<&str>, &str) -> Result<String, LlmError>,
+{
+    resolve_model(model, default_model)
+        .ok()
+        .map(|_| ToolCallingProtocol::ChatCompletionsToolCalls)
 }
 
 fn chat_completions_tool_defs(metadata: Vec<ToolMetadata>) -> Vec<Value> {
@@ -359,8 +401,7 @@ fn add_optional(left: Option<u64>, right: Option<u64>) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tool::{Tool, ToolOutput};
-    use async_trait::async_trait;
+    use crate::provider::test_support::{WeatherToolStub, test_tool_context};
     use axum::{
         Json, Router,
         body::Body,
@@ -411,47 +452,6 @@ mod tests {
         (format!("http://{addr}/v1"), state)
     }
 
-    struct WeatherToolStub;
-
-    #[async_trait]
-    impl Tool for WeatherToolStub {
-        fn metadata(&self) -> ToolMetadata {
-            ToolMetadata {
-                name: "get_weather".to_owned(),
-                description: "get weather".to_owned(),
-                parameters: json!({
-                    "type": "object",
-                    "properties": {
-                        "city": {"type": "string"}
-                    },
-                    "required": ["city"],
-                    "additionalProperties": false
-                }),
-            }
-        }
-
-        async fn execute(
-            &self,
-            _context: ToolContext,
-            arguments: Value,
-        ) -> Result<ToolOutput, LlmError> {
-            Ok(ToolOutput::json(json!({
-                "ok": true,
-                "city": arguments["city"],
-                "weather": "小雨"
-            })))
-        }
-    }
-
-    fn test_context() -> ToolContext {
-        ToolContext {
-            task_id: "task-1".to_owned(),
-            user_id: Some("u1".to_owned()),
-            scope_id: "private:u1".to_owned(),
-            tool_call_id: None,
-        }
-    }
-
     #[tokio::test]
     async fn tool_loop_executes_function_call_and_returns_output_to_model() {
         let (base_url, state) = spawn_mock_tool_loop(vec![
@@ -485,7 +485,9 @@ mod tests {
         .await;
         let client =
             ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
-        let tools = ToolRegistry::new().register(WeatherToolStub).unwrap();
+        let tools = ToolRegistry::new()
+            .register(WeatherToolStub::new("小雨"))
+            .unwrap();
 
         let outcome = chat_completions_tool_loop(ChatCompletionsToolLoopRequest {
             client: &client,
@@ -494,7 +496,7 @@ mod tests {
             max_output_tokens: 1200,
             messages: &[ChatMessage::user("杭州天气怎么样")],
             tools,
-            tool_context: test_context(),
+            tool_context: test_tool_context(),
             max_rounds: 2,
         })
         .await
@@ -552,7 +554,9 @@ mod tests {
         .await;
         let client =
             ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
-        let tools = ToolRegistry::new().register(WeatherToolStub).unwrap();
+        let tools = ToolRegistry::new()
+            .register(WeatherToolStub::new("小雨"))
+            .unwrap();
 
         let err = chat_completions_tool_loop(ChatCompletionsToolLoopRequest {
             client: &client,
@@ -561,7 +565,7 @@ mod tests {
             max_output_tokens: 1200,
             messages: &[ChatMessage::user("杭州天气怎么样")],
             tools,
-            tool_context: test_context(),
+            tool_context: test_tool_context(),
             max_rounds: 1,
         })
         .await

--- a/qq-maid-llm/src/provider/openai/mod.rs
+++ b/qq-maid-llm/src/provider/openai/mod.rs
@@ -4,6 +4,7 @@
 //! 出现可恢复上游错误时，降级到同 endpoint 的 Chat Completions。
 
 mod chat;
+mod chat_tool_loop;
 mod extract;
 mod fallback;
 mod payload;
@@ -30,6 +31,7 @@ use crate::{
 pub(crate) use chat::{
     ChatCompletionsClient, chat_completions_stream, chat_completions_with_stream_fallback,
 };
+pub(crate) use chat_tool_loop::{ChatCompletionsToolLoopRequest, chat_completions_tool_loop};
 
 struct OpenAiChatFallbackRequest<'a> {
     api_mode: OpenAiApiMode,

--- a/qq-maid-llm/src/provider/openai/mod.rs
+++ b/qq-maid-llm/src/provider/openai/mod.rs
@@ -31,7 +31,9 @@ use crate::{
 pub(crate) use chat::{
     ChatCompletionsClient, chat_completions_stream, chat_completions_with_stream_fallback,
 };
-pub(crate) use chat_tool_loop::{ChatCompletionsToolLoopRequest, chat_completions_tool_loop};
+pub(crate) use chat_tool_loop::{
+    provider_chat_completions_tool_calling_protocol, provider_chat_with_chat_completions_tools,
+};
 
 struct OpenAiChatFallbackRequest<'a> {
     api_mode: OpenAiApiMode,

--- a/qq-maid-llm/src/provider/test_support.rs
+++ b/qq-maid-llm/src/provider/test_support.rs
@@ -1,0 +1,61 @@
+//! provider 单测共享辅助。
+//!
+//! 这里只放多个 provider 测试都会复用的轻量 stub，避免把同一组测试工具在
+//! DeepSeek / BigModel / OpenAI 之间各复制一份。
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::{
+    error::LlmError,
+    tool::{Tool, ToolContext, ToolMetadata, ToolOutput},
+};
+
+pub(crate) struct WeatherToolStub {
+    weather: &'static str,
+}
+
+impl WeatherToolStub {
+    pub(crate) fn new(weather: &'static str) -> Self {
+        Self { weather }
+    }
+}
+
+#[async_trait]
+impl Tool for WeatherToolStub {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            name: "get_weather".to_owned(),
+            description: "get weather".to_owned(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"}
+                },
+                "required": ["city"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    async fn execute(
+        &self,
+        _context: ToolContext,
+        arguments: Value,
+    ) -> Result<ToolOutput, LlmError> {
+        Ok(ToolOutput::json(json!({
+            "ok": true,
+            "city": arguments["city"],
+            "weather": self.weather
+        })))
+    }
+}
+
+pub(crate) fn test_tool_context() -> ToolContext {
+    ToolContext {
+        task_id: "task-1".to_owned(),
+        user_id: Some("u1".to_owned()),
+        scope_id: "private:u1".to_owned(),
+        tool_call_id: None,
+    }
+}


### PR DESCRIPTION
## 概要
- 为 DeepSeek 和 BigModel provider 接入 OpenAI 兼容 Chat Completions Tool Calling
- 新增共享的 Chat Completions tool loop，并复用现有 ToolRegistry / ToolContext / ToolPreparation
- 补充 DeepSeek、BigModel 和共享 loop 的单测，并抽取共享测试 helper，避免重复 stub

## 变更原因
- 目前只有 OpenAI Responses 路径支持原生 Tool Calling，导致 DeepSeek / GLM 在私聊工具链路上只能退回普通聊天
- 这次把两类 OpenAI 兼容 provider 统一接到 `tools` / `tool_calls` 协议，保持 Core 侧统一入口不变

## 影响
- `TOOL_CALLING_ENABLED` / `TOOL_CALLING_MAX_ROUNDS` 现在同样对 DeepSeek / BigModel 生效
- DeepSeek 与 BigModel provider 会在支持的模型上声明 `ChatCompletionsToolCalls` 协议
- BigModel 按官方文档保持 `tool_choice=auto` 的兼容交集实现

## 验证
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`

Closes #119