### PR TITLE
docs: 精简根 AGENTS.md 并修正过期文档路径与描述

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,28 +1,23 @@
-
 # AGENTS.md
 
-给 Codex / AI Agent 后续维护本仓库使用的简短说明。
+给 Codex / AI Agent 后续维护本仓库使用的长期规则。请使用中文回复。
 
-项目运行、部署、排障细节以根 `README.md`、`qq-maid-gateway-rs/README.md`、`qq-maid-core/` 配置说明、`Makefile` 和相关源码为准；不要在这里重复 README。
+项目运行、部署、排障和详细架构以 [README.md](./README.md)、[docs/DEVELOPMENT.md](./docs/DEVELOPMENT.md)、各 crate README、[Makefile](./Makefile)、[runtime/config/.env.example](./runtime/config/.env.example) 和源码为准；根 `AGENTS.md` 只保留每次进入仓库都应遵守的硬约束。
 
-请使用中文回复。
+## 项目概述
 
-新增或修改代码时，应补充必要的中文注释，并保留已有的有效注释。
+这是一个 Rust 编写的 QQ 官方机器人本地版项目，由根目录 Cargo Workspace 统一管理。
 
-## 项目定位
+主要边界：
 
-这是一个 QQ 官方机器人本地版项目。
-
-当前主线只保留：
-
-* `qq-maid-gateway-rs/`：Rust QQ 官方 gateway 接入层，负责 QQ 事件、消息转换、白名单、本地 `/ping` 和回复发送。
-* `qq-maid-core/`：Rust Core 模块，负责 `CoreService`、查询、记忆、session、todo、命令、prompt 和业务模型路由；通过 `qq-maid-llm` 调用模型。
-* `qq-maid-llm/`：Rust LLM 基础设施 crate，负责模型调用协议、Provider 路由、fallback、SSE、usage、健康观测和 OpenAI Web Search 协议；不依赖 `qq-maid-core`。
-* `qq-maid-common/`：Rust 共享基础工具，仅承载两个及以上 crate 共用的通用逻辑，且不得依赖业务状态。
-* `runtime/`：服务器部署运行目录，只放 release 二进制、运行配置和运行产物。
+* `qq-maid-gateway-rs/`：QQ 官方 gateway 接入、事件解析、白名单、本地 `/ping` 和回复发送。
+* `qq-maid-core/`：`CoreService`、普通聊天、查询、记忆、session、todo、RSS、命令、prompt 和业务 Tool。
+* `qq-maid-llm/`：模型协议、Provider 路由、fallback、SSE、usage、健康观测、OpenAI Web Search 和 Tool Loop 协议。
+* `qq-maid-common/`：两个及以上 crate 共用、无业务状态的基础工具。
+* `runtime/`：部署运行目录，只放 release 二进制、运行配置和运行产物。
 * `scripts/`：部署、进程控制和诊断脚本源码。
 
-依赖方向固定为：
+依赖方向保持：
 
 ```text
 qq-maid-gateway-rs
@@ -34,275 +29,79 @@ qq-maid-llm
 qq-maid-common / reqwest / serde / tokio
 ```
 
-禁止 `qq-maid-llm` 反向依赖 `qq-maid-core`，也不要让 `qq-maid-core` 绕过 `qq-maid-llm` 直接维护 Provider 协议实现。
+禁止让 `qq-maid-llm` 反向依赖 `qq-maid-core`，也不要让 `qq-maid-core` 绕过 `qq-maid-llm` 直接维护 Provider 协议实现。
 
-当前 Rust 构建由仓库根目录 Cargo Workspace 统一管理：
+## 开始工作前
 
-* 根 `Cargo.toml` 维护 workspace members；
-* 根 `Cargo.lock` 是唯一锁文件；
-* release 产物位于根 `target/release/`；
-* 不要恢复子目录 `Cargo.lock`，也不要在文档或脚本中继续引用 `qq-maid-*/target/` 旧路径。
+* 不要直接修改默认分支 `master`；代码或文档修改应在功能分支完成，提交后创建 PR，不要自行合并。
+* 先检查工作区已有改动，不能回滚无关用户修改。
+* 修改前先读相关 README、`docs/DEVELOPMENT.md`、`Makefile`、`runtime/config/.env.example` 和邻近源码。
+* 以当前代码和调用链为准，不根据旧文档、文件名或历史印象推测实现。
+* 搜索现有实现并优先复用现有模块、helper、错误类型和测试结构。
+* 不确定的内容标注“当前未发现 / 需确认”，不要编造结论。
+* 不要读取、打印或提交真实 `.env`、私有 prompt、知识资料、SQLite、日志、openid、群 ID、聊天记录、token、secret、API Key 或账号信息。
 
-不要恢复或新增：
+## 通用修改原则
 
-* Python 接入层；
-* Python adapter；
-* Python fallback；
-* Python 本地 LLM / 查询 / 记忆 / session / 命令 / prompt 入口；
-* 独立 HTTP `/query`、HTTP `/memory`、`/v1/chat` 等旧入口。
-
-Rust HTTP 层只公开外部运维和控制台能力：
-
-* `GET /healthz`
-* 启用控制台时的 `/console/` 和 `/api/v1/markdown/render`
-
-## 分支与 PR 策略
-
-* 不要直接修改默认分支（`master`）。
-* 所有修改请新建功能分支完成。
-* 修改完成后运行格式化和测试。
-* 提交并推送功能分支后创建 Pull Request。
-* 不要自行合并 Pull Request。
-
-## 工作方式
-
-* 默认做小改动，保持用户可见行为稳定。
-* 修改前先读相关 README、Makefile、`runtime/config/.env.example` 和邻近源码。
-* 不确定的内容标注“当前未发现 / 需确认”，不要编造。
-* 不要未经要求重写架构、迁移运行路径或引入大依赖。
+* 默认做小改动，保持用户可见行为稳定；不要未经要求重写架构、迁移运行路径或引入大依赖。
+* 不要恢复 Python 接入层、adapter、fallback、本地 LLM / 查询 / 记忆 / session / 命令 / prompt 入口。
+* 不要恢复独立 HTTP `/query`、HTTP `/memory`、`/v1/chat` 等旧入口；Rust HTTP 层只保留外部运维和控制台能力。
+* 不要吞错误、返回空字符串或只生成成功文案来伪造成功状态；工具、构建、测试和发送结果必须以真实返回为准。
+* 新增或修改代码时补充必要中文注释，并保留说明业务背景、边界条件、兼容原因、安全要求或设计意图的有效注释。
+* 修改已有逻辑时同步检查附近注释是否仍准确；只有注释明显错误、重复或失去意义时才删除。
 * 不要把具体人设、群聊内容、真实用户信息或业务材料写死进代码。
-* 不要回滚无关用户改动。
-* 不要为了压缩代码、统一风格或重构而随意删除已有注释。
-* 如果代码修改导致原注释不再准确，应同步更新注释，而不是直接删除。
-* 只有在注释明显错误、完全重复或已经失去意义时才可以删除。
+* 修改文档时避免复制 README 大段细节，优先链接到已有权威文档。
 
-## 代码修改原则
+## 重要业务与兼容性约束
 
