### PR TITLE
[codex] 优化 Todo Markdown 展示格式

### DIFF
--- a/qq-maid-common/src/time_context/mod.rs
+++ b/qq-maid-common/src/time_context/mod.rs
@@ -503,7 +503,7 @@ pub fn format_todo_time_for_display(value: &str) -> String {
 /// - 当前年内显示 `MM-DD`，跨年显示 `YY-MM-DD`；
 /// - 只有日期时不显示时间；
 /// - 有具体时间时显示 `H:MM`；
-/// - 星期始终放在反引号外，例如 `` `07-10 7:00`（五）``。
+/// - 星期放在日期时间后面，例如 07-10 7:00（五）。
 pub fn format_todo_time_chip_for_display(value: &str) -> String {
     format_todo_time_chip_for_display_with_year(value, current_cn_year())
 }
@@ -723,7 +723,7 @@ impl RequestTimeContext {
 fn format_todo_datetime_chip(datetime: NaiveDateTime, current_year: i32) -> String {
     let date = datetime.date();
     format!(
-        "`{} {}:{:02}`（{}）",
+        "{} {}:{:02}（{}）",
         todo_chip_date_label(date, current_year),
         datetime.hour(),
         datetime.minute(),
@@ -733,7 +733,7 @@ fn format_todo_datetime_chip(datetime: NaiveDateTime, current_year: i32) -> Stri
 
 fn format_todo_date_chip(date: NaiveDate, current_year: i32) -> String {
     format!(
-        "`{}`（{}）",
+        "{}（{}）",
         todo_chip_date_label(date, current_year),
         chinese_weekday(date)
     )

--- a/qq-maid-common/src/time_context/tests.rs
+++ b/qq-maid-common/src/time_context/tests.rs
@@ -143,19 +143,19 @@ fn formats_and_parses_local_timestamp_dates() {
     );
     assert_eq!(
         format_todo_time_chip_for_display_with_year("2025-07-10 07:00:00", 2025),
-        "`07-10 7:00`（四）"
+        "07-10 7:00（四）"
     );
     assert_eq!(
         format_todo_time_chip_for_display_with_year("2025-07-10", 2025),
-        "`07-10`（四）"
+        "07-10（四）"
     );
     assert_eq!(
         format_todo_time_chip_for_display_with_year("2026-01-02 05:00", 2025),
-        "`26-01-02 5:00`（五）"
+        "26-01-02 5:00（五）"
     );
     assert_eq!(
         format_todo_time_chip_for_display_with_year("2025-08-02T05:00:00+08:00", 2025),
-        "`08-02 5:00`（六）"
+        "08-02 5:00（六）"
     );
     assert_eq!(
         format_todo_time_chip_for_display_with_year("坏数据（推测）", 2025),

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -1401,9 +1401,9 @@ async fn todo_create_receipt_shows_full_user_visible_card() {
 
     let text = response.text.unwrap();
     assert!(text.contains("✅ 已新增待办"));
-    assert!(text.contains("装宽带 · 时间：`99-01-01 10:00`"));
+    assert!(text.contains("装宽带 · 时间：99-01-01 10:00"));
     assert!(text.contains("提醒时间："));
-    assert!(text.contains("`99-01-01 9:30`"));
+    assert!(text.contains("99-01-01 9:30"));
     assert!(text.contains("详情：提前确认地址并携带身份证"));
     assert!(!text.contains("created_at"));
     assert!(!text.contains("scope"));
@@ -1448,7 +1448,7 @@ async fn todo_edit_receipt_shows_final_detail_card() {
 
     let text = response.text.unwrap();
     assert!(text.contains("✏️ 已修改待办"));
-    assert!(text.contains("装宽带 · 时间：`99-01-01`"));
+    assert!(text.contains("装宽带 · 时间：99-01-01"));
     assert!(text.contains("详情：提前确认地址"));
     // 修改回执和自动刷新的当前列表都应展示详情，避免用户误以为详情没有写入。
     assert_eq!(text.matches("详情：提前确认地址").count(), 2);
@@ -1498,9 +1498,9 @@ async fn todo_complete_receipt_reuses_full_user_visible_card() {
     let text = response.text.unwrap();
     assert!(text.contains("✅ 已完成待办"));
     assert!(text.contains("状态：已完成"));
-    assert!(text.contains("装宽带 · 时间：`99-01-01 10:00`"));
+    assert!(text.contains("装宽带 · 时间：99-01-01 10:00"));
     assert!(text.contains("提醒时间："));
-    assert!(text.contains("`99-01-01 9:30`"));
+    assert!(text.contains("99-01-01 9:30"));
     assert!(text.contains("详情：提前确认地址并携带身份证"));
     assert!(text.contains("完成时间："));
     assert!(!text.contains("created_at"));

--- a/qq-maid-core/src/runtime/respond/tests/todo.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo.rs
@@ -1108,9 +1108,9 @@ async fn todo_single_status_lists_render_board_style_and_remember_visible_order(
     assert!(pending_text.starts_with("🚧 进行中 · 共 3 项"));
     assert!(pending_text.contains(" · 时间："));
     assert!(!pending_text.contains("无时间事项 · 时间："));
-    assert!(pending_text.contains("（提醒: `"));
-    assert!(pending_text.contains("9:30`"));
-    assert!(pending_text.contains("   > 详情：需要保留详情"));
+    assert!(pending_text.contains("（提醒: "));
+    assert!(pending_text.contains("9:30"));
+    assert!(pending_text.contains("   详情：需要保留详情"));
     assert!(!pending_text.contains("（未完成）"));
     assert_in_order(
         &pending_text,
@@ -1144,7 +1144,7 @@ async fn todo_single_status_lists_render_board_style_and_remember_visible_order(
     let cancelled_text = cancelled.text.unwrap();
     assert!(cancelled_text.starts_with("⛔ 已取消 · 共 2 项"));
     assert!(cancelled_text.contains(" · 取消时间："));
-    assert!(cancelled_text.contains("   > 详情：取消原因记录在详情里"));
+    assert!(cancelled_text.contains("   详情：取消原因记录在详情里"));
     assert!(!cancelled_text.contains("（已取消）"));
     assert_in_order(&cancelled_text, &["1. 最近放弃", "2. 较早放弃"]);
     assert_eq!(last_todo_result_ids(&service), vec!["6", "7"]);
@@ -1335,7 +1335,7 @@ async fn todo_all_renders_grouped_board_and_remembers_visible_order() {
     assert!(text.contains("🚧 进行中（3 项）"));
     assert!(text.contains("✅ 已完成（2 项）"));
     assert!(text.contains("⛔ 已取消（2 项）"));
-    assert!(text.contains("   > 详情：有详情"));
+    assert!(text.contains("   详情：有详情"));
     assert!(text.contains(" · 完成时间："));
     assert!(text.contains(" · 原定时间："));
     assert!(!text.contains("（未完成）"));

--- a/qq-maid-core/src/runtime/respond/todo_flow/format.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/format.rs
@@ -38,14 +38,14 @@ pub(super) fn visible_todo_all_board_items(items: &[TodoItem], force_full: bool)
     }
 }
 
-pub(super) fn format_todo_detail_quote(detail: &str, markdown: bool) -> String {
+pub(super) fn format_todo_detail_line(detail: &str, markdown: bool) -> String {
     if markdown {
         format!(
-            "   > **详情**：{}",
+            "   **详情**：{}",
             escape_markdown_text(&truncate_chars(detail, 80))
         )
     } else {
-        format!("   > 详情：{}", truncate_chars(detail, 80))
+        format!("   详情：{}", truncate_chars(detail, 80))
     }
 }
 
@@ -294,7 +294,7 @@ pub(super) fn format_completed_todo_time_query_reply(
     CommandBody::dual(rows.join("\n"), markdown_rows.join("\n"))
 }
 
-/// 通用待办行格式化：`序号. 标题 · 时间`，详情使用引用行。内部 ID 只能留在
+/// 通用待办行格式化：`序号. 标题 · 时间`，详情使用缩进附属行。内部 ID 只能留在
 /// 快照映射和存储层，这里只渲染用户可读字段。
 fn format_todo_rows_with_time(
     items: &[TodoItem],
@@ -312,7 +312,7 @@ fn format_todo_rows_with_time(
                 .as_deref()
                 .and_then(|value| clean_string(value.to_owned()))
             {
-                row.push_str(&format!("\n{}", format_todo_detail_quote(&detail, false)));
+                row.push_str(&format!("\n{}", format_todo_detail_line(&detail, false)));
             }
             row
         })
@@ -446,10 +446,7 @@ fn format_todo_all_board_item_rows(
                 .as_deref()
                 .and_then(|value| clean_string(value.to_owned()))
             {
-                row.push_str(&format!(
-                    "\n{}",
-                    format_todo_detail_quote(&detail, markdown)
-                ));
+                row.push_str(&format!("\n{}", format_todo_detail_line(&detail, markdown)));
             }
             row
         })
@@ -512,7 +509,7 @@ fn format_todo_rows_markdown(items: &[TodoItem], with_status: bool) -> Vec<Strin
                 .as_deref()
                 .and_then(|value| clean_string(value.to_owned()))
             {
-                line.push_str(&format!("\n{}", format_todo_detail_quote(&detail, true)));
+                line.push_str(&format!("\n{}", format_todo_detail_line(&detail, true)));
             }
             vec![line]
         })
@@ -539,7 +536,7 @@ fn format_todo_rows_markdown_with_time(
                 .as_deref()
                 .and_then(|value| clean_string(value.to_owned()))
             {
-                line.push_str(&format!("\n{}", format_todo_detail_quote(&detail, true)));
+                line.push_str(&format!("\n{}", format_todo_detail_line(&detail, true)));
             }
             vec![line]
         })

--- a/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 
 use super::format::{
-    append_todo_collapse_hint, format_todo_detail_quote, format_todo_inline,
+    append_todo_collapse_hint, format_todo_detail_line, format_todo_inline,
     format_todo_inline_markdown, format_todo_list_line, todo_due_chip, todo_reminder_chip,
     todo_timestamp_chip, visible_todo_all_board_items, visible_todo_items,
 };
@@ -796,7 +796,7 @@ fn append_related_detail(rows: &mut Vec<String>, item: &TodoItem, markdown: bool
     else {
         return;
     };
-    rows.push(format_todo_detail_quote(&detail, markdown));
+    rows.push(format_todo_detail_line(&detail, markdown));
 }
 
 fn collapse_prompt_for_related_spec(
@@ -1152,7 +1152,7 @@ fn append_todo_detail_card_lines(
         });
     }
     if let Some(detail) = item.detail.as_deref() {
-        lines.push(format_todo_detail_quote(detail, markdown));
+        lines.push(format_todo_detail_line(detail, markdown));
     }
     if item.status.as_deref() == Some("completed")
         && let Some(completed_at) = item.completed_at.as_deref()


### PR DESCRIPTION
## 变更内容

- 去掉 Todo 时间 chip 中的 Markdown 反引号，日期和提醒时间直接以普通文本展示。
- Todo 详情不再渲染为引用块，改为缩进的附属详情行。
- 同步更新 Todo 列表、详情卡、写操作回执和相关测试断言。

## 影响

- 用户看到的 Todo 列表和回执更紧凑，日期、提醒和详情不再混用代码样式和引用样式。
- 只调整用户可见展示格式，不改变 Todo 存储、编号快照、时间解析或业务状态流转。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p qq-maid-common time_context`
- `cargo test -p qq-maid-core runtime::respond::tests::todo`
- `cargo test -p qq-maid-core receipt_shows`
- `cargo test -p qq-maid-core todo_complete_receipt_reuses_full_user_visible_card`
- `git diff --check`
