### PR TITLE
fix: 修复 Todo 写操作守卫误判

### DIFF
--- a/qq-maid-core/src/http/routes.rs
+++ b/qq-maid-core/src/http/routes.rs
@@ -310,6 +310,7 @@ mod tests {
                 }),
                 fallback_used: false,
                 executed_tools: Vec::new(),
+                tool_results: Vec::new(),
             })
         }
 

--- a/qq-maid-core/src/runtime/respond.rs
+++ b/qq-maid-core/src/runtime/respond.rs
@@ -259,9 +259,9 @@ impl RustRespondService {
 
     /// 为响应入口计算本轮响应计划。
     ///
-    /// 这里是普通聊天是否走流式、是否因当前已接入的 Weather/Todo Tool
-    /// 进入 Complete Tool Loop 的唯一决策点。pending 和确定性命令仍优先
-    /// 走 `Immediate`，避免完整业务流程误入 stream。
+    /// 这里是普通私聊是否进入完整 Tool Loop 的唯一决策点。
+    /// pending、slash 命令和确定性 Todo 查询仍优先走 `Immediate`；
+    /// 工具关闭、provider 不支持工具或群聊时继续保留原流式路径。
     pub(crate) fn plan_core_respond(&self, req: &RespondRequest) -> Result<RespondPlan, LlmError> {
         let user_text = req.effective_user_text();
         let trimmed = user_text.trim();
@@ -292,7 +292,7 @@ impl RustRespondService {
             return Ok(RespondPlan::Immediate);
         }
 
-        let tool_route = self.route_tool_loop(req, active_session.as_ref());
+        let tool_route = self.route_tool_loop(req);
         if matches!(tool_route, ToolLoopRoute::CompleteToolLoop) {
             Ok(RespondPlan::CompleteToolLoop)
         } else {
@@ -300,11 +300,7 @@ impl RustRespondService {
         }
     }
 
-    fn route_tool_loop(
-        &self,
-        req: &RespondRequest,
-        active_session: Option<&SessionRecord>,
-    ) -> ToolLoopRoute {
+    fn route_tool_loop(&self, req: &RespondRequest) -> ToolLoopRoute {
         tool_route::route_tool_loop(
             req,
             ToolRouteContext {
@@ -313,7 +309,6 @@ impl RustRespondService {
                     .provider
                     .tool_calling_protocol(req.model.as_deref())
                     .is_some(),
-                active_session,
             },
         )
     }
@@ -410,8 +405,8 @@ impl RustRespondService {
             return Ok(response);
         }
 
-        // Core 计划已判定为 CompleteToolLoop 时，Todo 查询/续指等自然语言工具意图
-        // 交给 Tool Loop 处理；slash 命令和 pending 已在前面保持完整响应路径。
+        // CompleteToolLoop 下由 Agent 自行决定是否调用 Todo Tool；
+        // slash 命令、pending 和确定性 Todo 查询已在前面保持原路径。
         if !force_tool_loop {
             // 检查是否为待办相关操作（新增、查看、完成、编辑、删除等）
             if let Some(response) = self

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -134,20 +134,28 @@ impl RustRespondService {
         let service =
             LlmChatService::with_context_budget(self.provider.clone(), self.context_budget);
         let use_tool_loop = matches!(chat_tool_plan, ChatToolPlan::ForceCompleteToolLoop);
-        let todo_requirement = if use_tool_loop {
-            todo_guard::required_todo_tool_kind(&user_text, &session)
-        } else {
-            None
-        };
-        let (output, tool_retry_count, required_tool_called) = if use_tool_loop {
-            // 明显的 Todo 写操作必须产生真实成功的 Tool 结果；否则模型可能只口头声称
-            // “已生成草稿/已完成”，但 pending/session 实际没有发生状态变更。
-            let (output, retry_count, required_tool_called) = self
-                .respond_with_required_todo_tool(&service, chat_req, todo_requirement)
+        let (output, todo_success_validation) = if use_tool_loop {
+            let output = service
+                .respond_with_tools(
+                    chat_req,
+                    self.tool_registry.clone(),
+                    self.tool_calling_max_rounds,
+                )
                 .await?;
-            (output, retry_count, required_tool_called)
+            let validation = todo_guard::validate_todo_success_reply(&output);
+            let output = if validation.passed() {
+                output
+            } else {
+                todo_success_not_verified_output(output)
+            };
+            (output, validation)
         } else {
-            (service.respond(chat_req).await?, 0, false)
+            (
+                service.respond(chat_req).await?,
+                todo_guard::TodoSuccessValidation::Passed {
+                    claimed_success: false,
+                },
+            )
         };
 
         let reply = output.reply.clone();
@@ -190,85 +198,16 @@ impl RustRespondService {
             "used_search": false,
             "tool_calling_enabled": use_tool_loop,
             "tool_loop_executed_tools": executed_tools,
-            "required_tool_kind": todo_requirement.map(todo_guard::TodoMutationToolKind::as_str),
-            "required_tool_called": required_tool_called,
-            "tool_retry_count": tool_retry_count,
-            "error_code": if use_tool_loop && todo_requirement.is_some() && !required_tool_called {
-                json!("required_tool_not_called")
+            "todo_success_claimed": todo_success_validation.claimed_success(),
+            "todo_success_verified": todo_success_validation.passed(),
+            "tool_retry_count": 0,
+            "error_code": if use_tool_loop && !todo_success_validation.passed() {
+                json!("todo_success_not_verified")
             } else {
                 Value::Null
             },
         }));
         Ok(response)
-    }
-
-    async fn respond_with_required_todo_tool(
-        &self,
-        service: &LlmChatService,
-        chat_req: RespondRequest,
-        required_tool_kind: Option<todo_guard::TodoMutationToolKind>,
-    ) -> Result<(super::llm_service::RespondOutput, usize, bool), LlmError> {
-        let mut retry_count = 0;
-        let mut request = chat_req.clone();
-        let mut output = service
-            .respond_with_tools(
-                request.clone(),
-                self.tool_registry.clone(),
-                self.tool_calling_max_rounds,
-            )
-            .await?;
-        let mut required_called = required_tool_kind
-            .as_ref()
-            .is_none_or(|kind| kind.matches_output(&output));
-
-        if required_called {
-            return Ok((output, retry_count, true));
-        }
-
-        retry_count = 1;
-        // 只做一次受控重试；仍未调用 Tool 时直接返回中文失败提示，禁止透传假成功。
-        request.system_prompts.push(
-            "本轮用户是在执行待办写操作。你必须调用对应的 Todo Tool；在 Tool 返回成功前，禁止回复“已生成草稿”“已记录”“已完成”“已取消”“已恢复”“已删除”等成功性文案。".to_owned(),
-        );
-        request.metadata = merge_metadata(
-            request.metadata,
-            &[("tool_retry_reason", "required_todo_tool_not_called")],
-        );
-        output = service
-            .respond_with_tools(
-                request,
-                self.tool_registry.clone(),
-                self.tool_calling_max_rounds,
-            )
-            .await?;
-        required_called = required_tool_kind
-            .as_ref()
-            .is_none_or(|kind| kind.matches_output(&output));
-        if required_called {
-            return Ok((output, retry_count, true));
-        }
-
-        let reply = todo_guard::todo_required_tool_not_called_reply(required_tool_kind);
-        let response = super::llm_service::RespondOutput {
-            reply: reply.clone(),
-            text: reply.clone(),
-            markdown: None,
-            chat: super::types::ChatResponse::ok(
-                reply,
-                crate::util::metrics::LlmMetrics {
-                    provider: "rust".to_owned(),
-                    model: "tool-loop-guard".to_owned(),
-                    stream: false,
-                    ttfe_ms: None,
-                    ttft_ms: None,
-                    total_latency_ms: 0,
-                },
-                None,
-            ),
-            executed_tools: output.executed_tools.clone(),
-            tool_results: output.tool_results.clone(),
-        };
-        Ok((response, retry_count, false))
     }
 
     /// 普通聊天真流式路径：复用非流式聊天的上下文构造和后处理，只替换 LLM 调用方式。
@@ -492,6 +431,31 @@ impl RustRespondService {
                 }
             }
         });
+    }
+}
+
+fn todo_success_not_verified_output(
+    output: super::llm_service::RespondOutput,
+) -> super::llm_service::RespondOutput {
+    let reply = todo_guard::todo_success_not_verified_reply();
+    super::llm_service::RespondOutput {
+        reply: reply.clone(),
+        text: reply.clone(),
+        markdown: None,
+        chat: super::types::ChatResponse::ok(
+            reply,
+            crate::util::metrics::LlmMetrics {
+                provider: "rust".to_owned(),
+                model: "tool-loop-guard".to_owned(),
+                stream: false,
+                ttfe_ms: None,
+                ttft_ms: None,
+                total_latency_ms: 0,
+            },
+            None,
+        ),
+        executed_tools: output.executed_tools,
+        tool_results: output.tool_results,
     }
 }
 

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -140,7 +140,7 @@ impl RustRespondService {
             None
         };
         let (output, tool_retry_count, required_tool_called) = if use_tool_loop {
-            // 明显的 Todo 写操作必须真的执行对应 Tool；否则模型可能只口头声称
+            // 明显的 Todo 写操作必须产生真实成功的 Tool 结果；否则模型可能只口头声称
             // “已生成草稿/已完成”，但 pending/session 实际没有发生状态变更。
             let (output, retry_count, required_tool_called) = self
                 .respond_with_required_todo_tool(&service, chat_req, todo_requirement)
@@ -219,7 +219,7 @@ impl RustRespondService {
             .await?;
         let mut required_called = required_tool_kind
             .as_ref()
-            .is_none_or(|kind| kind.matches_executed_tools(&output.executed_tools));
+            .is_none_or(|kind| kind.matches_output(&output));
 
         if required_called {
             return Ok((output, retry_count, true));
@@ -243,7 +243,7 @@ impl RustRespondService {
             .await?;
         required_called = required_tool_kind
             .as_ref()
-            .is_none_or(|kind| kind.matches_executed_tools(&output.executed_tools));
+            .is_none_or(|kind| kind.matches_output(&output));
         if required_called {
             return Ok((output, retry_count, true));
         }
@@ -266,6 +266,7 @@ impl RustRespondService {
                 None,
             ),
             executed_tools: output.executed_tools.clone(),
+            tool_results: output.tool_results.clone(),
         };
         Ok((response, retry_count, false))
     }

--- a/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
@@ -1,75 +1,71 @@
-//! 普通 Chat flow 的 `required Todo Tool` 守卫。
+//! 普通 Chat flow 的 Todo 成功文案守卫。
 //!
-//! 集中判断本轮普通聊天是否需要强制调用某个 Todo 写操作 Tool，避免模型不调 Tool
-//! 却发"已生成草稿/已完成"等假成功文案；判定边界与 session 状态依赖在此封装。
+//! 本模块只做“输出验真”：当模型回复声称已新增、已修改、已完成或已删除
+//! Todo 时，必须能在本轮 Tool Loop 结果里看到真实成功的 Todo 写工具输出。
+//! 这里不再根据用户输入猜测本轮应该调用哪个工具，避免路由、模型和守卫三套
+//! 意图判断互相冲突。
 
-use std::sync::OnceLock;
-
-use regex::Regex;
 use serde_json::Value;
 
-use super::{super::llm_service::RespondOutput, contains_any};
-use crate::{
-    provider::ToolExecutionResult,
-    runtime::{respond::todo_flow::is_natural_todo_query_text, session::SessionRecord},
-};
+use super::super::llm_service::RespondOutput;
+use crate::provider::ToolExecutionResult;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum TodoMutationToolKind {
-    Create,
-    Complete,
-    Edit,
-    Cancel,
-    Restore,
-    Delete,
+/// 判定模型是否可以安全透传 Todo 成功文案。
+///
+/// - 未声称 Todo 写入成功：直接放行。
+/// - 声称成功：必须存在本轮真实成功的 Todo 写工具结果。
+pub(super) fn validate_todo_success_reply(output: &RespondOutput) -> TodoSuccessValidation {
+    if !reply_claims_todo_write_success(&output.reply) {
+        return TodoSuccessValidation::Passed {
+            claimed_success: false,
+        };
+    }
+    if has_successful_todo_write_result(output) {
+        TodoSuccessValidation::Passed {
+            claimed_success: true,
+        }
+    } else {
+        TodoSuccessValidation::Blocked
+    }
 }
 
-impl TodoMutationToolKind {
-    pub(super) fn as_str(self) -> &'static str {
-        match self {
-            Self::Create => "create",
-            Self::Complete => "complete",
-            Self::Edit => "edit",
-            Self::Cancel => "cancel",
-            Self::Restore => "restore",
-            Self::Delete => "delete",
-        }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TodoSuccessValidation {
+    Passed { claimed_success: bool },
+    Blocked,
+}
+
+impl TodoSuccessValidation {
+    pub(super) fn claimed_success(self) -> bool {
+        matches!(
+            self,
+            Self::Passed {
+                claimed_success: true
+            } | Self::Blocked
+        )
     }
 
-    pub(super) fn matches_output(self, output: &RespondOutput) -> bool {
-        output
-            .tool_results
-            .iter()
-            .any(|result| self.matches_tool_result(result))
+    pub(super) fn passed(self) -> bool {
+        matches!(self, Self::Passed { .. })
     }
+}
 
-    fn matches_tool_result(self, result: &ToolExecutionResult) -> bool {
-        if !result.succeeded || result_has_explicit_failure(&result.output) {
-            return false;
-        }
-        match self {
-            Self::Create => {
-                result.name == "create_todo" && pending_action_matches(&result.output, "create")
-            }
-            Self::Complete => {
-                result.name == "complete_todos"
-                    && non_empty_array_field(&result.output, "completed")
-            }
-            Self::Edit => result.name == "edit_todo" && result.output.get("updated").is_some(),
-            Self::Cancel => {
-                result.name == "cancel_todo" && pending_action_matches(&result.output, "cancel")
-            }
-            Self::Restore => {
-                result.name == "restore_todos" && non_empty_array_field(&result.output, "restored")
-            }
-            Self::Delete => {
-                // 用户说“删除未完成待办”时，正确业务语义是软取消，因此
-                // `cancel_todo` 成功创建取消确认也属于删除意图的合法结果。
-                (result.name == "delete_todos" && pending_action_matches(&result.output, "delete"))
-                    || (result.name == "cancel_todo"
-                        && pending_action_matches(&result.output, "cancel"))
-            }
-        }
+fn has_successful_todo_write_result(output: &RespondOutput) -> bool {
+    output.tool_results.iter().any(successful_todo_write_result)
+}
+
+fn successful_todo_write_result(result: &ToolExecutionResult) -> bool {
+    if !result.succeeded || result_has_explicit_failure(&result.output) {
+        return false;
+    }
+    match result.name.as_str() {
+        "create_todo" => pending_action_matches(&result.output, "create"),
+        "cancel_todo" => pending_action_matches(&result.output, "cancel"),
+        "delete_todos" => pending_action_matches(&result.output, "delete"),
+        "edit_todo" => result.output.get("updated").is_some(),
+        "complete_todos" => non_empty_array_field(&result.output, "completed"),
+        "restore_todos" => non_empty_array_field(&result.output, "restored"),
+        _ => false,
     }
 }
 
@@ -89,396 +85,208 @@ fn non_empty_array_field(output: &Value, field: &str) -> bool {
         .is_some_and(|items| !items.is_empty())
 }
 
-/// 判断本轮是否需要强制调用某个 Todo 写操作 Tool，防止模型不调 Tool 却发假成功文案。
-///
-/// 设计约束：
-/// - 查询意图始终最优先排除，永返回 `None`。
-/// - 创建意图单独识别，不依赖已有 session 状态，但必须同时存在明确创建动词和创建目标。
-/// - 完成/取消/恢复/删除只在存在 Todo 目标上下文时才强制：
-///   明确提到待办/任务/todo，或有编号引用（依赖 `last_todo_query`），
-///   或有最近对象引用（依赖 `last_todo_action`）。
-/// - 编号引用仅在 session 存在 `last_todo_query` 时才算目标；最近对象引用仅在
-///   `last_todo_action` 时才算目标。这样可避免“完成这个项目/取消明天会议/删除服务器上的旧日志”
-///   等普通聊天被误判成 Todo 写操作。
-pub(super) fn required_todo_tool_kind(
-    user_text: &str,
-    session: &SessionRecord,
-) -> Option<TodoMutationToolKind> {
-    required_todo_tool_kind_with_context(
-        user_text,
-        session.last_todo_query.is_some(),
-        session.last_todo_action.is_some(),
-    )
-}
-
-fn required_todo_tool_kind_with_context(
-    user_text: &str,
-    has_last_todo_query: bool,
-    has_last_todo_action: bool,
-) -> Option<TodoMutationToolKind> {
-    let text = user_text.trim();
-    if text.is_empty() {
-        return None;
-    }
-    // 查询意图始终最优先排除，不得进入 Todo 写操作受控重试。
-    if looks_like_todo_query_text(text) {
-        return None;
-    }
-
-    // 创建意图单独识别：不依赖已有 session 状态，但必须同时存在明确创建动词和创建目标，
-    // 避免仅出现“待办”就误判为创建（如“待办功能怎么用”）。
-    if let Some(kind) = detect_create_todo_kind(text) {
-        return Some(kind);
-    }
-
-    // 完成/取消/恢复/删除必须同时存在 Todo 目标上下文，否则普通聊天里的
-    // “完成项目/取消会议/删除日志”会被误强制成 Todo Tool，甚至真的修改用户待办。
-    let has_todo_noun = contains_any(text, &["待办", "任务", "todo"]);
-    let has_visible_reference = contains_visible_number_reference(text) && has_last_todo_query;
-    let has_last_reference = contains_last_todo_reference(text) && has_last_todo_action;
-    if !(has_todo_noun || has_visible_reference || has_last_reference) {
-        return None;
-    }
-
-    // 检测写操作动词时屏蔽参照/状态子串，避免“已完成/刚恢复的那个”里的动词误被当成主操作。
-    let operative = strip_todo_reference_and_status(text);
-    // 顺序很关键：删除/恢复优先检测，避免“永久删除已完成待办”被“完成”抢先、“取消完成”（=恢复）被“取消”抢先。
-    if contains_any(&operative, &["删除", "删掉", "移除", "永久删除"]) {
-        return Some(TodoMutationToolKind::Delete);
-    }
-    if contains_any(&operative, &["恢复", "撤销完成", "恢复完成", "取消完成"]) {
-        return Some(TodoMutationToolKind::Restore);
-    }
-    if contains_any(
-        &operative,
-        &["修改", "改成", "改为", "更新", "改一下", "改下"],
-    ) {
-        return Some(TodoMutationToolKind::Edit);
-    }
-    if contains_any(&operative, &["完成", "做完", "标记完成", "搞定"]) {
-        return Some(TodoMutationToolKind::Complete);
-    }
-    if contains_any(&operative, &["取消", "不做了", "算了", "作废"]) {
-        return Some(TodoMutationToolKind::Cancel);
-    }
-    None
-}
-
-pub(in crate::runtime::respond) fn requires_todo_tool_with_context(
-    user_text: &str,
-    has_last_todo_query: bool,
-    has_last_todo_action: bool,
-) -> bool {
-    required_todo_tool_kind_with_context(user_text, has_last_todo_query, has_last_todo_action)
-        .is_some()
-}
-
-/// 识别明确的待办创建意图。
-///
-/// 必须同时满足创建动词和创建目标：
-/// - 创建动词：记一个 / 记个 / 帮我记 / 新增 / 添加 / 提醒我
-/// - 创建目标：明确出现待办 / 任务，或“提醒我 + 具体事项”。
-///
-/// 例如“待办功能怎么用 / 这个待办是不是有 bug”只出现待办名词、没有创建动词，不会被误判为创建。
-fn detect_create_todo_kind(text: &str) -> Option<TodoMutationToolKind> {
-    let has_create_verb = contains_any(
-        text,
-        &["记一个", "记个", "帮我记", "新增", "添加", "提醒我"],
-    );
-    if !has_create_verb {
-        return None;
-    }
-    let has_explicit_target = contains_any(text, &["待办", "任务"]);
-    let has_reminder_target = text.contains("提醒我") && has_text_after_reminder(text);
-    if has_explicit_target || has_reminder_target {
-        Some(TodoMutationToolKind::Create)
-    } else {
-        None
-    }
-}
-
-/// “提醒我 + 具体事项”判定：“提醒我”之后还有非空内容才算创建目标。
-fn has_text_after_reminder(text: &str) -> bool {
-    let Some((_, rest)) = text.split_once("提醒我") else {
+fn reply_claims_todo_write_success(reply: &str) -> bool {
+    let text = reply.trim();
+    if text.is_empty() || looks_like_non_success_explanation(text) {
         return false;
-    };
-    rest.trim().chars().count() >= 2
+    }
+    let normalized: String = text.chars().filter(|ch| !ch.is_whitespace()).collect();
+    let success_markers = [
+        "已新增",
+        "已新建",
+        "已创建",
+        "已添加",
+        "已记录",
+        "已生成待确认",
+        "已发起",
+        "已完成",
+        "已修改",
+        "已更新",
+        "已取消",
+        "已恢复",
+        "已删除",
+        "已经新增",
+        "已经新建",
+        "已经创建",
+        "已经添加",
+        "已经记录",
+        "已经完成",
+        "已经修改",
+        "已经更新",
+        "已经取消",
+        "已经恢复",
+        "已经删除",
+    ];
+    // 不读取用户输入、不推断“本轮必须调用哪个工具”；这里只从模型最终回复
+    // 本身识别高风险成功文案，避免无 Tool 结果时透传“已新增/已删除”。
+    if success_markers
+        .iter()
+        .any(|marker| normalized.starts_with(marker))
+    {
+        return true;
+    }
+
+    let has_todo_context = contains_any(
+        &normalized,
+        &[
+            "待办",
+            "任务",
+            "todo",
+            "Todo",
+            "草稿",
+            "确认",
+            "第一条",
+            "第二条",
+            "第三条",
+            "第1条",
+            "第2条",
+            "第3条",
+            "刚才那个",
+            "刚刚那条",
+            "那个",
+            "它",
+        ],
+    );
+    if !has_todo_context {
+        return false;
+    }
+    contains_any(&normalized, &success_markers)
 }
 
-/// 检测明确的待办编号引用：“第 1 个 / 第一个 / 编号 2 / 第 3 条”等。
-///
-/// 只检测是否存在编号引用句式本身，不检测孤立数字，避免普通文本里出现数字就误强制 Todo Tool。
-fn contains_visible_number_reference(text: &str) -> bool {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    let re = RE.get_or_init(|| {
-        Regex::new(r"第\s*[0-9一二三四五六七八九十]+\s*[个条项]|编号\s*[0-9]+")
-            .expect("todo number reference regex")
-    });
-    re.is_match(text)
-}
-
-/// 检测最近待办对象引用：“刚才那个 / 刚恢复的那个 / 它 / 把它…”等。
-///
-/// 不包含裸“那个”（会误命中“那个项目我完成了”这类非 Todo 语句）；“那个待办”已通过 `has_todo_noun` 覆盖。
-/// 是否算作目标还需要 `session.last_todo_action` 存在，该约束在 `required_todo_tool_kind` 中处理。
-fn contains_last_todo_reference(text: &str) -> bool {
+fn looks_like_non_success_explanation(text: &str) -> bool {
     contains_any(
         text,
         &[
-            "刚才那个",
-            "刚恢复的那个",
-            "刚完成的那个",
-            "刚取消的那个",
-            "刚删除的那个",
-            "刚创建的那个",
-            "刚新建的那个",
-            "把它",
-            "它",
+            "没有真正执行",
+            "没有执行",
+            "未执行",
+            "无法确认",
+            "不能确认",
+            "没有收到",
+            "没有调用",
+            "不能算",
+            "不算",
         ],
     )
 }
 
-/// 屏蔽参照与状态子串（“已完成 / 已取消 / 刚恢复的那个 / 第 N 个”），返回只保留主操作动词的文本。
-///
-/// 这些子串里的“完成 / 取消 / 恢复”是状态/参照描述，不是本轮主操作，检测写操作动词时需先移除。
-fn strip_todo_reference_and_status(text: &str) -> String {
-    let mut out = text.to_owned();
-    for phrase in [
-        "刚恢复的那个",
-        "刚完成的那个",
-        "刚取消的那个",
-        "刚删除的那个",
-        "刚创建的那个",
-        "刚新建的那个",
-        "刚才那个",
-        "已完成的",
-        "已取消的",
-        "已完成",
-        "已取消",
-        "把它",
-        "它",
-    ] {
-        out = out.replace(phrase, " ");
-    }
-    // 移除编号引用，避免“第 N 个”干扰动词检测。
-    static RE: OnceLock<Regex> = OnceLock::new();
-    let re = RE.get_or_init(|| {
-        Regex::new(r"第\s*[0-9一二三四五六七八九十]+\s*[个条项]|编号\s*[0-9]+")
-            .expect("todo number reference strip regex")
-    });
-    out = re.replace_all(&out, " ").to_string();
-    out
+fn contains_any(text: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| text.contains(needle))
 }
 
-fn looks_like_todo_query_text(text: &str) -> bool {
-    is_natural_todo_query_text(text)
-}
-
-pub(super) fn todo_required_tool_not_called_reply(
-    required_tool_kind: Option<TodoMutationToolKind>,
-) -> String {
-    let action = match required_tool_kind {
-        Some(TodoMutationToolKind::Create) => "新增待办",
-        Some(TodoMutationToolKind::Complete) => "完成待办",
-        Some(TodoMutationToolKind::Edit) => "修改待办",
-        Some(TodoMutationToolKind::Cancel) => "取消待办",
-        Some(TodoMutationToolKind::Restore) => "恢复待办",
-        Some(TodoMutationToolKind::Delete) => "删除待办",
-        None => "处理待办",
-    };
-    format!("我这次没有真正执行到{action}操作。请再说一次，我会先调用待办工具，再告诉你结果。")
+pub(super) fn todo_success_not_verified_reply() -> String {
+    "我这次没有收到待办工具的成功回执，所以不能确认已经完成该待办操作。请再说一次，或使用 /todo 查看当前待办状态。".to_owned()
 }
 
 #[cfg(test)]
 mod tests {
     use serde_json::json;
 
-    use crate::runtime::session::{LastTodoAction, LastTodoQuery, SessionRecord};
-    use crate::runtime::todo::TodoStatus;
+    use crate::{
+        provider::ToolExecutionResult,
+        runtime::respond::{llm_service::RespondOutput, types::ChatResponse},
+        util::metrics::LlmMetrics,
+    };
 
-    use super::{TodoMutationToolKind, required_todo_tool_kind};
+    use super::{TodoSuccessValidation, validate_todo_success_reply};
 
-    /// 通过反序列化构造一个全默认字段的 session，便于隔离测试 Todo 意图判定。
-    fn empty_session() -> SessionRecord {
-        serde_json::from_value(json!({})).unwrap()
+    fn output(reply: &str, tool_results: Vec<ToolExecutionResult>) -> RespondOutput {
+        RespondOutput {
+            reply: reply.to_owned(),
+            text: reply.to_owned(),
+            markdown: None,
+            chat: ChatResponse::ok(
+                reply.to_owned(),
+                LlmMetrics {
+                    provider: "test".to_owned(),
+                    model: "test".to_owned(),
+                    stream: false,
+                    ttfe_ms: None,
+                    ttft_ms: None,
+                    total_latency_ms: 1,
+                },
+                None,
+            ),
+            executed_tools: tool_results
+                .iter()
+                .map(|result| result.name.clone())
+                .collect(),
+            tool_results,
+        }
     }
 
-    fn session_with_last_query() -> SessionRecord {
-        let mut session = empty_session();
-        session.last_todo_query = Some(LastTodoQuery {
-            owner_key: "private:u1".to_owned(),
-            query_type: "list".to_owned(),
-            condition: String::new(),
-            result_ids: vec!["item-1".to_owned()],
-            created_at: "2026-06-30T00:00:00+08:00".to_owned(),
-        });
-        session
+    fn tool_result(name: &str, value: serde_json::Value, succeeded: bool) -> ToolExecutionResult {
+        ToolExecutionResult {
+            name: name.to_owned(),
+            output: value,
+            succeeded,
+        }
     }
 
-    fn session_with_last_action() -> SessionRecord {
-        let mut session = empty_session();
-        session.last_todo_action = Some(LastTodoAction {
-            owner_key: "private:u1".to_owned(),
-            item_id: "item-1".to_owned(),
-            title: "示例待办".to_owned(),
-            action: "completed".to_owned(),
-            resulting_status: TodoStatus::Completed,
-            created_at: "2026-06-30T00:00:00+08:00".to_owned(),
-        });
-        session
-    }
-
-    fn assert_kind(text: &str, session: &SessionRecord, expected: Option<TodoMutationToolKind>) {
+    #[test]
+    fn non_success_chat_passes_without_tool_result() {
         assert_eq!(
-            required_todo_tool_kind(text, session),
-            expected,
-            "text = {text:?}"
-        );
-    }
-
-    // ----- 创建意图：不依赖 session 状态，但必须有明确创建动词和创建目标 -----
-
-    #[test]
-    fn create_intent_recognized_without_session_state() {
-        let session = empty_session();
-        assert_kind(
-            "帮我记一个待办，今晚检查日志",
-            &session,
-            Some(TodoMutationToolKind::Create),
-        );
-        assert_kind(
-            "新增一个任务，明天交报告",
-            &session,
-            Some(TodoMutationToolKind::Create),
-        );
-        assert_kind(
-            "提醒我明天下午三点开会",
-            &session,
-            Some(TodoMutationToolKind::Create),
+            validate_todo_success_reply(&output("晚上好，今天想聊点什么？", Vec::new())),
+            TodoSuccessValidation::Passed {
+                claimed_success: false
+            }
         );
     }
 
     #[test]
-    fn create_intent_not_forced_for_todo_mentions_without_create_verb() {
-        let session = empty_session();
-        // 有待办但没有创建动词，不应被误判为创建。
-        assert_kind("待办功能怎么用", &session, None);
-        assert_kind("我们聊聊待办设计", &session, None);
-        assert_kind("这个待办是不是有 bug", &session, None);
-        assert_kind("为什么我的待办没显示", &session, None);
-    }
-
-    // ----- 非 Todo 普通聊天：不应强制任何 mutation Tool -----
-    #[test]
-    fn non_todo_chat_is_not_forced() {
-        let session = empty_session();
-        assert_kind("我终于完成这个项目了", &session, None);
-        assert_kind("取消明天的会议", &session, None);
-        assert_kind("删除服务器上的旧日志", &session, None);
-        assert_kind("这个方案算了，不做了", &session, None);
-        assert_kind("帮我恢复刚才删除的文档", &session, None);
-    }
-
-    // ----- 状态修改依赖 Todo 目标上下文：名词 / 编号 / 最近对象引用 -----
-
-    #[test]
-    fn mutation_with_todo_noun_recognized_without_session_state() {
-        let session = empty_session();
-        assert_kind(
-            "完成第 1 个待办",
-            &session,
-            Some(TodoMutationToolKind::Complete),
-        );
-        assert_kind(
-            "修改第 2 个待办",
-            &session,
-            Some(TodoMutationToolKind::Edit),
-        );
-        assert_kind(
-            "取消第 2 个任务",
-            &session,
-            Some(TodoMutationToolKind::Cancel),
-        );
-        // “已完成”是状态描述，不应被“完成”抢先；主操作是删除。
-        assert_kind(
-            "永久删除已完成待办第 3 个",
-            &session,
-            Some(TodoMutationToolKind::Delete),
+    fn explicit_non_success_explanation_passes_without_tool_result() {
+        assert_eq!(
+            validate_todo_success_reply(&output(
+                "没有收到待办工具的成功回执，不能确认已经新增待办。",
+                Vec::new()
+            )),
+            TodoSuccessValidation::Passed {
+                claimed_success: false
+            }
         );
     }
 
     #[test]
-    fn mutation_with_number_reference_requires_last_todo_query() {
-        // last_todo_query 存在时，编号引用算 Todo 目标。
-        let session = session_with_last_query();
-        assert_kind(
-            "完成第 1 个",
-            &session,
-            Some(TodoMutationToolKind::Complete),
+    fn todo_success_reply_without_tool_result_is_blocked() {
+        assert_eq!(
+            validate_todo_success_reply(&output("已新增待办：明天接老公", Vec::new())),
+            TodoSuccessValidation::Blocked
         );
-        assert_kind("取消第 1 个", &session, Some(TodoMutationToolKind::Cancel));
-
-        // last_todo_query 缺失时，裸编号引用不应强制 Tool。
-        let session = empty_session();
-        assert_kind("完成第 1 个", &session, None);
-        assert_kind("删除第 2 个", &session, None);
-    }
-
-    #[test]
-    fn mutation_with_last_reference_requires_last_todo_action() {
-        // last_todo_action 存在时，“刚才那个 / 刚恢复的那个 / 它”算 Todo 目标。
-        let session = session_with_last_action();
-        assert_kind(
-            "把刚才那个完成",
-            &session,
-            Some(TodoMutationToolKind::Complete),
+        assert_eq!(
+            validate_todo_success_reply(&output("已新增：明天接老公", Vec::new())),
+            TodoSuccessValidation::Blocked
         );
-        assert_kind(
-            "取消刚恢复的那个",
-            &session,
-            Some(TodoMutationToolKind::Cancel),
-        );
-        assert_kind("删除它", &session, Some(TodoMutationToolKind::Delete));
-        assert_kind("把它取消掉", &session, Some(TodoMutationToolKind::Cancel));
-        assert_kind(
-            "删除刚取消的那个",
-            &session,
-            Some(TodoMutationToolKind::Delete),
-        );
-
-        // last_todo_action 缺失时，最近对象引用不应强制 Tool。
-        let session = empty_session();
-        assert_kind("删除它", &session, None);
-        assert_kind("取消刚才那个", &session, None);
-    }
-
-    #[test]
-    fn mutation_restore_phrases_override_complete_and_cancel() {
-        let session = empty_session();
-        // “取消完成 / 恢复完成”表示撤销完成（=恢复），不应被“取消 / 完成”抢先。
-        assert_kind(
-            "取消完成第 1 个待办",
-            &session,
-            Some(TodoMutationToolKind::Restore),
-        );
-        assert_kind(
-            "恢复完成第 2 个任务",
-            &session,
-            Some(TodoMutationToolKind::Restore),
+        assert_eq!(
+            validate_todo_success_reply(&output("第二条待办已删除。", Vec::new())),
+            TodoSuccessValidation::Blocked
         );
     }
 
-    // ----- 查询意图最优先排除，永返回 None -----
-
     #[test]
-    fn query_intent_is_always_excluded() {
-        let session = session_with_last_query();
-        assert_kind("看看我的待办", &session, None);
-        assert_kind("有哪些任务", &session, None);
-        assert_kind("列出已完成的待办", &session, None);
-        assert_kind("看看已完成", &session, None);
-        assert_kind("看看已取消", &session, None);
-        assert_kind("我的待办", &session, None);
-        assert_kind("待办列表", &session, None);
+    fn todo_success_reply_requires_successful_structured_result() {
+        assert_eq!(
+            validate_todo_success_reply(&output(
+                "第二条待办已删除。",
+                vec![tool_result(
+                    "delete_todos",
+                    json!({"ok": false, "message": "failed"}),
+                    false,
+                )],
+            )),
+            TodoSuccessValidation::Blocked
+        );
+        assert_eq!(
+            validate_todo_success_reply(&output(
+                "第二条待办已删除。",
+                vec![tool_result(
+                    "delete_todos",
+                    json!({"ok": true, "requires_confirmation": true, "pending_action": "delete"}),
+                    true,
+                )],
+            )),
+            TodoSuccessValidation::Passed {
+                claimed_success: true
+            }
+        );
     }
 }

--- a/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
@@ -6,9 +6,13 @@
 use std::sync::OnceLock;
 
 use regex::Regex;
+use serde_json::Value;
 
-use super::contains_any;
-use crate::runtime::{respond::todo_flow::is_natural_todo_query_text, session::SessionRecord};
+use super::{super::llm_service::RespondOutput, contains_any};
+use crate::{
+    provider::ToolExecutionResult,
+    runtime::{respond::todo_flow::is_natural_todo_query_text, session::SessionRecord},
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum TodoMutationToolKind {
@@ -32,22 +36,57 @@ impl TodoMutationToolKind {
         }
     }
 
-    fn required_tool_name(self) -> &'static str {
-        match self {
-            Self::Create => "create_todo",
-            Self::Complete => "complete_todos",
-            Self::Edit => "edit_todo",
-            Self::Cancel => "cancel_todo",
-            Self::Restore => "restore_todos",
-            Self::Delete => "delete_todos",
-        }
+    pub(super) fn matches_output(self, output: &RespondOutput) -> bool {
+        output
+            .tool_results
+            .iter()
+            .any(|result| self.matches_tool_result(result))
     }
 
-    pub(super) fn matches_executed_tools(self, executed_tools: &[String]) -> bool {
-        executed_tools
-            .iter()
-            .any(|tool| tool == self.required_tool_name())
+    fn matches_tool_result(self, result: &ToolExecutionResult) -> bool {
+        if !result.succeeded || result_has_explicit_failure(&result.output) {
+            return false;
+        }
+        match self {
+            Self::Create => {
+                result.name == "create_todo" && pending_action_matches(&result.output, "create")
+            }
+            Self::Complete => {
+                result.name == "complete_todos"
+                    && non_empty_array_field(&result.output, "completed")
+            }
+            Self::Edit => result.name == "edit_todo" && result.output.get("updated").is_some(),
+            Self::Cancel => {
+                result.name == "cancel_todo" && pending_action_matches(&result.output, "cancel")
+            }
+            Self::Restore => {
+                result.name == "restore_todos" && non_empty_array_field(&result.output, "restored")
+            }
+            Self::Delete => {
+                // 用户说“删除未完成待办”时，正确业务语义是软取消，因此
+                // `cancel_todo` 成功创建取消确认也属于删除意图的合法结果。
+                (result.name == "delete_todos" && pending_action_matches(&result.output, "delete"))
+                    || (result.name == "cancel_todo"
+                        && pending_action_matches(&result.output, "cancel"))
+            }
+        }
     }
+}
+
+fn result_has_explicit_failure(output: &Value) -> bool {
+    output.get("ok").and_then(Value::as_bool) == Some(false)
+}
+
+fn pending_action_matches(output: &Value, action: &str) -> bool {
+    output.get("requires_confirmation").and_then(Value::as_bool) == Some(true)
+        && output.get("pending_action").and_then(Value::as_str) == Some(action)
+}
+
+fn non_empty_array_field(output: &Value, field: &str) -> bool {
+    output
+        .get(field)
+        .and_then(Value::as_array)
+        .is_some_and(|items| !items.is_empty())
 }
 
 /// 判断本轮是否需要强制调用某个 Todo 写操作 Tool，防止模型不调 Tool 却发假成功文案。

--- a/qq-maid-core/src/runtime/respond/llm_service/mod.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service/mod.rs
@@ -18,7 +18,7 @@ use futures::StreamExt;
 use crate::{
     error::LlmError,
     provider::{
-        ChatOutcome, DynLlmProvider, LlmStreamEvent, ToolChatRequest,
+        ChatOutcome, DynLlmProvider, LlmStreamEvent, ToolChatRequest, ToolExecutionResult,
         types::{ChatMessage, ChatRequest, ChatRole},
     },
     runtime::session::redact_sensitive_text,
@@ -68,6 +68,8 @@ pub struct RespondOutput {
     pub chat: ChatResponse,
     /// Tool Loop 中实际执行过的工具名列表；普通聊天为空。
     pub executed_tools: Vec<String>,
+    /// Tool Loop 中实际工具输出摘要；普通聊天为空。
+    pub tool_results: Vec<ToolExecutionResult>,
 }
 
 /// `ChatService` 的默认实现。
@@ -163,6 +165,7 @@ impl LlmChatService {
             usage,
             fallback_used,
             executed_tools: Vec::new(),
+            tool_results: Vec::new(),
         };
         log_llm_request_completed(&req, &outcome);
         output_from_raw_reply(&req, raw_reply, outcome)
@@ -300,6 +303,7 @@ fn output_from_raw_reply(
         markdown,
         chat,
         executed_tools: outcome.executed_tools,
+        tool_results: outcome.tool_results,
     })
 }
 

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -75,7 +75,7 @@ async fn private_chat_with_openai_responses_capability_enters_tool_loop() {
 }
 
 #[tokio::test]
-async fn private_general_chat_with_tool_capability_uses_plain_chat() {
+async fn private_general_chat_with_tool_capability_uses_tool_loop_without_tool_call() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
 
@@ -89,14 +89,18 @@ async fn private_general_chat_with_tool_capability_uses_plain_chat() {
             .text
             .as_deref()
             .unwrap()
-            .contains("回复：聊聊 Rust 的所有权")
+            .contains("工具回复：聊聊 Rust 的所有权")
     );
-    assert_eq!(inspector.tool_call_count(), 0);
-    assert_eq!(inspector.requests().len(), 1);
+    assert_eq!(inspector.tool_call_count(), 1);
+    assert_eq!(inspector.requests().len(), 0);
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["tool_calling_enabled"], serde_json::json!(true));
     assert_eq!(
-        response.diagnostics.unwrap()["tool_calling_enabled"],
-        serde_json::json!(false)
+        diagnostics["tool_loop_executed_tools"],
+        serde_json::json!([])
     );
+    assert_eq!(diagnostics["todo_success_claimed"], false);
+    assert_eq!(diagnostics["todo_success_verified"], true);
 }
 
 #[tokio::test]
@@ -586,8 +590,8 @@ async fn tool_loop_created_todo_pending_survives_chat_history_save_and_confirm_s
         .unwrap();
     assert!(first.text.unwrap().contains("工具回复"));
     let first_diagnostics = first.diagnostics.unwrap();
-    assert_eq!(first_diagnostics["required_tool_kind"], "create");
-    assert_eq!(first_diagnostics["required_tool_called"], true);
+    assert_eq!(first_diagnostics["todo_success_claimed"], false);
+    assert_eq!(first_diagnostics["todo_success_verified"], true);
     assert_eq!(first_diagnostics["tool_retry_count"], 0);
     assert_eq!(
         first_diagnostics["tool_loop_executed_tools"],
@@ -618,6 +622,40 @@ async fn tool_loop_created_todo_pending_survives_chat_history_save_and_confirm_s
 }
 
 #[tokio::test]
+async fn private_todo_create_phrase_is_handled_by_agent_tool_loop() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_create_todo_tool_call("明天接老公");
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+
+    let response = service
+        .respond(private_message("新增待办，明天接老公"))
+        .await
+        .unwrap();
+
+    assert!(response.text.unwrap().contains("工具回复"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(
+        diagnostics["tool_loop_executed_tools"],
+        serde_json::json!(["create_todo"])
+    );
+    assert_eq!(diagnostics["todo_success_verified"], true);
+    let session = service
+        .session_store
+        .get_or_create_active(&private_test_meta())
+        .unwrap();
+    match session.pending_operation {
+        Some(PendingOperation::TodoAdd { draft, .. }) => {
+            assert_eq!(draft.raw_text.as_deref(), Some("明天接老公"));
+        }
+        other => panic!("expected TodoAdd pending operation, got {other:?}"),
+    }
+    assert!(service.todo_store.list_all(&owner).unwrap().is_empty());
+    assert_eq!(inspector.tool_call_count(), 1);
+}
+
+#[tokio::test]
 async fn todo_create_intent_without_tool_call_does_not_leak_fake_success_reply() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
@@ -632,12 +670,12 @@ async fn todo_create_intent_without_tool_call_does_not_leak_fake_success_reply()
         .unwrap();
 
     let text = response.text.unwrap();
-    assert!(text.contains("没有真正执行到新增待办操作"));
+    assert!(text.contains("没有收到待办工具的成功回执"));
     let diagnostics = response.diagnostics.unwrap();
-    assert_eq!(diagnostics["required_tool_kind"], "create");
-    assert_eq!(diagnostics["required_tool_called"], false);
-    assert_eq!(diagnostics["tool_retry_count"], 1);
-    assert_eq!(diagnostics["error_code"], "required_tool_not_called");
+    assert_eq!(diagnostics["todo_success_claimed"], true);
+    assert_eq!(diagnostics["todo_success_verified"], false);
+    assert_eq!(diagnostics["tool_retry_count"], 0);
+    assert_eq!(diagnostics["error_code"], "todo_success_not_verified");
     assert_eq!(
         diagnostics["tool_loop_executed_tools"],
         serde_json::json!([])
@@ -648,7 +686,7 @@ async fn todo_create_intent_without_tool_call_does_not_leak_fake_success_reply()
         .get_or_create_active(&private_test_meta())
         .unwrap();
     assert!(session.pending_operation.is_none());
-    assert_eq!(inspector.tool_call_count(), 2);
+    assert_eq!(inspector.tool_call_count(), 1);
     assert_eq!(inspector.requests().len(), 0);
 }
 
@@ -692,10 +730,7 @@ async fn todo_delete_pending_item_accepts_cancel_tool_pending_result() {
         )
         .unwrap();
 
-    service
-        .respond(private_message("看一下待办"))
-        .await
-        .unwrap();
+    service.respond(private_message("/todo")).await.unwrap();
     let response = service
         .respond(private_message("删除第二条"))
         .await
@@ -703,8 +738,8 @@ async fn todo_delete_pending_item_accepts_cancel_tool_pending_result() {
 
     assert!(response.text.as_deref().unwrap().contains("取消待办"));
     let diagnostics = response.diagnostics.unwrap();
-    assert_eq!(diagnostics["required_tool_kind"], "delete");
-    assert_eq!(diagnostics["required_tool_called"], true);
+    assert_eq!(diagnostics["todo_success_claimed"], true);
+    assert_eq!(diagnostics["todo_success_verified"], true);
     assert_eq!(diagnostics["tool_retry_count"], 0);
     assert_eq!(diagnostics["error_code"], Value::Null);
     let session = service
@@ -756,8 +791,8 @@ async fn todo_edit_guard_requires_successful_update_result() {
         .unwrap();
 
     let diagnostics = response.diagnostics.unwrap();
-    assert_eq!(diagnostics["required_tool_kind"], "edit");
-    assert_eq!(diagnostics["required_tool_called"], true);
+    assert_eq!(diagnostics["todo_success_claimed"], true);
+    assert_eq!(diagnostics["todo_success_verified"], true);
     assert_eq!(diagnostics["tool_retry_count"], 0);
     assert_eq!(
         service.todo_store.list_pending(&owner).unwrap()[0].title,
@@ -766,7 +801,70 @@ async fn todo_edit_guard_requires_successful_update_result() {
 }
 
 #[tokio::test]
-async fn todo_edit_tool_false_result_does_not_pass_required_guard() {
+async fn todo_edit_second_item_uses_latest_visible_snapshot() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json(
+            "edit_todo",
+            r#"{"number":2,"reference":null,"raw_text":"把第二条改成明天","title":null,"detail":null,"due_date":"2026-07-02","due_at":null,"time_precision":"date"}"#,
+            "第二条待办已修改",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "第一条".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "第二条要改时间".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+
+    service.respond(private_message("/todo")).await.unwrap();
+    let response = service
+        .respond(private_message("把第二条改成明天"))
+        .await
+        .unwrap();
+
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["todo_success_claimed"], true);
+    assert_eq!(diagnostics["todo_success_verified"], true);
+    let todos = service.todo_store.list_pending(&owner).unwrap();
+    let first = todos
+        .iter()
+        .find(|item| item.title == "第一条")
+        .expect("missing first todo");
+    let second = todos
+        .iter()
+        .find(|item| item.title == "第二条要改时间")
+        .expect("missing second todo");
+    assert_eq!(first.due_date, None);
+    assert_eq!(second.due_date.as_deref(), Some("2026-07-02"));
+    assert_eq!(inspector.tool_call_count(), 1);
+}
+
+#[tokio::test]
+async fn todo_edit_tool_false_result_does_not_pass_success_guard() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
         .with_tool_call_json(
@@ -807,17 +905,17 @@ async fn todo_edit_tool_false_result_does_not_pass_required_guard() {
         .unwrap();
 
     let text = response.text.unwrap();
-    assert!(text.contains("没有真正执行到修改待办操作"));
+    assert!(text.contains("没有收到待办工具的成功回执"));
     let diagnostics = response.diagnostics.unwrap();
-    assert_eq!(diagnostics["required_tool_kind"], "edit");
-    assert_eq!(diagnostics["required_tool_called"], false);
-    assert_eq!(diagnostics["tool_retry_count"], 1);
-    assert_eq!(diagnostics["error_code"], "required_tool_not_called");
-    assert_eq!(inspector.tool_call_count(), 2);
+    assert_eq!(diagnostics["todo_success_claimed"], true);
+    assert_eq!(diagnostics["todo_success_verified"], false);
+    assert_eq!(diagnostics["tool_retry_count"], 0);
+    assert_eq!(diagnostics["error_code"], "todo_success_not_verified");
+    assert_eq!(inspector.tool_call_count(), 1);
 }
 
 #[tokio::test]
-async fn todo_delete_tool_false_result_does_not_pass_required_guard() {
+async fn todo_delete_tool_false_result_does_not_pass_success_guard() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
         .with_tool_call_json(
@@ -857,12 +955,12 @@ async fn todo_delete_tool_false_result_does_not_pass_required_guard() {
         .unwrap();
 
     let text = response.text.unwrap();
-    assert!(text.contains("没有真正执行到删除待办操作"));
+    assert!(text.contains("没有收到待办工具的成功回执"));
     let diagnostics = response.diagnostics.unwrap();
-    assert_eq!(diagnostics["required_tool_kind"], "delete");
-    assert_eq!(diagnostics["required_tool_called"], false);
-    assert_eq!(diagnostics["tool_retry_count"], 1);
-    assert_eq!(diagnostics["error_code"], "required_tool_not_called");
+    assert_eq!(diagnostics["todo_success_claimed"], true);
+    assert_eq!(diagnostics["todo_success_verified"], false);
+    assert_eq!(diagnostics["tool_retry_count"], 0);
+    assert_eq!(diagnostics["error_code"], "todo_success_not_verified");
     assert!(service.todo_store.list_pending(&owner).unwrap().len() == 1);
 }
 
@@ -903,8 +1001,8 @@ async fn todo_delete_completed_item_accepts_delete_tool_pending_result() {
         .unwrap();
 
     let diagnostics = response.diagnostics.unwrap();
-    assert_eq!(diagnostics["required_tool_kind"], "delete");
-    assert_eq!(diagnostics["required_tool_called"], true);
+    assert_eq!(diagnostics["todo_success_claimed"], true);
+    assert_eq!(diagnostics["todo_success_verified"], true);
     assert_eq!(diagnostics["tool_retry_count"], 0);
     let session = service
         .session_store
@@ -1556,7 +1654,7 @@ async fn natural_language_cancelled_todo_query_lists_cancelled_items() {
 }
 
 #[tokio::test]
-async fn non_todo_chat_phrase_does_not_force_required_tool() {
+async fn non_todo_chat_phrase_does_not_mutate_when_model_calls_no_tool() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
@@ -1581,16 +1679,17 @@ async fn non_todo_chat_phrase_does_not_force_required_tool() {
         .unwrap();
 
     let diagnostics = response.diagnostics.unwrap();
-    assert_eq!(diagnostics["required_tool_kind"], Value::Null);
+    assert_eq!(diagnostics["todo_success_claimed"], false);
+    assert_eq!(diagnostics["todo_success_verified"], true);
     assert_eq!(diagnostics["tool_retry_count"], 0);
     assert_eq!(diagnostics["error_code"], Value::Null);
     assert_eq!(
         diagnostics["tool_loop_executed_tools"],
         serde_json::json!([])
     );
-    // 没有 Todo 目标上下文时不触发受控重试，也不让 Tool Loop 抢走普通聊天流式链路。
-    assert_eq!(inspector.tool_call_count(), 0);
-    assert_eq!(inspector.requests().len(), 1);
+    // 私聊普通消息统一进入 Tool Loop，但模型未调用 Todo 工具时不应修改待办。
+    assert_eq!(inspector.tool_call_count(), 1);
+    assert_eq!(inspector.requests().len(), 0);
     // 待办不应被误修改。
     assert_eq!(
         service.todo_store.list_pending(&owner).unwrap()[0].status,
@@ -1599,11 +1698,10 @@ async fn non_todo_chat_phrase_does_not_force_required_tool() {
 }
 
 #[tokio::test]
-async fn last_reference_complete_without_tool_emits_required_tool_failure() {
+async fn last_reference_complete_without_tool_blocks_fake_success_reply() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
-        .with_tool_loop_reply_without_tool("已完成了")
-        .with_tool_loop_reply_without_tool("好的，已完成刚才那个");
+        .with_tool_loop_reply_without_tool("好的，刚才那个待办已完成");
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
     let todo = service
@@ -1635,17 +1733,17 @@ async fn last_reference_complete_without_tool_emits_required_tool_failure() {
         .unwrap();
 
     let text = response.text.unwrap();
-    assert!(text.contains("没有真正执行到完成待办操作"));
+    assert!(text.contains("没有收到待办工具的成功回执"));
     let diagnostics = response.diagnostics.unwrap();
-    assert_eq!(diagnostics["required_tool_kind"], "complete");
-    assert_eq!(diagnostics["required_tool_called"], false);
-    assert_eq!(diagnostics["tool_retry_count"], 1);
-    assert_eq!(diagnostics["error_code"], "required_tool_not_called");
+    assert_eq!(diagnostics["todo_success_claimed"], true);
+    assert_eq!(diagnostics["todo_success_verified"], false);
+    assert_eq!(diagnostics["tool_retry_count"], 0);
+    assert_eq!(diagnostics["error_code"], "todo_success_not_verified");
     assert_eq!(
         diagnostics["tool_loop_executed_tools"],
         serde_json::json!([])
     );
-    assert_eq!(inspector.tool_call_count(), 2);
+    assert_eq!(inspector.tool_call_count(), 1);
     // 未真正调用 complete_todos，待办状态不应改变。
     assert_eq!(
         service.todo_store.list_pending(&owner).unwrap()[0].status,

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -653,6 +653,277 @@ async fn todo_create_intent_without_tool_call_does_not_leak_fake_success_reply()
 }
 
 #[tokio::test]
+async fn todo_delete_pending_item_accepts_cancel_tool_pending_result() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json(
+            "cancel_todo",
+            r#"{"number":2,"reference":null}"#,
+            "已发起取消待办确认",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "第一条".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "第二条待取消".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+
+    service
+        .respond(private_message("看一下待办"))
+        .await
+        .unwrap();
+    let response = service
+        .respond(private_message("删除第二条"))
+        .await
+        .unwrap();
+
+    assert!(response.text.as_deref().unwrap().contains("取消待办"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["required_tool_kind"], "delete");
+    assert_eq!(diagnostics["required_tool_called"], true);
+    assert_eq!(diagnostics["tool_retry_count"], 0);
+    assert_eq!(diagnostics["error_code"], Value::Null);
+    let session = service
+        .session_store
+        .get_or_create_active(&private_test_meta())
+        .unwrap();
+    match session.pending_operation {
+        Some(PendingOperation::TodoDelete { item, .. }) => {
+            assert_eq!(item.title, "第二条待取消");
+        }
+        other => panic!("expected TodoDelete pending operation, got {other:?}"),
+    }
+    assert_eq!(inspector.tool_call_count(), 1);
+}
+
+#[tokio::test]
+async fn todo_edit_guard_requires_successful_update_result() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json(
+            "edit_todo",
+            r#"{"number":1,"reference":null,"raw_text":"改成检查新版守卫","title":"检查新版守卫","detail":null,"due_date":null,"due_at":null,"time_precision":null}"#,
+            "已修改待办",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "检查旧守卫".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+
+    service
+        .respond(private_message("看一下待办"))
+        .await
+        .unwrap();
+    let response = service
+        .respond(private_message("把第一条改成检查新版守卫"))
+        .await
+        .unwrap();
+
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["required_tool_kind"], "edit");
+    assert_eq!(diagnostics["required_tool_called"], true);
+    assert_eq!(diagnostics["tool_retry_count"], 0);
+    assert_eq!(
+        service.todo_store.list_pending(&owner).unwrap()[0].title,
+        "检查新版守卫"
+    );
+}
+
+#[tokio::test]
+async fn todo_edit_tool_false_result_does_not_pass_required_guard() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json(
+            "edit_todo",
+            r#"{"number":1,"reference":null,"raw_text":"改成不应成功","title":"不应成功","detail":null,"due_date":null,"due_at":null,"time_precision":null}"#,
+            "已修改待办",
+        )
+        .with_tool_call_json(
+            "edit_todo",
+            r#"{"number":1,"reference":null,"raw_text":"改成不应成功","title":"不应成功","detail":null,"due_date":null,"due_at":null,"time_precision":null}"#,
+            "已修改待办",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let todo = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "已先完成".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+
+    service
+        .respond(private_message("看一下待办"))
+        .await
+        .unwrap();
+    service.todo_store.complete(&owner, &todo.id).unwrap();
+    let response = service
+        .respond(private_message("把第一条改成不应成功"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert!(text.contains("没有真正执行到修改待办操作"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["required_tool_kind"], "edit");
+    assert_eq!(diagnostics["required_tool_called"], false);
+    assert_eq!(diagnostics["tool_retry_count"], 1);
+    assert_eq!(diagnostics["error_code"], "required_tool_not_called");
+    assert_eq!(inspector.tool_call_count(), 2);
+}
+
+#[tokio::test]
+async fn todo_delete_tool_false_result_does_not_pass_required_guard() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json(
+            "delete_todos",
+            r#"{"numbers":[1],"reference":null}"#,
+            "已删除待办",
+        )
+        .with_tool_call_json(
+            "delete_todos",
+            r#"{"numbers":[1],"reference":null}"#,
+            "已删除待办",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "未完成不能永久删除".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+
+    service
+        .respond(private_message("看一下待办"))
+        .await
+        .unwrap();
+    let response = service
+        .respond(private_message("永久删除第一条"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert!(text.contains("没有真正执行到删除待办操作"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["required_tool_kind"], "delete");
+    assert_eq!(diagnostics["required_tool_called"], false);
+    assert_eq!(diagnostics["tool_retry_count"], 1);
+    assert_eq!(diagnostics["error_code"], "required_tool_not_called");
+    assert!(service.todo_store.list_pending(&owner).unwrap().len() == 1);
+}
+
+#[tokio::test]
+async fn todo_delete_completed_item_accepts_delete_tool_pending_result() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json(
+            "delete_todos",
+            r#"{"numbers":[1],"reference":null}"#,
+            "已发起永久删除确认",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let todo = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "已完成可永久删除".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    service.todo_store.complete(&owner, &todo.id).unwrap();
+
+    service
+        .respond(private_message("看看已完成"))
+        .await
+        .unwrap();
+    let response = service
+        .respond(private_message("删除第一条"))
+        .await
+        .unwrap();
+
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["required_tool_kind"], "delete");
+    assert_eq!(diagnostics["required_tool_called"], true);
+    assert_eq!(diagnostics["tool_retry_count"], 0);
+    let session = service
+        .session_store
+        .get_or_create_active(&private_test_meta())
+        .unwrap();
+    match session.pending_operation {
+        Some(PendingOperation::TodoBulkDelete {
+            matched_count,
+            status,
+            ..
+        }) => {
+            assert_eq!(matched_count, 1);
+            assert_eq!(status, TodoStatus::Completed);
+        }
+        other => panic!("expected TodoBulkDelete pending operation, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn natural_language_todo_query_prefers_listing_over_todo_parse_creation_chain() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     // Tool Calling 关闭时仍保留确定性 Todo 查询路径；开启时由前置路由交给 Tool Loop。

--- a/qq-maid-core/src/runtime/respond/tests/support.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support.rs
@@ -56,8 +56,17 @@ pub(super) struct MockProvider {
 
 #[derive(Clone)]
 enum MockToolAction {
-    CreateTodo { content: String },
-    ReplyWithoutTool { reply: String },
+    CreateTodo {
+        content: String,
+    },
+    ExecuteTool {
+        name: String,
+        arguments: String,
+        reply: String,
+    },
+    ReplyWithoutTool {
+        reply: String,
+    },
 }
 
 pub(super) struct MockQueryExecutor;
@@ -160,6 +169,23 @@ impl MockProvider {
             .unwrap()
             .push(MockToolAction::CreateTodo {
                 content: content.into(),
+            });
+        self
+    }
+
+    pub(super) fn with_tool_call_json(
+        self,
+        name: impl Into<String>,
+        arguments: impl Into<String>,
+        reply: impl Into<String>,
+    ) -> Self {
+        self.tool_actions
+            .lock()
+            .unwrap()
+            .push(MockToolAction::ExecuteTool {
+                name: name.into(),
+                arguments: arguments.into(),
+                reply: reply.into(),
             });
         self
     }
@@ -330,6 +356,7 @@ impl LlmProvider for MockProvider {
                 }),
                 fallback_used: false,
                 executed_tools: Vec::new(),
+                tool_results: Vec::new(),
             });
         }
         let last_user = req
@@ -367,6 +394,7 @@ impl LlmProvider for MockProvider {
             }),
             fallback_used: false,
             executed_tools: Vec::new(),
+            tool_results: Vec::new(),
         })
     }
 
@@ -400,6 +428,10 @@ impl LlmProvider for MockProvider {
                     req.tools
                         .execute_json(&req.tool_context, "create_todo", &arguments)
                         .await?;
+                    let output = json!({
+                        "requires_confirmation": true,
+                        "pending_action": "create",
+                    });
                     return Ok(ChatOutcome {
                         reply: format!("工具回复：{}", last_user_from_tool_request(&req)),
                         metrics: LlmMetrics {
@@ -422,6 +454,55 @@ impl LlmProvider for MockProvider {
                         }),
                         fallback_used: false,
                         executed_tools: vec!["create_todo".to_owned()],
+                        tool_results: vec![crate::provider::ToolExecutionResult {
+                            name: "create_todo".to_owned(),
+                            output,
+                            succeeded: true,
+                        }],
+                    });
+                }
+                MockToolAction::ExecuteTool {
+                    name,
+                    arguments,
+                    reply,
+                } => {
+                    let output = req
+                        .tools
+                        .execute_json(&req.tool_context, &name, &arguments)
+                        .await?;
+                    let output = serde_json::from_str::<Value>(&output).unwrap_or_else(|_| {
+                        json!({
+                            "raw": output,
+                        })
+                    });
+                    let succeeded = output.get("ok").and_then(Value::as_bool) != Some(false);
+                    return Ok(ChatOutcome {
+                        reply,
+                        metrics: LlmMetrics {
+                            provider: "mock".to_owned(),
+                            model: req
+                                .chat
+                                .model
+                                .clone()
+                                .unwrap_or_else(|| "mock-model".to_owned()),
+                            stream: false,
+                            ttfe_ms: None,
+                            ttft_ms: None,
+                            total_latency_ms: 1,
+                        },
+                        usage: Some(TokenUsage {
+                            input_tokens: None,
+                            cached_input_tokens: None,
+                            output_tokens: None,
+                            total_tokens: None,
+                        }),
+                        fallback_used: false,
+                        executed_tools: vec![name.clone()],
+                        tool_results: vec![crate::provider::ToolExecutionResult {
+                            name,
+                            output,
+                            succeeded,
+                        }],
                     });
                 }
                 MockToolAction::ReplyWithoutTool { reply } => {
@@ -447,6 +528,7 @@ impl LlmProvider for MockProvider {
                         }),
                         fallback_used: false,
                         executed_tools: Vec::new(),
+                        tool_results: Vec::new(),
                     });
                 }
             }
@@ -474,6 +556,7 @@ impl LlmProvider for MockProvider {
             }),
             fallback_used: false,
             executed_tools: Vec::new(),
+            tool_results: Vec::new(),
         })
     }
 

--- a/qq-maid-core/src/runtime/respond/tool_route.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route.rs
@@ -1,12 +1,10 @@
 //! 普通私聊 Tool Loop 前置路由。
 //!
-//! 当前这里只覆盖已经接入 Tool Loop 的 Weather 和 Todo，用来决定本轮普通
-//! 私聊是否要走 Complete Tool Loop。它不是通用语义分类器，也不负责 Memory、
-//! RSS、MCP、Skills 等未来工具；完整通用 Tool Loop 流式能力留给 #83 处理。
+//! 私聊普通消息不再按 Todo/Weather 关键词猜测意图；只要工具能力可用，就进入
+//! 具备受控工具的 Agent 路径，由模型决定是否调用工具。slash 命令、确定性
+//! Todo 查询和群聊仍在更外层保持原有路径。
 
-use crate::runtime::session::SessionRecord;
-
-use super::{RespondRequest, chat_flow::todo_guard};
+use super::RespondRequest;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ToolLoopRoute {
@@ -15,13 +13,12 @@ pub(super) enum ToolLoopRoute {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(super) struct ToolRouteContext<'a> {
+pub(super) struct ToolRouteContext {
     pub tool_calling_enabled: bool,
     pub provider_supports_tool_calling: bool,
-    pub active_session: Option<&'a SessionRecord>,
 }
 
-pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext<'_>) -> ToolLoopRoute {
+pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> ToolLoopRoute {
     if !ctx.tool_calling_enabled || !ctx.provider_supports_tool_calling {
         return ToolLoopRoute::PlainChat;
     }
@@ -38,94 +35,11 @@ pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext<'_>) -
         return ToolLoopRoute::PlainChat;
     }
 
-    if looks_like_weather_tool_request(trimmed) || looks_like_todo_tool_request(trimmed, ctx) {
-        ToolLoopRoute::CompleteToolLoop
-    } else {
-        ToolLoopRoute::PlainChat
-    }
-}
-
-/// 判断普通私聊是否明显需要天气 Tool。
-///
-/// 这里只识别当前稳定接入的天气工具请求，不处理“天气 API 怎么设计”这类
-/// 元讨论，避免工具链路抢走本该流式输出的普通聊天。
-fn looks_like_weather_tool_request(text: &str) -> bool {
-    if looks_like_weather_meta_discussion(text) {
-        return false;
-    }
-    contains_any(
-        text,
-        &[
-            "下雨",
-            "下雪",
-            "带伞",
-            "温度",
-            "气温",
-            "几度",
-            "降雨",
-            "降雪",
-            "空气质量",
-            "雾霾",
-            "预警",
-            "台风",
-            "风力",
-            "冷不冷",
-            "热不热",
-            "穿什么",
-        ],
-    ) || (text.contains("天气")
-        && contains_any(text, &["今天", "明天", "后天", "现在", "本周", "周末"]))
-}
-
-fn looks_like_weather_meta_discussion(text: &str) -> bool {
-    text.contains("天气")
-        && contains_any(
-            text,
-            &[
-                "API",
-                "api",
-                "接口",
-                "设计",
-                "实现",
-                "架构",
-                "模块",
-                "代码",
-                "怎么做",
-                "怎么写",
-            ],
-        )
-}
-
-/// 判断普通私聊是否明显需要 Todo Tool。
-///
-/// 这里只覆盖创建、修改、完成、取消、恢复、删除等写操作，以及依赖最近
-/// Todo 查询/操作上下文的续指。普通列表查询必须继续交给 `handle_todo_flow()`
-/// 的确定性流程，避免同义词和默认过滤语义回归。
-fn looks_like_todo_tool_request(text: &str, ctx: ToolRouteContext<'_>) -> bool {
-    let has_last_query = ctx
-        .active_session
-        .and_then(|session| session.last_todo_query.as_ref())
-        .is_some();
-    let has_last_action = ctx
-        .active_session
-        .and_then(|session| session.last_todo_action.as_ref())
-        .is_some();
-    todo_guard::requires_todo_tool_with_context(text, has_last_query, has_last_action)
-}
-
-fn contains_any(text: &str, needles: &[&str]) -> bool {
-    needles.iter().any(|needle| text.contains(needle))
+    ToolLoopRoute::CompleteToolLoop
 }
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
-
-    use crate::runtime::{
-        session::{LastTodoAction, LastTodoQuery, SessionRecord},
-        todo::TodoStatus,
-    };
-
     use super::*;
 
     fn request(text: &str) -> RespondRequest {
@@ -138,123 +52,40 @@ mod tests {
         }
     }
 
-    fn context(active_session: Option<&SessionRecord>) -> ToolRouteContext<'_> {
+    fn context() -> ToolRouteContext {
         ToolRouteContext {
             tool_calling_enabled: true,
             provider_supports_tool_calling: true,
-            active_session,
         }
     }
 
-    fn empty_session() -> SessionRecord {
-        serde_json::from_value(json!({})).unwrap()
-    }
-
-    fn session_with_last_query() -> SessionRecord {
-        let mut session = empty_session();
-        session.last_todo_query = Some(LastTodoQuery {
-            owner_key: "private:u1".to_owned(),
-            query_type: "list".to_owned(),
-            condition: String::new(),
-            result_ids: vec!["item-1".to_owned()],
-            created_at: "2026-06-30T00:00:00+08:00".to_owned(),
-        });
-        session
-    }
-
-    fn session_with_last_action() -> SessionRecord {
-        let mut session = empty_session();
-        session.last_todo_action = Some(LastTodoAction {
-            owner_key: "private:u1".to_owned(),
-            item_id: "item-1".to_owned(),
-            title: "示例待办".to_owned(),
-            action: "restored".to_owned(),
-            resulting_status: TodoStatus::Pending,
-            created_at: "2026-06-30T00:00:00+08:00".to_owned(),
-        });
-        session
-    }
-
     #[test]
-    fn general_chat_keeps_plain_route_even_with_tool_calling_enabled() {
+    fn private_plain_message_uses_tool_loop_when_tool_calling_enabled() {
         assert_eq!(
-            route_tool_loop(&request("聊聊 Rust 的所有权"), context(None)),
-            ToolLoopRoute::PlainChat
-        );
-    }
-
-    #[test]
-    fn weather_route_avoids_meta_discussion() {
-        assert_eq!(
-            route_tool_loop(&request("杭州明天要带伞吗"), context(None)),
+            route_tool_loop(&request("晚上好"), context()),
             ToolLoopRoute::CompleteToolLoop
         );
         assert_eq!(
-            route_tool_loop(&request("聊聊天气 API 怎么设计"), context(None)),
-            ToolLoopRoute::PlainChat
+            route_tool_loop(&request("删除第二条"), context()),
+            ToolLoopRoute::CompleteToolLoop
         );
-        // 当前阶段只覆盖明确 Weather/Todo 工具意图；泛化外出建议留给 #83 的通用 Tool Loop。
         assert_eq!(
-            route_tool_loop(&request("杭州明天适合出门吗"), context(None)),
-            ToolLoopRoute::PlainChat
+            route_tool_loop(&request("新增待办，明天接老公"), context()),
+            ToolLoopRoute::CompleteToolLoop
         );
-    }
-
-    #[test]
-    fn todo_mutations_and_queries_route_to_tool_loop() {
-        let with_query = session_with_last_query();
-        let with_action = session_with_last_action();
-        for (text, session) in [
-            ("提醒我明天下午三点开会", None),
-            ("完成第 1 个待办", None),
-            ("完成第一条", Some(&with_query)),
-            ("修改第 2 个待办", None),
-            ("取消第 2 个任务", None),
-            ("永久删除已完成待办第 3 个", None),
-            ("恢复第 1 个", Some(&with_query)),
-            ("取消它", Some(&with_action)),
-        ] {
-            assert_eq!(
-                route_tool_loop(&request(text), context(session)),
-                ToolLoopRoute::CompleteToolLoop,
-                "{text}"
-            );
-        }
-    }
-
-    #[test]
-    fn todo_list_queries_keep_plain_route_for_deterministic_flow() {
-        for text in [
-            "看看已完成",
-            "看看待办",
-            "查看待办",
-            "列出待办",
-            "还有什么待办",
-            "有哪些待办",
-        ] {
-            assert_eq!(
-                route_tool_loop(&request(text), context(None)),
-                ToolLoopRoute::PlainChat,
-                "{text}"
-            );
-        }
     }
 
     #[test]
     fn disabled_or_group_request_keeps_plain_route() {
         let mut group = request("杭州明天要带伞吗");
         group.group_id = Some("g1".to_owned());
-        assert_eq!(
-            route_tool_loop(&group, context(None)),
-            ToolLoopRoute::PlainChat
-        );
+        assert_eq!(route_tool_loop(&group, context()), ToolLoopRoute::PlainChat);
         assert_eq!(
             route_tool_loop(
                 &request("杭州明天要带伞吗"),
                 ToolRouteContext {
                     tool_calling_enabled: false,
                     provider_supports_tool_calling: true,
-                    active_session: None,
                 },
             ),
             ToolLoopRoute::PlainChat

--- a/qq-maid-core/src/runtime/rss/scheduler.rs
+++ b/qq-maid-core/src/runtime/rss/scheduler.rs
@@ -553,6 +553,7 @@ mod tests {
                 }),
                 fallback_used: false,
                 executed_tools: Vec::new(),
+                tool_results: Vec::new(),
             })
         }
 

--- a/qq-maid-core/src/runtime/translation.rs
+++ b/qq-maid-core/src/runtime/translation.rs
@@ -270,6 +270,7 @@ mod tests {
                 }),
                 fallback_used: false,
                 executed_tools: Vec::new(),
+                tool_results: Vec::new(),
             })
         }
 

--- a/qq-maid-core/src/service/mod.rs
+++ b/qq-maid-core/src/service/mod.rs
@@ -195,7 +195,7 @@ impl CoreService for CoreHandle {
             info!(
                 scope_key,
                 transport = "complete",
-                reason = "tool_loop_intent",
+                reason = "private_agent_tool_loop",
                 "core respond stream bypassed for tool loop"
             );
         }

--- a/qq-maid-core/src/service/tests.rs
+++ b/qq-maid-core/src/service/tests.rs
@@ -24,8 +24,8 @@ use crate::{
         prompt::PromptConfig,
         query::{QueryExecutor, QueryOutcome, QueryRequest},
         rss::{RssFetchConfig, RssFetcher, RssStore},
-        session::{LastTodoAction, SessionMeta, SessionStore},
-        todo::{TodoItemDraft, TodoStatus, TodoStore, TodoTimePrecision},
+        session::{SessionMeta, SessionStore},
+        todo::{TodoItemDraft, TodoStore, TodoTimePrecision},
         train::{TrainExecutor, TrainSchedule, TrainScheduleRequest},
         weather::{WeatherExecutor, WeatherOutcome, WeatherRequest},
     },
@@ -117,7 +117,7 @@ fn core_response_keeps_public_fields_from_respond_response() {
 }
 
 #[test]
-fn core_plan_routes_general_private_chat_to_streaming() {
+fn core_plan_routes_general_private_chat_to_complete_tool_loop_when_available() {
     let provider =
         TestProvider::replying("普通回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_tool_calling(provider, 5, true);
@@ -126,12 +126,12 @@ fn core_plan_routes_general_private_chat_to_streaming() {
 
     assert_eq!(
         service.plan_core_respond(&req).unwrap(),
-        RespondPlan::StreamingChat
+        RespondPlan::CompleteToolLoop
     );
 }
 
 #[test]
-fn core_plan_routes_weather_tool_intent_to_complete_tool_loop() {
+fn core_plan_routes_private_plain_message_to_complete_tool_loop_when_tools_available() {
     let provider =
         TestProvider::replying("工具回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_tool_calling(provider, 5, true);
@@ -162,37 +162,10 @@ fn core_plan_routes_simple_todo_queries_to_immediate() {
 }
 
 #[test]
-fn core_plan_routes_todo_mutations_and_followups_to_complete_tool_loop() {
+fn core_plan_routes_private_todo_like_messages_to_agent_tool_loop() {
     let provider =
         TestProvider::replying("工具回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_tool_calling(provider, 5, true);
-    let session_store = state.session_store.clone();
-    let meta = SessionMeta::new(
-        "private:u1",
-        Some("u1".to_owned()),
-        None,
-        None,
-        None,
-        "qq_official",
-    );
-    let mut session = session_store.get_or_create_active(&meta).unwrap();
-    session.last_todo_query = Some(crate::runtime::session::LastTodoQuery {
-        owner_key: "private:u1".to_owned(),
-        query_type: "list".to_owned(),
-        condition: String::new(),
-        result_ids: vec!["todo-1".to_owned()],
-        created_at: "2026-06-30T00:00:00+08:00".to_owned(),
-    });
-    session.last_todo_action = Some(LastTodoAction {
-        owner_key: "private:u1".to_owned(),
-        item_id: "todo-1".to_owned(),
-        title: "检查日志".to_owned(),
-        action: "completed".to_owned(),
-        resulting_status: TodoStatus::Completed,
-        created_at: "2026-06-30T00:00:00+08:00".to_owned(),
-    });
-    session_store.save(&mut session).unwrap();
-
     let service = CoreHandle::new(state).respond_service();
     for input in [
         "提醒我明天下午三点开会",
@@ -434,17 +407,20 @@ async fn core_private_simple_todo_queries_use_deterministic_path() {
 }
 
 #[tokio::test]
-async fn core_private_general_chat_with_tool_capability_keeps_stream_path() {
-    let provider = TestProvider::replying("普通流式回复")
+async fn core_private_general_chat_with_tool_capability_uses_single_complete_tool_loop() {
+    let provider = TestProvider::replying("普通完整回复")
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_tool_calling(provider.clone(), 5, true);
     let service = CoreHandle::new(state);
 
-    let response = collect_stream_completed(service.respond(private_request("hello")).await).await;
+    let output = service.respond(private_request("晚上好")).await.unwrap();
+    let CoreRespondOutput::Complete(response) = output else {
+        panic!("expected complete response");
+    };
 
-    assert_eq!(response.text.as_deref(), Some("普通流式回复"));
-    assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
-    assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(response.text.as_deref(), Some("普通完整回复"));
+    assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/service/tests.rs
+++ b/qq-maid-core/src/service/tests.rs
@@ -793,6 +793,7 @@ fn chat_outcome(reply: &str) -> ChatOutcome {
         }),
         fallback_used: false,
         executed_tools: Vec::new(),
+        tool_results: Vec::new(),
     }
 }
 

--- a/qq-maid-llm/src/provider/limiter.rs
+++ b/qq-maid-llm/src/provider/limiter.rs
@@ -237,6 +237,7 @@ mod tests {
                 usage: None,
                 fallback_used: false,
                 executed_tools: Vec::new(),
+                tool_results: Vec::new(),
             })
         }
 

--- a/qq-maid-llm/src/provider/mod.rs
+++ b/qq-maid-llm/src/provider/mod.rs
@@ -25,6 +25,20 @@ use crate::{
     tool::{ToolContext, ToolRegistry},
 };
 
+/// Tool Loop 中单次工具执行的结果摘要。
+///
+/// LLM 层只记录通用的工具名、结构化输出和 `ok:false` 约定，不理解任何上层业务语义；
+/// 具体业务是否算“写入成功”由调用方基于工具输出字段再判断。
+#[derive(Debug, Clone, PartialEq)]
+pub struct ToolExecutionResult {
+    /// 实际执行或跳过的工具名。
+    pub name: String,
+    /// 回传给模型的工具输出；不可解析时保留为字符串，避免丢失诊断信息。
+    pub output: serde_json::Value,
+    /// 通用成功标记：仅当工具输出明确 `ok:false` 或执行失败/被跳过时为 false。
+    pub succeeded: bool,
+}
+
 /// LLM 调用的最终输出结果。
 #[derive(Debug, Clone)]
 pub struct ChatOutcome {
@@ -38,6 +52,8 @@ pub struct ChatOutcome {
     pub fallback_used: bool,
     /// Tool Loop 中实际执行过的工具名列表；普通聊天为空。
     pub executed_tools: Vec<String>,
+    /// Tool Loop 中实际工具输出摘要；普通聊天为空。
+    pub tool_results: Vec<ToolExecutionResult>,
 }
 
 /// 原生 Tool Calling 请求。
@@ -166,6 +182,7 @@ pub async fn collect_llm_stream(
         usage,
         fallback_used,
         executed_tools: Vec::new(),
+        tool_results: Vec::new(),
     })
 }
 
@@ -1072,6 +1089,7 @@ mod tests {
             usage: None,
             fallback_used: false,
             executed_tools: Vec::new(),
+            tool_results: Vec::new(),
         }
     }
 

--- a/qq-maid-llm/src/provider/openai/chat.rs
+++ b/qq-maid-llm/src/provider/openai/chat.rs
@@ -253,6 +253,7 @@ pub(crate) async fn non_stream_completion(
         usage,
         fallback_used: false,
         executed_tools: Vec::new(),
+        tool_results: Vec::new(),
     })
 }
 

--- a/qq-maid-llm/src/provider/openai/chat_tool_loop.rs
+++ b/qq-maid-llm/src/provider/openai/chat_tool_loop.rs
@@ -14,7 +14,7 @@ use crate::{
     error::LlmError,
     metrics::MetricsRecorder,
     provider::{
-        ChatOutcome, ToolCallingProtocol, ToolChatRequest,
+        ChatOutcome, ToolCallingProtocol, ToolChatRequest, ToolExecutionResult,
         types::{ChatMessage, TokenUsage},
     },
     tool::{PreparedToolCall, ToolCallDependency, ToolContext, ToolMetadata, ToolRegistry},
@@ -78,6 +78,7 @@ pub(crate) async fn chat_completions_tool_loop(
     let tools = chat_completions_tool_defs(req.tools.metadata());
     let mut usage = None;
     let mut executed_tools = Vec::new();
+    let mut tool_results = Vec::new();
 
     for round in 0..=req.max_rounds {
         let payload =
@@ -112,6 +113,7 @@ pub(crate) async fn chat_completions_tool_loop(
                 usage,
                 fallback_used: false,
                 executed_tools,
+                tool_results,
             });
         }
         if round >= req.max_rounds {
@@ -135,26 +137,34 @@ pub(crate) async fn chat_completions_tool_loop(
             messages.push(tool_round.assistant_message);
             let prepared_calls = prepare_function_calls(&req, &tool_round.calls, round)?;
             for call in prepared_calls {
-                let (output, succeeded) = match call.prepared {
+                let (tool_name, output, succeeded) = match call.prepared {
                     Ok(prepared) => {
-                        executed_tools.push(prepared.name.clone());
+                        let tool_name = prepared.name.clone();
+                        executed_tools.push(tool_name.clone());
                         if prepared.dependency == ToolCallDependency::PreviousCallSuccess
                             && !previous_call_succeeded
                         {
-                            (tool_skip_output("dependency_previous_call_failed"), false)
+                            (
+                                tool_name,
+                                tool_skip_output("dependency_previous_call_failed"),
+                                false,
+                            )
                         } else {
                             match req.tools.execute_prepared(prepared).await {
                                 Ok(output) => {
                                     let succeeded = tool_output_indicates_success(&output);
-                                    (output, succeeded)
+                                    (tool_name, output, succeeded)
                                 }
-                                Err(err) => (tool_error_output(&err), false),
+                                Err(err) => (tool_name, tool_error_output(&err), false),
                             }
                         }
                     }
-                    Err(err) => (tool_error_output(&err), false),
+                    Err(err) => ("unknown".to_owned(), tool_error_output(&err), false),
                 };
                 previous_call_succeeded = succeeded;
+                if tool_name != "unknown" {
+                    tool_results.push(tool_execution_result(&tool_name, &output, succeeded));
+                }
                 messages.push(json!({
                     "role": "tool",
                     "tool_call_id": call.call_id,
@@ -394,6 +404,15 @@ fn tool_output_indicates_success(output: &str) -> bool {
         .ok()
         .and_then(|value| value.get("ok").and_then(Value::as_bool))
         .unwrap_or(true)
+}
+
+fn tool_execution_result(name: &str, output: &str, succeeded: bool) -> ToolExecutionResult {
+    let output = serde_json::from_str::<Value>(output).unwrap_or_else(|_| json!(output));
+    ToolExecutionResult {
+        name: name.to_owned(),
+        output,
+        succeeded,
+    }
 }
 
 fn required_string(item: &Value, key: &str, label: &str) -> Result<String, LlmError> {

--- a/qq-maid-llm/src/provider/openai/fallback.rs
+++ b/qq-maid-llm/src/provider/openai/fallback.rs
@@ -48,6 +48,7 @@ mod tests {
             usage: None,
             fallback_used: false,
             executed_tools: Vec::new(),
+            tool_results: Vec::new(),
         }
     }
 

--- a/qq-maid-llm/src/provider/openai/responses.rs
+++ b/qq-maid-llm/src/provider/openai/responses.rs
@@ -121,6 +121,7 @@ pub(crate) async fn openai_responses_non_stream_chat(
         usage,
         fallback_used: false,
         executed_tools: Vec::new(),
+        tool_results: Vec::new(),
     })
 }
 

--- a/qq-maid-llm/src/provider/openai/tool_loop.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop.rs
@@ -14,7 +14,7 @@ use crate::{
     error::LlmError,
     metrics::MetricsRecorder,
     provider::{
-        ChatOutcome,
+        ChatOutcome, ToolExecutionResult,
         types::{ChatMessage, TokenUsage},
     },
     tool::{PreparedToolCall, ToolCallDependency, ToolContext, ToolMetadata, ToolRegistry},
@@ -76,6 +76,7 @@ pub(crate) async fn openai_responses_tool_loop(
     let tools = openai_tool_defs(req.tools.metadata());
     let mut usage = None;
     let mut executed_tools = Vec::new();
+    let mut tool_results = Vec::new();
 
     for round in 0..=req.max_rounds {
         let payload = openai_tool_loop_payload(
@@ -114,6 +115,7 @@ pub(crate) async fn openai_responses_tool_loop(
                 usage,
                 fallback_used: false,
                 executed_tools,
+                tool_results,
             });
         }
         if round >= req.max_rounds {
@@ -135,26 +137,34 @@ pub(crate) async fn openai_responses_tool_loop(
         let prepared_calls = prepare_function_calls(&req, &calls, round)?;
         let mut previous_call_succeeded = true;
         for call in prepared_calls {
-            let (output, succeeded) = match call.prepared {
+            let (tool_name, output, succeeded) = match call.prepared {
                 Ok(prepared) => {
-                    executed_tools.push(prepared.name.clone());
+                    let tool_name = prepared.name.clone();
+                    executed_tools.push(tool_name.clone());
                     if prepared.dependency == ToolCallDependency::PreviousCallSuccess
                         && !previous_call_succeeded
                     {
-                        (tool_skip_output("dependency_previous_call_failed"), false)
+                        (
+                            tool_name,
+                            tool_skip_output("dependency_previous_call_failed"),
+                            false,
+                        )
                     } else {
                         match req.tools.execute_prepared(prepared).await {
                             Ok(output) => {
                                 let succeeded = tool_output_indicates_success(&output);
-                                (output, succeeded)
+                                (tool_name, output, succeeded)
                             }
-                            Err(err) => (tool_error_output(&err), false),
+                            Err(err) => (tool_name, tool_error_output(&err), false),
                         }
                     }
                 }
-                Err(err) => (tool_error_output(&err), false),
+                Err(err) => ("unknown".to_owned(), tool_error_output(&err), false),
             };
             previous_call_succeeded = succeeded;
+            if tool_name != "unknown" {
+                tool_results.push(tool_execution_result(&tool_name, &output, succeeded));
+            }
             input.push(json!({
                 "type": "function_call_output",
                 "call_id": call.call_id,
@@ -253,6 +263,15 @@ fn tool_output_indicates_success(output: &str) -> bool {
         .ok()
         .and_then(|value| value.get("ok").and_then(Value::as_bool))
         .unwrap_or(true)
+}
+
+fn tool_execution_result(name: &str, output: &str, succeeded: bool) -> ToolExecutionResult {
+    let output = serde_json::from_str::<Value>(output).unwrap_or_else(|_| json!(output));
+    ToolExecutionResult {
+        name: name.to_owned(),
+        output,
+        succeeded,
+    }
 }
 
 fn openai_tool_loop_input(messages: &[ChatMessage]) -> Result<Vec<Value>, LlmError> {

--- a/qq-maid-llm/src/provider/status.rs
+++ b/qq-maid-llm/src/provider/status.rs
@@ -288,6 +288,7 @@ async fn next_observed_stream_event(
                 usage: state.usage.clone(),
                 fallback_used: state.fallback_used,
                 executed_tools: Vec::new(),
+                tool_results: Vec::new(),
             };
             state.status.record_success(&outcome);
             if let Some(attempt) = state.attempt.take() {
@@ -466,6 +467,7 @@ mod tests {
             usage: None,
             fallback_used: true,
             executed_tools: Vec::new(),
+            tool_results: Vec::new(),
         });
 
         let snapshot = status.snapshot();
@@ -492,6 +494,7 @@ mod tests {
             usage: None,
             fallback_used: false,
             executed_tools: Vec::new(),
+            tool_results: Vec::new(),
         });
         let success_at = status.snapshot().last_success_at;
 
@@ -571,6 +574,7 @@ mod tests {
             usage: None,
             fallback_used: true,
             executed_tools: Vec::new(),
+            tool_results: Vec::new(),
         });
         let provider = observe_provider(Arc::new(PendingProvider), status.clone());
         let request = ChatRequest {


### PR DESCRIPTION
## 概要
- 修复 Todo required-tool guard 只按工具名判断导致的误判
- LLM Tool Loop 增加工具结果摘要，core 基于真实工具输出验真
- 允许“删除未完成待办”通过 cancel_todo 创建软取消确认，不再误报 required_tool_not_called

## 验真规则
- create_todo 需要成功创建 create pending
- cancel_todo/delete_todos 需要成功创建对应 pending；delete 意图允许 cancel_todo 软取消 pending
- edit_todo 需要返回 updated
- complete_todos/restore_todos 需要实际变更至少一条
- ok:false 或空变更结果不会通过守卫

## 测试
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test -p qq-maid-core
- cargo test -p qq-maid-llm
- cargo test --workspace --all-features

Closes #122