-优先复用现有代码、现有模块、现有 helper、现有错误类型和现有测试结构。
+* Cargo 由根 workspace 统一管理：根 `Cargo.lock` 是唯一锁文件，release 产物位于根 `target/release/`；不要恢复子目录 `Cargo.lock` 或旧 `qq-maid-*/target/` 路径。
+* Gateway 负责 QQ 平台字段解析、消息兼容、发送分支、`/ping` 和日志脱敏；Core / LLM 不应理解 QQ `msg_seq`、stream id、群 at 前缀等平台发送细节。
+* Core 业务入口优先复用 `CoreService` 和 `qq-maid-core/src/runtime/respond/` 现有 flow；pending 类型与确认分类优先复用 `qq-maid-core/src/runtime/pending/` 和 `qq-maid-core/src/runtime/respond/pending.rs`。
+* LLM 协议、Provider、路由、fallback、SSE、usage、健康观测、Web Search 和 Tool Loop 协议留在 `qq-maid-llm`；业务 prompt、session、todo、memory、RSS 和具体 Tool 留在 `qq-maid-core`。
+* Tool Calling 只执行服务端显式注册的白名单 Tool。工具调用是否成功、Todo 是否写入、Memory 是否保存等必须以真实工具或持久化结果为准，不能让模型文案代替执行结果。
+* 当前私聊普通聊天可进入 Tool Loop；群聊、slash 命令、pending 确认、文件处理和宿主机代码执行不得默认进入 Tool Loop。
+* Todo 对用户展示的编号与数据库内部 ID 分离。后续“第一条”“刚刚那条”等指代必须依赖 session 中最近可见列表快照或最近操作对象，不能把内部 ID 暴露给模型或用户。
+* Todo 删除/取消/恢复语义、session 作用域、记忆确认流程和已确认持久化数据格式不要随意改变。
+* 长期记忆只能通过明确记忆指令生成草稿，并由用户确认后写入；普通聊天不要自动写长期记忆。
+* SQLite schema 变更必须通过 migration，并考虑已有 `APP_DB_FILE` 历史数据兼容；业务模块不要在运行时方法里自行建表。
+* C2C 流式发送首帧成功后，本轮回复归同一个 QQ stream 所有；中间帧或最终帧失败不得再补发第二条普通全文。
+* 日志和诊断输出默认脱敏，不记录 QQ raw event envelope、Authorization header、AppSecret、token、完整 openid、群 ID 或聊天正文。`scripts/diagnose-network.sh` 只能打印 secret 是否存在、脱敏后的 ID/URL、代理和公网出口检查结果。
+* 通用日期、时间和时区语义优先复用 `qq-maid-common/src/time_context/`。
 
-重点保持这些边界：
+## 测试与检查
 
-* gateway 负责 QQ 接入、事件解析、`/ping` 本地诊断和回复发送。
-* LLM 协议、Provider、路由、fallback、SSE、usage、健康观测和 Web Search 协议放在 `qq-maid-llm`。
-* 业务 prompt、查询、记忆、session、todo、命令和业务模型路由放在 `qq-maid-core`，通过 `qq-maid-llm` 的统一入口调用模型。
-* 新功能优先通过 `CoreService` 或 Rust 内部模块承载，不要恢复内部 HTTP respond 主入口。
-* 具体 session/search/todo/memory/chat flow 在 `runtime/respond/` 下维护。
-* pending operation 类型与确认分类优先复用 `runtime/pending/`。
-* respond pending 分发逻辑保留在 `runtime/respond/pending.rs`。
-* provider-facing chat primitives 保留在 `qq-maid-llm/src/provider/types.rs`；core 侧 `provider/` 仅作为兼容 re-export 入口。
-* 查询模块保留在 `runtime/query/`；`/查` 的模型协议实现保留在 `qq-maid-llm/src/web_search.rs`。
-* 文件持久化实现放在 `storage/session.rs`、`storage/memory.rs`、`storage/todo.rs`。
-
-不要随意改变：
-
-* QQ 消息入口；
-* slash 指令；
-* 记忆确认流程；
-* session 作用域；
-* todo 软删除语义；
-* OpenAI / DeepSeek fallback；
-* Rust `CoreService` 调用路径；
-* 已确认持久化数据格式。
-
-不要在 `qq-maid-core` 中重新实现已迁入 `qq-maid-llm` 的 Provider 协议、SSE frame 解析、模型候选链或健康观测逻辑；需要这些能力时直接复用 `qq-maid-llm` 的公开入口（`LlmService::chat` / `web_search` / `web_search_stream` / `upstream_status`）。
-
-通用逻辑优先复用，不要在具体命令里重复实现。
-
-例如日期、时间和时区语义优先复用 `qq-maid-common/src/time_context.rs`；Core 内部原 `util/time_context.rs` 仅作为兼容入口保留。
-
-### 注释规则
-
-* 保留已有能够说明业务背景、边界条件、兼容原因、安全要求或设计意图的注释。
-* 不要在重构、抽取 helper、合并测试或格式化时批量删除注释。
-* 移动代码时，应将相关注释一并移动到新的实现位置。
-* 修改已有逻辑时，应检查附近注释是否仍然准确，并同步更新。
-* 新增或修改非显而易见的逻辑时，需要添加必要的中文注释。
-* 下列内容应优先添加注释：
-
-  * 业务边界和特殊规则；
-  * fallback、兼容分支和降级行为；
-  * 时间、日期和时区语义；
-  * session、pending、todo、memory 的状态转换；
-  * 持久化格式和兼容约束；
-  * QQ 平台字段或特殊消息处理；
-  * 脱敏、安全和敏感信息保护逻辑；
-  * 看似可以简化但实际不能简化的实现原因。
-* 注释应优先说明“为什么这样做”和“需要保持什么约束”，不要只重复代码表面行为。
-* 不要给每一行代码添加机械翻译式注释。
-* 不要保留已经失真、误导或与当前实现冲突的注释。
-
-## QQ Gateway 注意事项
-
-修改 QQ 事件、intent、权限、白名单、群聊 / 私聊响应逻辑前，先读：
-
-* `README.md`
-* `qq-maid-gateway-rs/README.md`
-* gateway 相关源码
-
-要求：
-
-* 平台字段解析和发送分支优先放在 `qq-maid-gateway-rs/`。
-* 图片、贴纸、emoji、结构化消息处理要保持现有兼容行为。
-* 日志和调试输出默认脱敏。
-* 不记录 QQ raw event envelope、Authorization header、AppSecret、token 或完整 openid。
-
-## Core / Todo / Memory / Session 注意事项
-
-* 修改 session、prompt、会话命令、记忆确认、查询命令时，优先改 Rust `CoreService` 入口及其复用的 respond flow。
-
-* 修改指令、记忆或 session 逻辑时，优先保持已确认的持久化数据兼容。
-
-* 一次性待确认 pending 状态可通过 README 迁移说明清理，不必在运行时长期兼容。
-
-* `/resume` / `/恢复` 是推荐恢复会话入口。
-
-* `/list` 只作为 deprecated 兼容别名保留。
-
-* 待办查询、完成、删除和批量删除优先在 Rust `CoreService` 调用链与 `runtime/todo.rs` 业务出口中维护。
-
-* todo 文件持久化在 `storage/todo.rs`，删除应保持软删除语义。
-
-* 记忆指令保持 Rust `CoreService` 语义：
-
-  * `/memory`、`/记忆`、`/记` 不带内容用于查看长期记忆列表；
-  * 带内容才创建待确认记忆草稿。
-
-* 长期记忆只能通过明确记忆指令生成草稿，并由用户确认后写入。
-
-* 普通聊天不要自动写长期记忆。
-
-## 常用验证
-
-`.github/workflows/ci.yml` 在 PR / push 到 master 时会跑以下四步，提交前在本地直接复跑，避免 CI 失败往返：
+CI 当前在 PR / push 到 `master` 时执行：
 
 ```bash
-# 1. 格式化检查（不写入，仅校验）
 cargo fmt --all -- --check
-
-# 2. Clippy，警告视为错误
 cargo clippy --workspace --all-targets --all-features -- -D warnings
-
-# 3. 全 workspace 测试
 cargo test --workspace --all-features
-
-# 4. release 构建
 cargo build --workspace --release --all-features
 ```
 
-最低要求：
+本地按影响范围选择检查：
 
