### PR TITLE
fix: 修复已取消待办自然语言查询误入进行中快照

### DIFF
--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -146,7 +146,10 @@ impl RustRespondService {
             let output = if validation.passed() {
                 output
             } else {
-                todo_success_not_verified_output(output)
+                todo_success_not_verified_output(
+                    output,
+                    todo_guard::todo_success_not_verified_reply_for_output,
+                )
             };
             (output, validation)
         } else {
@@ -160,6 +163,33 @@ impl RustRespondService {
 
         let reply = output.reply.clone();
         let executed_tools = output.executed_tools.clone();
+        let todo_tool_summaries = todo_guard::todo_tool_result_summaries(&output);
+        if use_tool_loop {
+            if todo_tool_summaries.is_empty() {
+                tracing::info!(
+                    entered_tool_loop = true,
+                    executed_tools = ?executed_tools,
+                    todo_success_claimed = todo_success_validation.claimed_success(),
+                    todo_success_verified = todo_success_validation.passed(),
+                    "todo tool loop completed without todo write tool result"
+                );
+            } else {
+                for summary in &todo_tool_summaries {
+                    tracing::info!(
+                        entered_tool_loop = true,
+                        tool = %summary.tool,
+                        succeeded = summary.succeeded,
+                        error_code = summary.error_code.as_deref().unwrap_or(""),
+                        requires_confirmation = summary.requires_confirmation,
+                        requires_clarification = summary.requires_clarification,
+                        pending_action = summary.pending_action.as_deref().unwrap_or(""),
+                        todo_success_claimed = todo_success_validation.claimed_success(),
+                        todo_success_verified = todo_success_validation.passed(),
+                        "todo tool result"
+                    );
+                }
+            }
+        }
         if use_tool_loop {
             let mut latest_session = self
                 .session_store
@@ -198,6 +228,14 @@ impl RustRespondService {
             "used_search": false,
             "tool_calling_enabled": use_tool_loop,
             "tool_loop_executed_tools": executed_tools,
+            "todo_tool_results": todo_tool_summaries.iter().map(|summary| json!({
+                "tool": &summary.tool,
+                "succeeded": summary.succeeded,
+                "error_code": &summary.error_code,
+                "requires_confirmation": summary.requires_confirmation,
+                "requires_clarification": summary.requires_clarification,
+                "pending_action": &summary.pending_action,
+            })).collect::<Vec<_>>(),
             "todo_success_claimed": todo_success_validation.claimed_success(),
             "todo_success_verified": todo_success_validation.passed(),
             "tool_retry_count": 0,
@@ -436,8 +474,9 @@ impl RustRespondService {
 
 fn todo_success_not_verified_output(
     output: super::llm_service::RespondOutput,
+    reply_builder: impl FnOnce(&super::llm_service::RespondOutput) -> String,
 ) -> super::llm_service::RespondOutput {
-    let reply = todo_guard::todo_success_not_verified_reply();
+    let reply = reply_builder(&output);
     super::llm_service::RespondOutput {
         reply: reply.clone(),
         text: reply.clone(),

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -166,13 +166,21 @@ impl RustRespondService {
         let todo_tool_summaries = todo_guard::todo_tool_result_summaries(&output);
         if use_tool_loop {
             if todo_tool_summaries.is_empty() {
-                tracing::info!(
-                    entered_tool_loop = true,
-                    executed_tools = ?executed_tools,
-                    todo_success_claimed = todo_success_validation.claimed_success(),
-                    todo_success_verified = todo_success_validation.passed(),
-                    "todo tool loop completed without todo write tool result"
-                );
+                if todo_success_validation.claimed_success() {
+                    tracing::warn!(
+                        entered_tool_loop = true,
+                        executed_tools = ?executed_tools,
+                        todo_success_claimed = true,
+                        todo_success_verified = todo_success_validation.passed(),
+                        "todo success claim blocked without todo write tool result"
+                    );
+                } else {
+                    tracing::debug!(
+                        entered_tool_loop = true,
+                        executed_tools = ?executed_tools,
+                        "tool loop completed without todo write tool result"
+                    );
+                }
             } else {
                 for summary in &todo_tool_summaries {
                     tracing::info!(
@@ -182,6 +190,8 @@ impl RustRespondService {
                         error_code = summary.error_code.as_deref().unwrap_or(""),
                         requires_confirmation = summary.requires_confirmation,
                         requires_clarification = summary.requires_clarification,
+                        skipped = summary.skipped,
+                        skip_reason = summary.skip_reason.as_deref().unwrap_or(""),
                         pending_action = summary.pending_action.as_deref().unwrap_or(""),
                         todo_success_claimed = todo_success_validation.claimed_success(),
                         todo_success_verified = todo_success_validation.passed(),
@@ -234,6 +244,8 @@ impl RustRespondService {
                 "error_code": &summary.error_code,
                 "requires_confirmation": summary.requires_confirmation,
                 "requires_clarification": summary.requires_clarification,
+                "skipped": summary.skipped,
+                "skip_reason": &summary.skip_reason,
                 "pending_action": &summary.pending_action,
             })).collect::<Vec<_>>(),
             "todo_success_claimed": todo_success_validation.claimed_success(),

--- a/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
@@ -130,6 +130,8 @@ pub(super) struct TodoToolResultSummary {
     pub(super) requires_clarification: bool,
     pub(super) pending_action: Option<String>,
     pub(super) exception: bool,
+    pub(super) skipped: bool,
+    pub(super) skip_reason: Option<String>,
 }
 
 impl From<&ToolExecutionResult> for TodoToolResultSummary {
@@ -154,6 +156,12 @@ impl From<&ToolExecutionResult> for TodoToolResultSummary {
                 .and_then(Value::as_str)
                 .map(str::to_owned),
             exception: result.output.get("error").is_some(),
+            skipped: result.output.get("skipped").and_then(Value::as_bool) == Some(true),
+            skip_reason: result
+                .output
+                .get("reason")
+                .and_then(Value::as_str)
+                .map(str::to_owned),
         }
     }
 }
@@ -377,10 +385,30 @@ pub(super) fn todo_success_not_verified_reply_for_output(output: &RespondOutput)
         };
         return format!("已发起{action}待办确认，请回复“确认”继续，或回复“取消”放弃。");
     }
-    if let Some(summary) = summaries.iter().rev().find(|summary| !summary.succeeded) {
+    if let Some(summary) = best_failure_summary(&summaries) {
         return todo_tool_failure_reply(summary);
     }
     "待办工具已返回结果，但这次回复没有通过成功验真。请使用 /todo 查看当前待办状态。".to_owned()
+}
+
+fn best_failure_summary(summaries: &[TodoToolResultSummary]) -> Option<&TodoToolResultSummary> {
+    let failures = summaries
+        .iter()
+        .filter(|summary| !summary.succeeded)
+        .collect::<Vec<_>>();
+    failures
+        .iter()
+        .copied()
+        .find(|summary| summary.error_code.is_some() && !summary.exception)
+        .or_else(|| failures.iter().copied().find(|summary| summary.exception))
+        .or_else(|| {
+            failures
+                .iter()
+                .copied()
+                .find(|summary| summary.requires_clarification)
+        })
+        .or_else(|| failures.iter().copied().find(|summary| summary.skipped))
+        .or_else(|| failures.first().copied())
 }
 
 fn todo_tool_failure_reply(summary: &TodoToolResultSummary) -> String {
@@ -410,6 +438,9 @@ fn todo_tool_failure_reply(summary: &TodoToolResultSummary) -> String {
         }
         Some(_) => "待办工具返回业务失败，未确认完成操作。请先查看当前待办状态。".to_owned(),
         None if summary.requires_clarification => "目标不明确，请选择具体待办。".to_owned(),
+        None if summary.skipped => {
+            "前一个待办工具没有成功，后续待办工具已跳过；本轮未确认完成操作。".to_owned()
+        }
         None => todo_success_not_verified_reply(),
     }
 }
@@ -424,7 +455,10 @@ mod tests {
         util::metrics::LlmMetrics,
     };
 
-    use super::{TodoSuccessValidation, validate_todo_success_reply};
+    use super::{
+        TodoSuccessValidation, todo_success_not_verified_reply_for_output,
+        validate_todo_success_reply,
+    };
 
     fn output(reply: &str, tool_results: Vec<ToolExecutionResult>) -> RespondOutput {
         RespondOutput {
@@ -607,5 +641,35 @@ mod tests {
             )),
             TodoSuccessValidation::Blocked
         );
+    }
+
+    #[test]
+    fn tool_failure_reply_prefers_business_error_over_dependency_skip() {
+        let output = output(
+            "已删除待办。",
+            vec![
+                tool_result(
+                    "delete_todos",
+                    json!({
+                        "ok": false,
+                        "error_code": "todo_selection_not_found",
+                        "message": "no completed or cancelled todo matched query",
+                    }),
+                    false,
+                ),
+                tool_result(
+                    "complete_todos",
+                    json!({
+                        "ok": false,
+                        "skipped": true,
+                        "reason": "dependency_previous_call_failed",
+                    }),
+                    false,
+                ),
+            ],
+        );
+
+        let reply = todo_success_not_verified_reply_for_output(&output);
+        assert!(reply.contains("没有找到可删除的已完成或已取消待办"));
     }
 }

--- a/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
@@ -77,6 +77,15 @@ impl TodoSuccessValidation {
     }
 }
 
+pub(super) fn todo_tool_result_summaries(output: &RespondOutput) -> Vec<TodoToolResultSummary> {
+    output
+        .tool_results
+        .iter()
+        .filter(|result| is_todo_tool(&result.name))
+        .map(TodoToolResultSummary::from)
+        .collect()
+}
+
 fn has_successful_todo_write_result(output: &RespondOutput) -> bool {
     output.tool_results.iter().any(successful_todo_write_result)
 }
@@ -110,6 +119,68 @@ fn non_empty_array_field(output: &Value, field: &str) -> bool {
         .get(field)
         .and_then(Value::as_array)
         .is_some_and(|items| !items.is_empty())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct TodoToolResultSummary {
+    pub(super) tool: String,
+    pub(super) succeeded: bool,
+    pub(super) error_code: Option<String>,
+    pub(super) requires_confirmation: bool,
+    pub(super) requires_clarification: bool,
+    pub(super) pending_action: Option<String>,
+    pub(super) exception: bool,
+}
+
+impl From<&ToolExecutionResult> for TodoToolResultSummary {
+    fn from(result: &ToolExecutionResult) -> Self {
+        Self {
+            tool: result.name.clone(),
+            succeeded: result.succeeded && !result_has_explicit_failure(&result.output),
+            error_code: structured_error_code(&result.output),
+            requires_confirmation: result
+                .output
+                .get("requires_confirmation")
+                .and_then(Value::as_bool)
+                == Some(true),
+            requires_clarification: result
+                .output
+                .get("requires_clarification")
+                .and_then(Value::as_bool)
+                == Some(true),
+            pending_action: result
+                .output
+                .get("pending_action")
+                .and_then(Value::as_str)
+                .map(str::to_owned),
+            exception: result.output.get("error").is_some(),
+        }
+    }
+}
+
+fn structured_error_code(output: &Value) -> Option<String> {
+    output
+        .get("error_code")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            output
+                .get("error")
+                .and_then(|error| error.get("code"))
+                .and_then(Value::as_str)
+        })
+        .map(str::to_owned)
+}
+
+fn is_todo_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "create_todo"
+            | "cancel_todo"
+            | "delete_todos"
+            | "edit_todo"
+            | "complete_todos"
+            | "restore_todos"
+    )
 }
 
 fn reply_claims_todo_write_success(reply: &str) -> bool {
@@ -285,6 +356,62 @@ fn is_explanatory_clear_success_usage(text: &str, pos: usize, marker: &str) -> b
 
 pub(super) fn todo_success_not_verified_reply() -> String {
     "我这次没有收到待办工具的成功回执，所以不能确认已经完成该待办操作。请再说一次，或使用 /todo 查看当前待办状态。".to_owned()
+}
+
+pub(super) fn todo_success_not_verified_reply_for_output(output: &RespondOutput) -> String {
+    let summaries = todo_tool_result_summaries(output);
+    if summaries.is_empty() {
+        return todo_success_not_verified_reply();
+    }
+    if let Some(summary) = summaries.iter().find(|summary| {
+        summary.succeeded && summary.requires_confirmation && summary.pending_action.is_some()
+    }) {
+        let action = match summary.pending_action.as_deref() {
+            Some("delete") => "删除",
+            Some("cancel") => "取消",
+            Some("create") => "新增",
+            Some("edit") => "修改",
+            Some("complete") => "完成",
+            Some("restore") => "恢复",
+            _ => "待办",
+        };
+        return format!("已发起{action}待办确认，请回复“确认”继续，或回复“取消”放弃。");
+    }
+    if let Some(summary) = summaries.iter().rev().find(|summary| !summary.succeeded) {
+        return todo_tool_failure_reply(summary);
+    }
+    "待办工具已返回结果，但这次回复没有通过成功验真。请使用 /todo 查看当前待办状态。".to_owned()
+}
+
+fn todo_tool_failure_reply(summary: &TodoToolResultSummary) -> String {
+    match summary.error_code.as_deref() {
+        Some("todo_delete_invalid_state") => {
+            "进行中待办不能永久删除，请先取消，再从已取消列表里永久删除。".to_owned()
+        }
+        Some("todo_selection_not_found") if summary.tool == "delete_todos" => {
+            "没有找到可删除的已完成或已取消待办，请先查看对应列表后再选择。".to_owned()
+        }
+        Some("todo_selection_not_found") => "没有找到匹配的待办，请先查看列表后再选择。".to_owned(),
+        Some("todo_reference_unavailable") | Some("todo_visible_numbers_unavailable") => {
+            "目标不明确，请先查看待办列表，再选择具体编号。".to_owned()
+        }
+        Some("todo_reference_invalid_state") => {
+            "当前状态的待办不能执行这项操作，请先查看列表确认目标状态。".to_owned()
+        }
+        Some("pending_operation_exists") => {
+            "当前已有待确认操作，请先回复“确认”或“取消”，再继续新的待办操作。".to_owned()
+        }
+        Some("bad_tool_arguments") if summary.requires_clarification => {
+            "目标不明确，请选择具体待办。".to_owned()
+        }
+        Some("bad_tool_arguments") => "这次待办工具参数不完整，请换个说法说明目标。".to_owned(),
+        Some(_) if summary.exception => {
+            "待办工具执行时发生异常，未确认完成操作。请稍后重试或先查看当前待办状态。".to_owned()
+        }
+        Some(_) => "待办工具返回业务失败，未确认完成操作。请先查看当前待办状态。".to_owned(),
+        None if summary.requires_clarification => "目标不明确，请选择具体待办。".to_owned(),
+        None => todo_success_not_verified_reply(),
+    }
 }
 
 #[cfg(test)]

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -1021,12 +1021,16 @@ async fn todo_edit_tool_false_result_does_not_pass_success_guard() {
         .unwrap();
 
     let text = response.text.unwrap();
-    assert!(text.contains("没有收到待办工具的成功回执"));
+    assert!(text.contains("当前状态的待办不能执行这项操作"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["todo_success_claimed"], true);
     assert_eq!(diagnostics["todo_success_verified"], false);
     assert_eq!(diagnostics["tool_retry_count"], 0);
     assert_eq!(diagnostics["error_code"], "todo_success_not_verified");
+    assert_eq!(
+        diagnostics["todo_tool_results"][0]["error_code"],
+        "todo_reference_invalid_state"
+    );
     assert_eq!(inspector.tool_call_count(), 1);
 }
 
@@ -1071,12 +1075,16 @@ async fn todo_delete_tool_false_result_does_not_pass_success_guard() {
         .unwrap();
 
     let text = response.text.unwrap();
-    assert!(text.contains("没有收到待办工具的成功回执"));
+    assert!(text.contains("进行中待办不能永久删除"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["todo_success_claimed"], true);
     assert_eq!(diagnostics["todo_success_verified"], false);
     assert_eq!(diagnostics["tool_retry_count"], 0);
     assert_eq!(diagnostics["error_code"], "todo_success_not_verified");
+    assert_eq!(
+        diagnostics["todo_tool_results"][0]["error_code"],
+        "todo_delete_invalid_state"
+    );
     assert!(service.todo_store.list_pending(&owner).unwrap().len() == 1);
 }
 
@@ -1226,11 +1234,15 @@ async fn todo_delete_completed_tool_failure_cannot_be_reported_as_success() {
         .unwrap();
 
     let text = response.text.unwrap();
-    assert!(text.contains("没有收到待办工具的成功回执"));
+    assert!(text.contains("没有找到可删除的已完成或已取消待办"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["todo_success_claimed"], true);
     assert_eq!(diagnostics["todo_success_verified"], false);
     assert_eq!(diagnostics["error_code"], "todo_success_not_verified");
+    assert_eq!(
+        diagnostics["todo_tool_results"][0]["error_code"],
+        "todo_selection_not_found"
+    );
     assert_eq!(
         diagnostics["tool_loop_executed_tools"],
         serde_json::json!(["delete_todos"])
@@ -1364,21 +1376,54 @@ async fn natural_language_todo_query_aliases_and_filters_stay_deterministic() {
     assert!(completed_text.contains("已完成条目"));
     assert!(!completed_text.contains("已取消条目"));
 
-    let cancelled_only = service
-        .respond(private_message("查看已取消待办"))
-        .await
-        .unwrap();
-    let cancelled_text = cancelled_only.text.unwrap();
-    assert_eq!(
-        cancelled_only.command.as_deref(),
-        Some("todo_cancelled_list")
-    );
-    assert!(!cancelled_text.contains("未完成条目"));
-    assert!(!cancelled_text.contains("已完成条目"));
-    assert!(cancelled_text.contains("已取消条目"));
+    for input in ["查看完成的待办", "看看做完的任务"] {
+        let response = service.respond(private_message(input)).await.unwrap();
+        let text = response.text.unwrap();
+        assert_eq!(response.command.as_deref(), Some("todo_done"), "{input}");
+        assert!(!text.contains("未完成条目"), "{input}");
+        assert!(text.contains("已完成条目"), "{input}");
+        assert!(!text.contains("已取消条目"), "{input}");
+    }
+
+    for input in [
+        "查看取消的待办",
+        "看看取消的任务",
+        "查询已取消待办",
+        "列出取消列表",
+        "查看被取消的待办",
+    ] {
+        let response = service.respond(private_message(input)).await.unwrap();
+        let text = response.text.unwrap();
+        assert_eq!(
+            response.command.as_deref(),
+            Some("todo_cancelled_list"),
+            "{input}"
+        );
+        assert!(!text.contains("未完成条目"), "{input}");
+        assert!(!text.contains("已完成条目"), "{input}");
+        assert!(text.contains("已取消条目"), "{input}");
+    }
 
     assert_eq!(pending.status, TodoStatus::Pending);
     assert!(inspector.requests().is_empty());
+    assert_eq!(inspector.tool_call_count(), 0);
+}
+
+#[tokio::test]
+async fn todo_write_or_question_phrases_do_not_enter_natural_query_path() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), false);
+
+    for input in ["取消这个待办", "怎么取消待办", "帮我取消第一条", "不做了"]
+    {
+        let response = service.respond(private_message(input)).await.unwrap();
+        assert_ne!(response.command.as_deref(), Some("todo_list"), "{input}");
+        assert_ne!(
+            response.command.as_deref(),
+            Some("todo_cancelled_list"),
+            "{input}"
+        );
+    }
     assert_eq!(inspector.tool_call_count(), 0);
 }
 
@@ -1727,6 +1772,136 @@ async fn deterministic_cancelled_query_then_tool_loop_restore_first_uses_latest_
             .status,
         TodoStatus::Pending
     );
+}
+
+#[tokio::test]
+async fn cancelled_query_then_delete_all_creates_bulk_pending_and_confirm_deletes_only_cancelled() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json(
+            "delete_todos",
+            r#"{"numbers":null,"reference":null,"query":null,"all_status":"cancelled"}"#,
+            "已发起删除已取消待办确认",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let pending_a = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "进行中 A".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    let cancelled_a = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "已取消 A".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    let cancelled_b = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "已取消 B".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    service.todo_store.cancel(&owner, &cancelled_a.id).unwrap();
+    service.todo_store.cancel(&owner, &cancelled_b.id).unwrap();
+
+    let listed = service
+        .respond(private_message("查看取消的待办"))
+        .await
+        .unwrap();
+    let listed_text = listed.text.unwrap();
+    assert_eq!(listed.command.as_deref(), Some("todo_cancelled_list"));
+    assert!(listed_text.contains("⛔ 已取消 · 共 2 项"));
+    assert!(listed_text.contains("已取消 A"));
+    assert!(listed_text.contains("已取消 B"));
+    assert!(!listed_text.contains("进行中 A"));
+    let session = service
+        .session_store
+        .get_or_create_active(&private_test_meta())
+        .unwrap();
+    let snapshot = session.last_todo_query.expect("missing cancelled snapshot");
+    let expected_cancelled_ids = service
+        .todo_store
+        .list_cancelled(&owner)
+        .unwrap()
+        .into_iter()
+        .map(|item| item.id)
+        .collect::<Vec<_>>();
+    assert_eq!(snapshot.query_type, "cancelled-list");
+    assert_eq!(snapshot.condition, "已取消列表");
+    assert_eq!(snapshot.result_ids, expected_cancelled_ids);
+
+    let delete = service
+        .respond(private_message("都删除了吧"))
+        .await
+        .unwrap();
+    assert!(delete.text.as_deref().unwrap().contains("已发起删除"));
+    let diagnostics = delete.diagnostics.unwrap();
+    assert_eq!(
+        diagnostics["tool_loop_executed_tools"],
+        serde_json::json!(["delete_todos"])
+    );
+    assert_eq!(diagnostics["todo_success_verified"], true);
+    assert_eq!(
+        diagnostics["todo_tool_results"][0]["requires_confirmation"],
+        true
+    );
+    let session = service
+        .session_store
+        .get_or_create_active(&private_test_meta())
+        .unwrap();
+    match session.pending_operation {
+        Some(PendingOperation::TodoBulkDelete {
+            item_ids, status, ..
+        }) => {
+            assert_eq!(status, TodoStatus::Cancelled);
+            assert_eq!(item_ids.len(), 2);
+            assert!(item_ids.contains(&cancelled_a.id));
+            assert!(item_ids.contains(&cancelled_b.id));
+            assert!(!item_ids.contains(&pending_a.id));
+        }
+        other => panic!("expected TodoBulkDelete pending operation, got {other:?}"),
+    }
+    assert_eq!(service.todo_store.list_cancelled(&owner).unwrap().len(), 2);
+    assert_eq!(service.todo_store.list_pending(&owner).unwrap().len(), 1);
+
+    let confirmed = service.respond(private_message("确认")).await.unwrap();
+    assert!(confirmed.text.as_deref().unwrap().contains("已永久删除"));
+    assert!(
+        service
+            .todo_store
+            .list_cancelled(&owner)
+            .unwrap()
+            .is_empty()
+    );
+    let pending = service.todo_store.list_pending(&owner).unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].id, pending_a.id);
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -1353,6 +1353,20 @@ async fn natural_language_todo_query_aliases_and_filters_stay_deterministic() {
         assert!(!text.contains("已取消条目"), "{input}");
     }
 
+    for input in [
+        "查看未完成的待办",
+        "看看没做完的任务",
+        "查看还没做完的任务",
+        "查看未结束的待办",
+    ] {
+        let response = service.respond(private_message(input)).await.unwrap();
+        let text = response.text.unwrap();
+        assert_eq!(response.command.as_deref(), Some("todo_list"), "{input}");
+        assert!(text.contains("未完成条目"), "{input}");
+        assert!(!text.contains("已完成条目"), "{input}");
+        assert!(!text.contains("已取消条目"), "{input}");
+    }
+
     for input in ["查看所有待办", "查看全部待办"] {
         let all = service.respond(private_message(input)).await.unwrap();
         let all_text = all.text.unwrap();
@@ -1407,6 +1421,37 @@ async fn natural_language_todo_query_aliases_and_filters_stay_deterministic() {
     assert_eq!(pending.status, TodoStatus::Pending);
     assert!(inspector.requests().is_empty());
     assert_eq!(inspector.tool_call_count(), 0);
+}
+
+#[tokio::test]
+async fn negated_cancelled_query_phrases_do_not_list_cancelled_items() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), false);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let cancelled = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "不应展示的已取消条目".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    service.todo_store.cancel(&owner, &cancelled.id).unwrap();
+
+    for input in ["查看未取消的待办", "查看没取消的待办"] {
+        let response = service.respond(private_message(input)).await.unwrap();
+        assert_ne!(
+            response.command.as_deref(),
+            Some("todo_cancelled_list"),
+            "{input}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -42,6 +42,10 @@ const TODO_QUERY_COMPLETED_EXACT: &[&str] =
     &["已完成的待办", "看看已完成", "查看已完成", "列出已完成"];
 const TODO_QUERY_CANCELLED_EXACT: &[&str] =
     &["已取消的待办", "看看已取消", "查看已取消", "列出已取消"];
+const TODO_QUERY_COMPLETED_MARKERS: &[&str] =
+    &["已完成", "完成的", "做完", "做完的", "搞定的", "结束的"];
+const TODO_QUERY_CANCELLED_MARKERS: &[&str] =
+    &["已取消", "取消的", "被取消", "取消列表", "已作废", "作废的"];
 
 fn remember_todo_query(
     session: &mut SessionRecord,
@@ -293,11 +297,17 @@ fn detect_natural_todo_query_kind(user_text: &str) -> Option<NaturalTodoQueryKin
     if TODO_QUERY_CANCELLED_EXACT.contains(&text.as_str()) {
         return Some(NaturalTodoQueryKind::Cancelled);
     }
-    let mentions_todo = TODO_QUERY_NOUNS.iter().any(|needle| text.contains(needle));
+    let mentions_todo = contains_any(&text, TODO_QUERY_NOUNS);
     let asks_list = TODO_QUERY_LIST_VERBS
         .iter()
         .any(|needle| text.contains(needle));
-    if !mentions_todo || !asks_list {
+    if !asks_list {
+        return None;
+    }
+    let mentions_list = text.contains("列表") || text.contains("清单");
+    let mentions_completed = contains_any(&text, TODO_QUERY_COMPLETED_MARKERS);
+    let mentions_cancelled = contains_any(&text, TODO_QUERY_CANCELLED_MARKERS);
+    if !mentions_todo && !(mentions_list && (mentions_completed || mentions_cancelled)) {
         return None;
     }
     if TODO_QUERY_ALL_MARKERS
@@ -306,13 +316,18 @@ fn detect_natural_todo_query_kind(user_text: &str) -> Option<NaturalTodoQueryKin
     {
         return Some(NaturalTodoQueryKind::All);
     }
-    if text.contains("已取消") {
+    // 状态判断只在“列表查询语义”确认后执行，避免“取消这个待办”等写操作被抢走。
+    if mentions_cancelled {
         return Some(NaturalTodoQueryKind::Cancelled);
     }
-    if text.contains("已完成") {
+    if mentions_completed {
         return Some(NaturalTodoQueryKind::Completed);
     }
     Some(NaturalTodoQueryKind::Pending)
+}
+
+fn contains_any(text: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| text.contains(needle))
 }
 
 /// 自然语言待办查询入口统一做别字归一化，避免“代办/待办”落到不同链路。

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -46,6 +46,22 @@ const TODO_QUERY_COMPLETED_MARKERS: &[&str] =
     &["已完成", "完成的", "做完", "做完的", "搞定的", "结束的"];
 const TODO_QUERY_CANCELLED_MARKERS: &[&str] =
     &["已取消", "取消的", "被取消", "取消列表", "已作废", "作废的"];
+const TODO_QUERY_PENDING_NEGATED_COMPLETED_MARKERS: &[&str] = &[
+    "未完成",
+    "没完成",
+    "没有完成",
+    "未做完",
+    "没做完",
+    "没有做完",
+    "还没做完",
+    "还没有做完",
+    "未结束",
+    "没结束",
+    "没有结束",
+    "还没结束",
+];
+const TODO_QUERY_NEGATED_CANCELLED_MARKERS: &[&str] =
+    &["未取消", "没取消", "没有取消", "还没取消", "还没有取消"];
 
 fn remember_todo_query(
     session: &mut SessionRecord,
@@ -307,7 +323,22 @@ fn detect_natural_todo_query_kind(user_text: &str) -> Option<NaturalTodoQueryKin
     let mentions_list = text.contains("列表") || text.contains("清单");
     let mentions_completed = contains_any(&text, TODO_QUERY_COMPLETED_MARKERS);
     let mentions_cancelled = contains_any(&text, TODO_QUERY_CANCELLED_MARKERS);
-    if !mentions_todo && !(mentions_list && (mentions_completed || mentions_cancelled)) {
+    let mentions_pending_by_negated_completed =
+        contains_any(&text, TODO_QUERY_PENDING_NEGATED_COMPLETED_MARKERS);
+    let mentions_negated_cancelled = contains_any(&text, TODO_QUERY_NEGATED_CANCELLED_MARKERS);
+    let mentions_state = mentions_completed
+        || mentions_cancelled
+        || mentions_pending_by_negated_completed
+        || mentions_negated_cancelled;
+    if !(mentions_todo || mentions_list && mentions_state) {
+        return None;
+    }
+    // 否定状态必须先于肯定子串判断；例如“未完成的待办”包含“完成的”，
+    // 但语义是进行中列表，不是已完成列表。
+    if mentions_pending_by_negated_completed {
+        return Some(NaturalTodoQueryKind::Pending);
+    }
+    if mentions_negated_cancelled {
         return None;
     }
     if TODO_QUERY_ALL_MARKERS


### PR DESCRIPTION
## 变更概述

修复 `detect_natural_todo_query_kind` 状态判断缺陷：将"查询/列表语义"和"取消/完成状态词"分开判断，确保"查看取消的待办"等表达正确命中已取消状态而非默认 Pending。

## 原问题

`detect_natural_todo_query_kind` 只通过 `text.contains("已取消")` 识别取消列表，但"查看取消的待办"中"取消的"未被识别，导致状态判断未命中，最终落入默认 Pending 分支，写入了进行中列表快照。后续"都删除了吧"如果基于这份错误快照调用 `delete_todos`，参数类别会落到最近列表编号/引用一类，工具会拒绝永久删除进行中待办并返回 `todo_delete_invalid_state` 业务失败。

## 具体改动

### 1. `todo_flow/mod.rs` — 修复状态判断逻辑

- 将"列表查询语义"（`asks_list`）和"状态词匹配"（`已完成/已取消`）分开判断
- 新增取消词汇表：`已取消`、`取消的`、`被取消`、`取消列表`、`已作废`、`作废的`
- 新增完成词汇表：`已完成`、`完成的`、`做完`、`做完的`、`搞定的`、`结束的`
- 保留 `TODO_QUERY_CANCELLED_EXACT` / `TODO_QUERY_COMPLETED_EXACT` 精确匹配作为快速路径
- 保持"取消这个待办""怎么取消待办""帮我取消第一条""不做了"不进入自然语言查询路径

### 2. `chat_flow.rs` — Tool Loop 后安全日志与 diagnostics

- 新增 `todo_tool_result_summaries` 收集结构化工具结果
- Tool Loop 完成后输出安全诊断日志（工具名、成功/失败、error_code、需确认/澄清、pending action、验真结果）
- diagnostics 中新增 `todo_tool_results` 字段，不记录工具参数、内部 Todo ID、聊天正文或敏感配置

### 3. `todo_guard.rs` — 结构化错误回复

- 新增 `TodoToolResultSummary` 结构体和 `From<ToolExecutionResult>` 转换
- 新增 `todo_success_not_verified_reply_for_output`：失败时优先根据结构化工具结果返回真实原因
- 覆盖错误码：`todo_delete_invalid_state`、`todo_selection_not_found`、`todo_reference_unavailable`、`todo_reference_invalid_state`、`pending_operation_exists`、`bad_tool_arguments` 及工具异常

### 4. `tests/chat.rs` — 回归测试

- 扩展完成待办查询口语变体（"查看完成的待办""看看做完的任务"）
- 扩展已取消待办查询口语变体（"查看取消的待办""看看取消的任务""查询已取消待办""列出取消列表""查看被取消的待办"）
- 新增 `todo_write_or_question_phrases_do_not_enter_natural_query_path`：验证写操作不误入查询
- 新增 `cancelled_query_then_delete_all_creates_bulk_pending_and_confirm_deletes_only_cancelled`：完整端到端回归"查看已取消→全部删除→确认→只删已取消"
- 更新 `todo_edit_tool_false_result`、`todo_delete_tool_false_result`、`todo_delete_completed_tool_failure` 断言，验证真实错误码和用户可见原因

## 检查结果

| 检查项 | 结果 |
|--------|------|
| `cargo fmt --all -- --check` | ✅ 通过 |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | ✅ 通过 |
| `cargo test -p qq-maid-core` (462 tests) | ✅ 全部通过 |
| `git diff --check` | ✅ 无空白问题 |

## 兼容性

- 不调整 PR #163 原有事件流或编号优先级语义
- 不修改 `qq-maid-llm`，不需要跑 LLM workspace 测试
- 不写入真实 `.env`、token、openid、群 ID、聊天记录或数据库内部 Todo ID
- 潜在风险：更多口语状态表达可能需要后续按真实对话补词表，但当前验收表达已覆盖