### PR TITLE
fix: 单状态待办列表统一看板式展示，补全已取消列表 slash 入口

### DIFF
--- a/qq-maid-core/src/runtime/respond/pending.rs
+++ b/qq-maid-core/src/runtime/respond/pending.rs
@@ -84,7 +84,14 @@ impl RustRespondService {
     ) -> Result<RespondResponse, LlmError> {
         let reply = reply.into();
         self.session_store
-            .append_exchange(session, user_text, &reply.text)
+            .append_exchange_with_latest(session, user_text, &reply.text, |latest, current| {
+                // 确认流和管理命令可能在追加回复前已经更新 pending / 记忆列表快照。
+                // 这里只合并这些明确由当前轮次产生的字段，避免旧 SessionRecord 覆盖
+                // 其他路径刚写入的历史、最近 Todo 操作等状态。
+                latest.state = current.state.clone();
+                latest.pending_operation = current.pending_operation.clone();
+                latest.last_memory_query = current.last_memory_query.clone();
+            })
             .map_err(session_error)?;
         Ok(command_response(
             reply,

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -1048,7 +1048,13 @@ async fn natural_language_todo_query_prefers_listing_over_todo_parse_creation_ch
         .unwrap();
 
     assert_eq!(response.command.as_deref(), Some("todo_list"));
-    assert!(response.text.as_deref().unwrap().contains("待办列表"));
+    assert!(
+        response
+            .text
+            .as_deref()
+            .unwrap()
+            .contains("🚧 进行中 · 共 1 项")
+    );
     let session = service
         .session_store
         .get_or_create_active(&private_test_meta())
@@ -1118,15 +1124,18 @@ async fn natural_language_todo_query_aliases_and_filters_stay_deterministic() {
         assert!(!text.contains("已取消条目"), "{input}");
     }
 
-    let all = service
-        .respond(private_message("查看所有待办"))
-        .await
-        .unwrap();
-    let all_text = all.text.unwrap();
-    assert_eq!(all.command.as_deref(), Some("todo_all"));
-    assert!(all_text.contains("未完成条目"));
-    assert!(all_text.contains("已完成条目"));
-    assert!(all_text.contains("已取消条目"));
+    for input in ["查看所有待办", "查看全部待办"] {
+        let all = service.respond(private_message(input)).await.unwrap();
+        let all_text = all.text.unwrap();
+        assert_eq!(all.command.as_deref(), Some("todo_all"), "{input}");
+        assert!(all_text.contains("全部待办"), "{input}");
+        assert!(all_text.contains("进行中"), "{input}");
+        assert!(all_text.contains("已完成"), "{input}");
+        assert!(all_text.contains("已取消"), "{input}");
+        assert!(all_text.contains("未完成条目"), "{input}");
+        assert!(all_text.contains("已完成条目"), "{input}");
+        assert!(all_text.contains("已取消条目"), "{input}");
+    }
 
     let completed_only = service
         .respond(private_message("查看已完成待办"))
@@ -1538,7 +1547,7 @@ async fn deterministic_empty_query_clears_old_snapshot_before_number_mutation() 
             .text
             .as_deref()
             .unwrap()
-            .contains("当前没有未完成待办")
+            .contains("暂无未完成待办")
     );
     let session = service
         .session_store
@@ -1648,7 +1657,13 @@ async fn natural_language_cancelled_todo_query_lists_cancelled_items() {
         .unwrap();
 
     assert_eq!(response.command.as_deref(), Some("todo_cancelled_list"));
-    assert!(response.text.as_deref().unwrap().contains("已取消待办"));
+    assert!(
+        response
+            .text
+            .as_deref()
+            .unwrap()
+            .contains("⛔ 已取消 · 共 1 项")
+    );
     assert!(inspector.requests().is_empty());
     assert_eq!(inspector.tool_call_count(), 0);
 }

--- a/qq-maid-core/src/runtime/respond/tests/memory.rs
+++ b/qq-maid-core/src/runtime/respond/tests/memory.rs
@@ -923,6 +923,36 @@ async fn memory_management_uses_recent_list_index() {
 }
 
 #[tokio::test]
+async fn memory_list_then_show_parses_visible_index() {
+    let service = test_service();
+    service
+        .memory_store
+        .create(CreateMemoryRequest {
+            user_id: Some("u1".to_owned()),
+            group_id: Some("g1".to_owned()),
+            content: "列表后按序号查看的记忆".to_owned(),
+            source_text: "seed".to_owned(),
+            memory_type: "note".to_owned(),
+            scope: "general".to_owned(),
+        })
+        .unwrap();
+
+    let list = service
+        .respond(message("/memory list"))
+        .await
+        .unwrap()
+        .text
+        .unwrap();
+    assert!(list.contains("1 "));
+    assert!(list.contains("列表后按序号查看的记忆"));
+
+    let detail = service.respond(message("/memory show 1")).await.unwrap();
+    let detail_text = detail.text.as_deref().unwrap();
+    assert_eq!(detail.command.as_deref(), Some("memory_show"));
+    assert!(detail_text.contains("列表后按序号查看的记忆"));
+}
+
+#[tokio::test]
 async fn memory_management_rejects_id_target_and_requires_list_index() {
     let service = test_service();
     let record = service

--- a/qq-maid-core/src/runtime/respond/tests/todo.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo.rs
@@ -1,5 +1,5 @@
 use super::support::*;
-use crate::runtime::todo::{TodoItemDraft, TodoStatus, TodoStore, TodoTimePrecision};
+use crate::runtime::todo::{TodoItem, TodoItemDraft, TodoStatus, TodoStore, TodoTimePrecision};
 
 fn draft(title: &str) -> TodoItemDraft {
     TodoItemDraft {
@@ -9,6 +9,16 @@ fn draft(title: &str) -> TodoItemDraft {
         due_date: None,
         due_at: None,
         time_precision: TodoTimePrecision::None,
+    }
+}
+
+fn assert_in_order(text: &str, needles: &[&str]) {
+    let mut cursor = 0;
+    for needle in needles {
+        let offset = text[cursor..]
+            .find(needle)
+            .unwrap_or_else(|| panic!("missing ordered text: {needle}"));
+        cursor += offset + needle.len();
     }
 }
 
@@ -168,6 +178,185 @@ async fn todo_all_and_search_remain_deterministic_queries() {
 
     let search = service.respond(message("/todo search 查找")).await.unwrap();
     assert!(search.text.unwrap().contains("查找目标"));
+}
+
+#[tokio::test]
+async fn todo_all_renders_grouped_board_and_remembers_visible_order() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    let items = vec![
+        TodoItem {
+            id: "1".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "无时间进行中".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: None,
+            due_at: None,
+            time_precision: TodoTimePrecision::None,
+            status: TodoStatus::Pending,
+            created_at: "2026-07-01T12:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T12:00:00+08:00".to_owned(),
+            completed_at: None,
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "2".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "稍后进行中".to_owned(),
+            detail: Some("有详情".to_owned()),
+            raw_text: None,
+            due_date: Some("2026-07-03".to_owned()),
+            due_at: None,
+            time_precision: TodoTimePrecision::Date,
+            status: TodoStatus::Pending,
+            created_at: "2026-07-01T11:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T11:00:00+08:00".to_owned(),
+            completed_at: None,
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "3".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "更早进行中".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: Some("2026-07-02".to_owned()),
+            due_at: None,
+            time_precision: TodoTimePrecision::Date,
+            status: TodoStatus::Pending,
+            created_at: "2026-07-01T10:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T10:00:00+08:00".to_owned(),
+            completed_at: None,
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "4".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "较早完成".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: None,
+            due_at: None,
+            time_precision: TodoTimePrecision::None,
+            status: TodoStatus::Completed,
+            created_at: "2026-07-01T09:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T09:00:00+08:00".to_owned(),
+            completed_at: Some("2026-06-30T18:00:00+08:00".to_owned()),
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "5".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "较新完成".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: None,
+            due_at: None,
+            time_precision: TodoTimePrecision::None,
+            status: TodoStatus::Completed,
+            created_at: "2026-07-01T08:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T08:00:00+08:00".to_owned(),
+            completed_at: Some("2026-07-01T18:00:00+08:00".to_owned()),
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "6".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "已取消新项".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: Some("2026-07-04".to_owned()),
+            due_at: None,
+            time_precision: TodoTimePrecision::Date,
+            status: TodoStatus::Cancelled,
+            created_at: "2026-07-01T13:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T13:00:00+08:00".to_owned(),
+            completed_at: None,
+            cancelled_at: Some("2026-07-01T13:10:00+08:00".to_owned()),
+        },
+        TodoItem {
+            id: "7".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "已取消旧项".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: Some("2026-07-05".to_owned()),
+            due_at: None,
+            time_precision: TodoTimePrecision::Date,
+            status: TodoStatus::Cancelled,
+            created_at: "2026-07-01T07:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T07:00:00+08:00".to_owned(),
+            completed_at: None,
+            cancelled_at: Some("2026-07-01T07:10:00+08:00".to_owned()),
+        },
+    ];
+    service
+        .todo_store
+        .set_items_for_test(&owner, &items)
+        .unwrap();
+
+    let response = service.respond(message("/todo all")).await.unwrap();
+    assert_eq!(response.command.as_deref(), Some("todo_all"));
+    let text = response.text.unwrap();
+    assert!(text.starts_with("📋 全部待办 · 共 7 项"));
+    assert!(text.contains("🚧 进行中（3 项）"));
+    assert!(text.contains("✅ 已完成（2 项）"));
+    assert!(text.contains("⛔ 已取消（2 项）"));
+    assert!(text.contains("   详情：有详情"));
+    assert!(text.contains("   完成时间："));
+    assert!(text.contains("   原定时间："));
+    assert!(!text.contains("（未完成）"));
+    assert!(!text.contains("（已完成）"));
+    assert!(!text.contains("（已取消）"));
+    assert_in_order(
+        &text,
+        &[
+            "🚧 进行中（3 项）",
+            "1. 更早进行中",
+            "2. 稍后进行中",
+            "3. 无时间进行中",
+            "✅ 已完成（2 项）",
+            "4. 较新完成",
+            "5. 较早完成",
+            "⛔ 已取消（2 项）",
+            "6. 已取消新项",
+            "7. 已取消旧项",
+        ],
+    );
+
+    let markdown = response.markdown.unwrap();
+    assert!(markdown.starts_with("# 📋 全部待办 · 共 7 项"));
+    assert_in_order(
+        &markdown,
+        &[
+            "## 🚧 进行中（3 项）",
+            "1. **更早进行中**",
+            "2. **稍后进行中**",
+            "3. **无时间进行中**",
+            "## ✅ 已完成（2 项）",
+            "4. **较新完成**",
+            "5. **较早完成**",
+            "## ⛔ 已取消（2 项）",
+            "6. **已取消新项**",
+            "7. **已取消旧项**",
+        ],
+    );
+
+    let session = service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap();
+    let snapshot = session.last_todo_query.expect("missing all todo snapshot");
+    assert_eq!(snapshot.query_type, "all");
+    assert_eq!(snapshot.result_ids, vec!["3", "2", "1", "5", "4", "6", "7"]);
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tests/todo.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo.rs
@@ -22,6 +22,133 @@ fn assert_in_order(text: &str, needles: &[&str]) {
     }
 }
 
+fn status_list_items() -> Vec<TodoItem> {
+    vec![
+        TodoItem {
+            id: "1".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "无时间事项".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: None,
+            due_at: None,
+            time_precision: TodoTimePrecision::None,
+            status: TodoStatus::Pending,
+            created_at: "2026-07-01T12:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T12:00:00+08:00".to_owned(),
+            completed_at: None,
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "2".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "后天事项".to_owned(),
+            detail: Some("需要保留详情".to_owned()),
+            raw_text: None,
+            due_date: Some("2026-07-03".to_owned()),
+            due_at: None,
+            time_precision: TodoTimePrecision::Date,
+            status: TodoStatus::Pending,
+            created_at: "2026-07-01T11:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T11:00:00+08:00".to_owned(),
+            completed_at: None,
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "3".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "明天事项".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: Some("2026-07-02".to_owned()),
+            due_at: None,
+            time_precision: TodoTimePrecision::Date,
+            status: TodoStatus::Pending,
+            created_at: "2026-07-01T10:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T10:00:00+08:00".to_owned(),
+            completed_at: None,
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "4".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "较早归档".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: None,
+            due_at: None,
+            time_precision: TodoTimePrecision::None,
+            status: TodoStatus::Completed,
+            created_at: "2026-07-01T09:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T09:00:00+08:00".to_owned(),
+            completed_at: Some("2026-06-30T18:00:00+08:00".to_owned()),
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "5".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "较新归档".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: None,
+            due_at: None,
+            time_precision: TodoTimePrecision::None,
+            status: TodoStatus::Completed,
+            created_at: "2026-07-01T08:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T08:00:00+08:00".to_owned(),
+            completed_at: Some("2026-07-01T18:00:00+08:00".to_owned()),
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "6".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "最近放弃".to_owned(),
+            detail: Some("取消原因记录在详情里".to_owned()),
+            raw_text: None,
+            due_date: Some("2026-07-04".to_owned()),
+            due_at: None,
+            time_precision: TodoTimePrecision::Date,
+            status: TodoStatus::Cancelled,
+            created_at: "2026-07-01T13:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T13:00:00+08:00".to_owned(),
+            completed_at: None,
+            cancelled_at: Some("2026-07-01T13:10:00+08:00".to_owned()),
+        },
+        TodoItem {
+            id: "7".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "group:g1".to_owned(),
+            title: "较早放弃".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: Some("2026-07-05".to_owned()),
+            due_at: None,
+            time_precision: TodoTimePrecision::Date,
+            status: TodoStatus::Cancelled,
+            created_at: "2026-07-01T07:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T07:00:00+08:00".to_owned(),
+            completed_at: None,
+            cancelled_at: Some("2026-07-01T07:10:00+08:00".to_owned()),
+        },
+    ]
+}
+
+fn last_todo_result_ids(service: &crate::runtime::respond::RustRespondService) -> Vec<String> {
+    service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap()
+        .last_todo_query
+        .expect("missing todo query snapshot")
+        .result_ids
+}
+
 #[tokio::test]
 async fn todo_root_aliases_list_pending_items() {
     let service = test_service();
@@ -30,7 +157,7 @@ async fn todo_root_aliases_list_pending_items() {
         let response = service.respond(message(command)).await.unwrap();
         assert_eq!(response.command.as_deref(), Some("todo_list"));
         let text = response.text.unwrap();
-        assert!(text.contains("当前没有未完成待办"));
+        assert!(text.contains("暂无未完成待办"));
         assert!(!text.starts_with("null"));
     }
 }
@@ -178,6 +305,108 @@ async fn todo_all_and_search_remain_deterministic_queries() {
 
     let search = service.respond(message("/todo search 查找")).await.unwrap();
     assert!(search.text.unwrap().contains("查找目标"));
+}
+
+#[tokio::test]
+async fn todo_single_status_lists_render_board_style_and_remember_visible_order() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    service
+        .todo_store
+        .set_items_for_test(&owner, &status_list_items())
+        .unwrap();
+
+    let pending = service.respond(message("/todo")).await.unwrap();
+    assert_eq!(pending.command.as_deref(), Some("todo_list"));
+    let pending_text = pending.text.unwrap();
+    assert!(pending_text.starts_with("🚧 进行中 · 共 3 项"));
+    assert!(pending_text.contains("   时间："));
+    assert!(pending_text.contains("   详情：需要保留详情"));
+    assert!(!pending_text.contains("（未完成）"));
+    assert_in_order(
+        &pending_text,
+        &["1. 明天事项", "2. 后天事项", "3. 无时间事项"],
+    );
+    assert_eq!(last_todo_result_ids(&service), vec!["3", "2", "1"]);
+    assert!(
+        pending
+            .markdown
+            .unwrap()
+            .starts_with("# 🚧 进行中 · 共 3 项")
+    );
+
+    let completed = service.respond(message("/todo done")).await.unwrap();
+    assert_eq!(completed.command.as_deref(), Some("todo_done"));
+    let completed_text = completed.text.unwrap();
+    assert!(completed_text.starts_with("✅ 已完成 · 共 2 项"));
+    assert!(completed_text.contains("   完成时间："));
+    assert!(!completed_text.contains("（已完成）"));
+    assert_in_order(&completed_text, &["1. 较新归档", "2. 较早归档"]);
+    assert_eq!(last_todo_result_ids(&service), vec!["5", "4"]);
+    assert!(
+        completed
+            .markdown
+            .unwrap()
+            .starts_with("# ✅ 已完成 · 共 2 项")
+    );
+
+    let cancelled = service.respond(message("/todo 已取消")).await.unwrap();
+    assert_eq!(cancelled.command.as_deref(), Some("todo_cancelled_list"));
+    let cancelled_text = cancelled.text.unwrap();
+    assert!(cancelled_text.starts_with("⛔ 已取消 · 共 2 项"));
+    assert!(cancelled_text.contains("   取消时间："));
+    assert!(cancelled_text.contains("   详情：取消原因记录在详情里"));
+    assert!(!cancelled_text.contains("（已取消）"));
+    assert_in_order(&cancelled_text, &["1. 最近放弃", "2. 较早放弃"]);
+    assert_eq!(last_todo_result_ids(&service), vec!["6", "7"]);
+    assert!(
+        cancelled
+            .markdown
+            .unwrap()
+            .starts_with("# ⛔ 已取消 · 共 2 项")
+    );
+}
+
+#[tokio::test]
+async fn todo_single_status_lists_render_empty_notices() {
+    let service = test_service();
+
+    for (command, expected) in [
+        ("/todo", "暂无未完成待办"),
+        ("/todo done", "暂无已完成待办"),
+        ("/todo 已取消", "暂无已取消待办"),
+    ] {
+        let response = service.respond(message(command)).await.unwrap();
+        let text = response.text.unwrap();
+        assert_eq!(text, expected, "{command}");
+        assert!(!text.starts_with("null"), "{command}");
+    }
+}
+
+#[tokio::test]
+async fn natural_and_slash_status_queries_use_same_visible_order() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    service
+        .todo_store
+        .set_items_for_test(&owner, &status_list_items())
+        .unwrap();
+
+    for (slash, natural, expected_ids) in [
+        ("/todo", "查看待办", vec!["3", "2", "1"]),
+        ("/todo done", "查看已完成待办", vec!["5", "4"]),
+        ("/todo 已取消", "查看已取消待办", vec!["6", "7"]),
+    ] {
+        let expected_ids = expected_ids
+            .iter()
+            .map(|id| (*id).to_owned())
+            .collect::<Vec<_>>();
+        service.respond(message(slash)).await.unwrap();
+        assert_eq!(last_todo_result_ids(&service), expected_ids, "{slash}");
+
+        service.respond(message(natural)).await.unwrap();
+        assert_eq!(last_todo_result_ids(&service), expected_ids, "{natural}");
+    }
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/todo_flow/command.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/command.rs
@@ -31,6 +31,7 @@ pub(in crate::runtime::respond) fn parse_todo_command(text: &str) -> Option<Pars
         Some("todo_add") => "todo_add",
         Some("todo_done") => "todo_done",
         Some("todo_undo") => "todo_undo",
+        Some("todo_cancelled_list") => "todo_cancelled_list",
         Some("todo_edit") => "todo_edit",
         Some("todo_delete") => "todo_delete",
         Some(_) => "todo_search",
@@ -63,6 +64,7 @@ fn normalize_todo_action(value: &str) -> Option<&'static str> {
         "undo" | "restore" | "恢复" | "恢复完成" | "取消完成" | "设为未完成" | "未完成" => {
             Some("todo_undo")
         }
+        "cancelled" | "canceled" | "已取消" | "取消列表" => Some("todo_cancelled_list"),
         "edit" | "update" | "modify" | "set" | "修改" | "更新" | "改" | "调整" => {
             Some("todo_edit")
         }

--- a/qq-maid-core/src/runtime/respond/todo_flow/format.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/format.rs
@@ -21,14 +21,15 @@ pub(super) fn format_todo_write_tool_only_reply() -> CommandBody {
 }
 
 pub(super) fn format_todo_list_reply(items: &[TodoItem]) -> CommandBody {
-    if items.is_empty() {
-        return simple_todo_notice("当前没有未完成待办。");
-    }
-    let mut rows = vec!["待办列表：".to_owned()];
-    rows.extend(format_todo_rows(items));
-    let mut markdown_rows = vec!["# 待办列表".to_owned()];
-    markdown_rows.extend(format_todo_rows_markdown(items, false));
-    CommandBody::dual(rows.join("\n"), markdown_rows.join("\n"))
+    format_todo_status_list_reply(
+        items,
+        TodoStatusListFormat {
+            title: "🚧 进行中",
+            empty_text: "暂无未完成待办",
+            time_label: "时间",
+            time_value: display_todo_time,
+        },
+    )
 }
 
 pub(super) fn format_todo_all_reply(items: &[TodoItem]) -> CommandBody {
@@ -43,25 +44,27 @@ pub(super) fn format_todo_all_reply(items: &[TodoItem]) -> CommandBody {
 }
 
 pub(super) fn format_todo_done_list_reply(items: &[TodoItem]) -> CommandBody {
-    if items.is_empty() {
-        return simple_todo_notice("当前没有已完成待办。");
-    }
-    let mut rows = vec!["已完成待办：".to_owned()];
-    rows.extend(format_completed_todo_rows(items));
-    let mut markdown_rows = vec!["# 已完成待办".to_owned()];
-    markdown_rows.extend(format_completed_todo_rows_markdown(items));
-    CommandBody::dual(rows.join("\n"), markdown_rows.join("\n"))
+    format_todo_status_list_reply(
+        items,
+        TodoStatusListFormat {
+            title: "✅ 已完成",
+            empty_text: "暂无已完成待办",
+            time_label: "完成时间",
+            time_value: display_todo_completed_at,
+        },
+    )
 }
 
 pub(super) fn format_todo_cancelled_list_reply(items: &[TodoItem]) -> CommandBody {
-    if items.is_empty() {
-        return simple_todo_notice("当前没有已取消待办。");
-    }
-    let mut rows = vec!["已取消待办：".to_owned()];
-    rows.extend(format_cancelled_todo_rows(items));
-    let mut markdown_rows = vec!["# 已取消待办".to_owned()];
-    markdown_rows.extend(format_cancelled_todo_rows_markdown(items));
-    CommandBody::dual(rows.join("\n"), markdown_rows.join("\n"))
+    format_todo_status_list_reply(
+        items,
+        TodoStatusListFormat {
+            title: "⛔ 已取消",
+            empty_text: "暂无已取消待办",
+            time_label: "取消时间",
+            time_value: display_todo_cancelled_at,
+        },
+    )
 }
 
 pub(super) fn format_todo_search_reply(items: &[TodoItem], query: &str) -> CommandBody {
@@ -136,8 +139,32 @@ fn format_completed_todo_rows(items: &[TodoItem]) -> Vec<String> {
     format_todo_rows_with_time(items, "完成时间", display_todo_completed_at)
 }
 
-fn format_cancelled_todo_rows(items: &[TodoItem]) -> Vec<String> {
-    format_todo_rows_with_time(items, "取消时间", display_todo_cancelled_at)
+struct TodoStatusListFormat {
+    title: &'static str,
+    empty_text: &'static str,
+    time_label: &'static str,
+    time_value: fn(&TodoItem) -> String,
+}
+
+fn format_todo_status_list_reply(items: &[TodoItem], spec: TodoStatusListFormat) -> CommandBody {
+    if items.is_empty() {
+        return simple_todo_notice(spec.empty_text);
+    }
+    // 单状态列表复用 `/todo all` 的看板式标题与无状态行格式；编号快照由调用方按
+    // 同一 items 顺序写入 session，后续“第一条/第二条”才能精确对应用户刚看到的列表。
+    let mut rows = vec![format!("{} · 共 {} 项", spec.title, items.len())];
+    rows.extend(format_todo_rows_with_time(
+        items,
+        spec.time_label,
+        spec.time_value,
+    ));
+    let mut markdown_rows = vec![format!("# {} · 共 {} 项", spec.title, items.len())];
+    markdown_rows.extend(format_todo_rows_markdown_with_time(
+        items,
+        spec.time_label,
+        spec.time_value,
+    ));
+    CommandBody::dual(rows.join("\n"), markdown_rows.join("\n"))
 }
 
 fn format_todo_all_board_rows(items: &[TodoItem], markdown: bool) -> Vec<String> {
@@ -371,32 +398,39 @@ fn format_todo_rows_markdown(items: &[TodoItem], with_status: bool) -> Vec<Strin
 }
 
 fn format_completed_todo_rows_markdown(items: &[TodoItem]) -> Vec<String> {
-    format_todo_rows_markdown(items, false)
+    format_todo_rows_markdown_with_time(items, "完成时间", display_todo_completed_at)
 }
 
-fn format_cancelled_todo_rows_markdown(items: &[TodoItem]) -> Vec<String> {
+fn format_todo_rows_markdown_with_time(
+    items: &[TodoItem],
+    time_label: &str,
+    time_value: fn(&TodoItem) -> String,
+) -> Vec<String> {
     items
         .iter()
         .enumerate()
-        .map(|(index, item)| {
-            let mut rows = vec![
-                format!("{}. **{}**", index + 1, format_todo_inline_markdown(item)),
-                format!(
-                    "   - **取消时间**：{}",
-                    escape_markdown_inline(&display_todo_cancelled_at(item))
-                ),
-            ];
+        .flat_map(|(index, item)| {
+            let mut lines = vec![format!(
+                "{}. {}",
+                index + 1,
+                format_todo_inline_markdown(item)
+            )];
+            lines.push(format!(
+                "   - **{}**：{}",
+                escape_markdown_inline(time_label),
+                escape_markdown_inline(&time_value(item))
+            ));
             if let Some(detail) = item
                 .detail
                 .as_deref()
                 .and_then(|value| clean_string(value.to_owned()))
             {
-                rows.push(format!(
+                lines.push(format!(
                     "   - **详情**：{}",
                     escape_markdown_text(&truncate_chars(&detail, 80))
                 ));
             }
-            rows.join("\n")
+            lines
         })
         .collect()
 }

--- a/qq-maid-core/src/runtime/respond/todo_flow/format.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/format.rs
@@ -35,10 +35,10 @@ pub(super) fn format_todo_all_reply(items: &[TodoItem]) -> CommandBody {
     if items.is_empty() {
         return simple_todo_notice("当前没有待办。");
     }
-    let mut rows = vec!["全部待办：".to_owned()];
-    rows.extend(format_todo_rows_with_status(items));
-    let mut markdown_rows = vec!["# 全部待办".to_owned()];
-    markdown_rows.extend(format_todo_rows_markdown(items, true));
+    let mut rows = vec![format!("📋 全部待办 · 共 {} 项", items.len())];
+    rows.extend(format_todo_all_board_rows(items, false));
+    let mut markdown_rows = vec![format!("# 📋 全部待办 · 共 {} 项", items.len())];
+    markdown_rows.extend(format_todo_all_board_rows(items, true));
     CommandBody::dual(rows.join("\n"), markdown_rows.join("\n"))
 }
 
@@ -140,29 +140,81 @@ fn format_cancelled_todo_rows(items: &[TodoItem]) -> Vec<String> {
     format_todo_rows_with_time(items, "取消时间", display_todo_cancelled_at)
 }
 
-fn format_todo_rows_with_status(items: &[TodoItem]) -> Vec<String> {
+fn format_todo_all_board_rows(items: &[TodoItem], markdown: bool) -> Vec<String> {
+    let groups = [
+        (TodoStatus::Pending, "🚧 进行中", "时间"),
+        (TodoStatus::Completed, "✅ 已完成", "完成时间"),
+        (TodoStatus::Cancelled, "⛔ 已取消", "原定时间"),
+    ];
+    let mut rows = Vec::new();
+    for (status, title, time_label) in groups {
+        let group_items = items
+            .iter()
+            .enumerate()
+            .filter(|(_, item)| item.status == status)
+            .collect::<Vec<_>>();
+        if group_items.is_empty() {
+            continue;
+        }
+        if !rows.is_empty() {
+            rows.push(String::new());
+        }
+        rows.push(if markdown {
+            format!("## {title}（{} 项）", group_items.len())
+        } else {
+            format!("{title}（{} 项）", group_items.len())
+        });
+        rows.extend(format_todo_all_board_item_rows(
+            &group_items,
+            time_label,
+            markdown,
+        ));
+    }
+    rows
+}
+
+fn format_todo_all_board_item_rows(
+    items: &[(usize, &TodoItem)],
+    time_label: &str,
+    markdown: bool,
+) -> Vec<String> {
     items
         .iter()
-        .enumerate()
         .map(|(index, item)| {
-            let (time_label, time_text) = match item.status {
+            let time_text = match item.status {
                 TodoStatus::Completed => ("完成时间", display_todo_completed_at(item).to_owned()),
-                _ => ("时间", display_todo_time(item)),
+                _ => (time_label, display_todo_time(item)),
             };
-            let mut row = format!(
-                "{}. {}（{}）\n   {}：{}",
-                index + 1,
-                format_todo_inline(item),
-                crate::runtime::todo::status::status_cn_short(&item.status),
-                time_label,
-                time_text
-            );
+            let mut row = if markdown {
+                format!(
+                    "{}. {}\n   - **{}**：{}",
+                    index + 1,
+                    format_todo_inline_markdown(item),
+                    escape_markdown_inline(time_text.0),
+                    escape_markdown_inline(&time_text.1)
+                )
+            } else {
+                format!(
+                    "{}. {}\n   {}：{}",
+                    index + 1,
+                    format_todo_inline(item),
+                    time_text.0,
+                    time_text.1
+                )
+            };
             if let Some(detail) = item
                 .detail
                 .as_deref()
                 .and_then(|value| clean_string(value.to_owned()))
             {
-                row.push_str(&format!("\n   详情：{}", truncate_chars(&detail, 80)));
+                if markdown {
+                    row.push_str(&format!(
+                        "\n   - **详情**：{}",
+                        escape_markdown_text(&truncate_chars(&detail, 80))
+                    ));
+                } else {
+                    row.push_str(&format!("\n   详情：{}", truncate_chars(&detail, 80)));
+                }
             }
             row
         })

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -114,7 +114,10 @@ impl RustRespondService {
                 (format_todo_list_reply(&items), "todo_list".to_owned(), true)
             }
             "todo_all" => {
-                let items = self.todo_store.list_all(&owner).map_err(todo_error)?;
+                let items = self
+                    .todo_store
+                    .list_all_for_board(&owner)
+                    .map_err(todo_error)?;
                 remember_todo_query(session, &owner, "all", "全部待办", &items);
                 (format_todo_all_reply(&items), "todo_all".to_owned(), true)
             }
@@ -230,7 +233,10 @@ impl RustRespondService {
                 (format_todo_list_reply(&items), "todo_list".to_owned())
             }
             NaturalTodoQueryKind::All => {
-                let items = self.todo_store.list_all(owner).map_err(todo_error)?;
+                let items = self
+                    .todo_store
+                    .list_all_for_board(owner)
+                    .map_err(todo_error)?;
                 remember_todo_query(session, owner, "all", "全部待办", &items);
                 (format_todo_all_reply(&items), "todo_all".to_owned())
             }

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -195,6 +195,15 @@ impl RustRespondService {
                     )
                 }
             }
+            "todo_cancelled_list" => {
+                let items = self.todo_store.list_cancelled(&owner).map_err(todo_error)?;
+                remember_todo_query(session, &owner, "cancelled-list", "已取消列表", &items);
+                (
+                    format_todo_cancelled_list_reply(&items),
+                    "todo_cancelled_list".to_owned(),
+                    true,
+                )
+            }
             "todo_add" | "todo_edit" | "todo_delete" => {
                 // 旧 slash 写入口只给迁移提示，没有真正修改待办；
                 // 保留用户刚看见的编号快照，便于随后按提示用“完成第一条待办”等自然语言续指。

--- a/qq-maid-core/src/runtime/tools/todo/list.rs
+++ b/qq-maid-core/src/runtime/tools/todo/list.rs
@@ -62,7 +62,9 @@ impl Tool for ListTodoTool {
             TodoToolListStatus::Pending => self.todo_store.list_pending(&scope.owner),
             TodoToolListStatus::Completed => self.todo_store.list_completed(&scope.owner),
             TodoToolListStatus::Cancelled => self.todo_store.list_cancelled(&scope.owner),
-            TodoToolListStatus::All => self.todo_store.list_all(&scope.owner),
+            // Tool 可见编号也必须和 `/todo all` 看板一致，否则模型随后按“第 N 个”
+            // 调用 complete/restore/delete 时会绑定到用户没有按该顺序看到的条目。
+            TodoToolListStatus::All => self.todo_store.list_all_for_board(&scope.owner),
         }
         .map_err(todo_tool_error)?;
         scope.remember(status.query_type(), status.condition(), &items);

--- a/qq-maid-core/src/runtime/tools/todo/tests.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests.rs
@@ -5,7 +5,9 @@ use qq_maid_llm::tool::{Tool, ToolContext};
 
 use crate::runtime::pending::PendingOperation;
 use crate::runtime::session::{SessionMeta, SessionStore};
-use crate::runtime::todo::{TodoItemDraft, TodoOwner, TodoStatus, TodoStore, TodoTimePrecision};
+use crate::runtime::todo::{
+    TodoItem, TodoItemDraft, TodoOwner, TodoStatus, TodoStore, TodoTimePrecision,
+};
 
 use super::{CompleteTodoTool, CreateTodoTool, EditTodoTool, ListTodoTool};
 use crate::storage::{APP_MIGRATIONS, database::SqliteDatabase};
@@ -25,6 +27,161 @@ fn test_stores() -> (TodoStore, SessionStore, TodoOwner) {
     let session_store = SessionStore::new(database);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
     (todo_store, session_store, owner)
+}
+
+fn tool_order_items() -> Vec<TodoItem> {
+    vec![
+        TodoItem {
+            id: "1".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "private:u1".to_owned(),
+            title: "无时间事项".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: None,
+            due_at: None,
+            time_precision: TodoTimePrecision::None,
+            status: TodoStatus::Pending,
+            created_at: "2026-07-01T12:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T12:00:00+08:00".to_owned(),
+            completed_at: None,
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "2".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "private:u1".to_owned(),
+            title: "后天事项".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: Some("2026-07-03".to_owned()),
+            due_at: None,
+            time_precision: TodoTimePrecision::Date,
+            status: TodoStatus::Pending,
+            created_at: "2026-07-01T11:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T11:00:00+08:00".to_owned(),
+            completed_at: None,
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "3".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "private:u1".to_owned(),
+            title: "明天事项".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: Some("2026-07-02".to_owned()),
+            due_at: None,
+            time_precision: TodoTimePrecision::Date,
+            status: TodoStatus::Pending,
+            created_at: "2026-07-01T10:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T10:00:00+08:00".to_owned(),
+            completed_at: None,
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "4".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "private:u1".to_owned(),
+            title: "较早归档".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: None,
+            due_at: None,
+            time_precision: TodoTimePrecision::None,
+            status: TodoStatus::Completed,
+            created_at: "2026-07-01T09:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T09:00:00+08:00".to_owned(),
+            completed_at: Some("2026-06-30T18:00:00+08:00".to_owned()),
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "5".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "private:u1".to_owned(),
+            title: "较新归档".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: None,
+            due_at: None,
+            time_precision: TodoTimePrecision::None,
+            status: TodoStatus::Completed,
+            created_at: "2026-07-01T08:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T08:00:00+08:00".to_owned(),
+            completed_at: Some("2026-07-01T18:00:00+08:00".to_owned()),
+            cancelled_at: None,
+        },
+        TodoItem {
+            id: "6".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_key: "private:u1".to_owned(),
+            title: "最近放弃".to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: Some("2026-07-04".to_owned()),
+            due_at: None,
+            time_precision: TodoTimePrecision::Date,
+            status: TodoStatus::Cancelled,
+            created_at: "2026-07-01T13:00:00+08:00".to_owned(),
+            updated_at: "2026-07-01T13:00:00+08:00".to_owned(),
+            completed_at: None,
+            cancelled_at: Some("2026-07-01T13:10:00+08:00".to_owned()),
+        },
+    ]
+}
+
+#[tokio::test]
+async fn list_tool_all_uses_board_order_for_visible_numbers() {
+    let (todo_store, session_store, owner) = test_stores();
+    todo_store
+        .set_items_for_test(&owner, &tool_order_items())
+        .unwrap();
+    let list_tool = ListTodoTool::new(todo_store, session_store.clone());
+
+    let output = list_tool
+        .execute(test_context(), json!({"status":"all"}))
+        .await
+        .unwrap()
+        .value;
+
+    let titles = output["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|item| item["title"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        titles,
+        vec![
+            "明天事项",
+            "后天事项",
+            "无时间事项",
+            "较新归档",
+            "较早归档",
+            "最近放弃"
+        ]
+    );
+    assert_eq!(output["items"][0]["visible_number"], 1);
+
+    let session = session_store
+        .get_or_create_active(&SessionMeta::new(
+            "private:u1",
+            Some("u1".to_owned()),
+            None,
+            None,
+            None,
+            "qq_official",
+        ))
+        .unwrap();
+    let snapshot = session.last_todo_query.expect("missing todo snapshot");
+    assert_eq!(snapshot.query_type, "all");
+    assert_eq!(
+        snapshot.result_ids,
+        vec!["3", "2", "1", "5", "4", "6"]
+            .into_iter()
+            .map(str::to_owned)
+            .collect::<Vec<_>>()
+    );
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/storage/session/tests.rs
+++ b/qq-maid-core/src/storage/session/tests.rs
@@ -264,6 +264,14 @@ fn append_exchange_with_latest_merges_query_snapshot_without_overwriting_newer_f
         "",
         vec!["todo-a".to_owned(), "todo-b".to_owned()],
     );
+    stale.last_memory_query = Some(LastMemoryQuery {
+        query_type: "list".to_owned(),
+        condition: String::new(),
+        scope_type: Some("personal".to_owned()),
+        scope_id: Some("u1".to_owned()),
+        result_ids: vec!["memory-a".to_owned()],
+        created_at: now_iso_cn(),
+    });
     store
         .append_exchange_with_latest(
             &mut stale,
@@ -272,6 +280,7 @@ fn append_exchange_with_latest_merges_query_snapshot_without_overwriting_newer_f
             |current, stale| {
                 current.state = stale.state.clone();
                 current.last_todo_query = stale.last_todo_query.clone();
+                current.last_memory_query = stale.last_memory_query.clone();
             },
         )
         .unwrap();
@@ -291,6 +300,13 @@ fn append_exchange_with_latest_merges_query_snapshot_without_overwriting_newer_f
             .as_ref()
             .map(|query| query.result_ids.clone()),
         Some(vec!["todo-a".to_owned(), "todo-b".to_owned()])
+    );
+    assert_eq!(
+        merged
+            .last_memory_query
+            .as_ref()
+            .map(|query| query.result_ids.clone()),
+        Some(vec!["memory-a".to_owned()])
     );
     assert_eq!(
         merged

--- a/qq-maid-core/src/storage/todo/mod.rs
+++ b/qq-maid-core/src/storage/todo/mod.rs
@@ -41,8 +41,8 @@ use query::{
 };
 use search::search_score;
 use sort::{
-    compare_todo_order, sort_completed_todos, sort_completed_todos_desc, sort_todos,
-    sort_todos_by_created_desc,
+    compare_todo_order, sort_completed_todos, sort_completed_todos_desc, sort_todo_all_board,
+    sort_todos, sort_todos_by_created_desc,
 };
 
 /// Todo schema migration，由应用启动时的通用数据库初始化流程统一执行。
@@ -394,6 +394,16 @@ impl TodoStore {
         let conn = self.connection()?;
         let mut items = query_items(&conn, owner)?;
         sort_todos_by_created_desc(&mut items);
+        Ok(items)
+    }
+
+    /// 列出 `/todo all` 看板使用的全部待办，按用户可见分组顺序排列。
+    pub fn list_all_for_board(&self, owner: &TodoOwner) -> Result<Vec<TodoItem>, TodoError> {
+        let conn = self.connection()?;
+        let mut items = query_items(&conn, owner)?;
+        // 先复用原全部列表顺序，后续分组时让已取消组自然保留既有稳定顺序。
+        sort_todos_by_created_desc(&mut items);
+        sort_todo_all_board(&mut items);
         Ok(items)
     }
 

--- a/qq-maid-core/src/storage/todo/sort.rs
+++ b/qq-maid-core/src/storage/todo/sort.rs
@@ -4,6 +4,7 @@
 //! - pending 默认按真实待办时间升序（date-only 视为当天 00:00:00，无时间排最后）；
 //! - 已完成列表按完成时间降序；
 //! - 已取消 / 全部列表按创建时间降序。
+//! - `/todo all` 看板按状态分组展示，其中已取消组保留全部列表里的稳定顺序。
 //!
 //! 改动这里要同步关注 pending / 已完成 / 已取消列表的展示语义。
 
@@ -43,6 +44,31 @@ pub(super) fn sort_todos_by_created_desc(items: &mut [TodoItem]) {
             .cmp(&left.created_at)
             .then_with(|| left.id.cmp(&right.id))
     });
+}
+
+/// `/todo all` 看板的可见顺序。
+///
+/// 这里显式先分组再排序，确保用户看到的编号快照与看板顺序一致；已取消组不引入
+/// 新的取消时间语义，只沿用 `list_all` 的创建时间稳定顺序。
+pub(super) fn sort_todo_all_board(items: &mut Vec<TodoItem>) {
+    let mut pending = Vec::new();
+    let mut completed = Vec::new();
+    let mut cancelled = Vec::new();
+
+    for item in items.drain(..) {
+        match item.status {
+            super::TodoStatus::Pending => pending.push(item),
+            super::TodoStatus::Completed => completed.push(item),
+            super::TodoStatus::Cancelled => cancelled.push(item),
+        }
+    }
+
+    sort_todos(&mut pending);
+    sort_completed_todos_desc(&mut completed);
+
+    items.extend(pending);
+    items.extend(completed);
+    items.extend(cancelled);
 }
 
 /// 比较两个待办事项的排列顺序：有截止时间的排前面，其次按 ID。


### PR DESCRIPTION
## 改动概要

单状态待办列表（进行中/已完成/已取消）统一使用看板式展示，与 `/todo all` 风格一致。

### 原路径

- **未完成**：slash `/todo`、自然语言查询走 `list_pending`，按待办时间升序，旧标题 "待办列表："
- **已完成**：`/todo done`、自然语言查询走 `list_completed`，按完成时间降序，旧标题 "已完成待办："
- **已取消**：原先主要是自然语言查询走 `list_cancelled`，按创建时间降序，旧标题 "已取消待办："。现在补了 `/todo 已取消` / `/todo cancelled` 只读 slash 入口
- **Tool list_todos**：原先单状态用对应 store 排序；`status=all` 走 `list_all` 创建时间降序，现在改为 `list_all_for_board`，和 `/todo all` 看板编号一致

### 具体改动

- **format.rs**：新增共享单状态列表 formatter，标题统一为：
  - 🚧 进行中 · 共 N 项
  - ✅ 已完成 · 共 N 项
  - ⛔ 已取消 · 共 N 项
  空状态为 暂无未完成待办 / 暂无已完成待办 / 暂无已取消待办。任务行不再输出状态文字。
- **command.rs / mod.rs**：补齐已取消列表 slash 路由，并写入 `cancelled-list` 快照
- **list.rs**：`list_todos(status=all)` 复用 `/todo all` 的看板排序
- 已取消列表使用真实存在的 `cancelled_at` 显示"取消时间"

### 测试

- 新增/更新 Todo respond 测试，覆盖三种状态的非空、空状态、标题数量、时间字段、无重复状态文字、自然语言/slash 同序、快照顺序
- 新增 Tool 测试，覆盖 `list_todos(status=all)` 的可见编号顺序
- 更新 chat 测试中旧标题/空文案断言