-* 代码变更提交前至少跑完 1–3 步。
-* 纯文档变更（仅 `docs/`、`README.md`、`AGENTS.md` 等说明文档）不需要走一遍整套 CI；按影响范围做必要的文本自检即可。
-  * CI 行为：`ci.yml` 在 PR 阶段永远触发（保证状态检查不缺失），job 内通过 `git diff` 检测变更文件，纯文档则自动跳过 Rust 步骤。push 到 master 时通过 `paths-ignore` 从源头跳过纯文档推送。
-* 改动涉及启动、配置、依赖或发布时，再跑第 4 步。
-* 修改 `scripts/*.sh`：至少执行 `bash -n` 对应脚本。
+* 代码变更提交前至少执行格式化检查、clippy 和测试；涉及启动、配置、依赖或发布时再执行 release 构建。
+* 只影响某个 crate 时可先使用 `make test-common`、`make test-llm`、`make test-core` 或 `make test-gateway` 做局部检查；跨模块或提交前执行 `make test` 并按需补充 CI 中的 clippy / release 构建。
+* 修改 `scripts/*.sh` 时至少执行 `bash -n` 对应脚本。
 * 涉及诊断入口时执行 `make diagnose`。
-* 修改启动、配置、依赖、QQ 事件或 OpenAI / DeepSeek 调用：需要本地启动验证。
-* 修改 `qq-maid-llm` 的 Provider 协议、SSE 解析或模型候选链：需要跑 `qq-maid-llm` 的单测，并确认 core 侧调用链无回归。
-* 修改代码后按项目已有命令格式化，不要为了格式化引入新依赖。
+* 修改启动、配置、依赖、QQ 事件或 OpenAI / DeepSeek / BigModel 调用时，需要本地启动或运行相应诊断验证。
+* 修改 `qq-maid-llm` 的 Provider 协议、SSE 解析、模型候选链或 Tool Loop 时，至少跑 `make test-llm`，并确认 Core 调用链无回归。
+* 纯文档变更不需要跑完整 Rust CI；至少执行 `git diff --check`，人工核对相对链接、文件路径、命令和敏感信息。
 
-如果某项检查无法执行，需要在最终说明里写明原因。
+如果某项检查无法执行，最终说明里必须写明原因。不得伪造未执行的检查结果。
 
-## 配置与敏感信息
-
-环境变量模板在：
-
-```text
-runtime/config/.env.example
-```
-
-不要读取、打印或提交真实 `.env`。
-
-禁止提交：
-
-* token、secret、API Key、bot appid、私钥、账号信息；
-* 真实 QQ 群聊、私聊内容、openid、群 ID、用户数据；
-* `qq-maid-core/data/`
-* `runtime/data/`
-* `runtime/logs/`
-* `runtime/run/`
-* `runtime/qq-maid-bot`
-* `runtime/diagnose-network.sh`
-* 各目录下真实 `.env`
-
-日志和调试输出默认脱敏。
-
-`scripts/diagnose-network.sh` 只能打印 secret 是否存在、脱敏后的 ID/URL、代理和公网出口检查结果。
-
-## 提交规范
-
-commit message 使用简洁中文：
-
-```text
-类型: 简短说明
-```
-
-常用类型：
-
-* `feat`：新增功能
-* `fix`：修复问题
-* `docs`：文档更新
-* `refactor`：重构代码
-* `style`：格式调整
-* `test`：测试相关
-* `chore`：构建、依赖、配置、脚本等杂项
-
-要求：
-
-* 一次 commit 只做一类事情。
-* 不要混入无关修改。
-* 涉及配置、启动方式、环境变量时，commit 说明里要体现。
-* 不要提交密钥、token、账号、私聊记录或真实用户数据。
-
-## 发版本流程
-
-每个发布版本对应一个 `vX.Y.Z` git tag（历史 tag 见 `git tag --list 'v*'`）。
-发版本时按顺序执行：
-
-1. 改版本号：根 `Cargo.toml` 的 `version` 字段（如 `0.4.1` → `0.4.2`）。
-   * 子 crate（`qq-maid-core`、`qq-maid-gateway-rs`、`qq-maid-llm`、`qq-maid-common`）的版本号独立维护，不跟随根包，除非该 crate 本身有变更需要发布。
-   * 改完 `cargo build` 让 `Cargo.lock` 同步更新，一并提交。
-2. 更新 `CHANGELOG.md`：在顶部新增 `## [vX.Y.Z] - YYYY-MM-DD` 条目，按 keep a changelog 格式写变更。
-3. 提交：`git commit -m "chore: 发布 vX.Y.Z"` 或与版本内容合并的 commit。
-4. 打 tag：`git tag vX.Y.Z`（annotated tag 可加 `-a -m "release vX.Y.Z"`，历史均为轻量 tag，保持一致即可）。
-5. 推送：`git push && git push --tags`（或 `git push origin vX.Y.Z` 单独推 tag）。
-
-注意：
-
-* tag 必须打在对应版本的 commit 上，不要漏打或打错版本号。
-* tag 必须打在 master 分支上。`release.yml` 的 `preflight` job 会在矩阵构建前校验：
-  * tag commit 是否为 master 的祖先（`git merge-base --is-ancestor`），不在 master 上则立即失败，不启动 5 平台构建。
-  * tag commit 相对第一父提交是否包含有效代码变更（通过 `git diff` 检查变更文件），纯文档 tag 会跳过构建和发布。
-* 发版本前确保版本 commit 已合并到 master，再打 tag 推送。
-* 发版本前先跑完"常用验证"里的 CI 四步。
-* 不要把未发布的版本号写进 README 或文档里提前预告。
-
-## 修改前后检查
-
-修改前：
-
-* 先查看 README、Makefile、`runtime/config/.env.example` 和相关源码。
-* 检查工作区已有改动，不要回滚无关用户修改。
-* 搜索现有实现，优先复用已有代码。
-* 检查相关代码附近是否存在说明业务约束或设计原因的注释。
-
-修改后：
-
-* 执行对应格式化命令。
-* 按影响范围执行测试。
-* 检查已有有效注释是否被误删。
-* 检查新增或修改的复杂逻辑是否补充了必要中文注释。
-* 检查代码与注释是否一致，不保留失真或过期注释。
-* 文档改动需确认没有写入敏感信息，也没有复制 README 大段细节。
-* 如果涉及结构变更，需要同步更新本文及 README 文件。
+## 完成报告
 
 最终总结需要说明：
 
 * 改了什么；
-* 复用了哪些现有代码 / helper；
+* 复用了哪些现有代码 / helper / 文档位置；
 * 添加或更新了哪些必要注释；
 * 是否删除了已有注释，以及删除原因；
-* 执行了什么格式化；
+* 执行了什么格式化或文档检查；
 * 执行了什么测试；
 * 没执行的检查及原因；
 * 是否确认没有写入敏感信息。
+
+commit message 使用简洁中文：`类型: 简短说明`，例如 `docs: 精简 Agent 维护规则`。一次 commit 只做一类事情，不要混入无关修改。

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -130,7 +130,7 @@ Rust HTTP 层只公开外部运维 / 管理能力：
 
 - 会话：`/new`、`/rename`、`/resume`、`/clear`、`/state`、`/compact`、`/help`。`/list` 仍作为 deprecated 兼容别名保留，推荐使用 `/resume` 或 `/恢复`。
 - 记忆：`/memory`、`/memory 记忆内容`、`/memory show 1`、`/memory edit 1 新内容`、`/memory delete 1`；中文别名 `/记忆`、`/记`。
