### PR TITLE
refactor: 拆分 Gateway dispatcher 会话 worker 状态机 (#114)

### DIFF
--- a/qq-maid-gateway-rs/src/gateway/dispatcher/actor.rs
+++ b/qq-maid-gateway-rs/src/gateway/dispatcher/actor.rs
@@ -1,0 +1,572 @@
+//! Dispatcher actor：scope 状态机、入队分发与 worker 生命周期管理。
+//!
+//! 这里承载原来集中在 `dispatcher/mod.rs` 中的会话级状态机：
+//! - 维护每个 scope 的 `ScopeEntry`（Active / Retiring、队列与 backlog）；
+//! - 处理 `DispatcherCommand`，决定串行执行、backlog 缓存或容量拒绝；
+//! - 在 idle 到期、worker 退出、shutdown flush 之间维护串行化和回收语义。
+//!
+//! 拆分约束：不改变 QQ 消息入口、去重、队列容量、活跃 worker 上限、idle timeout
+//! 的配置语义，也不改 CoreService 调用路径或 `/ping` 本地诊断。`MessageDispatcher`
+//! / `MessageDispatcherHandle` 入口仍由 `mod.rs` 暴露。
+
+use std::{
+    collections::{HashMap, VecDeque},
+    future::Future,
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use tokio::{
+    sync::{Semaphore, mpsc},
+    time::timeout,
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use super::super::{
+    BotOutboundCache, ReplyCache, dedupe::MessageDedupe, group_filter::GroupCooldowns,
+    handle_c2c_message, handle_group_message, logging::mask_scope_key, ping::GatewayRuntimeStatus,
+};
+use super::reject::run_reject_worker;
+use super::types::{
+    DispatcherCommand, DispatcherEnqueueError, DispatcherEnqueueResult, IdleDecision,
+    InboundEnvelope, QueuedMessage, REJECT_QUEUE_TEXT, RejectMetrics, RejectNotification,
+    RejectTarget, SHUTDOWN_DRAIN_TIMEOUT_SECS, ScopeEntry, ScopeState, WORKER_CANCEL_TIMEOUT_SECS,
+    WorkerExitReason,
+};
+use super::worker::{WorkerContext, run_worker};
+use crate::{
+    api::QqApiClient, auth::AccessTokenManager, config::AppConfig, respond::RespondClient,
+};
+
+pub(super) type HandlerFuture<'a> = Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
+
+/// 统一的入站消息处理抽象，便于在 actor 与 worker 之间解耦，也便于测试注入
+/// `RecordingHandler`。真实实现是 `RealMessageHandler`，转发到 gateway 的
+/// `handle_c2c_message` / `handle_group_message`。
+pub(super) trait MessageHandler: Send + Sync {
+    fn handle<'a>(&'a self, message: InboundEnvelope) -> HandlerFuture<'a>;
+}
+
+pub(super) struct RealMessageHandler {
+    config: AppConfig,
+    auth: AccessTokenManager,
+    respond: RespondClient,
+    api: QqApiClient,
+    dedupe: Arc<MessageDedupe>,
+    reply_cache: ReplyCache,
+    group_outbound_cache: Arc<std::sync::Mutex<BotOutboundCache>>,
+    group_cooldowns: Arc<std::sync::Mutex<GroupCooldowns>>,
+    runtime: GatewayRuntimeStatus,
+}
+
+impl RealMessageHandler {
+    /// 由 `MessageDispatcher::new` 在装配阶段调用，字段保持私有，避免暴露内部结构。
+    // 返回 `Arc<dyn MessageHandler>` 而非 `Self`，是为了让 mod.rs 装配时直接得到
+    // trait object、避免跨模块再做一次 unsizing 转换。
+    #[allow(clippy::new_ret_no_self, clippy::too_many_arguments)]
+    pub(super) fn new(
+        config: AppConfig,
+        auth: AccessTokenManager,
+        respond: RespondClient,
+        api: QqApiClient,
+        dedupe: Arc<MessageDedupe>,
+        reply_cache: ReplyCache,
+        group_outbound_cache: Arc<std::sync::Mutex<BotOutboundCache>>,
+        group_cooldowns: Arc<std::sync::Mutex<GroupCooldowns>>,
+        runtime: GatewayRuntimeStatus,
+    ) -> Arc<dyn MessageHandler> {
+        Arc::new(Self {
+            config,
+            auth,
+            respond,
+            api,
+            dedupe,
+            reply_cache,
+            group_outbound_cache,
+            group_cooldowns,
+            runtime,
+        })
+    }
+}
+
+impl MessageHandler for RealMessageHandler {
+    fn handle<'a>(&'a self, message: InboundEnvelope) -> HandlerFuture<'a> {
+        Box::pin(async move {
+            match message {
+                InboundEnvelope::C2c(message) => {
+                    handle_c2c_message(
+                        message,
+                        &self.config,
+                        &self.auth,
+                        &self.respond,
+                        &self.api,
+                        &self.dedupe,
+                        &self.reply_cache,
+                        &self.runtime,
+                    )
+                    .await
+                }
+                InboundEnvelope::Group(message) => {
+                    handle_group_message(
+                        message,
+                        &self.config,
+                        &self.respond,
+                        &self.api,
+                        &self.dedupe,
+                        &self.group_outbound_cache,
+                        &self.group_cooldowns,
+                        &self.runtime,
+                    )
+                    .await
+                }
+            }
+        })
+    }
+}
+
+pub(super) struct DispatcherActor {
+    // 下面四个字段被 dispatcher 内联测试直接窥探（`actor.scopes`、
+    // `actor.shutdown_token`、`actor.config`、`actor.worker_slots`），因此标注
+    // `pub(super)`，仅对 `gateway::dispatcher` 模块及其子模块可见；gateway 外部
+    // 仍然看不到这些字段，对外公开 API 不变。
+    pub(super) config: AppConfig,
+    api: QqApiClient,
+    runtime: GatewayRuntimeStatus,
+    command_rx: mpsc::Receiver<DispatcherCommand>,
+    command_tx: mpsc::Sender<DispatcherCommand>,
+    reject_tx: mpsc::Sender<RejectNotification>,
+    reject_rx: mpsc::Receiver<RejectNotification>,
+    pub(super) worker_slots: Arc<Semaphore>,
+    active_workers: Arc<AtomicU64>,
+    reject_metrics: Arc<RejectMetrics>,
+    handler: Arc<dyn MessageHandler>,
+    pub(super) scopes: HashMap<String, ScopeEntry>,
+    pub(super) shutdown_token: CancellationToken,
+}
+
+impl DispatcherActor {
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn new(
+        config: AppConfig,
+        api: QqApiClient,
+        runtime: GatewayRuntimeStatus,
+        command_rx: mpsc::Receiver<DispatcherCommand>,
+        command_tx: mpsc::Sender<DispatcherCommand>,
+        reject_tx: mpsc::Sender<RejectNotification>,
+        reject_rx: mpsc::Receiver<RejectNotification>,
+        reject_metrics: Arc<RejectMetrics>,
+        handler: Arc<dyn MessageHandler>,
+        shutdown_token: CancellationToken,
+    ) -> Self {
+        Self {
+            worker_slots: Arc::new(Semaphore::new(config.max_active_conversation_workers)),
+            active_workers: Arc::new(AtomicU64::new(0)),
+            config,
+            api,
+            runtime,
+            command_rx,
+            command_tx,
+            reject_tx,
+            reject_rx,
+            reject_metrics,
+            handler,
+            scopes: HashMap::new(),
+            shutdown_token,
+        }
+    }
+
+    pub(super) async fn run(mut self) {
+        // 启动拒绝通知 worker：把 actor 持有的 reject_rx 移交给 reject_worker，
+        // actor 后续只通过 reject_tx 投递拒绝通知，不再亲自处理发送。
+        let reject_worker = tokio::spawn(run_reject_worker(
+            self.api.clone(),
+            self.runtime.clone(),
+            std::mem::replace(&mut self.reject_rx, mpsc::channel(1).1),
+            self.shutdown_token.child_token(),
+        ));
+
+        loop {
+            tokio::select! {
+                _ = self.shutdown_token.cancelled() => {
+                    break;
+                }
+                command = self.command_rx.recv() => {
+                    let Some(command) = command else {
+                        break;
+                    };
+                    self.handle_command(command).await;
+                }
+            }
+        }
+
+        self.drain_shutdown().await;
+        self.shutdown_token.cancel();
+        let _ = timeout(
+            Duration::from_secs(WORKER_CANCEL_TIMEOUT_SECS + 1),
+            reject_worker,
+        )
+        .await;
+    }
+
+    pub(super) async fn handle_command(&mut self, command: DispatcherCommand) {
+        match command {
+            DispatcherCommand::Enqueue {
+                scope_key,
+                message,
+                ack,
+            } => {
+                let result = self.enqueue(scope_key, *message).await;
+                let _ = ack.send(result);
+            }
+            DispatcherCommand::WorkerIdleExpired {
+                scope_key,
+                generation,
+                reply,
+            } => {
+                let _ = reply.send(self.worker_idle_expired(&scope_key, generation));
+            }
+            DispatcherCommand::WorkerExited {
+                scope_key,
+                generation,
+                reason,
+            } => {
+                self.worker_exited(scope_key, generation, reason).await;
+            }
+            DispatcherCommand::WorkerDequeued {
+                scope_key,
+                generation,
+            } => {
+                if let Some(entry) = self.scopes.get_mut(&scope_key)
+                    && entry.generation == generation
+                    && entry.queue_len > 0
+                {
+                    entry.queue_len -= 1;
+                }
+            }
+        }
+    }
+
+    pub(super) async fn enqueue(
+        &mut self,
+        scope_key: String,
+        message: QueuedMessage,
+    ) -> DispatcherEnqueueResult {
+        if self.shutdown_token.is_cancelled() {
+            return Err(DispatcherEnqueueError::Unavailable {
+                reason: "dispatcher_shutdown",
+            });
+        }
+        if let Some(entry) = self.scopes.get_mut(&scope_key) {
+            let total_len = entry.queue_len + entry.backlog.len();
+            if total_len >= self.config.conversation_queue_capacity {
+                if message.notify_on_reject
+                    && self
+                        .reject(scope_key, message.reject_target, "conversation_queue_full")
+                        .await
+                {
+                    return Err(DispatcherEnqueueError::RejectedAndNotified {
+                        reason: "conversation_queue_full",
+                    });
+                }
+                return Err(DispatcherEnqueueError::Unavailable {
+                    reason: "conversation_queue_full_reject_dropped",
+                });
+            }
+            match entry.state {
+                ScopeState::Active => {
+                    if let Some(sender) = entry.sender.as_ref() {
+                        sender.try_send(message).map_err(|_| {
+                            DispatcherEnqueueError::Unavailable {
+                                reason: "worker_queue_unavailable",
+                            }
+                        })?;
+                        entry.queue_len += 1;
+                        debug!(
+                            scope_key = %mask_scope_key(&scope_key),
+                            queue_len = entry.queue_len,
+                            backlog_len = entry.backlog.len(),
+                            "dispatcher enqueued message to active worker"
+                        );
+                        return Ok(());
+                    }
+                }
+                ScopeState::Retiring => {
+                    entry.backlog.push_back(message);
+                    debug!(
+                        scope_key = %mask_scope_key(&scope_key),
+                        queue_len = entry.queue_len,
+                        backlog_len = entry.backlog.len(),
+                        "dispatcher buffered message in retiring backlog"
+                    );
+                    return Ok(());
+                }
+            }
+        }
+
+        let permit = match self.worker_slots.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                if message.notify_on_reject
+                    && self
+                        .reject(scope_key, message.reject_target, "worker_slot_exhausted")
+                        .await
+                {
+                    return Err(DispatcherEnqueueError::RejectedAndNotified {
+                        reason: "worker_slot_exhausted",
+                    });
+                }
+                return Err(DispatcherEnqueueError::Unavailable {
+                    reason: "worker_slot_exhausted_reject_dropped",
+                });
+            }
+        };
+        let generation = self.next_generation();
+        let worker_cancel = self.shutdown_token.child_token();
+        let sender =
+            self.spawn_worker(scope_key.clone(), generation, worker_cancel.clone(), permit);
+        sender
+            .try_send(message)
+            .map_err(|_| DispatcherEnqueueError::Unavailable {
+                reason: "worker_queue_unavailable",
+            })?;
+        self.scopes.insert(
+            scope_key.clone(),
+            ScopeEntry {
+                state: ScopeState::Active,
+                generation,
+                sender: Some(sender),
+                queue_len: 1,
+                backlog: VecDeque::new(),
+                worker_cancel,
+            },
+        );
+        info!(
+            scope_key = %mask_scope_key(&scope_key),
+            generation,
+            active_workers = self.active_workers.load(Ordering::Relaxed),
+            max_active_workers = self.config.max_active_conversation_workers,
+            "dispatcher created worker"
+        );
+        Ok(())
+    }
+
+    pub(super) fn worker_idle_expired(&mut self, scope_key: &str, generation: u64) -> IdleDecision {
+        let Some(entry) = self.scopes.get_mut(scope_key) else {
+            return IdleDecision::RetireNow;
+        };
+        if entry.generation != generation
+            || entry.state != ScopeState::Active
+            || entry.queue_len > 0
+        {
+            return IdleDecision::StayActive;
+        }
+        entry.state = ScopeState::Retiring;
+        entry.sender = None;
+        info!(
+            scope_key = %mask_scope_key(scope_key),
+            generation,
+            backlog_len = entry.backlog.len(),
+            "dispatcher marked worker retiring"
+        );
+        IdleDecision::RetireNow
+    }
+
+    pub(super) async fn worker_exited(
+        &mut self,
+        scope_key: String,
+        generation: u64,
+        reason: WorkerExitReason,
+    ) {
+        self.active_workers.fetch_sub(1, Ordering::Relaxed);
+        let Some(mut entry) = self.scopes.remove(&scope_key) else {
+            return;
+        };
+        if entry.generation != generation {
+            self.scopes.insert(scope_key, entry);
+            return;
+        }
+        match reason {
+            WorkerExitReason::Completed => info!(
+                scope_key = %mask_scope_key(&scope_key),
+                generation,
+                "dispatcher observed worker exit"
+            ),
+            WorkerExitReason::Cancelled => warn!(
+                scope_key = %mask_scope_key(&scope_key),
+                generation,
+                queued_messages = entry.queue_len,
+                backlog_len = entry.backlog.len(),
+                "dispatcher observed cancelled worker"
+            ),
+            WorkerExitReason::Panic => warn!(
+                scope_key = %mask_scope_key(&scope_key),
+                generation,
+                queued_messages = entry.queue_len,
+                backlog_len = entry.backlog.len(),
+                "dispatcher observed panicked worker"
+            ),
+        }
+        if entry.backlog.is_empty() || self.shutdown_token.is_cancelled() {
+            return;
+        }
+        let permit = match self.worker_slots.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                while let Some(message) = entry.backlog.pop_front() {
+                    self.reject(
+                        scope_key.clone(),
+                        message.reject_target,
+                        "worker_slot_exhausted",
+                    )
+                    .await;
+                }
+                return;
+            }
+        };
+        let next_generation = self.next_generation();
+        let worker_cancel = self.shutdown_token.child_token();
+        let sender = self.spawn_worker(
+            scope_key.clone(),
+            next_generation,
+            worker_cancel.clone(),
+            permit,
+        );
+        let mut queue_len = 0usize;
+        while let Some(message) = entry.backlog.pop_front() {
+            if sender.try_send(message).is_ok() {
+                queue_len += 1;
+            } else {
+                warn!(
+                    scope_key = %mask_scope_key(&scope_key),
+                    generation = next_generation,
+                    "dispatcher successor worker queue unavailable while replaying backlog"
+                );
+            }
+        }
+        self.scopes.insert(
+            scope_key.clone(),
+            ScopeEntry {
+                state: ScopeState::Active,
+                generation: next_generation,
+                sender: Some(sender),
+                queue_len,
+                backlog: VecDeque::new(),
+                worker_cancel,
+            },
+        );
+        info!(
+            scope_key = %mask_scope_key(&scope_key),
+            generation = next_generation,
+            queue_len,
+            "dispatcher started successor worker"
+        );
+    }
+
+    fn spawn_worker(
+        &mut self,
+        scope_key: String,
+        generation: u64,
+        worker_cancel: CancellationToken,
+        permit: tokio::sync::OwnedSemaphorePermit,
+    ) -> mpsc::Sender<QueuedMessage> {
+        let (tx, rx) = mpsc::channel(self.config.conversation_queue_capacity);
+        let command_tx = self.command_tx.clone();
+        let handler = self.handler.clone();
+        let idle_timeout = self.config.conversation_worker_idle_timeout;
+        self.active_workers.fetch_add(1, Ordering::Relaxed);
+        tokio::spawn(async move {
+            let worker = tokio::spawn(run_worker(WorkerContext {
+                scope_key: scope_key.clone(),
+                generation,
+                handler,
+                command_tx: command_tx.clone(),
+                rx,
+                idle_timeout,
+                shutdown_token: worker_cancel.clone(),
+            }));
+            let reason = match worker.await {
+                Ok(reason) => reason,
+                Err(error) if error.is_panic() => WorkerExitReason::Panic,
+                Err(_) => WorkerExitReason::Cancelled,
+            };
+            drop(permit);
+            let _ = command_tx
+                .send(DispatcherCommand::WorkerExited {
+                    scope_key,
+                    generation,
+                    reason,
+                })
+                .await;
+        });
+        tx
+    }
+
+    async fn reject(
+        &mut self,
+        scope_key: String,
+        target: RejectTarget,
+        reason: &'static str,
+    ) -> bool {
+        self.reject_metrics.total.fetch_add(1, Ordering::Relaxed);
+        let notification = RejectNotification {
+            scope_key: scope_key.clone(),
+            target,
+            message: REJECT_QUEUE_TEXT.to_owned(),
+        };
+        if self.reject_tx.try_send(notification).is_err() {
+            let reject_total = self.reject_metrics.total.load(Ordering::Relaxed);
+            let reject_dropped = self.reject_metrics.dropped.fetch_add(1, Ordering::Relaxed) + 1;
+            warn!(
+                scope_key = %mask_scope_key(&scope_key),
+                reject_total,
+                reject_dropped,
+                reason,
+                "dispatcher reject queue full"
+            );
+            return false;
+        }
+        true
+    }
+
+    async fn drain_shutdown(&mut self) {
+        let start = Instant::now();
+        for entry in self.scopes.values() {
+            entry.worker_cancel.cancel();
+        }
+        while !self.scopes.is_empty()
+            && start.elapsed() < Duration::from_secs(SHUTDOWN_DRAIN_TIMEOUT_SECS)
+        {
+            if let Ok(Some(command)) =
+                timeout(Duration::from_millis(100), self.command_rx.recv()).await
+            {
+                self.handle_command(command).await;
+            }
+        }
+        let remaining_scopes = self.scopes.len();
+        if remaining_scopes > 0 {
+            warn!(
+                remaining_scopes,
+                active_workers = self.active_workers.load(Ordering::Relaxed),
+                reject_total = self.reject_metrics.total.load(Ordering::Relaxed),
+                reject_dropped = self.reject_metrics.dropped.load(Ordering::Relaxed),
+                "dispatcher shutdown drained with remaining work"
+            );
+        } else {
+            info!(
+                reject_total = self.reject_metrics.total.load(Ordering::Relaxed),
+                reject_dropped = self.reject_metrics.dropped.load(Ordering::Relaxed),
+                "dispatcher shutdown completed"
+            );
+        }
+    }
+
+    pub(super) fn next_generation(&self) -> u64 {
+        static NEXT_GENERATION: AtomicU64 = AtomicU64::new(1);
+        NEXT_GENERATION.fetch_add(1, Ordering::Relaxed)
+    }
+}

