### PR TITLE
fix: 优化 todo all 看板展示

### DIFF
--- a/qq-maid-core/src/runtime/respond/pending.rs
+++ b/qq-maid-core/src/runtime/respond/pending.rs
@@ -84,7 +84,14 @@ impl RustRespondService {
     ) -> Result<RespondResponse, LlmError> {
         let reply = reply.into();
         self.session_store
-            .append_exchange(session, user_text, &reply.text)
+            .append_exchange_with_latest(session, user_text, &reply.text, |latest, current| {
+                // 确认流和管理命令可能在追加回复前已经更新 pending / 记忆列表快照。
+                // 这里只合并这些明确由当前轮次产生的字段，避免旧 SessionRecord 覆盖
+                // 其他路径刚写入的历史、最近 Todo 操作等状态。
+                latest.state = current.state.clone();
+                latest.pending_operation = current.pending_operation.clone();
+                latest.last_memory_query = current.last_memory_query.clone();
+            })
             .map_err(session_error)?;
         Ok(command_response(
             reply,

--- a/qq-maid-core/src/runtime/respond/tests/todo.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo.rs
@@ -1,5 +1,5 @@
 use super::support::*;
-use crate::runtime::todo::{TodoItemDraft, TodoStatus, TodoStore, TodoTimePrecision};
+use crate::runtime::todo::{TodoItem, TodoItemDraft, TodoStatus, TodoStore, TodoTimePrecision};
 
 fn draft(title: &str) -> TodoItemDraft {
     TodoItemDraft {
@@ -9,6 +9,16 @@ fn draft(title: &str) -> TodoItemDraft {
         due_date: None,
         due_at: None,
         time_precision: TodoTimePrecision::None,
+    }
+}
+
+fn assert_in_order(text: &str, needles: &[&str]) {
+    let mut cursor = 0;
+    for needle in needles {
+        let offset = text[cursor..]
+            .find(needle)
+            .unwrap_or_else(|| panic!("missing ordered text: {needle}"));
+        cursor += offset + needle.len();
     }
 }
 
@@ -168,6 +178,185 @@ async fn todo_all_and_search_remain_deterministic_queries() {
 
     let search = service.respond(message("/todo search 查找")).await.unwrap();
     assert!(search.text.unwrap().contains("查找目标"));
+}
+
+#[tokio::test]
+async fn todo_all_renders_grouped_board_and_remembers_visible_order() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    let items = vec![
+        TodoItem {
+            id: "1".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "无时间进行中".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: None,
+            due_at: None,
+            time_precision: TodoTimePrecision::None,
+            status: TodoStatus::Pending,
+            created_at: "2026-07-01T12:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T12:00:00+08:00".to_owned(),
+            completed_at: None,
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "2".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "稍后进行中".to_owned(),
+            detail: Some("有详情".to_owned()),
+            raw_text: None,
+            due_date: Some("2026-07-03".to_owned()),
+            due_at: None,
+            time_precision: TodoTimePrecision::Date,
+            status: TodoStatus::Pending,
+            created_at: "2026-07-01T11:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T11:00:00+08:00".to_owned(),
+            completed_at: None,
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "3".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "更早进行中".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: Some("2026-07-02".to_owned()),
+            due_at: None,
+            time_precision: TodoTimePrecision::Date,
+            status: TodoStatus::Pending,
+            created_at: "2026-07-01T10:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T10:00:00+08:00".to_owned(),
+            completed_at: None,
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "4".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "较早完成".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: None,
+            due_at: None,
+            time_precision: TodoTimePrecision::None,
+            status: TodoStatus::Completed,
+            created_at: "2026-07-01T09:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T09:00:00+08:00".to_owned(),
+            completed_at: Some("2026-06-30T18:00:00+08:00".to_owned()),
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "5".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "较新完成".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: None,
+            due_at: None,
+            time_precision: TodoTimePrecision::None,
+            status: TodoStatus::Completed,
+            created_at: "2026-07-01T08:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T08:00:00+08:00".to_owned(),
+            completed_at: Some("2026-07-01T18:00:00+08:00".to_owned()),
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "6".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "已取消新项".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: Some("2026-07-04".to_owned()),
+            due_at: None,
+            time_precision: TodoTimePrecision::Date,
+            status: TodoStatus::Cancelled,
+            created_at: "2026-07-01T13:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T13:00:00+08:00".to_owned(),
+            completed_at: None,
+            cancelled_at: Some("2026-07-01T13:10:00+08:00".to_owned()),
+        },
+        TodoItem {
+            id: "7".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "已取消旧项".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: Some("2026-07-05".to_owned()),
+            due_at: None,
+            time_precision: TodoTimePrecision::Date,
+            status: TodoStatus::Cancelled,
+            created_at: "2026-07-01T07:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T07:00:00+08:00".to_owned(),
+            completed_at: None,
+            cancelled_at: Some("2026-07-01T07:10:00+08:00".to_owned()),
+        },
+    ];
+    service
+        .todo_store
+        .set_items_for_test(&owner, &items)
+        .unwrap();
+
+    let response = service.respond(message("/todo all")).await.unwrap();
+    assert_eq!(response.command.as_deref(), Some("todo_all"));
+    let text = response.text.unwrap();
+    assert!(text.starts_with("📋 全部待办 · 共 7 项"));
+    assert!(text.contains("🚧 进行中（3 项）"));
+    assert!(text.contains("✅ 已完成（2 项）"));
+    assert!(text.contains("⛔ 已取消（2 项）"));
+    assert!(text.contains("   详情：有详情"));
+    assert!(text.contains("   完成时间："));
+    assert!(text.contains("   原定时间："));
+    assert!(!text.contains("（未完成）"));
+    assert!(!text.contains("（已完成）"));
+    assert!(!text.contains("（已取消）"));
+    assert_in_order(
+        &text,
+        &[
+            "🚧 进行中（3 项）",
+            "1. 更早进行中",
+            "2. 稍后进行中",
+            "3. 无时间进行中",
+            "✅ 已完成（2 项）",
+            "4. 较新完成",
+            "5. 较早完成",
+            "⛔ 已取消（2 项）",
+            "6. 已取消新项",
+            "7. 已取消旧项",
+        ],
+    );
+
+    let markdown = response.markdown.unwrap();
+    assert!(markdown.starts_with("# 📋 全部待办 · 共 7 项"));
+    assert_in_order(
+        &markdown,
+        &[
+            "## 🚧 进行中（3 项）",
+            "1. **更早进行中**",
+            "2. **稍后进行中**",
+            "3. **无时间进行中**",
+            "## ✅ 已完成（2 项）",
+            "4. **较新完成**",
+            "5. **较早完成**",
+            "## ⛔ 已取消（2 项）",
+            "6. **已取消新项**",
+            "7. **已取消旧项**",
+        ],
+    );
+
+    let session = service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap();
+    let snapshot = session.last_todo_query.expect("missing all todo snapshot");
+    assert_eq!(snapshot.query_type, "all");
+    assert_eq!(snapshot.result_ids, vec!["3", "2", "1", "5", "4", "6", "7"]);
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/todo_flow/format.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/format.rs
@@ -35,10 +35,10 @@ pub(super) fn format_todo_all_reply(items: &[TodoItem]) -> CommandBody {
     if items.is_empty() {
         return simple_todo_notice("当前没有待办。");
     }
-    let mut rows = vec!["全部待办：".to_owned()];
-    rows.extend(format_todo_rows_with_status(items));
-    let mut markdown_rows = vec!["# 全部待办".to_owned()];
-    markdown_rows.extend(format_todo_rows_markdown(items, true));
+    let mut rows = vec![format!("📋 全部待办 · 共 {} 项", items.len())];
+    rows.extend(format_todo_all_board_rows(items, false));
+    let mut markdown_rows = vec![format!("# 📋 全部待办 · 共 {} 项", items.len())];
+    markdown_rows.extend(format_todo_all_board_rows(items, true));
     CommandBody::dual(rows.join("\n"), markdown_rows.join("\n"))
 }
 
@@ -140,29 +140,81 @@ fn format_cancelled_todo_rows(items: &[TodoItem]) -> Vec<String> {
     format_todo_rows_with_time(items, "取消时间", display_todo_cancelled_at)
 }
 
-fn format_todo_rows_with_status(items: &[TodoItem]) -> Vec<String> {
+fn format_todo_all_board_rows(items: &[TodoItem], markdown: bool) -> Vec<String> {
+    let groups = [
+        (TodoStatus::Pending, "🚧 进行中", "时间"),
+        (TodoStatus::Completed, "✅ 已完成", "完成时间"),
+        (TodoStatus::Cancelled, "⛔ 已取消", "原定时间"),
+    ];
+    let mut rows = Vec::new();
+    for (status, title, time_label) in groups {
+        let group_items = items
+            .iter()
+            .enumerate()
+            .filter(|(_, item)| item.status == status)
+            .collect::<Vec<_>>();
+        if group_items.is_empty() {
+            continue;
+        }
+        if !rows.is_empty() {
+            rows.push(String::new());
+        }
+        rows.push(if markdown {
+            format!("## {title}（{} 项）", group_items.len())
+        } else {
+            format!("{title}（{} 项）", group_items.len())
+        });
+        rows.extend(format_todo_all_board_item_rows(
+            &group_items,
+            time_label,
+            markdown,
+        ));
+    }
+    rows
+}
+
+fn format_todo_all_board_item_rows(
+    items: &[(usize, &TodoItem)],
+    time_label: &str,
+    markdown: bool,
+) -> Vec<String> {
     items
         .iter()
-        .enumerate()
         .map(|(index, item)| {
-            let (time_label, time_text) = match item.status {
+            let time_text = match item.status {
                 TodoStatus::Completed => ("完成时间", display_todo_completed_at(item).to_owned()),
-                _ => ("时间", display_todo_time(item)),
+                _ => (time_label, display_todo_time(item)),
             };
-            let mut row = format!(
-                "{}. {}（{}）\n   {}：{}",
-                index + 1,
-                format_todo_inline(item),
-                crate::runtime::todo::status::status_cn_short(&item.status),
-                time_label,
-                time_text
-            );
+            let mut row = if markdown {
+                format!(
+                    "{}. {}\n   - **{}**：{}",
+                    index + 1,
+                    format_todo_inline_markdown(item),
+                    escape_markdown_inline(time_text.0),
+                    escape_markdown_inline(&time_text.1)
+                )
+            } else {
+                format!(
+                    "{}. {}\n   {}：{}",
+                    index + 1,
+                    format_todo_inline(item),
+                    time_text.0,
+                    time_text.1
+                )
+            };
             if let Some(detail) = item
                 .detail
                 .as_deref()
                 .and_then(|value| clean_string(value.to_owned()))
             {
-                row.push_str(&format!("\n   详情：{}", truncate_chars(&detail, 80)));
+                if markdown {
+                    row.push_str(&format!(
+                        "\n   - **详情**：{}",
+                        escape_markdown_text(&truncate_chars(&detail, 80))
+                    ));
+                } else {
+                    row.push_str(&format!("\n   详情：{}", truncate_chars(&detail, 80)));
+                }
             }
             row
         })

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -114,7 +114,10 @@ impl RustRespondService {
                 (format_todo_list_reply(&items), "todo_list".to_owned(), true)
             }
             "todo_all" => {
-                let items = self.todo_store.list_all(&owner).map_err(todo_error)?;
+                let items = self
+                    .todo_store
+                    .list_all_for_board(&owner)
+                    .map_err(todo_error)?;
                 remember_todo_query(session, &owner, "all", "全部待办", &items);
                 (format_todo_all_reply(&items), "todo_all".to_owned(), true)
             }
@@ -230,7 +233,10 @@ impl RustRespondService {
                 (format_todo_list_reply(&items), "todo_list".to_owned())
             }
             NaturalTodoQueryKind::All => {
-                let items = self.todo_store.list_all(owner).map_err(todo_error)?;
+                let items = self
+                    .todo_store
+                    .list_all_for_board(owner)
+                    .map_err(todo_error)?;
                 remember_todo_query(session, owner, "all", "全部待办", &items);
                 (format_todo_all_reply(&items), "todo_all".to_owned())
             }

--- a/qq-maid-core/src/storage/session/tests.rs
+++ b/qq-maid-core/src/storage/session/tests.rs
@@ -264,6 +264,14 @@ fn append_exchange_with_latest_merges_query_snapshot_without_overwriting_newer_f
         "",
         vec!["todo-a".to_owned(), "todo-b".to_owned()],
     );
+    stale.last_memory_query = Some(LastMemoryQuery {
+        query_type: "list".to_owned(),
+        condition: String::new(),
+        scope_type: Some("personal".to_owned()),
+        scope_id: Some("u1".to_owned()),
+        result_ids: vec!["memory-a".to_owned()],
+        created_at: now_iso_cn(),
+    });
     store
         .append_exchange_with_latest(
             &mut stale,
@@ -272,6 +280,7 @@ fn append_exchange_with_latest_merges_query_snapshot_without_overwriting_newer_f
             |current, stale| {
                 current.state = stale.state.clone();
                 current.last_todo_query = stale.last_todo_query.clone();
+                current.last_memory_query = stale.last_memory_query.clone();
             },
         )
         .unwrap();
@@ -291,6 +300,13 @@ fn append_exchange_with_latest_merges_query_snapshot_without_overwriting_newer_f
             .as_ref()
             .map(|query| query.result_ids.clone()),
         Some(vec!["todo-a".to_owned(), "todo-b".to_owned()])
+    );
+    assert_eq!(
+        merged
+            .last_memory_query
+            .as_ref()
+            .map(|query| query.result_ids.clone()),
+        Some(vec!["memory-a".to_owned()])
     );
     assert_eq!(
         merged

--- a/qq-maid-core/src/storage/todo/mod.rs
+++ b/qq-maid-core/src/storage/todo/mod.rs
@@ -41,8 +41,8 @@ use query::{
 };
 use search::search_score;
 use sort::{
-    compare_todo_order, sort_completed_todos, sort_completed_todos_desc, sort_todos,
-    sort_todos_by_created_desc,
+    compare_todo_order, sort_completed_todos, sort_completed_todos_desc, sort_todo_all_board,
+    sort_todos, sort_todos_by_created_desc,
 };
 
 /// Todo schema migration，由应用启动时的通用数据库初始化流程统一执行。
@@ -394,6 +394,16 @@ impl TodoStore {
         let conn = self.connection()?;
         let mut items = query_items(&conn, owner)?;
         sort_todos_by_created_desc(&mut items);
+        Ok(items)
+    }
+
+    /// 列出 `/todo all` 看板使用的全部待办，按用户可见分组顺序排列。
+    pub fn list_all_for_board(&self, owner: &TodoOwner) -> Result<Vec<TodoItem>, TodoError> {
+        let conn = self.connection()?;
+        let mut items = query_items(&conn, owner)?;
+        // 先复用原全部列表顺序，后续分组时让已取消组自然保留既有稳定顺序。
+        sort_todos_by_created_desc(&mut items);
+        sort_todo_all_board(&mut items);
         Ok(items)
     }
 

--- a/qq-maid-core/src/storage/todo/sort.rs
+++ b/qq-maid-core/src/storage/todo/sort.rs
@@ -4,6 +4,7 @@
 //! - pending 默认按真实待办时间升序（date-only 视为当天 00:00:00，无时间排最后）；
 //! - 已完成列表按完成时间降序；
 //! - 已取消 / 全部列表按创建时间降序。
+//! - `/todo all` 看板按状态分组展示，其中已取消组保留全部列表里的稳定顺序。
 //!
 //! 改动这里要同步关注 pending / 已完成 / 已取消列表的展示语义。
 
@@ -43,6 +44,31 @@ pub(super) fn sort_todos_by_created_desc(items: &mut [TodoItem]) {
             .cmp(&left.created_at)
             .then_with(|| left.id.cmp(&right.id))
     });
+}
+
+/// `/todo all` 看板的可见顺序。
+///
+/// 这里显式先分组再排序，确保用户看到的编号快照与看板顺序一致；已取消组不引入
+/// 新的取消时间语义，只沿用 `list_all` 的创建时间稳定顺序。
+pub(super) fn sort_todo_all_board(items: &mut Vec<TodoItem>) {
+    let mut pending = Vec::new();
+    let mut completed = Vec::new();
+    let mut cancelled = Vec::new();
+
+    for item in items.drain(..) {
+        match item.status {
+            super::TodoStatus::Pending => pending.push(item),
+            super::TodoStatus::Completed => completed.push(item),
+            super::TodoStatus::Cancelled => cancelled.push(item),
+        }
+    }
+
+    sort_todos(&mut pending);
+    sort_completed_todos_desc(&mut completed);
+
+    items.extend(pending);
+    items.extend(completed);
+    items.extend(cancelled);
 }
 
 /// 比较两个待办事项的排列顺序：有截止时间的排前面，其次按 ID。


### PR DESCRIPTION
## 变更
- 将 /todo all 改为按进行中、已完成、已取消分组展示，并显示总数与分组数量
- 新增 /todo all 看板可见排序，快照编号与最终展示顺序保持一致
- 修复记忆列表快照在追加命令回复时可能丢失的问题，避免 /memory show/edit/delete 序号失效

## 验证
- cargo fmt --all -- --check
- cargo test -p qq-maid-core --all-features
- cargo test --workspace --all-features
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo build --workspace --all-features