### PR TITLE
feat: Todo 批量操作原生支持 + 选择解析 + 确认策略收敛

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,7 +1413,7 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "qq-maid-bot"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "qq-maid-core",
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-core"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-gateway-rs"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-llm"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "async-trait",
  "axum",

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -27,7 +27,7 @@ use super::{
     llm_service::{ChatService, LlmChatService, response_from_output},
     session_flow::build_session_context,
     title::{context_session_title, generate_session_title},
-    todo_flow::tool_outcome_from_todo_result,
+    todo_flow::{append_todo_related_list_for_turn, tool_outcome_from_todo_result},
     tool_presenters::tool_outcome_from_weather_result,
 };
 
@@ -563,6 +563,7 @@ fn build_agent_turn_outcome(
             outcomes.push(super::agent_outcome::ToolExecutionOutcome::generic(result));
         }
     }
+    append_todo_related_list_for_turn(todo_store, session, owner, &mut outcomes)?;
     Ok(AgentTurnOutcome::from_outcomes(outcomes))
 }
 

--- a/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
@@ -95,8 +95,11 @@ fn successful_todo_write_result(result: &ToolExecutionResult) -> bool {
         return false;
     }
     match result.name.as_str() {
-        "create_todo" => result.output.get("created").is_some(),
-        "cancel_todo" => pending_action_matches(&result.output, "cancel"),
+        "create_todo" => {
+            result.output.get("created").is_some()
+                || non_empty_array_field(&result.output, "created_items")
+        }
+        "cancel_todo" => non_empty_array_field(&result.output, "cancelled"),
         "delete_todos" => pending_action_matches(&result.output, "delete"),
         "edit_todo" => result.output.get("updated").is_some(),
         "complete_todos" => non_empty_array_field(&result.output, "completed"),

--- a/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
@@ -417,7 +417,7 @@ fn best_failure_summary(summaries: &[TodoToolResultSummary]) -> Option<&TodoTool
 fn todo_tool_failure_reply(summary: &TodoToolResultSummary) -> String {
     match summary.error_code.as_deref() {
         Some("todo_delete_invalid_state") => {
-            "进行中待办不能永久删除，请先取消，再从已取消列表里永久删除。".to_owned()
+            "目标待办当前无法永久删除，请查看最新列表后再试。".to_owned()
         }
         Some("todo_selection_not_found") if summary.tool == "delete_todos" => {
             "没有找到可删除的已完成或已取消待办，请先查看对应列表后再选择。".to_owned()

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -243,9 +243,9 @@ async fn todo_tools_create_cancel_restore_and_delete_use_existing_pending_bounda
         .await
         .unwrap();
     let cancel: Value = serde_json::from_str(&cancel_output).unwrap();
-    assert_eq!(cancel["requires_confirmation"], true);
-    assert_eq!(cancel["pending_action"], "cancel");
-    service.respond(private_message("确认")).await.unwrap();
+    assert_eq!(cancel["ok"], true);
+    assert_eq!(cancel["cancelled"][0]["visible_number"], 1);
+    assert!(cancel["missing_numbers"].as_array().unwrap().is_empty());
     assert_eq!(
         service.todo_store.list_all(&owner).unwrap()[0].status,
         TodoStatus::Cancelled
@@ -306,7 +306,7 @@ async fn todo_tools_create_cancel_restore_and_delete_use_existing_pending_bounda
 }
 
 #[tokio::test]
-async fn restore_then_cancel_last_reference_creates_pending_without_relisting() {
+async fn restore_then_cancel_last_reference_executes_without_relisting() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
@@ -355,21 +355,24 @@ async fn restore_then_cancel_last_reference_creates_pending_without_relisting() 
     let cancel: Value = serde_json::from_str(&cancel_output).unwrap();
 
     assert_eq!(cancel["ok"], true);
-    assert_eq!(cancel["requires_confirmation"], true);
-    assert_eq!(cancel["pending_action"], "cancel");
-    assert_eq!(cancel["item"]["reference"], "last");
+    assert_eq!(cancel["cancelled"][0]["reference"], "last");
 
     let session = service
         .session_store
         .get_or_create_active(&private_test_meta())
         .unwrap();
-    match session.pending_operation {
-        Some(PendingOperation::TodoDelete { item, .. }) => {
-            assert_eq!(item.title, "恢复后继续取消");
-            assert_eq!(item.status, TodoStatus::Pending);
-        }
-        other => panic!("expected TodoDelete pending, got {other:?}"),
-    }
+    assert!(session.pending_operation.is_none());
+    assert_eq!(
+        service
+            .todo_store
+            .list_all(&owner)
+            .unwrap()
+            .into_iter()
+            .find(|item| item.title == "恢复后继续取消")
+            .unwrap()
+            .status,
+        TodoStatus::Cancelled
+    );
 }
 
 #[tokio::test]
@@ -824,7 +827,7 @@ async fn todo_success_then_failure_is_partial_success_and_keeps_database_change(
 }
 
 #[tokio::test]
-async fn two_successful_todo_results_are_both_rendered() {
+async fn multiple_successful_todo_writes_share_one_related_list() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
         .with_tool_calls_json(
@@ -841,6 +844,7 @@ async fn two_successful_todo_results_are_both_rendered() {
             "已新增最后一条",
         );
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
 
     let response = service
         .respond(private_message("新增两条待办"))
@@ -849,11 +853,22 @@ async fn two_successful_todo_results_are_both_rendered() {
 
     let text = response.text.unwrap();
     assert_eq!(text.matches("✅ 已新增待办").count(), 2);
+    assert_eq!(text.matches("🚧 当前进行中").count(), 1);
     assert!(text.contains("第一条新增"));
     assert!(text.contains("第二条新增"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["agent_turn_status"], "succeeded");
-    assert_eq!(diagnostics["tool_outcomes"].as_array().unwrap().len(), 2);
+    assert_eq!(diagnostics["tool_outcomes"].as_array().unwrap().len(), 3);
+    let todos = service.todo_store.list_pending(&owner).unwrap();
+    assert_eq!(todos.len(), 2);
+    let session = service
+        .session_store
+        .get_or_create_active(&private_test_meta())
+        .unwrap();
+    let snapshot = session
+        .last_todo_query
+        .expect("missing final related list snapshot");
+    assert_eq!(snapshot.result_ids.len(), 2);
 }
 
 #[tokio::test]
@@ -1351,13 +1366,13 @@ async fn todo_missing_argument_reply_without_tool_call_is_not_blocked() {
 }
 
 #[tokio::test]
-async fn todo_delete_pending_item_accepts_cancel_tool_pending_result() {
+async fn todo_cancel_pending_item_executes_without_confirmation() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
         .with_tool_call_json(
             "cancel_todo",
             r#"{"number":2,"reference":null}"#,
-            "已发起取消待办确认",
+            "已取消待办",
         );
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
@@ -1396,20 +1411,16 @@ async fn todo_delete_pending_item_accepts_cancel_tool_pending_result() {
         .await
         .unwrap();
 
-    assert_eq!(response.command.as_deref(), Some("todo_pending"));
+    assert_eq!(response.command.as_deref(), Some("todo_cancel"));
+    let text = response.text.as_deref().unwrap();
+    assert!(text.contains("⛔ 已取消待办"));
     assert!(
-        response
-            .text
-            .as_deref()
-            .unwrap()
-            .contains("请确认是否取消这条待办")
+        text.contains("第二条待取消"),
+        "response should mention cancelled item: {text}"
     );
     let diagnostics = response.diagnostics.unwrap();
-    assert_eq!(diagnostics["agent_turn_status"], "pending_confirmation");
-    assert_eq!(
-        diagnostics["tool_outcomes"][0]["status"],
-        "pending_confirmation"
-    );
+    assert_eq!(diagnostics["agent_turn_status"], "succeeded");
+    assert_eq!(diagnostics["tool_outcomes"][0]["status"], "succeeded");
     assert_eq!(diagnostics["todo_success_claimed"], true);
     assert_eq!(diagnostics["todo_success_verified"], true);
     assert_eq!(diagnostics["tool_retry_count"], 0);
@@ -1418,12 +1429,18 @@ async fn todo_delete_pending_item_accepts_cancel_tool_pending_result() {
         .session_store
         .get_or_create_active(&private_test_meta())
         .unwrap();
-    match session.pending_operation {
-        Some(PendingOperation::TodoDelete { item, .. }) => {
-            assert_eq!(item.title, "第二条待取消");
-        }
-        other => panic!("expected TodoDelete pending operation, got {other:?}"),
-    }
+    assert!(session.pending_operation.is_none());
+    assert_eq!(
+        service
+            .todo_store
+            .list_all(&owner)
+            .unwrap()
+            .into_iter()
+            .find(|item| item.title == "第二条待取消")
+            .unwrap()
+            .status,
+        TodoStatus::Cancelled
+    );
     assert_eq!(inspector.tool_call_count(), 1);
 }
 
@@ -1734,8 +1751,8 @@ async fn todo_delete_completed_pending_confirmation_is_verified_by_real_tool_res
         .unwrap();
 
     let text = response.text.unwrap();
-    assert!(text.contains("准备永久删除 1 条待办"));
-    assert!(text.contains("永久删除需要二次确认"));
+    assert!(text.contains("确认删除以下 1 项待办吗"));
+    assert!(text.contains("删除后不可恢复"));
     assert!(!text.contains("没有收到待办工具的成功回执"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["todo_success_claimed"], true);
@@ -2526,7 +2543,7 @@ async fn cancelled_query_then_delete_all_creates_bulk_pending_and_confirm_delete
             .text
             .as_deref()
             .unwrap()
-            .contains("准备永久删除 2 条待办")
+            .contains("确认删除以下 2 项待办吗")
     );
     let diagnostics = delete.diagnostics.unwrap();
     assert_eq!(

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -1553,6 +1553,77 @@ async fn todo_edit_second_item_uses_latest_visible_snapshot() {
 }
 
 #[tokio::test]
+async fn todo_write_with_explicit_list_does_not_append_auto_related_list() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_calls_json(
+            vec![
+                (
+                    "complete_todos",
+                    r#"{"numbers":[1],"selection_text":null,"reference":null}"#,
+                ),
+                ("list_todos", r#"{"status":"completed"}"#),
+            ],
+            "已完成第一条",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let first = service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "先完成".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    service
+        .todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "仍进行中".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+
+    service.respond(private_message("/todo")).await.unwrap();
+    let response = service
+        .respond(private_message("处理第一项，然后列出已完成项目"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert!(text.contains("✅ 已完成待办"));
+    assert!(text.contains("✅ 当前已完成 · 共 1 项"));
+    assert!(!text.contains("🚧 当前进行中 · 共 1 项"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(
+        diagnostics["tool_loop_executed_tools"],
+        serde_json::json!(["complete_todos", "list_todos"])
+    );
+    assert_eq!(diagnostics["tool_outcomes"].as_array().unwrap().len(), 2);
+    let session = service
+        .session_store
+        .get_or_create_active(&private_test_meta())
+        .unwrap();
+    let snapshot = session.last_todo_query.expect("missing visible snapshot");
+    assert_eq!(snapshot.query_type, "completed-list");
+    assert_eq!(snapshot.result_ids, vec![first.id]);
+    assert_eq!(inspector.tool_call_count(), 1);
+}
+
+#[tokio::test]
 async fn todo_edit_tool_false_result_does_not_pass_success_guard() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -1730,11 +1730,13 @@ async fn todo_delete_pending_item_false_deleted_text_does_not_pass_success_guard
         .get_or_create_active(&private_test_meta())
         .unwrap();
     match session.pending_operation {
-        Some(PendingOperation::TodoDelete { item, .. }) => {
-            assert_eq!(item.title, "进行中可发起永久删除确认");
-            assert_eq!(item.status, TodoStatus::Pending);
+        Some(PendingOperation::TodoBulkDelete {
+            item_ids, status, ..
+        }) => {
+            assert_eq!(item_ids.len(), 1);
+            assert_eq!(status, TodoStatus::Pending);
         }
-        other => panic!("expected delete pending operation, got {other:?}"),
+        other => panic!("expected pending bulk delete operation, got {other:?}"),
     }
 }
 

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -1608,7 +1608,7 @@ async fn todo_edit_tool_false_result_does_not_pass_success_guard() {
 }
 
 #[tokio::test]
-async fn todo_delete_tool_false_result_does_not_pass_success_guard() {
+async fn todo_delete_pending_item_false_deleted_text_does_not_pass_success_guard() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
         .with_tool_call_json(
@@ -1628,7 +1628,7 @@ async fn todo_delete_tool_false_result_does_not_pass_success_guard() {
         .create(
             &owner,
             TodoItemDraft {
-                title: "未完成不能永久删除".to_owned(),
+                title: "进行中可发起永久删除确认".to_owned(),
                 detail: None,
                 raw_text: None,
                 due_date: None,
@@ -1648,17 +1648,23 @@ async fn todo_delete_tool_false_result_does_not_pass_success_guard() {
         .unwrap();
 
     let text = response.text.unwrap();
-    assert!(text.contains("进行中的待办不能永久删除"));
+    assert!(text.contains("确认删除以下 1 项待办吗"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["todo_success_claimed"], true);
-    assert_eq!(diagnostics["todo_success_verified"], false);
+    assert_eq!(diagnostics["todo_success_verified"], true);
     assert_eq!(diagnostics["tool_retry_count"], 0);
-    assert_eq!(diagnostics["error_code"], "todo_delete_invalid_state");
-    assert_eq!(
-        diagnostics["todo_tool_results"][0]["error_code"],
-        "todo_delete_invalid_state"
-    );
     assert!(service.todo_store.list_pending(&owner).unwrap().len() == 1);
+    let session = service
+        .session_store
+        .get_or_create_active(&private_test_meta())
+        .unwrap();
+    match session.pending_operation {
+        Some(PendingOperation::TodoDelete { item, .. }) => {
+            assert_eq!(item.title, "进行中可发起永久删除确认");
+            assert_eq!(item.status, TodoStatus::Pending);
+        }
+        other => panic!("expected delete pending operation, got {other:?}"),
+    }
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tests/pending.rs
+++ b/qq-maid-core/src/runtime/respond/tests/pending.rs
@@ -130,7 +130,7 @@ async fn todo_add_pending_confirm_and_cancel_are_supported_for_tool_path() {
 }
 
 #[tokio::test]
-async fn todo_delete_pending_cancel_and_confirm_are_supported_for_tool_path() {
+async fn todo_delete_pending_pending_item_confirm_does_not_cancel() {
     let service = test_service();
     let owner = TodoStore::owner(Some("u1"), "group:g1");
     let item = service.todo_store.create(&owner, draft("买牛奶")).unwrap();
@@ -161,13 +161,21 @@ async fn todo_delete_pending_cancel_and_confirm_are_supported_for_tool_path() {
         PendingOperation::TodoDelete {
             initiator_user_id: Some("u1".to_owned()),
             owner_key: owner.key.clone(),
-            item,
+            item: item.clone(),
             created_at: now_iso_cn(),
         },
     );
     let confirmed = service.respond(message("确认")).await.unwrap();
-    assert!(confirmed.text.unwrap().contains("已取消待办"));
-    assert_eq!(service.todo_store.list_pending(&owner).unwrap().len(), 0);
+    assert!(confirmed.text.unwrap().contains("不能作为删除确认执行"));
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
 }
 
 #[tokio::test]
@@ -245,13 +253,12 @@ async fn todo_add_confirm_keeps_fresh_last_todo_action_over_stale_db_snapshot() 
 }
 
 #[tokio::test]
-async fn todo_delete_confirm_replaces_stale_snapshot_with_cancelled_list() {
+async fn todo_delete_confirm_pending_item_keeps_stale_snapshot_without_mutation() {
     let service = test_service();
     let owner = TodoStore::owner(Some("u1"), "group:g1");
     let item = service.todo_store.create(&owner, draft("待取消")).unwrap();
 
-    // 数据库 session 里已有旧的进行中列表快照；软取消成功后确定性回执会展示
-    // 最新已取消列表，并用这份用户真实看到的列表替换旧快照。
+    // 删除确认只允许永久删除终态待办；进行中待办不会在确认分支降级为取消。
     let mut session = service
         .session_store
         .get_or_create_active(&test_meta())
@@ -267,8 +274,7 @@ async fn todo_delete_confirm_replaces_stale_snapshot_with_cancelled_list() {
 
     let confirmed = service.respond(message("确认")).await.unwrap();
     let text = confirmed.text.unwrap();
-    assert!(text.contains("⛔ 已取消待办"));
-    assert!(text.contains("⛔ 当前已取消 · 共 1 项"));
+    assert!(text.contains("不能作为删除确认执行"));
 
     let session = service
         .session_store
@@ -277,11 +283,17 @@ async fn todo_delete_confirm_replaces_stale_snapshot_with_cancelled_list() {
     let snapshot = session
         .last_todo_query
         .as_ref()
-        .expect("missing cancelled snapshot");
-    assert_eq!(snapshot.query_type, "cancelled-list");
+        .expect("missing original snapshot");
+    assert_eq!(snapshot.query_type, "list");
     assert_eq!(snapshot.result_ids, vec![item.id.clone()]);
-    // 同时 last_todo_action 应指向被取消的待办，而非旧值。
-    let last_action = session.last_todo_action.expect("missing last_todo_action");
-    assert_eq!(last_action.title, "待取消");
-    assert_eq!(last_action.action, "cancelled");
+    assert!(session.last_todo_action.is_none());
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
 }

--- a/qq-maid-core/src/runtime/respond/tests/pending.rs
+++ b/qq-maid-core/src/runtime/respond/tests/pending.rs
@@ -130,7 +130,7 @@ async fn todo_add_pending_confirm_and_cancel_are_supported_for_tool_path() {
 }
 
 #[tokio::test]
-async fn todo_delete_pending_item_confirm_permanently_deletes() {
+async fn legacy_todo_delete_pending_item_confirm_soft_cancels() {
     let service = test_service();
     let owner = TodoStore::owner(Some("u1"), "group:g1");
     let item = service.todo_store.create(&owner, draft("买牛奶")).unwrap();
@@ -166,18 +166,15 @@ async fn todo_delete_pending_item_confirm_permanently_deletes() {
         },
     );
     let confirmed = service.respond(message("确认")).await.unwrap();
-    assert!(
-        confirmed
-            .text
-            .unwrap()
-            .contains("已永久删除 1 条进行中待办")
-    );
-    assert!(
+    assert!(confirmed.text.unwrap().contains("已取消待办 1 条"));
+    assert_eq!(
         service
             .todo_store
             .get_by_id(&owner, &item.id)
             .unwrap()
-            .is_none()
+            .unwrap()
+            .status,
+        TodoStatus::Cancelled
     );
 }
 
@@ -263,7 +260,8 @@ async fn todo_delete_confirm_pending_item_refreshes_snapshot_after_delete() {
 
     let other = service.todo_store.create(&owner, draft("保留")).unwrap();
 
-    // 删除确认执行保存的原始 delete 计划；即使目标仍在进行中，也不会降级为取消。
+    // 新版进行中待办永久删除使用 TodoBulkDelete 保存明确 status，避免复用旧
+    // TodoDelete + Pending 的软取消语义。
     let mut session = service
         .session_store
         .get_or_create_active(&test_meta())
@@ -274,10 +272,14 @@ async fn todo_delete_confirm_pending_item_refreshes_snapshot_after_delete() {
         "",
         vec![item.id.clone(), other.id.clone()],
     );
-    session.pending_operation = Some(PendingOperation::TodoDelete {
+    session.pending_operation = Some(PendingOperation::TodoBulkDelete {
         initiator_user_id: Some("u1".to_owned()),
         owner_key: owner.key.clone(),
-        item: item.clone(),
+        item_ids: vec![item.id.clone()],
+        matched_count: 1,
+        status: TodoStatus::Pending,
+        summary: "待取消".to_owned(),
+        source_condition: "进行中待办".to_owned(),
         created_at: now_iso_cn(),
     });
     service.session_store.save(&mut session).unwrap();
@@ -312,5 +314,102 @@ async fn todo_delete_confirm_pending_item_refreshes_snapshot_after_delete() {
             .unwrap()
             .status,
         TodoStatus::Pending
+    );
+}
+
+#[tokio::test]
+async fn todo_delete_confirm_skips_item_when_status_changed_after_pending_created() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    let item = service
+        .todo_store
+        .create(&owner, draft("临时取消"))
+        .unwrap();
+    service
+        .todo_store
+        .cancel_by_ids(&owner, std::slice::from_ref(&item.id))
+        .unwrap();
+    let cancelled_item = service
+        .todo_store
+        .get_by_id(&owner, &item.id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(cancelled_item.status, TodoStatus::Cancelled);
+
+    save_pending(
+        &service,
+        PendingOperation::TodoDelete {
+            initiator_user_id: Some("u1".to_owned()),
+            owner_key: owner.key.clone(),
+            item: cancelled_item,
+            created_at: now_iso_cn(),
+        },
+    );
+
+    service
+        .todo_store
+        .restore_cancelled_by_ids(&owner, std::slice::from_ref(&item.id))
+        .unwrap();
+    let confirmed = service.respond(message("确认")).await.unwrap();
+    assert!(confirmed.text.unwrap().contains("没有执行删除"));
+
+    let current = service
+        .todo_store
+        .get_by_id(&owner, &item.id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(current.status, TodoStatus::Pending);
+}
+
+#[tokio::test]
+async fn todo_bulk_delete_confirm_keeps_items_whose_status_changed_after_pending_created() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    let keep = service
+        .todo_store
+        .create(&owner, draft("恢复保留"))
+        .unwrap();
+    let delete = service
+        .todo_store
+        .create(&owner, draft("保持完成"))
+        .unwrap();
+    let ids = vec![keep.id.clone(), delete.id.clone()];
+    service.todo_store.complete_by_ids(&owner, &ids).unwrap();
+
+    save_pending(
+        &service,
+        PendingOperation::TodoBulkDelete {
+            initiator_user_id: Some("u1".to_owned()),
+            owner_key: owner.key.clone(),
+            item_ids: ids.clone(),
+            matched_count: ids.len(),
+            status: TodoStatus::Completed,
+            summary: "恢复保留、保持完成".to_owned(),
+            source_condition: "已完成待办".to_owned(),
+            created_at: now_iso_cn(),
+        },
+    );
+
+    service
+        .todo_store
+        .restore_completed_by_ids(&owner, std::slice::from_ref(&keep.id))
+        .unwrap();
+    let confirmed = service.respond(message("确认")).await.unwrap();
+    let text = confirmed.text.unwrap();
+    assert!(text.contains("已永久删除 1 条已完成待办"));
+    assert!(text.contains("跳过 1 条已不存在或状态已变化的待办"));
+
+    let kept = service
+        .todo_store
+        .get_by_id(&owner, &keep.id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(kept.status, TodoStatus::Pending);
+    assert!(
+        service
+            .todo_store
+            .get_by_id(&owner, &delete.id)
+            .unwrap()
+            .is_none()
     );
 }

--- a/qq-maid-core/src/runtime/respond/tests/pending.rs
+++ b/qq-maid-core/src/runtime/respond/tests/pending.rs
@@ -130,7 +130,7 @@ async fn todo_add_pending_confirm_and_cancel_are_supported_for_tool_path() {
 }
 
 #[tokio::test]
-async fn todo_delete_pending_pending_item_confirm_does_not_cancel() {
+async fn todo_delete_pending_item_confirm_permanently_deletes() {
     let service = test_service();
     let owner = TodoStore::owner(Some("u1"), "group:g1");
     let item = service.todo_store.create(&owner, draft("买牛奶")).unwrap();
@@ -166,15 +166,18 @@ async fn todo_delete_pending_pending_item_confirm_does_not_cancel() {
         },
     );
     let confirmed = service.respond(message("确认")).await.unwrap();
-    assert!(confirmed.text.unwrap().contains("不能作为删除确认执行"));
-    assert_eq!(
+    assert!(
+        confirmed
+            .text
+            .unwrap()
+            .contains("已永久删除 1 条进行中待办")
+    );
+    assert!(
         service
             .todo_store
             .get_by_id(&owner, &item.id)
             .unwrap()
-            .unwrap()
-            .status,
-        TodoStatus::Pending
+            .is_none()
     );
 }
 
@@ -253,17 +256,24 @@ async fn todo_add_confirm_keeps_fresh_last_todo_action_over_stale_db_snapshot() 
 }
 
 #[tokio::test]
-async fn todo_delete_confirm_pending_item_keeps_stale_snapshot_without_mutation() {
+async fn todo_delete_confirm_pending_item_refreshes_snapshot_after_delete() {
     let service = test_service();
     let owner = TodoStore::owner(Some("u1"), "group:g1");
     let item = service.todo_store.create(&owner, draft("待取消")).unwrap();
 
-    // 删除确认只允许永久删除终态待办；进行中待办不会在确认分支降级为取消。
+    let other = service.todo_store.create(&owner, draft("保留")).unwrap();
+
+    // 删除确认执行保存的原始 delete 计划；即使目标仍在进行中，也不会降级为取消。
     let mut session = service
         .session_store
         .get_or_create_active(&test_meta())
         .unwrap();
-    session.remember_last_todo_query(&owner.key, "list", "", vec![item.id.clone()]);
+    session.remember_last_todo_query(
+        &owner.key,
+        "list",
+        "",
+        vec![item.id.clone(), other.id.clone()],
+    );
     session.pending_operation = Some(PendingOperation::TodoDelete {
         initiator_user_id: Some("u1".to_owned()),
         owner_key: owner.key.clone(),
@@ -274,7 +284,7 @@ async fn todo_delete_confirm_pending_item_keeps_stale_snapshot_without_mutation(
 
     let confirmed = service.respond(message("确认")).await.unwrap();
     let text = confirmed.text.unwrap();
-    assert!(text.contains("不能作为删除确认执行"));
+    assert!(text.contains("已永久删除 1 条进行中待办"));
 
     let session = service
         .session_store
@@ -283,14 +293,21 @@ async fn todo_delete_confirm_pending_item_keeps_stale_snapshot_without_mutation(
     let snapshot = session
         .last_todo_query
         .as_ref()
-        .expect("missing original snapshot");
+        .expect("missing refreshed snapshot");
     assert_eq!(snapshot.query_type, "list");
-    assert_eq!(snapshot.result_ids, vec![item.id.clone()]);
+    assert_eq!(snapshot.result_ids, vec![other.id.clone()]);
     assert!(session.last_todo_action.is_none());
-    assert_eq!(
+    assert!(
         service
             .todo_store
             .get_by_id(&owner, &item.id)
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &other.id)
             .unwrap()
             .unwrap()
             .status,

--- a/qq-maid-core/src/runtime/respond/tests/todo.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo.rs
@@ -301,11 +301,11 @@ async fn todo_clarification_llm_tool_call_completes_candidate_scope() {
 }
 
 #[tokio::test]
-async fn todo_clarification_cancel_todo_reply_does_not_abandon_pending() {
+async fn todo_clarification_cancel_todo_reply_executes_without_confirmation() {
     let provider = MockProvider::new().with_tool_call_json(
         "cancel_todo",
         r#"{"number":1,"reference":null}"#,
-        "已发起取消确认。",
+        "已取消待办。",
     );
     let service = test_service_with_provider(provider);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
@@ -325,14 +325,14 @@ async fn todo_clarification_cancel_todo_reply_does_not_abandon_pending() {
         .unwrap();
 
     assert_eq!(response.command.as_deref(), Some("todo_clarify_resumed"));
-    assert!(matches!(
+    assert!(
         service
             .session_store
             .get_or_create_active(&private_todo_meta())
             .unwrap()
-            .pending_operation,
-        Some(PendingOperation::TodoDelete { .. })
-    ));
+            .pending_operation
+            .is_none()
+    );
     assert_eq!(
         service
             .todo_store
@@ -340,7 +340,7 @@ async fn todo_clarification_cancel_todo_reply_does_not_abandon_pending() {
             .unwrap()
             .unwrap()
             .status,
-        TodoStatus::Pending
+        TodoStatus::Cancelled
     );
 }
 
@@ -354,7 +354,7 @@ async fn todo_clarification_original_tool_result_wins_over_same_round_control() 
                 r#"{"action":"abandon","question":null}"#,
             ),
         ],
-        "已发起取消确认。",
+        "已取消待办。",
     );
     let service = test_service_with_provider(provider);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
@@ -374,14 +374,14 @@ async fn todo_clarification_original_tool_result_wins_over_same_round_control() 
         .unwrap();
 
     assert_eq!(response.command.as_deref(), Some("todo_clarify_resumed"));
-    assert!(matches!(
+    assert!(
         service
             .session_store
             .get_or_create_active(&private_todo_meta())
             .unwrap()
-            .pending_operation,
-        Some(PendingOperation::TodoDelete { .. })
-    ));
+            .pending_operation
+            .is_none()
+    );
     assert_eq!(
         service
             .todo_store
@@ -389,7 +389,7 @@ async fn todo_clarification_original_tool_result_wins_over_same_round_control() 
             .unwrap()
             .unwrap()
             .status,
-        TodoStatus::Pending
+        TodoStatus::Cancelled
     );
 }
 

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -25,7 +25,9 @@ mod receipt;
 pub(super) use command::parse_todo_command;
 use completed_query::parse_completed_todo_time_query;
 use format::*;
-pub(in crate::runtime::respond) use receipt::tool_outcome_from_todo_result;
+pub(in crate::runtime::respond) use receipt::{
+    append_todo_related_list_for_turn, tool_outcome_from_todo_result,
+};
 
 const TODO_QUERY_NOUNS: &[&str] = &["待办", "代办", "任务"];
 const TODO_QUERY_LIST_VERBS: &[&str] = &[

--- a/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
@@ -34,7 +34,7 @@ use crate::{
             todo_lexicon,
         },
         session::{LAST_QUERY_TTL_SECONDS, SessionRecord, query_is_fresh},
-        todo::TodoOwner,
+        todo::{TodoBulkDeleteOutcome, TodoOwner, TodoStatus},
         tools::{CancelTodoTool, CompleteTodoTool, DeleteTodoTool, EditTodoTool, RestoreTodoTool},
     },
 };
@@ -112,10 +112,39 @@ impl RustRespondService {
                     )?));
                 }
                 if matches!(reply_kind, PendingReplyKind::Confirm) {
-                    let outcome = self
-                        .todo_store
-                        .delete_by_ids(owner, std::slice::from_ref(&item.id))
+                    if item.status == TodoStatus::Pending {
+                        // 旧版本的 `TodoDelete` + Pending 表示“确认后软取消待办”。
+                        // 该变体没有持久化 delete/cancel 意图，升级后必须保留旧语义，
+                        // 避免把用户原本确认取消的旧 pending 解释成永久删除。
+                        let outcome = crate::runtime::todo::ops::cancel_many(
+                            &self.todo_store,
+                            session,
+                            owner,
+                            std::slice::from_ref(&item.id),
+                        )
                         .map_err(todo_error)?;
+                        if outcome.cancelled.is_empty() {
+                            return Ok(Some(self.clear_pending_response(
+                                session,
+                                user_text,
+                                CommandBody::plain("这条待办已不存在或状态已变化，没有执行取消。"),
+                                "todo_cancel",
+                            )?));
+                        }
+                        return Ok(Some(self.clear_pending_response(
+                            session,
+                            user_text,
+                            CommandBody::plain("⛔ 已取消待办 1 条。"),
+                            "todo_cancel",
+                        )?));
+                    }
+                    let outcome = delete_by_ids_with_pending_status(
+                        &self.todo_store,
+                        owner,
+                        std::slice::from_ref(&item.id),
+                        &item.status,
+                    )
+                    .map_err(todo_error)?;
                     if outcome.deleted_count == 0 {
                         return Ok(Some(self.clear_pending_response(
                             session,
@@ -168,10 +197,13 @@ impl RustRespondService {
                     )?));
                 }
                 if matches!(reply_kind, PendingReplyKind::Confirm) {
-                    let outcome = self
-                        .todo_store
-                        .delete_by_ids(owner, &item_ids)
-                        .map_err(todo_error)?;
+                    let outcome = delete_by_ids_with_pending_status(
+                        &self.todo_store,
+                        owner,
+                        &item_ids,
+                        &status,
+                    )
+                    .map_err(todo_error)?;
                     session.clear_last_todo_action_if_matches_any(&owner.key, &item_ids);
                     let source_count = if matched_count == 0 {
                         item_ids.len()
@@ -501,6 +533,21 @@ impl RustRespondService {
             })?;
         *session = latest;
         Ok(())
+    }
+}
+
+fn delete_by_ids_with_pending_status(
+    todo_store: &crate::runtime::todo::TodoStore,
+    owner: &TodoOwner,
+    item_ids: &[String],
+    status: &TodoStatus,
+) -> Result<TodoBulkDeleteOutcome, crate::runtime::todo::TodoError> {
+    // 删除确认是按“发起确认时的状态”授权的；执行确认时仍必须在 SQL 条件里校验
+    // 当前状态，避免过期确认把已经恢复或重新变为进行中的待办永久删除。
+    match status {
+        TodoStatus::Completed => todo_store.delete_completed_by_ids(owner, item_ids),
+        TodoStatus::Cancelled => todo_store.delete_cancelled_by_ids(owner, item_ids),
+        TodoStatus::Pending => todo_store.delete_pending_by_ids(owner, item_ids),
     }
 }
 

--- a/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
@@ -2,8 +2,8 @@
 //!
 //! Todo 写操作统一由 Tool Loop 触发；slash 写入口已移除。这里处理 Tool 仍会产生的
 //! 两类跨轮状态：
-//! - 确认类 pending：旧版 `TodoAdd`、取消/单条永久删除 `TodoDelete`、批量永久删除
-//!   `TodoBulkDelete`；新建/修改/完成/恢复不再进入确认；
+//! - 确认类 pending：旧版 `TodoAdd`、永久删除 `TodoDelete` / `TodoBulkDelete`；
+//!   新建/修改/完成/取消/恢复不再进入确认；
 //! - 澄清类 pending：`TodoClarify`，保存原工具、原始参数和精简候选边界，用户补充后
 //!   通过受限 Tool Loop 重入原 Todo Tool，由 LLM 只负责选择/继续澄清，真正校验与副作用
 //!   仍由原 Tool 重新读取 `TodoStore` 后执行。
@@ -40,7 +40,7 @@ use crate::{
 };
 
 use super::format::*;
-use super::receipt::{receipt_after_cancelled, receipt_after_created, receipt_after_deleted};
+use super::receipt::{receipt_after_created, receipt_after_deleted};
 
 use crate::runtime::respond::common::CommandBody;
 use crate::runtime::respond::{RespondResponse, RustRespondService, common::todo_error};
@@ -113,19 +113,9 @@ impl RustRespondService {
                 }
                 if matches!(reply_kind, PendingReplyKind::Confirm) {
                     let reply = match item.status {
-                        TodoStatus::Pending => {
-                            // 未完成待办的软删除（状态变更为已取消）+ 清空
-                            // last_todo_query / 更新 last_todo_action 统一交由 ops 门面维护。
-                            let deleted = crate::runtime::todo::ops::cancel_one(
-                                &self.todo_store,
-                                session,
-                                owner,
-                                &item.id,
-                            )
-                            .map_err(todo_error)?;
-                            receipt_after_cancelled(&self.todo_store, session, owner, &deleted)?
-                                .body
-                        }
+                        TodoStatus::Pending => CommandBody::plain(
+                            "这条待办仍在进行中，不能作为删除确认执行。若不再需要，请重新说“取消这条待办”。",
+                        ),
                         TodoStatus::Completed => {
                             let outcome = self
                                 .todo_store

--- a/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
@@ -34,7 +34,7 @@ use crate::{
             todo_lexicon,
         },
         session::{LAST_QUERY_TTL_SECONDS, SessionRecord, query_is_fresh},
-        todo::{TodoOwner, TodoStatus},
+        todo::TodoOwner,
         tools::{CancelTodoTool, CompleteTodoTool, DeleteTodoTool, EditTodoTool, RestoreTodoTool},
     },
 };
@@ -112,65 +112,31 @@ impl RustRespondService {
                     )?));
                 }
                 if matches!(reply_kind, PendingReplyKind::Confirm) {
-                    let reply = match item.status {
-                        TodoStatus::Pending => CommandBody::plain(
-                            "这条待办仍在进行中，不能作为删除确认执行。若不再需要，请重新说“取消这条待办”。",
-                        ),
-                        TodoStatus::Completed => {
-                            let outcome = self
-                                .todo_store
-                                .delete_completed_by_ids(owner, std::slice::from_ref(&item.id))
-                                .map_err(todo_error)?;
-                            if outcome.deleted_count == 0 {
-                                return Ok(Some(self.clear_pending_response(
-                                    session,
-                                    user_text,
-                                    CommandBody::plain("没有可删除的已完成待办。"),
-                                    "todo_confirm",
-                                )?));
-                            }
-                            session.clear_last_todo_action_if_matches_any(
-                                &owner.key,
-                                std::slice::from_ref(&item.id),
-                            );
-                            receipt_after_deleted(
-                                &self.todo_store,
-                                session,
-                                owner,
-                                TodoStatus::Completed,
-                                outcome.deleted_count,
-                                0,
-                            )?
-                            .body
-                        }
-                        TodoStatus::Cancelled => {
-                            let outcome = self
-                                .todo_store
-                                .delete_cancelled_by_ids(owner, std::slice::from_ref(&item.id))
-                                .map_err(todo_error)?;
-                            if outcome.deleted_count == 0 {
-                                return Ok(Some(self.clear_pending_response(
-                                    session,
-                                    user_text,
-                                    CommandBody::plain("当前没有已取消待办需要删除。"),
-                                    "todo_confirm",
-                                )?));
-                            }
-                            session.clear_last_todo_action_if_matches_any(
-                                &owner.key,
-                                std::slice::from_ref(&item.id),
-                            );
-                            receipt_after_deleted(
-                                &self.todo_store,
-                                session,
-                                owner,
-                                TodoStatus::Cancelled,
-                                outcome.deleted_count,
-                                0,
-                            )?
-                            .body
-                        }
-                    };
+                    let outcome = self
+                        .todo_store
+                        .delete_by_ids(owner, std::slice::from_ref(&item.id))
+                        .map_err(todo_error)?;
+                    if outcome.deleted_count == 0 {
+                        return Ok(Some(self.clear_pending_response(
+                            session,
+                            user_text,
+                            CommandBody::plain("这条待办已不存在或不属于当前会话，没有执行删除。"),
+                            "todo_confirm",
+                        )?));
+                    }
+                    session.clear_last_todo_action_if_matches_any(
+                        &owner.key,
+                        std::slice::from_ref(&item.id),
+                    );
+                    let reply = receipt_after_deleted(
+                        &self.todo_store,
+                        session,
+                        owner,
+                        item.status,
+                        outcome.deleted_count,
+                        0,
+                    )?
+                    .body;
                     return Ok(Some(self.clear_pending_response(
                         session,
                         user_text,
@@ -202,53 +168,26 @@ impl RustRespondService {
                     )?));
                 }
                 if matches!(reply_kind, PendingReplyKind::Confirm) {
-                    let reply = match status {
-                        TodoStatus::Completed => {
-                            let outcome = self
-                                .todo_store
-                                .delete_completed_by_ids(owner, &item_ids)
-                                .map_err(todo_error)?;
-                            session.clear_last_todo_action_if_matches_any(&owner.key, &item_ids);
-                            let source_count = if matched_count == 0 {
-                                item_ids.len()
-                            } else {
-                                matched_count
-                            };
-                            let skipped_count = source_count.saturating_sub(outcome.deleted_count);
-                            receipt_after_deleted(
-                                &self.todo_store,
-                                session,
-                                owner,
-                                TodoStatus::Completed,
-                                outcome.deleted_count,
-                                skipped_count,
-                            )?
-                            .body
-                        }
-                        TodoStatus::Cancelled => {
-                            let outcome = self
-                                .todo_store
-                                .delete_cancelled_by_ids(owner, &item_ids)
-                                .map_err(todo_error)?;
-                            session.clear_last_todo_action_if_matches_any(&owner.key, &item_ids);
-                            let source_count = if matched_count == 0 {
-                                item_ids.len()
-                            } else {
-                                matched_count
-                            };
-                            let skipped_count = source_count.saturating_sub(outcome.deleted_count);
-                            receipt_after_deleted(
-                                &self.todo_store,
-                                session,
-                                owner,
-                                TodoStatus::Cancelled,
-                                outcome.deleted_count,
-                                skipped_count,
-                            )?
-                            .body
-                        }
-                        TodoStatus::Pending => CommandBody::plain("不支持批量删除未完成待办。"),
+                    let outcome = self
+                        .todo_store
+                        .delete_by_ids(owner, &item_ids)
+                        .map_err(todo_error)?;
+                    session.clear_last_todo_action_if_matches_any(&owner.key, &item_ids);
+                    let source_count = if matched_count == 0 {
+                        item_ids.len()
+                    } else {
+                        matched_count
                     };
+                    let skipped_count = source_count.saturating_sub(outcome.deleted_count);
+                    let reply = receipt_after_deleted(
+                        &self.todo_store,
+                        session,
+                        owner,
+                        status,
+                        outcome.deleted_count,
+                        skipped_count,
+                    )?
+                    .body;
                     return Ok(Some(self.clear_pending_response(
                         session,
                         user_text,

--- a/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
@@ -96,6 +96,14 @@ pub(in crate::runtime::respond) fn append_todo_related_list_for_turn(
     owner: &TodoOwner,
     outcomes: &mut Vec<ToolExecutionOutcome>,
 ) -> Result<(), LlmError> {
+    if outcomes.iter().any(|outcome| {
+        outcome.domain == "todo"
+            && outcome.tool_name == LIST_TODOS_TOOL_NAME
+            && outcome.status == ToolOutcomeStatus::Succeeded
+    }) {
+        return Ok(());
+    }
+
     let mut specs = Vec::new();
     for outcome in outcomes.iter() {
         if outcome.domain != "todo" || outcome.status != ToolOutcomeStatus::Succeeded {

--- a/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
@@ -40,7 +40,7 @@ enum TodoWriteOperation {
     Create,
     Edit,
     Complete,
-    CancelPending,
+    Cancel,
     Restore,
     DeletePending,
 }
@@ -88,6 +88,44 @@ pub(in crate::runtime::respond) fn tool_outcome_from_todo_result(
         error_code: receipt.error_code.clone(),
         command: Some(receipt.command.to_owned()),
     }))
+}
+
+pub(in crate::runtime::respond) fn append_todo_related_list_for_turn(
+    todo_store: &TodoStore,
+    session: &mut SessionRecord,
+    owner: &TodoOwner,
+    outcomes: &mut Vec<ToolExecutionOutcome>,
+) -> Result<(), LlmError> {
+    let mut specs = Vec::new();
+    for outcome in outcomes.iter() {
+        if outcome.domain != "todo" || outcome.status != ToolOutcomeStatus::Succeeded {
+            continue;
+        }
+        match outcome.effect {
+            ToolEffect::Created | ToolEffect::Updated | ToolEffect::Completed => {
+                specs.push(pending_list_spec())
+            }
+            ToolEffect::Cancelled => specs.push(cancelled_list_spec()),
+            ToolEffect::Deleted => specs.push(completed_list_spec()),
+            ToolEffect::ReadOnly | ToolEffect::ExternalSideEffect => {}
+        }
+    }
+    if specs.is_empty() {
+        return Ok(());
+    }
+    let spec = merge_related_list_specs(&specs);
+    let body = related_list_body(todo_store, session, owner, &spec)?;
+    outcomes.push(ToolExecutionOutcome {
+        tool_name: "todo_related_list".to_owned(),
+        domain: "todo".to_owned(),
+        status: ToolOutcomeStatus::Succeeded,
+        effect: ToolEffect::ReadOnly,
+        presentation: OutcomePresentation::Trusted,
+        blocks: vec![ResponseBlock::RelatedList(body)],
+        error_code: None,
+        command: None,
+    });
+    Ok(())
 }
 
 fn list_todos_outcome(
@@ -201,36 +239,6 @@ pub(in crate::runtime::respond) fn receipt_after_created(
     )
 }
 
-pub(in crate::runtime::respond) fn receipt_after_cancelled(
-    todo_store: &TodoStore,
-    session: &mut SessionRecord,
-    owner: &TodoOwner,
-    item: &TodoItem,
-) -> Result<TodoWriteReceipt, LlmError> {
-    let lines = vec![
-        "⛔ 已取消待办".to_owned(),
-        String::new(),
-        affected_item_line(item),
-    ];
-    let markdown_lines = vec![
-        "# ⛔ 已取消待办".to_owned(),
-        String::new(),
-        affected_item_line_markdown(item),
-    ];
-    receipt_with_related_list(
-        todo_store,
-        session,
-        owner,
-        RelatedReceiptDraft {
-            lines,
-            markdown_lines,
-            spec: cancelled_list_spec(),
-            command: "todo_confirm",
-            trailing_hint: Some("可说：删除全部取消的待办"),
-        },
-    )
-}
-
 pub(in crate::runtime::respond) fn receipt_after_deleted(
     todo_store: &TodoStore,
     session: &mut SessionRecord,
@@ -267,9 +275,9 @@ pub(in crate::runtime::respond) fn receipt_after_deleted(
 }
 
 fn receipt_from_tool_result_with_status(
-    todo_store: &TodoStore,
-    session: &mut SessionRecord,
-    owner: &TodoOwner,
+    _todo_store: &TodoStore,
+    _session: &mut SessionRecord,
+    _owner: &TodoOwner,
     result: &ToolExecutionResult,
     status: ToolOutcomeStatus,
 ) -> Result<TodoWriteReceipt, LlmError> {
@@ -310,37 +318,24 @@ fn receipt_from_tool_result_with_status(
 
     let receipt = match operation {
         TodoWriteOperation::Create => {
-            let item = item_from_value(result.output.get("created"));
-            let lines = success_lines("✅ 已新增待办", item.as_ref());
-            let markdown_lines = success_markdown_lines("✅ 已新增待办", item.as_ref());
-            receipt_with_related_list(
-                todo_store,
-                session,
-                owner,
-                RelatedReceiptDraft {
-                    lines,
-                    markdown_lines,
-                    spec: pending_list_spec(),
-                    command: "todo_create",
-                    trailing_hint: None,
-                },
+            let items = receipt_items_from_array(&result.output, "created_items")
+                .or_else(|| item_from_value(result.output.get("created")).map(|item| vec![item]))
+                .unwrap_or_default();
+            mutation_receipt(
+                CommandBody::dual(
+                    success_items_lines("✅ 已新增待办", &items).join("\n"),
+                    success_items_markdown_lines("✅ 已新增待办", &items).join("\n"),
+                ),
+                "todo_create",
             )?
         }
         TodoWriteOperation::Edit => {
             let item = item_from_value(result.output.get("updated"));
             let lines = success_lines("✏️ 已修改待办", item.as_ref());
             let markdown_lines = success_markdown_lines("✏️ 已修改待办", item.as_ref());
-            receipt_with_related_list(
-                todo_store,
-                session,
-                owner,
-                RelatedReceiptDraft {
-                    lines,
-                    markdown_lines,
-                    spec: pending_list_spec(),
-                    command: "todo_edit",
-                    trailing_hint: None,
-                },
+            mutation_receipt(
+                CommandBody::dual(lines.join("\n"), markdown_lines.join("\n")),
+                "todo_edit",
             )?
         }
         TodoWriteOperation::Complete => {
@@ -358,17 +353,29 @@ fn receipt_from_tool_result_with_status(
                 "completed",
                 &result.output,
             );
-            receipt_with_related_list(
-                todo_store,
-                session,
-                owner,
-                RelatedReceiptDraft {
-                    lines,
-                    markdown_lines,
-                    spec: pending_list_spec(),
-                    command: "todo_complete",
-                    trailing_hint: None,
-                },
+            mutation_receipt(
+                CommandBody::dual(lines.join("\n"), markdown_lines.join("\n")),
+                "todo_complete",
+            )?
+        }
+        TodoWriteOperation::Cancel => {
+            let count = result
+                .output
+                .get("cancelled")
+                .and_then(Value::as_array)
+                .map_or(0, Vec::len);
+            let lines =
+                success_count_lines("⛔ 已取消待办", count, "条", "cancelled", &result.output);
+            let markdown_lines = success_count_markdown_lines(
+                "⛔ 已取消待办",
+                count,
+                "条",
+                "cancelled",
+                &result.output,
+            );
+            mutation_receipt(
+                CommandBody::dual(lines.join("\n"), markdown_lines.join("\n")),
+                "todo_cancel",
             )?
         }
         TodoWriteOperation::Restore => {
@@ -386,22 +393,12 @@ fn receipt_from_tool_result_with_status(
                 "restored",
                 &result.output,
             );
-            receipt_with_related_list(
-                todo_store,
-                session,
-                owner,
-                RelatedReceiptDraft {
-                    lines,
-                    markdown_lines,
-                    spec: pending_list_spec(),
-                    command: "todo_restore",
-                    trailing_hint: None,
-                },
+            mutation_receipt(
+                CommandBody::dual(lines.join("\n"), markdown_lines.join("\n")),
+                "todo_restore",
             )?
         }
-        TodoWriteOperation::CancelPending | TodoWriteOperation::DeletePending => {
-            pending_confirmation_receipt(&result.output)
-        }
+        TodoWriteOperation::DeletePending => pending_confirmation_receipt(&result.output),
     };
     Ok(receipt)
 }
@@ -421,7 +418,7 @@ fn tool_effect_for_operation(operation: TodoWriteOperation) -> ToolEffect {
         TodoWriteOperation::Create => ToolEffect::Created,
         TodoWriteOperation::Edit => ToolEffect::Updated,
         TodoWriteOperation::Complete => ToolEffect::Completed,
-        TodoWriteOperation::CancelPending => ToolEffect::Cancelled,
+        TodoWriteOperation::Cancel => ToolEffect::Cancelled,
         TodoWriteOperation::Restore => ToolEffect::Updated,
         TodoWriteOperation::DeletePending => ToolEffect::Deleted,
     }
@@ -440,32 +437,14 @@ fn receipt_with_related_list(
         command,
         trailing_hint,
     } = draft;
-    let items = list_for_spec(todo_store, owner, &spec).map_err(todo_error)?;
-    let total_count = items.len();
-    let shown = items
-        .iter()
-        .take(RECEIPT_LIST_LIMIT)
-        .cloned()
-        .collect::<Vec<_>>();
-    let truncated = total_count > shown.len();
-    // 快照只保存本次真正展示的可编号条目；隐藏项不能拥有用户没看到的编号。
-    session.remember_last_todo_query(
-        &owner.key,
-        spec.query_type,
-        spec.condition,
-        shown.iter().map(|item| item.id.clone()).collect(),
-    );
-
     lines.push(String::new());
     markdown_lines.push(String::new());
-    append_related_list(&mut lines, &shown, total_count, truncated, &spec, false);
-    append_related_list(
-        &mut markdown_lines,
-        &shown,
-        total_count,
-        truncated,
-        &spec,
-        true,
+    let related = related_list_body(todo_store, session, owner, &spec)?;
+    lines.push(related.text);
+    markdown_lines.push(
+        related
+            .markdown
+            .unwrap_or_else(|| lines.last().cloned().unwrap_or_default()),
     );
     if let Some(hint) = trailing_hint {
         lines.push(String::new());
@@ -481,45 +460,84 @@ fn receipt_with_related_list(
     })
 }
 
+fn related_list_body(
+    todo_store: &TodoStore,
+    session: &mut SessionRecord,
+    owner: &TodoOwner,
+    spec: &RelatedListSpec,
+) -> Result<CommandBody, LlmError> {
+    let items = list_for_related_spec(todo_store, owner, spec).map_err(todo_error)?;
+    let total_count = items.len();
+    let shown = items
+        .iter()
+        .take(RECEIPT_LIST_LIMIT)
+        .cloned()
+        .collect::<Vec<_>>();
+    let truncated = total_count > shown.len();
+    // 快照只保存本次真正展示的可编号条目；隐藏项不能拥有用户没看到的编号。
+    session.remember_last_todo_query(
+        &owner.key,
+        spec.query_type,
+        spec.condition,
+        shown.iter().map(|item| item.id.clone()).collect(),
+    );
+    let mut lines = Vec::new();
+    let mut markdown_lines = Vec::new();
+    append_related_list(&mut lines, &shown, total_count, truncated, spec, false);
+    append_related_list(
+        &mut markdown_lines,
+        &shown,
+        total_count,
+        truncated,
+        spec,
+        true,
+    );
+    Ok(CommandBody::dual(
+        lines.join("\n"),
+        markdown_lines.join("\n"),
+    ))
+}
+
+fn merge_related_list_specs(specs: &[RelatedListSpec]) -> RelatedListSpec {
+    let Some(first) = specs.first() else {
+        return pending_list_spec();
+    };
+    if specs
+        .iter()
+        .all(|spec| spec.query_type == first.query_type && spec.condition == first.condition)
+    {
+        return first.clone();
+    }
+    all_list_spec()
+}
+
 fn pending_confirmation_receipt(output: &Value) -> TodoWriteReceipt {
     let pending_action = output
         .get("pending_action")
         .and_then(Value::as_str)
         .unwrap_or("");
     let body = match pending_action {
-        "cancel" => {
-            let item = item_from_value(output.get("item"));
-            let mut lines = vec!["请确认是否取消这条待办".to_owned()];
-            let mut markdown_lines = vec!["# 请确认是否取消这条待办".to_owned()];
-            if let Some(item) = item.as_ref() {
-                lines.push(String::new());
-                lines.push(format!("- {}", item.title));
-                markdown_lines.push(String::new());
-                markdown_lines.push(format!("- {}", item.title));
-            }
-            lines.push(String::new());
-            lines.push("回复“确认”继续，回复“取消”放弃。".to_owned());
-            markdown_lines.push(String::new());
-            markdown_lines.push("回复“确认”继续，回复“取消”放弃。".to_owned());
-            CommandBody::dual(lines.join("\n"), markdown_lines.join("\n"))
-        }
         "delete" => {
-            let count = output
-                .get("items")
-                .and_then(Value::as_array)
-                .map(Vec::len)
-                .or_else(|| output.get("item").map(|_| 1))
-                .unwrap_or(0);
+            let items = receipt_items_from_array(output, "items")
+                .or_else(|| item_from_value(output.get("item")).map(|item| vec![item]))
+                .unwrap_or_default();
+            let count = items.len();
             let source = string_field(output, "selection_source");
-            let mut lines = vec![format!("准备永久删除 {count} 条待办")];
-            let mut markdown_lines = vec![format!("# 准备永久删除 {count} 条待办")];
+            let mut lines = vec![format!("⚠️ 确认删除以下 {count} 项待办吗？")];
+            let mut markdown_lines = vec![format!("# ⚠️ 确认删除以下 {count} 项待办吗？")];
             if let Some(source) = source {
                 lines.push(format!("范围：{source}"));
                 markdown_lines.push(format!("范围：{source}"));
             }
-            lines.push("永久删除需要二次确认，确认前不会修改数据库。".to_owned());
+            for (index, item) in items.iter().enumerate() {
+                lines.push(format!("{}. {}", index + 1, item.title));
+                markdown_lines.push(format!("{}. {}", index + 1, item.title));
+            }
+            lines.push(String::new());
+            lines.push("删除后不可恢复。".to_owned());
             lines.push("回复“确认”继续，回复“取消”放弃。".to_owned());
-            markdown_lines.push("永久删除需要二次确认，确认前不会修改数据库。".to_owned());
+            markdown_lines.push(String::new());
+            markdown_lines.push("删除后不可恢复。".to_owned());
             markdown_lines.push("回复“确认”继续，回复“取消”放弃。".to_owned());
             CommandBody::dual(lines.join("\n"), markdown_lines.join("\n"))
         }
@@ -540,6 +558,17 @@ fn simple_receipt(
         command,
         error_code,
     }
+}
+
+fn mutation_receipt(
+    body: CommandBody,
+    command: &'static str,
+) -> Result<TodoWriteReceipt, LlmError> {
+    Ok(TodoWriteReceipt {
+        body,
+        command,
+        error_code: None,
+    })
 }
 
 fn append_related_list(
@@ -618,7 +647,7 @@ fn todo_write_operation(name: &str) -> Option<TodoWriteOperation> {
         "create_todo" => Some(TodoWriteOperation::Create),
         "edit_todo" => Some(TodoWriteOperation::Edit),
         "complete_todos" => Some(TodoWriteOperation::Complete),
-        "cancel_todo" => Some(TodoWriteOperation::CancelPending),
+        "cancel_todo" => Some(TodoWriteOperation::Cancel),
         "restore_todos" => Some(TodoWriteOperation::Restore),
         "delete_todos" => Some(TodoWriteOperation::DeletePending),
         _ => None,
@@ -665,16 +694,20 @@ fn list_spec_from_output(output: &Value) -> RelatedListSpec {
     match string_field(output, "status").as_deref() {
         Some("completed") => completed_list_spec(),
         Some("cancelled") => cancelled_list_spec(),
-        Some("all") => RelatedListSpec {
-            status: TodoStatus::Pending,
-            query_type: "all",
-            condition: "全部待办",
-            title: "📋 全部待办",
-            empty_text: "当前没有待办。",
-            time_label: "时间",
-            time_value: display_todo_time,
-        },
+        Some("all") => RelatedListSpec { ..all_list_spec() },
         _ => pending_list_spec(),
+    }
+}
+
+fn all_list_spec() -> RelatedListSpec {
+    RelatedListSpec {
+        status: TodoStatus::Pending,
+        query_type: "all",
+        condition: "全部待办",
+        title: "📋 全部待办",
+        empty_text: "当前没有待办。",
+        time_label: "时间",
+        time_value: display_todo_time,
     }
 }
 
@@ -710,6 +743,33 @@ fn success_lines(title: &str, item: Option<&ReceiptItem>) -> Vec<String> {
 
 fn success_markdown_lines(title: &str, item: Option<&ReceiptItem>) -> Vec<String> {
     success_lines(&format!("# {title}"), item)
+}
+
+fn success_items_lines(title: &str, items: &[ReceiptItem]) -> Vec<String> {
+    let mut lines = vec![if items.len() > 1 {
+        format!("{title} · {} 条", items.len())
+    } else {
+        title.to_owned()
+    }];
+    for item in items {
+        lines.push(format!("- {}", item.title));
+        if let Some(time) = item
+            .display_time
+            .as_deref()
+            .filter(|value| !value.is_empty())
+        {
+            lines.push(format!("  时间：{time}"));
+        }
+    }
+    lines
+}
+
+fn success_items_markdown_lines(title: &str, items: &[ReceiptItem]) -> Vec<String> {
+    let mut lines = success_items_lines(title, items);
+    if let Some(first) = lines.first_mut() {
+        *first = format!("# {first}");
+    }
+    lines
 }
 
 fn success_count_lines(
@@ -776,6 +836,16 @@ fn item_from_value(value: Option<&Value>) -> Option<ReceiptItem> {
         title: truncate_chars(&title, 80),
         display_time: string_field(value, "display_time"),
     })
+}
+
+fn receipt_items_from_array(output: &Value, key: &str) -> Option<Vec<ReceiptItem>> {
+    let items = output
+        .get(key)?
+        .as_array()?
+        .iter()
+        .filter_map(|value| item_from_value(Some(value)))
+        .collect::<Vec<_>>();
+    (!items.is_empty()).then_some(items)
 }
 
 fn error_reply_for_tool_result(output: &Value) -> String {

--- a/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
@@ -864,10 +864,10 @@ fn error_reply_for_tool_result(output: &Value) -> String {
             "没有找到符合条件的待办，或可见编号已经失效。请查看最新列表后再操作。".to_owned()
         }
         Some("todo_delete_invalid_state") => {
-            "进行中的待办不能永久删除；如不再需要，请先取消它。".to_owned()
+            "目标待办当前无法永久删除，请查看最新列表后再试。".to_owned()
         }
         Some("todo_delete_mixed_status") => {
-            "不能把已完成和已取消待办混在同一次永久删除里。请分状态删除。".to_owned()
+            "这次永久删除没有成功，请查看最新列表后再试。".to_owned()
         }
         Some("todo_pending_exists") | Some("todo_pending_conflict") => {
             "当前已有待确认的待办操作，请先回复“确认”或“取消”。".to_owned()

--- a/qq-maid-core/src/runtime/todo/ops.rs
+++ b/qq-maid-core/src/runtime/todo/ops.rs
@@ -17,8 +17,8 @@
 use crate::runtime::{
     session::SessionRecord,
     todo::{
-        TodoBulkCompleteOutcome, TodoBulkRestoreOutcome, TodoItem, TodoItemDraft, TodoOwner,
-        TodoStore,
+        TodoBulkCancelOutcome, TodoBulkCompleteOutcome, TodoBulkRestoreOutcome, TodoItem,
+        TodoItemDraft, TodoOwner, TodoStore,
     },
 };
 
@@ -35,6 +35,28 @@ pub fn create_one(
     let created = store.create(owner, draft)?;
     session.last_todo_query = None;
     session.remember_last_todo_action(&owner.key, &created, "created");
+    Ok(created)
+}
+
+/// 批量新增待办，并维护 session 最近对象快照。
+///
+/// Tool Loop 一轮可表达多个待办创建意图时，必须把它们作为同一用户操作处理；
+/// 成功后只清空一次旧列表快照。多条创建不会记录单一 `last_todo_action`，
+/// 避免“刚刚那个”在批量上下文里错误指向任意一条。
+pub fn create_many(
+    store: &TodoStore,
+    session: &mut SessionRecord,
+    owner: &TodoOwner,
+    drafts: Vec<TodoItemDraft>,
+) -> Result<Vec<TodoItem>, crate::runtime::todo::TodoError> {
+    let mut created = Vec::new();
+    for draft in drafts {
+        created.push(store.create(owner, draft)?);
+    }
+    if !created.is_empty() {
+        session.last_todo_query = None;
+        session.update_last_todo_action_from_items(&owner.key, "created", &created);
+    }
     Ok(created)
 }
 
@@ -154,4 +176,22 @@ pub fn cancel_one(
     session.last_todo_query = None;
     session.remember_last_todo_action(&owner.key, &deleted, "cancelled");
     Ok(deleted)
+}
+
+/// 批量软取消待办（仅 Pending -> Cancelled），并维护 session 快照。
+///
+/// 取消是可恢复状态变更，不进入确认 Pending；目标 ID 必须由 Tool 层先完成
+/// 可见编号或候选边界解析，本层只负责真实存储副作用和 session 不变量。
+pub fn cancel_many(
+    store: &TodoStore,
+    session: &mut SessionRecord,
+    owner: &TodoOwner,
+    ids: &[String],
+) -> Result<TodoBulkCancelOutcome, crate::runtime::todo::TodoError> {
+    let outcome = store.cancel_by_ids(owner, ids)?;
+    if !outcome.cancelled.is_empty() {
+        session.last_todo_query = None;
+        session.update_last_todo_action_from_items(&owner.key, "cancelled", &outcome.cancelled);
+    }
+    Ok(outcome)
 }

--- a/qq-maid-core/src/runtime/todo/ops.rs
+++ b/qq-maid-core/src/runtime/todo/ops.rs
@@ -49,10 +49,7 @@ pub fn create_many(
     owner: &TodoOwner,
     drafts: Vec<TodoItemDraft>,
 ) -> Result<Vec<TodoItem>, crate::runtime::todo::TodoError> {
-    let mut created = Vec::new();
-    for draft in drafts {
-        created.push(store.create(owner, draft)?);
-    }
+    let created = store.create_many(owner, drafts)?;
     if !created.is_empty() {
         session.last_todo_query = None;
         session.update_last_todo_action_from_items(&owner.key, "created", &created);

--- a/qq-maid-core/src/runtime/todo/ops.rs
+++ b/qq-maid-core/src/runtime/todo/ops.rs
@@ -161,23 +161,6 @@ pub fn restore_both(
     })
 }
 
-/// 软取消单条待办（仅状态变更为已取消），并维护 session 快照。
-///
-/// 用于 pending `TodoDelete` 确认分支中“未完成待办”的软删除语义：历史实现会清空
-/// `last_todo_query` 并记录 “cancelled” 最近对象，这里保持完全一致。
-/// 物理删除已完成/已取消待办不经过这里，仍由调用方直接走带状态校验的存储接口。
-pub fn cancel_one(
-    store: &TodoStore,
-    session: &mut SessionRecord,
-    owner: &TodoOwner,
-    id: &str,
-) -> Result<TodoItem, crate::runtime::todo::TodoError> {
-    let deleted = store.cancel(owner, id)?;
-    session.last_todo_query = None;
-    session.remember_last_todo_action(&owner.key, &deleted, "cancelled");
-    Ok(deleted)
-}
-
 /// 批量软取消待办（仅 Pending -> Cancelled），并维护 session 快照。
 ///
 /// 取消是可恢复状态变更，不进入确认 Pending；目标 ID 必须由 Tool 层先完成

--- a/qq-maid-core/src/runtime/tools/todo/cancel.rs
+++ b/qq-maid-core/src/runtime/tools/todo/cancel.rs
@@ -132,6 +132,18 @@ impl Tool for CancelTodoTool {
         }
         scope.save()?;
 
+        if cancelled.is_empty() {
+            let output = ToolOutput::json(json!({
+                "ok": false,
+                "error_code": TODO_SELECTION_NOT_FOUND_CODE,
+                "cancelled": [],
+                "missing_numbers": missing_numbers_json(&missing),
+                "message": "没有取消任何待办；所选编号不存在、状态不是未完成，或条目已被其他操作改变。",
+            }));
+            scope.remember_dedup_output(&context, &arguments, &output)?;
+            return Ok(output);
+        }
+
         let output = ToolOutput::json(json!({
             "ok": true,
             "cancelled": todo_selected_items_json(&cancelled),

--- a/qq-maid-core/src/runtime/tools/todo/cancel.rs
+++ b/qq-maid-core/src/runtime/tools/todo/cancel.rs
@@ -5,20 +5,18 @@ use serde_json::json;
 
 use qq_maid_llm::tool::{Tool, ToolContext, ToolMetadata, ToolOutput};
 
-use crate::{
-    error::LlmError,
-    runtime::{pending::PendingOperation, session::now_iso_cn, todo::TodoStatus},
-};
+use crate::{error::LlmError, runtime::todo::TodoStatus};
 
 use super::common::{
-    CANCEL_TODO_TOOL_NAME, TODO_REFERENCE_INVALID_STATE_CODE, single_number_or_reference_schema,
-    todo_tool_error_output,
+    CANCEL_TODO_TOOL_NAME, TODO_REFERENCE_INVALID_STATE_CODE, TODO_SELECTION_NOT_FOUND_CODE,
+    number_list_or_reference_schema, todo_tool_error, todo_tool_error_output,
 };
-use super::json::todo_selected_item_json;
-use super::scope::{
-    SelectionScope, TodoToolScope, TodoToolSingleItemResolution, clarification_error_fields,
+use super::json::todo_selected_items_json;
+use super::scope::{SelectionScope, TodoToolScope, clarification_error_fields};
+use super::selection::{
+    missing_numbers_json, missing_selection_labels_for_result, prepare_selection_arguments,
+    prepared_selection_ids, resolved_selection_from_arguments, selected_items_for_result,
 };
-use super::selection::{prepare_selection_arguments, resolved_selection_from_arguments};
 
 pub struct CancelTodoTool {
     todo_store: crate::runtime::todo::TodoStore,
@@ -51,8 +49,8 @@ impl Tool for CancelTodoTool {
     fn metadata(&self) -> ToolMetadata {
         ToolMetadata {
             name: CANCEL_TODO_TOOL_NAME.to_owned(),
-            description: "发起取消未完成待办。用户明确说“第 N 个”时只能传 number 并依赖最近一次 list_todos 的 visible_number；用户说“刚才那个 / 它 / 恢复的那个”时传 reference=\"last\"。取消只是状态变更为已取消，不是永久删除；需要用户确认后才执行。".to_owned(),
-            parameters: single_number_or_reference_schema("要取消的 visible_number"),
+            description: "取消一个或多个未完成待办，直接把状态变更为已取消，不需要二次确认。用户明确说“第 N 个/1-5/1,3,5”时传 numbers 或 selection_text 并依赖最近一次 list_todos 的 visible_number；用户说“刚才那个 / 它 / 恢复的那个”时传 reference=\"last\"。取消不是永久删除。".to_owned(),
+            parameters: number_list_or_reference_schema("要取消的 visible_number 列表"),
         }
     }
 
@@ -66,7 +64,7 @@ impl Tool for CancelTodoTool {
             &self.todo_store,
             context,
             arguments,
-            false,
+            true,
             self.selection_scope.clone(),
         )
     }
@@ -82,33 +80,37 @@ impl Tool for CancelTodoTool {
             return Ok(output);
         }
         let resolved =
-            resolved_selection_from_arguments(&mut scope, &self.todo_store, &arguments, false)?;
+            resolved_selection_from_arguments(&mut scope, &self.todo_store, &arguments, true)?;
         if let Some(output) = resolved.error_output.as_ref() {
             let (error_code, message) = clarification_error_fields(output);
             return scope.save_clarification(
                 &self.todo_store,
                 CANCEL_TODO_TOOL_NAME,
                 &arguments,
-                false,
+                true,
                 error_code,
                 message,
             );
         }
-        let item = match resolved.single_item(&self.todo_store, &scope.owner)? {
-            TodoToolSingleItemResolution::Item(item) => *item,
-            TodoToolSingleItemResolution::Output(output) => {
-                let (error_code, message) = clarification_error_fields(&output);
-                return scope.save_clarification(
-                    &self.todo_store,
-                    CANCEL_TODO_TOOL_NAME,
-                    &arguments,
-                    false,
-                    error_code,
-                    message,
-                );
-            }
-        };
-        if item.status != TodoStatus::Pending {
+        let ids = prepared_selection_ids(&resolved);
+        if ids.is_empty() {
+            return scope.save_clarification(
+                &self.todo_store,
+                CANCEL_TODO_TOOL_NAME,
+                &arguments,
+                true,
+                TODO_SELECTION_NOT_FOUND_CODE,
+                "no visible numbers matched",
+            );
+        }
+        let selected_items = ids
+            .iter()
+            .filter_map(|id| self.todo_store.get_by_id(&scope.owner, id).ok().flatten())
+            .collect::<Vec<_>>();
+        if selected_items
+            .iter()
+            .any(|item| item.status != TodoStatus::Pending)
+        {
             return Ok(todo_tool_error_output(
                 TODO_REFERENCE_INVALID_STATE_CODE,
                 "cancel_todo only accepts pending todos; use restore_todos or delete_todos for terminal states",
@@ -116,20 +118,25 @@ impl Tool for CancelTodoTool {
         }
 
         scope.ensure_no_pending()?;
-        scope.session.pending_operation = Some(PendingOperation::TodoDelete {
-            initiator_user_id: scope.owner.user_id.clone(),
-            owner_key: scope.owner.key.clone(),
-            item: item.clone(),
-            created_at: now_iso_cn(),
-        });
+        let outcome = crate::runtime::todo::ops::cancel_many(
+            &self.todo_store,
+            &mut scope.session,
+            &scope.owner,
+            &ids,
+        )
+        .map_err(todo_tool_error)?;
+        let cancelled = selected_items_for_result(&resolved, &outcome.cancelled);
+        let missing = missing_selection_labels_for_result(&resolved, &outcome.skipped_ids);
+        if !cancelled.is_empty() {
+            scope.clear_clarification_if_scoped();
+        }
         scope.save()?;
 
         let output = ToolOutput::json(json!({
             "ok": true,
-            "requires_confirmation": true,
-            "pending_action": "cancel",
-            "message": "已发起取消待办确认；用户确认后只会标记为已取消，不会永久删除。",
-            "item": todo_selected_item_json(resolved.single_label(), &item),
+            "cancelled": todo_selected_items_json(&cancelled),
+            "missing_numbers": missing_numbers_json(&missing),
+            "message": "已取消的条目已变更为 cancelled；missing_numbers 表示编号不存在、状态不是未完成或条目已变化。",
         }));
         scope.remember_dedup_output(&context, &arguments, &output)?;
         Ok(output)

--- a/qq-maid-core/src/runtime/tools/todo/common.rs
+++ b/qq-maid-core/src/runtime/tools/todo/common.rs
@@ -35,6 +35,7 @@ pub(super) const TODO_VISIBLE_NUMBERS_UNAVAILABLE_CODE: &str = "todo_visible_num
 pub(super) const TODO_REFERENCE_UNAVAILABLE_CODE: &str = "todo_reference_unavailable";
 pub(super) const TODO_REFERENCE_INVALID_STATE_CODE: &str = "todo_reference_invalid_state";
 pub(super) const TODO_SELECTION_NOT_FOUND_CODE: &str = "todo_selection_not_found";
+pub(super) const TODO_DELETE_MIXED_STATUS_CODE: &str = "todo_delete_mixed_status";
 
 // prepare 阶段写进 arguments 的预解析键；以下划线开头，避免与模型参数冲突。
 pub(super) const PREBOUND_SELECTION_KEY: &str = "_resolved_selection";

--- a/qq-maid-core/src/runtime/tools/todo/common.rs
+++ b/qq-maid-core/src/runtime/tools/todo/common.rs
@@ -24,6 +24,7 @@ pub(super) const DELETE_TODOS_TOOL_NAME: &str = "delete_todos";
 
 // 输入上限；超长直接拒绝，避免把异常长参数带进 pending / 存储。
 pub(super) const TODO_TOOL_MAX_NUMBERS: usize = 20;
+pub(super) const TODO_TOOL_MAX_BATCH_CREATE_ITEMS: usize = 20;
 pub(super) const TODO_TOOL_MAX_TEXT_CHARS: usize = 500;
 
 // 引用关键字；模型只能用 "last" 触发最近对象引用，不能传内部 ID。
@@ -180,28 +181,40 @@ pub(super) fn number_list_or_reference_schema(description: &str) -> Value {
     json!({
         "type": "object",
         "properties": {
-            "numbers": {
-                "type": "array",
-                "description": description,
-                "minItems": 1,
-                "maxItems": TODO_TOOL_MAX_NUMBERS,
-                "items": {
-                    "type": "integer",
-                    "minimum": 1
-                }
-            },
-            "selection_text": {
-                "type": ["string", "null"],
-                "description": "用户显式给出的编号文本，例如 \"1-5\"、\"1,3,5\"、\"1 到 5\"。仅在 numbers 无法表达原文范围时使用；与 numbers/reference 三选一。"
-            },
-            "reference": {
-                "type": ["string", "null"],
-                "enum": [TODO_REFERENCE_LAST, null],
-                "description": "当用户说“刚才那个 / 它 / 恢复的那个 / 刚完成的”时传 \"last\"；与 numbers/selection_text 三选一。"
-            }
+            "numbers": todo_numbers_schema(description),
+            "selection_text": todo_selection_text_schema(),
+            "reference": todo_reference_schema("当用户说“刚才那个 / 它 / 恢复的那个 / 刚完成的”时传 \"last\"；与 numbers/selection_text 三选一。")
         },
         "required": ["numbers", "selection_text", "reference"],
         "additionalProperties": false
+    })
+}
+
+pub(super) fn todo_numbers_schema(description: &str) -> Value {
+    json!({
+        "type": ["array", "null"],
+        "description": description,
+        "minItems": 1,
+        "maxItems": TODO_TOOL_MAX_NUMBERS,
+        "items": {
+            "type": "integer",
+            "minimum": 1
+        }
+    })
+}
+
+pub(super) fn todo_selection_text_schema() -> Value {
+    json!({
+        "type": ["string", "null"],
+        "description": "用户显式给出的编号文本，例如 \"1-5\"、\"1,3,5\"、\"1 到 5\"。仅在 numbers 无法表达原文范围时使用；与 numbers/reference 三选一。"
+    })
+}
+
+pub(super) fn todo_reference_schema(description: &str) -> Value {
+    json!({
+        "type": ["string", "null"],
+        "enum": [TODO_REFERENCE_LAST, null],
+        "description": description
     })
 }
 
@@ -326,6 +339,7 @@ pub(super) fn single_todo_selection_request(
 fn optional_number_list(arguments: &Value, key: &str) -> Result<Option<Vec<usize>>, LlmError> {
     match arguments.get(key) {
         None | Some(Value::Null) => Ok(None),
+        Some(Value::Array(values)) if values.is_empty() => Ok(None),
         Some(Value::Array(values)) => Ok(Some(parse_number_list(values)?)),
         _ => Err(bad_tool_arguments(format!(
             "{key} must be an array or null"
@@ -367,7 +381,8 @@ fn optional_positive_usize(arguments: &Value, key: &str) -> Result<Option<usize>
 fn optional_reference(arguments: &Value, key: &str) -> Result<Option<TodoReference>, LlmError> {
     match arguments.get(key) {
         None | Some(Value::Null) => Ok(None),
-        Some(Value::String(value)) => match value.as_str() {
+        Some(Value::String(value)) if value.trim().is_empty() => Ok(None),
+        Some(Value::String(value)) => match value.trim() {
             TODO_REFERENCE_LAST => Ok(Some(TodoReference::Last)),
             _ => Err(bad_tool_arguments(format!(
                 "{key} must be \"last\" or null"

--- a/qq-maid-core/src/runtime/tools/todo/common.rs
+++ b/qq-maid-core/src/runtime/tools/todo/common.rs
@@ -191,34 +191,17 @@ pub(super) fn number_list_or_reference_schema(description: &str) -> Value {
                     "minimum": 1
                 }
             },
-            "reference": {
+            "selection_text": {
                 "type": ["string", "null"],
-                "enum": [TODO_REFERENCE_LAST, null],
-                "description": "当用户说“刚才那个 / 它 / 恢复的那个 / 刚完成的”时传 \"last\"；与 numbers 二选一。"
-            }
-        },
-        "required": ["numbers", "reference"],
-        "additionalProperties": false
-    })
-}
-
-/// 单编号 + reference 的 schema，cancel 复用。
-pub(super) fn single_number_or_reference_schema(description: &str) -> Value {
-    json!({
-        "type": "object",
-        "properties": {
-            "number": {
-                "type": ["integer", "null"],
-                "minimum": 1,
-                "description": description
+                "description": "用户显式给出的编号文本，例如 \"1-5\"、\"1,3,5\"、\"1 到 5\"。仅在 numbers 无法表达原文范围时使用；与 numbers/reference 三选一。"
             },
             "reference": {
                 "type": ["string", "null"],
                 "enum": [TODO_REFERENCE_LAST, null],
-                "description": "当用户说“刚才那个 / 它 / 恢复的那个 / 刚完成的”时传 \"last\"；与 number 二选一。"
+                "description": "当用户说“刚才那个 / 它 / 恢复的那个 / 刚完成的”时传 \"last\"；与 numbers/selection_text 三选一。"
             }
         },
-        "required": ["number", "reference"],
+        "required": ["numbers", "selection_text", "reference"],
         "additionalProperties": false
     })
 }
@@ -229,7 +212,19 @@ pub(super) fn todo_selection_request(
     allow_many: bool,
 ) -> Result<TodoSelectionRequest, LlmError> {
     let numbers = optional_number_list(arguments, "numbers")?;
+    let single_number = optional_single_number_as_list(arguments, "number")?;
+    let selection_text_numbers = optional_selection_text_numbers(arguments, "selection_text")?;
     let reference = optional_reference(arguments, "reference")?;
+    let selected_count = usize::from(numbers.is_some())
+        + usize::from(single_number.is_some())
+        + usize::from(selection_text_numbers.is_some())
+        + usize::from(reference.is_some());
+    if selected_count != 1 {
+        return Err(bad_tool_arguments(
+            "exactly one of numbers/number/selection_text/reference is required",
+        ));
+    }
+    let numbers = numbers.or(single_number).or(selection_text_numbers);
     match (numbers, reference) {
         (Some(numbers), None) => {
             if !allow_many && numbers.len() != 1 {
@@ -245,6 +240,72 @@ pub(super) fn todo_selection_request(
             "either numbers or reference is required",
         )),
     }
+}
+
+fn optional_single_number_as_list(
+    arguments: &Value,
+    key: &str,
+) -> Result<Option<Vec<usize>>, LlmError> {
+    optional_positive_usize(arguments, key).map(|value| value.map(|number| vec![number]))
+}
+
+fn optional_selection_text_numbers(
+    arguments: &Value,
+    key: &str,
+) -> Result<Option<Vec<usize>>, LlmError> {
+    let Some(text) = optional_text(arguments, key)? else {
+        return Ok(None);
+    };
+    Ok(Some(parse_selection_text(&text)?))
+}
+
+fn parse_selection_text(text: &str) -> Result<Vec<usize>, LlmError> {
+    let compact = text
+        .trim()
+        .replace(['，', '、'], ",")
+        .replace(['～', '—', '－'], "-")
+        .replace("到", "-")
+        .replace("至", "-");
+    if compact.contains('-') && !compact.contains(',') {
+        let parts = compact.split('-').collect::<Vec<_>>();
+        if parts.len() == 2 {
+            let start = parse_visible_number_token(parts[0])?;
+            let end = parse_visible_number_token(parts[1])?;
+            if start == 0 || end == 0 || start > end {
+                return Err(bad_tool_arguments("selection range is invalid"));
+            }
+            let count = end - start + 1;
+            if count > TODO_TOOL_MAX_NUMBERS {
+                return Err(bad_tool_arguments("numbers length is out of range"));
+            }
+            return Ok((start..=end).collect());
+        }
+    }
+    let mut numbers = Vec::new();
+    for part in compact.split(',') {
+        let number = parse_visible_number_token(part)?;
+        if number == 0 {
+            return Err(bad_tool_arguments("selection numbers must be positive"));
+        }
+        if !numbers.contains(&number) {
+            numbers.push(number);
+        }
+    }
+    if numbers.is_empty() || numbers.len() > TODO_TOOL_MAX_NUMBERS {
+        return Err(bad_tool_arguments("numbers length is out of range"));
+    }
+    Ok(numbers)
+}
+
+fn parse_visible_number_token(value: &str) -> Result<usize, LlmError> {
+    let token = value
+        .trim()
+        .trim_start_matches('第')
+        .trim_end_matches(['条', '个', '项'])
+        .trim();
+    token
+        .parse::<usize>()
+        .map_err(|_| bad_tool_arguments("selection_text must contain explicit visible numbers"))
 }
 
 /// 从 number/reference 互斥参数解析单条选择请求。

--- a/qq-maid-core/src/runtime/tools/todo/common.rs
+++ b/qq-maid-core/src/runtime/tools/todo/common.rs
@@ -35,8 +35,6 @@ pub(super) const TODO_VISIBLE_NUMBERS_UNAVAILABLE_CODE: &str = "todo_visible_num
 pub(super) const TODO_REFERENCE_UNAVAILABLE_CODE: &str = "todo_reference_unavailable";
 pub(super) const TODO_REFERENCE_INVALID_STATE_CODE: &str = "todo_reference_invalid_state";
 pub(super) const TODO_SELECTION_NOT_FOUND_CODE: &str = "todo_selection_not_found";
-pub(super) const TODO_DELETE_INVALID_STATE_CODE: &str = "todo_delete_invalid_state";
-pub(super) const TODO_DELETE_MIXED_STATUS_CODE: &str = "todo_delete_mixed_status";
 
 // prepare 阶段写进 arguments 的预解析键；以下划线开头，避免与模型参数冲突。
 pub(super) const PREBOUND_SELECTION_KEY: &str = "_resolved_selection";

--- a/qq-maid-core/src/runtime/tools/todo/create.rs
+++ b/qq-maid-core/src/runtime/tools/todo/create.rs
@@ -1,7 +1,7 @@
 //! `create_todo` Tool。
 
 use async_trait::async_trait;
-use serde_json::json;
+use serde_json::{Value, json};
 
 use qq_maid_llm::tool::{Tool, ToolContext, ToolMetadata, ToolOutput};
 
@@ -12,7 +12,8 @@ use crate::{
 };
 
 use super::common::{
-    CREATE_TODO_TOOL_NAME, optional_text, optional_time_precision, todo_tool_error,
+    CREATE_TODO_TOOL_NAME, optional_text, optional_time_precision, required_non_empty_text,
+    todo_tool_error,
 };
 use super::json::todo_plain_item_json;
 use super::scope::TodoToolScope;
@@ -39,13 +40,35 @@ impl Tool for CreateTodoTool {
     fn metadata(&self) -> ToolMetadata {
         ToolMetadata {
             name: CREATE_TODO_TOOL_NAME.to_owned(),
-            description: "为当前私聊用户直接创建待办。成功后立即写入数据库，并记录为最近操作对象；新增不需要二次确认。".to_owned(),
+            description: "为当前私聊用户直接创建一个或多个待办。成功后立即写入数据库；新增不需要二次确认。优先使用 items 批量表达同一轮拆解出的多个待办，旧单项字段仍兼容。".to_owned(),
             parameters: json!({
                 "type": "object",
                 "properties": {
+                    "items": {
+                        "type": ["array", "null"],
+                        "description": "同一用户意图下要创建的待办列表；创建多项时必须使用此字段。",
+                        "minItems": 1,
+                        "maxItems": 20,
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "content": {"type": "string"},
+                                "title": {"type": ["string", "null"]},
+                                "detail": {"type": ["string", "null"]},
+                                "due_date": {"type": ["string", "null"]},
+                                "due_at": {"type": ["string", "null"]},
+                                "time_precision": {
+                                    "type": ["string", "null"],
+                                    "enum": ["none", "date", "date_time", "inferred", null]
+                                }
+                            },
+                            "required": ["content", "title", "detail", "due_date", "due_at", "time_precision"],
+                            "additionalProperties": false
+                        }
+                    },
                     "content": {
-                        "type": "string",
-                        "description": "用户原始待办内容，例如“今晚检查机器人日志”"
+                        "type": ["string", "null"],
+                        "description": "旧单项兼容字段：用户原始待办内容，例如“今晚检查机器人日志”。items 非空时传 null。"
                     },
                     "title": {
                         "type": ["string", "null"],
@@ -69,7 +92,7 @@ impl Tool for CreateTodoTool {
                         "description": "时间精度；不确定时传 null"
                     }
                 },
-                "required": ["content", "title", "detail", "due_date", "due_at", "time_precision"],
+                "required": ["items", "content", "title", "detail", "due_date", "due_at", "time_precision"],
                 "additionalProperties": false
             }),
         }
@@ -80,36 +103,18 @@ impl Tool for CreateTodoTool {
         context: ToolContext,
         arguments: serde_json::Value,
     ) -> Result<ToolOutput, LlmError> {
-        use super::common::required_non_empty_text;
-
         let mut scope = TodoToolScope::load(&self.session_store, &context, None)?;
         if let Some(output) = scope.take_dedup_output(&context, &arguments)? {
             return Ok(output);
         }
-        let content = required_non_empty_text(&arguments, "content")?;
-        let title = optional_text(&arguments, "title")?.unwrap_or_else(|| content.clone());
-        let detail = optional_text(&arguments, "detail")?;
-        let due_date = optional_text(&arguments, "due_date")?;
-        let due_at = optional_text(&arguments, "due_at")?;
-        let time_precision: TodoTimePrecision =
-            optional_time_precision(&arguments, "time_precision")?;
-        let mut draft = TodoItemDraft {
-            title,
-            detail,
-            raw_text: Some(content.clone()),
-            due_date,
-            due_at,
-            time_precision,
-        };
-        // Tool 创建仍复用本地时间推断；模型未传结构化时间时，保持普通待办创建的保守体验。
-        enrich_draft_time_from_text(&mut draft, &content, &request_time_context());
+        let drafts = create_drafts_from_arguments(&arguments)?;
 
         scope.ensure_no_pending()?;
-        let created = crate::runtime::todo::ops::create_one(
+        let created = crate::runtime::todo::ops::create_many(
             &self.todo_store,
             &mut scope.session,
             &scope.owner,
-            draft,
+            drafts,
         )
         .map_err(todo_tool_error)?;
         scope.clear_clarification_if_scoped();
@@ -117,10 +122,44 @@ impl Tool for CreateTodoTool {
 
         let output = ToolOutput::json(json!({
             "ok": true,
-            "created": todo_plain_item_json(&created),
-            "message": "待办已新增并写入数据库；后续“刚才那个/刚刚那条”可用 reference=\"last\" 指向这条待办。",
+            "created": created.first().map(todo_plain_item_json),
+            "created_items": created.iter().map(todo_plain_item_json).collect::<Vec<_>>(),
+            "message": if created.len() == 1 {
+                "待办已新增并写入数据库；后续“刚才那个/刚刚那条”可用 reference=\"last\" 指向这条待办。"
+            } else {
+                "多条待办已作为同一批创建并写入数据库；批量创建后不会把“刚才那个”绑定到任意单条。"
+            },
         }));
         scope.remember_dedup_output(&context, &arguments, &output)?;
         Ok(output)
     }
+}
+
+fn create_drafts_from_arguments(arguments: &Value) -> Result<Vec<TodoItemDraft>, LlmError> {
+    if let Some(items) = arguments.get("items").and_then(Value::as_array)
+        && !items.is_empty()
+    {
+        return items.iter().map(create_draft_from_value).collect();
+    }
+    Ok(vec![create_draft_from_value(arguments)?])
+}
+
+fn create_draft_from_value(value: &Value) -> Result<TodoItemDraft, LlmError> {
+    let content = required_non_empty_text(value, "content")?;
+    let title = optional_text(value, "title")?.unwrap_or_else(|| content.clone());
+    let detail = optional_text(value, "detail")?;
+    let due_date = optional_text(value, "due_date")?;
+    let due_at = optional_text(value, "due_at")?;
+    let time_precision: TodoTimePrecision = optional_time_precision(value, "time_precision")?;
+    let mut draft = TodoItemDraft {
+        title,
+        detail,
+        raw_text: Some(content.clone()),
+        due_date,
+        due_at,
+        time_precision,
+    };
+    // Tool 创建仍复用本地时间推断；模型未传结构化时间时，保持普通待办创建的保守体验。
+    enrich_draft_time_from_text(&mut draft, &content, &request_time_context());
+    Ok(draft)
 }

--- a/qq-maid-core/src/runtime/tools/todo/create.rs
+++ b/qq-maid-core/src/runtime/tools/todo/create.rs
@@ -12,8 +12,8 @@ use crate::{
 };
 
 use super::common::{
-    CREATE_TODO_TOOL_NAME, optional_text, optional_time_precision, required_non_empty_text,
-    todo_tool_error,
+    CREATE_TODO_TOOL_NAME, TODO_TOOL_MAX_BATCH_CREATE_ITEMS, bad_tool_arguments, optional_text,
+    optional_time_precision, required_non_empty_text, todo_tool_error,
 };
 use super::json::todo_plain_item_json;
 use super::scope::TodoToolScope;
@@ -48,7 +48,7 @@ impl Tool for CreateTodoTool {
                         "type": ["array", "null"],
                         "description": "同一用户意图下要创建的待办列表；创建多项时必须使用此字段。",
                         "minItems": 1,
-                        "maxItems": 20,
+                        "maxItems": TODO_TOOL_MAX_BATCH_CREATE_ITEMS,
                         "items": {
                             "type": "object",
                             "properties": {
@@ -103,11 +103,11 @@ impl Tool for CreateTodoTool {
         context: ToolContext,
         arguments: serde_json::Value,
     ) -> Result<ToolOutput, LlmError> {
+        let drafts = create_drafts_from_arguments(&arguments)?;
         let mut scope = TodoToolScope::load(&self.session_store, &context, None)?;
         if let Some(output) = scope.take_dedup_output(&context, &arguments)? {
             return Ok(output);
         }
-        let drafts = create_drafts_from_arguments(&arguments)?;
 
         scope.ensure_no_pending()?;
         let created = crate::runtime::todo::ops::create_many(
@@ -136,12 +136,27 @@ impl Tool for CreateTodoTool {
 }
 
 fn create_drafts_from_arguments(arguments: &Value) -> Result<Vec<TodoItemDraft>, LlmError> {
-    if let Some(items) = arguments.get("items").and_then(Value::as_array)
-        && !items.is_empty()
-    {
-        return items.iter().map(create_draft_from_value).collect();
+    match arguments.get("items") {
+        Some(Value::Array(items)) => {
+            validate_batch_create_item_count(items.len())?;
+            return items.iter().map(create_draft_from_value).collect();
+        }
+        Some(Value::Null) | None => {}
+        Some(_) => return Err(bad_tool_arguments("items must be an array or null")),
     }
     Ok(vec![create_draft_from_value(arguments)?])
+}
+
+fn validate_batch_create_item_count(count: usize) -> Result<(), LlmError> {
+    if count == 0 {
+        return Err(bad_tool_arguments("items must contain at least one todo"));
+    }
+    if count > TODO_TOOL_MAX_BATCH_CREATE_ITEMS {
+        return Err(bad_tool_arguments(format!(
+            "单次最多创建 {TODO_TOOL_MAX_BATCH_CREATE_ITEMS} 项待办，请减少本次项目数量后重试。"
+        )));
+    }
+    Ok(())
 }
 
 fn create_draft_from_value(value: &Value) -> Result<TodoItemDraft, LlmError> {

--- a/qq-maid-core/src/runtime/tools/todo/delete.rs
+++ b/qq-maid-core/src/runtime/tools/todo/delete.rs
@@ -16,8 +16,9 @@ use crate::{
 
 use super::common::{
     DELETE_TODOS_TOOL_NAME, TODO_DELETE_MIXED_STATUS_CODE, TODO_REFERENCE_UNAVAILABLE_CODE,
-    TODO_SELECTION_NOT_FOUND_CODE, bad_tool_arguments, optional_text, todo_selection_request,
-    todo_tool_error, todo_tool_error_output,
+    TODO_SELECTION_NOT_FOUND_CODE, bad_tool_arguments, optional_text, todo_numbers_schema,
+    todo_reference_schema, todo_selection_request, todo_selection_text_schema, todo_tool_error,
+    todo_tool_error_output,
 };
 use super::json::{status_label, todo_plain_item_json, todo_plain_items_json};
 use super::scope::{
@@ -137,21 +138,9 @@ fn delete_todos_schema() -> Value {
     json!({
         "type": "object",
         "properties": {
-            "numbers": {
-                "type": ["array", "null"],
-                "description": "用户最近实际看到的待办列表 visible_number。只在用户明确说“第 N 个/删除4”时使用。",
-                "minItems": 1,
-                "items": { "type": "integer", "minimum": 1 }
-            },
-            "selection_text": {
-                "type": ["string", "null"],
-                "description": "用户显式给出的编号文本，例如 \"1-5\"、\"1,3,5\"、\"1 到 5\"。仅在 numbers 无法表达原文范围时使用。"
-            },
-            "reference": {
-                "type": ["string", "null"],
-                "enum": ["last", null],
-                "description": "用户说“刚才那个/它/刚完成的/刚取消的”时传 last。"
-            },
+            "numbers": todo_numbers_schema("用户最近实际看到的待办列表 visible_number。只在用户明确说“第 N 个/删除4”时使用。"),
+            "selection_text": todo_selection_text_schema(),
+            "reference": todo_reference_schema("用户说“刚才那个/它/刚完成的/刚取消的”时传 last。"),
             "query": {
                 "type": ["string", "null"],
                 "description": "按标题、详情或原始文本在全部待办中查找目标；例如“和老公出门”“飞机票”。"
@@ -179,7 +168,8 @@ fn delete_selection_request(arguments: &Value) -> Result<DeleteSelectionRequest,
         .is_some_and(|value| !value.trim().is_empty());
     let reference_selected = arguments
         .get("reference")
-        .is_some_and(|value| !value.is_null());
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty());
     let query = optional_text(arguments, "query")?;
     let all_status = optional_all_status(arguments)?;
     let selected_count =
@@ -381,7 +371,9 @@ fn create_delete_confirmation(
     scope.ensure_no_pending()?;
     let created_at = now_iso_cn();
     let message = delete_confirmation_message(&items, &status);
-    if items.len() == 1 {
+    // `TodoDelete` 的历史 Pending 语义是确认后软取消。进行中待办的新版永久删除
+    // 必须使用带 status 字段的 `TodoBulkDelete`，避免升级后无法区分旧确认意图。
+    if items.len() == 1 && status != TodoStatus::Pending {
         scope.session.pending_operation = Some(PendingOperation::TodoDelete {
             initiator_user_id: scope.owner.user_id.clone(),
             owner_key: scope.owner.key.clone(),

--- a/qq-maid-core/src/runtime/tools/todo/delete.rs
+++ b/qq-maid-core/src/runtime/tools/todo/delete.rs
@@ -143,6 +143,10 @@ fn delete_todos_schema() -> Value {
                 "minItems": 1,
                 "items": { "type": "integer", "minimum": 1 }
             },
+            "selection_text": {
+                "type": ["string", "null"],
+                "description": "用户显式给出的编号文本，例如 \"1-5\"、\"1,3,5\"、\"1 到 5\"。仅在 numbers 无法表达原文范围时使用。"
+            },
             "reference": {
                 "type": ["string", "null"],
                 "enum": ["last", null],
@@ -158,7 +162,7 @@ fn delete_todos_schema() -> Value {
                 "description": "删除全部已完成或全部已取消待办时使用；只能是 completed 或 cancelled。"
             }
         },
-        "required": ["numbers", "reference", "query", "all_status"],
+        "required": ["numbers", "selection_text", "reference", "query", "all_status"],
         "additionalProperties": false
     })
 }
@@ -169,20 +173,25 @@ fn delete_selection_request(arguments: &Value) -> Result<DeleteSelectionRequest,
         Value::Array(values) => !values.is_empty(),
         _ => true,
     });
+    let selection_text_selected = arguments
+        .get("selection_text")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty());
     let reference_selected = arguments
         .get("reference")
         .is_some_and(|value| !value.is_null());
     let query = optional_text(arguments, "query")?;
     let all_status = optional_all_status(arguments)?;
-    let selected_count = usize::from(numbers_selected || reference_selected)
-        + usize::from(query.is_some())
-        + usize::from(all_status.is_some());
+    let selected_count =
+        usize::from(numbers_selected || selection_text_selected || reference_selected)
+            + usize::from(query.is_some())
+            + usize::from(all_status.is_some());
     if selected_count != 1 {
         return Err(bad_tool_arguments(
             "delete_todos requires exactly one of numbers/reference/query/all_status",
         ));
     }
-    if numbers_selected || reference_selected {
+    if numbers_selected || selection_text_selected || reference_selected {
         // 复用原有 numbers/reference 互斥校验，保持旧参数兼容。
         todo_selection_request(arguments, true)?;
         return Ok(DeleteSelectionRequest::NumbersOrReference);

--- a/qq-maid-core/src/runtime/tools/todo/delete.rs
+++ b/qq-maid-core/src/runtime/tools/todo/delete.rs
@@ -15,9 +15,9 @@ use crate::{
 };
 
 use super::common::{
-    DELETE_TODOS_TOOL_NAME, TODO_REFERENCE_UNAVAILABLE_CODE, TODO_SELECTION_NOT_FOUND_CODE,
-    bad_tool_arguments, optional_text, todo_selection_request, todo_tool_error,
-    todo_tool_error_output,
+    DELETE_TODOS_TOOL_NAME, TODO_DELETE_MIXED_STATUS_CODE, TODO_REFERENCE_UNAVAILABLE_CODE,
+    TODO_SELECTION_NOT_FOUND_CODE, bad_tool_arguments, optional_text, todo_selection_request,
+    todo_tool_error, todo_tool_error_output,
 };
 use super::json::{status_label, todo_plain_item_json, todo_plain_items_json};
 use super::scope::{
@@ -371,6 +371,12 @@ fn create_delete_confirmation(
             "no todo selected for deletion",
         ));
     };
+    if items.iter().any(|item| item.status != status) {
+        return Ok(todo_tool_error_output(
+            TODO_DELETE_MIXED_STATUS_CODE,
+            "delete_todos requires selected todos to have the same status",
+        ));
+    }
 
     scope.ensure_no_pending()?;
     let created_at = now_iso_cn();

--- a/qq-maid-core/src/runtime/tools/todo/delete.rs
+++ b/qq-maid-core/src/runtime/tools/todo/delete.rs
@@ -15,9 +15,9 @@ use crate::{
 };
 
 use super::common::{
-    DELETE_TODOS_TOOL_NAME, TODO_DELETE_INVALID_STATE_CODE, TODO_DELETE_MIXED_STATUS_CODE,
-    TODO_REFERENCE_UNAVAILABLE_CODE, TODO_SELECTION_NOT_FOUND_CODE, bad_tool_arguments,
-    optional_text, todo_selection_request, todo_tool_error, todo_tool_error_output,
+    DELETE_TODOS_TOOL_NAME, TODO_REFERENCE_UNAVAILABLE_CODE, TODO_SELECTION_NOT_FOUND_CODE,
+    bad_tool_arguments, optional_text, todo_selection_request, todo_tool_error,
+    todo_tool_error_output,
 };
 use super::json::{status_label, todo_plain_item_json, todo_plain_items_json};
 use super::scope::{
@@ -58,7 +58,7 @@ impl Tool for DeleteTodoTool {
     fn metadata(&self) -> ToolMetadata {
         ToolMetadata {
             name: DELETE_TODOS_TOOL_NAME.to_owned(),
-            description: "发起永久删除已完成或已取消待办，必须二次确认后才真正删除。支持四种互斥选择：numbers=用户最近实际看到的 visible_number；reference=\"last\"；query=标题或文本条件；all_status=\"completed\"/\"cancelled\" 表示全部对应终态。未完成待办不能永久删除，用户说“不做了/取消/算了”时必须调用 cancel_todo。".to_owned(),
+            description: "发起永久删除待办，必须二次确认后才真正删除。支持四种互斥选择：numbers=用户最近实际看到的 visible_number；selection_text=用户原始编号范围；reference=\"last\"；query=标题或文本条件；all_status=\"completed\"/\"cancelled\" 表示全部对应状态。用户明确说“删除/永久删除”时使用本工具；用户说“不做了/取消/算了”时使用 cancel_todo。".to_owned(),
             parameters: delete_todos_schema(),
         }
     }
@@ -154,7 +154,7 @@ fn delete_todos_schema() -> Value {
             },
             "query": {
                 "type": ["string", "null"],
-                "description": "按标题、详情或原始文本在已完成/已取消待办中查找目标；例如“和老公出门”“飞机票”。"
+                "description": "按标题、详情或原始文本在全部待办中查找目标；例如“和老公出门”“飞机票”。"
             },
             "all_status": {
                 "type": ["string", "null"],
@@ -296,22 +296,17 @@ impl DeleteTodoTool {
         arguments: &Value,
         query: &str,
     ) -> Result<DeleteSelection, LlmError> {
-        let mut terminal = self
+        let all_items = self
             .todo_store
-            .list_completed(&scope.owner)
+            .list_all(&scope.owner)
             .map_err(todo_tool_error)?;
-        terminal.extend(
-            self.todo_store
-                .list_cancelled(&scope.owner)
-                .map_err(todo_tool_error)?,
-        );
-        let exact = terminal
+        let exact = all_items
             .iter()
             .filter(|item| normalized(&item.title) == normalized(query))
             .cloned()
             .collect::<Vec<_>>();
         let matches = if exact.is_empty() {
-            terminal
+            all_items
                 .into_iter()
                 .filter(|item| item_matches_query(item, query))
                 .collect::<Vec<_>>()
@@ -320,22 +315,9 @@ impl DeleteTodoTool {
         };
 
         if matches.is_empty() {
-            let pending_matches = self
-                .todo_store
-                .list_pending(&scope.owner)
-                .map_err(todo_tool_error)?
-                .into_iter()
-                .filter(|item| item_matches_query(item, query))
-                .collect::<Vec<_>>();
-            if !pending_matches.is_empty() {
-                return Ok(DeleteSelection::Output(todo_tool_error_output(
-                    TODO_DELETE_INVALID_STATE_CODE,
-                    "matched pending todos cannot be permanently deleted; use cancel_todo first",
-                )));
-            }
             return Ok(DeleteSelection::Output(todo_tool_error_output(
                 TODO_SELECTION_NOT_FOUND_CODE,
-                "no completed or cancelled todo matched query",
+                "no todo matched query",
             )));
         }
         if matches.len() == 1 {
@@ -352,7 +334,7 @@ impl DeleteTodoTool {
                 arguments,
                 false,
                 TODO_SELECTION_NOT_FOUND_CODE,
-                "multiple completed or cancelled todos matched query",
+                "multiple todos matched query",
                 candidates,
             )?,
         ))
@@ -383,24 +365,12 @@ fn create_delete_confirmation(
     items: Vec<TodoItem>,
     source_condition: String,
 ) -> Result<ToolOutput, LlmError> {
-    if items.iter().any(|item| item.status == TodoStatus::Pending) {
-        return Ok(todo_tool_error_output(
-            TODO_DELETE_INVALID_STATE_CODE,
-            "pending todos cannot be permanently deleted; use cancel_todo to mark them cancelled",
-        ));
-    }
     let Some(status) = items.first().map(|item| item.status.clone()) else {
         return Ok(todo_tool_error_output(
             TODO_SELECTION_NOT_FOUND_CODE,
             "no todo selected for deletion",
         ));
     };
-    if items.iter().any(|item| item.status != status) {
-        return Ok(todo_tool_error_output(
-            TODO_DELETE_MIXED_STATUS_CODE,
-            "delete_todos requires all selected todos to have the same terminal status",
-        ));
-    }
 
     scope.ensure_no_pending()?;
     let created_at = now_iso_cn();

--- a/qq-maid-core/src/runtime/tools/todo/scope.rs
+++ b/qq-maid-core/src/runtime/tools/todo/scope.rs
@@ -570,8 +570,10 @@ impl TodoToolScope {
                 clarification_candidates_from(todo_store, &self.owner, false)
                     .map_err(todo_tool_error)?
             }
-            RESTORE_TODOS_TOOL_NAME | DELETE_TODOS_TOOL_NAME => {
-                clarification_candidates_from(todo_store, &self.owner, true)
+            RESTORE_TODOS_TOOL_NAME => clarification_candidates_from(todo_store, &self.owner, true)
+                .map_err(todo_tool_error)?,
+            DELETE_TODOS_TOOL_NAME => {
+                clarification_candidates_all_statuses_from(todo_store, &self.owner)
                     .map_err(todo_tool_error)?
             }
             _ => Vec::new(),
@@ -692,7 +694,7 @@ fn clarification_question(
     }
 }
 
-/// 按 `terminal_only` 选择候选集：完成/编辑/取消看未完成，恢复/删除看已完成+已取消。
+/// 按 `terminal_only` 选择候选集：完成/编辑/取消看未完成，恢复看已完成+已取消。
 /// 候选数量与单项标题长度有上限，避免持久化过大的 pending。
 fn clarification_candidates_from(
     todo_store: &TodoStore,
@@ -706,6 +708,17 @@ fn clarification_candidates_from(
     } else {
         todo_store.list_pending(owner)?
     };
+    const MAX_CANDIDATES: usize = 20;
+    items.truncate(MAX_CANDIDATES);
+    Ok(clarification_candidates_for_items(&items))
+}
+
+/// 删除工具可永久删除任意状态，澄清候选也必须覆盖进行中、已完成和已取消。
+fn clarification_candidates_all_statuses_from(
+    todo_store: &TodoStore,
+    owner: &crate::runtime::todo::TodoOwner,
+) -> Result<Vec<crate::runtime::pending::ClarificationCandidate>, crate::runtime::todo::TodoError> {
+    let mut items = todo_store.list_all_for_board(owner)?;
     const MAX_CANDIDATES: usize = 20;
     items.truncate(MAX_CANDIDATES);
     Ok(clarification_candidates_for_items(&items))

--- a/qq-maid-core/src/runtime/tools/todo/tests.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests.rs
@@ -9,7 +9,9 @@ use crate::runtime::todo::{
     TodoItem, TodoItemDraft, TodoOwner, TodoStatus, TodoStore, TodoTimePrecision,
 };
 
-use super::{CompleteTodoTool, CreateTodoTool, DeleteTodoTool, EditTodoTool, ListTodoTool};
+use super::{
+    CancelTodoTool, CompleteTodoTool, CreateTodoTool, DeleteTodoTool, EditTodoTool, ListTodoTool,
+};
 use crate::storage::{APP_MIGRATIONS, database::SqliteDatabase};
 
 fn test_context() -> ToolContext {
@@ -617,6 +619,101 @@ async fn delete_tool_all_completed_zero_match_does_not_create_pending() {
         ))
         .unwrap();
     assert!(session.pending_operation.is_none());
+}
+
+#[tokio::test]
+async fn cancel_tool_selection_text_range_executes_batch_without_confirmation() {
+    let (todo_store, session_store, owner) = test_stores();
+    for title in ["第一条", "第二条", "第三条"] {
+        todo_store
+            .create(
+                &owner,
+                TodoItemDraft {
+                    title: title.to_owned(),
+                    detail: None,
+                    raw_text: None,
+                    due_date: None,
+                    due_at: None,
+                    time_precision: TodoTimePrecision::None,
+                },
+            )
+            .unwrap();
+    }
+    let list_tool = ListTodoTool::new(todo_store.clone(), session_store.clone());
+    let cancel_tool = CancelTodoTool::new(todo_store.clone(), session_store.clone());
+    let context = test_context();
+    list_tool
+        .execute(context.clone(), json!({"status":"pending"}))
+        .await
+        .unwrap();
+
+    let output = cancel_tool
+        .execute(
+            context,
+            json!({"numbers": null, "selection_text": "1-3", "reference": null}),
+        )
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(output["ok"], true);
+    assert_eq!(output["cancelled"].as_array().unwrap().len(), 3);
+    assert!(output.get("requires_confirmation").is_none());
+    assert!(output["missing_numbers"].as_array().unwrap().is_empty());
+    assert!(todo_store.list_pending(&owner).unwrap().is_empty());
+    assert_eq!(todo_store.list_cancelled(&owner).unwrap().len(), 3);
+    let session = session_store
+        .get_or_create_active(&SessionMeta::new(
+            "private:u1",
+            Some("u1".to_owned()),
+            None,
+            None,
+            None,
+            "qq_official",
+        ))
+        .unwrap();
+    assert!(session.pending_operation.is_none());
+}
+
+#[tokio::test]
+async fn complete_tool_selection_text_discrete_deduplicates_numbers() {
+    let (todo_store, session_store, owner) = test_stores();
+    for title in ["第一条", "第二条", "第三条"] {
+        todo_store
+            .create(
+                &owner,
+                TodoItemDraft {
+                    title: title.to_owned(),
+                    detail: None,
+                    raw_text: None,
+                    due_date: None,
+                    due_at: None,
+                    time_precision: TodoTimePrecision::None,
+                },
+            )
+            .unwrap();
+    }
+    let list_tool = ListTodoTool::new(todo_store.clone(), session_store.clone());
+    let complete_tool = CompleteTodoTool::new(todo_store.clone(), session_store.clone());
+    let context = test_context();
+    list_tool
+        .execute(context.clone(), json!({"status":"pending"}))
+        .await
+        .unwrap();
+
+    let output = complete_tool
+        .execute(
+            context,
+            json!({"numbers": null, "selection_text": "1,3,3", "reference": null}),
+        )
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(output["ok"], true);
+    assert_eq!(output["completed"].as_array().unwrap().len(), 2);
+    assert_eq!(todo_store.list_completed(&owner).unwrap().len(), 2);
+    assert_eq!(todo_store.list_pending(&owner).unwrap().len(), 1);
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/tools/todo/tests.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests.rs
@@ -1010,3 +1010,92 @@ async fn delete_numbers_prefer_current_task_query_over_stale_visible_snapshot() 
         other => panic!("expected single delete pending, got {other:?}"),
     }
 }
+
+#[tokio::test]
+async fn delete_tool_rejects_mixed_status_bulk_selection_without_pending() {
+    let (todo_store, session_store, owner) = test_stores();
+    let pending = todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "进行中目标".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    let completed = todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "已完成目标".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    todo_store.complete(&owner, &completed.id).unwrap();
+    let mut session = session_store
+        .get_or_create_active(&SessionMeta::new(
+            "private:u1",
+            Some("u1".to_owned()),
+            None,
+            None,
+            None,
+            "qq_official",
+        ))
+        .unwrap();
+    session.remember_last_todo_query(
+        &owner.key,
+        "all",
+        "全部待办",
+        vec![pending.id.clone(), completed.id.clone()],
+    );
+    session_store.save(&mut session).unwrap();
+    let delete_tool = DeleteTodoTool::new(todo_store.clone(), session_store.clone());
+
+    let output = delete_tool
+        .execute(
+            test_context(),
+            json!({"numbers": [1, 2], "reference": null, "query": null, "all_status": null}),
+        )
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(output["ok"], false);
+    assert_eq!(output["error_code"], "todo_delete_mixed_status");
+    let session = session_store
+        .get_or_create_active(&SessionMeta::new(
+            "private:u1",
+            Some("u1".to_owned()),
+            None,
+            None,
+            None,
+            "qq_official",
+        ))
+        .unwrap();
+    assert!(session.pending_operation.is_none());
+    assert_eq!(
+        todo_store
+            .get_by_id(&owner, &pending.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
+    assert_eq!(
+        todo_store
+            .get_by_id(&owner, &completed.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Completed
+    );
+}

--- a/qq-maid-core/src/runtime/tools/todo/tests.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests.rs
@@ -1,5 +1,5 @@
 // 拆分后这些不再随 `super::*` 自动进入命名空间，测试体里仍直接引用完整类型/宏。
-use serde_json::json;
+use serde_json::{Value, json};
 
 use qq_maid_llm::tool::{Tool, ToolContext};
 
@@ -13,6 +13,10 @@ use super::{
     CancelTodoTool, CompleteTodoTool, CreateTodoTool, DeleteTodoTool, EditTodoTool, ListTodoTool,
 };
 use crate::storage::{APP_MIGRATIONS, database::SqliteDatabase};
+
+use super::common::{
+    TODO_TOOL_MAX_BATCH_CREATE_ITEMS, TODO_TOOL_MAX_NUMBERS, TodoReference, TodoSelectionRequest,
+};
 
 fn test_context() -> ToolContext {
     ToolContext {
@@ -29,6 +33,37 @@ fn test_stores() -> (TodoStore, SessionStore, TodoOwner) {
     let session_store = SessionStore::new(database);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
     (todo_store, session_store, owner)
+}
+
+fn create_item_value(index: usize) -> Value {
+    json!({
+        "content": format!("批量事项 {index}"),
+        "title": null,
+        "detail": null,
+        "due_date": null,
+        "due_at": null,
+        "time_precision": null
+    })
+}
+
+fn batch_create_arguments(count: usize) -> Value {
+    json!({
+        "items": (1..=count).map(create_item_value).collect::<Vec<_>>(),
+        "content": null,
+        "title": null,
+        "detail": null,
+        "due_date": null,
+        "due_at": null,
+        "time_precision": null
+    })
+}
+
+fn json_type_contains(value: &Value, expected: &str) -> bool {
+    match value.get("type") {
+        Some(Value::String(actual)) => actual == expected,
+        Some(Value::Array(values)) => values.iter().any(|value| value.as_str() == Some(expected)),
+        _ => false,
+    }
 }
 
 fn tool_order_items() -> Vec<TodoItem> {
@@ -130,6 +165,153 @@ fn tool_order_items() -> Vec<TodoItem> {
             cancelled_at: Some("2026-07-01T13:10:00+08:00".to_owned()),
         },
     ]
+}
+
+#[test]
+fn todo_selector_schemas_allow_null_for_unused_strict_fields() {
+    let (todo_store, session_store, _) = test_stores();
+    let schemas = vec![
+        (
+            "complete_todos",
+            CompleteTodoTool::new(todo_store.clone(), session_store.clone())
+                .metadata()
+                .parameters,
+        ),
+        (
+            "cancel_todo",
+            CancelTodoTool::new(todo_store.clone(), session_store.clone())
+                .metadata()
+                .parameters,
+        ),
+        (
+            "restore_todos",
+            super::RestoreTodoTool::new(todo_store.clone(), session_store.clone())
+                .metadata()
+                .parameters,
+        ),
+        (
+            "delete_todos",
+            DeleteTodoTool::new(todo_store.clone(), session_store.clone())
+                .metadata()
+                .parameters,
+        ),
+    ];
+
+    for (tool_name, schema) in schemas {
+        let properties = schema["properties"].as_object().unwrap();
+        assert!(
+            json_type_contains(&properties["numbers"], "array")
+                && json_type_contains(&properties["numbers"], "null"),
+            "{tool_name} numbers must accept array|null"
+        );
+        assert_eq!(
+            properties["numbers"]["maxItems"],
+            json!(TODO_TOOL_MAX_NUMBERS),
+            "{tool_name} numbers maxItems must use the shared selector limit"
+        );
+        assert!(
+            json_type_contains(&properties["selection_text"], "string")
+                && json_type_contains(&properties["selection_text"], "null"),
+            "{tool_name} selection_text must accept string|null"
+        );
+        assert!(
+            json_type_contains(&properties["reference"], "string")
+                && json_type_contains(&properties["reference"], "null"),
+            "{tool_name} reference must accept string|null"
+        );
+    }
+
+    let edit_schema = EditTodoTool::new(todo_store, session_store)
+        .metadata()
+        .parameters;
+    assert!(json_type_contains(
+        &edit_schema["properties"]["number"],
+        "integer"
+    ));
+    assert!(json_type_contains(
+        &edit_schema["properties"]["number"],
+        "null"
+    ));
+    assert!(json_type_contains(
+        &edit_schema["properties"]["reference"],
+        "string"
+    ));
+    assert!(json_type_contains(
+        &edit_schema["properties"]["reference"],
+        "null"
+    ));
+}
+
+#[test]
+fn todo_selection_request_counts_only_effective_selectors() {
+    assert_eq!(
+        super::common::todo_selection_request(
+            &json!({"numbers": [1, 2, 3], "selection_text": null, "reference": null}),
+            true,
+        )
+        .unwrap(),
+        TodoSelectionRequest::Numbers(vec![1, 2, 3])
+    );
+    assert_eq!(
+        super::common::todo_selection_request(
+            &json!({"numbers": null, "selection_text": "1-3", "reference": null}),
+            true,
+        )
+        .unwrap(),
+        TodoSelectionRequest::Numbers(vec![1, 2, 3])
+    );
+    assert_eq!(
+        super::common::todo_selection_request(
+            &json!({"numbers": null, "selection_text": null, "reference": "last"}),
+            true,
+        )
+        .unwrap(),
+        TodoSelectionRequest::Reference(TodoReference::Last)
+    );
+    assert_eq!(
+        super::common::todo_selection_request(
+            &json!({"numbers": [], "selection_text": "1-2", "reference": null}),
+            true,
+        )
+        .unwrap(),
+        TodoSelectionRequest::Numbers(vec![1, 2])
+    );
+    assert_eq!(
+        super::common::todo_selection_request(
+            &json!({"numbers": [1], "selection_text": "   ", "reference": "   "}),
+            true,
+        )
+        .unwrap(),
+        TodoSelectionRequest::Numbers(vec![1])
+    );
+
+    let multiple = super::common::todo_selection_request(
+        &json!({"numbers": [1], "selection_text": "1-3", "reference": null}),
+        true,
+    )
+    .unwrap_err();
+    assert_eq!(multiple.code, "bad_tool_arguments");
+    assert!(multiple.message.contains("exactly one"));
+
+    let missing = super::common::todo_selection_request(
+        &json!({"numbers": null, "selection_text": "   ", "reference": null}),
+        true,
+    )
+    .unwrap_err();
+    assert_eq!(missing.code, "bad_tool_arguments");
+    assert!(missing.message.contains("exactly one"));
+}
+
+#[test]
+fn create_todo_schema_uses_shared_batch_limit() {
+    let (todo_store, session_store, _) = test_stores();
+    let schema = CreateTodoTool::new(todo_store, session_store)
+        .metadata()
+        .parameters;
+    assert_eq!(
+        schema["properties"]["items"]["maxItems"],
+        json!(TODO_TOOL_MAX_BATCH_CREATE_ITEMS)
+    );
 }
 
 #[tokio::test]
@@ -330,6 +512,103 @@ async fn create_tool_replay_with_same_call_id_does_not_duplicate_created_todo() 
 }
 
 #[tokio::test]
+async fn create_tool_accepts_batch_at_contract_limit() {
+    let (todo_store, session_store, owner) = test_stores();
+    let create_tool = CreateTodoTool::new(todo_store.clone(), session_store);
+
+    let output = create_tool
+        .execute(
+            test_context(),
+            batch_create_arguments(TODO_TOOL_MAX_BATCH_CREATE_ITEMS),
+        )
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(output["ok"], true);
+    assert_eq!(
+        output["created_items"].as_array().unwrap().len(),
+        TODO_TOOL_MAX_BATCH_CREATE_ITEMS
+    );
+    assert_eq!(
+        todo_store.list_pending(&owner).unwrap().len(),
+        TODO_TOOL_MAX_BATCH_CREATE_ITEMS
+    );
+}
+
+#[tokio::test]
+async fn create_tool_rejects_empty_batch_without_writes() {
+    let (todo_store, session_store, owner) = test_stores();
+    let create_tool = CreateTodoTool::new(todo_store.clone(), session_store);
+
+    let err = create_tool
+        .execute(test_context(), batch_create_arguments(0))
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code, "bad_tool_arguments");
+    assert!(err.message.contains("at least one"));
+    assert!(todo_store.list_pending(&owner).unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn create_tool_rejects_batch_over_contract_limit_without_partial_writes() {
+    let (todo_store, session_store, owner) = test_stores();
+    let create_tool = CreateTodoTool::new(todo_store.clone(), session_store);
+
+    let err = create_tool
+        .execute(
+            test_context(),
+            batch_create_arguments(TODO_TOOL_MAX_BATCH_CREATE_ITEMS + 1),
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code, "bad_tool_arguments");
+    assert!(err.message.contains("单次最多创建"));
+    assert!(
+        err.message
+            .contains(&TODO_TOOL_MAX_BATCH_CREATE_ITEMS.to_string())
+    );
+    assert!(todo_store.list_pending(&owner).unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn create_tool_batch_limit_does_not_cap_existing_todo_total() {
+    let (todo_store, session_store, owner) = test_stores();
+    for index in 0..(TODO_TOOL_MAX_BATCH_CREATE_ITEMS + 3) {
+        todo_store
+            .create(
+                &owner,
+                TodoItemDraft {
+                    title: format!("已有事项 {index}"),
+                    detail: None,
+                    raw_text: None,
+                    due_date: None,
+                    due_at: None,
+                    time_precision: TodoTimePrecision::None,
+                },
+            )
+            .unwrap();
+    }
+    assert!(todo_store.list_pending(&owner).unwrap().len() > TODO_TOOL_MAX_BATCH_CREATE_ITEMS);
+
+    let create_tool = CreateTodoTool::new(todo_store.clone(), session_store);
+    let output = create_tool
+        .execute(test_context(), batch_create_arguments(2))
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(output["ok"], true);
+    assert_eq!(output["created_items"].as_array().unwrap().len(), 2);
+    assert_eq!(
+        todo_store.list_pending(&owner).unwrap().len(),
+        TODO_TOOL_MAX_BATCH_CREATE_ITEMS + 5
+    );
+}
+
+#[tokio::test]
 async fn same_task_query_numbers_prefer_current_list_over_stale_visible_snapshot() {
     let (todo_store, session_store, owner) = test_stores();
     let stale_visible = todo_store
@@ -517,6 +796,56 @@ async fn unresolved_last_reference_creates_todo_clarification_pending() {
 }
 
 #[tokio::test]
+async fn delete_tool_number_clarification_includes_pending_candidates_without_visible_snapshot() {
+    let (todo_store, session_store, owner) = test_stores();
+    let item = todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "进行中也能永久删除".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    let delete_tool = DeleteTodoTool::new(todo_store, session_store.clone());
+
+    let output = delete_tool
+        .execute(
+            test_context(),
+            json!({"numbers": [1], "reference": null, "query": null, "all_status": null}),
+        )
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(output["ok"], false);
+    assert_eq!(output["requires_clarification"], true);
+    let session = session_store
+        .get_or_create_active(&SessionMeta::new(
+            "private:u1",
+            Some("u1".to_owned()),
+            None,
+            None,
+            None,
+            "qq_official",
+        ))
+        .unwrap();
+    match session.pending_operation {
+        Some(PendingOperation::TodoClarify { request, .. }) => {
+            assert_eq!(request.tool_name, "delete_todos");
+            assert_eq!(request.candidates.len(), 1);
+            assert_eq!(request.candidates[0].id, item.id);
+            assert_eq!(request.candidates[0].status, TodoStatus::Pending);
+        }
+        other => panic!("expected delete clarification pending, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn delete_tool_all_cancelled_creates_bulk_pending_without_deleting() {
     let (todo_store, session_store, owner) = test_stores();
     let first = todo_store
@@ -673,6 +1002,52 @@ async fn cancel_tool_selection_text_range_executes_batch_without_confirmation() 
         ))
         .unwrap();
     assert!(session.pending_operation.is_none());
+}
+
+#[tokio::test]
+async fn cancel_tool_returns_failure_when_prepared_selection_no_longer_writes() {
+    let (todo_store, session_store, owner) = test_stores();
+    let item = todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "会被并发删除的待办".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                time_precision: TodoTimePrecision::None,
+            },
+        )
+        .unwrap();
+    let list_tool = ListTodoTool::new(todo_store.clone(), session_store.clone());
+    let cancel_tool = CancelTodoTool::new(todo_store.clone(), session_store.clone());
+    let context = test_context();
+    list_tool
+        .execute(context.clone(), json!({"status":"pending"}))
+        .await
+        .unwrap();
+    let prepared = cancel_tool
+        .prepare(
+            &context,
+            json!({"numbers": [1], "selection_text": null, "reference": null}),
+        )
+        .unwrap();
+    todo_store
+        .delete_pending_by_ids(&owner, std::slice::from_ref(&item.id))
+        .unwrap();
+
+    let output = cancel_tool
+        .execute(context, prepared.arguments)
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(output["ok"], false);
+    assert_eq!(output["error_code"], "todo_selection_not_found");
+    assert!(output["cancelled"].as_array().unwrap().is_empty());
+    assert_eq!(output["missing_numbers"], json!([1]));
+    assert!(todo_store.list_cancelled(&owner).unwrap().is_empty());
 }
 
 #[tokio::test]
@@ -903,11 +1278,13 @@ async fn delete_tool_query_pending_match_creates_confirmation() {
         ))
         .unwrap();
     match session.pending_operation {
-        Some(PendingOperation::TodoDelete { item, .. }) => {
-            assert_eq!(item.title, "还没做不能永久删");
-            assert_eq!(item.status, TodoStatus::Pending);
+        Some(PendingOperation::TodoBulkDelete {
+            item_ids, status, ..
+        }) => {
+            assert_eq!(item_ids.len(), 1);
+            assert_eq!(status, TodoStatus::Pending);
         }
-        other => panic!("expected delete pending, got {other:?}"),
+        other => panic!("expected pending bulk delete operation, got {other:?}"),
     }
 }
 

--- a/qq-maid-core/src/runtime/tools/todo/tests.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests.rs
@@ -863,7 +863,7 @@ async fn delete_tool_query_multiple_creates_clarification_without_snapshot_pollu
 }
 
 #[tokio::test]
-async fn delete_tool_query_pending_match_rejects_permanent_delete() {
+async fn delete_tool_query_pending_match_creates_confirmation() {
     let (todo_store, session_store, owner) = test_stores();
     todo_store
         .create(
@@ -889,8 +889,9 @@ async fn delete_tool_query_pending_match_rejects_permanent_delete() {
         .unwrap()
         .value;
 
-    assert_eq!(output["ok"], false);
-    assert_eq!(output["error_code"], "todo_delete_invalid_state");
+    assert_eq!(output["ok"], true);
+    assert_eq!(output["requires_confirmation"], true);
+    assert_eq!(output["pending_action"], "delete");
     let session = session_store
         .get_or_create_active(&SessionMeta::new(
             "private:u1",
@@ -901,7 +902,13 @@ async fn delete_tool_query_pending_match_rejects_permanent_delete() {
             "qq_official",
         ))
         .unwrap();
-    assert!(session.pending_operation.is_none());
+    match session.pending_operation {
+        Some(PendingOperation::TodoDelete { item, .. }) => {
+            assert_eq!(item.title, "还没做不能永久删");
+            assert_eq!(item.status, TodoStatus::Pending);
+        }
+        other => panic!("expected delete pending, got {other:?}"),
+    }
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/storage/todo/mod.rs
+++ b/qq-maid-core/src/storage/todo/mod.rs
@@ -263,31 +263,30 @@ impl TodoStore {
         let draft = normalize_draft(draft)?;
         let now = now_iso_cn();
         let conn = self.connection()?;
-        conn.execute(
-            "INSERT INTO todos (
-                owner_key, user_id, scope_key, title, detail, raw_text,
-                due_date, due_at, time_precision, status, completed,
-                created_at, updated_at, completed_at, cancelled_at
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 0, ?11, ?12, NULL, NULL)",
-            params![
-                owner.key.as_str(),
-                owner.user_id.as_deref(),
-                owner.scope_key.as_str(),
-                draft.title,
-                draft.detail,
-                draft.raw_text,
-                draft.due_date,
-                draft.due_at,
-                draft.time_precision.as_str(),
-                TodoStatus::Pending.as_str(),
-                now,
-                now,
-            ],
-        )
-        .map_err(TodoError::from_sql)?;
-        let id = conn.last_insert_rowid();
-        get_by_id_unlocked(&conn, owner, id)?
-            .ok_or_else(|| TodoError::io("todo disappeared after insert"))
+        insert_todo_unlocked(&conn, owner, draft, &now)
+    }
+
+    /// 批量创建待办事项，整批在同一事务中提交。
+    ///
+    /// Tool Loop 可一次提交多条创建意图；任一条规范化或 SQLite 写入失败时，
+    /// 已经插入的同批记录必须随事务回滚，避免用户看到失败但数据库留下半批结果。
+    pub fn create_many(
+        &self,
+        owner: &TodoOwner,
+        drafts: Vec<TodoItemDraft>,
+    ) -> Result<Vec<TodoItem>, TodoError> {
+        let mut conn = self.connection()?;
+        let now = now_iso_cn();
+        let tx = conn.transaction().map_err(TodoError::from_sql)?;
+        let mut created = Vec::with_capacity(drafts.len());
+
+        for draft in drafts {
+            let draft = normalize_draft(draft)?;
+            created.push(insert_todo_unlocked(&tx, owner, draft, &now)?);
+        }
+
+        tx.commit().map_err(TodoError::from_sql)?;
+        Ok(created)
     }
 
     /// 列出所有待处理（Pending）的待办事项，按截止时间排序。
@@ -798,10 +797,22 @@ impl TodoStore {
         self.delete_by_ids_with_status(owner, ids, TodoStatus::Cancelled)
     }
 
+    /// 物理删除进行中的待办事项（按 ID 列表匹配）。
+    ///
+    /// 删除确认只能删除发起确认时仍处于 Pending 的记录；如果确认期间记录状态变化，
+    /// 这里会按 skipped 处理，避免过期确认越过用户当前状态授权。
+    pub fn delete_pending_by_ids(
+        &self,
+        owner: &TodoOwner,
+        ids: &[String],
+    ) -> Result<TodoBulkDeleteOutcome, TodoError> {
+        self.delete_by_ids_with_status(owner, ids, TodoStatus::Pending)
+    }
+
     /// 按 ID 物理删除任意状态的待办事项。
     ///
-    /// 业务层已经把 `delete` 明确为永久删除，并在进入这里前完成用户确认；存储层只
-    /// 继续校验 owner 与 scope，避免状态变化期间误删其他会话或其他用户的记录。
+    /// 仅用于调用方明确授权删除任意当前状态的场景；确认链路应使用带状态条件的
+    /// `delete_*_by_ids`，避免过期确认越过发起确认时的状态边界。
     pub fn delete_by_ids(
         &self,
         owner: &TodoOwner,
@@ -1017,6 +1028,39 @@ impl TodoStore {
         }
         tx.commit().map_err(TodoError::from_sql)
     }
+}
+
+fn insert_todo_unlocked(
+    conn: &Connection,
+    owner: &TodoOwner,
+    draft: TodoItemDraft,
+    now: &str,
+) -> Result<TodoItem, TodoError> {
+    conn.execute(
+        "INSERT INTO todos (
+            owner_key, user_id, scope_key, title, detail, raw_text,
+            due_date, due_at, time_precision, status, completed,
+            created_at, updated_at, completed_at, cancelled_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 0, ?11, ?12, NULL, NULL)",
+        params![
+            owner.key.as_str(),
+            owner.user_id.as_deref(),
+            owner.scope_key.as_str(),
+            draft.title,
+            draft.detail,
+            draft.raw_text,
+            draft.due_date,
+            draft.due_at,
+            draft.time_precision.as_str(),
+            TodoStatus::Pending.as_str(),
+            now,
+            now,
+        ],
+    )
+    .map_err(TodoError::from_sql)?;
+    let id = conn.last_insert_rowid();
+    get_by_id_unlocked(conn, owner, id)?
+        .ok_or_else(|| TodoError::io("todo disappeared after insert"))
 }
 
 impl TodoError {

--- a/qq-maid-core/src/storage/todo/mod.rs
+++ b/qq-maid-core/src/storage/todo/mod.rs
@@ -172,7 +172,7 @@ pub struct TodoStore {
     database: SqliteDatabase,
 }
 
-/// 批量取消已完成的待办事项的结果。
+/// 批量取消待办事项的结果。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TodoBulkCancelOutcome {
     pub cancelled: Vec<TodoItem>,
@@ -710,6 +710,24 @@ impl TodoStore {
         owner: &TodoOwner,
         ids: &[String],
     ) -> Result<TodoBulkCancelOutcome, TodoError> {
+        self.cancel_by_ids_with_status(owner, ids, TodoStatus::Completed)
+    }
+
+    /// 批量取消未完成待办事项（按 ID 列表匹配 Pending 项）。
+    pub fn cancel_by_ids(
+        &self,
+        owner: &TodoOwner,
+        ids: &[String],
+    ) -> Result<TodoBulkCancelOutcome, TodoError> {
+        self.cancel_by_ids_with_status(owner, ids, TodoStatus::Pending)
+    }
+
+    fn cancel_by_ids_with_status(
+        &self,
+        owner: &TodoOwner,
+        ids: &[String],
+        expected_status: TodoStatus,
+    ) -> Result<TodoBulkCancelOutcome, TodoError> {
         let mut conn = self.connection()?;
         let now = now_iso_cn();
         let tx = conn.transaction().map_err(TodoError::from_sql)?;
@@ -740,7 +758,7 @@ impl TodoStore {
                         owner.scope_key.as_str(),
                         TodoStatus::Cancelled.as_str(),
                         now,
-                        TodoStatus::Completed.as_str(),
+                        expected_status.as_str(),
                     ],
                 )
                 .map_err(TodoError::from_sql)?;

--- a/qq-maid-core/src/storage/todo/mod.rs
+++ b/qq-maid-core/src/storage/todo/mod.rs
@@ -193,7 +193,7 @@ pub struct TodoBulkRestoreOutcome {
     pub skipped_ids: Vec<String>,
 }
 
-/// 批量物理删除已取消待办事项的结果。
+/// 批量物理删除待办事项的结果。
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TodoBulkDeleteOutcome {
     pub deleted_count: usize,
@@ -796,6 +796,49 @@ impl TodoStore {
         ids: &[String],
     ) -> Result<TodoBulkDeleteOutcome, TodoError> {
         self.delete_by_ids_with_status(owner, ids, TodoStatus::Cancelled)
+    }
+
+    /// 按 ID 物理删除任意状态的待办事项。
+    ///
+    /// 业务层已经把 `delete` 明确为永久删除，并在进入这里前完成用户确认；存储层只
+    /// 继续校验 owner 与 scope，避免状态变化期间误删其他会话或其他用户的记录。
+    pub fn delete_by_ids(
+        &self,
+        owner: &TodoOwner,
+        ids: &[String],
+    ) -> Result<TodoBulkDeleteOutcome, TodoError> {
+        let mut conn = self.connection()?;
+        let tx = conn.transaction().map_err(TodoError::from_sql)?;
+        let mut deleted_count = 0usize;
+        let mut skipped_ids = Vec::new();
+
+        for id_text in ids.iter().map(|id| clean_todo_id(id)) {
+            let Some(id) = parse_todo_db_id(&id_text) else {
+                if !id_text.is_empty() {
+                    skipped_ids.push(id_text);
+                }
+                continue;
+            };
+            let affected = tx
+                .execute(
+                    "DELETE FROM todos
+                     WHERE id = ?1
+                       AND owner_key = ?2
+                       AND scope_key = ?3",
+                    params![id, owner.key.as_str(), owner.scope_key.as_str()],
+                )
+                .map_err(TodoError::from_sql)?;
+            if affected == 0 {
+                skipped_ids.push(id_text);
+            } else {
+                deleted_count += affected;
+            }
+        }
+        tx.commit().map_err(TodoError::from_sql)?;
+        Ok(TodoBulkDeleteOutcome {
+            deleted_count,
+            skipped_ids,
+        })
     }
 
     /// 按指定终态物理删除记录，并在事务内校验 owner、scope 和 status。

--- a/qq-maid-core/src/storage/todo/tests.rs
+++ b/qq-maid-core/src/storage/todo/tests.rs
@@ -111,6 +111,39 @@ fn sqlite_ids_are_stable_and_not_reused_after_soft_delete() {
 }
 
 #[test]
+fn create_many_rolls_back_when_later_draft_is_invalid() {
+    let store = test_store();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+
+    let err = store
+        .create_many(
+            &owner,
+            vec![
+                TodoItemDraft {
+                    title: "第一条有效待办".to_owned(),
+                    detail: None,
+                    raw_text: None,
+                    due_date: None,
+                    due_at: None,
+                    time_precision: TodoTimePrecision::None,
+                },
+                TodoItemDraft {
+                    title: "   ".to_owned(),
+                    detail: None,
+                    raw_text: None,
+                    due_date: None,
+                    due_at: None,
+                    time_precision: TodoTimePrecision::None,
+                },
+            ],
+        )
+        .unwrap_err();
+
+    assert_eq!(err.code(), "bad_request");
+    assert!(store.list_pending(&owner).unwrap().is_empty());
+}
+
+#[test]
 fn sqlite_store_persists_after_reopen_without_json_todo_dir() {
     let base = std::env::temp_dir().join(format!("qq-maid-todo-reopen-{}", uuid::Uuid::new_v4()));
     let path = base.join("app.db");


### PR DESCRIPTION
Closes #178, closes #179。关联 #139。关联 #182。

## 根因

- 批量创建会变成多个单项调用：原 create_todo Tool Schema 只能表达单项，LLM 只能拆成多次 create_todo。
- 每个调用都会附加完整列表：原回执层按单个 ToolExecutionOutcome 生成“已新增/已取消 + 当前进行中列表”，AgentTurnOutcome 再直接拼接多个结果。
- 1-5 只剩第一项：原 schema 只有 `numbers: [usize]`，没有保留 `selection_text`，如果模型把范围降成 `[1]`，服务端没有确定性范围解析补救。
- delete 变 cancel：旧 TodoDelete Pending 同时承载“永久删除”和“取消进行中待办”，确认恢复时看到 Pending 状态会调用 `cancel_one`。
- Pending 缺口：澄清 Pending 已保存原工具名、参数和候选边界；确认 Pending 旧路径仍复制业务逻辑，且未保证原始 action 不变。
- #139 属于部分落地后残留旧路径造成的回归/遗漏叠加；#178、#179 是同一链路上尚未收敛的问题。

## 最终架构

- Todo 写操作统一走 Tool 层和 `runtime/todo/ops.rs` 的业务执行入口；单项是批量的一个元素。
- `create_todo` 支持原生 `items` 批量输入，同时保留旧单项字段兼容现有模型调用。
- 选择解析归 `runtime/tools/todo/common.rs`：支持 1-5、1～5、1 到 5、1,3,5、中文逗号/顿号、去重和越界校验；解析失败不会默认第一项。
- 确认策略收敛：只有永久 delete 需要二次确认；create/edit/complete/cancel/restore 都不确认。
- 删除确认 Pending 只保存并恢复 delete 计划；确认后不重新解析编号、不重新让模型猜动作，也不会把 delete 降级成 cancel。
- 结果输出从“每个底层工具调用一份列表”改为“一轮用户意图最多追加一份相关列表”；`last_todo_query` 只在最终真正展示列表时保存。

## 验证

- `cargo check -p qq-maid-core` ✅
- `cargo test -p qq-maid-core -- --test-threads=1` ✅
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo test --workspace --all-features` ✅
- `cargo build --workspace --release --all-features` ✅
- `git diff --check` ✅

手工/测试复现：批量创建只附加一次列表；`删除1-5` 保持 delete 并整体确认；确认后删除保存的目标集合；`取消1-5` 直接批量取消，无二次确认。