### PR TITLE
feat: C2C 最终回复流默认启用 + QQ 原生 typing 支持

### DIFF
--- a/qq-maid-gateway-rs/src/api/mod.rs
+++ b/qq-maid-gateway-rs/src/api/mod.rs
@@ -92,6 +92,14 @@ struct C2cTextPayload<'a> {
 }
 
 #[derive(Debug, Serialize)]
+struct C2cTypingPayload<'a> {
+    msg_type: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    msg_id: Option<&'a str>,
+    msg_seq: u32,
+}
+
+#[derive(Debug, Serialize)]
 struct GroupTextPayload<'a> {
     content: &'a str,
     msg_type: u8,
@@ -290,6 +298,12 @@ impl QqApiClient {
     ) -> SendResult {
         let payload = build_c2c_text_payload(text, msg_id, self.next_msg_seq());
         self.post_c2c_message(user_openid, msg_id, "text", &payload)
+            .await
+    }
+
+    pub async fn send_c2c_typing(&self, user_openid: &str, msg_id: Option<&str>) -> SendResult {
+        let payload = build_c2c_typing_payload(msg_id, self.next_msg_seq());
+        self.post_c2c_message(user_openid, msg_id, "typing", &payload)
             .await
     }
 
@@ -659,6 +673,15 @@ pub fn build_c2c_text_payload(text: &str, msg_id: Option<&str>, msg_seq: u32) ->
         msg_seq,
     })
     .expect("C2C text payload should serialize")
+}
+
+fn build_c2c_typing_payload(msg_id: Option<&str>, msg_seq: u32) -> Value {
+    serde_json::to_value(C2cTypingPayload {
+        msg_type: 6,
+        msg_id,
+        msg_seq,
+    })
+    .expect("C2C typing payload should serialize")
 }
 
 pub fn build_group_text_payload(text: &str, msg_id: Option<&str>, msg_seq: u32) -> Value {

--- a/qq-maid-gateway-rs/src/api/tests.rs
+++ b/qq-maid-gateway-rs/src/api/tests.rs
@@ -35,6 +35,18 @@ fn c2c_text_payload_matches_qq_shape() {
 }
 
 #[test]
+fn c2c_typing_payload_uses_native_typing_message_type() {
+    let payload = build_c2c_typing_payload(Some("msg-1"), 8);
+
+    assert_eq!(payload["msg_type"], 6);
+    assert_eq!(payload["msg_id"], "msg-1");
+    assert_eq!(payload["msg_seq"], 8);
+    assert!(payload.get("content").is_none());
+    assert!(payload.get("markdown").is_none());
+    assert!(payload.get("stream").is_none());
+}
+
+#[test]
 fn c2c_markdown_stream_payload_matches_reference_shape() {
     let first_markdown = MarkdownPayload::new("**hello**");
     let first_payload = build_c2c_markdown_stream_payload(

--- a/qq-maid-gateway-rs/src/config/mod.rs
+++ b/qq-maid-gateway-rs/src/config/mod.rs
@@ -16,6 +16,9 @@ pub const DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS: u64 = 3000;
 pub const DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES: usize = 10;
 pub const DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS: usize = 12000;
 pub const DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS: usize = 1024;
+pub const DEFAULT_C2C_FINAL_REPLY_STREAM_ENABLED: bool = true;
+pub const DEFAULT_AGENT_TYPING_ENABLED: bool = true;
+pub const DEFAULT_AGENT_TYPING_DELAY_MS: u64 = 1000;
 /// 普通回复分段软限制默认值（非平台硬上限，仅保守软限制）。
 /// 默认对齐官方非流式长消息分段的 5000 字符基线，尽量减少段数；
 /// 真实 QQ 单条限制仍需真机验证后再校准。
@@ -49,6 +52,9 @@ pub struct AppConfig {
     pub max_active_conversation_workers: usize,
     pub conversation_worker_idle_timeout: Duration,
     pub message_aggregation: MessageAggregationConfig,
+    /// 私聊 Agent 最终回复是否接入 QQ C2C Markdown 流式发送；默认启用，可关闭回滚。
+    pub c2c_final_reply_stream_enabled: bool,
+    pub agent_typing: AgentTypingConfig,
     /// 普通回复 Markdown 通道分段软限制（非平台硬上限）。
     pub markdown_chunk_soft_limit: usize,
     /// 普通回复纯文本通道分段软限制（非平台硬上限）。
@@ -64,6 +70,12 @@ pub struct MessageAggregationConfig {
     pub max_messages: usize,
     pub max_chars: usize,
     pub max_active_keys: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentTypingConfig {
+    pub enabled: bool,
+    pub delay: Duration,
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -149,6 +161,10 @@ impl AppConfig {
             3600,
         )?;
         let message_aggregation = parse_message_aggregation_config(env)?;
+        let c2c_final_reply_stream_enabled =
+            parse_bool(env, "QQ_MAID_C2C_FINAL_REPLY_STREAM_ENABLED")?
+                .unwrap_or(DEFAULT_C2C_FINAL_REPLY_STREAM_ENABLED);
+        let agent_typing = parse_agent_typing_config(env)?;
         let markdown_chunk_soft_limit = parse_ranged_usize(
             env,
             "QQ_MARKDOWN_CHUNK_SOFT_LIMIT",
@@ -181,10 +197,30 @@ impl AppConfig {
                 conversation_worker_idle_timeout_seconds,
             ),
             message_aggregation,
+            c2c_final_reply_stream_enabled,
+            agent_typing,
             markdown_chunk_soft_limit,
             text_chunk_soft_limit,
         })
     }
+}
+
+fn parse_agent_typing_config(
+    env: &HashMap<String, String>,
+) -> Result<AgentTypingConfig, ConfigError> {
+    let enabled =
+        parse_bool(env, "QQ_MAID_AGENT_TYPING_ENABLED")?.unwrap_or(DEFAULT_AGENT_TYPING_ENABLED);
+    let delay_ms = parse_ranged_u64(
+        env,
+        "QQ_MAID_AGENT_TYPING_DELAY_MS",
+        DEFAULT_AGENT_TYPING_DELAY_MS,
+        100,
+        60_000,
+    )?;
+    Ok(AgentTypingConfig {
+        enabled,
+        delay: Duration::from_millis(delay_ms),
+    })
 }
 
 fn parse_message_aggregation_config(
@@ -426,6 +462,17 @@ mod tests {
             }
         );
         assert_eq!(
+            config.c2c_final_reply_stream_enabled,
+            DEFAULT_C2C_FINAL_REPLY_STREAM_ENABLED
+        );
+        assert_eq!(
+            config.agent_typing,
+            AgentTypingConfig {
+                enabled: DEFAULT_AGENT_TYPING_ENABLED,
+                delay: Duration::from_millis(DEFAULT_AGENT_TYPING_DELAY_MS),
+            }
+        );
+        assert_eq!(
             config.markdown_chunk_soft_limit,
             DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT
         );
@@ -540,6 +587,9 @@ mod tests {
             ("MESSAGE_AGGREGATION_MAX_MESSAGES", "5"),
             ("MESSAGE_AGGREGATION_MAX_CHARS", "4096"),
             ("MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS", "32"),
+            ("QQ_MAID_C2C_FINAL_REPLY_STREAM_ENABLED", "true"),
+            ("QQ_MAID_AGENT_TYPING_ENABLED", "false"),
+            ("QQ_MAID_AGENT_TYPING_DELAY_MS", "1500"),
             ("QQ_MARKDOWN_CHUNK_SOFT_LIMIT", "1600"),
             ("QQ_TEXT_CHUNK_SOFT_LIMIT", "1500"),
         ]))
@@ -568,6 +618,14 @@ mod tests {
                 max_messages: 5,
                 max_chars: 4096,
                 max_active_keys: 32,
+            }
+        );
+        assert!(config.c2c_final_reply_stream_enabled);
+        assert_eq!(
+            config.agent_typing,
+            AgentTypingConfig {
+                enabled: false,
+                delay: Duration::from_millis(1500),
             }
         );
         assert_eq!(config.markdown_chunk_soft_limit, 1600);
