### PR TITLE
[codex] 修复非流式回复发送链路

### DIFF
--- a/qq-maid-core/src/service/mod.rs
+++ b/qq-maid-core/src/service/mod.rs
@@ -15,7 +15,7 @@ use std::{
 
 use async_trait::async_trait;
 use tokio::{sync::mpsc, time::timeout};
-use tracing::{error, warn};
+use tracing::{debug, error, warn};
 
 use crate::{
     config::AppConfig,
@@ -425,7 +425,16 @@ async fn run_streaming_respond(
 ) -> Result<RespondResponse, LlmError> {
     if matches!(plan, RespondPlan::CompleteToolLoop) || !provider_stream_enabled {
         let response = service.respond_with_plan(req, plan).await?;
-        send_final_response_delta(&tx, &cancelled, &response).await?;
+        debug!(
+            respond_plan = respond_plan_name(plan),
+            provider_stream_enabled,
+            synthetic_final_delta = false,
+            response_delivery_mode = "ordinary_complete",
+            final_chars = response_visible_content(&response)
+                .map(|content| content.chars().count())
+                .unwrap_or_default(),
+            "core stream completed without synthetic final delta"
+        );
         return Ok(response);
     }
     service
@@ -435,27 +444,6 @@ async fn run_streaming_respond(
             Box::pin(async move { send_core_delta(&tx, &cancelled, delta).await })
         })
         .await
-}
-
-async fn send_final_response_delta(
-    tx: &mpsc::Sender<CoreResponseEvent>,
-    cancelled: &Arc<AtomicBool>,
-    response: &RespondResponse,
-) -> Result<(), LlmError> {
-    // 非 SSE 或 Tool Loop 路径只在完整响应完成后合成用户可见增量。
-    // 对 Tool Loop 来说，这也是最终可信回复的边界：此时工具副作用、Todo 成功校验、
-    // session/history 和 diagnostics 均已由 RespondService 完成提交。
-    if response.ok
-        && let Some(delta) = response
-            .markdown
-            .as_deref()
-            .or(response.text.as_deref())
-            .map(str::to_owned)
-            .filter(|value| !value.trim().is_empty())
-    {
-        send_core_delta(tx, cancelled, delta).await?;
-    }
-    Ok(())
 }
 
 async fn send_core_delta(
@@ -469,6 +457,18 @@ async fn send_core_delta(
     tx.send(CoreResponseEvent::TextDelta(delta))
         .await
         .map_err(|_| LlmError::new("cancelled", "stream receiver dropped", "stream"))
+}
+
+fn response_visible_content(response: &RespondResponse) -> Option<&str> {
+    response.markdown.as_deref().or(response.text.as_deref())
+}
+
+fn respond_plan_name(plan: RespondPlan) -> &'static str {
+    match plan {
+        RespondPlan::Immediate => "immediate",
+        RespondPlan::StreamingChat => "streaming_chat",
+        RespondPlan::CompleteToolLoop => "complete_tool_loop",
+    }
 }
 
 impl CoreRequest {

--- a/qq-maid-core/src/service/tests.rs
+++ b/qq-maid-core/src/service/tests.rs
@@ -322,7 +322,7 @@ async fn chat_stream_forwards_text_delta_and_completed_from_same_stream() {
 }
 
 #[tokio::test]
-async fn stream_disabled_chat_is_wrapped_as_process_stream() {
+async fn stream_disabled_chat_completes_without_synthetic_delta() {
     let provider = TestProvider::replying("非流完整回复");
     let state = test_state(provider.clone(), 5);
     let service = CoreHandle::new(state);
@@ -332,10 +332,6 @@ async fn stream_disabled_chat_is_wrapped_as_process_stream() {
         panic!("expected stream output");
     };
 
-    assert_eq!(
-        stream.recv().await,
-        Some(CoreResponseEvent::TextDelta("非流完整回复".to_owned()))
-    );
     let Some(CoreResponseEvent::Completed(response)) = stream.recv().await else {
         panic!("expected completed response");
     };
@@ -349,7 +345,7 @@ async fn stream_disabled_chat_is_wrapped_as_process_stream() {
 }
 
 #[tokio::test]
-async fn core_private_weather_chat_with_tool_capability_streams_final_tool_loop_reply() {
+async fn core_private_weather_chat_with_tool_capability_completes_without_synthetic_delta() {
     let provider = TestProvider::replying("工具完整回复")
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_tool_calling(provider.clone(), 5, true);
@@ -362,10 +358,6 @@ async fn core_private_weather_chat_with_tool_capability_streams_final_tool_loop_
             .unwrap(),
     );
 
-    assert_eq!(
-        stream.recv().await,
-        Some(CoreResponseEvent::TextDelta("工具完整回复".to_owned()))
-    );
     let Some(CoreResponseEvent::Completed(response)) = stream.recv().await else {
         panic!("expected completed response");
     };
@@ -376,7 +368,7 @@ async fn core_private_weather_chat_with_tool_capability_streams_final_tool_loop_
 }
 
 #[tokio::test]
-async fn core_tool_loop_stream_buffers_until_final_answer_is_trusted() {
+async fn core_tool_loop_completes_only_after_final_answer_is_trusted() {
     let provider = TestProvider::streaming(vec![
         Ok(LlmStreamEvent::TextDelta("候选草稿".to_owned())),
         Ok(LlmStreamEvent::Completed {
@@ -396,10 +388,6 @@ async fn core_tool_loop_stream_buffers_until_final_answer_is_trusted() {
             .unwrap(),
     );
 
-    assert_eq!(
-        stream.recv().await,
-        Some(CoreResponseEvent::TextDelta("候选草稿".to_owned()))
-    );
     let Some(CoreResponseEvent::Completed(response)) = stream.recv().await else {
         panic!("expected completed response");
     };

--- a/qq-maid-gateway-rs/src/api/mod.rs
+++ b/qq-maid-gateway-rs/src/api/mod.rs
@@ -11,7 +11,7 @@ use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
-use tracing::{info, warn};
+use tracing::{info, trace, warn};
 
 use crate::{
     auth::{AccessTokenManager, AuthError},
@@ -477,7 +477,7 @@ impl QqApiClient {
         let (qq_code, qq_message) = qq_api_error_fields(&body);
         let success_fields =
             stream_request_log_fields(stream_state_value, stream_state, msg_seq_attempt, true);
-        info!(
+        trace!(
             user = %masked_user,
             source_message_id = %masked_message_id,
             phase = %stream_log_phase(stream_state_value, stream_state.index),

--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -353,12 +353,39 @@ where
     E: RespondEventStream,
     S: OutboundSender + ?Sized,
 {
+    let mut text_delta_count = 0_usize;
     while let Some(event) = stream.recv_event().await {
         match event {
-            RespondEvent::TextDelta(_) => {}
+            RespondEvent::TextDelta(delta) => {
+                if !delta.is_empty() {
+                    text_delta_count += 1;
+                }
+            }
             RespondEvent::Completed(response) => {
                 stop_typing(typing, TypingStopReason::FinalReply);
-                send_c2c_respond_response_with_sender(sender, message, &response, config).await?;
+                send_c2c_respond_response_with_sender(sender, message, &response, config)
+                    .await
+                    .inspect(|_| {
+                        debug!(
+                            message_id = %message.message_id,
+                            user = %mask_openid(&message.user_openid),
+                            response_delivery_mode = "ordinary_complete",
+                            final_send_exit = "ordinary_reply",
+                            text_delta_count,
+                            "C2C stream disabled; ordinary final reply sent"
+                        );
+                    })
+                    .inspect_err(|send_err| {
+                        warn!(
+                            message_id = %message.message_id,
+                            user = %mask_openid(&message.user_openid),
+                            response_delivery_mode = "ordinary_complete",
+                            final_send_exit = "ordinary_reply",
+                            text_delta_count,
+                            error = %send_err,
+                            "C2C stream disabled; ordinary final reply failed"
+                        );
+                    })?;
                 return Ok(DisabledStreamOutcome::Completed);
             }
             RespondEvent::Failed(failure) => {
@@ -368,6 +395,7 @@ where
                     user = %mask_openid(&message.user_openid),
                     kind = ?failure.kind,
                     retryable = failure.retryable,
+                    text_delta_count,
                     "core respond stream failed while C2C stream was disabled"
                 );
                 send_local_c2c_failure_text(sender, message, &failure.message).await?;

--- a/qq-maid-gateway-rs/src/gateway/stream/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/mod.rs
@@ -9,7 +9,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use tracing::{debug, warn};
+use tracing::{info, trace, warn};
 
 use super::{
     c2c::send_c2c_respond_response_with_sender,
@@ -171,6 +171,7 @@ where
     let masked_user = mask_openid(user_openid);
     let reply_msg_id = &message.message_id;
     let masked_reply_msg_id = mask_identifier(reply_msg_id);
+    let started_at = Instant::now();
     let mut phase = C2cStreamingPhase::Pending(C2cStreamState::new());
     let mut accumulated = String::new();
     // QQ stream 的 reset=false 是“续接本次 Markdown content”，因此内容分片不能反复提交全文。
@@ -178,6 +179,7 @@ where
     let mut pending_delta = String::new();
     let mut last_send_at = Instant::now();
     let mut stream_first_attempted = false;
+    let mut text_delta_count = 0_usize;
 
     while let Some(event) = stream.recv_event().await {
         match event {
@@ -185,6 +187,7 @@ where
                 if delta.is_empty() {
                     continue;
                 }
+                text_delta_count += 1;
                 accumulated.push_str(&delta);
                 pending_delta.push_str(&delta);
 
@@ -215,16 +218,19 @@ where
                                 let content_chars = pending_delta.chars().count();
                                 pending_delta.clear();
                                 last_send_at = Instant::now();
-                                debug!(
+                                trace!(
                                     user = %masked_user,
                                     reply_msg_id = %masked_reply_msg_id,
                                     phase = "first_chunk",
+                                    response_delivery_mode = "live_stream",
                                     stream_state = "active",
                                     stream_state_value = 1_u8,
                                     reset = false,
                                     index,
                                     has_stream_id_before_send = had_stream_id,
                                     has_stream_id_after_send = stream_state.stream_id.is_some(),
+                                    text_delta_count,
+                                    stream_entered_active = true,
                                     content_chars,
                                     accumulated_chars = accumulated.chars().count(),
                                     "QQ stream first send succeeded"
@@ -236,12 +242,15 @@ where
                                     user = %masked_user,
                                     reply_msg_id = %masked_reply_msg_id,
                                     phase = "first_chunk",
+                                    response_delivery_mode = "stream_fallback",
                                     stream_state = "pending",
                                     stream_state_value = 1_u8,
                                     reset = false,
                                     index,
                                     has_stream_id_before_send = had_stream_id,
                                     has_stream_id_after_send = false,
+                                    text_delta_count,
+                                    stream_entered_active = false,
                                     content_chars = pending_delta.chars().count(),
                                     accumulated_chars = accumulated.chars().count(),
                                     "QQ stream first send returned no stream id; ordinary reply remains allowed on Completed"
@@ -253,11 +262,14 @@ where
                                     user = %masked_user,
                                     reply_msg_id = %masked_reply_msg_id,
                                     phase = "first_chunk",
+                                    response_delivery_mode = "stream_fallback",
                                     stream_state = "pending",
                                     stream_state_value = 1_u8,
                                     reset = false,
                                     index,
                                     has_stream_id_before_send = had_stream_id,
+                                    text_delta_count,
+                                    stream_entered_active = false,
                                     content_chars = pending_delta.chars().count(),
                                     error = %err.log_summary(),
                                     accumulated_chars = accumulated.chars().count(),
@@ -289,16 +301,19 @@ where
                                 Ok(_) => {
                                     pending_delta.clear();
                                     last_send_at = Instant::now();
-                                    debug!(
+                                    trace!(
                                         user = %masked_user,
                                         reply_msg_id = %masked_reply_msg_id,
                                         phase = "middle_chunk",
+                                        response_delivery_mode = "live_stream",
                                         stream_state = "active",
                                         stream_state_value = 1_u8,
                                         reset = false,
                                         index,
                                         has_stream_id_before_send = had_stream_id,
                                         has_stream_id_after_send = stream_state.stream_id.is_some(),
+                                        text_delta_count,
+                                        stream_entered_active = true,
                                         sent_len = accumulated.len(),
                                         chunk_chars = chunk.chars().count(),
                                         "QQ stream middle send succeeded"
@@ -310,11 +325,14 @@ where
                                         user = %masked_user,
                                         reply_msg_id = %masked_reply_msg_id,
                                         phase = "middle_chunk",
+                                        response_delivery_mode = "live_stream",
                                         stream_state = "broken_active",
                                         stream_state_value = 1_u8,
                                         reset = false,
                                         index,
                                         has_stream_id_before_send = had_stream_id,
+                                        text_delta_count,
+                                        stream_entered_active = true,
                                         content_chars = chunk.chars().count(),
                                         error = %err.log_summary(),
                                         accumulated_chars = accumulated.chars().count(),
@@ -359,7 +377,7 @@ where
                             {
                                 Ok(_) => {
                                     pending_delta.clear();
-                                    debug!(
+                                    trace!(
                                         user = %masked_user,
                                         reply_msg_id = %masked_reply_msg_id,
                                         phase = "completed_flush",
@@ -369,6 +387,8 @@ where
                                         index,
                                         has_stream_id_before_send = had_stream_id,
                                         has_stream_id_after_send = stream_state.stream_id.is_some(),
+                                        text_delta_count,
+                                        qq_stream_send_count = stream_state.index,
                                         content_chars = chunk.chars().count(),
                                         final_chars,
                                         "QQ stream pending delta flushed before final"
@@ -384,6 +404,10 @@ where
                                         reset = false,
                                         index,
                                         has_stream_id_before_send = had_stream_id,
+                                        text_delta_count,
+                                        qq_stream_send_count = stream_state.index,
+                                        accumulated_chars = accumulated.chars().count(),
+                                        elapsed_ms = started_at.elapsed().as_millis(),
                                         content_chars = chunk.chars().count(),
                                         error = %err.log_summary(),
                                         final_chars,
@@ -399,19 +423,41 @@ where
                                     .await
                                     {
                                         Ok(()) => {
-                                            debug!(
+                                            trace!(
                                                 user = %masked_user,
                                                 reply_msg_id = %masked_reply_msg_id,
                                                 phase = "completed_flush_final_chunk",
+                                                response_delivery_mode = "live_stream",
                                                 stream_state = C2cStreamingPhase::Completed.name(),
                                                 stream_state_value = 10_u8,
                                                 reset = false,
                                                 index = stream_state.index,
                                                 has_stream_id_before_send = stream_state.stream_id.is_some(),
                                                 has_stream_id_after_send = stream_state.stream_id.is_some(),
+                                                text_delta_count,
+                                                stream_entered_active = true,
+                                                final_send_exit = "qq_stream_final",
+                                                qq_stream_send_count = stream_state.index,
+                                                accumulated_chars = accumulated.chars().count(),
+                                                elapsed_ms = started_at.elapsed().as_millis(),
                                                 content_chars = final_chars,
                                                 final_chars,
                                                 "QQ stream end after pending delta flush failure succeeded"
+                                            );
+                                            info!(
+                                                user = %masked_user,
+                                                reply_msg_id = %masked_reply_msg_id,
+                                                response_delivery_mode = "live_stream",
+                                                final_send_exit = "qq_stream_final",
+                                                stream_state = C2cStreamingPhase::Completed.name(),
+                                                text_delta_count,
+                                                accumulated_chars = accumulated.chars().count(),
+                                                final_chars,
+                                                qq_stream_send_count = stream_state.index,
+                                                elapsed_ms = started_at.elapsed().as_millis(),
+                                                stream_entered_active = true,
+                                                fallback_used = false,
+                                                "QQ C2C stream response completed"
                                             );
                                             return Ok(C2cStreamingPhase::Completed);
                                         }
@@ -420,11 +466,18 @@ where
                                                 user = %masked_user,
                                                 reply_msg_id = %masked_reply_msg_id,
                                                 phase = "completed_flush_final_chunk",
+                                                response_delivery_mode = "live_stream",
                                                 stream_state = "broken_active",
                                                 stream_state_value = 10_u8,
                                                 reset = false,
                                                 index = stream_state.index,
                                                 has_stream_id_before_send = stream_state.stream_id.is_some(),
+                                                text_delta_count,
+                                                stream_entered_active = true,
+                                                final_send_exit = "qq_stream_final",
+                                                qq_stream_send_count = stream_state.index,
+                                                accumulated_chars = accumulated.chars().count(),
+                                                elapsed_ms = started_at.elapsed().as_millis(),
                                                 content_chars = final_chars,
                                                 error = %end_err.log_summary(),
                                                 final_chars,
@@ -449,9 +502,10 @@ where
                         .await
                         {
                             Ok(()) => {
-                                debug!(
+                                info!(
                                     user = %masked_user,
                                     reply_msg_id = %masked_reply_msg_id,
+                                    response_delivery_mode = "live_stream",
                                     phase = "final_chunk",
                                     stream_state = C2cStreamingPhase::Completed.name(),
                                     stream_state_value = 10_u8,
@@ -459,9 +513,16 @@ where
                                     index = stream_state.index,
                                     has_stream_id_before_send = had_stream_id,
                                     has_stream_id_after_send = stream_state.stream_id.is_some(),
+                                    text_delta_count,
+                                    stream_entered_active = true,
+                                    final_send_exit = "qq_stream_final",
+                                    qq_stream_send_count = stream_state.index,
+                                    accumulated_chars = accumulated.chars().count(),
+                                    elapsed_ms = started_at.elapsed().as_millis(),
+                                    fallback_used = false,
                                     content_chars = final_chars,
                                     final_chars,
-                                    "QQ stream final send succeeded"
+                                    "QQ C2C stream response completed"
                                 );
                                 return Ok(C2cStreamingPhase::Completed);
                             }
@@ -470,11 +531,18 @@ where
                                     user = %masked_user,
                                     reply_msg_id = %masked_reply_msg_id,
                                     phase = "final_chunk",
+                                    response_delivery_mode = "live_stream",
                                     stream_state = "broken_active",
                                     stream_state_value = 10_u8,
                                     reset = false,
                                     index = stream_state.index,
                                     has_stream_id_before_send = had_stream_id,
+                                    text_delta_count,
+                                    stream_entered_active = true,
+                                    final_send_exit = "qq_stream_final",
+                                    qq_stream_send_count = stream_state.index,
+                                    accumulated_chars = accumulated.chars().count(),
+                                    elapsed_ms = started_at.elapsed().as_millis(),
                                     content_chars = final_chars,
                                     error = %err.log_summary(),
                                     final_chars,
@@ -496,9 +564,10 @@ where
                         .await
                         {
                             Ok(()) => {
-                                debug!(
+                                info!(
                                     user = %masked_user,
                                     reply_msg_id = %masked_reply_msg_id,
+                                    response_delivery_mode = "live_stream",
                                     phase = "broken_active_final_chunk",
                                     stream_state = C2cStreamingPhase::Completed.name(),
                                     stream_state_value = 10_u8,
@@ -506,9 +575,16 @@ where
                                     index = stream_state.index,
                                     has_stream_id_before_send = had_stream_id,
                                     has_stream_id_after_send = stream_state.stream_id.is_some(),
+                                    text_delta_count,
+                                    stream_entered_active = true,
+                                    final_send_exit = "qq_stream_final",
+                                    qq_stream_send_count = stream_state.index,
+                                    accumulated_chars = accumulated.chars().count(),
+                                    elapsed_ms = started_at.elapsed().as_millis(),
+                                    fallback_used = false,
                                     content_chars = final_chars,
                                     final_chars,
-                                    "QQ stream end after broken active succeeded"
+                                    "QQ C2C stream response completed after broken active"
                                 );
                                 return Ok(C2cStreamingPhase::Completed);
                             }
@@ -517,11 +593,18 @@ where
                                     user = %masked_user,
                                     reply_msg_id = %masked_reply_msg_id,
                                     phase = "broken_active_final_chunk",
+                                    response_delivery_mode = "live_stream",
                                     stream_state = "broken_active",
                                     stream_state_value = 10_u8,
                                     reset = false,
                                     index = stream_state.index,
                                     has_stream_id_before_send = had_stream_id,
+                                    text_delta_count,
+                                    stream_entered_active = true,
+                                    final_send_exit = "qq_stream_final",
+                                    qq_stream_send_count = stream_state.index,
+                                    accumulated_chars = accumulated.chars().count(),
+                                    elapsed_ms = started_at.elapsed().as_millis(),
                                     content_chars = final_chars,
                                     error = %err.log_summary(),
                                     final_chars,
@@ -534,16 +617,29 @@ where
                     C2cStreamingPhase::Completed => return Ok(C2cStreamingPhase::Completed),
                     C2cStreamingPhase::Pending(_) => {
                         let stream_state_name = phase.name();
+                        let response_delivery_mode = if stream_first_attempted {
+                            "stream_fallback"
+                        } else {
+                            "ordinary_complete"
+                        };
                         send_c2c_respond_response_with_sender(sender, message, &response, config)
                             .await
                             .inspect(|_| {
-                                debug!(
+                                info!(
                                     user = %masked_user,
                                     reply_msg_id = %masked_reply_msg_id,
                                     phase = "ordinary_fallback_on_completed",
+                                    response_delivery_mode,
                                     stream_state = stream_state_name,
+                                    text_delta_count,
+                                    stream_entered_active = false,
+                                    final_send_exit = "ordinary_reply",
+                                    qq_stream_send_count = 0_u32,
+                                    accumulated_chars = accumulated.chars().count(),
+                                    elapsed_ms = started_at.elapsed().as_millis(),
+                                    fallback_used = stream_first_attempted,
                                     final_chars,
-                                    "QQ ordinary fallback send succeeded"
+                                    "QQ C2C stream response completed"
                                 );
                             })
                             .inspect_err(|fallback_err| {
@@ -551,8 +647,12 @@ where
                                     user = %masked_user,
                                     reply_msg_id = %masked_reply_msg_id,
                                     phase = "ordinary_fallback_on_completed",
+                                    response_delivery_mode,
                                     stream_state = stream_state_name,
                                     error = %fallback_err,
+                                    text_delta_count,
+                                    stream_entered_active = false,
+                                    final_send_exit = "ordinary_reply",
                                     final_chars,
                                     "QQ ordinary fallback send failed"
                                 );
@@ -571,6 +671,7 @@ where
                     kind = ?failure.kind,
                     retryable = failure.retryable,
                     stream_state = phase.name(),
+                    text_delta_count,
                     accumulated_chars = accumulated.chars().count(),
                     "core respond stream failed"
                 );
@@ -615,6 +716,7 @@ where
         user = %masked_user,
         reply_msg_id = %masked_reply_msg_id,
         stream_state = phase.name(),
+        text_delta_count,
         accumulated_chars,
         "core respond stream closed before Completed"
     );

--- a/qq-maid-gateway-rs/src/gateway/stream/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests.rs
@@ -606,6 +606,67 @@ async fn stream_completed_without_delta_uses_ordinary_reply_path() {
     let events = FakeEventStream::new([RespondEvent::Completed(respond_response("晚上好"))]);
     let sender = FakeStreamSender::new([]);
 
+    let phase = stream_respond_c2c_with_sender(events, &sender, &c2c_message(), &test_config())
+        .await
+        .unwrap();
+
+    assert!(matches!(phase, C2cStreamingPhase::Completed));
+    assert_eq!(
+        sender.calls(),
+        vec![FakeCall::Markdown {
+            content: "晚上好".to_owned(),
+            msg_id: Some("msg-1".to_owned()),
+        }]
+    );
+}
+
+#[tokio::test]
+async fn stream_pending_completed_stops_typing_with_final_reply_before_ordinary_reply() {
+    let events = FakeEventStream::new([RespondEvent::Completed(respond_response("晚上好"))]);
+    let sender = FakeStreamSender::new([]);
+    let typing = C2cTypingStatusGuard::schedule_with_sender(
+        &AgentTypingConfig {
+            enabled: true,
+            delay: Duration::from_secs(60),
+        },
+        Arc::new(NoopTypingSender),
+        &c2c_message(),
+        "test",
+    )
+    .unwrap();
+    let stop_reason = typing.stop_reason_probe_for_test();
+
+    stream_respond_c2c_with_sender_and_typing(
+        events,
+        &sender,
+        &c2c_message(),
+        &test_config(),
+        Some(typing),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        *stop_reason.lock().unwrap(),
+        Some(TypingStopReason::FinalReply)
+    );
+    assert_eq!(
+        sender.calls(),
+        vec![FakeCall::Markdown {
+            content: "晚上好".to_owned(),
+            msg_id: Some("msg-1".to_owned()),
+        }]
+    );
+}
+
+#[tokio::test]
+async fn stream_pending_completed_sends_ordinary_reply_once() {
+    let events = FakeEventStream::new([
+        RespondEvent::Completed(respond_response("晚上好")),
+        RespondEvent::Completed(respond_response("不应重复发送")),
+    ]);
+    let sender = FakeStreamSender::new([]);
+
     stream_respond_c2c_with_sender(events, &sender, &c2c_message(), &test_config())
         .await
         .unwrap();

--- a/qq-maid-gateway-rs/src/message_chunk.rs
+++ b/qq-maid-gateway-rs/src/message_chunk.rs
@@ -12,7 +12,7 @@
 //! - 中文、Emoji、组合字符不会被切坏，按 Unicode scalar 安全切分。
 
 use thiserror::Error;
-use tracing::{debug, info, warn};
+use tracing::{debug, info, trace, warn};
 
 use crate::api::{
     ApiError, C2cReplyTarget, GroupOutboundSender, GroupReplyTarget, OutboundSender, SendResult,
@@ -802,7 +802,7 @@ where
     let chunks = chunk_outbound(message, limits);
     let total = chunks.len();
     let masked_user = mask_openid(&target.user_openid);
-    info!(
+    debug!(
         user = %masked_user,
         source_message_id = target.msg_id.as_deref().unwrap_or(""),
         chunk_count = total,
@@ -811,8 +811,9 @@ where
     );
 
     let mut sent_ids = Vec::with_capacity(total);
+    let mut fallback_chunks = 0_usize;
     for (index, chunk) in chunks.iter().enumerate() {
-        debug!(
+        trace!(
             user = %masked_user,
             source_message_id = target.msg_id.as_deref().unwrap_or(""),
             chunk_index = chunk.chunk_index,
@@ -824,7 +825,10 @@ where
         );
         match send_chunk_c2c(sender, target, chunk).await {
             (Ok(id), fallback_used) => {
-                info!(
+                if fallback_used {
+                    fallback_chunks += 1;
+                }
+                trace!(
                     user = %masked_user,
                     source_message_id = target.msg_id.as_deref().unwrap_or(""),
                     chunk_index = chunk.chunk_index,
@@ -844,6 +848,9 @@ where
                     source_message_id = target.msg_id.as_deref().unwrap_or(""),
                     chunk_index = chunk.chunk_index,
                     chunk_count = chunk.chunk_count,
+                    sent_chunks = index,
+                    fallback_chunks,
+                    remaining_chars = remaining_chars(&chunks, index),
                     error = %err.log_summary(),
                     "C2C chunk send failed; aborting remaining chunks"
                 );
@@ -856,6 +863,15 @@ where
             }
         }
     }
+    info!(
+        user = %masked_user,
+        source_message_id = target.msg_id.as_deref().unwrap_or(""),
+        chunk_count = total,
+        sent_chunks = sent_ids.len(),
+        fallback_chunks,
+        kind = outbound_kind(message),
+        "chunked C2C outbound completed"
+    );
     Ok(sent_ids)
 }
 
@@ -876,7 +892,7 @@ where
     let chunks = chunk_outbound(message, limits);
     let total = chunks.len();
     let masked_group = mask_openid(&target.group_openid);
-    info!(
+    debug!(
         group = %masked_group,
         source_message_id = target.msg_id.as_deref().unwrap_or(""),
         chunk_count = total,
@@ -885,8 +901,9 @@ where
     );
 
     let mut sent_ids = Vec::with_capacity(total);
+    let mut fallback_chunks = 0_usize;
     for (index, chunk) in chunks.iter().enumerate() {
-        debug!(
+        trace!(
             group = %masked_group,
             source_message_id = target.msg_id.as_deref().unwrap_or(""),
             chunk_index = chunk.chunk_index,
@@ -898,7 +915,10 @@ where
         );
         match send_chunk_group(sender, target, chunk).await {
             (Ok(id), fallback_used) => {
-                info!(
+                if fallback_used {
+                    fallback_chunks += 1;
+                }
+                trace!(
                     group = %masked_group,
                     source_message_id = target.msg_id.as_deref().unwrap_or(""),
                     chunk_index = chunk.chunk_index,
@@ -918,6 +938,9 @@ where
                     source_message_id = target.msg_id.as_deref().unwrap_or(""),
                     chunk_index = chunk.chunk_index,
                     chunk_count = chunk.chunk_count,
+                    sent_chunks = index,
+                    fallback_chunks,
+                    remaining_chars = remaining_chars(&chunks, index),
                     error = %err.log_summary(),
                     "group chunk send failed; aborting remaining chunks"
                 );
@@ -930,6 +953,15 @@ where
             }
         }
     }
+    info!(
+        group = %masked_group,
+        source_message_id = target.msg_id.as_deref().unwrap_or(""),
+        chunk_count = total,
+        sent_chunks = sent_ids.len(),
+        fallback_chunks,
+        kind = outbound_kind(message),
+        "chunked group outbound completed"
+    );
     Ok(sent_ids)
 }
 

--- a/qq-maid-gateway-rs/src/respond.rs
+++ b/qq-maid-gateway-rs/src/respond.rs
@@ -10,7 +10,7 @@ use qq_maid_core::service::{
     CoreRespondOutput, CoreResponse, CoreResponseEvent, CoreResponseStream, CoreService, Platform,
 };
 use thiserror::Error;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::{
     event::{C2cMessage, GroupMessage},
@@ -163,7 +163,7 @@ fn log_core_output_success(
             );
         }
         CoreRespondOutput::Stream(_) => {
-            info!(
+            debug!(
                 message_id,
                 user = masked_user.unwrap_or(""),
                 group = masked_group.unwrap_or(""),

--- a/qq-maid-llm/src/provider/stream_state.rs
+++ b/qq-maid-llm/src/provider/stream_state.rs
@@ -162,7 +162,7 @@ async fn start_next_route_candidate(state: &mut RouteStreamState) -> Result<bool
         candidate_req.model = Some(candidate.to_request_model());
         match provider.stream_chat(candidate_req).await {
             Ok(stream) => {
-                tracing::info!(
+                tracing::debug!(
                     task = state.task.as_str(),
                     candidate_index = index,
                     provider = provider_kind.as_str(),


### PR DESCRIPTION
## 变更
- 修复 CompleteToolLoop、Todo 和非流式 Provider 路径的合成最终 TextDelta 行为，改为 Completed 后走普通 C2C 回复。
- 保持真实 Provider 增量流继续使用 QQ C2C stream，Active 后仍不补发普通全文。
- 收敛流式/分段发送日志：逐 chunk 正常细节降到 trace/debug，成功路径保留汇总 info，异常继续 warn。

## 根因
非真实流式路径在完整响应完成后合成单个完整 TextDelta，Gateway 将其作为 QQ stream 首帧发送，并紧随 Completed 发送零宽结束帧。QQ 客户端在该场景下可能只显示 typing/流式占位，不稳定渲染正文。

## 验证
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test -p qq-maid-core service::tests
- cargo test -p qq-maid-gateway-rs gateway::stream::tests
- cargo test -p qq-maid-gateway-rs message_chunk::tests
- cargo test -p qq-maid-gateway-rs respond::tests
- cargo test --workspace --all-features
- cargo build --workspace --release --all-features

## 备注
未做真实 QQ 联调，仍需在线上确认 QQ 客户端对普通完整回复和真实流式回复的最终展示。