-- 待办：`/todo`、`/todo add 待办内容`、`/todo done 1`、`/todo undo 1`、`/todo edit 1 新内容`、`/todo delete 1`；中文别名 `/待办`、`/任务`。按编号完成或恢复通常依赖最近一次列表快照。
+- 待办：slash 入口只保留查询（`/todo`、`/todo all`、`/todo search 关键词`、`/todo done`、`/todo undo`；中文别名 `/待办`、`/任务`）。新增、完成、恢复、修改、取消和永久删除请直接用自然语言触发 Todo Tool；按编号继续操作依赖最近一次用户可见列表快照。
 - RSS：`/rss`、`/rss add RSS地址 [名称]`、`/rss delete 1`、`/rss test RSS地址`；中文别名 `/订阅`。
 - 查询：`/查 关键词`、`/查询 关键词`、`/search 关键词`。中文紧凑写法如 `/查今天新闻` 也会进入联网查询。
 - 天气：`/天气杭州`、`/天气 杭州`、`/杭州天气`、`/weather 杭州`。
@@ -144,7 +144,7 @@ Rust HTTP 层只公开外部运维 / 管理能力：
 - Gateway 内部继续保持分层边界：`gateway/mod.rs` 负责顶层编排，`gateway/protocol.rs` 负责 WebSocket 协议与事件分发，`gateway/outbound.rs` 负责 QQ 出站状态记录，`respond.rs` 负责 CoreService 进程内桥接；不要把这些职责重新混回单个超长文件。
 - 修改普通聊天、查询命令、记忆、session、待办、会话命令、prompt 或具体业务 Tool 时，优先修改 `qq-maid-core/`。
 - Rust HTTP 层只公开 `GET /healthz`，以及启用控制台时的 `/console/` 和 `/api/v1/markdown/render`；不要重新公开 `/query`、HTTP `/memory`、`/v1/chat` 或内部 respond 主入口。
-- 通用日期、时间和时区语义优先复用 `qq-maid-common/src/time_context.rs`；Core 内部的 `qq-maid-core/src/util/time_context.rs` 保留为兼容 re-export。
+- 通用日期、时间和时区语义优先复用 `qq-maid-common/src/time_context/`；Core 内部的 `qq-maid-core/src/util/time_context.rs` 保留为兼容 re-export。
 - Tool Calling 的最终目标参考 Codex 的受控工具调用体验，但本项目必须保持 QQ 场景边界：私聊优先、群聊谨慎、工具白名单、权限校验、超时和输出大小限制不可省略。
 - 未来目标是通用 QQ 机器人；不要把具体人设、群聊内容、真实用户信息或业务材料写死进代码。
 

--- a/docs/design/tool-calling-qq-delivery.md
+++ b/docs/design/tool-calling-qq-delivery.md
@@ -16,7 +16,7 @@
 - Gateway 到 Core 桥接：`qq-maid-gateway-rs/src/respond.rs::respond_c2c` / `respond_group`
 - Core 聊天与 Tool Calling 入口：`qq-maid-core/src/runtime/respond/chat_flow.rs::handle_chat`
 - LLM Tool Loop：`qq-maid-llm/src/provider/openai/tool_loop.rs::openai_responses_tool_loop`
-- QQ payload 构造：`qq-maid-gateway-rs/src/api.rs`、`qq-maid-gateway-rs/src/markdown.rs`、`qq-maid-gateway-rs/src/media.rs`
+- QQ payload 构造：`qq-maid-gateway-rs/src/api/mod.rs`、`qq-maid-gateway-rs/src/markdown.rs`、`qq-maid-gateway-rs/src/media.rs`
 
 > 说明：本次额外检索了公开 `Tencent/OpenClaw` 主仓库，但未直接定位到可对读的 QQ 插件源码，因此下面“与 OpenClaw QQ 插件的对比”只借鉴其公开可见的**通用分层思路**，不声称已经完成对其 QQ 插件实现的逐行对比。
 
@@ -35,7 +35,7 @@
    参考：`qq-maid-gateway-rs/src/gateway/aggregator/actor.rs::classify`、`qq-maid-gateway-rs/src/respond.rs::classify_c2c`、`qq-maid-core/src/runtime/respond.rs::RustRespondService::classify_inbound`
 
 3. 聚合后的逻辑消息进入 `MessageDispatcher`，按 `scope_key` 串行调度，同 scope 串行、不同 scope 并发。私聊 scope 由 Gateway 直接复用 Core 规则 `private:{user_openid}`。  
-   参考：`qq-maid-gateway-rs/src/gateway/dispatcher.rs::MessageDispatcherHandle::enqueue_c2c`、`qq-maid-gateway-rs/src/respond.rs::scope_key_from_c2c_message`
+   参考：`qq-maid-gateway-rs/src/gateway/dispatcher/mod.rs::MessageDispatcherHandle::enqueue_c2c`、`qq-maid-gateway-rs/src/respond.rs::scope_key_from_c2c_message`
 
 4. worker 调用 `qq-maid-gateway-rs/src/gateway/c2c.rs::handle_c2c_message`。这里会：
    - 做 reply cache 回填 `resolve_signals`
@@ -56,7 +56,7 @@
    参考：`qq-maid-gateway-rs/src/gateway/protocol.rs::handle_envelope`、`qq-maid-gateway-rs/src/gateway/event.rs::parse_group_message`
 
 2. 群消息不走私聊聚合分类，而是直接进入 dispatcher。dispatcher 使用 `group:{group_openid}` 作为 scope。  
-   参考：`qq-maid-gateway-rs/src/gateway/dispatcher.rs::MessageDispatcherHandle::enqueue_group`、`qq-maid-gateway-rs/src/respond.rs::scope_key_from_group_message`
+   参考：`qq-maid-gateway-rs/src/gateway/dispatcher/mod.rs::MessageDispatcherHandle::enqueue_group`、`qq-maid-gateway-rs/src/respond.rs::scope_key_from_group_message`
 
 3. worker 调用 `qq-maid-gateway-rs/src/gateway/group.rs::handle_group_message`，做群过滤、冷却、Core 调用和群回复发送。  
    参考：`qq-maid-gateway-rs/src/gateway/group.rs::handle_group_message`
@@ -73,7 +73,7 @@
    - `should_stream_respond(req)`
    - `should_use_tool_calling(state, req)`  
    私聊普通聊天若启用 Tool Calling，则**不会走 CoreResponseStream**，而是直接走完整 Tool Loop 的 `Complete` 路径。  
-   参考：`qq-maid-core/src/service.rs::CoreHandle::respond`、`should_stream_respond`、`should_use_tool_calling`
+   参考：`qq-maid-core/src/service/mod.rs::CoreHandle::respond`、`should_stream_respond`、`should_use_tool_calling`
 
 2. `RustRespondService::respond` 先做 pending、会话命令、翻译、天气、列车、搜索、RSS、Todo、Memory 等业务分流；只有兜底普通聊天才进入 `handle_chat`。  
    参考：`qq-maid-core/src/runtime/respond.rs::RustRespondService::respond`
@@ -90,7 +90,7 @@
    - 生成 `ToolContext`
    - 组装 `ToolChatRequest`
    - 调用 `provider.chat_with_tools(...)`  
-   参考：`qq-maid-core/src/runtime/respond/llm_service.rs::respond_with_tools`
+   参考：`qq-maid-core/src/runtime/respond/llm_service/mod.rs::respond_with_tools`
 
 5. OpenAI provider 当前的 Tool Loop 真正落在 `qq-maid-llm/src/provider/openai/tool_loop.rs::openai_responses_tool_loop`。它负责：
    - 请求 OpenAI Responses
@@ -103,18 +103,18 @@
 6. `ToolRegistry::execute_json` 是当前服务端工具执行入口。它只接受显式注册的工具，并附带超时、输出长度限制。  
    参考：`qq-maid-llm/src/tool.rs::ToolRegistry::execute_json`
 