--- a/qq-maid-gateway-rs/src/gateway/dispatcher/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/dispatcher/mod.rs
@@ -2,36 +2,62 @@
 //!
 //! 该模块把 QQ 入站消息从 WebSocket 读循环中解耦出来：同一 scope 串行、不同 scope 并发，
 //! 并通过有界 command channel / worker queue / reject channel 避免无界积压。
+//!
+//! 实现按职责拆分到子模块，对外公开入口仍只暴露 `MessageDispatcher` /
+//! `MessageDispatcherHandle` / `DispatcherEnqueueError`，gateway 侧调用方式不变：
+//! - [`types`]：命令、入站封装、拒绝通知等内部数据类型与常量。
+//! - [`actor`]：scope 状态机、入队分发与 worker 生命周期管理。
+//! - [`worker`]：会话 worker 执行循环与 idle 回收。
+//! - [`reject`]：拒绝通知发送 worker。
 
+mod actor;
+mod reject;
+mod types;
+mod worker;
+
+// 子模块内部类型原本是 mod.rs 的私有类型，dispatcher 内联测试通过 `use super::*`
+// 窥探它们；这里把它们引入 dispatcher 命名空间，使 `dispatcher/tests` 仍能保持
+// 原写法不变。`DispatcherEnqueueError` 还需要 `pub(super)` 再导出给 gateway 调用方。
+pub(super) use types::DispatcherEnqueueError;
+use types::{
+    COMMAND_CHANNEL_MULTIPLIER, DispatcherCommand, DispatcherEnqueueResult, InboundEnvelope,
+    QueuedMessage, RejectMetrics, RejectNotification, RejectTarget, SHUTDOWN_DRAIN_TIMEOUT_SECS,
+    WORKER_CANCEL_TIMEOUT_SECS,
+};
+// 仅内联测试用到的类型与 trait 单独按 cfg(test) 引入，避免非测试构建报应未使用导入。
+#[cfg(test)]
+use types::{IdleDecision, ScopeEntry, ScopeState, WorkerExitReason};
+
+// `DispatcherActor` / `RealMessageHandler` 由 actor 子模块提供，mod.rs 负责装配。
+// `RealMessageHandler::new` 已直接返回 `Arc<dyn MessageHandler>`，因此 mod.rs 无须
+// 为类型转换再引入 `MessageHandler` / `HandlerFuture`；这两者仅被内联测试使用。
+use actor::{DispatcherActor, RealMessageHandler};
+#[cfg(test)]
+use actor::{HandlerFuture, MessageHandler};
+
+use std::{sync::Arc, time::Duration};
+// 这几个标准类型/枚举仅被 dispatcher 内联测试使用（`use super::*` 窥探），按 cfg(test)
+// 引入，避免非测试构建报应未使用导入。
+#[cfg(test)]
 use std::{
     collections::{HashMap, VecDeque},
-    future::Future,
-    pin::Pin,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
-    time::{Duration, Instant},
+    sync::atomic::{AtomicU64, Ordering},
 };
 
 use anyhow::anyhow;
