### PR TITLE
feat: 统一 Todo 写操作确定性回执

### DIFF
--- a/qq-maid-core/src/runtime/respond.rs
+++ b/qq-maid-core/src/runtime/respond.rs
@@ -53,6 +53,7 @@ mod session_flow;
 mod tests;
 mod title;
 mod todo_flow;
+mod tool_presenters;
 mod tool_route;
 mod train_flow;
 mod translation_flow;

--- a/qq-maid-core/src/runtime/respond.rs
+++ b/qq-maid-core/src/runtime/respond.rs
@@ -35,6 +35,7 @@ mod types;
 use crate::service::{CoreInboundClassification, CoreInboundKind};
 pub use types::{ChatResponse, RespondPurpose, RespondRequest, RespondResponse};
 
+mod agent_outcome;
 mod chat_flow;
 mod command_render;
 mod common;

--- a/qq-maid-core/src/runtime/respond/agent_outcome.rs
+++ b/qq-maid-core/src/runtime/respond/agent_outcome.rs
@@ -1,0 +1,461 @@
+//! Tool Loop 执行结果的通用编排层。
+//!
+//! 这里只理解工具结果的通用状态、领域效果和可信响应块顺序，不解析 Todo 等
+//! 具体业务字段。各领域适配器负责把单次工具结果转换为 `ResponseBlock`。
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::provider::ToolExecutionResult;
+
+use super::common::CommandBody;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(in crate::runtime::respond) enum ToolOutcomeStatus {
+    Succeeded,
+    PendingConfirmation,
+    RequiresClarification,
+    Failed,
+    Skipped,
+}
+
+impl ToolOutcomeStatus {
+    pub(in crate::runtime::respond) fn from_tool_result(result: &ToolExecutionResult) -> Self {
+        if result.output.get("skipped").and_then(Value::as_bool) == Some(true) {
+            return Self::Skipped;
+        }
+        if result
+            .output
+            .get("requires_confirmation")
+            .and_then(Value::as_bool)
+            == Some(true)
+        {
+            return Self::PendingConfirmation;
+        }
+        if result
+            .output
+            .get("requires_clarification")
+            .and_then(Value::as_bool)
+            == Some(true)
+        {
+            return Self::RequiresClarification;
+        }
+        if !result.succeeded || result.output.get("ok").and_then(Value::as_bool) == Some(false) {
+            return Self::Failed;
+        }
+        Self::Succeeded
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Succeeded => "succeeded",
+            Self::PendingConfirmation => "pending_confirmation",
+            Self::RequiresClarification => "requires_clarification",
+            Self::Failed => "failed",
+            Self::Skipped => "skipped",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(in crate::runtime::respond) enum ToolEffect {
+    ReadOnly,
+    Created,
+    Updated,
+    Completed,
+    Cancelled,
+    Deleted,
+    ExternalSideEffect,
+}
+
+impl ToolEffect {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadOnly => "read_only",
+            Self::Created => "created",
+            Self::Updated => "updated",
+            Self::Completed => "completed",
+            Self::Cancelled => "cancelled",
+            Self::Deleted => "deleted",
+            Self::ExternalSideEffect => "external_side_effect",
+        }
+    }
+
+    fn is_completed_side_effect(self) -> bool {
+        !matches!(self, Self::ReadOnly)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(in crate::runtime::respond) enum ResponseBlock {
+    FactCard(CommandBody),
+    MutationReceipt(CommandBody),
+    RelatedList(CommandBody),
+    Confirmation(CommandBody),
+    Clarification(CommandBody),
+    Warning(CommandBody),
+    Error(CommandBody),
+}
+
+impl ResponseBlock {
+    fn body(&self) -> &CommandBody {
+        match self {
+            Self::FactCard(body)
+            | Self::MutationReceipt(body)
+            | Self::RelatedList(body)
+            | Self::Confirmation(body)
+            | Self::Clarification(body)
+            | Self::Warning(body)
+            | Self::Error(body) => body,
+        }
+    }
+
+    fn order(&self) -> u8 {
+        match self {
+            Self::FactCard(_) => 0,
+            Self::MutationReceipt(_) | Self::RelatedList(_) => 1,
+            Self::Confirmation(_) => 2,
+            Self::Clarification(_) => 3,
+            Self::Error(_) | Self::Warning(_) => 4,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::runtime::respond) struct ToolExecutionOutcome {
+    pub tool_name: String,
+    pub domain: String,
+    pub status: ToolOutcomeStatus,
+    pub effect: ToolEffect,
+    pub blocks: Vec<ResponseBlock>,
+    pub error_code: Option<String>,
+    pub command: Option<String>,
+}
+
+impl ToolExecutionOutcome {
+    pub(in crate::runtime::respond) fn generic(result: &ToolExecutionResult) -> Self {
+        Self {
+            tool_name: result.name.clone(),
+            domain: "generic".to_owned(),
+            status: ToolOutcomeStatus::from_tool_result(result),
+            effect: ToolEffect::ReadOnly,
+            blocks: Vec::new(),
+            error_code: structured_error_code(&result.output),
+            command: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(in crate::runtime::respond) enum AgentTurnStatus {
+    Succeeded,
+    PartialSuccess,
+    PendingConfirmation,
+    RequiresClarification,
+    Failed,
+}
+
+impl AgentTurnStatus {
+    pub(in crate::runtime::respond) fn as_str(self) -> &'static str {
+        match self {
+            Self::Succeeded => "succeeded",
+            Self::PartialSuccess => "partial_success",
+            Self::PendingConfirmation => "pending_confirmation",
+            Self::RequiresClarification => "requires_clarification",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::runtime::respond) struct AgentTurnOutcome {
+    pub status: AgentTurnStatus,
+    pub outcomes: Vec<ToolExecutionOutcome>,
+    pub blocks: Vec<ResponseBlock>,
+}
+
+impl AgentTurnOutcome {
+    pub(in crate::runtime::respond) fn from_outcomes(outcomes: Vec<ToolExecutionOutcome>) -> Self {
+        let status = calculate_turn_status(&outcomes);
+        let mut indexed_blocks = Vec::new();
+        for (outcome_index, outcome) in outcomes.iter().enumerate() {
+            for (block_index, block) in outcome.blocks.iter().cloned().enumerate() {
+                indexed_blocks.push((block.order(), outcome_index, block_index, block));
+            }
+        }
+        indexed_blocks.sort_by_key(|(order, outcome_index, block_index, _)| {
+            (*order, *outcome_index, *block_index)
+        });
+        let blocks = indexed_blocks
+            .into_iter()
+            .map(|(_, _, _, block)| block)
+            .collect();
+        Self {
+            status,
+            outcomes,
+            blocks,
+        }
+    }
+
+    pub(in crate::runtime::respond) fn has_trusted_response(&self) -> bool {
+        !self.blocks.is_empty()
+    }
+
+    pub(in crate::runtime::respond) fn render_body(&self) -> CommandBody {
+        let text = self
+            .blocks
+            .iter()
+            .map(|block| block.body().text.trim().to_owned())
+            .filter(|text| !text.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let markdown_parts = self
+            .blocks
+            .iter()
+            .map(|block| {
+                let body = block.body();
+                body.markdown
+                    .as_deref()
+                    .unwrap_or(body.text.as_str())
+                    .trim()
+                    .to_owned()
+            })
+            .filter(|text: &String| !text.is_empty())
+            .collect::<Vec<_>>();
+        let markdown = if markdown_parts.is_empty() {
+            None
+        } else {
+            Some(markdown_parts.join("\n\n"))
+        };
+        CommandBody { text, markdown }
+    }
+
+    pub(in crate::runtime::respond) fn primary_command(&self) -> Option<String> {
+        [
+            ToolOutcomeStatus::Failed,
+            ToolOutcomeStatus::RequiresClarification,
+            ToolOutcomeStatus::PendingConfirmation,
+            ToolOutcomeStatus::Succeeded,
+            ToolOutcomeStatus::Skipped,
+        ]
+        .into_iter()
+        .find_map(|status| {
+            let iter: Box<dyn Iterator<Item = &ToolExecutionOutcome>> =
+                if status == ToolOutcomeStatus::Succeeded {
+                    Box::new(self.outcomes.iter().rev())
+                } else {
+                    Box::new(self.outcomes.iter())
+                };
+            iter.filter(|outcome| outcome.status == status)
+                .find_map(|outcome| outcome.command.clone())
+        })
+    }
+
+    pub(in crate::runtime::respond) fn primary_error_code(&self) -> Option<String> {
+        self.outcomes
+            .iter()
+            .find(|outcome| {
+                matches!(outcome.status, ToolOutcomeStatus::Failed) && outcome.error_code.is_some()
+            })
+            .and_then(|outcome| outcome.error_code.clone())
+            .or_else(|| {
+                self.outcomes
+                    .iter()
+                    .find(|outcome| {
+                        matches!(outcome.status, ToolOutcomeStatus::RequiresClarification)
+                            && outcome.error_code.is_some()
+                    })
+                    .and_then(|outcome| outcome.error_code.clone())
+            })
+            .or_else(|| {
+                self.outcomes
+                    .iter()
+                    .find_map(|outcome| outcome.error_code.clone())
+            })
+    }
+
+    pub(in crate::runtime::respond) fn diagnostics(&self) -> Value {
+        json!({
+            "agent_turn_status": self.status.as_str(),
+            "tool_outcomes": self.outcomes.iter().map(|outcome| json!({
+                "tool": outcome.tool_name,
+                "domain": outcome.domain,
+                "status": outcome.status.as_str(),
+                "effect": outcome.effect.as_str(),
+                "error_code": outcome.error_code,
+            })).collect::<Vec<_>>(),
+        })
+    }
+}
+
+fn calculate_turn_status(outcomes: &[ToolExecutionOutcome]) -> AgentTurnStatus {
+    if outcomes.is_empty() {
+        return AgentTurnStatus::Succeeded;
+    }
+    if outcomes
+        .iter()
+        .all(|outcome| outcome.status == ToolOutcomeStatus::Succeeded)
+    {
+        return AgentTurnStatus::Succeeded;
+    }
+
+    let has_success = outcomes
+        .iter()
+        .any(|outcome| outcome.status == ToolOutcomeStatus::Succeeded);
+    let has_completed_side_effect = outcomes.iter().any(|outcome| {
+        outcome.status == ToolOutcomeStatus::Succeeded && outcome.effect.is_completed_side_effect()
+    });
+    let has_failed_or_skipped = outcomes.iter().any(|outcome| {
+        matches!(
+            outcome.status,
+            ToolOutcomeStatus::Failed | ToolOutcomeStatus::Skipped
+        )
+    });
+    let has_clarification = outcomes
+        .iter()
+        .any(|outcome| outcome.status == ToolOutcomeStatus::RequiresClarification);
+    let has_pending = outcomes
+        .iter()
+        .any(|outcome| outcome.status == ToolOutcomeStatus::PendingConfirmation);
+
+    if (has_success || has_completed_side_effect)
+        && (has_failed_or_skipped || has_clarification || has_pending)
+    {
+        return AgentTurnStatus::PartialSuccess;
+    }
+    if has_clarification {
+        return AgentTurnStatus::RequiresClarification;
+    }
+    if has_pending {
+        return AgentTurnStatus::PendingConfirmation;
+    }
+    AgentTurnStatus::Failed
+}
+
+fn structured_error_code(output: &Value) -> Option<String> {
+    output
+        .get("error_code")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            output
+                .get("error")
+                .and_then(|error| error.get("code"))
+                .and_then(Value::as_str)
+        })
+        .map(str::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn outcome(
+        tool: &str,
+        domain: &str,
+        status: ToolOutcomeStatus,
+        effect: ToolEffect,
+        blocks: Vec<ResponseBlock>,
+    ) -> ToolExecutionOutcome {
+        ToolExecutionOutcome {
+            tool_name: tool.to_owned(),
+            domain: domain.to_owned(),
+            status,
+            effect,
+            blocks,
+            error_code: None,
+            command: None,
+        }
+    }
+
+    #[test]
+    fn status_uses_ok_false_even_without_error_code() {
+        let result = ToolExecutionResult {
+            name: "edit_todo".to_owned(),
+            output: json!({"ok": false, "message": "failed"}),
+            succeeded: false,
+        };
+
+        assert_eq!(
+            ToolOutcomeStatus::from_tool_result(&result),
+            ToolOutcomeStatus::Failed
+        );
+    }
+
+    #[test]
+    fn dependency_skip_has_own_status() {
+        let result = ToolExecutionResult {
+            name: "complete_todos".to_owned(),
+            output: json!({"ok": false, "skipped": true, "reason": "dependency_previous_call_failed"}),
+            succeeded: false,
+        };
+
+        assert_eq!(
+            ToolOutcomeStatus::from_tool_result(&result),
+            ToolOutcomeStatus::Skipped
+        );
+    }
+
+    #[test]
+    fn partial_success_keeps_success_and_failure_blocks() {
+        let turn = AgentTurnOutcome::from_outcomes(vec![
+            outcome(
+                "create_todo",
+                "todo",
+                ToolOutcomeStatus::Succeeded,
+                ToolEffect::Created,
+                vec![ResponseBlock::MutationReceipt(CommandBody::plain(
+                    "✅ 已新增待办",
+                ))],
+            ),
+            outcome(
+                "edit_todo",
+                "todo",
+                ToolOutcomeStatus::Failed,
+                ToolEffect::Updated,
+                vec![ResponseBlock::Error(CommandBody::plain("⚠️ 编辑失败"))],
+            ),
+        ]);
+
+        assert_eq!(turn.status, AgentTurnStatus::PartialSuccess);
+        let body = turn.render_body();
+        assert!(body.text.contains("✅ 已新增待办"));
+        assert!(body.text.contains("⚠️ 编辑失败"));
+    }
+
+    #[test]
+    fn simulated_fact_card_and_todo_receipt_are_ordered_by_block_type() {
+        let turn = AgentTurnOutcome::from_outcomes(vec![
+            outcome(
+                "create_todo",
+                "todo",
+                ToolOutcomeStatus::Succeeded,
+                ToolEffect::Created,
+                vec![
+                    ResponseBlock::MutationReceipt(CommandBody::plain(
+                        "✅ 已新增待办\n乘坐 G34 前往北京南",
+                    )),
+                    ResponseBlock::RelatedList(CommandBody::plain("🚧 当前进行中 · 共 1 项")),
+                ],
+            ),
+            outcome(
+                "train_search",
+                "train",
+                ToolOutcomeStatus::Succeeded,
+                ToolEffect::ReadOnly,
+                vec![ResponseBlock::FactCard(CommandBody::plain(
+                    "🚄 已查到车次\nG34 · 杭州东 → 北京南 · 07:00",
+                ))],
+            ),
+        ]);
+
+        assert_eq!(turn.status, AgentTurnStatus::Succeeded);
+        let body = turn.render_body();
+        let fact_pos = body.text.find("🚄 已查到车次").unwrap();
+        let todo_pos = body.text.find("✅ 已新增待办").unwrap();
+        assert!(fact_pos < todo_pos);
+    }
+}

--- a/qq-maid-core/src/runtime/respond/agent_outcome.rs
+++ b/qq-maid-core/src/runtime/respond/agent_outcome.rs
@@ -70,6 +70,24 @@ pub(in crate::runtime::respond) enum ToolEffect {
     ExternalSideEffect,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(in crate::runtime::respond) enum OutcomePresentation {
+    Trusted,
+    Internal,
+    Unhandled,
+}
+
+impl OutcomePresentation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Trusted => "trusted",
+            Self::Internal => "internal",
+            Self::Unhandled => "unhandled",
+        }
+    }
+}
+
 impl ToolEffect {
     fn as_str(self) -> &'static str {
         match self {
@@ -130,6 +148,7 @@ pub(in crate::runtime::respond) struct ToolExecutionOutcome {
     pub domain: String,
     pub status: ToolOutcomeStatus,
     pub effect: ToolEffect,
+    pub presentation: OutcomePresentation,
     pub blocks: Vec<ResponseBlock>,
     pub error_code: Option<String>,
     pub command: Option<String>,
@@ -142,6 +161,7 @@ impl ToolExecutionOutcome {
             domain: "generic".to_owned(),
             status: ToolOutcomeStatus::from_tool_result(result),
             effect: ToolEffect::ReadOnly,
+            presentation: OutcomePresentation::Unhandled,
             blocks: Vec::new(),
             error_code: structured_error_code(&result.output),
             command: None,
@@ -201,8 +221,18 @@ impl AgentTurnOutcome {
         }
     }
 
-    pub(in crate::runtime::respond) fn has_trusted_response(&self) -> bool {
+    pub(in crate::runtime::respond) fn can_replace_model_reply(&self) -> bool {
         !self.blocks.is_empty()
+            && self
+                .outcomes
+                .iter()
+                .all(|outcome| outcome.presentation != OutcomePresentation::Unhandled)
+    }
+
+    pub(in crate::runtime::respond) fn has_unhandled_outcome(&self) -> bool {
+        self.outcomes
+            .iter()
+            .any(|outcome| outcome.presentation == OutcomePresentation::Unhandled)
     }
 
     pub(in crate::runtime::respond) fn render_body(&self) -> CommandBody {
@@ -232,6 +262,52 @@ impl AgentTurnOutcome {
             Some(markdown_parts.join("\n\n"))
         };
         CommandBody { text, markdown }
+    }
+
+    pub(in crate::runtime::respond) fn render_compat_body(&self) -> CommandBody {
+        let mut body = self.render_body();
+        let unhandled = self
+            .outcomes
+            .iter()
+            .filter(|outcome| outcome.presentation == OutcomePresentation::Unhandled)
+            .collect::<Vec<_>>();
+        if unhandled.is_empty() {
+            return body;
+        }
+
+        let mut lines = Vec::new();
+        let mut markdown_lines = Vec::new();
+        if !body.text.trim().is_empty() {
+            lines.push(body.text.trim().to_owned());
+            lines.push(String::new());
+        }
+        if let Some(markdown) = body
+            .markdown
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            markdown_lines.push(markdown.trim().to_owned());
+            markdown_lines.push(String::new());
+        }
+
+        lines.push("⚠️ 部分工具结果未生成确定性展示".to_owned());
+        markdown_lines.push("## ⚠️ 部分工具结果未生成确定性展示".to_owned());
+        for outcome in unhandled {
+            let status_text = match outcome.status {
+                ToolOutcomeStatus::Succeeded => "已执行，但当前没有可信展示适配器",
+                ToolOutcomeStatus::Failed => "执行失败，当前没有可信错误展示适配器",
+                ToolOutcomeStatus::Skipped => "已跳过，当前没有可信展示适配器",
+                ToolOutcomeStatus::RequiresClarification => "需要补充信息，当前没有可信展示适配器",
+                ToolOutcomeStatus::PendingConfirmation => "需要确认，当前没有可信展示适配器",
+            };
+            let line = format!("- {}：{}", outcome.tool_name, status_text);
+            lines.push(line.clone());
+            markdown_lines.push(line);
+        }
+
+        body.text = lines.join("\n");
+        body.markdown = Some(markdown_lines.join("\n"));
+        body
     }
 
     pub(in crate::runtime::respond) fn primary_command(&self) -> Option<String> {
@@ -286,6 +362,7 @@ impl AgentTurnOutcome {
                 "domain": outcome.domain,
                 "status": outcome.status.as_str(),
                 "effect": outcome.effect.as_str(),
+                "presentation": outcome.presentation.as_str(),
                 "error_code": outcome.error_code,
             })).collect::<Vec<_>>(),
         })
@@ -365,6 +442,11 @@ mod tests {
             domain: domain.to_owned(),
             status,
             effect,
+            presentation: if blocks.is_empty() {
+                OutcomePresentation::Internal
+            } else {
+                OutcomePresentation::Trusted
+            },
             blocks,
             error_code: None,
             command: None,
@@ -421,9 +503,37 @@ mod tests {
         ]);
 
         assert_eq!(turn.status, AgentTurnStatus::PartialSuccess);
+        assert!(turn.can_replace_model_reply());
         let body = turn.render_body();
         assert!(body.text.contains("✅ 已新增待办"));
         assert!(body.text.contains("⚠️ 编辑失败"));
+    }
+
+    #[test]
+    fn unhandled_outcome_blocks_full_replacement_even_with_trusted_blocks() {
+        let turn = AgentTurnOutcome::from_outcomes(vec![
+            outcome(
+                "create_todo",
+                "todo",
+                ToolOutcomeStatus::Succeeded,
+                ToolEffect::Created,
+                vec![ResponseBlock::MutationReceipt(CommandBody::plain(
+                    "✅ 已新增待办",
+                ))],
+            ),
+            ToolExecutionOutcome::generic(&ToolExecutionResult {
+                name: "unknown_tool".to_owned(),
+                output: json!({"ok": true, "summary": "unadapted result"}),
+                succeeded: true,
+            }),
+        ]);
+
+        assert_eq!(turn.status, AgentTurnStatus::Succeeded);
+        assert!(!turn.can_replace_model_reply());
+        assert_eq!(
+            turn.outcomes[1].presentation,
+            OutcomePresentation::Unhandled
+        );
     }
 
     #[test]

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -26,6 +26,7 @@ use super::{
     llm_service::{ChatService, LlmChatService, response_from_output},
     session_flow::build_session_context,
     title::{context_session_title, generate_session_title},
+    todo_flow::{TodoWriteReceipt, receipt_from_tool_loop_output},
 };
 
 pub(super) mod todo_guard;
@@ -134,30 +135,65 @@ impl RustRespondService {
         let service =
             LlmChatService::with_context_budget(self.provider.clone(), self.context_budget);
         let use_tool_loop = matches!(chat_tool_plan, ChatToolPlan::ForceCompleteToolLoop);
-        let (output, todo_success_validation) = if use_tool_loop {
-            let output = service
+        let (output, todo_success_validation, todo_write_receipt) = if use_tool_loop {
+            let mut output = service
                 .respond_with_tools(
                     chat_req,
                     self.tool_registry.clone(),
                     self.tool_calling_max_rounds,
                 )
                 .await?;
-            let validation = todo_guard::validate_todo_success_reply(&output);
-            let output = if validation.passed() {
-                output
+
+            let mut latest_session = self
+                .session_store
+                .get(&session.session_id)
+                .map_err(session_error)?
+                .ok_or_else(|| {
+                    LlmError::new(
+                        "session_missing",
+                        format!(
+                            "session `{}` disappeared after tool loop",
+                            session.session_id
+                        ),
+                        "session",
+                    )
+                })?;
+            // Tool 执行会基于同一 active session 保存 pending/最近 Todo 查询等字段；
+            // 这里只把本轮聊天在调用模型前更新的状态合并回最新记录，避免旧 SessionRecord 覆盖工具结果。
+            latest_session.state = session.state.clone();
+            session = latest_session;
+
+            let owner =
+                crate::runtime::todo::TodoStore::owner(meta.user_id.as_deref(), &meta.scope_key);
+            let receipt =
+                receipt_from_tool_loop_output(&self.todo_store, &mut session, &owner, &output)?;
+            let validation = if let Some(receipt) = receipt.as_ref() {
+                apply_todo_write_receipt(&mut output, receipt);
+                if receipt.error_code.is_some() {
+                    todo_guard::TodoSuccessValidation::Blocked
+                } else {
+                    todo_guard::TodoSuccessValidation::Passed {
+                        claimed_success: true,
+                    }
+                }
             } else {
-                todo_success_not_verified_output(
-                    output,
-                    todo_guard::todo_success_not_verified_reply_for_output,
-                )
+                let validation = todo_guard::validate_todo_success_reply(&output);
+                if !validation.passed() {
+                    output = todo_success_not_verified_output(
+                        output,
+                        todo_guard::todo_success_not_verified_reply_for_output,
+                    );
+                }
+                validation
             };
-            (output, validation)
+            (output, validation, receipt)
         } else {
             (
                 service.respond(chat_req).await?,
                 todo_guard::TodoSuccessValidation::Passed {
                     claimed_success: false,
                 },
+                None,
             )
         };
 
@@ -200,26 +236,6 @@ impl RustRespondService {
                 }
             }
         }
-        if use_tool_loop {
-            let mut latest_session = self
-                .session_store
-                .get(&session.session_id)
-                .map_err(session_error)?
-                .ok_or_else(|| {
-                    LlmError::new(
-                        "session_missing",
-                        format!(
-                            "session `{}` disappeared after tool loop",
-                            session.session_id
-                        ),
-                        "session",
-                    )
-                })?;
-            // Tool 执行会基于同一 active session 保存 pending/最近 Todo 查询等字段；
-            // 这里只把本轮聊天在调用模型前更新的状态合并回最新记录，避免旧 SessionRecord 覆盖工具结果。
-            latest_session.state = session.state.clone();
-            session = latest_session;
-        }
         self.session_store
             .append_exchange(&mut session, &user_text, &reply)
             .map_err(session_error)?;
@@ -250,8 +266,20 @@ impl RustRespondService {
             })).collect::<Vec<_>>(),
             "todo_success_claimed": todo_success_validation.claimed_success(),
             "todo_success_verified": todo_success_validation.passed(),
+            "todo_deterministic_receipt": todo_write_receipt.as_ref().map(|receipt| json!({
+                "operation": receipt.operation,
+                "command": receipt.command,
+                "query_type": receipt.query_type,
+                "condition": receipt.condition,
+                "displayed_count": receipt.displayed_count,
+                "total_count": receipt.total_count,
+                "truncated": receipt.truncated,
+                "error_code": receipt.error_code,
+            })),
             "tool_retry_count": 0,
-            "error_code": if use_tool_loop && !todo_success_validation.passed() {
+            "error_code": if let Some(error_code) = todo_write_receipt_error_code(&todo_write_receipt) {
+                json!(error_code)
+            } else if use_tool_loop && !todo_success_validation.passed() {
                 json!("todo_success_not_verified")
             } else {
                 Value::Null
@@ -508,6 +536,26 @@ fn todo_success_not_verified_output(
         executed_tools: output.executed_tools,
         tool_results: output.tool_results,
     }
+}
+
+fn apply_todo_write_receipt(
+    output: &mut super::llm_service::RespondOutput,
+    receipt: &TodoWriteReceipt,
+) {
+    output.reply = receipt
+        .body
+        .markdown
+        .clone()
+        .unwrap_or_else(|| receipt.body.text.clone());
+    output.text = receipt.body.text.clone();
+    output.markdown = receipt.body.markdown.clone();
+    output.chat.reply = Some(output.reply.clone());
+}
+
+fn todo_write_receipt_error_code(receipt: &Option<TodoWriteReceipt>) -> Option<&str> {
+    receipt
+        .as_ref()
+        .and_then(|receipt| receipt.error_code.as_deref())
 }
 
 /// 从会话历史中截取最近的 N 条消息，转换为 LLM `ChatMessage` 格式。

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -28,6 +28,7 @@ use super::{
     session_flow::build_session_context,
     title::{context_session_title, generate_session_title},
     todo_flow::tool_outcome_from_todo_result,
+    tool_presenters::tool_outcome_from_weather_result,
 };
 
 pub(super) mod todo_guard;
@@ -168,8 +169,11 @@ impl RustRespondService {
                 crate::runtime::todo::TodoStore::owner(meta.user_id.as_deref(), &meta.scope_key);
             let turn_outcome =
                 build_agent_turn_outcome(&self.todo_store, &mut session, &owner, &output)?;
-            let validation = if turn_outcome.has_trusted_response() {
+            let validation = if turn_outcome.can_replace_model_reply() {
                 apply_agent_turn_outcome(&mut output, &turn_outcome);
+                todo_success_validation_from_agent_outcome(&turn_outcome)
+            } else if turn_outcome.has_unhandled_outcome() && !turn_outcome.outcomes.is_empty() {
+                apply_agent_turn_compat_output(&mut output, &turn_outcome);
                 todo_success_validation_from_agent_outcome(&turn_outcome)
             } else {
                 let validation = todo_guard::validate_todo_success_reply(&output);
@@ -280,8 +284,12 @@ impl RustRespondService {
                 .and_then(AgentTurnOutcome::primary_error_code)
             {
                 json!(error_code)
-            } else if use_tool_loop && !todo_success_validation.passed() {
-                json!("todo_success_not_verified")
+            } else if let Some(error_code) = generic_agent_error_code(
+                agent_turn_outcome.as_ref(),
+                use_tool_loop,
+                &todo_success_validation,
+            ) {
+                json!(error_code)
             } else {
                 Value::Null
             },
@@ -549,6 +557,8 @@ fn build_agent_turn_outcome(
     for result in &output.tool_results {
         if let Some(outcome) = tool_outcome_from_todo_result(todo_store, session, owner, result)? {
             outcomes.push(outcome);
+        } else if let Some(outcome) = tool_outcome_from_weather_result(result) {
+            outcomes.push(outcome);
         } else {
             outcomes.push(super::agent_outcome::ToolExecutionOutcome::generic(result));
         }
@@ -561,6 +571,17 @@ fn apply_agent_turn_outcome(
     outcome: &AgentTurnOutcome,
 ) {
     let body = outcome.render_body();
+    output.reply = body.markdown.clone().unwrap_or_else(|| body.text.clone());
+    output.text = body.text;
+    output.markdown = body.markdown;
+    output.chat.reply = Some(output.reply.clone());
+}
+
+fn apply_agent_turn_compat_output(
+    output: &mut super::llm_service::RespondOutput,
+    outcome: &AgentTurnOutcome,
+) {
+    let body = outcome.render_compat_body();
     output.reply = body.markdown.clone().unwrap_or_else(|| body.text.clone());
     output.text = body.text;
     output.markdown = body.markdown;
@@ -588,6 +609,32 @@ fn todo_success_validation_from_agent_outcome(
     } else {
         todo_guard::TodoSuccessValidation::Blocked
     }
+}
+
+fn generic_agent_error_code(
+    outcome: Option<&AgentTurnOutcome>,
+    use_tool_loop: bool,
+    todo_success_validation: &todo_guard::TodoSuccessValidation,
+) -> Option<&'static str> {
+    if use_tool_loop
+        && !todo_success_validation.passed()
+        && outcome.is_none_or(|outcome| outcome.outcomes.is_empty())
+    {
+        return Some("todo_success_not_verified");
+    }
+    if let Some(outcome) = outcome {
+        if outcome.has_unhandled_outcome() {
+            return Some("tool_outcome_unhandled");
+        }
+        return match outcome.status {
+            AgentTurnStatus::Succeeded | AgentTurnStatus::PendingConfirmation => None,
+            AgentTurnStatus::PartialSuccess => Some("agent_turn_partial_success"),
+            AgentTurnStatus::RequiresClarification | AgentTurnStatus::Failed => {
+                Some("agent_turn_failed")
+            }
+        };
+    }
+    (use_tool_loop && !todo_success_validation.passed()).then_some("todo_success_not_verified")
 }
 
 /// 从会话历史中截取最近的 N 条消息，转换为 LLM `ChatMessage` 格式。

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -18,7 +18,7 @@ use crate::{
 
 use super::{
     ChatToolPlan, RespondPurpose, RespondRequest, RespondResponse, RustRespondService,
-    agent_outcome::{AgentTurnOutcome, AgentTurnStatus, ToolOutcomeStatus},
+    agent_outcome::{AgentTurnOutcome, AgentTurnStatus, ToolEffect, ToolOutcomeStatus},
     common::{
         SESSION_HISTORY_MESSAGE_LIMIT, SESSION_STATE_SHORT_TEXT_LIMIT, command_response,
         empty_respond_request, memory_error, merge_metadata, session_error, state_string,
@@ -591,24 +591,31 @@ fn apply_agent_turn_compat_output(
 fn todo_success_validation_from_agent_outcome(
     outcome: &AgentTurnOutcome,
 ) -> todo_guard::TodoSuccessValidation {
-    let verified = matches!(
-        outcome.status,
-        AgentTurnStatus::Succeeded | AgentTurnStatus::PendingConfirmation
-    ) && outcome.outcomes.iter().all(|item| {
-        !matches!(
-            item.status,
-            ToolOutcomeStatus::Failed
-                | ToolOutcomeStatus::Skipped
-                | ToolOutcomeStatus::RequiresClarification
-        )
-    });
-    if verified {
-        todo_guard::TodoSuccessValidation::Passed {
-            claimed_success: true,
-        }
-    } else {
-        todo_guard::TodoSuccessValidation::Blocked
+    let todo_write_outcomes = outcome
+        .outcomes
+        .iter()
+        .filter(|item| is_todo_write_outcome(item))
+        .collect::<Vec<_>>();
+    if todo_write_outcomes.is_empty() {
+        return todo_guard::TodoSuccessValidation::Passed {
+            claimed_success: false,
+        };
     }
+    if todo_write_outcomes.iter().all(|item| {
+        matches!(
+            item.status,
+            ToolOutcomeStatus::Succeeded | ToolOutcomeStatus::PendingConfirmation
+        )
+    }) {
+        return todo_guard::TodoSuccessValidation::Passed {
+            claimed_success: true,
+        };
+    }
+    todo_guard::TodoSuccessValidation::Blocked
+}
+
+fn is_todo_write_outcome(outcome: &super::agent_outcome::ToolExecutionOutcome) -> bool {
+    outcome.domain == "todo" && outcome.effect != ToolEffect::ReadOnly
 }
 
 fn generic_agent_error_code(

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -18,6 +18,7 @@ use crate::{
 
 use super::{
     ChatToolPlan, RespondPurpose, RespondRequest, RespondResponse, RustRespondService,
+    agent_outcome::{AgentTurnOutcome, AgentTurnStatus, ToolOutcomeStatus},
     common::{
         SESSION_HISTORY_MESSAGE_LIMIT, SESSION_STATE_SHORT_TEXT_LIMIT, command_response,
         empty_respond_request, memory_error, merge_metadata, session_error, state_string,
@@ -26,7 +27,7 @@ use super::{
     llm_service::{ChatService, LlmChatService, response_from_output},
     session_flow::build_session_context,
     title::{context_session_title, generate_session_title},
-    todo_flow::{TodoWriteReceipt, receipt_from_tool_loop_output},
+    todo_flow::tool_outcome_from_todo_result,
 };
 
 pub(super) mod todo_guard;
@@ -135,7 +136,7 @@ impl RustRespondService {
         let service =
             LlmChatService::with_context_budget(self.provider.clone(), self.context_budget);
         let use_tool_loop = matches!(chat_tool_plan, ChatToolPlan::ForceCompleteToolLoop);
-        let (output, todo_success_validation, todo_write_receipt) = if use_tool_loop {
+        let (output, todo_success_validation, agent_turn_outcome) = if use_tool_loop {
             let mut output = service
                 .respond_with_tools(
                     chat_req,
@@ -165,17 +166,11 @@ impl RustRespondService {
 
             let owner =
                 crate::runtime::todo::TodoStore::owner(meta.user_id.as_deref(), &meta.scope_key);
-            let receipt =
-                receipt_from_tool_loop_output(&self.todo_store, &mut session, &owner, &output)?;
-            let validation = if let Some(receipt) = receipt.as_ref() {
-                apply_todo_write_receipt(&mut output, receipt);
-                if receipt.error_code.is_some() {
-                    todo_guard::TodoSuccessValidation::Blocked
-                } else {
-                    todo_guard::TodoSuccessValidation::Passed {
-                        claimed_success: true,
-                    }
-                }
+            let turn_outcome =
+                build_agent_turn_outcome(&self.todo_store, &mut session, &owner, &output)?;
+            let validation = if turn_outcome.has_trusted_response() {
+                apply_agent_turn_outcome(&mut output, &turn_outcome);
+                todo_success_validation_from_agent_outcome(&turn_outcome)
             } else {
                 let validation = todo_guard::validate_todo_success_reply(&output);
                 if !validation.passed() {
@@ -186,7 +181,7 @@ impl RustRespondService {
                 }
                 validation
             };
-            (output, validation, receipt)
+            (output, validation, Some(turn_outcome))
         } else {
             (
                 service.respond(chat_req).await?,
@@ -243,8 +238,19 @@ impl RustRespondService {
 
         let mut response = response_from_output(output);
         response.session_id = Some(session.session_id);
-        response.command = None;
+        response.command = agent_turn_outcome
+            .as_ref()
+            .and_then(AgentTurnOutcome::primary_command);
         response.handled = Some(true);
+        let agent_diagnostics = agent_turn_outcome
+            .as_ref()
+            .map(AgentTurnOutcome::diagnostics)
+            .unwrap_or_else(|| {
+                json!({
+                    "agent_turn_status": Value::Null,
+                    "tool_outcomes": [],
+                })
+            });
         response.diagnostics = Some(json!({
             "backend": "rust",
             "session_backend": "rust",
@@ -266,18 +272,13 @@ impl RustRespondService {
             })).collect::<Vec<_>>(),
             "todo_success_claimed": todo_success_validation.claimed_success(),
             "todo_success_verified": todo_success_validation.passed(),
-            "todo_deterministic_receipt": todo_write_receipt.as_ref().map(|receipt| json!({
-                "operation": receipt.operation,
-                "command": receipt.command,
-                "query_type": receipt.query_type,
-                "condition": receipt.condition,
-                "displayed_count": receipt.displayed_count,
-                "total_count": receipt.total_count,
-                "truncated": receipt.truncated,
-                "error_code": receipt.error_code,
-            })),
+            "agent_turn_status": agent_diagnostics["agent_turn_status"].clone(),
+            "tool_outcomes": agent_diagnostics["tool_outcomes"].clone(),
             "tool_retry_count": 0,
-            "error_code": if let Some(error_code) = todo_write_receipt_error_code(&todo_write_receipt) {
+            "error_code": if let Some(error_code) = agent_turn_outcome
+                .as_ref()
+                .and_then(AgentTurnOutcome::primary_error_code)
+            {
                 json!(error_code)
             } else if use_tool_loop && !todo_success_validation.passed() {
                 json!("todo_success_not_verified")
@@ -538,24 +539,55 @@ fn todo_success_not_verified_output(
     }
 }
 
-fn apply_todo_write_receipt(
+fn build_agent_turn_outcome(
+    todo_store: &crate::runtime::todo::TodoStore,
+    session: &mut SessionRecord,
+    owner: &crate::runtime::todo::TodoOwner,
+    output: &super::llm_service::RespondOutput,
+) -> Result<AgentTurnOutcome, LlmError> {
+    let mut outcomes = Vec::new();
+    for result in &output.tool_results {
+        if let Some(outcome) = tool_outcome_from_todo_result(todo_store, session, owner, result)? {
+            outcomes.push(outcome);
+        } else {
+            outcomes.push(super::agent_outcome::ToolExecutionOutcome::generic(result));
+        }
+    }
+    Ok(AgentTurnOutcome::from_outcomes(outcomes))
+}
+
+fn apply_agent_turn_outcome(
     output: &mut super::llm_service::RespondOutput,
-    receipt: &TodoWriteReceipt,
+    outcome: &AgentTurnOutcome,
 ) {
-    output.reply = receipt
-        .body
-        .markdown
-        .clone()
-        .unwrap_or_else(|| receipt.body.text.clone());
-    output.text = receipt.body.text.clone();
-    output.markdown = receipt.body.markdown.clone();
+    let body = outcome.render_body();
+    output.reply = body.markdown.clone().unwrap_or_else(|| body.text.clone());
+    output.text = body.text;
+    output.markdown = body.markdown;
     output.chat.reply = Some(output.reply.clone());
 }
 
-fn todo_write_receipt_error_code(receipt: &Option<TodoWriteReceipt>) -> Option<&str> {
-    receipt
-        .as_ref()
-        .and_then(|receipt| receipt.error_code.as_deref())
+fn todo_success_validation_from_agent_outcome(
+    outcome: &AgentTurnOutcome,
+) -> todo_guard::TodoSuccessValidation {
+    let verified = matches!(
+        outcome.status,
+        AgentTurnStatus::Succeeded | AgentTurnStatus::PendingConfirmation
+    ) && outcome.outcomes.iter().all(|item| {
+        !matches!(
+            item.status,
+            ToolOutcomeStatus::Failed
+                | ToolOutcomeStatus::Skipped
+                | ToolOutcomeStatus::RequiresClarification
+        )
+    });
+    if verified {
+        todo_guard::TodoSuccessValidation::Passed {
+            claimed_success: true,
+        }
+    } else {
+        todo_guard::TodoSuccessValidation::Blocked
+    }
 }
 
 /// 从会话历史中截取最近的 N 条消息，转换为 LLM `ChatMessage` 格式。

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -583,9 +583,11 @@ async fn tool_loop_created_todo_survives_chat_history_save_and_records_last_acti
         .respond(private_message("帮我记一个待办，今晚检查机器人日志"))
         .await
         .unwrap();
-    assert!(first.text.unwrap().contains("工具回复"));
+    let first_text = first.text.unwrap();
+    assert!(first_text.contains("✅ 已新增待办"));
+    assert!(first_text.contains("🚧 当前进行中 · 共 1 项"));
     let first_diagnostics = first.diagnostics.unwrap();
-    assert_eq!(first_diagnostics["todo_success_claimed"], false);
+    assert_eq!(first_diagnostics["todo_success_claimed"], true);
     assert_eq!(first_diagnostics["todo_success_verified"], true);
     assert_eq!(first_diagnostics["tool_retry_count"], 0);
     assert_eq!(
@@ -600,6 +602,14 @@ async fn tool_loop_created_todo_survives_chat_history_save_and_records_last_acti
     let todos = service.todo_store.list_pending(&owner).unwrap();
     assert_eq!(todos.len(), 1);
     assert_eq!(todos[0].raw_text.as_deref(), Some("今晚检查机器人日志"));
+    assert_eq!(
+        session
+            .last_todo_query
+            .as_ref()
+            .expect("missing refreshed todo query")
+            .result_ids,
+        vec![todos[0].id.clone()]
+    );
     let last_action = session.last_todo_action.expect("missing last_todo_action");
     assert_eq!(last_action.item_id, todos[0].id);
     assert_eq!(last_action.action, "created");
@@ -620,7 +630,9 @@ async fn private_todo_create_phrase_is_handled_by_agent_tool_loop() {
         .await
         .unwrap();
 
-    assert!(response.text.unwrap().contains("工具回复"));
+    let text = response.text.unwrap();
+    assert!(text.contains("✅ 已新增待办"));
+    assert!(text.contains("明天接老公"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(
         diagnostics["tool_loop_executed_tools"],
@@ -852,7 +864,13 @@ async fn todo_delete_pending_item_accepts_cancel_tool_pending_result() {
         .await
         .unwrap();
 
-    assert!(response.text.as_deref().unwrap().contains("取消待办"));
+    assert!(
+        response
+            .text
+            .as_deref()
+            .unwrap()
+            .contains("请确认是否取消这条待办")
+    );
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["todo_success_claimed"], true);
     assert_eq!(diagnostics["todo_success_verified"], true);
@@ -1021,12 +1039,12 @@ async fn todo_edit_tool_false_result_does_not_pass_success_guard() {
         .unwrap();
 
     let text = response.text.unwrap();
-    assert!(text.contains("当前状态的待办不能执行这项操作"));
+    assert!(text.contains("目标待办当前状态不允许执行这次操作"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["todo_success_claimed"], true);
     assert_eq!(diagnostics["todo_success_verified"], false);
     assert_eq!(diagnostics["tool_retry_count"], 0);
-    assert_eq!(diagnostics["error_code"], "todo_success_not_verified");
+    assert_eq!(diagnostics["error_code"], "todo_reference_invalid_state");
     assert_eq!(
         diagnostics["todo_tool_results"][0]["error_code"],
         "todo_reference_invalid_state"
@@ -1075,12 +1093,12 @@ async fn todo_delete_tool_false_result_does_not_pass_success_guard() {
         .unwrap();
 
     let text = response.text.unwrap();
-    assert!(text.contains("进行中待办不能永久删除"));
+    assert!(text.contains("进行中的待办不能永久删除"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["todo_success_claimed"], true);
     assert_eq!(diagnostics["todo_success_verified"], false);
     assert_eq!(diagnostics["tool_retry_count"], 0);
-    assert_eq!(diagnostics["error_code"], "todo_success_not_verified");
+    assert_eq!(diagnostics["error_code"], "todo_delete_invalid_state");
     assert_eq!(
         diagnostics["todo_tool_results"][0]["error_code"],
         "todo_delete_invalid_state"
@@ -1178,7 +1196,8 @@ async fn todo_delete_completed_pending_confirmation_is_verified_by_real_tool_res
         .unwrap();
 
     let text = response.text.unwrap();
-    assert!(text.contains("已发起删除已完成待办确认"));
+    assert!(text.contains("准备永久删除 1 条待办"));
+    assert!(text.contains("永久删除需要二次确认"));
     assert!(!text.contains("没有收到待办工具的成功回执"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["todo_success_claimed"], true);
@@ -1234,11 +1253,11 @@ async fn todo_delete_completed_tool_failure_cannot_be_reported_as_success() {
         .unwrap();
 
     let text = response.text.unwrap();
-    assert!(text.contains("没有找到可删除的已完成或已取消待办"));
+    assert!(text.contains("这次选择的待办已经不可用或编号不存在"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["todo_success_claimed"], true);
     assert_eq!(diagnostics["todo_success_verified"], false);
-    assert_eq!(diagnostics["error_code"], "todo_success_not_verified");
+    assert_eq!(diagnostics["error_code"], "todo_selection_not_found");
     assert_eq!(
         diagnostics["todo_tool_results"][0]["error_code"],
         "todo_selection_not_found"
@@ -1641,6 +1660,65 @@ async fn deterministic_todo_query_alias_then_tool_loop_complete_first_uses_lates
 }
 
 #[tokio::test]
+async fn todo_complete_receipt_refreshes_pending_list_and_truncated_visible_snapshot() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json(
+            "complete_todos",
+            r#"{"numbers":[1],"reference":null}"#,
+            "已完成第一条",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    for index in 1..=7 {
+        service
+            .todo_store
+            .create(
+                &owner,
+                TodoItemDraft {
+                    title: format!("待办 {index}"),
+                    detail: None,
+                    raw_text: None,
+                    due_date: None,
+                    due_at: None,
+                    time_precision: TodoTimePrecision::None,
+                },
+            )
+            .unwrap();
+    }
+
+    service
+        .respond(private_message("看一下待办"))
+        .await
+        .unwrap();
+    let response = service
+        .respond(private_message("完成第一条"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert!(text.contains("✅ 已完成待办 · 1条"));
+    assert!(text.contains("🚧 当前进行中 · 共 6 项"));
+    assert!(text.contains("还有 1 项，可说“查看全部待办”。"));
+    let remaining = service.todo_store.list_pending(&owner).unwrap();
+    let session = service
+        .session_store
+        .get_or_create_active(&private_test_meta())
+        .unwrap();
+    let snapshot = session.last_todo_query.expect("missing refreshed snapshot");
+    assert_eq!(snapshot.query_type, "list");
+    assert_eq!(
+        snapshot.result_ids,
+        remaining
+            .iter()
+            .take(5)
+            .map(|item| item.id.clone())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(snapshot.result_ids.len(), 5);
+}
+
+#[tokio::test]
 async fn deterministic_completed_query_then_tool_loop_restore_first_uses_latest_snapshot() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
@@ -1905,7 +1983,13 @@ async fn cancelled_query_then_delete_all_creates_bulk_pending_and_confirm_delete
         .respond(private_message("都删除了吧"))
         .await
         .unwrap();
-    assert!(delete.text.as_deref().unwrap().contains("已发起删除"));
+    assert!(
+        delete
+            .text
+            .as_deref()
+            .unwrap()
+            .contains("准备永久删除 2 条待办")
+    );
     let diagnostics = delete.diagnostics.unwrap();
     assert_eq!(
         diagnostics["tool_loop_executed_tools"],

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -2,7 +2,7 @@ use std::fs;
 
 use serde_json::Value;
 
-use crate::provider::{ToolCallingProtocol, types::ChatRole};
+use crate::provider::{ToolCallingProtocol, ToolExecutionResult, types::ChatRole};
 
 use super::{
     super::{
@@ -21,6 +21,14 @@ use crate::runtime::{
     memory::{CreateScopedMemoryRequest, MemoryScopeType},
     pending::PendingOperation,
 };
+
+fn raw_tool_result(name: &str, output: serde_json::Value, succeeded: bool) -> ToolExecutionResult {
+    ToolExecutionResult {
+        name: name.to_owned(),
+        output,
+        succeeded,
+    }
+}
 
 #[tokio::test]
 async fn chat_writes_history_and_uses_prompt_files() {
@@ -630,6 +638,7 @@ async fn private_todo_create_phrase_is_handled_by_agent_tool_loop() {
         .await
         .unwrap();
 
+    assert_eq!(response.command.as_deref(), Some("todo_create"));
     let text = response.text.unwrap();
     assert!(text.contains("✅ 已新增待办"));
     assert!(text.contains("明天接老公"));
@@ -638,6 +647,10 @@ async fn private_todo_create_phrase_is_handled_by_agent_tool_loop() {
         diagnostics["tool_loop_executed_tools"],
         serde_json::json!(["create_todo"])
     );
+    assert_eq!(diagnostics["agent_turn_status"], "succeeded");
+    assert_eq!(diagnostics["tool_outcomes"][0]["domain"], "todo");
+    assert_eq!(diagnostics["tool_outcomes"][0]["status"], "succeeded");
+    assert_eq!(diagnostics["tool_outcomes"][0]["effect"], "created");
     assert_eq!(diagnostics["todo_success_verified"], true);
     let session = service
         .session_store
@@ -650,7 +663,195 @@ async fn private_todo_create_phrase_is_handled_by_agent_tool_loop() {
     let last_action = session.last_todo_action.expect("missing last_todo_action");
     assert_eq!(last_action.item_id, todos[0].id);
     assert_eq!(last_action.action, "created");
+    let snapshot = session
+        .last_todo_query
+        .expect("missing refreshed todo snapshot");
+    assert_eq!(snapshot.result_ids, vec![todos[0].id.clone()]);
     assert_eq!(inspector.tool_call_count(), 1);
+}
+
+#[tokio::test]
+async fn todo_tool_ok_false_without_error_code_is_failed_outcome() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_raw_tool_results(
+            vec![raw_tool_result(
+                "edit_todo",
+                serde_json::json!({
+                    "ok": false,
+                    "message": "没有成功修改待办"
+                }),
+                false,
+            )],
+            "已修改待办",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("把第一条改一下"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("todo_tool_error"));
+    let text = response.text.unwrap();
+    assert!(text.contains("没有成功修改待办"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["agent_turn_status"], "failed");
+    assert_eq!(diagnostics["tool_outcomes"][0]["status"], "failed");
+    assert_eq!(diagnostics["tool_outcomes"][0]["error_code"], Value::Null);
+    assert_eq!(diagnostics["todo_success_verified"], false);
+}
+
+#[tokio::test]
+async fn todo_clarification_is_not_marked_as_write_success() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_raw_tool_results(
+            vec![raw_tool_result(
+                "complete_todos",
+                serde_json::json!({
+                    "ok": false,
+                    "requires_clarification": true,
+                    "question": "请说明要完成哪条待办。"
+                }),
+                false,
+            )],
+            "已完成待办",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service.respond(private_message("完成一下")).await.unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("todo_clarify_wait"));
+    let text = response.text.unwrap();
+    assert!(text.contains("请说明要完成哪条待办"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["agent_turn_status"], "requires_clarification");
+    assert_eq!(
+        diagnostics["tool_outcomes"][0]["status"],
+        "requires_clarification"
+    );
+    assert_eq!(diagnostics["todo_success_verified"], false);
+}
+
+#[tokio::test]
+async fn todo_business_failure_keeps_root_error_before_dependency_skip() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_raw_tool_results(
+            vec![
+                raw_tool_result(
+                    "delete_todos",
+                    serde_json::json!({
+                        "ok": false,
+                        "error_code": "todo_selection_not_found",
+                        "message": "没有找到符合条件的待办"
+                    }),
+                    false,
+                ),
+                raw_tool_result(
+                    "complete_todos",
+                    serde_json::json!({
+                        "ok": false,
+                        "skipped": true,
+                        "reason": "dependency_previous_call_failed"
+                    }),
+                    false,
+                ),
+            ],
+            "已处理",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("删除第一条再完成第二条"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("todo_tool_error"));
+    let text = response.text.unwrap();
+    assert!(text.contains("没有找到符合条件的待办"));
+    assert!(text.contains("前序工具没有成功"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["agent_turn_status"], "failed");
+    assert_eq!(diagnostics["error_code"], "todo_selection_not_found");
+    assert_eq!(diagnostics["tool_outcomes"][0]["status"], "failed");
+    assert_eq!(diagnostics["tool_outcomes"][1]["status"], "skipped");
+}
+
+#[tokio::test]
+async fn todo_success_then_failure_is_partial_success_and_keeps_database_change() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_calls_json(
+            vec![
+                (
+                    "create_todo",
+                    r#"{"content":"新增后保留","title":null,"detail":null,"due_date":null,"due_at":null,"time_precision":null}"#,
+                ),
+                (
+                    "edit_todo",
+                    r#"{"number":99,"reference":null,"raw_text":"不应成功","title":"不应成功","detail":null,"due_date":null,"due_at":null,"time_precision":null}"#,
+                ),
+            ],
+            "已处理",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+
+    let response = service
+        .respond(private_message("新增一个待办再编辑不存在的待办"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert!(text.contains("✅ 已新增待办"));
+    assert!(text.contains("新增后保留"));
+    assert!(text.contains("我现在没有可用的待办列表编号"));
+    assert!(text.contains("可选待办"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["agent_turn_status"], "partial_success");
+    assert_eq!(diagnostics["tool_outcomes"][0]["status"], "succeeded");
+    assert_eq!(
+        diagnostics["tool_outcomes"][1]["status"],
+        "requires_clarification"
+    );
+    let todos = service.todo_store.list_pending(&owner).unwrap();
+    assert_eq!(todos.len(), 1);
+    assert_eq!(todos[0].title, "新增后保留");
+}
+
+#[tokio::test]
+async fn two_successful_todo_results_are_both_rendered() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_calls_json(
+            vec![
+                (
+                    "create_todo",
+                    r#"{"content":"第一条新增","title":null,"detail":null,"due_date":null,"due_at":null,"time_precision":null}"#,
+                ),
+                (
+                    "create_todo",
+                    r#"{"content":"第二条新增","title":null,"detail":null,"due_date":null,"due_at":null,"time_precision":null}"#,
+                ),
+            ],
+            "已新增最后一条",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("新增两条待办"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert_eq!(text.matches("✅ 已新增待办").count(), 2);
+    assert!(text.contains("第一条新增"));
+    assert!(text.contains("第二条新增"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["agent_turn_status"], "succeeded");
+    assert_eq!(diagnostics["tool_outcomes"].as_array().unwrap().len(), 2);
 }
 
 #[tokio::test]
@@ -864,6 +1065,7 @@ async fn todo_delete_pending_item_accepts_cancel_tool_pending_result() {
         .await
         .unwrap();
 
+    assert_eq!(response.command.as_deref(), Some("todo_pending"));
     assert!(
         response
             .text
@@ -872,6 +1074,11 @@ async fn todo_delete_pending_item_accepts_cancel_tool_pending_result() {
             .contains("请确认是否取消这条待办")
     );
     let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["agent_turn_status"], "pending_confirmation");
+    assert_eq!(
+        diagnostics["tool_outcomes"][0]["status"],
+        "pending_confirmation"
+    );
     assert_eq!(diagnostics["todo_success_claimed"], true);
     assert_eq!(diagnostics["todo_success_verified"], true);
     assert_eq!(diagnostics["tool_retry_count"], 0);

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -855,6 +855,292 @@ async fn two_successful_todo_results_are_both_rendered() {
 }
 
 #[tokio::test]
+async fn weather_success_and_todo_success_are_both_rendered_in_order() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_calls_json(
+            vec![
+                ("get_weather", r#"{"city":"杭州","forecast_days":3}"#),
+                (
+                    "create_todo",
+                    r#"{"content":"出门带伞","title":null,"detail":null,"due_date":null,"due_at":null,"time_precision":null}"#,
+                ),
+            ],
+            "杭州小雨，已新增带伞待办",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("查一下杭州天气，顺便加一个带伞待办"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    let weather_pos = text.find("杭州天气").expect("missing weather fact card");
+    let todo_pos = text.find("✅ 已新增待办").expect("missing todo receipt");
+    assert!(weather_pos < todo_pos);
+    assert!(text.contains("当前 20:15"));
+    assert!(text.contains("出门带伞"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["agent_turn_status"], "succeeded");
+    assert_eq!(diagnostics["error_code"], Value::Null);
+    assert_eq!(diagnostics["tool_outcomes"][0]["domain"], "weather");
+    assert_eq!(diagnostics["tool_outcomes"][0]["presentation"], "trusted");
+    assert_eq!(diagnostics["tool_outcomes"][1]["domain"], "todo");
+    assert_eq!(diagnostics["tool_outcomes"][1]["presentation"], "trusted");
+}
+
+#[tokio::test]
+async fn weather_success_and_todo_failure_keep_fact_and_error() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_calls_json(
+            vec![
+                ("get_weather", r#"{"city":"杭州","forecast_days":3}"#),
+                (
+                    "edit_todo",
+                    r#"{"number":99,"reference":null,"raw_text":"带伞","title":"带伞","detail":null,"due_date":null,"due_at":null,"time_precision":null}"#,
+                ),
+            ],
+            "杭州天气已查，待办已修改",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("查杭州天气，再把不存在的待办改成带伞"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert!(text.contains("杭州天气"));
+    assert!(text.contains("我现在没有可用的待办列表编号"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["agent_turn_status"], "partial_success");
+    assert_eq!(
+        diagnostics["error_code"],
+        "todo_visible_numbers_unavailable"
+    );
+    assert_eq!(diagnostics["tool_outcomes"][0]["status"], "succeeded");
+    assert_eq!(
+        diagnostics["tool_outcomes"][1]["status"],
+        "requires_clarification"
+    );
+}
+
+#[tokio::test]
+async fn weather_failure_and_todo_success_keep_error_and_side_effect() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_raw_tool_results(
+            vec![
+                raw_tool_result(
+                    "get_weather",
+                    serde_json::json!({
+                        "ok": false,
+                        "error": {
+                            "code": "timeout",
+                            "message": "upstream timed out",
+                            "stage": "tool"
+                        }
+                    }),
+                    false,
+                ),
+                raw_tool_result(
+                    "create_todo",
+                    serde_json::json!({
+                        "ok": true,
+                        "created": {
+                            "title": "出门带伞",
+                            "detail": null,
+                            "display_time": "无时间"
+                        }
+                    }),
+                    true,
+                ),
+            ],
+            "已新增待办",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("查杭州天气，顺便加带伞待办"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert!(text.contains("天气服务超时了"));
+    assert!(text.contains("✅ 已新增待办"));
+    assert!(text.contains("出门带伞"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["agent_turn_status"], "partial_success");
+    assert_eq!(diagnostics["error_code"], "timeout");
+    assert_eq!(diagnostics["tool_outcomes"][0]["presentation"], "trusted");
+    assert_eq!(diagnostics["tool_outcomes"][1]["presentation"], "trusted");
+}
+
+#[tokio::test]
+async fn weather_failure_and_dependency_skipped_todo_keep_root_cause() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_raw_tool_results(
+            vec![
+                raw_tool_result(
+                    "get_weather",
+                    serde_json::json!({
+                        "ok": false,
+                        "error_code": "not_found",
+                        "message": "city not found"
+                    }),
+                    false,
+                ),
+                raw_tool_result(
+                    "create_todo",
+                    serde_json::json!({
+                        "ok": false,
+                        "skipped": true,
+                        "reason": "dependency_previous_call_failed"
+                    }),
+                    false,
+                ),
+            ],
+            "已处理",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("查不存在城市天气后新增待办"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert!(text.contains("没找到这个城市"));
+    assert!(text.contains("前序工具没有成功"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["agent_turn_status"], "failed");
+    assert_eq!(diagnostics["error_code"], "not_found");
+    assert_eq!(diagnostics["tool_outcomes"][0]["status"], "failed");
+    assert_eq!(diagnostics["tool_outcomes"][1]["status"], "skipped");
+}
+
+#[tokio::test]
+async fn unadapted_success_with_todo_success_is_not_silently_dropped() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_raw_tool_results(
+            vec![
+                raw_tool_result(
+                    "unknown_tool",
+                    serde_json::json!({
+                        "ok": true,
+                        "summary": "未知工具成功"
+                    }),
+                    true,
+                ),
+                raw_tool_result(
+                    "create_todo",
+                    serde_json::json!({
+                        "ok": true,
+                        "created": {
+                            "title": "确认副作用",
+                            "detail": null,
+                            "display_time": "无时间"
+                        }
+                    }),
+                    true,
+                ),
+            ],
+            "未知工具成功，待办也已新增",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("执行两个工具"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert!(text.contains("✅ 已新增待办"));
+    assert!(text.contains("确认副作用"));
+    assert!(text.contains("部分工具结果未生成确定性展示"));
+    assert!(text.contains("unknown_tool"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["agent_turn_status"], "succeeded");
+    assert_eq!(diagnostics["error_code"], "tool_outcome_unhandled");
+    assert_eq!(diagnostics["tool_outcomes"][0]["presentation"], "unhandled");
+    assert_eq!(diagnostics["tool_outcomes"][1]["presentation"], "trusted");
+}
+
+#[tokio::test]
+async fn unadapted_failure_with_todo_success_is_user_visible() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_raw_tool_results(
+            vec![
+                raw_tool_result(
+                    "unknown_tool",
+                    serde_json::json!({
+                        "ok": false,
+                        "error_code": "unknown_failed",
+                        "message": "internal detail should not be rendered"
+                    }),
+                    false,
+                ),
+                raw_tool_result(
+                    "create_todo",
+                    serde_json::json!({
+                        "ok": true,
+                        "created": {
+                            "title": "仍然新增成功",
+                            "detail": null,
+                            "display_time": "无时间"
+                        }
+                    }),
+                    true,
+                ),
+            ],
+            "待办成功",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("执行未知工具并新增待办"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert!(text.contains("仍然新增成功"));
+    assert!(text.contains("unknown_tool"));
+    assert!(text.contains("执行失败，当前没有可信错误展示适配器"));
+    assert!(!text.contains("internal detail should not be rendered"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["agent_turn_status"], "partial_success");
+    assert_eq!(diagnostics["error_code"], "unknown_failed");
+    assert_eq!(diagnostics["tool_outcomes"][0]["presentation"], "unhandled");
+}
+
+#[tokio::test]
+async fn only_weather_tool_renders_fact_card() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json(
+            "get_weather",
+            r#"{"city":"杭州","forecast_days":3}"#,
+            "杭州天气如下",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service.respond(private_message("杭州天气")).await.unwrap();
+
+    let text = response.text.unwrap();
+    assert!(text.contains("杭州天气"));
+    assert!(text.contains("未来 3 天"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["agent_turn_status"], "succeeded");
+    assert_eq!(diagnostics["tool_outcomes"][0]["domain"], "weather");
+    assert_eq!(diagnostics["tool_outcomes"][0]["presentation"], "trusted");
+}
+
+#[tokio::test]
 async fn todo_create_intent_without_tool_call_does_not_leak_fake_success_reply() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -811,6 +811,8 @@ async fn todo_success_then_failure_is_partial_success_and_keeps_database_change(
     assert!(text.contains("可选待办"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["agent_turn_status"], "partial_success");
+    assert_eq!(diagnostics["todo_success_claimed"], true);
+    assert_eq!(diagnostics["todo_success_verified"], false);
     assert_eq!(diagnostics["tool_outcomes"][0]["status"], "succeeded");
     assert_eq!(
         diagnostics["tool_outcomes"][1]["status"],
@@ -920,6 +922,8 @@ async fn weather_success_and_todo_failure_keep_fact_and_error() {
         diagnostics["error_code"],
         "todo_visible_numbers_unavailable"
     );
+    assert_eq!(diagnostics["todo_success_claimed"], true);
+    assert_eq!(diagnostics["todo_success_verified"], false);
     assert_eq!(diagnostics["tool_outcomes"][0]["status"], "succeeded");
     assert_eq!(
         diagnostics["tool_outcomes"][1]["status"],
@@ -974,6 +978,8 @@ async fn weather_failure_and_todo_success_keep_error_and_side_effect() {
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["agent_turn_status"], "partial_success");
     assert_eq!(diagnostics["error_code"], "timeout");
+    assert_eq!(diagnostics["todo_success_claimed"], true);
+    assert_eq!(diagnostics["todo_success_verified"], true);
     assert_eq!(diagnostics["tool_outcomes"][0]["presentation"], "trusted");
     assert_eq!(diagnostics["tool_outcomes"][1]["presentation"], "trusted");
 }
@@ -1136,8 +1142,47 @@ async fn only_weather_tool_renders_fact_card() {
     assert!(text.contains("未来 3 天"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["agent_turn_status"], "succeeded");
+    assert_eq!(diagnostics["todo_success_claimed"], false);
+    assert_eq!(diagnostics["todo_success_verified"], true);
+    assert_eq!(diagnostics["todo_tool_results"], serde_json::json!([]));
     assert_eq!(diagnostics["tool_outcomes"][0]["domain"], "weather");
     assert_eq!(diagnostics["tool_outcomes"][0]["presentation"], "trusted");
+}
+
+#[tokio::test]
+async fn only_list_todos_success_does_not_claim_todo_write_success() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json("list_todos", r#"{"status":"pending"}"#, "当前待办列表");
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "只读查询不算写入".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+
+    let response = service
+        .respond(private_message("今天安排如何"))
+        .await
+        .unwrap();
+
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["agent_turn_status"], "succeeded");
+    assert_eq!(diagnostics["todo_success_claimed"], false);
+    assert_eq!(diagnostics["todo_success_verified"], true);
+    assert_eq!(diagnostics["tool_outcomes"][0]["domain"], "todo");
+    assert_eq!(diagnostics["tool_outcomes"][0]["effect"], "read_only");
+    assert_eq!(diagnostics["tool_outcomes"][0]["status"], "succeeded");
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tests/pending.rs
+++ b/qq-maid-core/src/runtime/respond/tests/pending.rs
@@ -110,8 +110,23 @@ async fn todo_add_pending_confirm_and_cancel_are_supported_for_tool_path() {
     assert!(service.todo_store.list_pending(&owner).unwrap().is_empty());
 
     let confirmed = service.respond(message("确认")).await.unwrap();
-    assert!(confirmed.text.unwrap().contains("已新增待办：买牛奶"));
-    assert_eq!(service.todo_store.list_pending(&owner).unwrap().len(), 1);
+    let text = confirmed.text.unwrap();
+    assert!(text.contains("✅ 已新增待办"));
+    assert!(text.contains("买牛奶"));
+    assert!(text.contains("🚧 当前进行中 · 共 1 项"));
+    let todos = service.todo_store.list_pending(&owner).unwrap();
+    assert_eq!(todos.len(), 1);
+    let session = service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap();
+    assert_eq!(
+        session
+            .last_todo_query
+            .expect("missing refreshed todo query")
+            .result_ids,
+        vec![todos[0].id.clone()]
+    );
 }
 
 #[tokio::test]
@@ -213,7 +228,10 @@ async fn todo_add_confirm_keeps_fresh_last_todo_action_over_stale_db_snapshot() 
     service.session_store.save(&mut session).unwrap();
 
     let confirmed = service.respond(message("确认")).await.unwrap();
-    assert!(confirmed.text.unwrap().contains("已新增待办：新待办"));
+    let text = confirmed.text.unwrap();
+    assert!(text.contains("✅ 已新增待办"));
+    assert!(text.contains("新待办"));
+    assert!(text.contains("🚧 当前进行中"));
 
     // 确认后 last_todo_action 必须指向刚新增的“新待办”；
     // 若 append_pending_response 未合并该字段，latest 里的旧值会反向覆盖。
@@ -227,13 +245,13 @@ async fn todo_add_confirm_keeps_fresh_last_todo_action_over_stale_db_snapshot() 
 }
 
 #[tokio::test]
-async fn todo_delete_confirm_clears_stale_last_todo_query_snapshot() {
+async fn todo_delete_confirm_replaces_stale_snapshot_with_cancelled_list() {
     let service = test_service();
     let owner = TodoStore::owner(Some("u1"), "group:g1");
     let item = service.todo_store.create(&owner, draft("待取消")).unwrap();
 
-    // 数据库 session 里已有旧的待办列表快照；软取消成功后 ops 门面会清空
-    // last_todo_query，避免后续“第一条”指向已不存在的条目。
+    // 数据库 session 里已有旧的进行中列表快照；软取消成功后确定性回执会展示
+    // 最新已取消列表，并用这份用户真实看到的列表替换旧快照。
     let mut session = service
         .session_store
         .get_or_create_active(&test_meta())
@@ -248,18 +266,20 @@ async fn todo_delete_confirm_clears_stale_last_todo_query_snapshot() {
     service.session_store.save(&mut session).unwrap();
 
     let confirmed = service.respond(message("确认")).await.unwrap();
-    assert!(confirmed.text.unwrap().contains("已取消待办"));
+    let text = confirmed.text.unwrap();
+    assert!(text.contains("⛔ 已取消待办"));
+    assert!(text.contains("⛔ 当前已取消 · 共 1 项"));
 
     let session = service
         .session_store
         .get_or_create_active(&test_meta())
         .unwrap();
-    // 软取消成功后 last_todo_query 必须被清空，不能被数据库旧快照恢复。
-    assert!(
-        session.last_todo_query.is_none(),
-        "expected last_todo_query cleared after soft cancel, got {:?}",
-        session.last_todo_query
-    );
+    let snapshot = session
+        .last_todo_query
+        .as_ref()
+        .expect("missing cancelled snapshot");
+    assert_eq!(snapshot.query_type, "cancelled-list");
+    assert_eq!(snapshot.result_ids, vec![item.id.clone()]);
     // 同时 last_todo_action 应指向被取消的待办，而非旧值。
     let last_action = session.last_todo_action.expect("missing last_todo_action");
     assert_eq!(last_action.title, "待取消");

--- a/qq-maid-core/src/runtime/respond/tests/support.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support.rs
@@ -21,7 +21,7 @@ use crate::{
     config::DEFAULT_RSS_SUMMARY_MAX_CHARS,
     error::LlmError,
     provider::{
-        ChatOutcome, LlmProvider, ToolCallingProtocol, ToolChatRequest,
+        ChatOutcome, LlmProvider, ToolCallingProtocol, ToolChatRequest, ToolExecutionResult,
         types::{ChatRequest, ChatRole, TokenUsage},
     },
     runtime::{
@@ -66,6 +66,10 @@ enum MockToolAction {
     },
     ExecuteTools {
         calls: Vec<(String, String)>,
+        reply: String,
+    },
+    ReturnToolResults {
+        results: Vec<ToolExecutionResult>,
         reply: String,
     },
     ReplyWithoutTool {
@@ -207,6 +211,21 @@ impl MockProvider {
                     .into_iter()
                     .map(|(name, arguments)| (name.to_owned(), arguments.to_owned()))
                     .collect(),
+                reply: reply.into(),
+            });
+        self
+    }
+
+    pub(super) fn with_raw_tool_results(
+        self,
+        results: Vec<ToolExecutionResult>,
+        reply: impl Into<String>,
+    ) -> Self {
+        self.tool_actions
+            .lock()
+            .unwrap()
+            .push(MockToolAction::ReturnToolResults {
+                results,
                 reply: reply.into(),
             });
         self
@@ -573,6 +592,36 @@ impl LlmProvider for MockProvider {
                         fallback_used: false,
                         executed_tools,
                         tool_results,
+                    });
+                }
+                MockToolAction::ReturnToolResults { results, reply } => {
+                    let executed_tools = results
+                        .iter()
+                        .map(|result| result.name.clone())
+                        .collect::<Vec<_>>();
+                    return Ok(ChatOutcome {
+                        reply,
+                        metrics: LlmMetrics {
+                            provider: "mock".to_owned(),
+                            model: req
+                                .chat
+                                .model
+                                .clone()
+                                .unwrap_or_else(|| "mock-model".to_owned()),
+                            stream: false,
+                            ttfe_ms: None,
+                            ttft_ms: None,
+                            total_latency_ms: 1,
+                        },
+                        usage: Some(TokenUsage {
+                            input_tokens: None,
+                            cached_input_tokens: None,
+                            output_tokens: None,
+                            total_tokens: None,
+                        }),
+                        fallback_used: false,
+                        executed_tools,
+                        tool_results: results,
                     });
                 }
                 MockToolAction::ReplyWithoutTool { reply } => {

--- a/qq-maid-core/src/runtime/respond/todo_flow/format.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/format.rs
@@ -274,62 +274,6 @@ fn format_todo_timestamp_for_display(value: &str) -> String {
     format_todo_time_for_display(value)
 }
 
-pub(super) fn format_todo_bulk_delete_result(
-    deleted_count: usize,
-    skipped_count: usize,
-    source_condition: &str,
-) -> CommandBody {
-    format_todo_bulk_delete_result_for_status(
-        TodoStatus::Completed,
-        deleted_count,
-        skipped_count,
-        source_condition,
-        None,
-    )
-}
-
-pub(super) fn format_todo_bulk_delete_result_for_status(
-    status: TodoStatus,
-    deleted_count: usize,
-    skipped_count: usize,
-    source_condition: &str,
-    items: Option<&[TodoItem]>,
-) -> CommandBody {
-    let status_label = crate::runtime::todo::status::status_cn_short(&status);
-    if deleted_count == 0 {
-        return simple_todo_notice(&format!("没有可删除的{status_label}待办。"));
-    }
-    let mut rows = vec![
-        format!("已永久删除 {} 条{status_label}待办。", deleted_count),
-        format!("范围：{}", source_condition.trim()),
-    ];
-    if skipped_count > 0 {
-        rows.push(format!(
-            "跳过 {skipped_count} 条已不存在或状态已变化的待办。"
-        ));
-    }
-    if let Some(items) = items {
-        rows.extend(format_completed_todo_rows(items));
-    }
-    let mut markdown_rows = vec![format!(
-        "# 已永久删除 {} 条{status_label}待办",
-        deleted_count
-    )];
-    markdown_rows.push(format!(
-        "范围：{}",
-        escape_markdown_inline(source_condition.trim())
-    ));
-    if skipped_count > 0 {
-        markdown_rows.push(format!(
-            "> 跳过 {skipped_count} 条已不存在或状态已变化的待办。"
-        ));
-    }
-    if let Some(items) = items {
-        markdown_rows.extend(format_completed_todo_rows_markdown(items));
-    }
-    CommandBody::dual(rows.join("\n"), markdown_rows.join("\n"))
-}
-
 pub(super) fn format_todo_pending_add_waiting_reply() -> CommandBody {
     simple_todo_notice(
         "这条旧版新增待办草稿还在等待确认。要新增请回复“确认 / 可以 / 好”；要放弃请回复“取消 / 不要 / 算了”。",

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -25,7 +25,7 @@ mod receipt;
 pub(super) use command::parse_todo_command;
 use completed_query::parse_completed_todo_time_query;
 use format::*;
-pub(in crate::runtime::respond) use receipt::{TodoWriteReceipt, receipt_from_tool_loop_output};
+pub(in crate::runtime::respond) use receipt::tool_outcome_from_todo_result;
 
 const TODO_QUERY_NOUNS: &[&str] = &["待办", "代办", "任务"];
 const TODO_QUERY_LIST_VERBS: &[&str] = &[

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -20,10 +20,12 @@ mod command;
 mod completed_query;
 mod format;
 mod pending;
+mod receipt;
 
 pub(super) use command::parse_todo_command;
 use completed_query::parse_completed_todo_time_query;
 use format::*;
+pub(in crate::runtime::respond) use receipt::{TodoWriteReceipt, receipt_from_tool_loop_output};
 
 const TODO_QUERY_NOUNS: &[&str] = &["待办", "代办", "任务"];
 const TODO_QUERY_LIST_VERBS: &[&str] = &[

--- a/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
@@ -40,6 +40,7 @@ use crate::{
 };
 
 use super::format::*;
+use super::receipt::{receipt_after_cancelled, receipt_after_created, receipt_after_deleted};
 
 use crate::runtime::respond::common::CommandBody;
 use crate::runtime::respond::{RespondResponse, RustRespondService, common::todo_error};
@@ -82,18 +83,13 @@ impl RustRespondService {
                         draft,
                     )
                     .map_err(todo_error)?;
-                    let reply = CommandBody::dual(
-                        format!("已新增待办：{}", format_todo_inline(&created)),
-                        format!(
-                            "# 已新增待办\n\n- {}",
-                            format_todo_inline_markdown(&created)
-                        ),
-                    );
+                    let receipt =
+                        receipt_after_created(&self.todo_store, session, owner, &created)?;
                     return Ok(Some(self.clear_pending_response(
                         session,
                         user_text,
-                        reply,
-                        "todo_confirm",
+                        receipt.body,
+                        receipt.command,
                     )?));
                 }
                 // Todo 写操作改为单入口后，不再在 pending 阶段做二次 LLM 修订。
@@ -127,13 +123,8 @@ impl RustRespondService {
                                 &item.id,
                             )
                             .map_err(todo_error)?;
-                            CommandBody::dual(
-                                format!("已取消待办：{}", format_todo_inline(&deleted)),
-                                format!(
-                                    "# 已取消待办\n\n- {}",
-                                    format_todo_inline_markdown(&deleted)
-                                ),
-                            )
+                            receipt_after_cancelled(&self.todo_store, session, owner, &deleted)?
+                                .body
                         }
                         TodoStatus::Completed => {
                             let outcome = self
@@ -152,13 +143,15 @@ impl RustRespondService {
                                 &owner.key,
                                 std::slice::from_ref(&item.id),
                             );
-                            CommandBody::dual(
-                                format!("已永久删除待办：{}", format_todo_inline(&item)),
-                                format!(
-                                    "# 已永久删除待办\n\n- {}",
-                                    format_todo_inline_markdown(&item)
-                                ),
-                            )
+                            receipt_after_deleted(
+                                &self.todo_store,
+                                session,
+                                owner,
+                                TodoStatus::Completed,
+                                outcome.deleted_count,
+                                0,
+                            )?
+                            .body
                         }
                         TodoStatus::Cancelled => {
                             let outcome = self
@@ -177,13 +170,15 @@ impl RustRespondService {
                                 &owner.key,
                                 std::slice::from_ref(&item.id),
                             );
-                            CommandBody::dual(
-                                format!("已永久删除待办：{}", format_todo_inline(&item)),
-                                format!(
-                                    "# 已永久删除待办\n\n- {}",
-                                    format_todo_inline_markdown(&item)
-                                ),
-                            )
+                            receipt_after_deleted(
+                                &self.todo_store,
+                                session,
+                                owner,
+                                TodoStatus::Cancelled,
+                                outcome.deleted_count,
+                                0,
+                            )?
+                            .body
                         }
                     };
                     return Ok(Some(self.clear_pending_response(
@@ -204,7 +199,7 @@ impl RustRespondService {
                 item_ids,
                 matched_count,
                 status,
-                source_condition,
+                source_condition: _,
                 ..
             } => {
                 let reply_kind = classify_reply(user_text, todo_lexicon());
@@ -230,11 +225,15 @@ impl RustRespondService {
                                 matched_count
                             };
                             let skipped_count = source_count.saturating_sub(outcome.deleted_count);
-                            format_todo_bulk_delete_result(
+                            receipt_after_deleted(
+                                &self.todo_store,
+                                session,
+                                owner,
+                                TodoStatus::Completed,
                                 outcome.deleted_count,
                                 skipped_count,
-                                &source_condition,
-                            )
+                            )?
+                            .body
                         }
                         TodoStatus::Cancelled => {
                             let outcome = self
@@ -248,13 +247,15 @@ impl RustRespondService {
                                 matched_count
                             };
                             let skipped_count = source_count.saturating_sub(outcome.deleted_count);
-                            format_todo_bulk_delete_result_for_status(
+                            receipt_after_deleted(
+                                &self.todo_store,
+                                session,
+                                owner,
                                 TodoStatus::Cancelled,
                                 outcome.deleted_count,
                                 skipped_count,
-                                &source_condition,
-                                None,
-                            )
+                            )?
+                            .body
                         }
                         TodoStatus::Pending => CommandBody::plain("不支持批量删除未完成待办。"),
                     };

--- a/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
@@ -11,7 +11,10 @@ use crate::{
     provider::ToolExecutionResult,
     runtime::{
         respond::{
-            agent_outcome::{ResponseBlock, ToolEffect, ToolExecutionOutcome, ToolOutcomeStatus},
+            agent_outcome::{
+                OutcomePresentation, ResponseBlock, ToolEffect, ToolExecutionOutcome,
+                ToolOutcomeStatus,
+            },
             common::{CommandBody, todo_error, truncate_chars},
         },
         session::SessionRecord,
@@ -23,6 +26,7 @@ use crate::{
 use super::format::{format_todo_inline, format_todo_inline_markdown};
 
 const RECEIPT_LIST_LIMIT: usize = 5;
+const LIST_TODOS_TOOL_NAME: &str = "list_todos";
 
 #[derive(Debug, Clone)]
 pub(in crate::runtime::respond) struct TodoWriteReceipt {
@@ -66,6 +70,9 @@ pub(in crate::runtime::respond) fn tool_outcome_from_todo_result(
     owner: &TodoOwner,
     result: &ToolExecutionResult,
 ) -> Result<Option<ToolExecutionOutcome>, LlmError> {
+    if result.name == LIST_TODOS_TOOL_NAME {
+        return list_todos_outcome(todo_store, session, owner, result).map(Some);
+    }
     let Some(operation) = todo_write_operation(&result.name) else {
         return Ok(None);
     };
@@ -76,10 +83,92 @@ pub(in crate::runtime::respond) fn tool_outcome_from_todo_result(
         domain: "todo".to_owned(),
         status,
         effect: tool_effect_for_operation(operation),
+        presentation: OutcomePresentation::Trusted,
         blocks: vec![response_block_for_receipt(status, receipt.body.clone())],
         error_code: receipt.error_code.clone(),
         command: Some(receipt.command.to_owned()),
     }))
+}
+
+fn list_todos_outcome(
+    todo_store: &TodoStore,
+    session: &mut SessionRecord,
+    owner: &TodoOwner,
+    result: &ToolExecutionResult,
+) -> Result<ToolExecutionOutcome, LlmError> {
+    let status = ToolOutcomeStatus::from_tool_result(result);
+    let error_code = structured_error_code(&result.output);
+    if status == ToolOutcomeStatus::Failed {
+        return Ok(ToolExecutionOutcome {
+            tool_name: result.name.clone(),
+            domain: "todo".to_owned(),
+            status,
+            effect: ToolEffect::ReadOnly,
+            presentation: OutcomePresentation::Trusted,
+            blocks: vec![ResponseBlock::Error(CommandBody::plain(
+                error_reply_for_tool_result(&result.output),
+            ))],
+            error_code,
+            command: Some("todo_tool_error".to_owned()),
+        });
+    }
+    if status == ToolOutcomeStatus::Skipped {
+        return Ok(ToolExecutionOutcome {
+            tool_name: result.name.clone(),
+            domain: "todo".to_owned(),
+            status,
+            effect: ToolEffect::ReadOnly,
+            presentation: OutcomePresentation::Trusted,
+            blocks: vec![ResponseBlock::Warning(CommandBody::plain(
+                skip_reply_for_tool_result(&result.output),
+            ))],
+            error_code,
+            command: Some("todo_tool_skipped".to_owned()),
+        });
+    }
+
+    let spec = list_spec_from_output(&result.output);
+    let items = list_for_related_spec(todo_store, owner, &spec).map_err(todo_error)?;
+    let total_count = items.len();
+    let shown = items
+        .iter()
+        .take(RECEIPT_LIST_LIMIT)
+        .cloned()
+        .collect::<Vec<_>>();
+    let truncated = total_count > shown.len();
+    // `list_todos` 若成为最终用户可见结果，必须同步写入真实可见快照；
+    // 仅在 Tool 内部执行但未展示时，原有内部查询上下文仍由 TodoToolScope 保持。
+    session.remember_last_todo_query(
+        &owner.key,
+        spec.query_type,
+        spec.condition,
+        shown.iter().map(|item| item.id.clone()).collect(),
+    );
+
+    let mut lines = Vec::new();
+    let mut markdown_lines = Vec::new();
+    append_related_list(&mut lines, &shown, total_count, truncated, &spec, false);
+    append_related_list(
+        &mut markdown_lines,
+        &shown,
+        total_count,
+        truncated,
+        &spec,
+        true,
+    );
+    Ok(ToolExecutionOutcome {
+        tool_name: result.name.clone(),
+        domain: "todo".to_owned(),
+        status,
+        effect: ToolEffect::ReadOnly,
+        presentation: OutcomePresentation::Trusted,
+        blocks: vec![ResponseBlock::RelatedList(CommandBody::dual(
+            lines.join("\n"),
+            markdown_lines.join("\n"),
+        ))],
+        error_code,
+        command: Some("todo_list".to_owned()),
+    })
 }
 
 pub(in crate::runtime::respond) fn receipt_after_created(
@@ -512,6 +601,18 @@ fn list_for_spec(
     }
 }
 
+fn list_for_related_spec(
+    todo_store: &TodoStore,
+    owner: &TodoOwner,
+    spec: &RelatedListSpec,
+) -> Result<Vec<TodoItem>, crate::runtime::todo::TodoError> {
+    if spec.query_type == "all" {
+        todo_store.list_all_for_board(owner)
+    } else {
+        list_for_spec(todo_store, owner, spec)
+    }
+}
+
 fn todo_write_operation(name: &str) -> Option<TodoWriteOperation> {
     match name {
         "create_todo" => Some(TodoWriteOperation::Create),
@@ -557,6 +658,23 @@ fn cancelled_list_spec() -> RelatedListSpec {
         empty_text: "当前没有已取消待办。",
         time_label: "取消时间",
         time_value: display_todo_cancelled_at,
+    }
+}
+
+fn list_spec_from_output(output: &Value) -> RelatedListSpec {
+    match string_field(output, "status").as_deref() {
+        Some("completed") => completed_list_spec(),
+        Some("cancelled") => cancelled_list_spec(),
+        Some("all") => RelatedListSpec {
+            status: TodoStatus::Pending,
+            query_type: "all",
+            condition: "全部待办",
+            title: "📋 全部待办",
+            empty_text: "当前没有待办。",
+            time_label: "时间",
+            time_value: display_todo_time,
+        },
+        _ => pending_list_spec(),
     }
 }
 

--- a/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
@@ -1,0 +1,741 @@
+//! Todo 写操作的确定性回执。
+//!
+//! Tool Loop 只负责理解意图并执行白名单 Tool；一旦 Todo 写工具返回，最终用户可见
+//! 文案、相关列表刷新和 `last_todo_query` 快照都在服务端生成，避免模型自由总结和
+//! session 编号快照出现偏差。
+
+use serde_json::Value;
+
+use crate::{
+    error::LlmError,
+    provider::ToolExecutionResult,
+    runtime::{
+        respond::{
+            common::{CommandBody, todo_error, truncate_chars},
+            llm_service::RespondOutput,
+        },
+        session::SessionRecord,
+        todo::{TodoItem, TodoOwner, TodoStatus, TodoStore, display_todo_time},
+    },
+    util::time_context::format_todo_time_for_display,
+};
+
+use super::format::{format_todo_inline, format_todo_inline_markdown};
+
+const RECEIPT_LIST_LIMIT: usize = 5;
+
+#[derive(Debug, Clone)]
+pub(in crate::runtime::respond) struct TodoWriteReceipt {
+    pub body: CommandBody,
+    pub command: &'static str,
+    pub operation: &'static str,
+    pub query_type: Option<&'static str>,
+    pub condition: Option<&'static str>,
+    pub displayed_count: usize,
+    pub total_count: usize,
+    pub truncated: bool,
+    pub error_code: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TodoWriteOperation {
+    Create,
+    Edit,
+    Complete,
+    CancelPending,
+    Restore,
+    DeletePending,
+}
+
+#[derive(Debug, Clone)]
+struct RelatedListSpec {
+    status: TodoStatus,
+    query_type: &'static str,
+    condition: &'static str,
+    title: &'static str,
+    empty_text: &'static str,
+    time_label: &'static str,
+    time_value: fn(&TodoItem) -> String,
+}
+
+struct RelatedReceiptDraft {
+    lines: Vec<String>,
+    markdown_lines: Vec<String>,
+    spec: RelatedListSpec,
+    command: &'static str,
+    operation: &'static str,
+    trailing_hint: Option<&'static str>,
+}
+
+pub(in crate::runtime::respond) fn receipt_from_tool_loop_output(
+    todo_store: &TodoStore,
+    session: &mut SessionRecord,
+    owner: &TodoOwner,
+    output: &RespondOutput,
+) -> Result<Option<TodoWriteReceipt>, LlmError> {
+    let Some(result) = output
+        .tool_results
+        .iter()
+        .rev()
+        .find(|result| todo_write_operation(&result.name).is_some())
+    else {
+        return Ok(None);
+    };
+    receipt_from_tool_result(todo_store, session, owner, result)
+}
+
+pub(in crate::runtime::respond) fn receipt_after_created(
+    todo_store: &TodoStore,
+    session: &mut SessionRecord,
+    owner: &TodoOwner,
+    item: &TodoItem,
+) -> Result<TodoWriteReceipt, LlmError> {
+    let lines = vec![
+        "✅ 已新增待办".to_owned(),
+        String::new(),
+        affected_item_line(item),
+    ];
+    let markdown_lines = vec![
+        "# ✅ 已新增待办".to_owned(),
+        String::new(),
+        affected_item_line_markdown(item),
+    ];
+    receipt_with_related_list(
+        todo_store,
+        session,
+        owner,
+        RelatedReceiptDraft {
+            lines,
+            markdown_lines,
+            spec: pending_list_spec(),
+            command: "todo_confirm",
+            operation: "create",
+            trailing_hint: None,
+        },
+    )
+}
+
+pub(in crate::runtime::respond) fn receipt_after_cancelled(
+    todo_store: &TodoStore,
+    session: &mut SessionRecord,
+    owner: &TodoOwner,
+    item: &TodoItem,
+) -> Result<TodoWriteReceipt, LlmError> {
+    let lines = vec![
+        "⛔ 已取消待办".to_owned(),
+        String::new(),
+        affected_item_line(item),
+    ];
+    let markdown_lines = vec![
+        "# ⛔ 已取消待办".to_owned(),
+        String::new(),
+        affected_item_line_markdown(item),
+    ];
+    receipt_with_related_list(
+        todo_store,
+        session,
+        owner,
+        RelatedReceiptDraft {
+            lines,
+            markdown_lines,
+            spec: cancelled_list_spec(),
+            command: "todo_confirm",
+            operation: "cancel",
+            trailing_hint: Some("可说：删除全部取消的待办"),
+        },
+    )
+}
+
+pub(in crate::runtime::respond) fn receipt_after_deleted(
+    todo_store: &TodoStore,
+    session: &mut SessionRecord,
+    owner: &TodoOwner,
+    status: TodoStatus,
+    deleted_count: usize,
+    skipped_count: usize,
+) -> Result<TodoWriteReceipt, LlmError> {
+    let status_text = status_label(&status);
+    let mut lines = vec![format!("🗑️ 已永久删除 {deleted_count} 条{status_text}")];
+    let mut markdown_lines = vec![format!("# 🗑️ 已永久删除 {deleted_count} 条{status_text}")];
+    if skipped_count > 0 {
+        let line = format!("跳过 {skipped_count} 条已不存在或状态已变化的待办。");
+        lines.push(line.clone());
+        markdown_lines.push(line);
+    }
+    let spec = match status {
+        TodoStatus::Completed => completed_list_spec(),
+        TodoStatus::Cancelled => cancelled_list_spec(),
+        TodoStatus::Pending => pending_list_spec(),
+    };
+    receipt_with_related_list(
+        todo_store,
+        session,
+        owner,
+        RelatedReceiptDraft {
+            lines,
+            markdown_lines,
+            spec,
+            command: "todo_confirm",
+            operation: "delete",
+            trailing_hint: None,
+        },
+    )
+}
+
+fn receipt_from_tool_result(
+    todo_store: &TodoStore,
+    session: &mut SessionRecord,
+    owner: &TodoOwner,
+    result: &ToolExecutionResult,
+) -> Result<Option<TodoWriteReceipt>, LlmError> {
+    let Some(operation) = todo_write_operation(&result.name) else {
+        return Ok(None);
+    };
+    if result
+        .output
+        .get("requires_clarification")
+        .and_then(Value::as_bool)
+        == Some(true)
+    {
+        let question = string_field(&result.output, "question")
+            .or_else(|| string_field(&result.output, "message"))
+            .unwrap_or_else(|| "请再具体说明要操作哪条待办。".to_owned());
+        return Ok(Some(simple_receipt(
+            CommandBody::plain(question),
+            "todo_clarify_wait",
+            operation_name(operation),
+            structured_error_code(&result.output),
+        )));
+    }
+    if !result.succeeded || result.output.get("ok").and_then(Value::as_bool) == Some(false) {
+        return Ok(Some(simple_receipt(
+            CommandBody::plain(error_reply_for_tool_result(&result.output)),
+            "todo_tool_error",
+            operation_name(operation),
+            structured_error_code(&result.output),
+        )));
+    }
+    if result
+        .output
+        .get("requires_confirmation")
+        .and_then(Value::as_bool)
+        == Some(true)
+    {
+        return Ok(Some(pending_confirmation_receipt(
+            operation,
+            &result.output,
+        )));
+    }
+
+    let receipt = match operation {
+        TodoWriteOperation::Create => {
+            let item = item_from_value(result.output.get("created"));
+            let lines = success_lines("✅ 已新增待办", item.as_ref());
+            let markdown_lines = success_markdown_lines("✅ 已新增待办", item.as_ref());
+            receipt_with_related_list(
+                todo_store,
+                session,
+                owner,
+                RelatedReceiptDraft {
+                    lines,
+                    markdown_lines,
+                    spec: pending_list_spec(),
+                    command: "todo_create",
+                    operation: "create",
+                    trailing_hint: None,
+                },
+            )?
+        }
+        TodoWriteOperation::Edit => {
+            let item = item_from_value(result.output.get("updated"));
+            let lines = success_lines("✏️ 已修改待办", item.as_ref());
+            let markdown_lines = success_markdown_lines("✏️ 已修改待办", item.as_ref());
+            receipt_with_related_list(
+                todo_store,
+                session,
+                owner,
+                RelatedReceiptDraft {
+                    lines,
+                    markdown_lines,
+                    spec: pending_list_spec(),
+                    command: "todo_edit",
+                    operation: "edit",
+                    trailing_hint: None,
+                },
+            )?
+        }
+        TodoWriteOperation::Complete => {
+            let count = result
+                .output
+                .get("completed")
+                .and_then(Value::as_array)
+                .map_or(0, Vec::len);
+            let lines =
+                success_count_lines("✅ 已完成待办", count, "条", "completed", &result.output);
+            let markdown_lines = success_count_markdown_lines(
+                "✅ 已完成待办",
+                count,
+                "条",
+                "completed",
+                &result.output,
+            );
+            receipt_with_related_list(
+                todo_store,
+                session,
+                owner,
+                RelatedReceiptDraft {
+                    lines,
+                    markdown_lines,
+                    spec: pending_list_spec(),
+                    command: "todo_complete",
+                    operation: "complete",
+                    trailing_hint: None,
+                },
+            )?
+        }
+        TodoWriteOperation::Restore => {
+            let count = result
+                .output
+                .get("restored")
+                .and_then(Value::as_array)
+                .map_or(0, Vec::len);
+            let lines =
+                success_count_lines("↩️ 已恢复待办", count, "条", "restored", &result.output);
+            let markdown_lines = success_count_markdown_lines(
+                "↩️ 已恢复待办",
+                count,
+                "条",
+                "restored",
+                &result.output,
+            );
+            receipt_with_related_list(
+                todo_store,
+                session,
+                owner,
+                RelatedReceiptDraft {
+                    lines,
+                    markdown_lines,
+                    spec: pending_list_spec(),
+                    command: "todo_restore",
+                    operation: "restore",
+                    trailing_hint: None,
+                },
+            )?
+        }
+        TodoWriteOperation::CancelPending | TodoWriteOperation::DeletePending => {
+            pending_confirmation_receipt(operation, &result.output)
+        }
+    };
+    Ok(Some(receipt))
+}
+
+fn receipt_with_related_list(
+    todo_store: &TodoStore,
+    session: &mut SessionRecord,
+    owner: &TodoOwner,
+    draft: RelatedReceiptDraft,
+) -> Result<TodoWriteReceipt, LlmError> {
+    let RelatedReceiptDraft {
+        mut lines,
+        mut markdown_lines,
+        spec,
+        command,
+        operation,
+        trailing_hint,
+    } = draft;
+    let items = list_for_spec(todo_store, owner, &spec).map_err(todo_error)?;
+    let total_count = items.len();
+    let shown = items
+        .iter()
+        .take(RECEIPT_LIST_LIMIT)
+        .cloned()
+        .collect::<Vec<_>>();
+    let truncated = total_count > shown.len();
+    // 快照只保存本次真正展示的可编号条目；隐藏项不能拥有用户没看到的编号。
+    session.remember_last_todo_query(
+        &owner.key,
+        spec.query_type,
+        spec.condition,
+        shown.iter().map(|item| item.id.clone()).collect(),
+    );
+
+    lines.push(String::new());
+    markdown_lines.push(String::new());
+    append_related_list(&mut lines, &shown, total_count, truncated, &spec, false);
+    append_related_list(
+        &mut markdown_lines,
+        &shown,
+        total_count,
+        truncated,
+        &spec,
+        true,
+    );
+    if let Some(hint) = trailing_hint {
+        lines.push(String::new());
+        lines.push(hint.to_owned());
+        markdown_lines.push(String::new());
+        markdown_lines.push(hint.to_owned());
+    }
+
+    Ok(TodoWriteReceipt {
+        body: CommandBody::dual(lines.join("\n"), markdown_lines.join("\n")),
+        command,
+        operation,
+        query_type: Some(spec.query_type),
+        condition: Some(spec.condition),
+        displayed_count: shown.len(),
+        total_count,
+        truncated,
+        error_code: None,
+    })
+}
+
+fn pending_confirmation_receipt(operation: TodoWriteOperation, output: &Value) -> TodoWriteReceipt {
+    let pending_action = output
+        .get("pending_action")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let body = match pending_action {
+        "cancel" => {
+            let item = item_from_value(output.get("item"));
+            let mut lines = vec!["请确认是否取消这条待办".to_owned()];
+            let mut markdown_lines = vec!["# 请确认是否取消这条待办".to_owned()];
+            if let Some(item) = item.as_ref() {
+                lines.push(String::new());
+                lines.push(format!("- {}", item.title));
+                markdown_lines.push(String::new());
+                markdown_lines.push(format!("- {}", item.title));
+            }
+            lines.push(String::new());
+            lines.push("回复“确认”继续，回复“取消”放弃。".to_owned());
+            markdown_lines.push(String::new());
+            markdown_lines.push("回复“确认”继续，回复“取消”放弃。".to_owned());
+            CommandBody::dual(lines.join("\n"), markdown_lines.join("\n"))
+        }
+        "delete" => {
+            let count = output
+                .get("items")
+                .and_then(Value::as_array)
+                .map(Vec::len)
+                .or_else(|| output.get("item").map(|_| 1))
+                .unwrap_or(0);
+            let source = string_field(output, "selection_source");
+            let mut lines = vec![format!("准备永久删除 {count} 条待办")];
+            let mut markdown_lines = vec![format!("# 准备永久删除 {count} 条待办")];
+            if let Some(source) = source {
+                lines.push(format!("范围：{source}"));
+                markdown_lines.push(format!("范围：{source}"));
+            }
+            lines.push("永久删除需要二次确认，确认前不会修改数据库。".to_owned());
+            lines.push("回复“确认”继续，回复“取消”放弃。".to_owned());
+            markdown_lines.push("永久删除需要二次确认，确认前不会修改数据库。".to_owned());
+            markdown_lines.push("回复“确认”继续，回复“取消”放弃。".to_owned());
+            CommandBody::dual(lines.join("\n"), markdown_lines.join("\n"))
+        }
+        _ => CommandBody::plain(
+            string_field(output, "message").unwrap_or_else(|| "这次待办操作需要确认。".to_owned()),
+        ),
+    };
+    simple_receipt(body, "todo_pending", operation_name(operation), None)
+}
+
+fn simple_receipt(
+    body: CommandBody,
+    command: &'static str,
+    operation: &'static str,
+    error_code: Option<String>,
+) -> TodoWriteReceipt {
+    TodoWriteReceipt {
+        body,
+        command,
+        operation,
+        query_type: None,
+        condition: None,
+        displayed_count: 0,
+        total_count: 0,
+        truncated: false,
+        error_code,
+    }
+}
+
+fn append_related_list(
+    rows: &mut Vec<String>,
+    items: &[TodoItem],
+    total_count: usize,
+    truncated: bool,
+    spec: &RelatedListSpec,
+    markdown: bool,
+) {
+    if total_count == 0 {
+        rows.push(spec.empty_text.to_owned());
+        return;
+    }
+    rows.push(if markdown {
+        format!("## {} · 共 {} 项", spec.title, total_count)
+    } else {
+        format!("{} · 共 {} 项", spec.title, total_count)
+    });
+    for (index, item) in items.iter().enumerate() {
+        if markdown {
+            rows.push(format!(
+                "{}. {}",
+                index + 1,
+                format_todo_inline_markdown(item)
+            ));
+            rows.push(format!(
+                "   - **{}**：{}",
+                spec.time_label,
+                (spec.time_value)(item)
+            ));
+        } else {
+            rows.push(format!("{}. {}", index + 1, format_todo_inline(item)));
+            rows.push(format!(
+                "   {}：{}",
+                spec.time_label,
+                (spec.time_value)(item)
+            ));
+        }
+    }
+    if truncated {
+        rows.push(String::new());
+        rows.push(format!(
+            "还有 {} 项，可说“查看全部待办”。",
+            total_count.saturating_sub(items.len())
+        ));
+    }
+}
+
+fn list_for_spec(
+    todo_store: &TodoStore,
+    owner: &TodoOwner,
+    spec: &RelatedListSpec,
+) -> Result<Vec<TodoItem>, crate::runtime::todo::TodoError> {
+    match &spec.status {
+        TodoStatus::Pending => todo_store.list_pending(owner),
+        TodoStatus::Completed => todo_store.list_completed(owner),
+        TodoStatus::Cancelled => todo_store.list_cancelled(owner),
+    }
+}
+
+fn todo_write_operation(name: &str) -> Option<TodoWriteOperation> {
+    match name {
+        "create_todo" => Some(TodoWriteOperation::Create),
+        "edit_todo" => Some(TodoWriteOperation::Edit),
+        "complete_todos" => Some(TodoWriteOperation::Complete),
+        "cancel_todo" => Some(TodoWriteOperation::CancelPending),
+        "restore_todos" => Some(TodoWriteOperation::Restore),
+        "delete_todos" => Some(TodoWriteOperation::DeletePending),
+        _ => None,
+    }
+}
+
+fn operation_name(operation: TodoWriteOperation) -> &'static str {
+    match operation {
+        TodoWriteOperation::Create => "create",
+        TodoWriteOperation::Edit => "edit",
+        TodoWriteOperation::Complete => "complete",
+        TodoWriteOperation::CancelPending => "cancel",
+        TodoWriteOperation::Restore => "restore",
+        TodoWriteOperation::DeletePending => "delete",
+    }
+}
+
+fn pending_list_spec() -> RelatedListSpec {
+    RelatedListSpec {
+        status: TodoStatus::Pending,
+        query_type: "list",
+        condition: "",
+        title: "🚧 当前进行中",
+        empty_text: "当前没有进行中的待办。",
+        time_label: "时间",
+        time_value: display_todo_time,
+    }
+}
+
+fn completed_list_spec() -> RelatedListSpec {
+    RelatedListSpec {
+        status: TodoStatus::Completed,
+        query_type: "completed-list",
+        condition: "已完成列表",
+        title: "✅ 当前已完成",
+        empty_text: "当前没有已完成待办。",
+        time_label: "完成时间",
+        time_value: display_todo_completed_at,
+    }
+}
+
+fn cancelled_list_spec() -> RelatedListSpec {
+    RelatedListSpec {
+        status: TodoStatus::Cancelled,
+        query_type: "cancelled-list",
+        condition: "已取消列表",
+        title: "⛔ 当前已取消",
+        empty_text: "当前没有已取消待办。",
+        time_label: "取消时间",
+        time_value: display_todo_cancelled_at,
+    }
+}
+
+fn display_todo_completed_at(item: &TodoItem) -> String {
+    item.completed_at
+        .as_deref()
+        .map(format_todo_time_for_display)
+        .unwrap_or_else(|| "未知".to_owned())
+}
+
+fn display_todo_cancelled_at(item: &TodoItem) -> String {
+    item.cancelled_at
+        .as_deref()
+        .map(format_todo_time_for_display)
+        .unwrap_or_else(|| "未知".to_owned())
+}
+
+fn success_lines(title: &str, item: Option<&ReceiptItem>) -> Vec<String> {
+    let mut lines = vec![title.to_owned()];
+    if let Some(item) = item {
+        lines.push(String::new());
+        lines.push(format!("- {}", item.title));
+        if let Some(time) = item
+            .display_time
+            .as_deref()
+            .filter(|value| !value.is_empty())
+        {
+            lines.push(format!("  时间：{time}"));
+        }
+    }
+    lines
+}
+
+fn success_markdown_lines(title: &str, item: Option<&ReceiptItem>) -> Vec<String> {
+    success_lines(&format!("# {title}"), item)
+}
+
+fn success_count_lines(
+    title: &str,
+    count: usize,
+    unit: &str,
+    field: &str,
+    output: &Value,
+) -> Vec<String> {
+    let mut lines = vec![format!("{title} · {count}{unit}")];
+    if let Some(items) = output.get(field).and_then(Value::as_array) {
+        for item in items
+            .iter()
+            .filter_map(|value| item_from_value(Some(value)))
+        {
+            lines.push(format!("- {}", item.title));
+        }
+    }
+    lines
+}
+
+fn success_count_markdown_lines(
+    title: &str,
+    count: usize,
+    unit: &str,
+    field: &str,
+    output: &Value,
+) -> Vec<String> {
+    let mut lines = success_count_lines(title, count, unit, field, output);
+    if let Some(first) = lines.first_mut() {
+        *first = format!("# {first}");
+    }
+    lines
+}
+
+fn affected_item_line(item: &TodoItem) -> String {
+    let mut line = format!("- {}", format_todo_inline(item));
+    let time = display_todo_time(item);
+    if !time.trim().is_empty() {
+        line.push_str(&format!("\n  时间：{time}"));
+    }
+    line
+}
+
+fn affected_item_line_markdown(item: &TodoItem) -> String {
+    let mut line = format!("- {}", format_todo_inline_markdown(item));
+    let time = display_todo_time(item);
+    if !time.trim().is_empty() {
+        line.push_str(&format!("\n  - **时间**：{time}"));
+    }
+    line
+}
+
+#[derive(Debug, Clone)]
+struct ReceiptItem {
+    title: String,
+    display_time: Option<String>,
+}
+
+fn item_from_value(value: Option<&Value>) -> Option<ReceiptItem> {
+    let value = value?;
+    let title = string_field(value, "title")?;
+    Some(ReceiptItem {
+        title: truncate_chars(&title, 80),
+        display_time: string_field(value, "display_time"),
+    })
+}
+
+fn error_reply_for_tool_result(output: &Value) -> String {
+    let code = structured_error_code(output);
+    match code.as_deref() {
+        Some("todo_visible_numbers_unavailable") => {
+            "没有可用的最近待办编号。请先查看对应待办列表，再按编号操作。".to_owned()
+        }
+        Some("todo_reference_unavailable") => {
+            "找不到“刚才那条”待办。请先查看列表或明确说明要操作哪一条。".to_owned()
+        }
+        Some("todo_reference_invalid_state") => {
+            "目标待办当前状态不允许执行这次操作。请查看最新列表后再试。".to_owned()
+        }
+        Some("todo_selection_not_found") => {
+            "没有找到符合条件的待办，或可见编号已经失效。请查看最新列表后再操作。".to_owned()
+        }
+        Some("todo_delete_invalid_state") => {
+            "进行中的待办不能永久删除；如不再需要，请先取消它。".to_owned()
+        }
+        Some("todo_delete_mixed_status") => {
+            "不能把已完成和已取消待办混在同一次永久删除里。请分状态删除。".to_owned()
+        }
+        Some("todo_pending_exists") | Some("todo_pending_conflict") => {
+            "当前已有待确认的待办操作，请先回复“确认”或“取消”。".to_owned()
+        }
+        _ => string_field(output, "message")
+            .or_else(|| {
+                output
+                    .get("error")
+                    .and_then(|error| string_field(error, "message"))
+            })
+            .unwrap_or_else(|| "这次待办操作没有成功，没有修改待办。".to_owned()),
+    }
+}
+
+fn structured_error_code(output: &Value) -> Option<String> {
+    output
+        .get("error_code")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            output
+                .get("error")
+                .and_then(|error| error.get("code"))
+                .and_then(Value::as_str)
+        })
+        .map(str::to_owned)
+}
+
+fn string_field(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn status_label(status: &TodoStatus) -> &'static str {
+    match status {
+        TodoStatus::Pending => "进行中待办",
+        TodoStatus::Completed => "已完成待办",
+        TodoStatus::Cancelled => "已取消待办",
+    }
+}

--- a/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
@@ -11,8 +11,8 @@ use crate::{
     provider::ToolExecutionResult,
     runtime::{
         respond::{
+            agent_outcome::{ResponseBlock, ToolEffect, ToolExecutionOutcome, ToolOutcomeStatus},
             common::{CommandBody, todo_error, truncate_chars},
-            llm_service::RespondOutput,
         },
         session::SessionRecord,
         todo::{TodoItem, TodoOwner, TodoStatus, TodoStore, display_todo_time},
@@ -28,12 +28,6 @@ const RECEIPT_LIST_LIMIT: usize = 5;
 pub(in crate::runtime::respond) struct TodoWriteReceipt {
     pub body: CommandBody,
     pub command: &'static str,
-    pub operation: &'static str,
-    pub query_type: Option<&'static str>,
-    pub condition: Option<&'static str>,
-    pub displayed_count: usize,
-    pub total_count: usize,
-    pub truncated: bool,
     pub error_code: Option<String>,
 }
 
@@ -63,25 +57,29 @@ struct RelatedReceiptDraft {
     markdown_lines: Vec<String>,
     spec: RelatedListSpec,
     command: &'static str,
-    operation: &'static str,
     trailing_hint: Option<&'static str>,
 }
 
-pub(in crate::runtime::respond) fn receipt_from_tool_loop_output(
+pub(in crate::runtime::respond) fn tool_outcome_from_todo_result(
     todo_store: &TodoStore,
     session: &mut SessionRecord,
     owner: &TodoOwner,
-    output: &RespondOutput,
-) -> Result<Option<TodoWriteReceipt>, LlmError> {
-    let Some(result) = output
-        .tool_results
-        .iter()
-        .rev()
-        .find(|result| todo_write_operation(&result.name).is_some())
-    else {
+    result: &ToolExecutionResult,
+) -> Result<Option<ToolExecutionOutcome>, LlmError> {
+    let Some(operation) = todo_write_operation(&result.name) else {
         return Ok(None);
     };
-    receipt_from_tool_result(todo_store, session, owner, result)
+    let status = ToolOutcomeStatus::from_tool_result(result);
+    let receipt = receipt_from_tool_result_with_status(todo_store, session, owner, result, status)?;
+    Ok(Some(ToolExecutionOutcome {
+        tool_name: result.name.clone(),
+        domain: "todo".to_owned(),
+        status,
+        effect: tool_effect_for_operation(operation),
+        blocks: vec![response_block_for_receipt(status, receipt.body.clone())],
+        error_code: receipt.error_code.clone(),
+        command: Some(receipt.command.to_owned()),
+    }))
 }
 
 pub(in crate::runtime::respond) fn receipt_after_created(
@@ -109,7 +107,6 @@ pub(in crate::runtime::respond) fn receipt_after_created(
             markdown_lines,
             spec: pending_list_spec(),
             command: "todo_confirm",
-            operation: "create",
             trailing_hint: None,
         },
     )
@@ -140,7 +137,6 @@ pub(in crate::runtime::respond) fn receipt_after_cancelled(
             markdown_lines,
             spec: cancelled_list_spec(),
             command: "todo_confirm",
-            operation: "cancel",
             trailing_hint: Some("可说：删除全部取消的待办"),
         },
     )
@@ -176,55 +172,51 @@ pub(in crate::runtime::respond) fn receipt_after_deleted(
             markdown_lines,
             spec,
             command: "todo_confirm",
-            operation: "delete",
             trailing_hint: None,
         },
     )
 }
 
-fn receipt_from_tool_result(
+fn receipt_from_tool_result_with_status(
     todo_store: &TodoStore,
     session: &mut SessionRecord,
     owner: &TodoOwner,
     result: &ToolExecutionResult,
-) -> Result<Option<TodoWriteReceipt>, LlmError> {
+    status: ToolOutcomeStatus,
+) -> Result<TodoWriteReceipt, LlmError> {
     let Some(operation) = todo_write_operation(&result.name) else {
-        return Ok(None);
+        return Err(LlmError::new(
+            "bad_tool_result",
+            format!("tool `{}` is not a Todo write tool", result.name),
+            "todo_receipt",
+        ));
     };
-    if result
-        .output
-        .get("requires_clarification")
-        .and_then(Value::as_bool)
-        == Some(true)
-    {
+    if status == ToolOutcomeStatus::Skipped {
+        return Ok(simple_receipt(
+            CommandBody::plain(skip_reply_for_tool_result(&result.output)),
+            "todo_tool_skipped",
+            structured_error_code(&result.output),
+        ));
+    }
+    if status == ToolOutcomeStatus::RequiresClarification {
         let question = string_field(&result.output, "question")
             .or_else(|| string_field(&result.output, "message"))
             .unwrap_or_else(|| "请再具体说明要操作哪条待办。".to_owned());
-        return Ok(Some(simple_receipt(
+        return Ok(simple_receipt(
             CommandBody::plain(question),
             "todo_clarify_wait",
-            operation_name(operation),
             structured_error_code(&result.output),
-        )));
+        ));
     }
-    if !result.succeeded || result.output.get("ok").and_then(Value::as_bool) == Some(false) {
-        return Ok(Some(simple_receipt(
+    if status == ToolOutcomeStatus::Failed {
+        return Ok(simple_receipt(
             CommandBody::plain(error_reply_for_tool_result(&result.output)),
             "todo_tool_error",
-            operation_name(operation),
             structured_error_code(&result.output),
-        )));
+        ));
     }
-    if result
-        .output
-        .get("requires_confirmation")
-        .and_then(Value::as_bool)
-        == Some(true)
-    {
-        return Ok(Some(pending_confirmation_receipt(
-            operation,
-            &result.output,
-        )));
+    if status == ToolOutcomeStatus::PendingConfirmation {
+        return Ok(pending_confirmation_receipt(&result.output));
     }
 
     let receipt = match operation {
@@ -241,7 +233,6 @@ fn receipt_from_tool_result(
                     markdown_lines,
                     spec: pending_list_spec(),
                     command: "todo_create",
-                    operation: "create",
                     trailing_hint: None,
                 },
             )?
@@ -259,7 +250,6 @@ fn receipt_from_tool_result(
                     markdown_lines,
                     spec: pending_list_spec(),
                     command: "todo_edit",
-                    operation: "edit",
                     trailing_hint: None,
                 },
             )?
@@ -288,7 +278,6 @@ fn receipt_from_tool_result(
                     markdown_lines,
                     spec: pending_list_spec(),
                     command: "todo_complete",
-                    operation: "complete",
                     trailing_hint: None,
                 },
             )?
@@ -317,16 +306,36 @@ fn receipt_from_tool_result(
                     markdown_lines,
                     spec: pending_list_spec(),
                     command: "todo_restore",
-                    operation: "restore",
                     trailing_hint: None,
                 },
             )?
         }
         TodoWriteOperation::CancelPending | TodoWriteOperation::DeletePending => {
-            pending_confirmation_receipt(operation, &result.output)
+            pending_confirmation_receipt(&result.output)
         }
     };
-    Ok(Some(receipt))
+    Ok(receipt)
+}
+
+fn response_block_for_receipt(status: ToolOutcomeStatus, body: CommandBody) -> ResponseBlock {
+    match status {
+        ToolOutcomeStatus::Succeeded => ResponseBlock::MutationReceipt(body),
+        ToolOutcomeStatus::PendingConfirmation => ResponseBlock::Confirmation(body),
+        ToolOutcomeStatus::RequiresClarification => ResponseBlock::Clarification(body),
+        ToolOutcomeStatus::Failed => ResponseBlock::Error(body),
+        ToolOutcomeStatus::Skipped => ResponseBlock::Warning(body),
+    }
+}
+
+fn tool_effect_for_operation(operation: TodoWriteOperation) -> ToolEffect {
+    match operation {
+        TodoWriteOperation::Create => ToolEffect::Created,
+        TodoWriteOperation::Edit => ToolEffect::Updated,
+        TodoWriteOperation::Complete => ToolEffect::Completed,
+        TodoWriteOperation::CancelPending => ToolEffect::Cancelled,
+        TodoWriteOperation::Restore => ToolEffect::Updated,
+        TodoWriteOperation::DeletePending => ToolEffect::Deleted,
+    }
 }
 
 fn receipt_with_related_list(
@@ -340,7 +349,6 @@ fn receipt_with_related_list(
         mut markdown_lines,
         spec,
         command,
-        operation,
         trailing_hint,
     } = draft;
     let items = list_for_spec(todo_store, owner, &spec).map_err(todo_error)?;
@@ -380,17 +388,11 @@ fn receipt_with_related_list(
     Ok(TodoWriteReceipt {
         body: CommandBody::dual(lines.join("\n"), markdown_lines.join("\n")),
         command,
-        operation,
-        query_type: Some(spec.query_type),
-        condition: Some(spec.condition),
-        displayed_count: shown.len(),
-        total_count,
-        truncated,
         error_code: None,
     })
 }
 
-fn pending_confirmation_receipt(operation: TodoWriteOperation, output: &Value) -> TodoWriteReceipt {
+fn pending_confirmation_receipt(output: &Value) -> TodoWriteReceipt {
     let pending_action = output
         .get("pending_action")
         .and_then(Value::as_str)
@@ -436,24 +438,17 @@ fn pending_confirmation_receipt(operation: TodoWriteOperation, output: &Value) -
             string_field(output, "message").unwrap_or_else(|| "这次待办操作需要确认。".to_owned()),
         ),
     };
-    simple_receipt(body, "todo_pending", operation_name(operation), None)
+    simple_receipt(body, "todo_pending", None)
 }
 
 fn simple_receipt(
     body: CommandBody,
     command: &'static str,
-    operation: &'static str,
     error_code: Option<String>,
 ) -> TodoWriteReceipt {
     TodoWriteReceipt {
         body,
         command,
-        operation,
-        query_type: None,
-        condition: None,
-        displayed_count: 0,
-        total_count: 0,
-        truncated: false,
         error_code,
     }
 }
@@ -526,17 +521,6 @@ fn todo_write_operation(name: &str) -> Option<TodoWriteOperation> {
         "restore_todos" => Some(TodoWriteOperation::Restore),
         "delete_todos" => Some(TodoWriteOperation::DeletePending),
         _ => None,
-    }
-}
-
-fn operation_name(operation: TodoWriteOperation) -> &'static str {
-    match operation {
-        TodoWriteOperation::Create => "create",
-        TodoWriteOperation::Edit => "edit",
-        TodoWriteOperation::Complete => "complete",
-        TodoWriteOperation::CancelPending => "cancel",
-        TodoWriteOperation::Restore => "restore",
-        TodoWriteOperation::DeletePending => "delete",
     }
 }
 
@@ -707,6 +691,16 @@ fn error_reply_for_tool_result(output: &Value) -> String {
                     .and_then(|error| string_field(error, "message"))
             })
             .unwrap_or_else(|| "这次待办操作没有成功，没有修改待办。".to_owned()),
+    }
+}
+
+fn skip_reply_for_tool_result(output: &Value) -> String {
+    match string_field(output, "reason").as_deref() {
+        Some("dependency_previous_call_failed") => {
+            "前序工具没有成功，本次待办操作已跳过，数据库未因此继续修改。".to_owned()
+        }
+        Some(reason) => format!("本次待办操作已跳过：{reason}。"),
+        None => "本次待办操作已跳过，数据库未因此继续修改。".to_owned(),
     }
 }
 

--- a/qq-maid-core/src/runtime/respond/tool_presenters.rs
+++ b/qq-maid-core/src/runtime/respond/tool_presenters.rs
@@ -1,0 +1,280 @@
+//! 非 Todo 业务 Tool 的确定性展示适配器。
+//!
+//! 通用 Agent 编排层不理解具体业务字段；这里按工具名把已注册业务 Tool 的
+//! 安全结构化输出转换为可信响应块，避免模型最终文案覆盖或丢弃真实工具结果。
+
+use serde_json::Value;
+
+use crate::{provider::ToolExecutionResult, util::time_context::format_local_time_for_display};
+
+use super::{
+    agent_outcome::{
+        OutcomePresentation, ResponseBlock, ToolEffect, ToolExecutionOutcome, ToolOutcomeStatus,
+    },
+    common::{CommandBody, truncate_chars},
+    weather_flow::{format_forecast_day_label, weather_code_label},
+};
+
+const WEATHER_TOOL_NAME: &str = "get_weather";
+const WEATHER_FACT_MAX_CHARS: usize = 900;
+
+pub(super) fn tool_outcome_from_weather_result(
+    result: &ToolExecutionResult,
+) -> Option<ToolExecutionOutcome> {
+    if result.name != WEATHER_TOOL_NAME {
+        return None;
+    }
+
+    let status = ToolOutcomeStatus::from_tool_result(result);
+    let error_code = structured_error_code(&result.output);
+    let block = match status {
+        ToolOutcomeStatus::Succeeded => ResponseBlock::FactCard(weather_fact_card(&result.output)),
+        ToolOutcomeStatus::Skipped => ResponseBlock::Warning(weather_skip_body(&result.output)),
+        ToolOutcomeStatus::RequiresClarification => {
+            ResponseBlock::Clarification(CommandBody::plain("请说明要查询哪个城市的天气。"))
+        }
+        ToolOutcomeStatus::PendingConfirmation | ToolOutcomeStatus::Failed => {
+            ResponseBlock::Error(weather_error_body(&result.output))
+        }
+    };
+
+    Some(ToolExecutionOutcome {
+        tool_name: result.name.clone(),
+        domain: "weather".to_owned(),
+        status,
+        effect: ToolEffect::ReadOnly,
+        presentation: OutcomePresentation::Trusted,
+        blocks: vec![block],
+        error_code,
+        command: Some("weather".to_owned()),
+    })
+}
+
+fn weather_fact_card(output: &Value) -> CommandBody {
+    let location = output.get("location").unwrap_or(&Value::Null);
+    let current = output.get("current").unwrap_or(&Value::Null);
+    let daily = output
+        .get("daily")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+
+    let name = string_field(location, "name").unwrap_or_else(|| "当前城市".to_owned());
+    let full_location = full_location_label(location, &name);
+    let weather = current
+        .get("weather_code")
+        .and_then(Value::as_u64)
+        .and_then(|code| u16::try_from(code).ok())
+        .map(weather_code_label)
+        .unwrap_or("未知");
+    let temp = number_field(current, "temperature_c")
+        .map(format_number)
+        .unwrap_or_else(|| "--".to_owned());
+    let time = string_field(current, "time")
+        .map(|value| short_time(&value))
+        .unwrap_or_else(|| "--:--".to_owned());
+
+    let mut text_lines = vec![format!("🌦 {name}天气")];
+    let mut markdown_lines = vec![format!("# 🌦 {name}天气")];
+    if let Some(detail) = location_detail(&name, &full_location) {
+        text_lines.push(detail.clone());
+        markdown_lines.push(format!("**{detail}**"));
+    }
+    text_lines.push(String::new());
+    markdown_lines.push(String::new());
+    text_lines.push(format!("当前 {time}｜{weather}｜{temp}°C"));
+    markdown_lines.push(format!("**当前 {time}｜{weather}｜{temp}°C**  "));
+    if let Some(details) = current_details(current) {
+        text_lines.push(details.clone());
+        markdown_lines.push(format!("{details}  "));
+    }
+    if let Some(air) = air_quality_summary(output) {
+        text_lines.push(air.clone());
+        markdown_lines.push(air);
+    }
+
+    let forecast = daily
+        .iter()
+        .take(3)
+        .filter_map(format_daily_summary)
+        .collect::<Vec<_>>();
+    if !forecast.is_empty() {
+        text_lines.push(String::new());
+        markdown_lines.push(String::new());
+        text_lines.push(format!("未来 {} 天", forecast.len()));
+        markdown_lines.push(format!("## 未来 {} 天", forecast.len()));
+        for line in forecast {
+            text_lines.push(format!("- {line}"));
+            markdown_lines.push(format!("- **{}**", line));
+        }
+    }
+
+    CommandBody::dual(
+        truncate_chars(&text_lines.join("\n"), WEATHER_FACT_MAX_CHARS),
+        truncate_chars(&markdown_lines.join("\n"), WEATHER_FACT_MAX_CHARS),
+    )
+}
+
+fn format_daily_summary(day: &Value) -> Option<String> {
+    let date = string_field(day, "date")?;
+    let weather = string_field(day, "weather_day")
+        .or_else(|| string_field(day, "weather_night"))
+        .or_else(|| {
+            day.get("weather_code")
+                .and_then(Value::as_u64)
+                .and_then(|code| u16::try_from(code).ok())
+                .map(weather_code_label)
+                .map(str::to_owned)
+        })
+        .unwrap_or_else(|| "未知".to_owned());
+    let min = number_field(day, "temperature_min_c").map(format_number);
+    let max = number_field(day, "temperature_max_c").map(format_number);
+    let temp = match (min, max) {
+        (Some(min), Some(max)) => format!("{min}～{max}°C"),
+        (None, Some(max)) => format!("最高 {max}°C"),
+        (Some(min), None) => format!("最低 {min}°C"),
+        (None, None) => "温度未知".to_owned(),
+    };
+    let mut parts = vec![format_forecast_day_label(&date, None), weather, temp];
+    if let Some(probability) = day
+        .get("precipitation_probability_max")
+        .and_then(Value::as_u64)
+    {
+        parts.push(format!("降水概率 {probability}%"));
+    }
+    Some(parts.join("，"))
+}
+
+fn current_details(current: &Value) -> Option<String> {
+    let mut parts = Vec::new();
+    if let Some(apparent) = number_field(current, "apparent_temperature_c") {
+        parts.push(format!("体感 {}°C", format_number(apparent)));
+    }
+    if let Some(humidity) = current.get("humidity_percent").and_then(Value::as_u64) {
+        parts.push(format!("湿度 {humidity}%"));
+    }
+    if let Some(precipitation) = number_field(current, "precipitation_mm")
+        && precipitation > 0.0
+    {
+        parts.push(format!("降水 {}mm", format_number(precipitation)));
+    }
+    if let Some(wind) = format_wind(
+        string_field(current, "wind_direction").as_deref(),
+        string_field(current, "wind_scale").as_deref(),
+    ) {
+        parts.push(wind);
+    }
+    (!parts.is_empty()).then(|| parts.join(" · "))
+}
+
+fn air_quality_summary(output: &Value) -> Option<String> {
+    let air = output.get("air_quality")?.get("summary")?;
+    let aqi = string_field(air, "aqi_display")?;
+    let category = string_field(air, "category");
+    let mut text = format!("空气质量：AQI {aqi}");
+    if let Some(category) = category {
+        text.push_str(&format!("（{category}）"));
+    }
+    if let Some(primary) = string_field(air, "primary_pollutant") {
+        text.push_str(&format!(" · 首要污染物 {primary}"));
+    }
+    Some(text)
+}
+
+fn weather_error_body(output: &Value) -> CommandBody {
+    let code = structured_error_code(output);
+    let text = match code.as_deref() {
+        Some("not_found") => "【天气】\n\n没找到这个城市。可以换成更完整的城市名再试。",
+        Some("timeout") => "【天气】\n\n天气服务超时了，请稍后再试。",
+        Some("bad_tool_arguments") => "【天气】\n\n天气查询参数不完整，请说明要查询的城市。",
+        _ => "【天气】\n\n天气服务暂时不可用，请稍后再试。",
+    };
+    CommandBody::plain(text)
+}
+
+fn weather_skip_body(output: &Value) -> CommandBody {
+    let text = match string_field(output, "reason").as_deref() {
+        Some("dependency_previous_call_failed") => {
+            "天气查询因前序工具失败已跳过；根因以上方失败信息为准。".to_owned()
+        }
+        Some(reason) => format!("天气查询已跳过：{reason}。"),
+        None => "天气查询已跳过。".to_owned(),
+    };
+    CommandBody::plain(text)
+}
+
+fn full_location_label(location: &Value, name: &str) -> String {
+    let mut parts = vec![name.trim().to_owned()];
+    for key in ["admin2", "admin1", "country"] {
+        if let Some(value) = string_field(location, key)
+            && !parts.iter().any(|part| part == &value)
+        {
+            parts.push(value);
+        }
+    }
+    parts.join("，")
+}
+
+fn location_detail(name: &str, full_location: &str) -> Option<String> {
+    let name = name.trim();
+    let full_location = full_location.trim();
+    if full_location.is_empty() || full_location == name {
+        None
+    } else {
+        Some(full_location.to_owned())
+    }
+}
+
+fn format_wind(direction: Option<&str>, scale: Option<&str>) -> Option<String> {
+    match (
+        direction.map(str::trim).filter(|value| !value.is_empty()),
+        scale.map(str::trim).filter(|value| !value.is_empty()),
+    ) {
+        (Some(direction), Some(scale)) => Some(format!("{direction} {scale}级")),
+        (Some(direction), None) => Some(direction.to_owned()),
+        (None, Some(scale)) => Some(format!("{scale}级风")),
+        (None, None) => None,
+    }
+}
+
+fn short_time(value: &str) -> String {
+    let display = format_local_time_for_display(value);
+    display
+        .split_once(' ')
+        .map(|(_, time)| time.get(..5).unwrap_or(time).to_owned())
+        .unwrap_or(display)
+}
+
+fn number_field(value: &Value, key: &str) -> Option<f64> {
+    value.get(key).and_then(Value::as_f64)
+}
+
+fn format_number(value: f64) -> String {
+    if value.fract().abs() < f64::EPSILON {
+        format!("{value:.0}")
+    } else {
+        format!("{value:.1}")
+    }
+}
+
+fn string_field(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn structured_error_code(output: &Value) -> Option<String> {
+    output
+        .get("error_code")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            output
+                .get("error")
+                .and_then(|error| error.get("code"))
+                .and_then(Value::as_str)
+        })
+        .map(str::to_owned)
+}


### PR DESCRIPTION
## 变更
- 新增 Todo 写操作确定性回执模块，服务端根据真实 Tool 结果生成最终回复。
- 写操作后重新读取 TodoStore，刷新相关状态列表，并只把实际展示的编号写入 last_todo_query。
- pending 确认完成后复用同一套回执，确认永久删除前不修改数据库。
- Tool ok=false / 澄清 / 需要确认时返回结构化、可验证的用户反馈。
- 包含 #168 第一阶段的通用工具结果编排骨架。

## 验证
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test -p qq-maid-core
- make test-core

Closes #164