-7. 当前 Core 在构造 `RustRespondService` 时只注册了一个 `WeatherTool`。  
+7. 当前 Core 在构造 `RustRespondService` 时注册天气 Tool 和 Todo Tool。
    参考：`qq-maid-core/src/runtime/respond.rs::RustRespondService::new`
 
-8. `WeatherTool` 内部没有 QQ 逻辑，只是把模型参数转成 `WeatherRequest`，再复用已有天气执行器。  
-   参考：`qq-maid-core/src/runtime/tools/weather.rs::WeatherTool::execute`
+8. Core 业务 Tool 内部没有 QQ 发送逻辑，只把模型参数适配到现有业务执行器、`TodoStore`、session 快照和 pending 机制。
+   参考：`qq-maid-core/src/runtime/tools/weather.rs::WeatherTool::execute`、`qq-maid-core/src/runtime/tools/todo/mod.rs`
 
 ### 2.3 从 Core 返回到 QQ 发送
 
 #### 私聊普通 complete 路径
 
 1. Tool Loop 或普通聊天最终都先变成 `RespondResponse` / `CoreResponse`。  
-   参考：`qq-maid-core/src/runtime/respond/llm_service.rs::response_from_output`、`qq-maid-core/src/service.rs::impl From<RespondResponse> for CoreResponse`
+  参考：`qq-maid-core/src/runtime/respond/llm_service/mod.rs::response_from_output`、`qq-maid-core/src/service/mod.rs::impl From<RespondResponse> for CoreResponse`
 
 2. Gateway 在 `send_c2c_respond_response_with_sender` 中调用 `render_respond_response` 把 CoreResponse 渲染成：
    - `OutboundMessage::Text`
@@ -123,18 +123,18 @@
    参考：`qq-maid-gateway-rs/src/gateway/c2c.rs::send_c2c_respond_response_with_sender`、`qq-maid-gateway-rs/src/render.rs::render_respond_response`
 
 3. `send_outbound_with_fallback` 再调用 `QqApiClient` 发送；Markdown/图片失败时 fallback 到文本。  
-   参考：`qq-maid-gateway-rs/src/api.rs::send_outbound_with_fallback`
+   参考：`qq-maid-gateway-rs/src/api/mod.rs::send_outbound_with_fallback`
 
 #### 私聊流式路径
 
 1. 当 Core 返回 `CoreRespondOutput::Stream` 时，Gateway 进入 `stream_respond_c2c`。  
-   参考：`qq-maid-gateway-rs/src/gateway/c2c.rs::handle_c2c_message`、`qq-maid-gateway-rs/src/gateway/stream.rs::stream_respond_c2c`
+   参考：`qq-maid-gateway-rs/src/gateway/c2c.rs::handle_c2c_message`、`qq-maid-gateway-rs/src/gateway/stream/mod.rs::stream_respond_c2c`
 
 2. `stream_respond_c2c` 把 `CoreResponseEvent::TextDelta` 转成 QQ C2C Markdown 流式 payload；首帧成功后，后续只能沿同一个 stream id/index 续接。  
-   参考：`qq-maid-gateway-rs/src/gateway/stream.rs::stream_respond_c2c_with_sender`、`send_stream_chunk`、`send_stream_end`
+   参考：`qq-maid-gateway-rs/src/gateway/stream/mod.rs::stream_respond_c2c_with_sender`、`send_stream_chunk`、`send_stream_end`
 
 3. 如果首帧没有成功创建 QQ stream id，则在 `Completed` 阶段回退到普通回复；一旦已进入 `Active`，就不再补发第二条普通全文。  
-   参考：`qq-maid-gateway-rs/src/gateway/stream.rs::stream_respond_c2c_with_sender`
+   参考：`qq-maid-gateway-rs/src/gateway/stream/mod.rs::stream_respond_c2c_with_sender`
 
 #### 群聊路径
 
@@ -152,12 +152,12 @@
 
 | 能力 | 模块 | 关键函数 |
 | --- | --- | --- |
-| C2C 文本发送 | `qq-maid-gateway-rs/src/api.rs` | `QqApiClient::send_c2c_text` |
-| C2C Markdown 发送 | `qq-maid-gateway-rs/src/api.rs` | `QqApiClient::send_c2c_markdown` |
-| C2C 图片发送 | `qq-maid-gateway-rs/src/api.rs` | `QqApiClient::send_c2c_image` |
-| C2C Markdown 流式发送 | `qq-maid-gateway-rs/src/api.rs` | `QqApiClient::send_c2c_markdown_stream` |
-| 群文本发送 | `qq-maid-gateway-rs/src/api.rs` | `QqApiClient::send_group_text` |
-| 群 Markdown 发送 | `qq-maid-gateway-rs/src/api.rs` | `QqApiClient::send_group_markdown` |
+| C2C 文本发送 | `qq-maid-gateway-rs/src/api/mod.rs` | `QqApiClient::send_c2c_text` |
+| C2C Markdown 发送 | `qq-maid-gateway-rs/src/api/mod.rs` | `QqApiClient::send_c2c_markdown` |
+| C2C 图片发送 | `qq-maid-gateway-rs/src/api/mod.rs` | `QqApiClient::send_c2c_image` |
+| C2C Markdown 流式发送 | `qq-maid-gateway-rs/src/api/mod.rs` | `QqApiClient::send_c2c_markdown_stream` |
+| 群文本发送 | `qq-maid-gateway-rs/src/api/mod.rs` | `QqApiClient::send_group_text` |
+| 群 Markdown 发送 | `qq-maid-gateway-rs/src/api/mod.rs` | `QqApiClient::send_group_markdown` |
 | 普通回复渲染 | `qq-maid-gateway-rs/src/render.rs` | `render_respond_response` |
 | 私聊发送包装 | `qq-maid-gateway-rs/src/gateway/c2c.rs` | `send_c2c_respond_response_with_sender` |
 | 群发送包装 | `qq-maid-gateway-rs/src/gateway/group.rs` | `send_group_respond_response` |
@@ -172,36 +172,36 @@
 - **主动推送**：没有原始入站消息，因此 `msg_id = None`。  
   参考：`qq-maid-gateway-rs/src/gateway/push.rs::send_private_push`、`send_group_push`
 - **说明**：当前代码把 `msg_id` 视为“回复所绑定的原始 QQ 消息 id”，不是 Tool Loop 任务 id，也不是 C2C stream id。  
-  参考：`qq-maid-gateway-rs/src/api.rs::send_c2c_markdown_stream` 注释
+  参考：`qq-maid-gateway-rs/src/api/mod.rs::send_c2c_markdown_stream` 注释
 
 ### `msg_seq`
 
 - 普通发送：由 `QqApiClient::next_msg_seq()` 生成。  
-  参考：`qq-maid-gateway-rs/src/api.rs::next_msg_seq`
+  参考：`qq-maid-gateway-rs/src/api/mod.rs::next_msg_seq`
 - C2C 流式发送：由 `C2cStreamState::begin_msg_seq_attempt` 管理重试时复用/提交语义。  
-  参考：`qq-maid-gateway-rs/src/api.rs::C2cStreamState::begin_msg_seq_attempt`、`commit_msg_seq_attempt`
+  参考：`qq-maid-gateway-rs/src/api/mod.rs::C2cStreamState::begin_msg_seq_attempt`、`commit_msg_seq_attempt`
 
 ### `msg_type`
 
 - 文本：`0`  
-  参考：`qq-maid-gateway-rs/src/api.rs::build_c2c_text_payload`、`build_group_text_payload`
+  参考：`qq-maid-gateway-rs/src/api/mod.rs::build_c2c_text_payload`、`build_group_text_payload`
 - Markdown：`2`  
   参考：`qq-maid-gateway-rs/src/markdown.rs::build_c2c_markdown_payload`、`build_group_markdown_payload`
 - C2C Markdown 流式：也是 `2`  
