### PR TITLE
feat: 统一 Todo 语义澄清、Pending 与受限任务恢复 (#139)

### DIFF
--- a/qq-maid-core/src/runtime/pending/mod.rs
+++ b/qq-maid-core/src/runtime/pending/mod.rs
@@ -4,8 +4,26 @@
 //! 将这些操作暂存为挂起状态，等待用户确认、取消或修改。
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::storage::todo::{TodoItem, TodoItemDraft, TodoStatus};
+
+/// 澄清候选的精简展示结构。
+///
+/// 只保存恢复任务与生成提示所需的最小字段，不持久化完整 [`TodoItem`]。内部 ID
+/// 仅供受限 Tool Loop 重新查询 [`crate::runtime::todo::TodoStore`] 校验和确定性编号映射，
+/// **不进入用户提示，也不能由 LLM 自由提交**；恢复执行前必须按 ID 重新读取真实状态。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClarificationCandidate {
+    /// 内部 Todo ID；仅供受限 Tool Loop 重新查询与编号映射。
+    pub id: String,
+    /// 展示顺序（从 1 开始），与给用户看的候选编号一致。
+    pub display_number: usize,
+    /// 标题，用于生成澄清提示。
+    pub title: String,
+    /// 捕获时的状态；仅用于检测变化和生成提示，不是执行依据。
+    pub status: TodoStatus,
+}
 
 /// 待确认的记忆创建操作。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -85,6 +103,34 @@ pub enum PendingTodoAction {
     Edit,
     /// 删除
     Delete,
+}
+
+/// Agent Loop 中等待用户补充目标的 Todo 工具调用。
+///
+/// 这里只保存恢复原任务必需的结构化信息：原工具名、原始参数、选择基数、触发澄清的
+/// 错误码和本次澄清候选集。后续用户补充目标后，运行时会以候选集作为请求级选择作用域
+/// 重入受限 Tool Loop，由 LLM 产出结构化工具调用，再由原 Todo Tool 重新读取
+/// `TodoStore` 校验当前目标并执行。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PendingTodoClarification {
+    /// 原始工具名，例如 `complete_todos` / `edit_todo`。
+    pub tool_name: String,
+    /// 原始工具参数；不包含数据库内部 ID。
+    pub arguments: Value,
+    /// 原工具是否允许一次操作多条。
+    #[serde(default)]
+    pub allow_many: bool,
+    /// 触发澄清的结构化错误码。
+    pub error_code: String,
+    /// 给用户看的最小澄清问题。
+    pub question: String,
+    /// 本次澄清候选集及展示顺序；下一轮编号只能映射这份候选，不得使用无关的
+    /// `last_todo_query` 快照。旧 pending 缺失该字段时兼容为空，恢复路径会安全提示
+    /// 用户重新发起。
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub candidates: Vec<ClarificationCandidate>,
+    /// 创建时间，按最近查询 TTL 过期。
+    pub created_at: String,
 }
 
 /// 挂起的操作枚举。
@@ -192,6 +238,14 @@ pub enum PendingOperation {
         edit_text: Option<String>,
         created_at: String,
     },
+    /// Agent Loop 内等待用户补充待办目标后恢复原工具动作。
+    TodoClarify {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        initiator_user_id: Option<String>,
+        owner_key: String,
+        request: PendingTodoClarification,
+        created_at: String,
+    },
 }
 
 fn default_todo_add_allow_revision() -> bool {
@@ -216,7 +270,8 @@ impl PendingOperation {
             | Self::TodoEdit { owner_key, .. }
             | Self::TodoDelete { owner_key, .. }
             | Self::TodoBulkDelete { owner_key, .. }
-            | Self::TodoSelectCandidate { owner_key, .. } => Some(owner_key.as_str()),
+            | Self::TodoSelectCandidate { owner_key, .. }
+            | Self::TodoClarify { owner_key, .. } => Some(owner_key.as_str()),
         }
     }
 
@@ -248,6 +303,9 @@ impl PendingOperation {
                 initiator_user_id, ..
             }
             | Self::TodoSelectCandidate {
+                initiator_user_id, ..
+            }
+            | Self::TodoClarify {
                 initiator_user_id, ..
             } => initiator_user_id.as_deref(),
         }