-use thiserror::Error;
 use tokio::{
-    sync::{Semaphore, mpsc, oneshot},
+    sync::{mpsc, oneshot},
     task::JoinHandle,
     time::timeout,
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::warn;
 
 use super::{
     BotOutboundCache, ReplyCache,
     dedupe::MessageDedupe,
     event::{C2cMessage, GroupMessage},
     group_filter::GroupCooldowns,
-    handle_c2c_message, handle_group_message,
-    logging::{mask_identifier, mask_scope_key},
-    outbound::{send_c2c_text_with_status, send_group_text_with_status},
     ping::GatewayRuntimeStatus,
 };
 use crate::{
@@ -40,23 +66,6 @@ use crate::{
     config::AppConfig,
     respond::{RespondClient, scope_key_from_c2c_message, scope_key_from_group_message},
 };
-
-const REJECT_QUEUE_TEXT: &str = "当前消息较多，请稍后再试。";
-const SHUTDOWN_DRAIN_TIMEOUT_SECS: u64 = 10;
-const WORKER_CANCEL_TIMEOUT_SECS: u64 = 1;
-const COMMAND_CHANNEL_MULTIPLIER: usize = 4;
-
-type DispatcherEnqueueResult = Result<(), DispatcherEnqueueError>;
-
-#[derive(Debug, Error)]
-pub(super) enum DispatcherEnqueueError {
-    /// Dispatcher 已经通过拒绝通道给用户发送过容量提示，上层不得重复发送服务不可用提示。
-    #[error("dispatcher rejected message and queued user notification: {reason}")]
-    RejectedAndNotified { reason: &'static str },
-    /// Dispatcher 已关闭或不可用且没有自行提示用户，上层需要决定是否给出兜底提示。
-    #[error("dispatcher unavailable: {reason}")]
-    Unavailable { reason: &'static str },
-}
 
 #[derive(Clone)]
 pub(super) struct MessageDispatcherHandle {
@@ -203,17 +212,17 @@ impl MessageDispatcher {
         let (reject_tx, reject_rx) = mpsc::channel(reject_capacity);
         let handle_reject_tx = reject_tx.clone();
         let reject_metrics = Arc::new(RejectMetrics::default());
-        let handler = Arc::new(RealMessageHandler {
-            config: config.clone(),
+        let handler = RealMessageHandler::new(
+            config.clone(),
             auth,
             respond,
-            api: api.clone(),
+            api.clone(),
             dedupe,
             reply_cache,
             group_outbound_cache,
             group_cooldowns,
-            runtime: runtime.clone(),
-        });
+            runtime.clone(),
+        );
         let actor = DispatcherActor::new(
             config,
             api,
@@ -222,7 +231,7 @@ impl MessageDispatcher {
             command_tx.clone(),
             reject_tx,
             reject_rx,
-            reject_metrics.clone(),
+            reject_metrics,
             handler,
             shutdown_token.clone(),
         );
@@ -252,740 +261,6 @@ impl MessageDispatcher {
             Ok(Ok(())) => {}
             Ok(Err(error)) => warn!(error = %error, "dispatcher task ended unexpectedly"),
             Err(_) => warn!("dispatcher shutdown timed out"),
-        }
-    }
-}
-
-#[derive(Debug)]
-enum DispatcherCommand {
-    Enqueue {
-        scope_key: String,
-        // QueuedMessage 可能携带完整平台消息，装箱后可避免 command 枚举整体尺寸过大。
-        message: Box<QueuedMessage>,
-        ack: oneshot::Sender<DispatcherEnqueueResult>,
-    },
-    WorkerIdleExpired {
-        scope_key: String,
-        generation: u64,
-        reply: oneshot::Sender<IdleDecision>,
-    },
-    WorkerExited {
-        scope_key: String,
-        generation: u64,
-        reason: WorkerExitReason,
-    },
-    WorkerDequeued {
-        scope_key: String,
-        generation: u64,
-    },
-}
-
-#[derive(Debug, Clone)]
-enum InboundEnvelope {
-    C2c(C2cMessage),
-    Group(GroupMessage),
-}
-
-#[derive(Debug)]
-struct QueuedMessage {
-    envelope: InboundEnvelope,
-    reject_target: RejectTarget,
-    // 仅供聚合器建立边界屏障：Dispatcher 入队 ack 只表示已接收，
-    // processed_ack 要等 worker 真正处理完边界消息后才触发。
-    processed_ack: Option<oneshot::Sender<()>>,
-    // shutdown flush 失败只回滚不提示；正常入站容量拒绝仍由 Dispatcher 提示“稍后再试”。
-    notify_on_reject: bool,
-}
-
-#[derive(Debug, Clone)]
-enum RejectTarget {
-    C2c {
-        user_openid: String,
-        message_id: String,
-    },
-    Group {
-        group_openid: String,
-        message_id: String,
-    },
-}
-
-#[derive(Debug)]
-struct RejectNotification {
-    scope_key: String,
-    target: RejectTarget,
-    message: String,
-}
-
-#[derive(Debug, Default)]
-struct RejectMetrics {
-    total: AtomicU64,
-    dropped: AtomicU64,
-}
-
-#[derive(Debug, PartialEq, Eq)]
-enum IdleDecision {
-    StayActive,
-    RetireNow,
-}
-
-#[derive(Debug)]
-enum WorkerExitReason {
-    Completed,
-    Cancelled,
-    Panic,
-}
-
-struct DispatcherActor {
-    config: AppConfig,
-    api: QqApiClient,
-    runtime: GatewayRuntimeStatus,
-    command_rx: mpsc::Receiver<DispatcherCommand>,
-    command_tx: mpsc::Sender<DispatcherCommand>,
-    reject_tx: mpsc::Sender<RejectNotification>,
-    reject_rx: mpsc::Receiver<RejectNotification>,
-    worker_slots: Arc<Semaphore>,
-    active_workers: Arc<AtomicU64>,
-    reject_metrics: Arc<RejectMetrics>,
-    handler: Arc<dyn MessageHandler>,
-    scopes: HashMap<String, ScopeEntry>,
-    shutdown_token: CancellationToken,
-}
-
-struct ScopeEntry {
-    state: ScopeState,
-    generation: u64,
-    sender: Option<mpsc::Sender<QueuedMessage>>,
-    queue_len: usize,
-    backlog: VecDeque<QueuedMessage>,
-    worker_cancel: CancellationToken,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ScopeState {
-    Active,
-    Retiring,
-}
-
-type HandlerFuture<'a> = Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
-
-trait MessageHandler: Send + Sync {
-    fn handle<'a>(&'a self, message: InboundEnvelope) -> HandlerFuture<'a>;
-}
-
-struct RealMessageHandler {
-    config: AppConfig,
-    auth: AccessTokenManager,
-    respond: RespondClient,
-    api: QqApiClient,
-    dedupe: Arc<MessageDedupe>,
-    reply_cache: ReplyCache,
-    group_outbound_cache: Arc<std::sync::Mutex<BotOutboundCache>>,
-    group_cooldowns: Arc<std::sync::Mutex<GroupCooldowns>>,
-    runtime: GatewayRuntimeStatus,
-}
-
-impl MessageHandler for RealMessageHandler {
-    fn handle<'a>(&'a self, message: InboundEnvelope) -> HandlerFuture<'a> {
-        Box::pin(async move {
-            match message {
-                InboundEnvelope::C2c(message) => {
-                    handle_c2c_message(
-                        message,
-                        &self.config,
-                        &self.auth,
-                        &self.respond,
-                        &self.api,
-                        &self.dedupe,
-                        &self.reply_cache,
-                        &self.runtime,
-                    )
-                    .await
-                }
-                InboundEnvelope::Group(message) => {
-                    handle_group_message(
-                        message,
-                        &self.config,
-                        &self.respond,
-                        &self.api,
-                        &self.dedupe,
-                        &self.group_outbound_cache,
-                        &self.group_cooldowns,
-                        &self.runtime,
-                    )
-                    .await
-                }
-            }
-        })
-    }
-}
-
-impl DispatcherActor {
-    #[allow(clippy::too_many_arguments)]
-    fn new(
-        config: AppConfig,
-        api: QqApiClient,
-        runtime: GatewayRuntimeStatus,
-        command_rx: mpsc::Receiver<DispatcherCommand>,
-        command_tx: mpsc::Sender<DispatcherCommand>,
-        reject_tx: mpsc::Sender<RejectNotification>,
-        reject_rx: mpsc::Receiver<RejectNotification>,
-        reject_metrics: Arc<RejectMetrics>,
-        handler: Arc<dyn MessageHandler>,
-        shutdown_token: CancellationToken,
-    ) -> Self {
-        Self {
-            worker_slots: Arc::new(Semaphore::new(config.max_active_conversation_workers)),
-            active_workers: Arc::new(AtomicU64::new(0)),
-            config,
-            api,
-            runtime,
-            command_rx,
-            command_tx,
-            reject_tx,
-            reject_rx,
-            reject_metrics,
-            handler,
-            scopes: HashMap::new(),
-            shutdown_token,
-        }
-    }
-
-    async fn run(mut self) {
-        let reject_worker = tokio::spawn(run_reject_worker(
-            self.api.clone(),
-            self.runtime.clone(),
-            std::mem::replace(&mut self.reject_rx, mpsc::channel(1).1),
-            self.shutdown_token.child_token(),
-        ));
-
-        loop {
-            tokio::select! {
-                _ = self.shutdown_token.cancelled() => {
-                    break;
-                }
-                command = self.command_rx.recv() => {
-                    let Some(command) = command else {
-                        break;
-                    };
-                    self.handle_command(command).await;
-                }
-            }
-        }
-
-        self.drain_shutdown().await;
-        self.shutdown_token.cancel();
-        let _ = timeout(
-            Duration::from_secs(WORKER_CANCEL_TIMEOUT_SECS + 1),
-            reject_worker,
-        )
-        .await;
-    }
-
-    async fn handle_command(&mut self, command: DispatcherCommand) {
-        match command {
-            DispatcherCommand::Enqueue {
-                scope_key,
-                message,
-                ack,
-            } => {
-                let result = self.enqueue(scope_key, *message).await;
-                let _ = ack.send(result);
-            }
-            DispatcherCommand::WorkerIdleExpired {
-                scope_key,
-                generation,
-                reply,
-            } => {
-                let _ = reply.send(self.worker_idle_expired(&scope_key, generation));
-            }
-            DispatcherCommand::WorkerExited {
-                scope_key,
-                generation,
-                reason,
-            } => {
-                self.worker_exited(scope_key, generation, reason).await;
-            }
-            DispatcherCommand::WorkerDequeued {
-                scope_key,
-                generation,
-            } => {
-                if let Some(entry) = self.scopes.get_mut(&scope_key)
-                    && entry.generation == generation
-                    && entry.queue_len > 0
-                {
-                    entry.queue_len -= 1;
-                }
-            }
-        }
-    }
-
-    async fn enqueue(
-        &mut self,
-        scope_key: String,
-        message: QueuedMessage,
-    ) -> DispatcherEnqueueResult {
-        if self.shutdown_token.is_cancelled() {
-            return Err(DispatcherEnqueueError::Unavailable {
-                reason: "dispatcher_shutdown",
-            });
-        }
-        if let Some(entry) = self.scopes.get_mut(&scope_key) {
-            let total_len = entry.queue_len + entry.backlog.len();
-            if total_len >= self.config.conversation_queue_capacity {
-                if message.notify_on_reject
-                    && self
-                        .reject(scope_key, message.reject_target, "conversation_queue_full")
-                        .await
-                {
-                    return Err(DispatcherEnqueueError::RejectedAndNotified {
-                        reason: "conversation_queue_full",
-                    });
-                }
-                return Err(DispatcherEnqueueError::Unavailable {
-                    reason: "conversation_queue_full_reject_dropped",
-                });
-            }
-            match entry.state {
-                ScopeState::Active => {
-                    if let Some(sender) = entry.sender.as_ref() {
-                        sender.try_send(message).map_err(|_| {
-                            DispatcherEnqueueError::Unavailable {
-                                reason: "worker_queue_unavailable",
-                            }
-                        })?;
-                        entry.queue_len += 1;
-                        debug!(
-                            scope_key = %mask_scope_key(&scope_key),
-                            queue_len = entry.queue_len,
-                            backlog_len = entry.backlog.len(),
-                            "dispatcher enqueued message to active worker"
-                        );
-                        return Ok(());
-                    }
-                }
-                ScopeState::Retiring => {
-                    entry.backlog.push_back(message);
-                    debug!(
-                        scope_key = %mask_scope_key(&scope_key),
-                        queue_len = entry.queue_len,
-                        backlog_len = entry.backlog.len(),
-                        "dispatcher buffered message in retiring backlog"
-                    );
-                    return Ok(());
-                }
-            }
-        }
-
-        let permit = match self.worker_slots.clone().try_acquire_owned() {
-            Ok(permit) => permit,
-            Err(_) => {
-                if message.notify_on_reject
-                    && self
-                        .reject(scope_key, message.reject_target, "worker_slot_exhausted")
-                        .await
-                {
-                    return Err(DispatcherEnqueueError::RejectedAndNotified {
-                        reason: "worker_slot_exhausted",
-                    });
-                }
-                return Err(DispatcherEnqueueError::Unavailable {
-                    reason: "worker_slot_exhausted_reject_dropped",
-                });
-            }
-        };
-        let generation = self.next_generation();
-        let worker_cancel = self.shutdown_token.child_token();
-        let sender =
-            self.spawn_worker(scope_key.clone(), generation, worker_cancel.clone(), permit);
-        sender
-            .try_send(message)
-            .map_err(|_| DispatcherEnqueueError::Unavailable {
-                reason: "worker_queue_unavailable",
-            })?;
-        self.scopes.insert(
-            scope_key.clone(),
-            ScopeEntry {
-                state: ScopeState::Active,
-                generation,
-                sender: Some(sender),
-                queue_len: 1,
-                backlog: VecDeque::new(),
-                worker_cancel,
-            },
-        );
-        info!(
-            scope_key = %mask_scope_key(&scope_key),
-            generation,
-            active_workers = self.active_workers.load(Ordering::Relaxed),
-            max_active_workers = self.config.max_active_conversation_workers,
-            "dispatcher created worker"
-        );
-        Ok(())
-    }
-
-    fn worker_idle_expired(&mut self, scope_key: &str, generation: u64) -> IdleDecision {
-        let Some(entry) = self.scopes.get_mut(scope_key) else {
-            return IdleDecision::RetireNow;
-        };
-        if entry.generation != generation
-            || entry.state != ScopeState::Active
-            || entry.queue_len > 0
-        {
-            return IdleDecision::StayActive;
-        }
-        entry.state = ScopeState::Retiring;
-        entry.sender = None;
-        info!(
-            scope_key = %mask_scope_key(scope_key),
-            generation,
-            backlog_len = entry.backlog.len(),
-            "dispatcher marked worker retiring"
-        );
-        IdleDecision::RetireNow
-    }
-
-    async fn worker_exited(
-        &mut self,
-        scope_key: String,
-        generation: u64,
-        reason: WorkerExitReason,
-    ) {
-        self.active_workers.fetch_sub(1, Ordering::Relaxed);
-        let Some(mut entry) = self.scopes.remove(&scope_key) else {
-            return;
-        };
-        if entry.generation != generation {
-            self.scopes.insert(scope_key, entry);
-            return;
-        }
-        match reason {
-            WorkerExitReason::Completed => info!(
-                scope_key = %mask_scope_key(&scope_key),
-                generation,
-                "dispatcher observed worker exit"
-            ),
-            WorkerExitReason::Cancelled => warn!(
-                scope_key = %mask_scope_key(&scope_key),
-                generation,
-                queued_messages = entry.queue_len,
-                backlog_len = entry.backlog.len(),
-                "dispatcher observed cancelled worker"
-            ),
-            WorkerExitReason::Panic => warn!(
-                scope_key = %mask_scope_key(&scope_key),
-                generation,
-                queued_messages = entry.queue_len,
-                backlog_len = entry.backlog.len(),
-                "dispatcher observed panicked worker"
-            ),
-        }
-        if entry.backlog.is_empty() || self.shutdown_token.is_cancelled() {
-            return;
-        }
-        let permit = match self.worker_slots.clone().try_acquire_owned() {
-            Ok(permit) => permit,
-            Err(_) => {
-                while let Some(message) = entry.backlog.pop_front() {
-                    self.reject(
-                        scope_key.clone(),
-                        message.reject_target,
-                        "worker_slot_exhausted",
-                    )
-                    .await;
-                }
-                return;
-            }
-        };
-        let next_generation = self.next_generation();
-        let worker_cancel = self.shutdown_token.child_token();
-        let sender = self.spawn_worker(
-            scope_key.clone(),
-            next_generation,
-            worker_cancel.clone(),
-            permit,
-        );
-        let mut queue_len = 0usize;
-        while let Some(message) = entry.backlog.pop_front() {
-            if sender.try_send(message).is_ok() {
-                queue_len += 1;
-            } else {
-                warn!(
-                    scope_key = %mask_scope_key(&scope_key),
-                    generation = next_generation,
-                    "dispatcher successor worker queue unavailable while replaying backlog"
-                );
-            }
-        }
-        self.scopes.insert(
-            scope_key.clone(),
-            ScopeEntry {
-                state: ScopeState::Active,
-                generation: next_generation,
-                sender: Some(sender),
-                queue_len,
-                backlog: VecDeque::new(),
-                worker_cancel,
-            },
-        );
-        info!(
-            scope_key = %mask_scope_key(&scope_key),
-            generation = next_generation,
-            queue_len,
-            "dispatcher started successor worker"
-        );
-    }
-
-    fn spawn_worker(
-        &mut self,
-        scope_key: String,
-        generation: u64,
-        worker_cancel: CancellationToken,
-        permit: tokio::sync::OwnedSemaphorePermit,
-    ) -> mpsc::Sender<QueuedMessage> {
-        let (tx, rx) = mpsc::channel(self.config.conversation_queue_capacity);
-        let command_tx = self.command_tx.clone();
-        let handler = self.handler.clone();
-        let idle_timeout = self.config.conversation_worker_idle_timeout;
-        self.active_workers.fetch_add(1, Ordering::Relaxed);
-        tokio::spawn(async move {
-            let worker = tokio::spawn(run_worker(WorkerContext {
-                scope_key: scope_key.clone(),
-                generation,
-                handler,
-                command_tx: command_tx.clone(),
-                rx,
-                idle_timeout,
-                shutdown_token: worker_cancel.clone(),
-            }));
-            let reason = match worker.await {
-                Ok(reason) => reason,
-                Err(error) if error.is_panic() => WorkerExitReason::Panic,
-                Err(_) => WorkerExitReason::Cancelled,
-            };
-            drop(permit);
-            let _ = command_tx
-                .send(DispatcherCommand::WorkerExited {
-                    scope_key,
-                    generation,
-                    reason,
-                })
-                .await;
-        });
-        tx
-    }
-
-    async fn reject(
-        &mut self,
-        scope_key: String,
-        target: RejectTarget,
-        reason: &'static str,
-    ) -> bool {
-        self.reject_metrics.total.fetch_add(1, Ordering::Relaxed);
-        let notification = RejectNotification {
-            scope_key: scope_key.clone(),
-            target,
-            message: REJECT_QUEUE_TEXT.to_owned(),
-        };
-        if self.reject_tx.try_send(notification).is_err() {
-            let reject_total = self.reject_metrics.total.load(Ordering::Relaxed);
-            let reject_dropped = self.reject_metrics.dropped.fetch_add(1, Ordering::Relaxed) + 1;
-            warn!(
-                scope_key = %mask_scope_key(&scope_key),
-                reject_total,
-                reject_dropped,
-                reason,
-                "dispatcher reject queue full"
-            );
-            return false;
-        }
-        true
-    }
-
-    async fn drain_shutdown(&mut self) {
-        let start = Instant::now();
-        for entry in self.scopes.values() {
-            entry.worker_cancel.cancel();
-        }
-        while !self.scopes.is_empty()
-            && start.elapsed() < Duration::from_secs(SHUTDOWN_DRAIN_TIMEOUT_SECS)
-        {
-            if let Ok(Some(command)) =
-                timeout(Duration::from_millis(100), self.command_rx.recv()).await
-            {
-                self.handle_command(command).await;
-            }
-        }
-        let remaining_scopes = self.scopes.len();
-        if remaining_scopes > 0 {
-            warn!(
-                remaining_scopes,
-                active_workers = self.active_workers.load(Ordering::Relaxed),
-                reject_total = self.reject_metrics.total.load(Ordering::Relaxed),
-                reject_dropped = self.reject_metrics.dropped.load(Ordering::Relaxed),
-                "dispatcher shutdown drained with remaining work"
-            );
-        } else {
-            info!(
-                reject_total = self.reject_metrics.total.load(Ordering::Relaxed),
-                reject_dropped = self.reject_metrics.dropped.load(Ordering::Relaxed),
-                "dispatcher shutdown completed"
-            );
-        }
-    }
-
-    fn next_generation(&self) -> u64 {
-        static NEXT_GENERATION: AtomicU64 = AtomicU64::new(1);
-        NEXT_GENERATION.fetch_add(1, Ordering::Relaxed)
-    }
-}
-
-struct WorkerContext {
-    scope_key: String,
-    generation: u64,
-    handler: Arc<dyn MessageHandler>,
-    command_tx: mpsc::Sender<DispatcherCommand>,
-    rx: mpsc::Receiver<QueuedMessage>,
-    idle_timeout: Duration,
-    shutdown_token: CancellationToken,
-}
-
-async fn run_worker(mut ctx: WorkerContext) -> WorkerExitReason {
-    loop {
-        let next = tokio::select! {
-            _ = ctx.shutdown_token.cancelled() => {
-                let dropped_messages = ctx.rx.len();
-                if dropped_messages > 0 {
-                    warn!(
-                        scope_key = %mask_scope_key(&ctx.scope_key),
-                        generation = ctx.generation,
-                        dropped_messages,
-                        "dispatcher worker cancelled with queued messages"
-                    );
-                }
-                return WorkerExitReason::Cancelled;
-            }
-            result = timeout(ctx.idle_timeout, ctx.rx.recv()) => result,
-        };
-        let message = match next {
-            Ok(Some(message)) => message,
-            Ok(None) => return WorkerExitReason::Completed,
-            Err(_) => {
-                let (reply_tx, reply_rx) = oneshot::channel();
-                if ctx
-                    .command_tx
-                    .send(DispatcherCommand::WorkerIdleExpired {
-                        scope_key: ctx.scope_key.clone(),
-                        generation: ctx.generation,
-                        reply: reply_tx,
-                    })
-                    .await
-                    .is_err()
-                {
-                    return WorkerExitReason::Cancelled;
-                }
-                match reply_rx.await {
-                    Ok(IdleDecision::StayActive) => continue,
-                    Ok(IdleDecision::RetireNow) => return WorkerExitReason::Completed,
-                    Err(_) => return WorkerExitReason::Cancelled,
-                }
-            }
-        };
-        if ctx
-            .command_tx
-            .send(DispatcherCommand::WorkerDequeued {
-                scope_key: ctx.scope_key.clone(),
-                generation: ctx.generation,
-            })
-            .await
-            .is_err()
-        {
-            warn!(
-                scope_key = %mask_scope_key(&ctx.scope_key),
-                generation = ctx.generation,
-                queued_messages = ctx.rx.len(),
-                "dispatcher worker dequeued message but command channel is closed"
-            );
-            return WorkerExitReason::Cancelled;
-        }
-        let QueuedMessage {
-            envelope,
-            processed_ack,
-            ..
-        } = message;
-        let result = ctx.handler.handle(envelope).await;
-        if let Some(ack) = processed_ack {
-            let _ = ack.send(());
-        }
-        if let Err(error) = result {
-            warn!(
-                scope_key = %mask_scope_key(&ctx.scope_key),
-                generation = ctx.generation,
-                error = %error,
-                "dispatcher worker failed to handle message"
-            );
-        } else {
-            debug!(
-                scope_key = %mask_scope_key(&ctx.scope_key),
-                generation = ctx.generation,
-                "dispatcher worker handled message"
-            );
-        }
-    }
-}
-
-async fn run_reject_worker(
-    api: QqApiClient,
-    runtime: GatewayRuntimeStatus,
-    mut reject_rx: mpsc::Receiver<RejectNotification>,
-    shutdown_token: CancellationToken,
-) {
-    loop {
-        let notification = tokio::select! {
-            _ = shutdown_token.cancelled() => break,
-            item = reject_rx.recv() => item,
-        };
-        let Some(notification) = notification else {
-            break;
-        };
-        let masked_target = match &notification.target {
-            RejectTarget::C2c { user_openid, .. } => mask_identifier(user_openid),
-            RejectTarget::Group { group_openid, .. } => mask_identifier(group_openid),
-        };
-        let result = match notification.target {
-            RejectTarget::C2c {
-                user_openid,
-                message_id,
-            } => {
-                send_c2c_text_with_status(
-                    &api,
-                    &runtime,
-                    &user_openid,
-                    Some(&message_id),
-                    &notification.message,
-                )
-                .await
-            }
-            RejectTarget::Group {
-                group_openid,
-                message_id,
-            } => {
-                send_group_text_with_status(
-                    &api,
-                    &runtime,
-                    &group_openid,
-                    Some(&message_id),
-                    &notification.message,
-                )
-                .await
-            }
-        };
-        if let Err(error) = result {
-            warn!(
-                scope_key = %mask_scope_key(&notification.scope_key),
-                target = %masked_target,
-                error = %error.log_summary(),
-                "dispatcher reject notification send failed"
-            );
         }
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/dispatcher/reject.rs
+++ b/qq-maid-gateway-rs/src/gateway/dispatcher/reject.rs
@@ -1,0 +1,76 @@
+//! Dispatcher 拒绝通知 worker。
+//!
+//! 单独的 task 从 reject channel 读取容量拒绝通知，并按目标类型（C2c / Group）
+//! 通过 outbound API 发送“稍后再试”提示。这里只负责发送，不改变拒绝策略：
+//! 真正的拒绝判定（队列满、worker slot 耗尽）仍在 `actor` 中完成。
+
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::warn;
+
+// outbound / logging / ping 都是 gateway 内 pub(pub(crate)/pub(super)) 项，
+// dispatcher 作为 gateway 的后代可以直接引用。
+use super::super::{
+    logging::{mask_identifier, mask_scope_key},
+    outbound::{send_c2c_text_with_status, send_group_text_with_status},
+    ping::GatewayRuntimeStatus,
+};
+use super::types::{RejectNotification, RejectTarget};
+use crate::api::QqApiClient;
+
+pub(super) async fn run_reject_worker(
+    api: QqApiClient,
+    runtime: GatewayRuntimeStatus,
+    mut reject_rx: mpsc::Receiver<RejectNotification>,
+    shutdown_token: CancellationToken,
+) {
+    loop {
+        let notification = tokio::select! {
+            _ = shutdown_token.cancelled() => break,
+            item = reject_rx.recv() => item,
+        };
+        let Some(notification) = notification else {
+            break;
+        };
+        let masked_target = match &notification.target {
+            RejectTarget::C2c { user_openid, .. } => mask_identifier(user_openid),
+            RejectTarget::Group { group_openid, .. } => mask_identifier(group_openid),
+        };
+        let result = match notification.target {
+            RejectTarget::C2c {
+                user_openid,
+                message_id,
+            } => {
+                send_c2c_text_with_status(
+                    &api,
+                    &runtime,
+                    &user_openid,
+                    Some(&message_id),
+                    &notification.message,
+                )
+                .await
+            }
+            RejectTarget::Group {
+                group_openid,
+                message_id,
+            } => {
+                send_group_text_with_status(
+                    &api,
+                    &runtime,
+                    &group_openid,
+                    Some(&message_id),
+                    &notification.message,
+                )
+                .await
+            }
+        };
+        if let Err(error) = result {
+            warn!(
+                scope_key = %mask_scope_key(&notification.scope_key),
+                target = %masked_target,
+                error = %error.log_summary(),
+                "dispatcher reject notification send failed"
+            );
+        }
+    }
+}

--- a/qq-maid-gateway-rs/src/gateway/dispatcher/types.rs
+++ b/qq-maid-gateway-rs/src/gateway/dispatcher/types.rs
@@ -1,0 +1,142 @@
+//! Dispatcher 内部数据类型定义。
+//!
+//! 这里集中放置 dispatcher 用到的命令、入站封装、队列消息、拒绝通知和 worker
+//! 状态枚举等纯数据类型，便于 `actor`、`worker`、`reject` 子模块共享，并降低
+//! `mod.rs` 的单文件复杂度。类型语义与拆分前完全一致，没有改变可观测行为。
+//!
+//! 注意：这些类型原本是 `dispatcher/mod.rs` 内的私有类型，拆分后统一标注为
+//! `pub(super)`（相对于 `dispatcher::types` 的父 `dispatcher`），仅对
+//! `gateway::dispatcher` 模块及其子模块可见；gateway 外部仍只能看到 `mod.rs`
+//! 暴露的 `MessageDispatcher` / `MessageDispatcherHandle` / `DispatcherEnqueueError`。
+
+use std::{collections::VecDeque, sync::atomic::AtomicU64};
+
+use thiserror::Error;
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
+
+// 平台消息类型来自 gateway::event，pub(super) 在 event 中对 gateway 可见，
+// dispatcher 作为 gateway 的后代可以引用。
+use super::super::event::{C2cMessage, GroupMessage};
+
+// 这些常量直接服务于 dispatcher 的容量、提示文案与超时语义，集中在此处便于引用。
+// 改动它们会影响 QQ 入站消息串行化、队列容量提示和 shutdown 回收行为，需谨慎。
+
+/// Dispatcher 通过拒绝通道给用户发送容量提示时使用的固定文案。
+pub(super) const REJECT_QUEUE_TEXT: &str = "当前消息较多，请稍后再试。";
+/// shutdown flush 阶段回收 worker 的最长等待秒数。
+pub(super) const SHUTDOWN_DRAIN_TIMEOUT_SECS: u64 = 10;
+/// worker 取消超时窗口，给被取消的 worker 一点收尾时间。
+pub(super) const WORKER_CANCEL_TIMEOUT_SECS: u64 = 1;
+/// command channel 容量相对活跃 worker 上限的倍数，避免指令通道成为瓶颈。
+pub(super) const COMMAND_CHANNEL_MULTIPLIER: usize = 4;
+
+pub(super) type DispatcherEnqueueResult = Result<(), DispatcherEnqueueError>;
+
+// `DispatcherEnqueueError` 会由 `mod.rs` 以 `pub(super)` 再导出给 gateway 调用方
+// （aggregator 等），因此这里需要比 `pub(super)` 更宽一点：可见到整个 gateway 模块。
+#[derive(Debug, Error)]
+pub(in crate::gateway) enum DispatcherEnqueueError {
+    /// Dispatcher 已经通过拒绝通道给用户发送过容量提示，上层不得重复发送服务不可用提示。
+    #[error("dispatcher rejected message and queued user notification: {reason}")]
+    RejectedAndNotified { reason: &'static str },
+    /// Dispatcher 已关闭或不可用且没有自行提示用户，上层需要决定是否给出兜底提示。
+    #[error("dispatcher unavailable: {reason}")]
+    Unavailable { reason: &'static str },
+}
+
+#[derive(Debug)]
+pub(super) enum DispatcherCommand {
+    Enqueue {
+        scope_key: String,
+        // QueuedMessage 可能携带完整平台消息，装箱后可避免 command 枚举整体尺寸过大。
+        message: Box<QueuedMessage>,
+        ack: oneshot::Sender<DispatcherEnqueueResult>,
+    },
+    WorkerIdleExpired {
+        scope_key: String,
+        generation: u64,
+        reply: oneshot::Sender<IdleDecision>,
+    },
+    WorkerExited {
+        scope_key: String,
+        generation: u64,
+        reason: WorkerExitReason,
+    },
+    WorkerDequeued {
+        scope_key: String,
+        generation: u64,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum InboundEnvelope {
+    C2c(C2cMessage),
+    Group(GroupMessage),
+}
+
+#[derive(Debug)]
+pub(super) struct QueuedMessage {
+    pub(super) envelope: InboundEnvelope,
+    pub(super) reject_target: RejectTarget,
+    // 仅供聚合器建立边界屏障：Dispatcher 入队 ack 只表示已接收，
+    // processed_ack 要等 worker 真正处理完边界消息后才触发。
+    pub(super) processed_ack: Option<oneshot::Sender<()>>,
+    // shutdown flush 失败只回滚不提示；正常入站容量拒绝仍由 Dispatcher 提示“稍后再试”。
+    pub(super) notify_on_reject: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum RejectTarget {
+    C2c {
+        user_openid: String,
+        message_id: String,
+    },
+    Group {
+        group_openid: String,
+        message_id: String,
+    },
+}
+
+#[derive(Debug)]
+pub(super) struct RejectNotification {
+    pub(super) scope_key: String,
+    pub(super) target: RejectTarget,
+    pub(super) message: String,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct RejectMetrics {
+    pub(super) total: AtomicU64,
+    pub(super) dropped: AtomicU64,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum IdleDecision {
+    StayActive,
+    RetireNow,
+}
+
+#[derive(Debug)]
+pub(super) enum WorkerExitReason {
+    Completed,
+    Cancelled,
+    Panic,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ScopeState {
+    Active,
+    Retiring,
+}
+
+/// 单个 scope 的运行时状态。sender 存在表示有活跃 worker 持有有界队列；
+/// worker 进入 Retiring 后 sender 被清空，新消息落入 backlog 等待继任 worker。
+pub(super) struct ScopeEntry {
+    pub(super) state: ScopeState,
+    pub(super) generation: u64,
+    pub(super) sender: Option<mpsc::Sender<QueuedMessage>>,
+    pub(super) queue_len: usize,
+    pub(super) backlog: VecDeque<QueuedMessage>,
+    pub(super) worker_cancel: CancellationToken,
+}

--- a/qq-maid-gateway-rs/src/gateway/dispatcher/worker.rs
+++ b/qq-maid-gateway-rs/src/gateway/dispatcher/worker.rs
@@ -1,0 +1,116 @@
+//! Dispatcher 会话 worker 执行循环与 idle 回收。
+//!
+//! `run_worker` 在独立 task 中串行消费某 scope 的队列消息，并在 idle 超时后向
+//! actor 询问是否回收。串行语义、idle 判定与取消处理保持与拆分前一致，没有
+//! 改变 QQ 消息串行化或 worker 回收行为。
+
+use std::{sync::Arc, time::Duration};
+
+use tokio::{
+    sync::{mpsc, oneshot},
+    time::timeout,
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+use super::super::logging::mask_scope_key;
+// `MessageHandler` 定义在 actor 子模块，actor 通过 `pub(super)` 暴露给 dispatcher
+// 后代；worker 作为 dispatcher 的子模块可以直接引用。`HandlerFuture` 仅作为
+// `handler.handle` 的返回类型被隐式使用，这里不需要具名导入。
+use super::actor::MessageHandler;
+use super::types::{DispatcherCommand, IdleDecision, QueuedMessage, WorkerExitReason};
+
+/// 单个 scope worker 的执行上下文，由 actor 在 `spawn_worker` 时构造。
+pub(super) struct WorkerContext {
+    pub(super) scope_key: String,
+    pub(super) generation: u64,
+    pub(super) handler: Arc<dyn MessageHandler>,
+    pub(super) command_tx: mpsc::Sender<DispatcherCommand>,
+    pub(super) rx: mpsc::Receiver<QueuedMessage>,
+    pub(super) idle_timeout: Duration,
+    pub(super) shutdown_token: CancellationToken,
+}
+
+pub(super) async fn run_worker(mut ctx: WorkerContext) -> WorkerExitReason {
+    loop {
+        let next = tokio::select! {
+            _ = ctx.shutdown_token.cancelled() => {
+                let dropped_messages = ctx.rx.len();
+                if dropped_messages > 0 {
+                    warn!(
+                        scope_key = %mask_scope_key(&ctx.scope_key),
+                        generation = ctx.generation,
+                        dropped_messages,
+                        "dispatcher worker cancelled with queued messages"
+                    );
+                }
+                return WorkerExitReason::Cancelled;
+            }
+            result = timeout(ctx.idle_timeout, ctx.rx.recv()) => result,
+        };
+        let message = match next {
+            Ok(Some(message)) => message,
+            Ok(None) => return WorkerExitReason::Completed,
+            Err(_) => {
+                let (reply_tx, reply_rx) = oneshot::channel();
+                if ctx
+                    .command_tx
+                    .send(DispatcherCommand::WorkerIdleExpired {
+                        scope_key: ctx.scope_key.clone(),
+                        generation: ctx.generation,
+                        reply: reply_tx,
+                    })
+                    .await
+                    .is_err()
+                {
+                    return WorkerExitReason::Cancelled;
+                }
+                match reply_rx.await {
+                    Ok(IdleDecision::StayActive) => continue,
+                    Ok(IdleDecision::RetireNow) => return WorkerExitReason::Completed,
+                    Err(_) => return WorkerExitReason::Cancelled,
+                }
+            }
+        };
+        if ctx
+            .command_tx
+            .send(DispatcherCommand::WorkerDequeued {
+                scope_key: ctx.scope_key.clone(),
+                generation: ctx.generation,
+            })
+            .await
+            .is_err()
+        {
+            warn!(
+                scope_key = %mask_scope_key(&ctx.scope_key),
+                generation = ctx.generation,
+                queued_messages = ctx.rx.len(),
+                "dispatcher worker dequeued message but command channel is closed"
+            );
+            return WorkerExitReason::Cancelled;
+        }
+        let QueuedMessage {
+            envelope,
+            processed_ack,
+            ..
+        } = message;
+        let result = ctx.handler.handle(envelope).await;
+        if let Some(ack) = processed_ack {
+            let _ = ack.send(());
+        }
+        if let Err(error) = result {
+            warn!(
+                scope_key = %mask_scope_key(&ctx.scope_key),
+                generation = ctx.generation,
+                error = %error,
+                "dispatcher worker failed to handle message"
+            );
+        } else {
+            debug!(
+                scope_key = %mask_scope_key(&ctx.scope_key),
+                generation = ctx.generation,
+                "dispatcher worker handled message"
+            );
+        }
+    }
+}


### PR DESCRIPTION
父任务：#106（拆分超长源文件）
子任务：#114

## 背景

`qq-maid-gateway-rs/src/gateway/dispatcher.rs`（现已为 `dispatcher/mod.rs`）测试外移后主体仍约 994 行，集中承载 dispatcher handle、actor、scope entry、worker、reject worker 和命令类型。该文件直接影响 QQ 入站消息串行化、队列容量、活跃 worker 上限和拒绝通知，按 #114 边界小步拆分。

## 拆分边界

- `dispatcher/types.rs`：`DispatcherCommand` / `InboundEnvelope` / `QueuedMessage` / `RejectTarget` / `RejectNotification` / `RejectMetrics` / `IdleDecision` / `WorkerExitReason` / `ScopeState` / `ScopeEntry` 等内部数据类型与常量。
- `dispatcher/actor.rs`：`DispatcherActor` 及 scope 状态机、入队分发、worker 生命周期管理；`MessageHandler` / `HandlerFuture` / `RealMessageHandler` 抽象。
- `dispatcher/worker.rs`：会话 worker 执行循环 `run_worker` 与 `WorkerContext`、idle 回收。
- `dispatcher/reject.rs`：拒绝通知发送 worker `run_reject_worker`。
- `dispatcher/mod.rs`：仍只对外暴露 `MessageDispatcher` / `MessageDispatcherHandle` / `DispatcherEnqueueError`，gateway 侧调用方式不变；内联测试 `mod tests;` 保持原写法。

## 不改变

- QQ 消息入口、去重、群聊/私聊响应策略。
- 队列容量、活跃 worker 上限、idle timeout 配置语义。
- CoreService 调用路径或 `/ping` 本地诊断。

## 验证

- `cargo fmt --all -- --check` ✅
- `cargo clippy -p qq-maid-gateway-rs --all-targets --all-features -- -D warnings` ✅
- `cargo test -p qq-maid-gateway-rs --all-features` ✅（155 passed）
- `cargo test --workspace --all-features` ✅
- `cargo build -p qq-maid-gateway-rs` ✅