-  参考：`qq-maid-gateway-rs/src/api.rs::build_c2c_markdown_stream_payload`
+  参考：`qq-maid-gateway-rs/src/api/mod.rs::build_c2c_markdown_stream_payload`
 - C2C 图片：`7`  
   参考：`qq-maid-gateway-rs/src/media.rs::build_c2c_image_payload`
 - **待确认**：这些数值当前可从本仓库 builder 和测试确认，但与 QQ 官方文档的一一对应关系仍建议在真机环境复核。  
-  参考：`qq-maid-gateway-rs/src/api.rs` 测试 `c2c_text_payload_matches_qq_shape`、`c2c_markdown_stream_payload_matches_reference_shape`
+  参考：`qq-maid-gateway-rs/src/api/mod.rs` 测试 `c2c_text_payload_matches_qq_shape`、`c2c_markdown_stream_payload_matches_reference_shape`
 
 ### `content`
 
 - 只在文本 payload 中作为顶层字段生成。  
-  参考：`qq-maid-gateway-rs/src/api.rs::build_c2c_text_payload`、`build_group_text_payload`
+  参考：`qq-maid-gateway-rs/src/api/mod.rs::build_c2c_text_payload`、`build_group_text_payload`
 - 内容来源一般是 `RespondResponse.text`，由 `render_respond_response` 或 fallback 逻辑决定。  
   参考：`qq-maid-gateway-rs/src/render.rs::render_respond_response`
 - Markdown/流式路径下，正文不走顶层 `content`，而走 `markdown.content`。  
-  参考：`qq-maid-gateway-rs/src/markdown.rs`、`qq-maid-gateway-rs/src/api.rs::build_c2c_markdown_stream_payload`
+  参考：`qq-maid-gateway-rs/src/markdown.rs`、`qq-maid-gateway-rs/src/api/mod.rs::build_c2c_markdown_stream_payload`
 
 ### `markdown`
 
@@ -210,20 +210,20 @@
 - 普通 Markdown payload 由 `build_c2c_markdown_payload` / `build_group_markdown_payload` 生成。  
   参考：`qq-maid-gateway-rs/src/markdown.rs`
 - 流式 Markdown payload 由 `build_c2c_markdown_stream_payload` 生成，内容可能是首帧正文、增量 chunk 或结束标记。  
-  参考：`qq-maid-gateway-rs/src/api.rs::build_c2c_markdown_stream_payload`、`qq-maid-gateway-rs/src/gateway/stream.rs::send_stream_chunk`、`send_stream_end`
+  参考：`qq-maid-gateway-rs/src/api/mod.rs::build_c2c_markdown_stream_payload`、`qq-maid-gateway-rs/src/gateway/stream/mod.rs::send_stream_chunk`、`send_stream_end`
 
 ### `stream`
 
 - 只在 **C2C Markdown 流式发送** payload 中生成。  
-  参考：`qq-maid-gateway-rs/src/api.rs::C2cMarkdownStreamPayload`
+  参考：`qq-maid-gateway-rs/src/api/mod.rs::C2cMarkdownStreamPayload`
 - 字段内容来自 `C2cStreamState` 和发送阶段参数：
   - `state`
   - `id`
   - `index`
   - `reset`  
-  参考：`qq-maid-gateway-rs/src/api.rs::build_c2c_markdown_stream_payload`
+  参考：`qq-maid-gateway-rs/src/api/mod.rs::build_c2c_markdown_stream_payload`
 - **待确认**：`state=1/10`、`reset=false`、首帧 `id=null`、后续使用首帧返回 id 的真实平台约束，代码里有注释和测试，但仍建议真机/官方文档复核。  
-  参考：`qq-maid-gateway-rs/src/api.rs` 相关注释、`qq-maid-gateway-rs/src/gateway/stream.rs` 模块注释
+  参考：`qq-maid-gateway-rs/src/api/mod.rs` 相关注释、`qq-maid-gateway-rs/src/gateway/stream/mod.rs` 模块注释
 
 ### `keyboard`
 
@@ -235,7 +235,7 @@
 - 入站解析为 `C2cMessage.user_openid`。  
   参考：`qq-maid-gateway-rs/src/gateway/event.rs::parse_c2c_message`
 - 出站发送时写入 API 路径 `/v2/users/{user_openid}/messages`。  
-  参考：`qq-maid-gateway-rs/src/api.rs::post_c2c_message`、`post_c2c_stream_message`
+  参考：`qq-maid-gateway-rs/src/api/mod.rs::post_c2c_message`、`post_c2c_stream_message`
 - Gateway 同时把它映射给 Core 的：
   - `actor.user_id`
   - 私聊会话 `peer_id`
@@ -247,7 +247,7 @@
 - 入站解析为 `GroupMessage.group_openid`。  
   参考：`qq-maid-gateway-rs/src/gateway/event.rs::parse_group_message`
 - 出站发送时写入 API 路径 `/v2/groups/{group_openid}/messages`。  
-  参考：`qq-maid-gateway-rs/src/api.rs::post_group_message`
+  参考：`qq-maid-gateway-rs/src/api/mod.rs::post_group_message`
 - Gateway 同时把它映射给 Core 的：
   - `conversation.group_id`
   - scope `group:{group_openid}`  
@@ -286,7 +286,7 @@
 - `BotOutboundCache`：只做群发机器人消息过滤
 - `C2cStreamState`：只用于 QQ C2C 流式续接
 - dispatcher/aggregator 内部的 `scope_key`、去重 reservation、冷却信息  
-  参考：`qq-maid-gateway-rs/src/gateway/cache.rs`、`qq-maid-gateway-rs/src/api.rs::C2cStreamState`、`qq-maid-gateway-rs/src/gateway/dispatcher.rs`
+  参考：`qq-maid-gateway-rs/src/gateway/cache.rs`、`qq-maid-gateway-rs/src/api/mod.rs::C2cStreamState`、`qq-maid-gateway-rs/src/gateway/dispatcher/mod.rs`
 
 **结论**：当前 Tool Calling 本身并不需要 `openid`、`group_openid`、`msg_seq`、QQ stream id 这些 QQ 细节；这些字段是 Gateway 为“最终把消息发回原目标”而持有的出站上下文，不应下沉进 Tool Loop。
 
@@ -301,11 +301,11 @@
 | Tool Calling 入口判断 | `qq-maid-core` | `chat_flow.rs::handle_chat` | 决定私聊普通聊天是否进入 Tool Loop |
 | Tool Calling 协议循环 | `qq-maid-llm` | `provider/openai/tool_loop.rs::openai_responses_tool_loop` | 处理 `function_call` / `function_call_output` |
 | 服务端工具注册表 | `qq-maid-llm` | `tool.rs::ToolRegistry` | 白名单、超时、输出截断 |
-| 具体工具适配 | `qq-maid-core` | `runtime/tools/weather.rs::WeatherTool` | 把业务执行器包装成 Tool |
-| 真实业务执行器 | `qq-maid-core` | `DynWeatherExecutor.weather(...)` | Tool 复用现有天气能力 |
+| 具体工具适配 | `qq-maid-core` | `qq-maid-core/src/runtime/tools/weather.rs`、`qq-maid-core/src/runtime/tools/todo/` | 把业务执行器和 Todo 业务能力包装成 Tool |
+| 真实业务执行器 / 存储 | `qq-maid-core` | `DynWeatherExecutor.weather(...)`、`TodoStore`、`SessionStore` | Tool 复用现有天气、Todo、session 快照和 pending 机制 |
 | QQ 回复渲染 | `qq-maid-gateway-rs` | `render.rs::render_respond_response` | 把 CoreResponse 变成 Text/Markdown/Image |