@@ -630,6 +688,16 @@ mod tests {
                     value: 16,
                     min: MIN_CHUNK_SOFT_LIMIT as u64,
                     max: 64_000,
+                },
+            },
+            Case {
+                name: "rejects_agent_typing_delay_below_minimum",
+                map: env_with_creds(&[("QQ_MAID_AGENT_TYPING_DELAY_MS", "10")]),
+                expected_err: ConfigError::IntegerOutOfRange {
+                    name: "QQ_MAID_AGENT_TYPING_DELAY_MS",
+                    value: 10,
+                    min: 100,
+                    max: 60_000,
                 },
             },
         ];

--- a/qq-maid-gateway-rs/src/gateway/aggregator/actor.rs
+++ b/qq-maid-gateway-rs/src/gateway/aggregator/actor.rs
@@ -719,7 +719,7 @@ impl AggregatorActor {
 mod tests {
     use super::*;
     use crate::{
-        config::{AppConfig, GroupMessageMode},
+        config::{AgentTypingConfig, AppConfig, GroupMessageMode},
         gateway::{dedupe::MessageDedupe, event::GroupMessage},
         respond::RespondClient,
     };
@@ -837,6 +837,11 @@ mod tests {
                 max_messages: 3,
                 max_chars: 12,
                 max_active_keys: 4,
+            },
+            c2c_final_reply_stream_enabled: false,
+            agent_typing: AgentTypingConfig {
+                enabled: false,
+                delay: Duration::from_secs(1),
             },
             markdown_chunk_soft_limit: 1800,
             text_chunk_soft_limit: 1800,

--- a/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
@@ -1,6 +1,6 @@
 use super::{AggregationDispatcher, MessageAggregator, MessageAggregatorHandle};
 use crate::{
-    config::{AppConfig, GroupMessageMode, MessageAggregationConfig},
+    config::{AgentTypingConfig, AppConfig, GroupMessageMode, MessageAggregationConfig},
     gateway::{
         dedupe::MessageDedupe,
         dispatcher::DispatcherEnqueueError,
@@ -303,6 +303,11 @@ fn test_config() -> AppConfig {
             max_messages: 3,
             max_chars: 12,
             max_active_keys: 4,
+        },
+        c2c_final_reply_stream_enabled: false,
+        agent_typing: AgentTypingConfig {
+            enabled: false,
+            delay: Duration::from_secs(1),
         },
         markdown_chunk_soft_limit: 1800,
         text_chunk_soft_limit: 1800,

--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -3,6 +3,8 @@
 //! 私聊链路负责本地 `/ping`、Signal Layer 回填、Core 调用和普通回复发送；
 //! C2C 流式发送状态机独立放在 `stream.rs`。
 
+use std::{future::Future, pin::Pin};
+
 use tracing::{debug, info, warn};
 
 use super::{
@@ -31,6 +33,27 @@ use crate::{
     },
 };
 use qq_maid_core::service::{CoreFailureKind, CoreInboundKind, CoreRespondFailure};
+
+const CORE_STREAM_CLOSED_FALLBACK_TEXT: &str = "处理失败，请稍后再试。";
+
+type RespondEventFuture<'a> = Pin<Box<dyn Future<Output = Option<RespondEvent>> + Send + 'a>>;
+
+trait RespondEventStream: Send {
+    fn recv_event<'a>(&'a mut self) -> RespondEventFuture<'a>;
+}
+
+impl RespondEventStream for qq_maid_core::service::CoreResponseStream {
+    fn recv_event<'a>(&'a mut self) -> RespondEventFuture<'a> {
+        Box::pin(async move { self.recv().await })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DisabledStreamOutcome {
+    Completed,
+    Failed(CoreFailureKind),
+    ClosedBeforeCompleted,
+}
 
 /// 发送 C2C 普通（非流式）回复消息，供真实网关入口调用。
 async fn send_c2c_respond_response(
@@ -265,37 +288,19 @@ pub(super) async fn handle_c2c_message(
             if config.c2c_final_reply_stream_enabled {
                 stream_respond_c2c(stream, api, runtime, &message, config, typing).await?;
             } else {
-                match consume_respond_stream_for_complete(stream).await {
-                    Ok(Some(response)) => {
-                        stop_typing(&mut typing, TypingStopReason::FinalReply);
-                        send_c2c_respond_response(api, runtime, &message, &response, config)
-                            .await?;
-                    }
-                    Ok(None) => {
-                        stop_typing(&mut typing, TypingStopReason::Cancelled);
-                        warn!(
-                            message_id = %message.message_id,
-                            user = %masked_user,
-                            "core respond stream closed before Completed while C2C stream was disabled"
-                        );
-                    }
-                    Err(failure) => {
-                        stop_typing(&mut typing, failure_stop_reason(&failure));
-                        warn!(
-                            message_id = %message.message_id,
-                            user = %masked_user,
-                            kind = ?failure.kind,
-                            retryable = failure.retryable,
-                            "core respond stream failed while C2C stream was disabled"
-                        );
-                        send_c2c_text_with_status(
-                            api,
-                            runtime,
-                            &message.user_openid,
-                            Some(&message.message_id),
-                            &failure.message,
-                        )
+                let sender = RuntimeRecordingSender {
+                    inner: api,
+                    runtime,
+                };
+                let outcome =
+                    handle_c2c_stream_disabled(stream, &sender, &message, config, &mut typing)
                         .await?;
+                match outcome {
+                    DisabledStreamOutcome::Completed => {}
+                    DisabledStreamOutcome::Failed(kind) => runtime
+                        .record_respond_failure(format!("stream_failed_before_completed:{kind:?}")),
+                    DisabledStreamOutcome::ClosedBeforeCompleted => {
+                        runtime.record_respond_failure("stream_closed_before_completed")
                     }
                 }
             }
@@ -337,17 +342,60 @@ fn stop_typing(typing: &mut Option<C2cTypingStatusGuard>, reason: TypingStopReas
     }
 }
 
-async fn consume_respond_stream_for_complete(
-    mut stream: qq_maid_core::service::CoreResponseStream,
-) -> Result<Option<RespondResponse>, CoreRespondFailure> {
-    while let Some(event) = stream.recv().await {
+async fn handle_c2c_stream_disabled<E, S>(
+    mut stream: E,
+    sender: &S,
+    message: &C2cMessage,
+    config: &AppConfig,
+    typing: &mut Option<C2cTypingStatusGuard>,
+) -> anyhow::Result<DisabledStreamOutcome>
+where
+    E: RespondEventStream,
+    S: OutboundSender + ?Sized,
+{
+    while let Some(event) = stream.recv_event().await {
         match event {
             RespondEvent::TextDelta(_) => {}
-            RespondEvent::Completed(response) => return Ok(Some(response)),
-            RespondEvent::Failed(failure) => return Err(failure),
+            RespondEvent::Completed(response) => {
+                stop_typing(typing, TypingStopReason::FinalReply);
+                send_c2c_respond_response_with_sender(sender, message, &response, config).await?;
+                return Ok(DisabledStreamOutcome::Completed);
+            }
+            RespondEvent::Failed(failure) => {
+                stop_typing(typing, failure_stop_reason(&failure));
+                warn!(
+                    message_id = %message.message_id,
+                    user = %mask_openid(&message.user_openid),
+                    kind = ?failure.kind,
+                    retryable = failure.retryable,
+                    "core respond stream failed while C2C stream was disabled"
+                );
+                send_local_c2c_failure_text(sender, message, &failure.message).await?;
+                return Ok(DisabledStreamOutcome::Failed(failure.kind));
+            }
         }
     }
-    Ok(None)
+    stop_typing(typing, TypingStopReason::Cancelled);
+    warn!(
+        message_id = %message.message_id,
+        user = %mask_openid(&message.user_openid),
+        "core respond stream closed before Completed while C2C stream was disabled"
+    );
+    send_local_c2c_failure_text(sender, message, CORE_STREAM_CLOSED_FALLBACK_TEXT).await?;
+    Ok(DisabledStreamOutcome::ClosedBeforeCompleted)
+}
+
+async fn send_local_c2c_failure_text<S: OutboundSender + ?Sized>(
+    sender: &S,
+    message: &C2cMessage,
+    text: &str,
+) -> anyhow::Result<()> {
+    let target = C2cReplyTarget {
+        user_openid: message.user_openid.clone(),
+        msg_id: Some(message.message_id.clone()),
+    };
+    sender.send_text(&target, text).await?;
+    Ok(())
 }
 
 fn failure_stop_reason(failure: &CoreRespondFailure) -> TypingStopReason {
@@ -396,6 +444,162 @@ fn log_c2c_message_received(message: &C2cMessage, verbose_log: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        api::{ApiError, SendFuture},
+        config::{
+            AgentTypingConfig, DEFAULT_CONVERSATION_QUEUE_CAPACITY,
+            DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT, DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS,
+            DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS, DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS,
+            DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES, DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS,
+            DEFAULT_MESSAGE_AGGREGATION_QUIET_MS, DEFAULT_TEXT_CHUNK_SOFT_LIMIT, GroupMessageMode,
+            MessageAggregationConfig,
+        },
+        media::ImagePayload,
+    };
+    use qq_maid_core::service::CoreRespondFailure;
+    use std::{collections::VecDeque, sync::Mutex, time::Duration};
+
+    #[derive(Debug)]
+    struct FakeEventStream {
+        events: VecDeque<RespondEvent>,
+    }
+
+    impl FakeEventStream {
+        fn new(events: impl IntoIterator<Item = RespondEvent>) -> Self {
+            Self {
+                events: events.into_iter().collect(),
+            }
+        }
+    }
+
+    impl RespondEventStream for FakeEventStream {
+        fn recv_event<'a>(&'a mut self) -> RespondEventFuture<'a> {
+            Box::pin(async move { self.events.pop_front() })
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum FakeCall {
+        Text {
+            content: String,
+            msg_id: Option<String>,
+        },
+        Markdown {
+            content: String,
+            msg_id: Option<String>,
+        },
+        Image,
+    }
+
+    #[derive(Debug, Default)]
+    struct FakeOutboundSender {
+        calls: Mutex<Vec<FakeCall>>,
+    }
+
+    impl FakeOutboundSender {
+        fn calls(&self) -> Vec<FakeCall> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    impl OutboundSender for FakeOutboundSender {
+        fn send_text<'a>(&'a self, target: &'a C2cReplyTarget, text: &'a str) -> SendFuture<'a> {
+            Box::pin(async move {
+                self.calls.lock().unwrap().push(FakeCall::Text {
+                    content: text.to_owned(),
+                    msg_id: target.msg_id.clone(),
+                });
+                Ok(Some("text-id".to_owned()))
+            })
+        }
+
+        fn send_markdown<'a>(
+            &'a self,
+            target: &'a C2cReplyTarget,
+            markdown: &'a MarkdownPayload,
+        ) -> SendFuture<'a> {
+            Box::pin(async move {
+                self.calls.lock().unwrap().push(FakeCall::Markdown {
+                    content: markdown.content.clone(),
+                    msg_id: target.msg_id.clone(),
+                });
+                Ok(Some("markdown-id".to_owned()))
+            })
+        }
+
+        fn send_image<'a>(
+            &'a self,
+            _target: &'a C2cReplyTarget,
+            _image: &'a ImagePayload,
+        ) -> SendFuture<'a> {
+            Box::pin(async move {
+                self.calls.lock().unwrap().push(FakeCall::Image);
+                Err(ApiError::Unsupported("image"))
+            })
+        }
+    }
+
+    fn c2c_message() -> C2cMessage {
+        C2cMessage {
+            message_id: "msg-1".to_owned(),
+            event_id: Some("event-1".to_owned()),
+            source_message_ids: vec!["msg-1".to_owned()],
+            source_event_ids: vec!["event-1".to_owned()],
+            user_openid: "user-1".to_owned(),
+            content: "晚上好".to_owned(),
+            reply: None,
+            timestamp: None,
+            first_message_timestamp: None,
+            last_message_timestamp: None,
+            attachments: Vec::new(),
+        }
+    }
+
+    fn respond_response(text: &str) -> RespondResponse {
+        RespondResponse {
+            text: Some(text.to_owned()),
+            markdown: Some(text.to_owned()),
+            handled: Some(true),
+            session_id: None,
+            command: None,
+            diagnostics: None,
+        }
+    }
+
+    fn test_config() -> AppConfig {
+        AppConfig {
+            app_id: "app".to_owned(),
+            app_secret: "secret".to_owned(),
+            sandbox: false,
+            api_base: "https://example.test".to_owned(),
+            token_refresh_margin: Duration::from_secs(60),
+            enable_markdown: true,
+            enable_image: false,
+            enable_group_messages: false,
+            verbose_log: false,
+            group_message_mode: GroupMessageMode::Mention,
+            group_active_keywords: vec!["小女仆".to_owned()],
+            conversation_queue_capacity: DEFAULT_CONVERSATION_QUEUE_CAPACITY,
+            max_active_conversation_workers: DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS,
+            conversation_worker_idle_timeout: Duration::from_secs(300),
+            message_aggregation: MessageAggregationConfig {
+                private_enabled: true,
+                group_enabled: false,
+                quiet: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_QUIET_MS),
+                max_wait: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS),
+                max_messages: DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES,
+                max_chars: DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS,
+                max_active_keys: DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS,
+            },
+            c2c_final_reply_stream_enabled: false,
+            agent_typing: AgentTypingConfig {
+                enabled: false,
+                delay: Duration::from_secs(1),
+            },
+            markdown_chunk_soft_limit: DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT,
+            text_chunk_soft_limit: DEFAULT_TEXT_CHUNK_SOFT_LIMIT,
+        }
+    }
 
     #[test]
     fn local_ping_reply_respects_markdown_config() {
@@ -414,6 +618,97 @@ mod tests {
             OutboundMessage::Text {
                 text: "# 状态".to_owned(),
             }
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_stream_completed_sends_single_ordinary_reply() {
+        let events = FakeEventStream::new([
+            RespondEvent::TextDelta("不应外发".to_owned()),
+            RespondEvent::Completed(respond_response("最终回复")),
+        ]);
+        let sender = FakeOutboundSender::default();
+        let mut typing = None;
+
+        let outcome = handle_c2c_stream_disabled(
+            events,
+            &sender,
+            &c2c_message(),
+            &test_config(),
+            &mut typing,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, DisabledStreamOutcome::Completed);
+        assert_eq!(
+            sender.calls(),
+            vec![FakeCall::Markdown {
+                content: "最终回复".to_owned(),
+                msg_id: Some("msg-1".to_owned()),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_stream_failed_sends_safe_failure_without_reinvoking_core() {
+        let events = FakeEventStream::new([
+            RespondEvent::TextDelta("不完整".to_owned()),
+            RespondEvent::Failed(CoreRespondFailure {
+                kind: CoreFailureKind::LlmFailed,
+                message: "上游服务暂时不可用，请稍后再试。".to_owned(),
+                retryable: true,
+            }),
+        ]);
+        let sender = FakeOutboundSender::default();
+        let mut typing = None;
+
+        let outcome = handle_c2c_stream_disabled(
+            events,
+            &sender,
+            &c2c_message(),
+            &test_config(),
+            &mut typing,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            DisabledStreamOutcome::Failed(CoreFailureKind::LlmFailed)
+        );
+        assert_eq!(
+            sender.calls(),
+            vec![FakeCall::Text {
+                content: "上游服务暂时不可用，请稍后再试。".to_owned(),
+                msg_id: Some("msg-1".to_owned()),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_stream_closed_before_completed_sends_fixed_failure_not_delta() {
+        let events = FakeEventStream::new([RespondEvent::TextDelta("半截回复".to_owned())]);
+        let sender = FakeOutboundSender::default();
+        let mut typing = None;
+
+        let outcome = handle_c2c_stream_disabled(
+            events,
+            &sender,
+            &c2c_message(),
+            &test_config(),
+            &mut typing,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, DisabledStreamOutcome::ClosedBeforeCompleted);
+        assert_eq!(
+            sender.calls(),
+            vec![FakeCall::Text {
+                content: CORE_STREAM_CLOSED_FALLBACK_TEXT.to_owned(),
+                msg_id: Some("msg-1".to_owned()),
+            }]
         );
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -16,6 +16,7 @@ use super::{
         is_ping_command,
     },
     stream::stream_respond_c2c,
+    typing::{C2cTypingStatusGuard, TypingStopReason},
 };
 use crate::{
     api::{C2cReplyTarget, OutboundSender, QqApiClient, send_outbound_with_fallback},
@@ -25,10 +26,11 @@ use crate::{
     message_chunk::{ChunkLimits, OutboundSendError, send_c2c_outbound_chunked},
     render::{OutboundMessage, render_respond_response},
     respond::{
-        RespondClient, RespondResponse, RespondTransport, build_respond_content,
+        RespondClient, RespondEvent, RespondResponse, RespondTransport, build_respond_content,
         respond_error_to_qq_text,
     },
 };
+use qq_maid_core::service::{CoreFailureKind, CoreInboundKind, CoreRespondFailure};
 
 /// 发送 C2C 普通（非流式）回复消息，供真实网关入口调用。
 async fn send_c2c_respond_response(
@@ -205,12 +207,21 @@ pub(super) async fn handle_c2c_message(
         user = %masked_user,
         "calling respond backend"
     );
+    let mut typing = schedule_agent_typing_if_needed(
+        config,
+        respond,
+        api.clone(),
+        &message,
+        respond_content.clone(),
+    )
+    .await;
     let transport = match respond.respond_c2c(&message, respond_content).await {
         Ok(response) => {
             runtime.record_respond_success();
             response
         }
         Err(err) => {
+            stop_typing(&mut typing, TypingStopReason::RequestFailed);
             runtime.record_respond_failure(err.log_summary());
             let qq_text = respond_error_to_qq_text(&err);
             warn!(
@@ -247,13 +258,103 @@ pub(super) async fn handle_c2c_message(
 
     match transport {
         RespondTransport::Complete(response) => {
+            stop_typing(&mut typing, TypingStopReason::FinalReply);
             send_c2c_respond_response(api, runtime, &message, &response, config).await?;
         }
         RespondTransport::Stream(stream) => {
-            stream_respond_c2c(stream, api, runtime, &message, config).await?;
+            if config.c2c_final_reply_stream_enabled {
+                stream_respond_c2c(stream, api, runtime, &message, config, typing).await?;
+            } else {
+                match consume_respond_stream_for_complete(stream).await {
+                    Ok(Some(response)) => {
+                        stop_typing(&mut typing, TypingStopReason::FinalReply);
+                        send_c2c_respond_response(api, runtime, &message, &response, config)
+                            .await?;
+                    }
+                    Ok(None) => {
+                        stop_typing(&mut typing, TypingStopReason::Cancelled);
+                        warn!(
+                            message_id = %message.message_id,
+                            user = %masked_user,
+                            "core respond stream closed before Completed while C2C stream was disabled"
+                        );
+                    }
+                    Err(failure) => {
+                        stop_typing(&mut typing, failure_stop_reason(&failure));
+                        warn!(
+                            message_id = %message.message_id,
+                            user = %masked_user,
+                            kind = ?failure.kind,
+                            retryable = failure.retryable,
+                            "core respond stream failed while C2C stream was disabled"
+                        );
+                        send_c2c_text_with_status(
+                            api,
+                            runtime,
+                            &message.user_openid,
+                            Some(&message.message_id),
+                            &failure.message,
+                        )
+                        .await?;
+                    }
+                }
+            }
         }
     }
     Ok(())
+}
+
+async fn schedule_agent_typing_if_needed(
+    config: &AppConfig,
+    respond: &RespondClient,
+    api: QqApiClient,
+    message: &C2cMessage,
+    respond_content: String,
+) -> Option<C2cTypingStatusGuard> {
+    if !config.agent_typing.enabled {
+        return None;
+    }
+    match respond.classify_c2c(message, respond_content).await {
+        Ok(classification) if classification.kind == CoreInboundKind::NormalChat => {
+            C2cTypingStatusGuard::schedule(&config.agent_typing, api, message, "c2c")
+        }
+        Ok(_) => None,
+        Err(error) => {
+            warn!(
+                message_id = %message.message_id,
+                user = %mask_openid(&message.user_openid),
+                error = %error.log_summary(),
+                "agent typing classification failed; skipping typing status"
+            );
+            None
+        }
+    }
+}
+
+fn stop_typing(typing: &mut Option<C2cTypingStatusGuard>, reason: TypingStopReason) {
+    if let Some(typing) = typing.as_mut() {
+        typing.stop(reason);
+    }
+}
+
+async fn consume_respond_stream_for_complete(
+    mut stream: qq_maid_core::service::CoreResponseStream,
+) -> Result<Option<RespondResponse>, CoreRespondFailure> {
+    while let Some(event) = stream.recv().await {
+        match event {
+            RespondEvent::TextDelta(_) => {}
+            RespondEvent::Completed(response) => return Ok(Some(response)),
+            RespondEvent::Failed(failure) => return Err(failure),
+        }
+    }
+    Ok(None)
+}
+
+fn failure_stop_reason(failure: &CoreRespondFailure) -> TypingStopReason {
+    match failure.kind {
+        CoreFailureKind::SearchTimeout | CoreFailureKind::LlmTimeout => TypingStopReason::Timeout,
+        _ => TypingStopReason::RequestFailed,
+    }
 }
 
 fn render_local_ping_reply(reply: String, enable_markdown: bool) -> OutboundMessage {

--- a/qq-maid-gateway-rs/src/gateway/dispatcher/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/dispatcher/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::config::GroupMessageMode;
+use crate::config::{AgentTypingConfig, GroupMessageMode};
 use std::sync::{Mutex, atomic::AtomicBool};
 use tokio::sync::{Barrier, Notify};
 
@@ -111,6 +111,11 @@ fn test_config() -> AppConfig {
             max_messages: 10,
             max_chars: 12000,
             max_active_keys: 1024,
+        },
+        c2c_final_reply_stream_enabled: false,
+        agent_typing: AgentTypingConfig {
+            enabled: false,
+            delay: Duration::from_secs(1),
         },
         markdown_chunk_soft_limit: 1800,
         text_chunk_soft_limit: 1800,

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -14,6 +14,7 @@ pub mod ping;
 mod protocol;
 pub mod push;
 mod stream;
+mod typing;
 
 use std::{
     collections::HashMap,

--- a/qq-maid-gateway-rs/src/gateway/ping/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/ping/tests.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use crate::{
     auth::{AccessTokenManager, AccessTokenSnapshot, AccessTokenSnapshotState},
-    config::AppConfig,
+    config::{AgentTypingConfig, AppConfig},
     gateway::event::C2cMessage,
 };
 use qq_maid_core::service::{CoreHealthSnapshot, UpstreamStatusSnapshot};
@@ -38,6 +38,11 @@ fn config() -> AppConfig {
             max_messages: 10,
             max_chars: 12000,
             max_active_keys: 1024,
+        },
+        c2c_final_reply_stream_enabled: false,
+        agent_typing: AgentTypingConfig {
+            enabled: false,
+            delay: Duration::from_secs(1),
         },
         markdown_chunk_soft_limit: 1800,
         text_chunk_soft_limit: 1800,

--- a/qq-maid-gateway-rs/src/gateway/stream/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/mod.rs
@@ -17,6 +17,7 @@ use super::{
     logging::{mask_identifier, mask_openid},
     outbound::{RuntimeRecordingSender, record_qq_send_result},
     ping::GatewayRuntimeStatus,
+    typing::{C2cTypingStatusGuard, TypingStopReason},
 };
 use crate::{
     api::{C2cStreamState, OutboundSender, QqApiClient, StreamSendResult},
@@ -122,21 +123,37 @@ pub(super) async fn stream_respond_c2c(
     runtime: &GatewayRuntimeStatus,
     message: &C2cMessage,
     config: &AppConfig,
+    typing: Option<C2cTypingStatusGuard>,
 ) -> anyhow::Result<()> {
     let sender = RuntimeRecordingSender {
         inner: api,
         runtime,
     };
-    stream_respond_c2c_with_sender(stream, &sender, message, config)
+    stream_respond_c2c_with_sender_and_typing(stream, &sender, message, config, typing)
         .await
         .map(|_| ())
 }
 
+#[cfg(test)]
 async fn stream_respond_c2c_with_sender<E, S>(
+    stream: E,
+    sender: &S,
+    message: &C2cMessage,
+    config: &AppConfig,
+) -> anyhow::Result<C2cStreamingPhase>
+where
+    E: RespondEventStream,
+    S: C2cStreamSender + ?Sized,
+{
+    stream_respond_c2c_with_sender_and_typing(stream, sender, message, config, None).await
+}
+
+async fn stream_respond_c2c_with_sender_and_typing<E, S>(
     mut stream: E,
     sender: &S,
     message: &C2cMessage,
     config: &AppConfig,
+    mut typing: Option<C2cTypingStatusGuard>,
 ) -> anyhow::Result<C2cStreamingPhase>
 where
     E: RespondEventStream,
@@ -184,6 +201,9 @@ where
                         .await
                         {
                             Ok(Some(_)) => {
+                                if let Some(typing) = typing.as_mut() {
+                                    typing.stop(TypingStopReason::FirstFrame);
+                                }
                                 let content_chars = pending_delta.chars().count();
                                 pending_delta.clear();
                                 last_send_at = Instant::now();
@@ -306,6 +326,9 @@ where
                 }
             }
             RespondEvent::Completed(response) => {
+                if let Some(typing) = typing.as_mut() {
+                    typing.stop(TypingStopReason::FinalReply);
+                }
                 let final_content = completed_response_content(&response).unwrap_or(&accumulated);
                 let final_chars = final_content.chars().count();
                 match phase {
@@ -531,6 +554,9 @@ where
                 }
             }
             RespondEvent::Failed(failure) => {
+                if let Some(typing) = typing.as_mut() {
+                    typing.stop(TypingStopReason::RequestFailed);
+                }
                 warn!(
                     user = %masked_user,
                     reply_msg_id = %masked_reply_msg_id,
@@ -584,6 +610,9 @@ where
         accumulated_chars,
         "core respond stream closed before Completed"
     );
+    if let Some(typing) = typing.as_mut() {
+        typing.stop(TypingStopReason::Cancelled);
+    }
     match phase {
         C2cStreamingPhase::Active(mut stream_state)
         | C2cStreamingPhase::BrokenActive(mut stream_state) => {

--- a/qq-maid-gateway-rs/src/gateway/stream/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/mod.rs
@@ -25,6 +25,7 @@ use crate::{
     markdown::MarkdownPayload,
     respond::{RespondEvent, RespondResponse},
 };
+use qq_maid_core::service::{CoreFailureKind, CoreRespondFailure};
 
 /// QQ C2C 流式发送的节流间隔（毫秒）。
 ///
@@ -45,6 +46,13 @@ trait RespondEventStream: Send {
 impl RespondEventStream for qq_maid_core::service::CoreResponseStream {
     fn recv_event<'a>(&'a mut self) -> RespondEventFuture<'a> {
         Box::pin(async move { self.recv().await })
+    }
+}
+
+fn failure_stop_reason(failure: &CoreRespondFailure) -> TypingStopReason {
+    match failure.kind {
+        CoreFailureKind::SearchTimeout | CoreFailureKind::LlmTimeout => TypingStopReason::Timeout,
+        _ => TypingStopReason::RequestFailed,
     }
 }
 
@@ -555,7 +563,7 @@ where
             }
             RespondEvent::Failed(failure) => {
                 if let Some(typing) = typing.as_mut() {
-                    typing.stop(TypingStopReason::RequestFailed);
+                    typing.stop(failure_stop_reason(&failure));
                 }
                 warn!(
                     user = %masked_user,

--- a/qq-maid-gateway-rs/src/gateway/stream/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::gateway::typing::{C2cTypingSender, TypingSendFuture};
 use crate::{
     api::{ApiError, C2cReplyTarget, SendFuture},
     config::{
@@ -11,7 +12,7 @@ use crate::{
     media::ImagePayload,
 };
 use qq_maid_core::service::{CoreFailureKind, CoreRespondFailure};
-use std::collections::VecDeque;
+use std::{collections::VecDeque, sync::Arc};
 
 #[derive(Debug)]
 struct FakeEventStream {
@@ -72,6 +73,19 @@ enum FakeCall {
 struct FakeStreamSender {
     stream_results: std::sync::Mutex<VecDeque<StreamSendResult>>,
     calls: std::sync::Mutex<Vec<FakeCall>>,
+}
+
+#[derive(Debug)]
+struct NoopTypingSender;
+
+impl C2cTypingSender for NoopTypingSender {
+    fn send_typing<'a>(
+        &'a self,
+        _user_openid: &'a str,
+        _msg_id: Option<&'a str>,
+    ) -> TypingSendFuture<'a> {
+        Box::pin(async move { Ok(None) })
+    }
 }
 
 impl FakeStreamSender {
@@ -788,4 +802,40 @@ async fn core_failed_event_is_returned_as_observable_error() {
 
     assert!(result.is_err());
     assert!(sender.calls().is_empty());
+}
+
+#[tokio::test]
+async fn stream_timeout_failure_stops_typing_with_timeout_reason() {
+    let events = FakeEventStream::new([RespondEvent::Failed(CoreRespondFailure {
+        kind: CoreFailureKind::LlmTimeout,
+        message: "LLM 服务处理超时，请稍后再试。".to_owned(),
+        retryable: true,
+    })]);
+    let sender = FakeStreamSender::new([]);
+    let typing = C2cTypingStatusGuard::schedule_with_sender(
+        &AgentTypingConfig {
+            enabled: true,
+            delay: Duration::from_secs(60),
+        },
+        Arc::new(NoopTypingSender),
+        &c2c_message(),
+        "test",
+    )
+    .unwrap();
+    let stop_reason = typing.stop_reason_probe_for_test();
+
+    let result = stream_respond_c2c_with_sender_and_typing(
+        events,
+        &sender,
+        &c2c_message(),
+        &test_config(),
+        Some(typing),
+    )
+    .await;
+
+    assert!(result.is_err());
+    assert_eq!(
+        *stop_reason.lock().unwrap(),
+        Some(TypingStopReason::Timeout)
+    );
 }

--- a/qq-maid-gateway-rs/src/gateway/stream/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{
     api::{ApiError, C2cReplyTarget, SendFuture},
     config::{
-        DEFAULT_CONVERSATION_QUEUE_CAPACITY, DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT,
+        AgentTypingConfig, DEFAULT_CONVERSATION_QUEUE_CAPACITY, DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT,
         DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS, DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS,
         DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS, DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES,
         DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS, DEFAULT_MESSAGE_AGGREGATION_QUIET_MS,
@@ -203,6 +203,11 @@ fn test_config() -> AppConfig {
             max_messages: DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES,
             max_chars: DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS,
             max_active_keys: DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS,
+        },
+        c2c_final_reply_stream_enabled: true,
+        agent_typing: AgentTypingConfig {
+            enabled: false,
+            delay: Duration::from_secs(1),
         },
         markdown_chunk_soft_limit: DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT,
         text_chunk_soft_limit: DEFAULT_TEXT_CHUNK_SOFT_LIMIT,

--- a/qq-maid-gateway-rs/src/gateway/typing.rs
+++ b/qq-maid-gateway-rs/src/gateway/typing.rs
@@ -3,6 +3,8 @@
 //! 这里只发送平台状态，不生成聊天文本，也不参与 Core 的工具成功判定。
 
 use std::{
+    future::Future,
+    pin::Pin,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -18,7 +20,30 @@ use super::{
     event::C2cMessage,
     logging::{mask_identifier, mask_openid},
 };
-use crate::{api::QqApiClient, config::AgentTypingConfig};
+use crate::{
+    api::{QqApiClient, SendResult},
+    config::AgentTypingConfig,
+};
+
+pub(super) type TypingSendFuture<'a> = Pin<Box<dyn Future<Output = SendResult> + Send + 'a>>;
+
+pub(super) trait C2cTypingSender: Send + Sync {
+    fn send_typing<'a>(
+        &'a self,
+        user_openid: &'a str,
+        msg_id: Option<&'a str>,
+    ) -> TypingSendFuture<'a>;
+}
+
+impl C2cTypingSender for QqApiClient {
+    fn send_typing<'a>(
+        &'a self,
+        user_openid: &'a str,
+        msg_id: Option<&'a str>,
+    ) -> TypingSendFuture<'a> {
+        Box::pin(async move { self.send_c2c_typing(user_openid, msg_id).await })
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum TypingStopReason {
@@ -45,18 +70,29 @@ impl TypingStopReason {
 pub(super) struct C2cTypingStatusGuard {
     token: CancellationToken,
     sent: Arc<AtomicBool>,
-    stopped: bool,
-    task: JoinHandle<()>,
+    stopped_flag: Arc<AtomicBool>,
+    task: Option<JoinHandle<()>>,
     masked_user: String,
     source_message_id: String,
     delay_ms: u128,
     started_at: Instant,
+    #[cfg(test)]
+    stop_reason: Arc<std::sync::Mutex<Option<TypingStopReason>>>,
 }
 
 impl C2cTypingStatusGuard {
     pub(super) fn schedule(
         config: &AgentTypingConfig,
         api: QqApiClient,
+        message: &C2cMessage,
+        transport: &'static str,
+    ) -> Option<Self> {
+        Self::schedule_with_sender(config, Arc::new(api), message, transport)
+    }
+
+    pub(super) fn schedule_with_sender(
+        config: &AgentTypingConfig,
+        sender: Arc<dyn C2cTypingSender>,
         message: &C2cMessage,
         transport: &'static str,
     ) -> Option<Self> {
@@ -67,6 +103,8 @@ impl C2cTypingStatusGuard {
         let task_token = token.clone();
         let sent = Arc::new(AtomicBool::new(false));
         let task_sent = sent.clone();
+        let stopped_flag = Arc::new(AtomicBool::new(false));
+        let task_stopped_flag = stopped_flag.clone();
         let delay = config.delay;
         let delay_ms = delay.as_millis();
         let user_openid = message.user_openid.clone();
@@ -86,7 +124,7 @@ impl C2cTypingStatusGuard {
         );
 
         let task = tokio::spawn(async move {
-            tokio::select! {
+            let delay_finished = tokio::select! {
                 _ = task_token.cancelled() => {
                     debug!(
                         user = %task_masked_user,
@@ -96,32 +134,55 @@ impl C2cTypingStatusGuard {
                         elapsed_ms = started_at.elapsed().as_millis(),
                         "typing_status_cancelled"
                     );
+                    false
                 }
                 _ = sleep(delay) => {
-                    match api.send_c2c_typing(&user_openid, Some(&msg_id)).await {
-                        Ok(_) => {
-                            task_sent.store(true, Ordering::SeqCst);
-                            debug!(
-                                user = %task_masked_user,
-                                source_message_id = %task_source_message_id,
-                                transport,
-                                delay_ms,
-                                elapsed_ms = started_at.elapsed().as_millis(),
-                                "typing_status_sent"
-                            );
-                        }
-                        Err(error) => {
-                            warn!(
-                                user = %task_masked_user,
-                                source_message_id = %task_source_message_id,
-                                transport,
-                                delay_ms,
-                                elapsed_ms = started_at.elapsed().as_millis(),
-                                error = %error.log_summary(),
-                                "typing_status_send_failed"
-                            );
-                        }
-                    }
+                    true
+                }
+            };
+            if !delay_finished || task_stopped_flag.load(Ordering::SeqCst) {
+                return;
+            }
+
+            let result = tokio::select! {
+                _ = task_token.cancelled() => {
+                    debug!(
+                        user = %task_masked_user,
+                        source_message_id = %task_source_message_id,
+                        transport,
+                        delay_ms,
+                        elapsed_ms = started_at.elapsed().as_millis(),
+                        "typing_status_cancelled"
+                    );
+                    return;
+                }
+                result = sender.send_typing(&user_openid, Some(&msg_id)) => result,
+            };
+            if task_stopped_flag.load(Ordering::SeqCst) {
+                return;
+            }
+            match result {
+                Ok(_) => {
+                    task_sent.store(true, Ordering::SeqCst);
+                    debug!(
+                        user = %task_masked_user,
+                        source_message_id = %task_source_message_id,
+                        transport,
+                        delay_ms,
+                        elapsed_ms = started_at.elapsed().as_millis(),
+                        "typing_status_sent"
+                    );
+                }
+                Err(error) => {
+                    warn!(
+                        user = %task_masked_user,
+                        source_message_id = %task_source_message_id,
+                        transport,
+                        delay_ms,
+                        elapsed_ms = started_at.elapsed().as_millis(),
+                        error = %error.log_summary(),
+                        "typing_status_send_failed"
+                    );
                 }
             }
         });
@@ -129,21 +190,29 @@ impl C2cTypingStatusGuard {
         Some(Self {
             token,
             sent,
-            stopped: false,
-            task,
+            stopped_flag,
+            task: Some(task),
             masked_user,
             source_message_id,
             delay_ms,
             started_at,
+            #[cfg(test)]
+            stop_reason: Arc::new(std::sync::Mutex::new(None)),
         })
     }
 
     pub(super) fn stop(&mut self, reason: TypingStopReason) {
-        if self.stopped {
+        if self.stopped_flag.swap(true, Ordering::SeqCst) {
             return;
         }
-        self.stopped = true;
         self.token.cancel();
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+        #[cfg(test)]
+        {
+            *self.stop_reason.lock().unwrap() = Some(reason);
+        }
         debug!(
             user = %self.masked_user,
             source_message_id = %self.source_message_id,
@@ -154,13 +223,324 @@ impl C2cTypingStatusGuard {
             "typing_status_stopped"
         );
     }
+
+    #[cfg(test)]
+    fn sent_for_test(&self) -> bool {
+        self.sent.load(Ordering::SeqCst)
+    }
+
+    #[cfg(test)]
+    pub(super) fn stop_reason_for_test(&self) -> Option<TypingStopReason> {
+        *self.stop_reason.lock().unwrap()
+    }
+
+    #[cfg(test)]
+    pub(super) fn stop_reason_probe_for_test(
+        &self,
+    ) -> Arc<std::sync::Mutex<Option<TypingStopReason>>> {
+        self.stop_reason.clone()
+    }
 }
 
 impl Drop for C2cTypingStatusGuard {
     fn drop(&mut self) {
-        if !self.stopped {
-            self.token.cancel();
+        self.stopped_flag.store(true, Ordering::SeqCst);
+        self.token.cancel();
+        if let Some(task) = self.task.take() {
+            task.abort();
         }
-        self.task.abort();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::ApiError;
+    use std::sync::{
+        Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use tokio::{
+        sync::{Notify, oneshot},
+        time::{Duration, advance, pause},
+    };
+
+    #[derive(Default)]
+    struct FakeTypingSender {
+        calls: AtomicUsize,
+        started: Notify,
+        finish_tx: Mutex<Option<oneshot::Sender<SendResult>>>,
+        finish_rx: Mutex<Option<oneshot::Receiver<SendResult>>>,
+        requests: Mutex<Vec<(String, Option<String>)>>,
+    }
+
+    impl FakeTypingSender {
+        fn ready(result: SendResult) -> Arc<Self> {
+            let (tx, rx) = oneshot::channel();
+            tx.send(result).ok();
+            Arc::new(Self {
+                finish_tx: Mutex::new(None),
+                finish_rx: Mutex::new(Some(rx)),
+                ..Self::default()
+            })
+        }
+
+        fn blocked() -> Arc<Self> {
+            let (tx, rx) = oneshot::channel();
+            Arc::new(Self {
+                finish_tx: Mutex::new(Some(tx)),
+                finish_rx: Mutex::new(Some(rx)),
+                ..Self::default()
+            })
+        }
+
+        fn complete(&self, result: SendResult) {
+            if let Some(tx) = self.finish_tx.lock().unwrap().take() {
+                tx.send(result).ok();
+            }
+        }
+
+        async fn wait_started(&self) {
+            self.started.notified().await;
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+
+        fn requests(&self) -> Vec<(String, Option<String>)> {
+            self.requests.lock().unwrap().clone()
+        }
+    }
+
+    impl C2cTypingSender for FakeTypingSender {
+        fn send_typing<'a>(
+            &'a self,
+            user_openid: &'a str,
+            msg_id: Option<&'a str>,
+        ) -> TypingSendFuture<'a> {
+            Box::pin(async move {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                self.requests
+                    .lock()
+                    .unwrap()
+                    .push((user_openid.to_owned(), msg_id.map(str::to_owned)));
+                self.started.notify_one();
+                let rx = self.finish_rx.lock().unwrap().take();
+                match rx {
+                    Some(rx) => rx
+                        .await
+                        .unwrap_or_else(|_| Err(ApiError::Unsupported("typing"))),
+                    None => Ok(None),
+                }
+            })
+        }
+    }
+
+    fn typing_config(delay: Duration) -> AgentTypingConfig {
+        AgentTypingConfig {
+            enabled: true,
+            delay,
+        }
+    }
+
+    fn c2c_message(id: &str, user: &str) -> C2cMessage {
+        C2cMessage {
+            message_id: id.to_owned(),
+            event_id: Some(format!("event-{id}")),
+            source_message_ids: vec![id.to_owned()],
+            source_event_ids: vec![format!("event-{id}")],
+            user_openid: user.to_owned(),
+            content: "晚上好".to_owned(),
+            reply: None,
+            timestamp: None,
+            first_message_timestamp: None,
+            last_message_timestamp: None,
+            attachments: Vec::new(),
+        }
+    }
+
+    async fn yield_tasks() {
+        for _ in 0..5 {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn stop_before_delay_threshold_does_not_send_typing() {
+        pause();
+        let sender = FakeTypingSender::ready(Ok(None));
+        let mut guard = C2cTypingStatusGuard::schedule_with_sender(
+            &typing_config(Duration::from_millis(100)),
+            sender.clone(),
+            &c2c_message("msg-1", "user-1"),
+            "test",
+        )
+        .unwrap();
+
+        yield_tasks().await;
+        advance(Duration::from_millis(99)).await;
+        guard.stop(TypingStopReason::FinalReply);
+        advance(Duration::from_millis(1)).await;
+        yield_tasks().await;
+
+        assert_eq!(sender.calls(), 0);
+        assert!(!guard.sent_for_test());
+    }
+
+    #[tokio::test]
+    async fn sends_typing_once_after_delay_threshold() {
+        let sender = FakeTypingSender::ready(Ok(Some("typing-id".to_owned())));
+        let guard = C2cTypingStatusGuard::schedule_with_sender(
+            &typing_config(Duration::from_millis(1)),
+            sender.clone(),
+            &c2c_message("msg-1", "user-1"),
+            "test",
+        )
+        .unwrap();
+
+        sender.wait_started().await;
+        yield_tasks().await;
+
+        assert_eq!(sender.calls(), 1);
+        assert!(guard.sent_for_test());
+    }
+
+    #[tokio::test]
+    async fn stop_at_delay_boundary_does_not_record_late_typing_sent() {
+        pause();
+        let sender = FakeTypingSender::blocked();
+        let mut guard = C2cTypingStatusGuard::schedule_with_sender(
+            &typing_config(Duration::from_millis(100)),
+            sender.clone(),
+            &c2c_message("msg-1", "user-1"),
+            "test",
+        )
+        .unwrap();
+
+        yield_tasks().await;
+        advance(Duration::from_millis(100)).await;
+        guard.stop(TypingStopReason::FinalReply);
+        sender.complete(Ok(Some("typing-id".to_owned())));
+        yield_tasks().await;
+
+        assert!(!guard.sent_for_test());
+    }
+
+    #[tokio::test]
+    async fn stop_while_send_is_blocked_aborts_local_task() {
+        pause();
+        let sender = FakeTypingSender::blocked();
+        let mut guard = C2cTypingStatusGuard::schedule_with_sender(
+            &typing_config(Duration::from_millis(10)),
+            sender.clone(),
+            &c2c_message("msg-1", "user-1"),
+            "test",
+        )
+        .unwrap();
+
+        yield_tasks().await;
+        advance(Duration::from_millis(10)).await;
+        sender.wait_started().await;
+        guard.stop(TypingStopReason::FirstFrame);
+        sender.complete(Ok(Some("typing-id".to_owned())));
+        yield_tasks().await;
+
+        assert_eq!(sender.calls(), 1);
+        assert!(!guard.sent_for_test());
+    }
+
+    #[tokio::test]
+    async fn typing_send_failure_is_best_effort_and_not_retried() {
+        let sender = FakeTypingSender::ready(Err(ApiError::Unsupported("typing")));
+        let guard = C2cTypingStatusGuard::schedule_with_sender(
+            &typing_config(Duration::from_millis(1)),
+            sender.clone(),
+            &c2c_message("msg-1", "user-1"),
+            "test",
+        )
+        .unwrap();
+
+        sender.wait_started().await;
+        yield_tasks().await;
+
+        assert_eq!(sender.calls(), 1);
+        assert!(!guard.sent_for_test());
+    }
+
+    #[tokio::test]
+    async fn repeated_stop_is_idempotent() {
+        pause();
+        let sender = FakeTypingSender::blocked();
+        let mut guard = C2cTypingStatusGuard::schedule_with_sender(
+            &typing_config(Duration::from_millis(100)),
+            sender.clone(),
+            &c2c_message("msg-1", "user-1"),
+            "test",
+        )
+        .unwrap();
+
+        yield_tasks().await;
+        guard.stop(TypingStopReason::FinalReply);
+        guard.stop(TypingStopReason::RequestFailed);
+        advance(Duration::from_millis(100)).await;
+        yield_tasks().await;
+
+        assert_eq!(sender.calls(), 0);
+        assert_eq!(
+            guard.stop_reason_for_test(),
+            Some(TypingStopReason::FinalReply)
+        );
+    }
+
+    #[tokio::test]
+    async fn different_source_message_ids_are_isolated() {
+        let sender = FakeTypingSender::ready(Ok(None));
+        let mut first = C2cTypingStatusGuard::schedule_with_sender(
+            &typing_config(Duration::from_secs(60)),
+            sender.clone(),
+            &c2c_message("msg-1", "user-1"),
+            "test",
+        )
+        .unwrap();
+        first.stop(TypingStopReason::FinalReply);
+        let second = C2cTypingStatusGuard::schedule_with_sender(
+            &typing_config(Duration::from_millis(1)),
+            sender.clone(),
+            &c2c_message("msg-2", "user-1"),
+            "test",
+        )
+        .unwrap();
+
+        sender.wait_started().await;
+        yield_tasks().await;
+
+        assert_eq!(sender.calls(), 1);
+        assert_eq!(
+            sender.requests(),
+            vec![("user-1".to_owned(), Some("msg-2".to_owned()))]
+        );
+        assert!(!first.sent_for_test());
+        assert!(second.sent_for_test());
+    }
+
+    #[tokio::test]
+    async fn drop_before_delay_cleans_task_without_late_typing() {
+        pause();
+        let sender = FakeTypingSender::ready(Ok(None));
+        let guard = C2cTypingStatusGuard::schedule_with_sender(
+            &typing_config(Duration::from_millis(100)),
+            sender.clone(),
+            &c2c_message("msg-1", "user-1"),
+            "test",
+        )
+        .unwrap();
+
+        yield_tasks().await;
+        drop(guard);
+        advance(Duration::from_millis(100)).await;
+        yield_tasks().await;
+
+        assert_eq!(sender.calls(), 0);
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/typing.rs
+++ b/qq-maid-gateway-rs/src/gateway/typing.rs
@@ -1,0 +1,166 @@
+//! QQ C2C 原生“正在输入”状态的请求级生命周期。
+//!
+//! 这里只发送平台状态，不生成聊天文本，也不参与 Core 的工具成功判定。
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Instant,
+};
+
+use tokio::{task::JoinHandle, time::sleep};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+use super::{
+    event::C2cMessage,
+    logging::{mask_identifier, mask_openid},
+};
+use crate::{api::QqApiClient, config::AgentTypingConfig};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TypingStopReason {
+    FirstFrame,
+    FinalReply,
+    RequestFailed,
+    Timeout,
+    Cancelled,
+}
+
+impl TypingStopReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::FirstFrame => "first_frame",
+            Self::FinalReply => "final_reply",
+            Self::RequestFailed => "request_failed",
+            Self::Timeout => "timeout",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct C2cTypingStatusGuard {
+    token: CancellationToken,
+    sent: Arc<AtomicBool>,
+    stopped: bool,
+    task: JoinHandle<()>,
+    masked_user: String,
+    source_message_id: String,
+    delay_ms: u128,
+    started_at: Instant,
+}
+
+impl C2cTypingStatusGuard {
+    pub(super) fn schedule(
+        config: &AgentTypingConfig,
+        api: QqApiClient,
+        message: &C2cMessage,
+        transport: &'static str,
+    ) -> Option<Self> {
+        if !config.enabled {
+            return None;
+        }
+        let token = CancellationToken::new();
+        let task_token = token.clone();
+        let sent = Arc::new(AtomicBool::new(false));
+        let task_sent = sent.clone();
+        let delay = config.delay;
+        let delay_ms = delay.as_millis();
+        let user_openid = message.user_openid.clone();
+        let msg_id = message.message_id.clone();
+        let masked_user = mask_openid(&user_openid);
+        let source_message_id = mask_identifier(&msg_id);
+        let task_masked_user = masked_user.clone();
+        let task_source_message_id = source_message_id.clone();
+        let started_at = Instant::now();
+
+        debug!(
+            user = %masked_user,
+            source_message_id = %source_message_id,
+            transport,
+            delay_ms,
+            "typing_status_scheduled"
+        );
+
+        let task = tokio::spawn(async move {
+            tokio::select! {
+                _ = task_token.cancelled() => {
+                    debug!(
+                        user = %task_masked_user,
+                        source_message_id = %task_source_message_id,
+                        transport,
+                        delay_ms,
+                        elapsed_ms = started_at.elapsed().as_millis(),
+                        "typing_status_cancelled"
+                    );
+                }
+                _ = sleep(delay) => {
+                    match api.send_c2c_typing(&user_openid, Some(&msg_id)).await {
+                        Ok(_) => {
+                            task_sent.store(true, Ordering::SeqCst);
+                            debug!(
+                                user = %task_masked_user,
+                                source_message_id = %task_source_message_id,
+                                transport,
+                                delay_ms,
+                                elapsed_ms = started_at.elapsed().as_millis(),
+                                "typing_status_sent"
+                            );
+                        }
+                        Err(error) => {
+                            warn!(
+                                user = %task_masked_user,
+                                source_message_id = %task_source_message_id,
+                                transport,
+                                delay_ms,
+                                elapsed_ms = started_at.elapsed().as_millis(),
+                                error = %error.log_summary(),
+                                "typing_status_send_failed"
+                            );
+                        }
+                    }
+                }
+            }
+        });
+
+        Some(Self {
+            token,
+            sent,
+            stopped: false,
+            task,
+            masked_user,
+            source_message_id,
+            delay_ms,
+            started_at,
+        })
+    }
+
+    pub(super) fn stop(&mut self, reason: TypingStopReason) {
+        if self.stopped {
+            return;
+        }
+        self.stopped = true;
+        self.token.cancel();
+        debug!(
+            user = %self.masked_user,
+            source_message_id = %self.source_message_id,
+            delay_ms = self.delay_ms,
+            elapsed_ms = self.started_at.elapsed().as_millis(),
+            sent = self.sent.load(Ordering::SeqCst),
+            stop_reason = reason.as_str(),
+            "typing_status_stopped"
+        );
+    }
+}
+
+impl Drop for C2cTypingStatusGuard {
+    fn drop(&mut self) {
+        if !self.stopped {
+            self.token.cancel();
+        }
+        self.task.abort();
+    }
+}

--- a/runtime/config/.env.example
+++ b/runtime/config/.env.example
@@ -13,6 +13,11 @@ QQ_MAID_GATEWAY_VERBOSE_LOG=false
 # 富媒体发送失败会 fallback 到文本；C2C 流式回复当前固定使用 Markdown 流式载荷。
 QQ_MAID_ENABLE_MARKDOWN=true
 QQ_MAID_ENABLE_IMAGE=false
+# 私聊 Agent 最终回复默认走 QQ C2C 流式发送；首帧失败或无 stream id 会自动降级为普通完整回复。
+QQ_MAID_C2C_FINAL_REPLY_STREAM_ENABLED=true
+# 私聊普通 Agent 请求超过阈值仍未产生用户可见内容时，发送 QQ 原生“正在输入”状态。
+QQ_MAID_AGENT_TYPING_ENABLED=true
+QQ_MAID_AGENT_TYPING_DELAY_MS=1000
 
 # 普通回复分段软限制（字符数）。这是 Gateway 保守软上限，并非 QQ 平台已确认的硬上限。
 # 超过软限制的普通回复会被拆成多条按 Markdown 安全边界发送，不再被 Core 静默截断。


### PR DESCRIPTION
Closes #141.

也包含 #129 里配套的 #156 代码侧实现。

## 改动要点

- **C2C 最终回复流默认启用**：`QQ_MAID_C2C_FINAL_REPLY_STREAM_ENABLED=true`，可设为 `false` 快速回滚。
- **流不可用降级**：首帧发送失败或没拿到 stream id 时，等待同一轮 Core Completed 后走普通完整回复，不重新运行 Agent Loop / 工具。
- **Active 后仍保持原约束**：中间帧或最终帧失败不再补发普通全文。
- **QQ 原生 typing**：新增 `msg_type=6` typing 模块，只对私聊普通 Agent 请求延迟发送，默认 1000ms；首个 QQ 流式首帧成功、完整回复、失败或取消时清理。

## 复用现有能力

- Core 的 `CoreEvent::{TextDelta, Completed, Failed}`。
- 现有 C2C stream 状态机、首帧/Active/BrokenActive 语义。
- 普通回复复用 `send_c2c_respond_response_with_sender` 和既有 Markdown/text 分段 fallback。
- 配置解析复用现有 `parse_bool` / ranged parser。

## 验证

- `cargo fmt --all -- --check` ✅
- `make test-gateway` ✅
- `make test-core` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo test --workspace --all-features` ✅
- `cargo build --workspace --release --all-features` ✅
- `git diff --check` ✅

## 未执行

真实 QQ 联调、`make diagnose` / runtime validate 未跑（需要真实 QQ 机器人凭据、运行配置和在线服务环境）。