### PR TITLE
fix: 收紧 Todo 工具成功验真

### DIFF
--- a/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
@@ -10,6 +10,33 @@ use serde_json::Value;
 use super::super::llm_service::RespondOutput;
 use crate::provider::ToolExecutionResult;
 
+const TODO_WRITE_SUCCESS_MARKERS: &[&str] = &[
+    "已新增",
+    "已新建",
+    "已创建",
+    "已添加",
+    "已记录",
+    "已生成待确认",
+    "已发起",
+    "已完成",
+    "已修改",
+    "已更新",
+    "已取消",
+    "已恢复",
+    "已删除",
+    "已经新增",
+    "已经新建",
+    "已经创建",
+    "已经添加",
+    "已经记录",
+    "已经完成",
+    "已经修改",
+    "已经更新",
+    "已经取消",
+    "已经恢复",
+    "已经删除",
+];
+
 /// 判定模型是否可以安全透传 Todo 成功文案。
 ///
 /// - 未声称 Todo 写入成功：直接放行。
@@ -94,38 +121,9 @@ fn reply_claims_todo_write_success(reply: &str) -> bool {
     if looks_like_todo_status_or_capability_explanation(&normalized) {
         return false;
     }
-    let action_markers = [
-        "已新增",
-        "已新建",
-        "已创建",
-        "已添加",
-        "已记录",
-        "已生成待确认",
-        "已发起",
-        "已完成",
-        "已修改",
-        "已更新",
-        "已取消",
-        "已恢复",
-        "已删除",
-        "已经新增",
-        "已经新建",
-        "已经创建",
-        "已经添加",
-        "已经记录",
-        "已经完成",
-        "已经修改",
-        "已经更新",
-        "已经取消",
-        "已经恢复",
-        "已经删除",
-    ];
     // 不读取用户输入、不推断“本轮必须调用哪个工具”；这里只从模型最终回复
     // 本身识别高风险成功文案，避免无 Tool 结果时透传“已新增/已删除”。
-    if action_markers
-        .iter()
-        .any(|marker| normalized.starts_with(marker))
-    {
+    if starts_with_todo_success_marker(&normalized) {
         return true;
     }
 
@@ -153,7 +151,7 @@ fn reply_claims_todo_write_success(reply: &str) -> bool {
     if !has_todo_context {
         return false;
     }
-    contains_any(&normalized, &action_markers)
+    contains_todo_success_marker(&normalized)
 }
 
 fn explicitly_denies_todo_success(text: &str) -> bool {
@@ -177,6 +175,9 @@ fn looks_like_todo_status_or_capability_explanation(text: &str) -> bool {
     // “已完成待办 / 已取消待办”常用于列表状态、能力说明或规则解释，
     // 不能等同于“我已经把某条待办完成/取消”。真正的动作成功文案仍会被
     // 后续“待办 + 已完成/已删除”等组合拦截。
+    if contains_clear_todo_write_success_marker(text) {
+        return false;
+    }
     let starts_with_status = [
         "已完成待办",
         "已取消待办",
@@ -230,6 +231,44 @@ fn looks_like_todo_status_or_capability_explanation(text: &str) -> bool {
 
 fn contains_any(text: &str, needles: &[&str]) -> bool {
     needles.iter().any(|needle| text.contains(needle))
+}
+
+fn contains_todo_success_marker(text: &str) -> bool {
+    contains_any(text, TODO_WRITE_SUCCESS_MARKERS)
+}
+
+fn starts_with_todo_success_marker(text: &str) -> bool {
+    TODO_WRITE_SUCCESS_MARKERS
+        .iter()
+        .any(|marker| text.starts_with(marker))
+}
+
+fn contains_clear_todo_write_success_marker(text: &str) -> bool {
+    contains_any(
+        text,
+        &[
+            "已新增",
+            "已新建",
+            "已创建",
+            "已添加",
+            "已记录",
+            "已生成待确认",
+            "已发起",
+            "已修改",
+            "已更新",
+            "已恢复",
+            "已删除",
+            "已经新增",
+            "已经新建",
+            "已经创建",
+            "已经添加",
+            "已经记录",
+            "已经修改",
+            "已经更新",
+            "已经恢复",
+            "已经删除",
+        ],
+    )
 }
 
 pub(super) fn todo_success_not_verified_reply() -> String {
@@ -349,6 +388,17 @@ mod tests {
                 "已删除第一条待办，请先用 /todo 查看确认。",
                 Vec::new()
             )),
+            TodoSuccessValidation::Blocked
+        );
+        assert_eq!(
+            validate_todo_success_reply(&output(
+                "暂不支持批量清理，但已删除第一条待办。",
+                Vec::new()
+            )),
+            TodoSuccessValidation::Blocked
+        );
+        assert_eq!(
+            validate_todo_success_reply(&output("已完成待办已删除。", Vec::new())),
             TodoSuccessValidation::Blocked
         );
     }

--- a/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
@@ -87,7 +87,7 @@ fn non_empty_array_field(output: &Value, field: &str) -> bool {
 
 fn reply_claims_todo_write_success(reply: &str) -> bool {
     let text = reply.trim();
-    if text.is_empty() || looks_like_non_success_explanation(text) {
+    if text.is_empty() || explicitly_denies_todo_success(text) {
         return false;
     }
     let normalized: String = text.chars().filter(|ch| !ch.is_whitespace()).collect();
@@ -156,7 +156,7 @@ fn reply_claims_todo_write_success(reply: &str) -> bool {
     contains_any(&normalized, &action_markers)
 }
 
-fn looks_like_non_success_explanation(text: &str) -> bool {
+fn explicitly_denies_todo_success(text: &str) -> bool {
     contains_any(
         text,
         &[
@@ -167,13 +167,6 @@ fn looks_like_non_success_explanation(text: &str) -> bool {
             "不能确认",
             "没有收到",
             "没有调用",
-            "暂不支持",
-            "不支持",
-            "不能直接",
-            "无法直接",
-            "请先",
-            "请提供",
-            "需要先",
             "不能算",
             "不算",
         ],
@@ -213,12 +206,22 @@ fn looks_like_todo_status_or_capability_explanation(text: &str) -> bool {
         || contains_any(
             text,
             &[
+                "请提供要删除的已完成待办",
+                "请提供要删除的已完成的待办",
+                "请先查看已完成列表",
+                "请先查询已完成列表",
+                "需要先列出",
+                "需要先查看",
+                "需要先查询",
                 "可以删除已完成待办",
                 "可以删除已完成的待办",
                 "可以查看已完成待办",
                 "可以查看已完成的待办",
                 "可以查询已完成待办",
                 "可以查询已完成的待办",
+                "当前不支持一句话批量清理全部已完成待办",
+                "暂不支持批量清理全部已完成待办",
+                "暂不支持一句话批量清理全部已完成待办",
                 "支持删除已完成待办",
                 "支持删除已完成的待办",
             ],
@@ -339,6 +342,13 @@ mod tests {
         );
         assert_eq!(
             validate_todo_success_reply(&output("已删除待办，还要继续吗？", Vec::new())),
+            TodoSuccessValidation::Blocked
+        );
+        assert_eq!(
+            validate_todo_success_reply(&output(
+                "已删除第一条待办，请先用 /todo 查看确认。",
+                Vec::new()
+            )),
             TodoSuccessValidation::Blocked
         );
     }

--- a/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
@@ -91,7 +91,10 @@ fn reply_claims_todo_write_success(reply: &str) -> bool {
         return false;
     }
     let normalized: String = text.chars().filter(|ch| !ch.is_whitespace()).collect();
-    let success_markers = [
+    if looks_like_todo_status_or_capability_explanation(&normalized) {
+        return false;
+    }
+    let action_markers = [
         "已新增",
         "已新建",
         "已创建",
@@ -119,7 +122,7 @@ fn reply_claims_todo_write_success(reply: &str) -> bool {
     ];
     // 不读取用户输入、不推断“本轮必须调用哪个工具”；这里只从模型最终回复
     // 本身识别高风险成功文案，避免无 Tool 结果时透传“已新增/已删除”。
-    if success_markers
+    if action_markers
         .iter()
         .any(|marker| normalized.starts_with(marker))
     {
@@ -150,7 +153,7 @@ fn reply_claims_todo_write_success(reply: &str) -> bool {
     if !has_todo_context {
         return false;
     }
-    contains_any(&normalized, &success_markers)
+    contains_any(&normalized, &action_markers)
 }
 
 fn looks_like_non_success_explanation(text: &str) -> bool {
@@ -164,10 +167,62 @@ fn looks_like_non_success_explanation(text: &str) -> bool {
             "不能确认",
             "没有收到",
             "没有调用",
+            "暂不支持",
+            "不支持",
+            "不能直接",
+            "无法直接",
+            "请先",
+            "请提供",
+            "需要先",
             "不能算",
             "不算",
         ],
     )
+}
+
+fn looks_like_todo_status_or_capability_explanation(text: &str) -> bool {
+    // “已完成待办 / 已取消待办”常用于列表状态、能力说明或规则解释，
+    // 不能等同于“我已经把某条待办完成/取消”。真正的动作成功文案仍会被
+    // 后续“待办 + 已完成/已删除”等组合拦截。
+    let starts_with_status = [
+        "已完成待办",
+        "已取消待办",
+        "已完成的待办",
+        "已取消的待办",
+        "已完成列表",
+        "已取消列表",
+    ]
+    .iter()
+    .any(|marker| text.starts_with(marker));
+    starts_with_status
+        && contains_any(
+            text,
+            &[
+                "可以删除",
+                "可以查看",
+                "可以查询",
+                "可以恢复",
+                "不能删除",
+                "不能直接删除",
+                "不支持删除",
+                "暂不支持",
+                "查看",
+                "查询",
+            ],
+        )
+        || contains_any(
+            text,
+            &[
+                "可以删除已完成待办",
+                "可以删除已完成的待办",
+                "可以查看已完成待办",
+                "可以查看已完成的待办",
+                "可以查询已完成待办",
+                "可以查询已完成的待办",
+                "支持删除已完成待办",
+                "支持删除已完成的待办",
+            ],
+        )
 }
 
 fn contains_any(text: &str, needles: &[&str]) -> bool {
@@ -247,6 +302,24 @@ mod tests {
     }
 
     #[test]
+    fn capability_and_status_explanations_pass_without_tool_result() {
+        for reply in [
+            "可以删除已完成待办，但需要先列出并选择具体条目。",
+            "暂不支持批量清理全部已完成待办；可以先查看已完成列表。",
+            "请提供要删除的已完成待办编号；我还不能确认已经删除任何待办。",
+            "已完成待办可以查看，也可以选择具体条目删除。",
+        ] {
+            assert_eq!(
+                validate_todo_success_reply(&output(reply, Vec::new())),
+                TodoSuccessValidation::Passed {
+                    claimed_success: false
+                },
+                "{reply}"
+            );
+        }
+    }
+
+    #[test]
     fn todo_success_reply_without_tool_result_is_blocked() {
         assert_eq!(
             validate_todo_success_reply(&output("已新增待办：明天接老公", Vec::new())),
@@ -258,6 +331,14 @@ mod tests {
         );
         assert_eq!(
             validate_todo_success_reply(&output("第二条待办已删除。", Vec::new())),
+            TodoSuccessValidation::Blocked
+        );
+        assert_eq!(
+            validate_todo_success_reply(&output("刚才那个待办已完成。", Vec::new())),
+            TodoSuccessValidation::Blocked
+        );
+        assert_eq!(
+            validate_todo_success_reply(&output("已删除待办，还要继续吗？", Vec::new())),
             TodoSuccessValidation::Blocked
         );
     }

--- a/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
@@ -174,10 +174,8 @@ fn explicitly_denies_todo_success(text: &str) -> bool {
 fn looks_like_todo_status_or_capability_explanation(text: &str) -> bool {
     // “已完成待办 / 已取消待办”常用于列表状态、能力说明或规则解释，
     // 不能等同于“我已经把某条待办完成/取消”。真正的动作成功文案仍会被
-    // 后续“待办 + 已完成/已删除”等组合拦截。
-    if contains_clear_todo_write_success_marker(text) {
-        return false;
-    }
+    // 后续“待办 + 已完成/已删除”等组合拦截；但风险提示里的“已删除项目不可恢复”
+    // 不应反向覆盖前面的缺参 / 能力说明。
     let starts_with_status = [
         "已完成待办",
         "已取消待办",
@@ -188,8 +186,8 @@ fn looks_like_todo_status_or_capability_explanation(text: &str) -> bool {
     ]
     .iter()
     .any(|marker| text.starts_with(marker));
-    starts_with_status
-        && contains_any(
+    if starts_with_status
+        && allowlist_marker_without_action_success(
             text,
             &[
                 "可以删除",
@@ -204,29 +202,32 @@ fn looks_like_todo_status_or_capability_explanation(text: &str) -> bool {
                 "查询",
             ],
         )
-        || contains_any(
-            text,
-            &[
-                "请提供要删除的已完成待办",
-                "请提供要删除的已完成的待办",
-                "请先查看已完成列表",
-                "请先查询已完成列表",
-                "需要先列出",
-                "需要先查看",
-                "需要先查询",
-                "可以删除已完成待办",
-                "可以删除已完成的待办",
-                "可以查看已完成待办",
-                "可以查看已完成的待办",
-                "可以查询已完成待办",
-                "可以查询已完成的待办",
-                "当前不支持一句话批量清理全部已完成待办",
-                "暂不支持批量清理全部已完成待办",
-                "暂不支持一句话批量清理全部已完成待办",
-                "支持删除已完成待办",
-                "支持删除已完成的待办",
-            ],
-        )
+    {
+        return true;
+    }
+    allowlist_marker_without_action_success(
+        text,
+        &[
+            "请提供要删除的已完成待办",
+            "请提供要删除的已完成的待办",
+            "请先查看已完成列表",
+            "请先查询已完成列表",
+            "需要先列出",
+            "需要先查看",
+            "需要先查询",
+            "可以删除已完成待办",
+            "可以删除已完成的待办",
+            "可以查看已完成待办",
+            "可以查看已完成的待办",
+            "可以查询已完成待办",
+            "可以查询已完成的待办",
+            "当前不支持一句话批量清理全部已完成待办",
+            "暂不支持批量清理全部已完成待办",
+            "暂不支持一句话批量清理全部已完成待办",
+            "支持删除已完成待办",
+            "支持删除已完成的待办",
+        ],
+    )
 }
 
 fn contains_any(text: &str, needles: &[&str]) -> bool {
@@ -243,32 +244,43 @@ fn starts_with_todo_success_marker(text: &str) -> bool {
         .any(|marker| text.starts_with(marker))
 }
 
-fn contains_clear_todo_write_success_marker(text: &str) -> bool {
-    contains_any(
-        text,
-        &[
-            "已新增",
-            "已新建",
-            "已创建",
-            "已添加",
-            "已记录",
-            "已生成待确认",
-            "已发起",
-            "已修改",
-            "已更新",
-            "已恢复",
-            "已删除",
-            "已经新增",
-            "已经新建",
-            "已经创建",
-            "已经添加",
-            "已经记录",
-            "已经修改",
-            "已经更新",
-            "已经恢复",
-            "已经删除",
-        ],
-    )
+fn allowlist_marker_without_action_success(text: &str, allowlist_markers: &[&str]) -> bool {
+    contains_any(text, allowlist_markers) && !contains_clear_todo_action_success_marker(text)
+}
+
+fn contains_clear_todo_action_success_marker(text: &str) -> bool {
+    [
+        "已新增",
+        "已新建",
+        "已创建",
+        "已添加",
+        "已记录",
+        "已生成待确认",
+        "已发起",
+        "已修改",
+        "已更新",
+        "已恢复",
+        "已删除",
+        "已经新增",
+        "已经新建",
+        "已经创建",
+        "已经添加",
+        "已经记录",
+        "已经修改",
+        "已经更新",
+        "已经恢复",
+        "已经删除",
+    ]
+    .iter()
+    .any(|marker| {
+        text.match_indices(marker)
+            .any(|(pos, _)| !is_explanatory_clear_success_usage(text, pos, marker))
+    })
+}
+
+fn is_explanatory_clear_success_usage(text: &str, pos: usize, marker: &str) -> bool {
+    // “已删除项目不可恢复”是缺参/能力说明里的风险提示，不表示本轮已经删除待办。
+    marker == "已删除" && text[pos..].starts_with("已删除项目不可恢复")
 }
 
 pub(super) fn todo_success_not_verified_reply() -> String {
@@ -349,6 +361,7 @@ mod tests {
             "可以删除已完成待办，但需要先列出并选择具体条目。",
             "暂不支持批量清理全部已完成待办；可以先查看已完成列表。",
             "请提供要删除的已完成待办编号；我还不能确认已经删除任何待办。",
+            "请提供要删除的已完成待办编号；已删除项目不可恢复。",
             "已完成待办可以查看，也可以选择具体条目删除。",
         ] {
             assert_eq!(
@@ -399,6 +412,20 @@ mod tests {
         );
         assert_eq!(
             validate_todo_success_reply(&output("已完成待办已删除。", Vec::new())),
+            TodoSuccessValidation::Blocked
+        );
+        assert_eq!(
+            validate_todo_success_reply(&output(
+                "请提供要删除的已完成待办编号；已删除第一条待办。",
+                Vec::new()
+            )),
+            TodoSuccessValidation::Blocked
+        );
+        assert_eq!(
+            validate_todo_success_reply(&output(
+                "请提供要删除的已完成待办编号；已删除项目不可恢复。第一条待办已删除。",
+                Vec::new()
+            )),
             TodoSuccessValidation::Blocked
         );
     }

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -716,6 +716,31 @@ async fn todo_fake_success_with_followup_instruction_is_still_blocked() {
 }
 
 #[tokio::test]
+async fn todo_mixed_unsupported_and_fake_success_reply_is_still_blocked() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_loop_reply_without_tool("暂不支持批量清理，但已删除第一条待办。");
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("批量清理已完成待办"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert!(text.contains("没有收到待办工具的成功回执"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["todo_success_claimed"], true);
+    assert_eq!(diagnostics["todo_success_verified"], false);
+    assert_eq!(diagnostics["error_code"], "todo_success_not_verified");
+    assert_eq!(
+        diagnostics["tool_loop_executed_tools"],
+        serde_json::json!([])
+    );
+    assert_eq!(inspector.tool_call_count(), 1);
+}
+
+#[tokio::test]
 async fn todo_capability_question_without_tool_call_is_not_required_tool_blocked() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -691,6 +691,86 @@ async fn todo_create_intent_without_tool_call_does_not_leak_fake_success_reply()
 }
 
 #[tokio::test]
+async fn todo_capability_question_without_tool_call_is_not_required_tool_blocked() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_loop_reply_without_tool("可以删除已完成待办，但需要先列出并选择具体条目；当前不支持一句话批量清理全部已完成待办。");
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("待办的话，能删除已完成待办么"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert!(text.contains("可以删除已完成待办"));
+    assert!(!text.contains("没有收到待办工具的成功回执"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["todo_success_claimed"], false);
+    assert_eq!(diagnostics["todo_success_verified"], true);
+    assert_eq!(diagnostics["error_code"], Value::Null);
+    assert_eq!(
+        diagnostics["tool_loop_executed_tools"],
+        serde_json::json!([])
+    );
+    assert_eq!(inspector.tool_call_count(), 1);
+}
+
+#[tokio::test]
+async fn todo_unsupported_operation_reply_without_tool_call_is_not_blocked() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_loop_reply_without_tool(
+            "暂不支持批量清理全部已完成待办；可以先查看已完成列表，再选择具体条目删除。",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("帮我批量清理已完成待办"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert!(text.contains("暂不支持批量清理"));
+    assert!(!text.contains("没有收到待办工具的成功回执"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["todo_success_claimed"], false);
+    assert_eq!(diagnostics["todo_success_verified"], true);
+    assert_eq!(diagnostics["error_code"], Value::Null);
+    assert_eq!(
+        diagnostics["tool_loop_executed_tools"],
+        serde_json::json!([])
+    );
+}
+
+#[tokio::test]
+async fn todo_missing_argument_reply_without_tool_call_is_not_blocked() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_loop_reply_without_tool(
+            "请提供要删除的已完成待办编号；我还不能确认已经删除任何待办。",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("删除已完成待办"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert!(text.contains("请提供"));
+    assert!(!text.contains("没有收到待办工具的成功回执"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["todo_success_claimed"], false);
+    assert_eq!(diagnostics["todo_success_verified"], true);
+    assert_eq!(diagnostics["error_code"], Value::Null);
+    assert_eq!(
+        diagnostics["tool_loop_executed_tools"],
+        serde_json::json!([])
+    );
+}
+
+#[tokio::test]
 async fn todo_delete_pending_item_accepts_cancel_tool_pending_result() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
@@ -1019,6 +1099,111 @@ async fn todo_delete_completed_item_accepts_delete_tool_pending_result() {
         }
         other => panic!("expected TodoBulkDelete pending operation, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn todo_delete_completed_pending_confirmation_is_verified_by_real_tool_result() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json(
+            "delete_todos",
+            r#"{"numbers":[1],"reference":null}"#,
+            "已发起删除已完成待办确认",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let todo = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "待确认永久删除".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    service.todo_store.complete(&owner, &todo.id).unwrap();
+    service
+        .respond(private_message("查看已完成待办"))
+        .await
+        .unwrap();
+
+    let response = service
+        .respond(private_message("删除第一条已完成待办"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert!(text.contains("已发起删除已完成待办确认"));
+    assert!(!text.contains("没有收到待办工具的成功回执"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["todo_success_claimed"], true);
+    assert_eq!(diagnostics["todo_success_verified"], true);
+    assert_eq!(
+        diagnostics["tool_loop_executed_tools"],
+        serde_json::json!(["delete_todos"])
+    );
+    let session = service
+        .session_store
+        .get_or_create_active(&private_test_meta())
+        .unwrap();
+    assert!(matches!(
+        session.pending_operation,
+        Some(PendingOperation::TodoBulkDelete { .. })
+    ));
+}
+
+#[tokio::test]
+async fn todo_delete_completed_tool_failure_cannot_be_reported_as_success() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json(
+            "delete_todos",
+            r#"{"numbers":[99],"reference":null}"#,
+            "已删除已完成待办",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let todo = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "仍应保留".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    service.todo_store.complete(&owner, &todo.id).unwrap();
+    service
+        .respond(private_message("查看已完成待办"))
+        .await
+        .unwrap();
+
+    let response = service
+        .respond(private_message("删除第 99 条已完成待办"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert!(text.contains("没有收到待办工具的成功回执"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["todo_success_claimed"], true);
+    assert_eq!(diagnostics["todo_success_verified"], false);
+    assert_eq!(diagnostics["error_code"], "todo_success_not_verified");
+    assert_eq!(
+        diagnostics["tool_loop_executed_tools"],
+        serde_json::json!(["delete_todos"])
+    );
+    assert!(service.todo_store.list_completed(&owner).unwrap().len() == 1);
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -691,6 +691,31 @@ async fn todo_create_intent_without_tool_call_does_not_leak_fake_success_reply()
 }
 
 #[tokio::test]
+async fn todo_fake_success_with_followup_instruction_is_still_blocked() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_loop_reply_without_tool("已删除第一条待办，请先用 /todo 查看确认。");
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("删除第一条待办"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert!(text.contains("没有收到待办工具的成功回执"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["todo_success_claimed"], true);
+    assert_eq!(diagnostics["todo_success_verified"], false);
+    assert_eq!(diagnostics["error_code"], "todo_success_not_verified");
+    assert_eq!(
+        diagnostics["tool_loop_executed_tools"],
+        serde_json::json!([])
+    );
+    assert_eq!(inspector.tool_call_count(), 1);
+}
+
+#[tokio::test]
 async fn todo_capability_question_without_tool_call_is_not_required_tool_blocked() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)


### PR DESCRIPTION
## 根因

普通私聊已经统一进入 Tool Loop，模型可以选择不调用工具并直接回答能力说明、暂不支持、参数不足等场景。现有 Todo 成功文案守卫虽不再读取用户原文预测 required tool，但对最终回复里的 `已完成待办` 等状态说明识别过宽，容易把能力说明误判成写操作成功声明，从而覆盖正常回复。

## 修改

- 收紧 `todo_guard` 的判断依据：仍只基于本轮最终回复和真实 `tool_results`，不根据用户原文要求工具必须成功。
- 将 `已完成待办 / 已取消待办` 这类状态、能力和规则说明排除出成功动作判断。
- 保留防伪能力：`已新增/已修改/已删除/待办已完成` 等成功声明仍必须有本轮成功的 Todo 写工具结果。
- 工具失败或结构化结果不满足写成功条件时，继续覆盖为未验真提示。

## 测试

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo build --workspace --release --all-features`

Closes #147