-| QQ payload 构造与发送 | `qq-maid-gateway-rs` | `api.rs::QqApiClient::*` | 负责路径、payload、msg_seq、stream 等 |
-| C2C 流式状态机 | `qq-maid-gateway-rs` | `gateway/stream.rs::stream_respond_c2c` | 只负责 Core delta → QQ stream |
+| QQ payload 构造与发送 | `qq-maid-gateway-rs` | `api/mod.rs::QqApiClient::*` | 负责路径、payload、msg_seq、stream 等 |
+| C2C 流式状态机 | `qq-maid-gateway-rs` | `gateway/stream/mod.rs::stream_respond_c2c` | 只负责 Core delta → QQ stream |
 
 ## 4.2 当前工具调用结果、中间状态和最终回复如何进入 QQ 发送链路
 
@@ -315,23 +315,23 @@
 
 它的实际路径是：
 
-`WeatherTool.execute` → `ToolRegistry::execute_json` → OpenAI `function_call_output` → 模型继续生成最终答案 → `ChatOutcome.reply` → `RespondResponse` → Gateway 渲染/发送。
+`WeatherTool.execute` / Todo Tool execute → `ToolRegistry::execute_json` → OpenAI `function_call_output` → 模型继续生成最终答案 → `ChatOutcome.reply` → `RespondResponse` → Gateway 渲染/发送。
 
 也就是说，当前工具结果默认只作为**模型上下文的一部分**回到 LLM，不直接变成一条 QQ 中间消息。  
-参考：`qq-maid-core/src/runtime/tools/weather.rs::WeatherTool::execute`、`qq-maid-llm/src/tool.rs::ToolRegistry::execute_json`、`qq-maid-llm/src/provider/openai/tool_loop.rs::openai_responses_tool_loop`
+参考：`qq-maid-core/src/runtime/tools/weather.rs::WeatherTool::execute`、`qq-maid-core/src/runtime/tools/todo/mod.rs`、`qq-maid-llm/src/tool.rs::ToolRegistry::execute_json`、`qq-maid-llm/src/provider/openai/tool_loop.rs::openai_responses_tool_loop`
 
 ### 中间状态
 
 当前只有两类“中间状态”能进入 QQ 发送链路：
 
 1. **普通聊天/搜索的 Core 文本增量**：
-   - 私聊：`CoreResponseEvent::TextDelta` → `gateway/stream.rs` → QQ C2C Markdown stream
+   - 私聊：`CoreResponseEvent::TextDelta` → `gateway/stream/mod.rs` → QQ C2C Markdown stream
    - 群聊：会被 Gateway 消费掉，不增量发给群  
-   参考：`qq-maid-core/src/service.rs::start_core_response_stream`、`qq-maid-gateway-rs/src/gateway/stream.rs::stream_respond_c2c_with_sender`、`qq-maid-gateway-rs/src/gateway/group.rs::consume_respond_stream`
+   参考：`qq-maid-core/src/service/mod.rs::start_core_response_stream`、`qq-maid-gateway-rs/src/gateway/stream/mod.rs::stream_respond_c2c_with_sender`、`qq-maid-gateway-rs/src/gateway/group.rs::consume_respond_stream`
 
 2. **本地 fallback/系统提示**：
    例如 `/ping` 本地回复、dispatcher 拒绝提示、Core 调用失败后的“稍后再试”。这类消息不经过 Tool Loop。  
-   参考：`qq-maid-gateway-rs/src/gateway/c2c.rs::render_local_ping_reply`、`qq-maid-gateway-rs/src/gateway/dispatcher.rs`
+   参考：`qq-maid-gateway-rs/src/gateway/c2c.rs::render_local_ping_reply`、`qq-maid-gateway-rs/src/gateway/dispatcher/mod.rs`
 
 当前**没有**下面这些东西：
 
@@ -344,8 +344,8 @@
 
 - 私聊普通 Tool Calling：当前走 `Complete` 路径，最终经 `send_c2c_respond_response_with_sender` 发送。  
   参考：`qq-maid-gateway-rs/src/gateway/c2c.rs::handle_c2c_message`
-- 私聊普通非 Tool Loop 流式聊天：最终收尾仍由 `gateway/stream.rs` 发送结束帧。  
-  参考：`qq-maid-gateway-rs/src/gateway/stream.rs::send_stream_end`
+- 私聊普通非 Tool Loop 流式聊天：最终收尾仍由 `gateway/stream/mod.rs` 发送结束帧。
+  参考：`qq-maid-gateway-rs/src/gateway/stream/mod.rs::send_stream_end`
 - 群聊：统一在拿到 `RespondResponse` 后一次性发出。  
   参考：`qq-maid-gateway-rs/src/gateway/group.rs::send_group_respond_response`
 
@@ -359,7 +359,7 @@
    - `user_id`
    - `scope_id`  
    没有 `openid`、`group_openid`、`msg_id`、`msg_seq`、QQ stream id。  
-   参考：`qq-maid-llm/src/tool.rs::ToolContext`、`qq-maid-core/src/runtime/respond/llm_service.rs::tool_context_from_request`
+   参考：`qq-maid-llm/src/tool.rs::ToolContext`、`qq-maid-core/src/runtime/respond/llm_service/mod.rs::tool_context_from_request`
 
 2. **Gateway 不理解模型 Tool Call 协议**。  
    Gateway 只知道：
@@ -367,17 +367,17 @@
    - `RespondTransport::Stream`
    - `RespondEvent::TextDelta/Completed/Failed`  
    它不解析 `function_call`、`function_call_output`、Tool schema。  
-   参考：`qq-maid-gateway-rs/src/respond.rs::RespondTransport`、`qq-maid-gateway-rs/src/gateway/stream.rs`
+   参考：`qq-maid-gateway-rs/src/respond.rs::RespondTransport`、`qq-maid-gateway-rs/src/gateway/stream/mod.rs`
 
 3. **具体 QQ 提及语法、群回复前缀、msg_type/msg_seq、stream payload 都仍在 Gateway**。  
    Core 和 LLM 没有去理解 `<@member_openid>`、`/v2/users/{openid}/messages` 等平台细节。  
-   参考：`qq-maid-gateway-rs/src/gateway/group.rs::prefix_group_reply_outbound`、`qq-maid-gateway-rs/src/api.rs`
+   参考：`qq-maid-gateway-rs/src/gateway/group.rs::prefix_group_reply_outbound`、`qq-maid-gateway-rs/src/api/mod.rs`
 
 ### 当前仍值得注意的边界点
 
 1. **`ToolContext.task_id` 当前复用了 `RespondRequest.message_id`，没有独立任务 ID**。  
-   对首期 WeatherTool 足够，但如果后续要做“状态提示、取消、文件结果、多步任务审计”，单靠平台 message_id 可能不够。  
-   参考：`qq-maid-core/src/runtime/respond/llm_service.rs::tool_context_from_request`
+   对当前天气 / Todo Tool 闭环足够，但如果后续要做“状态提示、取消、文件结果、多步任务审计”，单靠平台 message_id 可能不够。
+   参考：`qq-maid-core/src/runtime/respond/llm_service/mod.rs::tool_context_from_request`
 
 2. **Gateway 聚合器会调用 Core 的 `classify_inbound`**。  
    这不是 QQ/Tool 协议耦合，但说明 Gateway 的调度策略依赖 Core 的命令/pending 判断。当前这样做是为了避免在 Gateway 重写一套命令分类。  
@@ -407,7 +407,7 @@
 
 ### 2）工具执行只走服务端白名单
 