--- a/qq-maid-core/src/runtime/respond/pending.rs
+++ b/qq-maid-core/src/runtime/respond/pending.rs
@@ -50,7 +50,8 @@ impl RustRespondService {
             | PendingOperation::TodoEdit { .. }
             | PendingOperation::TodoDelete { .. }
             | PendingOperation::TodoBulkDelete { .. }
-            | PendingOperation::TodoSelectCandidate { .. } => {
+            | PendingOperation::TodoSelectCandidate { .. }
+            | PendingOperation::TodoClarify { .. } => {
                 let owner = TodoStore::owner(meta.user_id.as_deref(), &meta.scope_key);
                 if pending.owner_key().is_some_and(|key| key != owner.key) {
                     return Ok(Some(self.append_pending_response(

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -544,11 +544,13 @@ async fn last_reference_rejects_owner_mismatch_and_missing_todo() {
     let owner_mismatch: Value = serde_json::from_str(&owner_mismatch).unwrap();
     assert_eq!(owner_mismatch["ok"], false);
     assert_eq!(owner_mismatch["error_code"], "todo_reference_unavailable");
+    assert_eq!(owner_mismatch["requires_clarification"], true);
 
     let mut session = service
         .session_store
         .get_or_create_active(&private_test_meta())
         .unwrap();
+    session.pending_operation = None;
     session.last_todo_action.as_mut().unwrap().owner_key = owner.key.clone();
     service.session_store.save(&mut session).unwrap();
     service
@@ -568,12 +570,16 @@ async fn last_reference_rejects_owner_mismatch_and_missing_todo() {
     let missing: Value = serde_json::from_str(&missing).unwrap();
     assert_eq!(missing["ok"], false);
     assert_eq!(missing["error_code"], "todo_reference_unavailable");
+    assert_eq!(missing["requires_clarification"], true);
 
     let session = service
         .session_store
         .get_or_create_active(&private_test_meta())
         .unwrap();
-    assert!(session.pending_operation.is_none());
+    assert!(matches!(
+        session.pending_operation,
+        Some(crate::runtime::pending::PendingOperation::TodoClarify { .. })
+    ));
 }
 
 #[tokio::test]
@@ -1809,9 +1815,9 @@ async fn deterministic_empty_query_clears_old_snapshot_before_number_mutation() 
         .await
         .unwrap();
     let completed: Value = serde_json::from_str(&completed_output).unwrap();
-    assert_eq!(completed["ok"], true);
-    assert_eq!(completed["completed"], serde_json::json!([]));
-    assert_eq!(completed["missing_numbers"], serde_json::json!([1]));
+    assert_eq!(completed["ok"], false);
+    assert_eq!(completed["requires_clarification"], true);
+    assert_eq!(completed["pending_action"], "clarify");
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tests/support.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support.rs
@@ -64,6 +64,10 @@ enum MockToolAction {
         arguments: String,
         reply: String,
     },
+    ExecuteTools {
+        calls: Vec<(String, String)>,
+        reply: String,
+    },
     ReplyWithoutTool {
         reply: String,
     },
@@ -185,6 +189,24 @@ impl MockProvider {
             .push(MockToolAction::ExecuteTool {
                 name: name.into(),
                 arguments: arguments.into(),
+                reply: reply.into(),
+            });
+        self
+    }
+
+    pub(super) fn with_tool_calls_json(
+        self,
+        calls: Vec<(&str, &str)>,
+        reply: impl Into<String>,
+    ) -> Self {
+        self.tool_actions
+            .lock()
+            .unwrap()
+            .push(MockToolAction::ExecuteTools {
+                calls: calls
+                    .into_iter()
+                    .map(|(name, arguments)| (name.to_owned(), arguments.to_owned()))
+                    .collect(),
                 reply: reply.into(),
             });
         self
@@ -503,6 +525,52 @@ impl LlmProvider for MockProvider {
                             output,
                             succeeded,
                         }],
+                    });
+                }
+                MockToolAction::ExecuteTools { calls, reply } => {
+                    let mut executed_tools = Vec::new();
+                    let mut tool_results = Vec::new();
+                    for (name, arguments) in calls {
+                        let output = req
+                            .tools
+                            .execute_json(&req.tool_context, &name, &arguments)
+                            .await?;
+                        let output = serde_json::from_str::<Value>(&output).unwrap_or_else(|_| {
+                            json!({
+                                "raw": output,
+                            })
+                        });
+                        let succeeded = output.get("ok").and_then(Value::as_bool) != Some(false);
+                        executed_tools.push(name.clone());
+                        tool_results.push(crate::provider::ToolExecutionResult {
+                            name,
+                            output,
+                            succeeded,
+                        });
+                    }
+                    return Ok(ChatOutcome {
+                        reply,
+                        metrics: LlmMetrics {
+                            provider: "mock".to_owned(),
+                            model: req
+                                .chat
+                                .model
+                                .clone()
+                                .unwrap_or_else(|| "mock-model".to_owned()),
+                            stream: false,
+                            ttfe_ms: None,
+                            ttft_ms: None,
+                            total_latency_ms: 1,
+                        },
+                        usage: Some(TokenUsage {
+                            input_tokens: None,
+                            cached_input_tokens: None,
+                            output_tokens: None,
+                            total_tokens: None,
+                        }),
+                        fallback_used: false,
+                        executed_tools,
+                        tool_results,
                     });
                 }
                 MockToolAction::ReplyWithoutTool { reply } => {

--- a/qq-maid-core/src/runtime/respond/tests/todo.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo.rs
@@ -1,5 +1,10 @@
 use super::support::*;
-use crate::runtime::todo::{TodoItem, TodoItemDraft, TodoStatus, TodoStore, TodoTimePrecision};
+use crate::runtime::{
+    pending::{ClarificationCandidate, PendingOperation, PendingTodoClarification},
+    session::{SessionMeta, now_iso_cn},
+    todo::{TodoItem, TodoItemDraft, TodoStatus, TodoStore, TodoTimePrecision},
+};
+use serde_json::{Value, json};
 
 fn draft(title: &str) -> TodoItemDraft {
     TodoItemDraft {
@@ -149,6 +154,63 @@ fn last_todo_result_ids(service: &crate::runtime::respond::RustRespondService) -
         .result_ids
 }
 
+fn private_todo_meta() -> SessionMeta {
+    SessionMeta::new(
+        "private:u1",
+        Some("u1".to_owned()),
+        None,
+        None,
+        None,
+        "qq_official",
+    )
+}
+
+fn private_todo_message(text: &str) -> crate::runtime::respond::RespondRequest {
+    message_in_scope(text, "private:u1", "u1", "")
+}
+
+fn clarification_candidates(items: &[TodoItem]) -> Vec<ClarificationCandidate> {
+    items
+        .iter()
+        .enumerate()
+        .map(|(index, item)| ClarificationCandidate {
+            id: item.id.clone(),
+            display_number: index + 1,
+            title: item.title.clone(),
+            status: item.status.clone(),
+        })
+        .collect()
+}
+
+fn install_todo_clarification(
+    service: &crate::runtime::respond::RustRespondService,
+    tool_name: &str,
+    arguments: Value,
+    allow_many: bool,
+    created_at: String,
+    candidates: Vec<ClarificationCandidate>,
+) {
+    let mut session = service
+        .session_store
+        .get_or_create_active(&private_todo_meta())
+        .unwrap();
+    session.pending_operation = Some(PendingOperation::TodoClarify {
+        initiator_user_id: Some("u1".to_owned()),
+        owner_key: "u1".to_owned(),
+        request: PendingTodoClarification {
+            tool_name: tool_name.to_owned(),
+            arguments,
+            allow_many,
+            error_code: "todo_reference_unavailable".to_owned(),
+            question: "请补充要操作哪条待办。".to_owned(),
+            candidates,
+            created_at: created_at.clone(),
+        },
+        created_at,
+    });
+    service.session_store.save(&mut session).unwrap();
+}
+
 #[tokio::test]
 async fn todo_root_aliases_list_pending_items() {
     let service = test_service();
@@ -181,6 +243,527 @@ async fn todo_query_writes_visible_snapshot_for_tool_followup() {
         .unwrap();
     let snapshot = session.last_todo_query.expect("missing todo snapshot");
     assert_eq!(snapshot.result_ids, vec![first.id, second.id]);
+}
+
+#[tokio::test]
+async fn todo_clarification_llm_tool_call_completes_candidate_scope() {
+    let provider = MockProvider::new().with_tool_call_json(
+        "complete_todos",
+        r#"{"numbers":[1],"reference":null}"#,
+        "已完成待办：买票",
+    );
+    let service = test_service_with_provider(provider);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let ticket = service.todo_store.create(&owner, draft("买票")).unwrap();
+    let hotel = service.todo_store.create(&owner, draft("订酒店")).unwrap();
+    install_todo_clarification(
+        &service,
+        "complete_todos",
+        json!({"numbers": null, "reference": "last"}),
+        true,
+        now_iso_cn(),
+        clarification_candidates(&[ticket.clone(), hotel.clone()]),
+    );
+
+    let response = service
+        .respond(private_todo_message("买票那条"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("todo_clarify_resumed"));
+    assert!(response.text.unwrap().contains("已完成待办"));
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &ticket.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Completed
+    );
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &hotel.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
+    assert!(
+        service
+            .session_store
+            .get_or_create_active(&private_todo_meta())
+            .unwrap()
+            .pending_operation
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn todo_clarification_cancel_todo_reply_does_not_abandon_pending() {
+    let provider = MockProvider::new().with_tool_call_json(
+        "cancel_todo",
+        r#"{"number":1,"reference":null}"#,
+        "已发起取消确认。",
+    );
+    let service = test_service_with_provider(provider);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let item = service.todo_store.create(&owner, draft("买票")).unwrap();
+    install_todo_clarification(
+        &service,
+        "cancel_todo",
+        json!({"number": null, "reference": "last"}),
+        false,
+        now_iso_cn(),
+        clarification_candidates(std::slice::from_ref(&item)),
+    );
+
+    let response = service
+        .respond(private_todo_message("取消第一条"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("todo_clarify_resumed"));
+    assert!(matches!(
+        service
+            .session_store
+            .get_or_create_active(&private_todo_meta())
+            .unwrap()
+            .pending_operation,
+        Some(PendingOperation::TodoDelete { .. })
+    ));
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
+}
+
+#[tokio::test]
+async fn todo_clarification_original_tool_result_wins_over_same_round_control() {
+    let provider = MockProvider::new().with_tool_calls_json(
+        vec![
+            ("cancel_todo", r#"{"number":1,"reference":null}"#),
+            (
+                "clarification_control",
+                r#"{"action":"abandon","question":null}"#,
+            ),
+        ],
+        "已发起取消确认。",
+    );
+    let service = test_service_with_provider(provider);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let item = service.todo_store.create(&owner, draft("买票")).unwrap();
+    install_todo_clarification(
+        &service,
+        "cancel_todo",
+        json!({"number": null, "reference": "last"}),
+        false,
+        now_iso_cn(),
+        clarification_candidates(std::slice::from_ref(&item)),
+    );
+
+    let response = service
+        .respond(private_todo_message("取消第一条"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("todo_clarify_resumed"));
+    assert!(matches!(
+        service
+            .session_store
+            .get_or_create_active(&private_todo_meta())
+            .unwrap()
+            .pending_operation,
+        Some(PendingOperation::TodoDelete { .. })
+    ));
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
+}
+
+#[tokio::test]
+async fn todo_clarification_control_ask_again_keeps_pending_without_mutation() {
+    let provider = MockProvider::new().with_tool_call_json(
+        "clarification_control",
+        r#"{"action":"ask_again","question":"找到多条匹配待办，请回复候选编号。"}"#,
+        "找到多条匹配待办，请回复候选编号。",
+    );
+    let service = test_service_with_provider(provider);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let first = service.todo_store.create(&owner, draft("买票")).unwrap();
+    let second = service
+        .todo_store
+        .create(&owner, draft("买票确认"))
+        .unwrap();
+    install_todo_clarification(
+        &service,
+        "complete_todos",
+        json!({"numbers": null, "reference": "last"}),
+        true,
+        now_iso_cn(),
+        clarification_candidates(&[first.clone(), second.clone()]),
+    );
+
+    let response = service.respond(private_todo_message("买票")).await.unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("todo_clarify_wait"));
+    assert!(response.text.unwrap().contains("回复候选编号"));
+    for item in [first, second] {
+        assert_eq!(
+            service
+                .todo_store
+                .get_by_id(&owner, &item.id)
+                .unwrap()
+                .unwrap()
+                .status,
+            TodoStatus::Pending
+        );
+    }
+    assert!(matches!(
+        service
+            .session_store
+            .get_or_create_active(&private_todo_meta())
+            .unwrap()
+            .pending_operation,
+        Some(PendingOperation::TodoClarify { .. })
+    ));
+}
+
+#[tokio::test]
+async fn todo_clarification_cancel_and_expiry_do_not_mutate() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let item = service.todo_store.create(&owner, draft("买票")).unwrap();
+    install_todo_clarification(
+        &service,
+        "complete_todos",
+        json!({"numbers": null, "reference": "last"}),
+        true,
+        now_iso_cn(),
+        clarification_candidates(std::slice::from_ref(&item)),
+    );
+
+    let cancelled = service.respond(private_todo_message("取消")).await.unwrap();
+    assert_eq!(cancelled.command.as_deref(), Some("todo_clarify_cancel"));
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
+
+    install_todo_clarification(
+        &service,
+        "complete_todos",
+        json!({"numbers": null, "reference": "last"}),
+        true,
+        "2020-01-01T00:00:00+08:00".to_owned(),
+        clarification_candidates(std::slice::from_ref(&item)),
+    );
+    let expired = service.respond(private_todo_message("买票")).await.unwrap();
+    assert_eq!(expired.command.as_deref(), Some("todo_clarify_expired"));
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
+}
+
+#[tokio::test]
+async fn todo_clarification_number_target_changed_keeps_pending_without_side_effect() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let item = service.todo_store.create(&owner, draft("买票")).unwrap();
+    install_todo_clarification(
+        &service,
+        "complete_todos",
+        json!({"numbers": [1], "reference": null}),
+        true,
+        now_iso_cn(),
+        clarification_candidates(std::slice::from_ref(&item)),
+    );
+    service.todo_store.complete(&owner, &item.id).unwrap();
+
+    let response = service.respond(private_todo_message("1")).await.unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("todo_clarify_wait"));
+    assert!(
+        service
+            .session_store
+            .get_or_create_active(&private_todo_meta())
+            .unwrap()
+            .pending_operation
+            .is_some()
+    );
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Completed
+    );
+}
+
+#[tokio::test]
+async fn todo_clarification_candidate_scope_does_not_persist_as_last_query() {
+    let provider = MockProvider::new().with_tool_call_json(
+        "complete_todos",
+        r#"{"numbers":[1],"reference":null}"#,
+        "已完成候选。",
+    );
+    let service = test_service_with_provider(provider);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let unrelated = service
+        .todo_store
+        .create(&owner, draft("无关列表项"))
+        .unwrap();
+    let candidate = service
+        .todo_store
+        .create(&owner, draft("澄清候选"))
+        .unwrap();
+    let mut session = service
+        .session_store
+        .get_or_create_active(&private_todo_meta())
+        .unwrap();
+    session.remember_last_todo_query(&owner.key, "list", "原列表", vec![unrelated.id.clone()]);
+    service.session_store.save(&mut session).unwrap();
+    install_todo_clarification(
+        &service,
+        "complete_todos",
+        json!({"numbers": null, "reference": "last"}),
+        true,
+        now_iso_cn(),
+        clarification_candidates(std::slice::from_ref(&candidate)),
+    );
+
+    service
+        .respond(private_todo_message("候选那条"))
+        .await
+        .unwrap();
+
+    let latest = service
+        .session_store
+        .get_or_create_active(&private_todo_meta())
+        .unwrap();
+    assert_ne!(
+        latest.last_todo_query.map(|query| query.result_ids),
+        Some(vec![candidate.id.clone()])
+    );
+}
+
+#[tokio::test]
+async fn todo_clarification_loop_error_keeps_original_pending_and_blocks_other_tools() {
+    let provider = MockProvider::new().with_tool_call_json("weather", r#"{}"#, "不会返回");
+    let service = test_service_with_provider(provider);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let item = service.todo_store.create(&owner, draft("买票")).unwrap();
+    install_todo_clarification(
+        &service,
+        "complete_todos",
+        json!({"numbers": null, "reference": "last"}),
+        true,
+        now_iso_cn(),
+        clarification_candidates(std::slice::from_ref(&item)),
+    );
+
+    let response = service
+        .respond(private_todo_message("查天气吧"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("todo_clarify_loop_error"));
+    assert!(matches!(
+        service
+            .session_store
+            .get_or_create_active(&private_todo_meta())
+            .unwrap()
+            .pending_operation,
+        Some(PendingOperation::TodoClarify { .. })
+    ));
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
+}
+
+#[tokio::test]
+async fn todo_clarification_no_tool_reply_updates_question_and_keeps_pending() {
+    let provider = MockProvider::new().with_tool_loop_reply_without_tool("请再说明要选哪个候选。");
+    let service = test_service_with_provider(provider);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let item = service.todo_store.create(&owner, draft("买票")).unwrap();
+    install_todo_clarification(
+        &service,
+        "complete_todos",
+        json!({"numbers": null, "reference": "last"}),
+        true,
+        now_iso_cn(),
+        clarification_candidates(std::slice::from_ref(&item)),
+    );
+
+    let response = service
+        .respond(private_todo_message("不太确定"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("todo_clarify_wait"));
+    let session = service
+        .session_store
+        .get_or_create_active(&private_todo_meta())
+        .unwrap();
+    match session.pending_operation {
+        Some(PendingOperation::TodoClarify { request, .. }) => {
+            assert!(request.question.contains("请再说明"));
+        }
+        other => panic!("expected TodoClarify pending, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn todo_clarification_delete_tool_replaces_with_confirmation_pending() {
+    let provider = MockProvider::new().with_tool_call_json(
+        "delete_todos",
+        r#"{"numbers":[1],"reference":null}"#,
+        "已发起删除确认。",
+    );
+    let service = test_service_with_provider(provider);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let item = service.todo_store.create(&owner, draft("旧任务")).unwrap();
+    service.todo_store.complete(&owner, &item.id).unwrap();
+    let item = service
+        .todo_store
+        .get_by_id(&owner, &item.id)
+        .unwrap()
+        .unwrap();
+    install_todo_clarification(
+        &service,
+        "delete_todos",
+        json!({"numbers": null, "reference": "last"}),
+        true,
+        now_iso_cn(),
+        clarification_candidates(std::slice::from_ref(&item)),
+    );
+
+    let response = service
+        .respond(private_todo_message("旧任务那条"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("todo_clarify_resumed"));
+    assert!(matches!(
+        service
+            .session_store
+            .get_or_create_active(&private_todo_meta())
+            .unwrap()
+            .pending_operation,
+        Some(PendingOperation::TodoBulkDelete { .. })
+    ));
+}
+
+#[tokio::test]
+async fn todo_clarification_out_of_range_number_keeps_pending_without_side_effect() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let item = service.todo_store.create(&owner, draft("买票")).unwrap();
+    install_todo_clarification(
+        &service,
+        "complete_todos",
+        json!({"numbers": null, "reference": "last"}),
+        true,
+        now_iso_cn(),
+        clarification_candidates(std::slice::from_ref(&item)),
+    );
+
+    let response = service.respond(private_todo_message("2")).await.unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("todo_clarify_wait"));
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
+    assert!(matches!(
+        service
+            .session_store
+            .get_or_create_active(&private_todo_meta())
+            .unwrap()
+            .pending_operation,
+        Some(PendingOperation::TodoClarify { .. })
+    ));
+}
+
+#[tokio::test]
+async fn todo_clarification_control_abandon_clears_pending_without_mutation() {
+    let provider = MockProvider::new().with_tool_call_json(
+        "clarification_control",
+        r#"{"action":"abandon","question":null}"#,
+        "已放弃这次澄清。",
+    );
+    let service = test_service_with_provider(provider);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let item = service.todo_store.create(&owner, draft("买票")).unwrap();
+    install_todo_clarification(
+        &service,
+        "complete_todos",
+        json!({"numbers": null, "reference": "last"}),
+        true,
+        now_iso_cn(),
+        clarification_candidates(std::slice::from_ref(&item)),
+    );
+
+    let response = service
+        .respond(private_todo_message("我不处理这个了"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("todo_clarify_abandon"));
+    assert!(
+        service
+            .session_store
+            .get_or_create_active(&private_todo_meta())
+            .unwrap()
+            .pending_operation
+            .is_none()
+    );
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
@@ -1,21 +1,40 @@
-//! Todo 待确认操作状态机。
+//! Todo 待确认与澄清恢复状态机。
 //!
-//! 现在 Todo 写操作统一由 Tool Loop 触发；slash 写入口已移除。这里仅保留 Tool
-//! 仍会产生的待确认类型：
-//! - `TodoAdd`：`create_todo` 生成草稿，用户确认后写入；
-//! - `TodoDelete`：`cancel_todo` 生成软取消确认；
-//! - `TodoBulkDelete`：`delete_todos` 生成永久删除确认。
+//! Todo 写操作统一由 Tool Loop 触发；slash 写入口已移除。这里处理 Tool 仍会产生的
+//! 两类跨轮状态：
+//! - 确认类 pending：`TodoAdd` / `TodoDelete` / `TodoBulkDelete`，用户确认后才写入或删除；
+//! - 澄清类 pending：`TodoClarify`，保存原工具、原始参数和精简候选边界，用户补充后
+//!   通过受限 Tool Loop 重入原 Todo Tool，由 LLM 只负责选择/继续澄清，真正校验与副作用
+//!   仍由原 Tool 重新读取 `TodoStore` 后执行。
+//!
+//! `TodoClarify` 不在 Pending 层解析自然语言、不直接调用 `ops::*`、不构造确认 pending；
+//! 当前候选编号通过请求级 TodoTool selection scope 临时生效，不污染 `last_todo_query`。
 //!
 //! 旧 slash 写流程专用的 `TodoDone` / `TodoEdit` / `TodoSelectCandidate` 变体在
 //! `PendingOperation` 中保留为空壳兼容旧 session；运行时遇到会清理并提示重新用
 //! 自然语言发起操作，避免旧 pending 长期卡住会话。
 
+use std::{collections::HashMap, sync::Arc};
+
+use async_trait::async_trait;
+use qq_maid_llm::tool::{DynTool, Tool, ToolContext, ToolMetadata, ToolOutput, ToolRegistry};
+use serde_json::{Value, json};
+use uuid::Uuid;
+
 use crate::{
     error::LlmError,
+    provider::{
+        ChatOutcome, ToolChatRequest,
+        types::{ChatMessage, ChatRequest},
+    },
     runtime::{
-        pending::{PendingOperation, PendingReplyKind, classify_reply, todo_lexicon},
-        session::SessionRecord,
+        pending::{
+            PendingOperation, PendingReplyKind, PendingTodoClarification, classify_reply,
+            todo_lexicon,
+        },
+        session::{LAST_QUERY_TTL_SECONDS, SessionRecord, query_is_fresh},
         todo::{TodoOwner, TodoStatus},
+        tools::{CancelTodoTool, CompleteTodoTool, DeleteTodoTool, EditTodoTool, RestoreTodoTool},
     },
 };
 
@@ -25,10 +44,11 @@ use crate::runtime::respond::common::CommandBody;
 use crate::runtime::respond::{RespondResponse, RustRespondService, common::todo_error};
 
 impl RustRespondService {
-    /// 处理 Todo 待确认操作。
+    /// 处理 Todo 待确认与澄清恢复操作。
     ///
-    /// Tool 侧只会创建新增、软取消和永久删除三类 pending；旧 slash 专用 pending
-    /// 不再执行，直接清理，避免 #103 这类“澄清后返回成功但未写入”的旧状态机问题。
+    /// 确认类 pending 只接受确认/取消；`TodoClarify` 则在取消、过期和候选边界检查后，
+    /// 构造仅包含原 Todo Tool 与无副作用控制工具的受限 Tool Loop。恢复执行必须走原
+    /// Todo Tool 的 prepare/execute 路径，Pending 层只维护恢复上下文和候选边界。
     pub(in crate::runtime::respond) async fn handle_pending_todo_operation(
         &self,
         user_text: &str,
@@ -240,6 +260,10 @@ impl RustRespondService {
                     "todo_delete",
                 )?))
             }
+            PendingOperation::TodoClarify { request, .. } => {
+                self.handle_pending_todo_clarification(user_text, session, owner, request)
+                    .await
+            }
             PendingOperation::TodoDone { .. }
             | PendingOperation::TodoEdit { .. }
             | PendingOperation::TodoSelectCandidate { .. } => {
@@ -256,5 +280,590 @@ impl RustRespondService {
             | PendingOperation::MemoryUpdate { .. }
             | PendingOperation::MemoryDelete { .. } => Ok(None),
         }
+    }
+
+    async fn handle_pending_todo_clarification(
+        &self,
+        user_text: &str,
+        session: &mut SessionRecord,
+        owner: &TodoOwner,
+        request: PendingTodoClarification,
+    ) -> Result<Option<RespondResponse>, LlmError> {
+        if is_clarification_abandon_text(user_text) {
+            return Ok(Some(self.clear_pending_response(
+                session,
+                user_text,
+                CommandBody::plain("已取消，不执行这次待办操作。"),
+                "todo_clarify_cancel",
+            )?));
+        }
+        if !query_is_fresh(&request.created_at, LAST_QUERY_TTL_SECONDS) {
+            return Ok(Some(self.clear_pending_response(
+                session,
+                user_text,
+                CommandBody::plain("这次澄清已经过期，没有执行待办操作。请重新发起。"),
+                "todo_clarify_expired",
+            )?));
+        }
+        if request.candidates.is_empty() {
+            return Ok(Some(self.clear_pending_response(
+                session,
+                user_text,
+                CommandBody::plain("这条待办澄清状态缺少候选边界，没有执行待办操作。请重新发起。"),
+                "todo_clarify_invalid_scope",
+            )?));
+        }
+
+        if let Some(number) = parse_explicit_candidate_number(user_text) {
+            return self
+                .run_pending_todo_clarification_fast_path(
+                    user_text, session, owner, request, number,
+                )
+                .await;
+        }
+
+        self.run_pending_todo_clarification_loop(user_text, session, owner, request)
+            .await
+    }
+
+    async fn run_pending_todo_clarification_fast_path(
+        &self,
+        user_text: &str,
+        session: &mut SessionRecord,
+        owner: &TodoOwner,
+        request: PendingTodoClarification,
+        number: usize,
+    ) -> Result<Option<RespondResponse>, LlmError> {
+        let Some(arguments) = clarification_tool_arguments_for_number(&request, number)? else {
+            return Ok(Some(self.append_pending_response(
+                session,
+                user_text,
+                CommandBody::plain("这次澄清对应的工具不支持编号恢复，请重新发起操作。"),
+                "todo_clarify_unknown_tool",
+            )?));
+        };
+        let registry = self.restricted_todo_clarification_registry(&request)?;
+        let context = clarification_tool_context(session, owner);
+        let arguments_text = serde_json::to_string(&arguments).map_err(|err| {
+            LlmError::new(
+                "bad_tool_arguments",
+                format!("failed to serialize clarification tool arguments: {err}"),
+                "todo_pending",
+            )
+        })?;
+        let output = match registry
+            .execute_json(&context, &request.tool_name, &arguments_text)
+            .await
+        {
+            Ok(output) => output,
+            Err(err) => {
+                self.refresh_pending_session(session)?;
+                return Ok(Some(self.append_pending_response(
+                    session,
+                    user_text,
+                    CommandBody::plain(format!(
+                        "这次待办恢复执行失败，没有清除原澄清状态。错误：{}",
+                        err.message
+                    )),
+                    "todo_clarify_tool_error",
+                )?));
+            }
+        };
+        let output_value = serde_json::from_str::<Value>(&output).unwrap_or_else(|_| {
+            json!({
+                "ok": false,
+                "message": output,
+            })
+        });
+        self.refresh_pending_session(session)?;
+        if same_todo_clarification(session, &request) {
+            let question = output_value
+                .get("question")
+                .and_then(Value::as_str)
+                .or_else(|| output_value.get("message").and_then(Value::as_str))
+                .unwrap_or("目标待办状态已变化或无法唯一定位，没有执行待办操作。请重新选择候选。")
+                .to_owned();
+            keep_todo_clarification(session, owner, request, question.clone());
+            return Ok(Some(self.append_pending_response(
+                session,
+                user_text,
+                CommandBody::plain(question),
+                "todo_clarify_wait",
+            )?));
+        }
+        let reply = tool_output_reply(&output_value);
+        Ok(Some(self.append_pending_response(
+            session,
+            user_text,
+            CommandBody::plain(reply),
+            clarification_command_for_output(&output_value),
+        )?))
+    }
+
+    async fn run_pending_todo_clarification_loop(
+        &self,
+        user_text: &str,
+        session: &mut SessionRecord,
+        owner: &TodoOwner,
+        request: PendingTodoClarification,
+    ) -> Result<Option<RespondResponse>, LlmError> {
+        let registry = self.restricted_todo_clarification_registry(&request)?;
+        let context = clarification_tool_context(session, owner);
+        let chat = ChatRequest {
+            session_id: session.session_id.clone(),
+            model: None,
+            messages: build_todo_clarification_messages(user_text, &request),
+            context_budget: None,
+            metadata: HashMap::from([
+                ("purpose".to_owned(), "todo_clarification_resume".to_owned()),
+                ("tool_name".to_owned(), request.tool_name.clone()),
+            ]),
+        };
+        let outcome = match self
+            .provider
+            .chat_with_tools(ToolChatRequest {
+                chat,
+                tools: registry,
+                tool_context: context,
+                max_rounds: self.tool_calling_max_rounds.max(1),
+            })
+            .await
+        {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                self.refresh_pending_session(session)?;
+                return Ok(Some(self.append_pending_response(
+                    session,
+                    user_text,
+                    CommandBody::plain(format!(
+                        "这次待办恢复没有完成，原澄清状态已保留。错误：{}",
+                        err.message
+                    )),
+                    "todo_clarify_loop_error",
+                )?));
+            }
+        };
+
+        self.refresh_pending_session(session)?;
+        if outcome
+            .executed_tools
+            .iter()
+            .any(|name| name == &request.tool_name)
+            && !same_todo_clarification(session, &request)
+        {
+            return Ok(Some(self.append_pending_response(
+                session,
+                user_text,
+                CommandBody::plain(non_empty_reply(
+                    &outcome.reply,
+                    "已按你的补充继续执行待办操作。",
+                )),
+                "todo_clarify_resumed",
+            )?));
+        }
+
+        match clarification_control_action(&outcome) {
+            Some(ClarificationControlAction::Abandon) => {
+                return Ok(Some(self.clear_pending_response(
+                    session,
+                    user_text,
+                    CommandBody::plain(non_empty_reply(
+                        &outcome.reply,
+                        "已放弃这次待办澄清。若要处理新的请求，请重新发送。",
+                    )),
+                    "todo_clarify_abandon",
+                )?));
+            }
+            Some(ClarificationControlAction::AskAgain(question)) => {
+                if same_todo_clarification(session, &request) {
+                    keep_todo_clarification(session, owner, request, question.clone());
+                }
+                return Ok(Some(self.append_pending_response(
+                    session,
+                    user_text,
+                    CommandBody::plain(non_empty_reply(&outcome.reply, &question)),
+                    "todo_clarify_wait",
+                )?));
+            }
+            None => {}
+        }
+
+        // 没有执行原 Todo Tool，或工具返回仍需澄清且原 TodoClarify 仍在：把模型最终
+        // 回复视为新的最小澄清问题，保留候选边界，不产生副作用。
+        let question = non_empty_reply(&outcome.reply, &request.question);
+        if same_todo_clarification(session, &request) {
+            keep_todo_clarification(session, owner, request, question.clone());
+        }
+        Ok(Some(self.append_pending_response(
+            session,
+            user_text,
+            CommandBody::plain(question),
+            "todo_clarify_wait",
+        )?))
+    }
+
+    fn restricted_todo_clarification_registry(
+        &self,
+        request: &PendingTodoClarification,
+    ) -> Result<ToolRegistry, LlmError> {
+        let mut registry = self.tool_registry.subset(&[request.tool_name.as_str()])?;
+        registry.replace(self.scoped_todo_tool(&request.tool_name, candidate_scope(request)?)?)?;
+        registry.insert(Arc::new(ClarificationControlTool) as DynTool)?;
+        Ok(registry)
+    }
+
+    fn scoped_todo_tool(&self, tool_name: &str, scope: Arc<[String]>) -> Result<DynTool, LlmError> {
+        match tool_name {
+            "complete_todos" => Ok(Arc::new(
+                CompleteTodoTool::new(self.todo_store.clone(), self.session_store.clone())
+                    .with_selection_scope(scope),
+            ) as DynTool),
+            "edit_todo" => Ok(Arc::new(
+                EditTodoTool::new(self.todo_store.clone(), self.session_store.clone())
+                    .with_selection_scope(scope),
+            ) as DynTool),
+            "cancel_todo" => Ok(Arc::new(
+                CancelTodoTool::new(self.todo_store.clone(), self.session_store.clone())
+                    .with_selection_scope(scope),
+            ) as DynTool),
+            "restore_todos" => Ok(Arc::new(
+                RestoreTodoTool::new(self.todo_store.clone(), self.session_store.clone())
+                    .with_selection_scope(scope),
+            ) as DynTool),
+            "delete_todos" => Ok(Arc::new(
+                DeleteTodoTool::new(self.todo_store.clone(), self.session_store.clone())
+                    .with_selection_scope(scope),
+            ) as DynTool),
+            _ => Err(LlmError::new(
+                "unsupported_todo_clarification_tool",
+                format!("unsupported todo clarification tool `{tool_name}`"),
+                "todo_pending",
+            )),
+        }
+    }
+
+    fn refresh_pending_session(&self, session: &mut SessionRecord) -> Result<(), LlmError> {
+        let latest = self
+            .session_store
+            .get(&session.session_id)
+            .map_err(crate::runtime::respond::common::session_error)?
+            .ok_or_else(|| {
+                LlmError::new(
+                    "session_missing",
+                    format!(
+                        "session `{}` disappeared after todo clarification",
+                        session.session_id
+                    ),
+                    "session",
+                )
+            })?;
+        *session = latest;
+        Ok(())
+    }
+}
+
+const CLARIFICATION_CONTROL_TOOL_NAME: &str = "clarification_control";
+
+struct ClarificationControlTool;
+
+#[async_trait]
+impl Tool for ClarificationControlTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            name: CLARIFICATION_CONTROL_TOOL_NAME.to_owned(),
+            description: "澄清恢复控制工具。仅用于表示仍需追问或放弃当前澄清，不操作 Todo 数据。"
+                .to_owned(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["ask_again", "abandon"],
+                        "description": "ask_again=信息仍不足，需要继续追问；abandon=用户放弃或明显不是在回答当前澄清。"
+                    },
+                    "question": {
+                        "type": ["string", "null"],
+                        "description": "action=ask_again 时给用户的最小澄清问题；其他情况传 null。"
+                    }
+                },
+                "required": ["action", "question"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    async fn execute(
+        &self,
+        _context: ToolContext,
+        arguments: Value,
+    ) -> Result<ToolOutput, LlmError> {
+        let action = arguments
+            .get("action")
+            .and_then(Value::as_str)
+            .ok_or_else(|| LlmError::new("bad_tool_arguments", "action is required", "tool"))?;
+        let question = arguments
+            .get("question")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned);
+        match action {
+            "ask_again" => Ok(ToolOutput::json(json!({
+                "ok": true,
+                "action": "ask_again",
+                "question": question.unwrap_or_else(|| "请再具体说明要操作哪条待办。".to_owned()),
+            }))),
+            "abandon" => Ok(ToolOutput::json(json!({
+                "ok": true,
+                "action": "abandon",
+                "question": Value::Null,
+            }))),
+            _ => Err(LlmError::new(
+                "bad_tool_arguments",
+                "action must be ask_again or abandon",
+                "tool",
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ClarificationControlAction {
+    AskAgain(String),
+    Abandon,
+}
+
+fn clarification_control_action(outcome: &ChatOutcome) -> Option<ClarificationControlAction> {
+    outcome
+        .tool_results
+        .iter()
+        .rev()
+        .find(|result| result.name == CLARIFICATION_CONTROL_TOOL_NAME)
+        .and_then(
+            |result| match result.output.get("action").and_then(Value::as_str) {
+                Some("ask_again") => Some(ClarificationControlAction::AskAgain(
+                    result
+                        .output
+                        .get("question")
+                        .and_then(Value::as_str)
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .unwrap_or("请再具体说明要操作哪条待办。")
+                        .to_owned(),
+                )),
+                Some("abandon") => Some(ClarificationControlAction::Abandon),
+                _ => None,
+            },
+        )
+}
+
+fn candidate_scope(request: &PendingTodoClarification) -> Result<Arc<[String]>, LlmError> {
+    if request.candidates.is_empty() {
+        return Err(LlmError::new(
+            "todo_clarification_scope_empty",
+            "todo clarification candidates are empty",
+            "todo_pending",
+        ));
+    }
+    let ids = request
+        .candidates
+        .iter()
+        .map(|candidate| candidate.id.clone())
+        .collect::<Vec<_>>();
+    Ok(Arc::from(ids.into_boxed_slice()))
+}
+
+fn build_todo_clarification_messages(
+    user_text: &str,
+    request: &PendingTodoClarification,
+) -> Vec<ChatMessage> {
+    let candidates = request
+        .candidates
+        .iter()
+        .map(|candidate| format!("{}. {}", candidate.display_number, candidate.title))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let original_arguments =
+        serde_json::to_string_pretty(&request.arguments).unwrap_or_else(|_| "{}".to_owned());
+    let system = format!(
+        "你正在恢复一个待办工具澄清任务。\n\n\
+职责边界：\n\
+- 只能恢复原工具 `{tool_name}`，不得改成其他 Todo 操作。\n\
+- 当前候选编号只在本次澄清中有效，必须从候选 1..N 里选择；不要使用数据库内部 ID。\n\
+- 候选标题里的数字（例如“6 号”“买 2 个”）不是候选编号。\n\
+- 如果能唯一确定目标，请调用原工具 `{tool_name}`，用候选展示编号作为 number/numbers，并保留或补全原始参数里的其他业务字段。\n\
+- 如果仍无法唯一确定，请调用 `{control_tool}`，action=ask_again，并给出最小澄清问题。\n\
+- 如果用户明确放弃或明显不是在回答当前澄清，请调用 `{control_tool}`，action=abandon。\n\
+- 不要编造成功结果；工具结果才是真实执行状态。\n\n\
+原工具：{tool_name}\n原始参数 JSON：\n{original_arguments}\n\n上一次澄清问题：\n{question}\n\n当前候选：\n{candidates}",
+        tool_name = request.tool_name,
+        control_tool = CLARIFICATION_CONTROL_TOOL_NAME,
+        question = request.question,
+    );
+    vec![
+        ChatMessage::system(system),
+        ChatMessage::user(user_text.trim().to_owned()),
+    ]
+}
+
+fn clarification_tool_context(session: &SessionRecord, owner: &TodoOwner) -> ToolContext {
+    ToolContext {
+        task_id: format!("todo-clarify:{}", Uuid::new_v4()),
+        user_id: owner.user_id.clone(),
+        scope_id: owner.scope_key.clone(),
+        tool_call_id: Some(format!("clarify-{}", session.session_id)),
+    }
+}
+
+fn is_clarification_abandon_text(text: &str) -> bool {
+    let compact = text
+        .trim()
+        .chars()
+        .filter(|ch| {
+            !ch.is_whitespace()
+                && !matches!(
+                    ch,
+                    '，' | ','
+                        | '。'
+                        | '.'
+                        | '！'
+                        | '!'
+                        | '？'
+                        | '?'
+                        | '、'
+                        | ';'
+                        | '；'
+                        | ':'
+                        | '：'
+                )
+        })
+        .collect::<String>()
+        .trim_end_matches(['了', '吧', '啊', '呀', '呢'])
+        .to_owned();
+    matches!(
+        compact.as_str(),
+        "取消" | "放弃" | "算了" | "不用" | "不要" | "撤销"
+    )
+}
+
+fn parse_explicit_candidate_number(text: &str) -> Option<usize> {
+    let compact = text
+        .trim()
+        .chars()
+        .filter(|ch| !ch.is_whitespace())
+        .collect::<String>();
+    let compact = compact
+        .trim_matches(&['。', '.', '，', ',', '！', '!', '？', '?'][..])
+        .to_owned();
+    if compact.is_empty() {
+        return None;
+    }
+    if compact.chars().all(|ch| ch.is_ascii_digit()) {
+        return compact.parse::<usize>().ok().filter(|value| *value > 0);
+    }
+    let mut core = compact.strip_prefix('第')?;
+    for suffix in ["条", "个", "项"] {
+        if let Some(stripped) = core.strip_suffix(suffix) {
+            core = stripped;
+            break;
+        }
+    }
+    if core.chars().all(|ch| ch.is_ascii_digit()) {
+        return core.parse::<usize>().ok().filter(|value| *value > 0);
+    }
+    parse_simple_chinese_number(core)
+}
+
+fn parse_simple_chinese_number(text: &str) -> Option<usize> {
+    match text {
+        "一" => Some(1),
+        "二" | "两" => Some(2),
+        "三" => Some(3),
+        "四" => Some(4),
+        "五" => Some(5),
+        "六" => Some(6),
+        "七" => Some(7),
+        "八" => Some(8),
+        "九" => Some(9),
+        "十" => Some(10),
+        _ => None,
+    }
+}
+
+fn clarification_tool_arguments_for_number(
+    request: &PendingTodoClarification,
+    number: usize,
+) -> Result<Option<Value>, LlmError> {
+    let mut arguments = request.arguments.clone();
+    let object = arguments.as_object_mut().ok_or_else(|| {
+        LlmError::new(
+            "bad_tool_arguments",
+            "pending clarification arguments must be a JSON object",
+            "todo_pending",
+        )
+    })?;
+    match request.tool_name.as_str() {
+        "complete_todos" | "restore_todos" | "delete_todos" => {
+            object.insert("numbers".to_owned(), json!([number]));
+            object.insert("reference".to_owned(), Value::Null);
+            Ok(Some(arguments))
+        }
+        "cancel_todo" | "edit_todo" => {
+            object.insert("number".to_owned(), json!(number));
+            object.insert("reference".to_owned(), Value::Null);
+            Ok(Some(arguments))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn same_todo_clarification(session: &SessionRecord, request: &PendingTodoClarification) -> bool {
+    matches!(
+        session.pending_operation.as_ref(),
+        Some(PendingOperation::TodoClarify { request: current, .. })
+            if current.tool_name == request.tool_name && current.created_at == request.created_at
+    )
+}
+
+fn keep_todo_clarification(
+    session: &mut SessionRecord,
+    owner: &TodoOwner,
+    mut request: PendingTodoClarification,
+    question: String,
+) {
+    request.question = question;
+    session.pending_operation = Some(PendingOperation::TodoClarify {
+        initiator_user_id: owner.user_id.clone(),
+        owner_key: owner.key.clone(),
+        created_at: request.created_at.clone(),
+        request,
+    });
+}
+
+fn clarification_command_for_output(output: &Value) -> &'static str {
+    if output.get("requires_confirmation").and_then(Value::as_bool) == Some(true) {
+        "todo_clarify_confirm_ready"
+    } else if output.get("ok").and_then(Value::as_bool) == Some(false) {
+        "todo_clarify_wait"
+    } else {
+        "todo_clarify_resumed"
+    }
+}
+
+fn tool_output_reply(output: &Value) -> String {
+    output
+        .get("question")
+        .and_then(Value::as_str)
+        .or_else(|| output.get("message").and_then(Value::as_str))
+        .map(str::to_owned)
+        .unwrap_or_else(|| "已按澄清选择继续待办操作。".to_owned())
+}
+
+fn non_empty_reply(reply: &str, fallback: &str) -> String {
+    let reply = reply.trim();
+    if reply.is_empty() {
+        fallback.to_owned()
+    } else {
+        reply.to_owned()
     }
 }

--- a/qq-maid-core/src/runtime/tools/todo/cancel.rs
+++ b/qq-maid-core/src/runtime/tools/todo/cancel.rs
@@ -15,12 +15,16 @@ use super::common::{
     todo_tool_error_output,
 };
 use super::json::todo_selected_item_json;
-use super::scope::{TodoToolScope, TodoToolSingleItemResolution};
+use super::scope::{
+    SelectionScope, TodoToolScope, TodoToolSingleItemResolution, clarification_error_fields,
+};
 use super::selection::{prepare_selection_arguments, resolved_selection_from_arguments};
 
 pub struct CancelTodoTool {
     todo_store: crate::runtime::todo::TodoStore,
     session_store: crate::runtime::session::SessionStore,
+    /// 受限 Tool Loop 注入的请求级选择作用域；普通调用为 `None`。
+    selection_scope: Option<SelectionScope>,
 }
 
 impl CancelTodoTool {
@@ -31,7 +35,14 @@ impl CancelTodoTool {
         Self {
             todo_store,
             session_store,
+            selection_scope: None,
         }
+    }
+
+    /// 注入受限 Tool Loop 专属的请求级选择作用域，返回新实例。
+    pub fn with_selection_scope(mut self, scope: SelectionScope) -> Self {
+        self.selection_scope = Some(scope);
+        self
     }
 }
 
@@ -56,6 +67,7 @@ impl Tool for CancelTodoTool {
             context,
             arguments,
             false,
+            self.selection_scope.clone(),
         )
     }
 
@@ -64,15 +76,37 @@ impl Tool for CancelTodoTool {
         context: ToolContext,
         arguments: serde_json::Value,
     ) -> Result<ToolOutput, LlmError> {
-        let mut scope = TodoToolScope::load(&self.session_store, &context)?;
+        let mut scope =
+            TodoToolScope::load(&self.session_store, &context, self.selection_scope.clone())?;
         if let Some(output) = scope.take_dedup_output(&context, &arguments)? {
             return Ok(output);
         }
         let resolved =
             resolved_selection_from_arguments(&mut scope, &self.todo_store, &arguments, false)?;
+        if let Some(output) = resolved.error_output.as_ref() {
+            let (error_code, message) = clarification_error_fields(output);
+            return scope.save_clarification(
+                &self.todo_store,
+                CANCEL_TODO_TOOL_NAME,
+                &arguments,
+                false,
+                error_code,
+                message,
+            );
+        }
         let item = match resolved.single_item(&self.todo_store, &scope.owner)? {
             TodoToolSingleItemResolution::Item(item) => *item,
-            TodoToolSingleItemResolution::Output(output) => return Ok(output),
+            TodoToolSingleItemResolution::Output(output) => {
+                let (error_code, message) = clarification_error_fields(&output);
+                return scope.save_clarification(
+                    &self.todo_store,
+                    CANCEL_TODO_TOOL_NAME,
+                    &arguments,
+                    false,
+                    error_code,
+                    message,
+                );
+            }
         };
         if item.status != TodoStatus::Pending {
             return Ok(todo_tool_error_output(

--- a/qq-maid-core/src/runtime/tools/todo/complete.rs
+++ b/qq-maid-core/src/runtime/tools/todo/complete.rs
@@ -7,9 +7,12 @@ use qq_maid_llm::tool::{Tool, ToolContext, ToolMetadata, ToolOutput};
 
 use crate::error::LlmError;
 
-use super::common::{COMPLETE_TODOS_TOOL_NAME, number_list_or_reference_schema, todo_tool_error};
+use super::common::{
+    COMPLETE_TODOS_TOOL_NAME, TODO_SELECTION_NOT_FOUND_CODE, number_list_or_reference_schema,
+    todo_tool_error,
+};
 use super::json::todo_selected_items_json;
-use super::scope::TodoToolScope;
+use super::scope::{SelectionScope, TodoToolScope, clarification_error_fields};
 use super::selection::{
     missing_numbers_json, missing_selection_labels_for_result, prepare_selection_arguments,
     prepared_selection_ids, resolved_selection_from_arguments, selected_items_for_result,
@@ -18,6 +21,8 @@ use super::selection::{
 pub struct CompleteTodoTool {
     todo_store: crate::runtime::todo::TodoStore,
     session_store: crate::runtime::session::SessionStore,
+    /// 受限 Tool Loop 注入的请求级选择作用域；普通调用为 `None`。
+    selection_scope: Option<SelectionScope>,
 }
 
 impl CompleteTodoTool {
@@ -28,7 +33,17 @@ impl CompleteTodoTool {
         Self {
             todo_store,
             session_store,
+            selection_scope: None,
         }
+    }
+
+    /// 注入受限 Tool Loop 专属的请求级选择作用域，返回新实例。
+    ///
+    /// 该作用域不写入 Session / 数据库，仅用于本次受限 Loop 把模型给的可见编号映射到
+    /// 本次澄清候选。
+    pub fn with_selection_scope(mut self, scope: SelectionScope) -> Self {
+        self.selection_scope = Some(scope);
+        self
     }
 }
 
@@ -53,6 +68,7 @@ impl Tool for CompleteTodoTool {
             context,
             arguments,
             true,
+            self.selection_scope.clone(),
         )
     }
 
@@ -61,13 +77,35 @@ impl Tool for CompleteTodoTool {
         context: ToolContext,
         arguments: serde_json::Value,
     ) -> Result<ToolOutput, LlmError> {
-        let mut scope = TodoToolScope::load(&self.session_store, &context)?;
+        let mut scope =
+            TodoToolScope::load(&self.session_store, &context, self.selection_scope.clone())?;
         if let Some(output) = scope.take_dedup_output(&context, &arguments)? {
             return Ok(output);
         }
         let resolved =
             resolved_selection_from_arguments(&mut scope, &self.todo_store, &arguments, true)?;
+        if let Some(output) = resolved.error_output.as_ref() {
+            let (error_code, message) = clarification_error_fields(output);
+            return scope.save_clarification(
+                &self.todo_store,
+                COMPLETE_TODOS_TOOL_NAME,
+                &arguments,
+                true,
+                error_code,
+                message,
+            );
+        }
         let ids = prepared_selection_ids(&resolved);
+        if ids.is_empty() {
+            return scope.save_clarification(
+                &self.todo_store,
+                COMPLETE_TODOS_TOOL_NAME,
+                &arguments,
+                true,
+                TODO_SELECTION_NOT_FOUND_CODE,
+                "no visible numbers matched",
+            );
+        }
         // 批量完成 + 清空 last_todo_query / 更新 last_todo_action 统一由 ops 门面维护，
         // 避免与指令侧重写同一套时序。
         let outcome = crate::runtime::todo::ops::complete_many(
@@ -82,6 +120,7 @@ impl Tool for CompleteTodoTool {
         if !completed.is_empty() {
             // 状态变化后清空旧编号快照，避免模型继续沿用已变更的列表；
             // 快照清空和最近对象记忆已由 ops::complete_many 统一维护。
+            scope.clear_clarification_if_scoped();
             scope.save()?;
         }
 

--- a/qq-maid-core/src/runtime/tools/todo/create.rs
+++ b/qq-maid-core/src/runtime/tools/todo/create.rs
@@ -77,7 +77,7 @@ impl Tool for CreateTodoTool {
     ) -> Result<ToolOutput, LlmError> {
         use super::common::required_non_empty_text;
 
-        let mut scope = TodoToolScope::load(&self.session_store, &context)?;
+        let mut scope = TodoToolScope::load(&self.session_store, &context, None)?;
         if let Some(output) = scope.take_dedup_output(&context, &arguments)? {
             return Ok(output);
         }

--- a/qq-maid-core/src/runtime/tools/todo/delete.rs
+++ b/qq-maid-core/src/runtime/tools/todo/delete.rs
@@ -16,7 +16,7 @@ use super::common::{
     number_list_or_reference_schema, todo_tool_error, todo_tool_error_output,
 };
 use super::json::{status_label, todo_items_json};
-use super::scope::TodoToolScope;
+use super::scope::{SelectionScope, TodoToolScope, clarification_error_fields};
 use super::selection::{
     prepare_selection_arguments, prepared_selection_ids, resolved_selection_from_arguments,
     todo_selection_label_text,
@@ -25,6 +25,8 @@ use super::selection::{
 pub struct DeleteTodoTool {
     todo_store: crate::runtime::todo::TodoStore,
     session_store: crate::runtime::session::SessionStore,
+    /// 受限 Tool Loop 注入的请求级选择作用域；普通调用为 `None`。
+    selection_scope: Option<SelectionScope>,
 }
 
 impl DeleteTodoTool {
@@ -35,7 +37,14 @@ impl DeleteTodoTool {
         Self {
             todo_store,
             session_store,
+            selection_scope: None,
         }
+    }
+
+    /// 注入受限 Tool Loop 专属的请求级选择作用域，返回新实例。
+    pub fn with_selection_scope(mut self, scope: SelectionScope) -> Self {
+        self.selection_scope = Some(scope);
+        self
     }
 }
 
@@ -60,6 +69,7 @@ impl Tool for DeleteTodoTool {
             context,
             arguments,
             true,
+            self.selection_scope.clone(),
         )
     }
 
@@ -68,18 +78,34 @@ impl Tool for DeleteTodoTool {
         context: ToolContext,
         arguments: serde_json::Value,
     ) -> Result<ToolOutput, LlmError> {
-        let mut scope = TodoToolScope::load(&self.session_store, &context)?;
+        let mut scope =
+            TodoToolScope::load(&self.session_store, &context, self.selection_scope.clone())?;
         if let Some(output) = scope.take_dedup_output(&context, &arguments)? {
             return Ok(output);
         }
         let resolved =
             resolved_selection_from_arguments(&mut scope, &self.todo_store, &arguments, true)?;
+        if let Some(output) = resolved.error_output.as_ref() {
+            let (error_code, message) = clarification_error_fields(output);
+            return scope.save_clarification(
+                &self.todo_store,
+                DELETE_TODOS_TOOL_NAME,
+                &arguments,
+                true,
+                error_code,
+                message,
+            );
+        }
         let ids = prepared_selection_ids(&resolved);
         if ids.is_empty() {
-            return Ok(todo_tool_error_output(
+            return scope.save_clarification(
+                &self.todo_store,
+                DELETE_TODOS_TOOL_NAME,
+                &arguments,
+                true,
                 TODO_SELECTION_NOT_FOUND_CODE,
                 "no visible numbers matched",
-            ));
+            );
         }
 
         let mut items = Vec::new();
@@ -94,10 +120,14 @@ impl Tool for DeleteTodoTool {
             items.push(item);
         }
         if items.is_empty() {
-            return Ok(todo_tool_error_output(
+            return scope.save_clarification(
+                &self.todo_store,
+                DELETE_TODOS_TOOL_NAME,
+                &arguments,
+                true,
                 TODO_REFERENCE_UNAVAILABLE_CODE,
                 "selected todos no longer exist",
-            ));
+            );
         }
         if items.iter().any(|item| item.status == TodoStatus::Pending) {
             return Ok(todo_tool_error_output(

--- a/qq-maid-core/src/runtime/tools/todo/edit.rs
+++ b/qq-maid-core/src/runtime/tools/todo/edit.rs
@@ -18,12 +18,15 @@ use super::common::{
     todo_tool_error, todo_tool_error_output,
 };
 use super::json::todo_selected_item_json;
-use super::scope::TodoToolScope;
+use super::scope::clarification_error_fields;
+use super::scope::{SelectionScope, TodoToolScope};
 use super::selection::{TodoToolSingleItemResolutionWithDraft, prepared_edit_target};
 
 pub struct EditTodoTool {
     todo_store: crate::runtime::todo::TodoStore,
     session_store: crate::runtime::session::SessionStore,
+    /// 受限 Tool Loop 注入的请求级选择作用域；普通调用为 `None`。
+    selection_scope: Option<SelectionScope>,
 }
 
 impl EditTodoTool {
@@ -34,7 +37,14 @@ impl EditTodoTool {
         Self {
             todo_store,
             session_store,
+            selection_scope: None,
         }
+    }
+
+    /// 注入受限 Tool Loop 专属的请求级选择作用域，返回新实例。
+    pub fn with_selection_scope(mut self, scope: SelectionScope) -> Self {
+        self.selection_scope = Some(scope);
+        self
     }
 }
 
@@ -101,7 +111,8 @@ impl Tool for EditTodoTool {
         };
         use super::selection::resolve_prepared_selection;
 
-        let mut scope = TodoToolScope::load(&self.session_store, context)?;
+        let mut scope =
+            TodoToolScope::load(&self.session_store, context, self.selection_scope.clone())?;
         let selection = single_todo_selection_request(&arguments)?;
         let patch = todo_edit_patch(&arguments)?;
         let raw_text = required_non_empty_text(&arguments, "raw_text")?;
@@ -110,10 +121,13 @@ impl Tool for EditTodoTool {
                 let resolved =
                     resolve_prepared_selection(&mut scope, &selection, &self.todo_store)?;
                 if let Some(error_output) = resolved.error_output {
-                    return Ok(ToolPreparation::ready(json!({
-                        PREBOUND_ERROR_OUTPUT_KEY: error_output,
-                        "raw_text": raw_text,
-                    })));
+                    let mut prepared = arguments.clone();
+                    let object = prepared.as_object_mut().ok_or_else(|| {
+                        bad_tool_arguments("tool arguments must be a JSON object")
+                    })?;
+                    object.insert(PREBOUND_ERROR_OUTPUT_KEY.to_owned(), error_output);
+                    object.insert("raw_text".to_owned(), json!(raw_text));
+                    return Ok(ToolPreparation::ready(prepared));
                 }
                 let id = resolved
                     .matched
@@ -161,7 +175,8 @@ impl Tool for EditTodoTool {
         context: ToolContext,
         arguments: serde_json::Value,
     ) -> Result<ToolOutput, LlmError> {
-        let mut scope = TodoToolScope::load(&self.session_store, &context)?;
+        let mut scope =
+            TodoToolScope::load(&self.session_store, &context, self.selection_scope.clone())?;
         if let Some(output) = scope.take_dedup_output(&context, &arguments)? {
             return Ok(output);
         }
@@ -173,7 +188,17 @@ impl Tool for EditTodoTool {
                     patch,
                     raw_text,
                 } => (item, label, patch, raw_text),
-                TodoToolSingleItemResolutionWithDraft::Output(output) => return Ok(output),
+                TodoToolSingleItemResolutionWithDraft::Output(output) => {
+                    let (error_code, message) = clarification_error_fields(&output);
+                    return scope.save_clarification(
+                        &self.todo_store,
+                        EDIT_TODO_TOOL_NAME,
+                        &arguments,
+                        false,
+                        error_code,
+                        message,
+                    );
+                }
             };
         if item.status != TodoStatus::Pending {
             return Ok(todo_tool_error_output(
@@ -196,6 +221,7 @@ impl Tool for EditTodoTool {
         scope
             .session
             .remember_last_todo_action(&scope.owner.key, &updated, "edited");
+        scope.clear_clarification_if_scoped();
         let output = ToolOutput::json(json!({
             "ok": true,
             "updated": todo_selected_item_json(label, &updated),

--- a/qq-maid-core/src/runtime/tools/todo/list.rs
+++ b/qq-maid-core/src/runtime/tools/todo/list.rs
@@ -56,7 +56,7 @@ impl Tool for ListTodoTool {
     ) -> Result<ToolOutput, LlmError> {
         use super::common::TodoToolListStatus;
 
-        let mut scope = TodoToolScope::load(&self.session_store, &context)?;
+        let mut scope = TodoToolScope::load(&self.session_store, &context, None)?;
         let status = todo_status_argument(&arguments, "status")?;
         let items = match status {
             TodoToolListStatus::Pending => self.todo_store.list_pending(&scope.owner),

--- a/qq-maid-core/src/runtime/tools/todo/restore.rs
+++ b/qq-maid-core/src/runtime/tools/todo/restore.rs
@@ -7,9 +7,12 @@ use qq_maid_llm::tool::{Tool, ToolContext, ToolMetadata, ToolOutput};
 
 use crate::error::LlmError;
 
-use super::common::{RESTORE_TODOS_TOOL_NAME, number_list_or_reference_schema, todo_tool_error};
+use super::common::{
+    RESTORE_TODOS_TOOL_NAME, TODO_SELECTION_NOT_FOUND_CODE, number_list_or_reference_schema,
+    todo_tool_error,
+};
 use super::json::todo_selected_items_json;
-use super::scope::TodoToolScope;
+use super::scope::{SelectionScope, TodoToolScope, clarification_error_fields};
 use super::selection::{
     missing_numbers_json, missing_selection_labels_excluding_items, prepare_selection_arguments,
     prepared_selection_ids, resolved_selection_from_arguments, selected_items_for_result,
@@ -18,6 +21,8 @@ use super::selection::{
 pub struct RestoreTodoTool {
     todo_store: crate::runtime::todo::TodoStore,
     session_store: crate::runtime::session::SessionStore,
+    /// 受限 Tool Loop 注入的请求级选择作用域；普通调用为 `None`。
+    selection_scope: Option<SelectionScope>,
 }
 
 impl RestoreTodoTool {
@@ -28,7 +33,14 @@ impl RestoreTodoTool {
         Self {
             todo_store,
             session_store,
+            selection_scope: None,
         }
+    }
+
+    /// 注入受限 Tool Loop 专属的请求级选择作用域，返回新实例。
+    pub fn with_selection_scope(mut self, scope: SelectionScope) -> Self {
+        self.selection_scope = Some(scope);
+        self
     }
 }
 
@@ -53,6 +65,7 @@ impl Tool for RestoreTodoTool {
             context,
             arguments,
             true,
+            self.selection_scope.clone(),
         )
     }
 
@@ -61,13 +74,35 @@ impl Tool for RestoreTodoTool {
         context: ToolContext,
         arguments: serde_json::Value,
     ) -> Result<ToolOutput, LlmError> {
-        let mut scope = TodoToolScope::load(&self.session_store, &context)?;
+        let mut scope =
+            TodoToolScope::load(&self.session_store, &context, self.selection_scope.clone())?;
         if let Some(output) = scope.take_dedup_output(&context, &arguments)? {
             return Ok(output);
         }
         let resolved =
             resolved_selection_from_arguments(&mut scope, &self.todo_store, &arguments, true)?;
+        if let Some(output) = resolved.error_output.as_ref() {
+            let (error_code, message) = clarification_error_fields(output);
+            return scope.save_clarification(
+                &self.todo_store,
+                RESTORE_TODOS_TOOL_NAME,
+                &arguments,
+                true,
+                error_code,
+                message,
+            );
+        }
         let ids = prepared_selection_ids(&resolved);
+        if ids.is_empty() {
+            return scope.save_clarification(
+                &self.todo_store,
+                RESTORE_TODOS_TOOL_NAME,
+                &arguments,
+                true,
+                TODO_SELECTION_NOT_FOUND_CODE,
+                "no visible numbers matched",
+            );
+        }
         // 同时恢复已完成/已取消两类待办 + 清空 last_todo_query / 更新 last_todo_action
         // 统一由 ops 门面维护，避免与指令侧重写同一套时序。
         let outcome = crate::runtime::todo::ops::restore_both(
@@ -86,6 +121,7 @@ impl Tool for RestoreTodoTool {
         if !restored.is_empty() {
             // 状态变化后清空旧编号快照，避免模型继续沿用已变更的列表；
             // 快照清空和最近对象记忆已由 ops::restore_both 统一维护。
+            scope.clear_clarification_if_scoped();
             scope.save()?;
         }
 

--- a/qq-maid-core/src/runtime/tools/todo/scope.rs
+++ b/qq-maid-core/src/runtime/tools/todo/scope.rs
@@ -6,21 +6,34 @@
 
 use serde_json::Value;
 
+use std::sync::Arc;
+
 use qq_maid_llm::tool::{ToolContext, ToolOutput};
 
 use crate::{
     error::LlmError,
     runtime::{
-        session::{SessionMeta, SessionStore, valid_last_visible_todo_query},
+        pending::{PendingOperation, PendingTodoClarification},
+        session::{SessionMeta, SessionStore, now_iso_cn, valid_last_visible_todo_query},
         todo::{TodoItem, TodoOwner, TodoStore},
     },
 };
 
 use super::common::{
-    TODO_DEDUP_HISTORY_KEY, TODO_DEDUP_HISTORY_LIMIT, TODO_REFERENCE_UNAVAILABLE_CODE,
+    PREBOUND_EDIT_DRAFT_KEY, PREBOUND_ERROR_OUTPUT_KEY, PREBOUND_SELECTION_KEY,
+    PREBOUND_SINGLE_ID_KEY, PREBOUND_SINGLE_LABEL_KEY, TODO_DEDUP_HISTORY_KEY,
+    TODO_DEDUP_HISTORY_LIMIT, TODO_REFERENCE_UNAVAILABLE_CODE, TODO_SELECTION_NOT_FOUND_CODE,
     TODO_VISIBLE_NUMBERS_UNAVAILABLE_CODE, TodoReference, TodoSelectionLabel, TodoSelectionRequest,
     TodoToolDedupEntry, session_tool_error, todo_tool_error, todo_tool_error_output,
 };
+
+/// 受限 Tool Loop 专属的请求级选择作用域：按展示顺序排列的内部 ID 列表。
+///
+/// 该作用域是运行时内存态覆盖，由澄清恢复路径在构造受限 TodoTool 实例时注入，
+/// **不写入 Session / 数据库 / 全局共享状态**。`resolve_numbers` 优先用它把模型
+/// 给的 `numbers=[n]` 映射到本次澄清候选，只有它为空时才回退到会话默认的
+/// `last_todo_query` 快照，避免澄清候选污染后续“第二条”“刚刚列表”等语义。
+pub(crate) type SelectionScope = Arc<[String]>;
 
 /// 一次工具调用的 session + owner 作用域。
 ///
@@ -30,6 +43,8 @@ pub(in crate::runtime::tools::todo) struct TodoToolScope {
     pub owner: TodoOwner,
     pub session: crate::runtime::session::SessionRecord,
     pub session_store: SessionStore,
+    /// 本次调用可选的请求级选择作用域覆盖；`None` 走默认 `last_todo_query` 解析。
+    selection_scope: Option<SelectionScope>,
 }
 
 /// 可见编号 / 最近对象引用解析后出现错误时，用一条结构化输出替代抛 Err。
@@ -130,9 +145,13 @@ impl TodoToolScope {
     ///
     /// 这里只接受 `private:` 作用域，避免群聊里误开 Todo Tool 把共享 session
     /// 写满 pending。鉴权失败抛 Err，让 Tool Loop 直接报错而非降级。
+    ///
+    /// `selection_scope` 为受限 Tool Loop 注入的请求级选择作用域；普通调用传 `None`，
+    /// 编号解析走会话默认 `last_todo_query` 快照。
     pub(in crate::runtime::tools::todo) fn load(
         session_store: &SessionStore,
         context: &ToolContext,
+        selection_scope: Option<SelectionScope>,
     ) -> Result<Self, LlmError> {
         let user_id = context
             .user_id
@@ -169,6 +188,7 @@ impl TodoToolScope {
             owner,
             session,
             session_store: session_store.clone(),
+            selection_scope,
         })
     }
 
@@ -205,6 +225,36 @@ impl TodoToolScope {
     }
 
     fn resolve_numbers(&mut self, numbers: &[usize]) -> Result<ResolvedTodoSelection, LlmError> {
+        // 受限 Tool Loop 注入了请求级选择作用域时优先用它，把模型给的可见编号映射到
+        // 本次澄清候选；只有未注入时才回退会话默认 `last_todo_query` 快照。
+        let scoped_ids = self.selection_scope.as_deref();
+        let scoped_match = |number: usize| -> Option<String> {
+            scoped_ids?
+                .get(number.saturating_sub(1))
+                .filter(|_| number > 0)
+                .cloned()
+        };
+        if scoped_ids.is_some() {
+            let mut matched = Vec::new();
+            let mut missing = Vec::new();
+            let mut labels = Vec::new();
+            for number in numbers {
+                let label = TodoSelectionLabel::Number(*number);
+                labels.push(label.clone());
+                if let Some(id) = scoped_match(*number) {
+                    matched.push((label, id));
+                } else {
+                    missing.push(label);
+                }
+            }
+            return Ok(ResolvedTodoSelection {
+                labels,
+                matched,
+                missing,
+                error_output: None,
+            });
+        }
+
         let query = valid_last_visible_todo_query(&mut self.session, &self.owner.key);
         let Some(query) = query else {
             return Ok(ResolvedTodoSelection::error(
@@ -269,6 +319,22 @@ impl TodoToolScope {
         self.session_store
             .save(&mut self.session)
             .map_err(session_tool_error)
+    }
+
+    /// 受限澄清恢复 Loop 中，原工具已经真实完成副作用时清除原 `TodoClarify`。
+    ///
+    /// 只在请求级选择作用域存在且当前 pending 仍是同 owner 的 `TodoClarify` 时生效；
+    /// 如果工具已替换成确认 pending（如 `TodoBulkDelete`），这里不会覆盖它。
+    pub(in crate::runtime::tools::todo) fn clear_clarification_if_scoped(&mut self) {
+        if self.selection_scope.is_none() {
+            return;
+        }
+        if matches!(
+            self.session.pending_operation.as_ref(),
+            Some(PendingOperation::TodoClarify { owner_key, .. }) if owner_key == &self.owner.key
+        ) {
+            self.session.pending_operation = None;
+        }
     }
 
     /// 同一 call_id + 相同参数二次执行时直接复用上一次输出，避免重复 pending。
@@ -349,7 +415,20 @@ impl TodoToolScope {
     }
 
     /// 当前对话已有 pending 时拒绝覆盖，避免模型连续写工具静默丢失前一个确认。
+    ///
+    /// 受限澄清恢复 Loop 会把原 `TodoClarify` 保留在 Session 中运行原工具；当工具
+    /// 成功推进到 `TodoDelete` / `TodoBulkDelete` 等确认 pending 时，需要允许同 owner
+    /// 的 `TodoClarify` 被原工具原子替换。普通 Tool Loop 没有 `selection_scope`，仍保持
+    /// 严格拒绝，避免多个工具互相覆盖 pending。
     pub(in crate::runtime::tools::todo) fn ensure_no_pending(&self) -> Result<(), LlmError> {
+        if self.selection_scope.is_some()
+            && matches!(
+                self.session.pending_operation.as_ref(),
+                Some(PendingOperation::TodoClarify { owner_key, .. }) if owner_key == &self.owner.key
+            )
+        {
+            return Ok(());
+        }
         if self.session.pending_operation.is_some() {
             return Err(LlmError::new(
                 "pending_operation_exists",
@@ -358,6 +437,77 @@ impl TodoToolScope {
             ));
         }
         Ok(())
+    }
+
+    /// 将选择失败保存为可恢复的澄清 pending。
+    ///
+    /// 这里会剥离 prepare 阶段写入的内部预绑定字段，pending 中只保留原工具名、
+    /// 原始参数、澄清原因和本次候选集；用户补充后必须重新读取 TodoStore 校验当前目标。
+    /// 候选集按 `tool_name` 可接受的状态从 `todo_store` 查出，并在 pending 中保存为
+    /// 精简结构（不持久化完整 `TodoItem`），恢复时用作请求级选择作用域。
+    pub(in crate::runtime::tools::todo) fn save_clarification(
+        &mut self,
+        todo_store: &TodoStore,
+        tool_name: &str,
+        arguments: &Value,
+        allow_many: bool,
+        error_code: &str,
+        message: &str,
+    ) -> Result<ToolOutput, LlmError> {
+        use super::common::{
+            CANCEL_TODO_TOOL_NAME, COMPLETE_TODOS_TOOL_NAME, DELETE_TODOS_TOOL_NAME,
+            EDIT_TODO_TOOL_NAME, RESTORE_TODOS_TOOL_NAME,
+        };
+
+        if self.selection_scope.is_some() {
+            let question = clarification_question(error_code, message, &[]);
+            return Ok(ToolOutput::json(serde_json::json!({
+                "ok": false,
+                "requires_clarification": true,
+                "pending_action": "clarify",
+                "error_code": error_code,
+                "message": message,
+                "question": question,
+            })));
+        }
+
+        self.ensure_no_pending()?;
+        let candidates = match tool_name {
+            COMPLETE_TODOS_TOOL_NAME | EDIT_TODO_TOOL_NAME | CANCEL_TODO_TOOL_NAME => {
+                clarification_candidates_from(todo_store, &self.owner, false)
+                    .map_err(todo_tool_error)?
+            }
+            RESTORE_TODOS_TOOL_NAME | DELETE_TODOS_TOOL_NAME => {
+                clarification_candidates_from(todo_store, &self.owner, true)
+                    .map_err(todo_tool_error)?
+            }
+            _ => Vec::new(),
+        };
+        let question = clarification_question(error_code, message, &candidates);
+        let created_at = now_iso_cn();
+        self.session.pending_operation = Some(PendingOperation::TodoClarify {
+            initiator_user_id: self.owner.user_id.clone(),
+            owner_key: self.owner.key.clone(),
+            request: PendingTodoClarification {
+                tool_name: tool_name.to_owned(),
+                arguments: sanitize_clarification_arguments(arguments),
+                allow_many,
+                error_code: error_code.to_owned(),
+                question: question.clone(),
+                candidates,
+                created_at: created_at.clone(),
+            },
+            created_at,
+        });
+        self.save()?;
+        Ok(ToolOutput::json(serde_json::json!({
+            "ok": false,
+            "requires_clarification": true,
+            "pending_action": "clarify",
+            "error_code": error_code,
+            "message": message,
+            "question": question,
+        })))
     }
 }
 
@@ -368,4 +518,104 @@ pub(in crate::runtime::tools::todo) fn dedup_call_key(context: &ToolContext) -> 
         .map(str::trim)
         .filter(|value| !value.is_empty())?;
     Some(format!("{}:{tool_call_id}", context.task_id))
+}
+
+pub(in crate::runtime::tools::todo) fn clarification_error_fields(
+    output: &ToolOutput,
+) -> (&str, &str) {
+    let error_code = output
+        .value
+        .get("error_code")
+        .and_then(Value::as_str)
+        .unwrap_or(TODO_SELECTION_NOT_FOUND_CODE);
+    let message = output
+        .value
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or("todo target is unavailable");
+    (error_code, message)
+}
+
+fn clarification_question(
+    error_code: &str,
+    message: &str,
+    candidates: &[crate::runtime::pending::ClarificationCandidate],
+) -> String {
+    use crate::runtime::pending::ClarificationCandidate;
+    let candidate_lines = |items: &[ClarificationCandidate]| -> String {
+        if items.is_empty() {
+            return String::new();
+        }
+        let body = items
+            .iter()
+            .map(|item| format!("{}. {}", item.display_number, item.title))
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!("\n可选待办：\n{body}")
+    };
+    let list = candidate_lines(candidates);
+    match error_code {
+        TODO_VISIBLE_NUMBERS_UNAVAILABLE_CODE => format!(
+            "我现在没有可用的待办列表编号。请告诉我要操作哪条待办的标题关键词，或回复编号选择这次列出的候选。{list}"
+        ),
+        TODO_REFERENCE_UNAVAILABLE_CODE => format!(
+            "我现在不能唯一确定“刚才那个/它”指哪条待办。请补充这条待办的标题关键词，或回复编号选择下面列出的候选。{list}"
+        ),
+        TODO_SELECTION_NOT_FOUND_CODE => format!(
+            "这次选择的待办已经不可用或编号不存在。请补充这条待办的标题关键词，或回复编号选择下面列出的候选。{list}"
+        ),
+        _ => format!("请补充要操作哪条待办。{message}{list}"),
+    }
+}
+
+/// 按 `terminal_only` 选择候选集：完成/编辑/取消看未完成，恢复/删除看已完成+已取消。
+/// 候选数量与单项标题长度有上限，避免持久化过大的 pending。
+fn clarification_candidates_from(
+    todo_store: &TodoStore,
+    owner: &crate::runtime::todo::TodoOwner,
+    terminal_only: bool,
+) -> Result<Vec<crate::runtime::pending::ClarificationCandidate>, crate::runtime::todo::TodoError> {
+    use crate::runtime::pending::ClarificationCandidate;
+    const MAX_CANDIDATES: usize = 20;
+    const MAX_TITLE_CHARS: usize = 80;
+    let mut items = if terminal_only {
+        let mut items = todo_store.list_completed(owner)?;
+        items.extend(todo_store.list_cancelled(owner)?);
+        items
+    } else {
+        todo_store.list_pending(owner)?
+    };
+    items.truncate(MAX_CANDIDATES);
+    Ok(items
+        .into_iter()
+        .enumerate()
+        .map(|(index, item)| ClarificationCandidate {
+            id: item.id,
+            display_number: index + 1,
+            title: item.title.chars().take(MAX_TITLE_CHARS).collect::<String>(),
+            status: item.status,
+        })
+        .collect())
+}
+
+fn sanitize_clarification_arguments(arguments: &Value) -> Value {
+    let Value::Object(object) = arguments else {
+        return arguments.clone();
+    };
+    let mut sanitized = serde_json::Map::new();
+    for (key, value) in object {
+        if matches!(
+            key.as_str(),
+            PREBOUND_SELECTION_KEY
+                | PREBOUND_SINGLE_ID_KEY
+                | PREBOUND_SINGLE_LABEL_KEY
+                | PREBOUND_EDIT_DRAFT_KEY
+                | PREBOUND_ERROR_OUTPUT_KEY
+        ) || key.starts_with('_')
+        {
+            continue;
+        }
+        sanitized.insert(key.clone(), value.clone());
+    }
+    Value::Object(sanitized)
 }

--- a/qq-maid-core/src/runtime/tools/todo/selection.rs
+++ b/qq-maid-core/src/runtime/tools/todo/selection.rs
@@ -120,14 +120,17 @@ pub(in crate::runtime::tools::todo) fn resolved_selection_from_arguments(
 }
 
 /// 多编号 Tool 的通用 prepare：解析 selection，写回预解析，按 reference/numbers 设置依赖。
+///
+/// `selection_scope` 为受限 Tool Loop 注入的请求级选择作用域；普通调用传 `None`。
 pub(in crate::runtime::tools::todo) fn prepare_selection_arguments(
     session_store: &crate::runtime::session::SessionStore,
     todo_store: &TodoStore,
     context: &ToolContext,
     arguments: Value,
     allow_many: bool,
+    selection_scope: Option<super::scope::SelectionScope>,
 ) -> Result<ToolPreparation, LlmError> {
-    let mut scope = TodoToolScope::load(session_store, context)?;
+    let mut scope = TodoToolScope::load(session_store, context, selection_scope)?;
     let selection = if allow_many {
         todo_selection_request(&arguments, true)?
     } else {

--- a/qq-maid-core/src/runtime/tools/todo/tests.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests.rs
@@ -307,3 +307,42 @@ async fn create_tool_replay_with_same_call_id_does_not_duplicate_pending() {
         Some(PendingOperation::TodoAdd { .. })
     ));
 }
+
+#[tokio::test]
+async fn unresolved_last_reference_creates_todo_clarification_pending() {
+    let (todo_store, session_store, _owner) = test_stores();
+    let complete_tool = CompleteTodoTool::new(todo_store, session_store.clone());
+
+    let output = complete_tool
+        .execute(
+            test_context(),
+            json!({"numbers": null, "reference": "last"}),
+        )
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(output["ok"], false);
+    assert_eq!(output["requires_clarification"], true);
+    assert_eq!(output["pending_action"], "clarify");
+    let session = session_store
+        .get_or_create_active(&SessionMeta::new(
+            "private:u1",
+            Some("u1".to_owned()),
+            None,
+            None,
+            None,
+            "qq_official",
+        ))
+        .unwrap();
+    match session.pending_operation {
+        Some(PendingOperation::TodoClarify { request, .. }) => {
+            assert_eq!(request.tool_name, "complete_todos");
+            assert_eq!(
+                request.arguments,
+                json!({"numbers": null, "reference": "last"})
+            );
+        }
+        other => panic!("unexpected pending operation: {other:?}"),
+    }
+}

--- a/qq-maid-llm/src/tool.rs
+++ b/qq-maid-llm/src/tool.rs
@@ -179,8 +179,46 @@ impl ToolRegistry {
         Ok(())
     }
 
+    /// 用同名工具替换已注册实例，用于受限 Tool Loop 的请求级工具覆盖。
+    ///
+    /// 典型场景：澄清恢复需要为原 Todo 工具注入本次候选作用域，但又不污染主注册表
+    /// 与全局状态时，先 [`subset`](Self::subset) 出受限白名单，再用本方法把对应工具
+    /// 替换成携带请求级状态的实例。名字未注册时报错，避免静默新增工具绕过白名单。
+    pub fn replace(&mut self, tool: DynTool) -> Result<(), LlmError> {
+        let metadata = tool.metadata();
+        validate_tool_name(&metadata.name)?;
+        let tools = Arc::make_mut(&mut self.tools);
+        if !tools.contains_key(&metadata.name) {
+            return Err(LlmError::config(format!(
+                "cannot replace unregistered tool `{}`",
+                metadata.name
+            )));
+        }
+        tools.insert(metadata.name, tool);
+        Ok(())
+    }
+
     pub fn is_empty(&self) -> bool {
         self.tools.is_empty()
+    }
+
+    /// 构造一个只包含指定工具的受限注册表，复用原工具实例与限额。
+    ///
+    /// 用于澄清恢复等受限 Tool Loop：只开放原任务所需工具，禁止模型切换到其他有
+    /// 副作用工具。返回的注册表克隆同一份 `Arc<dyn Tool>`，因此与主注册表共享同一
+    /// 份 store / session 依赖，执行语义完全一致。任一指定工具不存在则报错，避免
+    /// 静默开放空注册表导致受限 Loop 无法执行原任务。
+    pub fn subset(&self, names: &[&str]) -> Result<ToolRegistry, LlmError> {
+        let mut restricted = ToolRegistry::new().with_limits(self.timeout, self.output_max_chars);
+        for name in names {
+            let Some(tool) = self.tools.get(*name).cloned() else {
+                return Err(LlmError::config(format!(
+                    "tool `{name}` not found for restricted subset"
+                )));
+            };
+            restricted.insert(tool)?;
+        }
+        Ok(restricted)
     }
 
     pub fn metadata(&self) -> Vec<ToolMetadata> {
@@ -496,5 +534,108 @@ mod tests {
         assert!(output.chars().count() <= MIN_TOOL_OUTPUT_MAX_CHARS);
         let parsed: Value = serde_json::from_str(&output).expect("output must be valid JSON");
         assert_eq!(parsed["truncated"], Value::Bool(true));
+    }
+
+    struct TaggedEcho {
+        name: String,
+        tag: &'static str,
+    }
+
+    #[async_trait]
+    impl Tool for TaggedEcho {
+        fn metadata(&self) -> ToolMetadata {
+            ToolMetadata {
+                name: self.name.clone(),
+                description: "tagged echo".to_owned(),
+                parameters: json!({"type": "object", "properties": {}}),
+            }
+        }
+
+        async fn execute(
+            &self,
+            _context: ToolContext,
+            _arguments: Value,
+        ) -> Result<ToolOutput, LlmError> {
+            Ok(ToolOutput::json(json!({"tag": self.tag})))
+        }
+    }
+
+    #[tokio::test]
+    async fn registry_subset_keeps_whitelist_and_limits() {
+        let registry = ToolRegistry::new()
+            .with_limits(DEFAULT_TOOL_TIMEOUT, 123)
+            .register(EchoTool)
+            .unwrap()
+            .register(TaggedEcho {
+                name: "alpha".to_owned(),
+                tag: "a",
+            })
+            .unwrap()
+            .register(TaggedEcho {
+                name: "beta".to_owned(),
+                tag: "b",
+            })
+            .unwrap();
+
+        let restricted = registry.subset(&["alpha", "beta"]).unwrap();
+        assert_eq!(restricted.output_max_chars, 123);
+        assert_eq!(restricted.metadata().len(), 2);
+        // 白名单外的工具不可执行。
+        let err = restricted
+            .execute_json(&test_context(), "echo", "{}")
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, "tool_not_found");
+        // 请求未注册的名字报错。
+        let err = match registry.subset(&["missing"]) {
+            Ok(_) => panic!("subset of unknown tool should fail"),
+            Err(err) => err,
+        };
+        assert_eq!(err.code, "config");
+    }
+
+    #[tokio::test]
+    async fn registry_replace_swaps_tool_instance_for_request_scoped_override() {
+        let mut registry = ToolRegistry::new()
+            .register(TaggedEcho {
+                name: "alpha".to_owned(),
+                tag: "original",
+            })
+            .unwrap();
+
+        let original = registry
+            .execute_json(&test_context(), "alpha", "{}")
+            .await
+            .unwrap();
+        assert_eq!(
+            serde_json::from_str::<Value>(&original).unwrap()["tag"],
+            "original"
+        );
+
+        registry
+            .replace(Arc::new(TaggedEcho {
+                name: "alpha".to_owned(),
+                tag: "overridden",
+            }) as DynTool)
+            .unwrap();
+        let overridden = registry
+            .execute_json(&test_context(), "alpha", "{}")
+            .await
+            .unwrap();
+        assert_eq!(
+            serde_json::from_str::<Value>(&overridden).unwrap()["tag"],
+            "overridden"
+        );
+
+        // 名字未注册时报错，避免静默新增工具绕过白名单。
+        let err = match registry.replace(Arc::new(TaggedEcho {
+            name: "ghost".to_owned(),
+            tag: "x",
+        }) as DynTool)
+        {
+            Ok(_) => panic!("replace of unregistered tool should fail"),
+            Err(err) => err,
+        };
+        assert_eq!(err.code, "config");
     }
 }


### PR DESCRIPTION
## 概述

实现 Agent Loop 3/5：统一语义澄清、Pending 与受限任务恢复（#139）。前置 #138 已合并。

## 架构要点

### 职责边界

| 层 | 负责 |
|---|---|
| LLM（受限 Tool Loop） | 理解用户补充，选择候选，调用原 Todo Tool |
| Pending TodoClarify | 保存原工具名、原始参数、精简候选边界；不解析自然语言、不直接调用 ops |
| Todo Tool（原实例 + 请求级 scope） | 重新读取 TodoStore，校验状态/权限，执行副作用 |

### 核心变更

- PendingTodoClarification 增加 candidates（id + display_number + title + status），不持久化完整 TodoItem。旧 pending 缺失该字段时兼容为空
- ClarificationControlTool：无副作用，支持 ask_again / abandon
- ToolRegistry::subset + replace：subset 保证白名单，replace 请求级覆盖
- 请求级 SelectionScope：resolve_numbers 优先使用 scope，其次 last_todo_query；不写入 Session/DB/全局状态
- 澄清态放弃判定：is_clarification_abandon_text 只识别独立元指令，避免“取消第一条”误清 pending

### 删除的 Pending 层错误逻辑

- resume/resolve/clarification
- parse_visible_numbers / parse_simple_chinese_ordinal
- todo_item_matches_text / normalize_match_text
- clarification_candidates / clarification_accepts_status
- edit_patch_from_arguments / item_ids / ClarificationResolution

## 测试

新增 12 条 todo_clarification_* 测试，覆盖候选 scope、取消/过期安全、编号越界、Loop/工具失败保留 pending、无工具调用更新问题、abandon、confirm pending 替换、cancel_todo “取消第一条”不误清等。

## 检查清单

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features
- git diff --check
- 未写入敏感信息

## 未完成

- replan_current_message（新独立请求重入正常规划）：当前 LLM 可调用 abandon 安全放弃。
- todo_guard success 验真：受限 Tool Loop 重入路径暂不启用。
