### PR TITLE
fix: 待确认操作合并 last_todo_action/last_todo_query 快照

### DIFF
--- a/qq-maid-core/src/runtime/respond/pending.rs
+++ b/qq-maid-core/src/runtime/respond/pending.rs
@@ -85,12 +85,16 @@ impl RustRespondService {
         let reply = reply.into();
         self.session_store
             .append_exchange_with_latest(session, user_text, &reply.text, |latest, current| {
-                // 确认流和管理命令可能在追加回复前已经更新 pending / 记忆列表快照。
-                // 这里只合并这些明确由当前轮次产生的字段，避免旧 SessionRecord 覆盖
-                // 其他路径刚写入的历史、最近 Todo 操作等状态。
+                // 确认流和管理命令可能在追加回复前已经更新 pending、记忆列表快照，
+                // 或在 Todo 写操作（新增 / 软取消 / 删除）后更新了 last_todo_action、
+                // 清空了 last_todo_query。这里必须把这些字段一并合并到 latest，
+                // 否则数据库旧值会反向覆盖调用方刚写入的最近 Todo 状态，导致
+                // “刚才那个”无法指向新待办，或“第一条”仍按旧列表解析。
                 latest.state = current.state.clone();
                 latest.pending_operation = current.pending_operation.clone();
                 latest.last_memory_query = current.last_memory_query.clone();
+                latest.last_todo_query = current.last_todo_query.clone();
+                latest.last_todo_action = current.last_todo_action.clone();
             })
             .map_err(session_error)?;
         Ok(command_response(

--- a/qq-maid-core/src/runtime/respond/tests/pending.rs
+++ b/qq-maid-core/src/runtime/respond/tests/pending.rs
@@ -187,3 +187,81 @@ async fn deprecated_slash_pending_is_cleared_without_execution() {
         .unwrap();
     assert!(session.pending_operation.is_none());
 }
+
+#[tokio::test]
+async fn todo_add_confirm_keeps_fresh_last_todo_action_over_stale_db_snapshot() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+
+    // 数据库 session 里先写入旧快照：模拟用户之前查询过待办、并新增过一条待办。
+    // 确认流程会重新从数据库读取 latest，当前轮次的新值必须覆盖这些旧值，
+    // 不能反过来被旧值覆盖，否则“刚才那个”会指向已被取代的旧待办。
+    let stale_item = service.todo_store.create(&owner, draft("旧待办")).unwrap();
+    let mut session = service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap();
+    session.remember_last_todo_action(&owner.key, &stale_item, "created");
+    session.remember_last_todo_query(&owner.key, "list", "", vec![stale_item.id.clone()]);
+    session.pending_operation = Some(PendingOperation::TodoAdd {
+        initiator_user_id: Some("u1".to_owned()),
+        owner_key: owner.key.clone(),
+        draft: draft("新待办"),
+        allow_revision: false,
+        created_at: now_iso_cn(),
+    });
+    service.session_store.save(&mut session).unwrap();
+
+    let confirmed = service.respond(message("确认")).await.unwrap();
+    assert!(confirmed.text.unwrap().contains("已新增待办：新待办"));
+
+    // 确认后 last_todo_action 必须指向刚新增的“新待办”；
+    // 若 append_pending_response 未合并该字段，latest 里的旧值会反向覆盖。
+    let session = service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap();
+    let last_action = session.last_todo_action.expect("missing last_todo_action");
+    assert_eq!(last_action.title, "新待办");
+    assert_eq!(last_action.action, "created");
+}
+
+#[tokio::test]
+async fn todo_delete_confirm_clears_stale_last_todo_query_snapshot() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    let item = service.todo_store.create(&owner, draft("待取消")).unwrap();
+
+    // 数据库 session 里已有旧的待办列表快照；软取消成功后 ops 门面会清空
+    // last_todo_query，避免后续“第一条”指向已不存在的条目。
+    let mut session = service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap();
+    session.remember_last_todo_query(&owner.key, "list", "", vec![item.id.clone()]);
+    session.pending_operation = Some(PendingOperation::TodoDelete {
+        initiator_user_id: Some("u1".to_owned()),
+        owner_key: owner.key.clone(),
+        item: item.clone(),
+        created_at: now_iso_cn(),
+    });
+    service.session_store.save(&mut session).unwrap();
+
+    let confirmed = service.respond(message("确认")).await.unwrap();
+    assert!(confirmed.text.unwrap().contains("已取消待办"));
+
+    let session = service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap();
+    // 软取消成功后 last_todo_query 必须被清空，不能被数据库旧快照恢复。
+    assert!(
+        session.last_todo_query.is_none(),
+        "expected last_todo_query cleared after soft cancel, got {:?}",
+        session.last_todo_query
+    );
+    // 同时 last_todo_action 应指向被取消的待办，而非旧值。
+    let last_action = session.last_todo_action.expect("missing last_todo_action");
+    assert_eq!(last_action.title, "待取消");
+    assert_eq!(last_action.action, "cancelled");
+}


### PR DESCRIPTION
## 背景

承接 #146 的 Codex review 反馈。原修复 commit 推送时 #146 已合并，未进入 master，本 PR 重新带入该修复。

## 问题

`append_pending_response`（`pending.rs`）调用 `append_exchange_with_latest` 重新读取 latest session 后，merge 闭包只合并了 `state` / `pending_operation` / `last_memory_query`，漏掉 `last_todo_action` 和 `last_todo_query`。

而 `TodoAdd` / `TodoDelete` 确认路径在进入该函数前已经：
- `TodoAdd` 确认：`session.remember_last_todo_action(...)` 更新为刚新增的待办
- `TodoDelete` 软取消：ops 门面清空 `last_todo_query`、更新 `last_todo_action` 为被取消的待办

结果 latest（数据库旧值）反向覆盖了调用方刚写入的新值，导致：
- “刚才那个”仍指向旧待办
- “第一条”仍按已被清空的旧列表解析

## 修复

merge 闭包补上两个字段的合并，与 `todo_flow/mod.rs::append_todo_query_response` 合并 `last_todo_query` 的处理保持一致：

```rust
latest.last_todo_query = current.last_todo_query.clone();
latest.last_todo_action = current.last_todo_action.clone();
```

## 回归测试

新增两个测试，修复前均失败、修复后通过：
- `todo_add_confirm_keeps_fresh_last_todo_action_over_stale_db_snapshot`
- `todo_delete_confirm_clears_stale_last_todo_query_snapshot`

## 验证
- `cargo fmt --all -- --check`
- `cargo clippy -p qq-maid-core --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`（423 passed, 0 failed）