-当前 `ToolRegistry` 已经是白名单执行器，且只注册了 `WeatherTool`。这个方向比把任意工具暴露给模型安全得多。  
+当前 `ToolRegistry` 已经是白名单执行器，只注册受控的天气和 Todo Tool。这个方向比把任意工具暴露给模型安全得多。
 参考：`qq-maid-llm/src/tool.rs::ToolRegistry`、`qq-maid-core/src/runtime/respond.rs::RustRespondService::new`
 
 ### 3）通道层只负责投递，不负责解释工具语义
@@ -464,7 +464,7 @@
 - 工具失败发生在哪一步
 
 证据：当前没有任何 Tool status event 类型；Gateway 只消费 `TextDelta/Completed/Failed`。  
-参考：`qq-maid-core/src/service.rs::CoreResponseEvent`、`qq-maid-gateway-rs/src/gateway/stream.rs`
+参考：`qq-maid-core/src/service/mod.rs::CoreResponseEvent`、`qq-maid-gateway-rs/src/gateway/stream/mod.rs`
 
 ### 2）`task_id` 还不是独立任务身份
 
@@ -475,7 +475,7 @@
 - 多工具多轮审计
 - 工具状态消息与最终回复关联
 
-参考：`qq-maid-core/src/runtime/respond/llm_service.rs::tool_context_from_request`
+参考：`qq-maid-core/src/runtime/respond/llm_service/mod.rs::tool_context_from_request`
 
 ### 3）群聊没有独立的流式/状态消息能力
 
@@ -565,13 +565,13 @@
 以下内容当前**不能只靠代码完全确认**，需要真机或官方文档复核：
 
 1. QQ C2C Markdown stream 的 `stream.state`、`stream.id`、`stream.index`、`reset` 的全部平台约束。  
-   代码侧依据：`qq-maid-gateway-rs/src/api.rs`、`qq-maid-gateway-rs/src/gateway/stream.rs`
+   代码侧依据：`qq-maid-gateway-rs/src/api/mod.rs`、`qq-maid-gateway-rs/src/gateway/stream/mod.rs`
 
 2. `msg_type=0/2/7` 与 QQ 官方发送能力的完整对应关系，尤其是不同会话类型下的限制。  
-   代码侧依据：`qq-maid-gateway-rs/src/api.rs`、`qq-maid-gateway-rs/src/markdown.rs`、`qq-maid-gateway-rs/src/media.rs`
+   代码侧依据：`qq-maid-gateway-rs/src/api/mod.rs`、`qq-maid-gateway-rs/src/markdown.rs`、`qq-maid-gateway-rs/src/media.rs`
 
 3. `extract_sent_message_id` 和 `extract_c2c_text_stream_id` 当前兼容的响应 JSON 形状是否覆盖所有真实 QQ 返回包。  
-   代码侧依据：`qq-maid-gateway-rs/src/api.rs::extract_sent_message_id`、`extract_c2c_text_stream_id`
+   代码侧依据：`qq-maid-gateway-rs/src/api/mod.rs::extract_sent_message_id`、`extract_c2c_text_stream_id`
 
 4. 群聊是否存在可用、稳定、值得接入的“真流式”发送语义；当前代码没有实现。  
    代码侧依据：`qq-maid-gateway-rs/src/gateway/group.rs::consume_respond_stream`

--- a/qq-maid-core/README.md
+++ b/qq-maid-core/README.md
@@ -43,7 +43,7 @@ qq-maid-core/src/
 └── util/                # 指标，以及 time_context 兼容 re-export
 ```
 
-`runtime/respond.rs` 是 `CoreService::respond` 后的统一业务入口；具体 flow 在 `runtime/respond/` 下维护。`runtime/tools/` 只负责把现有业务执行器包装成模型可调用 Tool，不加载 Skill 文件，也不把业务逻辑迁入 `qq-maid-llm`。通用日期、时间和时区语义优先复用 `qq-maid-common/src/time_context.rs`；Core 内部可继续通过 `util/time_context.rs` 兼容入口引用，不要在具体命令里重复实现。
+`runtime/respond.rs` 是 `CoreService::respond` 后的统一业务入口；具体 flow 在 `runtime/respond/` 下维护。`runtime/tools/` 只负责把现有业务执行器包装成模型可调用 Tool，不加载 Skill 文件，也不把业务逻辑迁入 `qq-maid-llm`。通用日期、时间和时区语义优先复用 `qq-maid-common/src/time_context/`；Core 内部可继续通过 `util/time_context.rs` 兼容入口引用，不要在具体命令里重复实现。
 
 ## HTTP 接口
 

--- a/qq-maid-llm/README.md
+++ b/qq-maid-llm/README.md
@@ -138,9 +138,7 @@ qq-maid-core /查
 从仓库根目录执行：
 
 ```bash
-make test-llm    # cargo test -p qq-maid-llm
-make check-llm   # cargo check -p qq-maid-llm
-make fmt-check-llm  # cargo fmt -p qq-maid-llm -- --check
+make test-llm    # 依次执行 common/llm 的 fmt check、测试和 cargo check
 ```
 
 修改 Provider 协议、SSE 解析或模型候选链后，需要跑 `qq-maid-llm` 的单测，并确认 core 侧调用链无回归：
@@ -150,7 +148,7 @@ make test-core   # 同时检查 qq-maid-common 和 qq-maid-llm
 make test        # 全 workspace
 ```
 
-完整 CI 四步见仓库根 [AGENTS.md](../AGENTS.md) 的"常用验证"。
+完整 CI 四步见仓库根 [AGENTS.md](../AGENTS.md) 的“测试与检查”。
 
 ## 开发边界
 


### PR DESCRIPTION
## 变更概要

仅文档整理，不涉及业务代码行为。

### 主要变更

- **根 AGENTS.md**：从 308 行精简到 107 行，只保留长期规则（工作前检查、依赖边界、Provider/Core/Gateway 职责、Tool Calling 真实结果约束、Todo 可见编号约束、SQLite migration、流式发送所有权、安全脱敏、测试与完成报告）。删除易随代码漂移的文件清单和发布流程细节。
- **docs/DEVELOPMENT.md**：修正过期 Todo slash 写入口描述为当前自然语言 Todo Tool。
- **docs/design/tool-calling-qq-delivery.md**：Weather-only 描述修正为天气 + Todo Tool，旧单文件路径（api.rs/stream.rs/dispatcher.rs/llm_service.rs）修正为当前 mod.rs 结构。
- **qq-maid-core/README.md、qq-maid-llm/README.md**：修正路径/Makefile 命令与根 AGENTS 章节引用。

### 整理原则

- 根 AGENTS.md 保留全仓长期有效、违反后容易出问题的规则。
- 架构细节、调用链、Tool/QQ 字段说明继续放在 README 和 design docs。
- 删除根文件中重复、过细、容易随代码漂移的文件清单和发布流程细节，没有把长文机械拆成多份。
- 保留关键兼容约束：workspace 单锁文件、禁止恢复 Python/旧 HTTP 入口、Tool 真实执行结果、Todo 可见编号、记忆确认、SQLite migration、流式发送 fallback 边界、日志脱敏。

### 发现并修正的不一致

- `docs/design/tool-calling-qq-delivery.md` 仍写只注册 WeatherTool，代码实际已注册天气和 Todo Tool。
- `docs/DEVELOPMENT.md` 仍把 `/todo add/edit/delete` 写成当前 slash 写入口，实际写操作走自然语言 Todo Tool。
- 多处文档路径仍指向旧单文件结构。
- `qq-maid-llm/README.md` 提到 Makefile 中不存在的 `make check-llm` / `make fmt-check-llm`。

### 检查结果

- `git diff --check`：通过
- 修改文件的 Markdown 相对链接检查：通过
- 修改文件中的仓库内联路径检查：通过
- 旧表述残留检查：无命中
- 敏感信息模式检查：无命中
- 未运行 Rust CI / cargo 测试：本次仅文档变更，不涉及业务代码行为