### PR TITLE
feat: 建立 Tool Loop 最终可信回复的 Core 事件流 (#140)

### DIFF
--- a/qq-maid-core/src/runtime/tools/todo/scope.rs
+++ b/qq-maid-core/src/runtime/tools/todo/scope.rs
@@ -310,12 +310,13 @@ impl TodoToolScope {
             });
         }
 
-        let query = if let Some(query) =
-            valid_last_visible_todo_query(&mut self.session, &self.owner.key)
-        {
+        // 同一 Tool Loop 内刚由 `list_todos` 产生的编号优先级高于旧用户可见快照。
+        // 否则模型在同轮工具链里根据当前查询结果传入 numbers 时，可能被上一轮
+        // `last_todo_query` 静默映射到旧列表，造成完成/恢复/删除错待办。
+        let query = if let Some(query) = self.valid_task_todo_query()? {
             Some(query)
         } else {
-            self.valid_task_todo_query()?
+            valid_last_visible_todo_query(&mut self.session, &self.owner.key)
         };
         let Some(query) = query else {
             return Ok(ResolvedTodoSelection::error(

--- a/qq-maid-core/src/runtime/tools/todo/tests.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests.rs
@@ -328,6 +328,91 @@ async fn create_tool_replay_with_same_call_id_does_not_duplicate_created_todo() 
 }
 
 #[tokio::test]
+async fn same_task_query_numbers_prefer_current_list_over_stale_visible_snapshot() {
+    let (todo_store, session_store, owner) = test_stores();
+    let stale_visible = todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "旧可见列表第一条".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    let current_completed = todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "当前已完成第一条".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    todo_store.complete(&owner, &current_completed.id).unwrap();
+    let mut session = session_store
+        .get_or_create_active(&SessionMeta::new(
+            "private:u1",
+            Some("u1".to_owned()),
+            None,
+            None,
+            None,
+            "qq_official",
+        ))
+        .unwrap();
+    session.remember_last_todo_query(
+        &owner.key,
+        "pending",
+        "旧列表",
+        vec![stale_visible.id.clone()],
+    );
+    session_store.save(&mut session).unwrap();
+    let list_tool = ListTodoTool::new(todo_store.clone(), session_store.clone());
+    let restore_tool = super::RestoreTodoTool::new(todo_store.clone(), session_store);
+    let context = test_context();
+
+    let listed = list_tool
+        .execute(context.clone(), json!({"status":"completed"}))
+        .await
+        .unwrap()
+        .value;
+    assert_eq!(listed["items"][0]["visible_number"], 1);
+    assert_eq!(listed["items"][0]["title"], "当前已完成第一条");
+
+    let restored = restore_tool
+        .execute(context, json!({"numbers":[1], "reference": null}))
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(restored["ok"], true);
+    assert_eq!(restored["restored"][0]["title"], "当前已完成第一条");
+    assert_eq!(
+        todo_store
+            .get_by_id(&owner, &current_completed.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
+    assert_eq!(
+        todo_store
+            .get_by_id(&owner, &stale_visible.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
+}
+
+#[tokio::test]
 async fn create_then_edit_reference_last_updates_same_todo_without_pending() {
     let (todo_store, session_store, owner) = test_stores();
     let create_tool = CreateTodoTool::new(todo_store.clone(), session_store.clone());
@@ -723,7 +808,7 @@ async fn delete_tool_query_pending_match_rejects_permanent_delete() {
 }
 
 #[tokio::test]
-async fn delete_numbers_prefer_user_visible_snapshot_over_internal_list() {
+async fn delete_numbers_prefer_current_task_query_over_stale_visible_snapshot() {
     let (todo_store, session_store, owner) = test_stores();
     let pending = todo_store
         .create(
@@ -797,7 +882,7 @@ async fn delete_numbers_prefer_user_visible_snapshot_over_internal_list() {
     let output = delete_tool
         .execute(
             test_context(),
-            json!({"numbers": [3], "reference": null, "query": null, "all_status": null}),
+            json!({"numbers": [1], "reference": null, "query": null, "all_status": null}),
         )
         .await
         .unwrap()
@@ -815,7 +900,9 @@ async fn delete_numbers_prefer_user_visible_snapshot_over_internal_list() {
         ))
         .unwrap();
     match session.pending_operation {
-        Some(PendingOperation::TodoDelete { item, .. }) => assert_eq!(item.title, "和老公出门"),
+        Some(PendingOperation::TodoDelete { item, .. }) => {
+            assert_eq!(item.title, "内部已取消第一条")
+        }
         other => panic!("expected single delete pending, got {other:?}"),
     }
 }

--- a/qq-maid-core/src/service/mod.rs
+++ b/qq-maid-core/src/service/mod.rs
@@ -15,7 +15,7 @@ use std::{
 
 use async_trait::async_trait;
 use tokio::{sync::mpsc, time::timeout};
-use tracing::{error, info, warn};
+use tracing::{error, warn};
 
 use crate::{
     config::AppConfig,
@@ -108,6 +108,10 @@ pub struct CoreResponseStream {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CoreResponseEvent {
+    /// 用户可见的最终文本增量。
+    ///
+    /// Tool Loop 路径只会在工具循环完成、业务校验通过并生成最终回复后发送该事件；
+    /// 工具参数、工具结果原文和模型中间候选文本不得通过此事件外发。
     TextDelta(String),
     Completed(CoreResponse),
     Failed(CoreRespondFailure),
@@ -191,15 +195,10 @@ impl CoreService for CoreHandle {
         let scope_key = req.scope_key.clone();
         let state = self.state.as_ref();
         let respond_plan = service.plan_core_respond(&req).map_err(CoreError::from)?;
-        if matches!(respond_plan, RespondPlan::CompleteToolLoop) {
-            info!(
-                scope_key,
-                transport = "complete",
-                reason = "private_agent_tool_loop",
-                "core respond stream bypassed for tool loop"
-            );
-        }
-        if matches!(respond_plan, RespondPlan::StreamingChat) {
+        if matches!(
+            respond_plan,
+            RespondPlan::StreamingChat | RespondPlan::CompleteToolLoop
+        ) {
             let provider_stream_enabled = state.provider.stream_enabled();
             let result = timeout(
                 Duration::from_secs(state.config.request_timeout_seconds),
@@ -207,7 +206,9 @@ impl CoreService for CoreHandle {
                     Ok::<_, LlmError>(start_core_response_stream(
                         service,
                         req,
+                        respond_plan,
                         provider_stream_enabled,
+                        Duration::from_secs(state.config.request_timeout_seconds),
                     ))
                 },
             )
@@ -351,7 +352,9 @@ impl Drop for CoreResponseStream {
 fn start_core_response_stream(
     service: RustRespondService,
     req: RespondRequest,
+    plan: RespondPlan,
     provider_stream_enabled: bool,
+    request_timeout: Duration,
 ) -> CoreResponseStream {
     let (tx, receiver) = mpsc::channel(16);
     let cancelled = Arc::new(AtomicBool::new(false));
@@ -364,14 +367,22 @@ fn start_core_response_stream(
                 .await;
             return;
         }
-        let result = run_streaming_respond(
+        let respond_future = run_streaming_respond(
             &service,
             req,
+            plan,
             tx.clone(),
             producer_cancelled.clone(),
             provider_stream_enabled,
-        )
-        .await;
+        );
+        let result = if matches!(plan, RespondPlan::CompleteToolLoop) {
+            match timeout(request_timeout, respond_future).await {
+                Ok(result) => result,
+                Err(_) => Err(LlmError::timeout("request")),
+            }
+        } else {
+            respond_future.await
+        };
         if producer_cancelled.load(Ordering::SeqCst) {
             return;
         }
@@ -407,24 +418,14 @@ fn start_core_response_stream(
 async fn run_streaming_respond(
     service: &RustRespondService,
     req: RespondRequest,
+    plan: RespondPlan,
     tx: mpsc::Sender<CoreResponseEvent>,
     cancelled: Arc<AtomicBool>,
     provider_stream_enabled: bool,
 ) -> Result<RespondResponse, LlmError> {
-    if !provider_stream_enabled {
-        let response = service.respond(req).await?;
-        // provider 流式关闭时仍维持 Core/Gateway 的进程内流契约；
-        // 这里合成单个 delta，但上游请求保持原有非 SSE 行为。
-        if response.ok
-            && let Some(delta) = response
-                .markdown
-                .as_deref()
-                .or(response.text.as_deref())
-                .map(str::to_owned)
-                .filter(|value| !value.trim().is_empty())
-        {
-            send_core_delta(&tx, &cancelled, delta).await?;
-        }
+    if matches!(plan, RespondPlan::CompleteToolLoop) || !provider_stream_enabled {
+        let response = service.respond_with_plan(req, plan).await?;
+        send_final_response_delta(&tx, &cancelled, &response).await?;
         return Ok(response);
     }
     service
@@ -434,6 +435,27 @@ async fn run_streaming_respond(
             Box::pin(async move { send_core_delta(&tx, &cancelled, delta).await })
         })
         .await
+}
+
+async fn send_final_response_delta(
+    tx: &mpsc::Sender<CoreResponseEvent>,
+    cancelled: &Arc<AtomicBool>,
+    response: &RespondResponse,
+) -> Result<(), LlmError> {
+    // 非 SSE 或 Tool Loop 路径只在完整响应完成后合成用户可见增量。
+    // 对 Tool Loop 来说，这也是最终可信回复的边界：此时工具副作用、Todo 成功校验、
+    // session/history 和 diagnostics 均已由 RespondService 完成提交。
+    if response.ok
+        && let Some(delta) = response
+            .markdown
+            .as_deref()
+            .or(response.text.as_deref())
+            .map(str::to_owned)
+            .filter(|value| !value.trim().is_empty())
+    {
+        send_core_delta(tx, cancelled, delta).await?;
+    }
+    Ok(())
 }
 
 async fn send_core_delta(

--- a/qq-maid-core/src/service/tests.rs
+++ b/qq-maid-core/src/service/tests.rs
@@ -349,23 +349,114 @@ async fn stream_disabled_chat_is_wrapped_as_process_stream() {
 }
 
 #[tokio::test]
-async fn core_private_weather_chat_with_tool_capability_uses_complete_tool_loop_path() {
+async fn core_private_weather_chat_with_tool_capability_streams_final_tool_loop_reply() {
     let provider = TestProvider::replying("工具完整回复")
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_tool_calling(provider.clone(), 5, true);
     let service = CoreHandle::new(state);
 
-    let output = service
-        .respond(private_request("杭州明天要带伞吗"))
-        .await
-        .unwrap();
+    let mut stream = expect_stream(
+        service
+            .respond(private_request("杭州明天要带伞吗"))
+            .await
+            .unwrap(),
+    );
 
-    let CoreRespondOutput::Complete(response) = output else {
-        panic!("expected complete output for tool loop path");
+    assert_eq!(
+        stream.recv().await,
+        Some(CoreResponseEvent::TextDelta("工具完整回复".to_owned()))
+    );
+    let Some(CoreResponseEvent::Completed(response)) = stream.recv().await else {
+        panic!("expected completed response");
     };
+
     assert_eq!(response.text.as_deref(), Some("工具完整回复"));
     assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
     assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn core_tool_loop_stream_buffers_until_final_answer_is_trusted() {
+    let provider = TestProvider::streaming(vec![
+        Ok(LlmStreamEvent::TextDelta("候选草稿".to_owned())),
+        Ok(LlmStreamEvent::Completed {
+            usage: None,
+            finish_reason: None,
+            fallback_used: false,
+        }),
+    ])
+    .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let state = test_state_with_tool_calling(provider.clone(), 5, true);
+    let service = CoreHandle::new(state);
+
+    let mut stream = expect_stream(
+        service
+            .respond(private_request("帮我新增待办"))
+            .await
+            .unwrap(),
+    );
+
+    assert_eq!(
+        stream.recv().await,
+        Some(CoreResponseEvent::TextDelta("候选草稿".to_owned()))
+    );
+    let Some(CoreResponseEvent::Completed(response)) = stream.recv().await else {
+        panic!("expected completed response");
+    };
+
+    assert_eq!(response.text.as_deref(), Some("候选草稿"));
+    // Tool Loop 事件流来自完整 Tool Loop 的最终结果，不消费 provider token 流，
+    // 因而不会提前外发任何模型中间文本或工具过程。
+    assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn core_tool_loop_failure_is_reported_as_stream_failure_without_delta() {
+    let provider = TestProvider::failing(LlmError::new(
+        "tool_loop_limit",
+        "tool loop exceeded maximum rounds",
+        "tool_loop",
+    ))
+    .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let state = test_state_with_tool_calling(provider.clone(), 5, true);
+    let service = CoreHandle::new(state);
+
+    let CoreRespondOutput::Stream(mut stream) = service
+        .respond(private_request("杭州明天要带伞吗"))
+        .await
+        .unwrap()
+    else {
+        panic!("expected stream output");
+    };
+    let Some(CoreResponseEvent::Failed(failure)) = stream.recv().await else {
+        panic!("expected failure event before any text delta");
+    };
+
+    assert_eq!(failure.kind, CoreFailureKind::Internal);
+    assert!(!failure.retryable);
+    assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn core_tool_loop_stream_preserves_request_timeout_for_background_complete_path() {
+    let provider = TestProvider::delayed("迟到回复", Duration::from_millis(80))
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let state = test_state_with_tool_calling(provider.clone(), 0, true);
+    let service = CoreHandle::new(state);
+    let CoreRespondOutput::Stream(mut stream) =
+        service.respond(private_request("晚上好")).await.unwrap()
+    else {
+        panic!("expected stream output");
+    };
+
+    let Some(CoreResponseEvent::Failed(failure)) = stream.recv().await else {
+        panic!("expected timeout failure before any text delta");
+    };
+
+    assert_eq!(failure.kind, CoreFailureKind::LlmTimeout);
+    assert!(failure.retryable);
 }
 
 #[tokio::test]
@@ -413,10 +504,7 @@ async fn core_private_general_chat_with_tool_capability_uses_single_complete_too
     let state = test_state_with_tool_calling(provider.clone(), 5, true);
     let service = CoreHandle::new(state);
 
-    let output = service.respond(private_request("晚上好")).await.unwrap();
-    let CoreRespondOutput::Complete(response) = output else {
-        panic!("expected complete response");
-    };
+    let response = collect_stream_completed(service.respond(private_request("晚上好")).await).await;
 
     assert_eq!(response.text.as_deref(), Some("普通完整回复"));
     assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
@@ -496,15 +584,20 @@ async fn collect_stream_failure(
 }
 
 async fn collect_stream_completed(output: Result<CoreRespondOutput, CoreError>) -> CoreResponse {
-    let CoreRespondOutput::Stream(mut stream) = output.unwrap() else {
-        panic!("expected stream output");
-    };
+    let mut stream = expect_stream(output.unwrap());
     while let Some(event) = stream.recv().await {
         if let CoreResponseEvent::Completed(response) = event {
             return response;
         }
     }
     panic!("stream ended without completed response");
+}
+
+fn expect_stream(output: CoreRespondOutput) -> CoreResponseStream {
+    let CoreRespondOutput::Stream(stream) = output else {
+        panic!("expected stream output");
+    };
+    stream
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## 变更概述

Closes #140

统一 Agent Loop 在任务完成后输出标准化 `CoreResponseEvent` 事件流，确保用户可见事件只包含已确认的最终自然语言回复。

## 具体改动

### 1. 统一 Tool Loop 输出事件流 (`service/mod.rs`)

- `CompleteToolLoop` 路径从原先的 `CoreRespondOutput::Complete` 旁路改为通过 `CoreResponseEvent` 流式输出
- Tool Loop 完成后合成 `TextDelta` + `Completed`/`Failed` 事件，不再直接返回完整响应
- 提取 `send_final_response_delta` 共享辅助函数，非 SSE Provider 与 Tool Loop 共用
- Tool Loop 后台完整路径增加 `request_timeout` 超时保护
- 工具参数、工具结果原文和模型中间候选文本不再能通过事件流外发

### 2. 修复同轮 Tool Loop Todo 编号解析优先级 (`scope.rs`)

- 同一 Tool Loop 内刚由 `list_todos` 产生的编号优先于旧用户可见快照
- 避免模型根据当前查询结果传入 `numbers` 时被静默映射到旧列表，造成完成/恢复/删除错待办

### 3. 新增测试 (`tests.rs`)

- `same_task_query_numbers_prefer_current_list_over_stale_visible_snapshot` — 验证同轮编号优先级
- `core_private_weather_chat_with_tool_capability_streams_final_tool_loop_reply` — 验证流式输出
- `core_tool_loop_stream_buffers_until_final_answer_is_trusted` — 验证缓冲不泄露
- `core_tool_loop_failure_is_reported_as_stream_failure_without_delta` — 验证失败无增量泄露
- `core_tool_loop_stream_preserves_request_timeout_for_background_complete_path` — 验证超时保护

## 检查结果

| 检查项 | 结果 |
|--------|------|
| `cargo fmt --all -- --check` | ✅ 通过 |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | ✅ 通过 |
| `cargo test -p qq-maid-core` (460 tests) | ✅ 全部通过 |

## 事件模型说明

- **无工具聊天**：Provider 流式增量经 Agent Loop 通过后直接转为 `TextDelta`
- **有工具任务**：工具循环执行完毕后，由 `RespondService` 生成最终回复文本，经 `send_final_response_delta` 合成 `TextDelta` + `Completed`
- **最终答案判定**：以 Agent Loop 确认不再继续调用工具、且业务校验（Todo 验真等）通过的时刻为边界
- **缓冲策略**：Tool Loop 完整路径天然缓冲（先完成再发送），无需额外缓冲层
- **兼容接口**：`respond_with_plan` 保留完整回复返回值，供 `respond`（灰度关闭、非流式回退）和诊断使用

## Gateway 接入契约

- Gateway 监听 `CoreResponseEvent::TextDelta` 获取用户可见文本增量
- 首帧后若为 Tool Loop，整个回复属于同一逻辑 stream
- 已完成/失败事件通过 `Completed`/`Failed` 变体传递最终状态