### PR TITLE
[codex] 调整待办时间展示

### DIFF
--- a/qq-maid-common/src/time_context/mod.rs
+++ b/qq-maid-common/src/time_context/mod.rs
@@ -503,7 +503,7 @@ pub fn format_todo_time_for_display(value: &str) -> String {
 /// - 当前年内显示 `MM-DD`，跨年显示 `YY-MM-DD`；
 /// - 只有日期时不显示时间；
 /// - 有具体时间时显示 `H:MM`；
-/// - 星期始终放在反引号外，例如 `` `07-10 7:00`（五）``。
+/// - 不使用反引号等 Markdown 语法，避免 QQ Markdown 对行内 code 支持不稳定。
 pub fn format_todo_time_chip_for_display(value: &str) -> String {
     format_todo_time_chip_for_display_with_year(value, current_cn_year())
 }
@@ -723,7 +723,7 @@ impl RequestTimeContext {
 fn format_todo_datetime_chip(datetime: NaiveDateTime, current_year: i32) -> String {
     let date = datetime.date();
     format!(
-        "`{} {}:{:02}`（{}）",
+        "{} {}:{:02}（{}）",
         todo_chip_date_label(date, current_year),
         datetime.hour(),
         datetime.minute(),
@@ -733,7 +733,7 @@ fn format_todo_datetime_chip(datetime: NaiveDateTime, current_year: i32) -> Stri
 
 fn format_todo_date_chip(date: NaiveDate, current_year: i32) -> String {
     format!(
-        "`{}`（{}）",
+        "{}（{}）",
         todo_chip_date_label(date, current_year),
         chinese_weekday(date)
     )

--- a/qq-maid-common/src/time_context/tests.rs
+++ b/qq-maid-common/src/time_context/tests.rs
@@ -143,19 +143,19 @@ fn formats_and_parses_local_timestamp_dates() {
     );
     assert_eq!(
         format_todo_time_chip_for_display_with_year("2025-07-10 07:00:00", 2025),
-        "`07-10 7:00`（四）"
+        "07-10 7:00（四）"
     );
     assert_eq!(
         format_todo_time_chip_for_display_with_year("2025-07-10", 2025),
-        "`07-10`（四）"
+        "07-10（四）"
     );
     assert_eq!(
         format_todo_time_chip_for_display_with_year("2026-01-02 05:00", 2025),
-        "`26-01-02 5:00`（五）"
+        "26-01-02 5:00（五）"
     );
     assert_eq!(
         format_todo_time_chip_for_display_with_year("2025-08-02T05:00:00+08:00", 2025),
-        "`08-02 5:00`（六）"
+        "08-02 5:00（六）"
     );
     assert_eq!(
         format_todo_time_chip_for_display_with_year("坏数据（推测）", 2025),

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -1401,9 +1401,9 @@ async fn todo_create_receipt_shows_full_user_visible_card() {
 
     let text = response.text.unwrap();
     assert!(text.contains("✅ 已新增待办"));
-    assert!(text.contains("装宽带 · 时间：`99-01-01 10:00`"));
+    assert!(text.contains("装宽带 · 时间：99-01-01 10:00（四）"));
     assert!(text.contains("提醒时间："));
-    assert!(text.contains("`99-01-01 9:30`"));
+    assert!(text.contains("99-01-01 9:30（四）"));
     assert!(text.contains("详情：提前确认地址并携带身份证"));
     assert!(!text.contains("created_at"));
     assert!(!text.contains("scope"));
@@ -1448,7 +1448,7 @@ async fn todo_edit_receipt_shows_final_detail_card() {
 
     let text = response.text.unwrap();
     assert!(text.contains("✏️ 已修改待办"));
-    assert!(text.contains("装宽带 · 时间：`99-01-01`"));
+    assert!(text.contains("装宽带 · 时间：99-01-01（四）"));
     assert!(text.contains("详情：提前确认地址"));
     // 修改回执和自动刷新的当前列表都应展示详情，避免用户误以为详情没有写入。
     assert_eq!(text.matches("详情：提前确认地址").count(), 2);
@@ -1498,9 +1498,9 @@ async fn todo_complete_receipt_reuses_full_user_visible_card() {
     let text = response.text.unwrap();
     assert!(text.contains("✅ 已完成待办"));
     assert!(text.contains("状态：已完成"));
-    assert!(text.contains("装宽带 · 时间：`99-01-01 10:00`"));
+    assert!(text.contains("装宽带 · 时间：99-01-01 10:00（四）"));
     assert!(text.contains("提醒时间："));
-    assert!(text.contains("`99-01-01 9:30`"));
+    assert!(text.contains("99-01-01 9:30（四）"));
     assert!(text.contains("详情：提前确认地址并携带身份证"));
     assert!(text.contains("完成时间："));
     assert!(!text.contains("created_at"));

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -1402,15 +1402,15 @@ async fn todo_create_receipt_shows_full_user_visible_card() {
     let text = response.text.unwrap();
     assert!(text.contains("✅ 已新增待办"));
     assert!(text.contains("装宽带 · 时间：99-01-01 10:00（四）"));
-    assert!(text.contains("提醒时间："));
+    assert!(text.contains("提醒："));
     assert!(text.contains("99-01-01 9:30（四）"));
-    assert!(text.contains("详情：提前确认地址并携带身份证"));
+    assert!(text.contains("详情：\n提前确认地址并携带身份证"));
     assert!(!text.contains("created_at"));
     assert!(!text.contains("scope"));
     let markdown = response.markdown.unwrap();
     assert!(markdown.contains("**时间**"));
-    assert!(markdown.contains("**提醒时间**"));
-    assert!(markdown.contains("**详情**"));
+    assert!(markdown.contains("**提醒**"));
+    assert!(markdown.contains("详情：\n提前确认地址并携带身份证"));
 }
 
 #[tokio::test]
@@ -1449,9 +1449,9 @@ async fn todo_edit_receipt_shows_final_detail_card() {
     let text = response.text.unwrap();
     assert!(text.contains("✏️ 已修改待办"));
     assert!(text.contains("装宽带 · 时间：99-01-01（四）"));
-    assert!(text.contains("详情：提前确认地址"));
+    assert!(text.contains("详情：\n提前确认地址"));
     // 修改回执和自动刷新的当前列表都应展示详情，避免用户误以为详情没有写入。
-    assert_eq!(text.matches("详情：提前确认地址").count(), 2);
+    assert!(text.contains("   提前确认地址"));
     assert!(!text.contains("旧详情"));
     assert!(!text.contains("created_at"));
     assert_eq!(
@@ -1499,9 +1499,9 @@ async fn todo_complete_receipt_reuses_full_user_visible_card() {
     assert!(text.contains("✅ 已完成待办"));
     assert!(text.contains("状态：已完成"));
     assert!(text.contains("装宽带 · 时间：99-01-01 10:00（四）"));
-    assert!(text.contains("提醒时间："));
+    assert!(text.contains("提醒："));
     assert!(text.contains("99-01-01 9:30（四）"));
-    assert!(text.contains("详情：提前确认地址并携带身份证"));
+    assert!(text.contains("详情：\n提前确认地址并携带身份证"));
     assert!(text.contains("完成时间："));
     assert!(!text.contains("created_at"));
 }

--- a/qq-maid-core/src/runtime/respond/tests/todo.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo.rs
@@ -1106,11 +1106,14 @@ async fn todo_single_status_lists_render_board_style_and_remember_visible_order(
     assert_eq!(pending.command.as_deref(), Some("todo_list"));
     let pending_text = pending.text.unwrap();
     assert!(pending_text.starts_with("🚧 进行中 · 共 3 项"));
-    assert!(pending_text.contains(" · 时间："));
-    assert!(!pending_text.contains("无时间事项 · 时间："));
-    assert!(pending_text.contains("（提醒: `"));
-    assert!(pending_text.contains("9:30`"));
-    assert!(pending_text.contains("   > 详情：需要保留详情"));
+    assert!(pending_text.contains("1. 明天事项\n   07-02（四）"));
+    assert!(pending_text.contains("2. 后天事项\n   07-03（五） · 提醒 9:30"));
+    assert!(pending_text.contains("   需要保留详情"));
+    assert!(!pending_text.contains("时间："));
+    assert!(!pending_text.contains("提醒时间："));
+    assert!(!pending_text.contains("（提醒:"));
+    assert!(!pending_text.contains("> 详情"));
+    assert!(!pending_text.contains("无时间事项\n   "));
     assert!(!pending_text.contains("（未完成）"));
     assert_in_order(
         &pending_text,
@@ -1128,7 +1131,7 @@ async fn todo_single_status_lists_render_board_style_and_remember_visible_order(
     assert_eq!(completed.command.as_deref(), Some("todo_done"));
     let completed_text = completed.text.unwrap();
     assert!(completed_text.starts_with("✅ 已完成 · 共 2 项"));
-    assert!(completed_text.contains(" · 完成时间："));
+    assert!(completed_text.contains("1. 较新归档\n   07-01 18:00（三）"));
     assert!(!completed_text.contains("（已完成）"));
     assert_in_order(&completed_text, &["1. 较新归档", "2. 较早归档"]);
     assert_eq!(last_todo_result_ids(&service), vec!["5", "4"]);
@@ -1143,8 +1146,10 @@ async fn todo_single_status_lists_render_board_style_and_remember_visible_order(
     assert_eq!(cancelled.command.as_deref(), Some("todo_cancelled_list"));
     let cancelled_text = cancelled.text.unwrap();
     assert!(cancelled_text.starts_with("⛔ 已取消 · 共 2 项"));
-    assert!(cancelled_text.contains(" · 取消时间："));
-    assert!(cancelled_text.contains("   > 详情：取消原因记录在详情里"));
+    assert!(cancelled_text.contains("1. 最近放弃\n   07-01 13:10（三）"));
+    assert!(cancelled_text.contains("   取消原因记录在详情里"));
+    assert!(!cancelled_text.contains("取消时间："));
+    assert!(!cancelled_text.contains("> 详情"));
     assert!(!cancelled_text.contains("（已取消）"));
     assert_in_order(&cancelled_text, &["1. 最近放弃", "2. 较早放弃"]);
     assert_eq!(last_todo_result_ids(&service), vec!["6", "7"]);
@@ -1170,6 +1175,24 @@ async fn todo_single_status_lists_render_empty_notices() {
         assert_eq!(text, expected, "{command}");
         assert!(!text.starts_with("null"), "{command}");
     }
+}
+
+#[tokio::test]
+async fn todo_pending_list_shows_reminder_without_due_time() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    let mut item = draft("买香蕉");
+    item.detail = Some("老公要买香蕉，要薰衣草味的".to_owned());
+    item.reminder_at = Some("2026-07-31 18:00:00".to_owned());
+    service.todo_store.create(&owner, item).unwrap();
+
+    let response = service.respond(message("/todo")).await.unwrap();
+    let text = response.text.unwrap();
+    assert!(text.contains("1. 买香蕉\n   提醒 07-31 18:00（五）"));
+    assert!(text.contains("   老公要买香蕉，要薰衣草味的"));
+    assert!(!text.contains("时间："));
+    assert!(!text.contains("提醒时间："));
+    assert!(!text.contains("（提醒:"));
 }
 
 #[tokio::test]
@@ -1225,7 +1248,10 @@ async fn todo_all_renders_grouped_board_and_remembers_visible_order() {
             user_id: Some("u1".to_owned()),
             scope_key: "group:g1".to_owned(),
             title: "稍后进行中".to_owned(),
-            detail: Some("有详情".to_owned()),
+            detail: Some(
+                "有详情，这是一段很长的补充说明，用来确认默认列表会截断详情，避免 QQ 卡片被长文本撑开，额外补充几句用于超过限制，尾部不应完整显示"
+                    .to_owned(),
+            ),
             raw_text: None,
             due_date: Some("2026-07-03".to_owned()),
             due_at: None,
@@ -1335,9 +1361,14 @@ async fn todo_all_renders_grouped_board_and_remembers_visible_order() {
     assert!(text.contains("🚧 进行中（3 项）"));
     assert!(text.contains("✅ 已完成（2 项）"));
     assert!(text.contains("⛔ 已取消（2 项）"));
-    assert!(text.contains("   > 详情：有详情"));
-    assert!(text.contains(" · 完成时间："));
-    assert!(text.contains(" · 原定时间："));
+    assert!(text.contains("2. 稍后进行中\n   07-03（五）\n   有详情，这是一段很长的补充说明"));
+    assert!(text.contains("…"));
+    assert!(!text.contains("尾部不应完整显示"));
+    assert!(text.contains("4. 较新完成\n   07-01 18:00（三）"));
+    assert!(text.contains("6. 已取消新项\n   07-04（六）"));
+    assert!(!text.contains("> 详情"));
+    assert!(!text.contains("完成时间："));
+    assert!(!text.contains("原定时间："));
     assert!(!text.contains("（未完成）"));
     assert!(!text.contains("（已完成）"));
     assert!(!text.contains("（已取消）"));

--- a/qq-maid-core/src/runtime/respond/todo_flow/format.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/format.rs
@@ -13,7 +13,7 @@ use crate::{
         },
         todo::{TodoItem, TodoStatus},
     },
-    util::time_context::format_todo_time_chip_for_display,
+    util::time_context::{format_todo_time_chip_for_display, local_date_from_timestamp},
 };
 
 pub(super) const TODO_LIST_VISIBLE_LIMIT: usize = 5;
@@ -38,14 +38,20 @@ pub(super) fn visible_todo_all_board_items(items: &[TodoItem], force_full: bool)
     }
 }
 
-pub(super) fn format_todo_detail_quote(detail: &str, markdown: bool) -> String {
+pub(super) fn format_todo_detail_line(detail: &str, markdown: bool) -> String {
+    let detail = truncate_chars(detail, 56);
     if markdown {
-        format!(
-            "   > **详情**：{}",
-            escape_markdown_text(&truncate_chars(detail, 80))
-        )
+        format!("   {}", escape_markdown_text(&detail))
     } else {
-        format!("   > 详情：{}", truncate_chars(detail, 80))
+        format!("   {detail}")
+    }
+}
+
+pub(super) fn format_todo_full_detail_line(detail: &str, markdown: bool) -> String {
+    if markdown {
+        format!("详情：\n{}", escape_markdown_text(detail))
+    } else {
+        format!("详情：\n{detail}")
     }
 }
 
@@ -57,21 +63,32 @@ pub(super) fn todo_due_chip(item: &TodoItem) -> Option<String> {
         .map(format_todo_time_chip_for_display)
 }
 
-pub(super) fn todo_reminder_chip(item: &TodoItem) -> Option<String> {
-    item.reminder_at
-        .as_deref()
-        .and_then(clean_todo_time_value)
-        .map(format_todo_time_chip_for_display)
-}
-
 pub(super) fn todo_timestamp_chip(value: &str) -> Option<String> {
     clean_todo_time_value(value).map(format_todo_time_chip_for_display)
 }
 
-pub(super) fn format_todo_list_line(
+pub(super) fn todo_reminder_list_text(item: &TodoItem, due_time: Option<&str>) -> Option<String> {
+    let reminder_at = item
+        .reminder_at
+        .as_deref()
+        .and_then(clean_todo_time_value)?;
+    let reminder = format_todo_time_chip_for_display(reminder_at);
+    let Some(due_time) = due_time else {
+        return Some(reminder);
+    };
+    let same_day = local_date_from_timestamp(due_time)
+        .zip(local_date_from_timestamp(reminder_at))
+        .is_some_and(|(due_date, reminder_date)| due_date == reminder_date);
+    if same_day {
+        Some(todo_time_of_day(reminder_at).unwrap_or(reminder))
+    } else {
+        Some(reminder)
+    }
+}
+
+pub(super) fn format_todo_natural_list_item(
     index: usize,
     item: &TodoItem,
-    time_label: &str,
     time: Option<String>,
     markdown: bool,
     status_suffix: Option<&str>,
@@ -81,29 +98,72 @@ pub(super) fn format_todo_list_line(
     } else {
         format_todo_inline(item)
     };
-    let mut line = format!("{}. {}", index + 1, title);
-    if let Some(status) = status_suffix {
-        line.push_str(&format!("（{}）", status));
+    let mut lines = vec![format!("{}. {}", index + 1, title)];
+    if let Some(status) = status_suffix
+        && let Some(title_line) = lines.first_mut()
+    {
+        title_line.push_str(&format!("（{}）", status));
     }
-    if let Some(time) = time {
-        if markdown {
-            line.push_str(&format!(
-                " · **{}**：{}",
-                escape_markdown_inline(time_label),
-                escape_markdown_inline(&time)
-            ));
-        } else {
-            line.push_str(&format!(" · {time_label}：{time}"));
-        }
+    if let Some(time_line) = format_todo_time_reminder_line(item, time, markdown) {
+        lines.push(time_line);
     }
-    if let Some(reminder) = todo_reminder_chip(item) {
-        if markdown {
-            line.push_str(&format!("（提醒: {}）", escape_markdown_inline(&reminder)));
-        } else {
-            line.push_str(&format!("（提醒: {reminder}）"));
-        }
+    if let Some(detail) = item
+        .detail
+        .as_deref()
+        .and_then(|value| clean_string(value.to_owned()))
+    {
+        lines.push(format_todo_detail_line(&detail, markdown));
     }
-    line
+    lines.join("\n")
+}
+
+fn format_todo_time_reminder_line(
+    item: &TodoItem,
+    time: Option<String>,
+    markdown: bool,
+) -> Option<String> {
+    let due_source = item
+        .due_at
+        .as_deref()
+        .and_then(clean_todo_time_value)
+        .or_else(|| item.due_date.as_deref().and_then(clean_todo_time_value));
+    let reminder = todo_reminder_list_text(item, due_source);
+    let text = match (time, reminder) {
+        (Some(time), Some(reminder)) => format!("{time} · 提醒 {reminder}"),
+        (Some(time), None) => time,
+        (None, Some(reminder)) => format!("提醒 {reminder}"),
+        (None, None) => return None,
+    };
+    if markdown {
+        Some(format!("   {}", escape_markdown_inline(&text)))
+    } else {
+        Some(format!("   {text}"))
+    }
+}
+
+pub(super) fn format_todo_receipt_item_line(item: &TodoItem, markdown: bool) -> Vec<String> {
+    let title = if markdown {
+        format!("- {}", format_todo_inline_markdown(item))
+    } else {
+        format!("- {}", format_todo_inline(item))
+    };
+    let mut lines = vec![title];
+    if let Some(time_line) = format_todo_time_reminder_line(item, todo_due_chip(item), markdown) {
+        lines.push(time_line);
+    }
+    lines
+}
+
+fn todo_time_of_day(value: &str) -> Option<String> {
+    let value = value.trim();
+    let time_part = value
+        .split_once('T')
+        .map(|(_, time)| time)
+        .or_else(|| value.split_once(' ').map(|(_, time)| time))?;
+    let mut parts = time_part.split(':');
+    let hour = parts.next()?.parse::<u32>().ok()?;
+    let minute = parts.next()?.parse::<u32>().ok()?;
+    Some(format!("{hour}:{minute:02}"))
 }
 
 fn clean_todo_time_value(value: &str) -> Option<&str> {
@@ -294,27 +354,18 @@ pub(super) fn format_completed_todo_time_query_reply(
     CommandBody::dual(rows.join("\n"), markdown_rows.join("\n"))
 }
 
-/// 通用待办行格式化：`序号. 标题 · 时间`，详情使用引用行。内部 ID 只能留在
+/// 通用待办行格式化：标题、时间/提醒和详情拆为自然清单行。内部 ID 只能留在
 /// 快照映射和存储层，这里只渲染用户可读字段。
 fn format_todo_rows_with_time(
     items: &[TodoItem],
-    time_label: &str,
+    _time_label: &str,
     time_value: impl Fn(&TodoItem) -> Option<String>,
 ) -> Vec<String> {
     items
         .iter()
         .enumerate()
         .map(|(index, item)| {
-            let mut row =
-                format_todo_list_line(index, item, time_label, time_value(item), false, None);
-            if let Some(detail) = item
-                .detail
-                .as_deref()
-                .and_then(|value| clean_string(value.to_owned()))
-            {
-                row.push_str(&format!("\n{}", format_todo_detail_quote(&detail, false)));
-            }
-            row
+            format_todo_natural_list_item(index, item, time_value(item), false, None)
         })
         .collect()
 }
@@ -426,32 +477,17 @@ fn format_todo_all_board_rows(items: &[TodoItem], markdown: bool) -> Vec<String>
 
 fn format_todo_all_board_item_rows(
     items: &[(usize, &TodoItem)],
-    time_label: &str,
+    _time_label: &str,
     markdown: bool,
 ) -> Vec<String> {
     items
         .iter()
         .map(|(index, item)| {
-            let (time_label, time_text) = match item.status {
-                TodoStatus::Completed => ("完成时间", display_todo_completed_at(item)),
-                _ => (time_label, todo_due_chip(item)),
+            let time_text = match item.status {
+                TodoStatus::Completed => display_todo_completed_at(item),
+                _ => todo_due_chip(item),
             };
-            let mut row = if markdown {
-                format_todo_list_line(*index, item, time_label, time_text, true, None)
-            } else {
-                format_todo_list_line(*index, item, time_label, time_text, false, None)
-            };
-            if let Some(detail) = item
-                .detail
-                .as_deref()
-                .and_then(|value| clean_string(value.to_owned()))
-            {
-                row.push_str(&format!(
-                    "\n{}",
-                    format_todo_detail_quote(&detail, markdown)
-                ));
-            }
-            row
+            format_todo_natural_list_item(*index, item, time_text, markdown, None)
         })
         .collect()
 }
@@ -500,21 +536,15 @@ fn format_todo_rows_markdown(items: &[TodoItem], with_status: bool) -> Vec<Strin
         .iter()
         .enumerate()
         .flat_map(|(index, item)| {
-            let (time_label, time_text) = match item.status {
-                TodoStatus::Completed => ("完成时间", display_todo_completed_at(item)),
-                _ => ("时间", todo_due_chip(item)),
+            let time_text = match item.status {
+                TodoStatus::Completed => display_todo_completed_at(item),
+                _ => todo_due_chip(item),
             };
             let status =
                 with_status.then(|| crate::runtime::todo::status::status_cn_short(&item.status));
-            let mut line = format_todo_list_line(index, item, time_label, time_text, true, status);
-            if let Some(detail) = item
-                .detail
-                .as_deref()
-                .and_then(|value| clean_string(value.to_owned()))
-            {
-                line.push_str(&format!("\n{}", format_todo_detail_quote(&detail, true)));
-            }
-            vec![line]
+            vec![format_todo_natural_list_item(
+                index, item, time_text, true, status,
+            )]
         })
         .collect()
 }
@@ -525,23 +555,20 @@ fn format_completed_todo_rows_markdown(items: &[TodoItem]) -> Vec<String> {
 
 fn format_todo_rows_markdown_with_time(
     items: &[TodoItem],
-    time_label: &str,
+    _time_label: &str,
     time_value: fn(&TodoItem) -> Option<String>,
 ) -> Vec<String> {
     items
         .iter()
         .enumerate()
         .flat_map(|(index, item)| {
-            let mut line =
-                format_todo_list_line(index, item, time_label, time_value(item), true, None);
-            if let Some(detail) = item
-                .detail
-                .as_deref()
-                .and_then(|value| clean_string(value.to_owned()))
-            {
-                line.push_str(&format!("\n{}", format_todo_detail_quote(&detail, true)));
-            }
-            vec![line]
+            vec![format_todo_natural_list_item(
+                index,
+                item,
+                time_value(item),
+                true,
+                None,
+            )]
         })
         .collect()
 }

--- a/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
@@ -18,7 +18,7 @@ use crate::{
                 OutcomePresentation, ResponseBlock, ToolEffect, ToolExecutionOutcome,
                 ToolOutcomeStatus,
             },
-            common::{CommandBody, clean_string, todo_error, truncate_chars},
+            common::{CommandBody, todo_error, truncate_chars},
         },
         session::SessionRecord,
         todo::{TodoItem, TodoOwner, TodoStatus, TodoStore},
@@ -26,9 +26,9 @@ use crate::{
 };
 
 use super::format::{
-    append_todo_collapse_hint, format_todo_detail_quote, format_todo_inline,
-    format_todo_inline_markdown, format_todo_list_line, todo_due_chip, todo_reminder_chip,
-    todo_timestamp_chip, visible_todo_all_board_items, visible_todo_items,
+    append_todo_collapse_hint, format_todo_full_detail_line, format_todo_natural_list_item,
+    format_todo_receipt_item_line, todo_due_chip, todo_timestamp_chip,
+    visible_todo_all_board_items, visible_todo_items,
 };
 
 const LIST_TODOS_TOOL_NAME: &str = "list_todos";
@@ -59,7 +59,6 @@ struct RelatedListSpec {
     due_date: Option<NaiveDate>,
     title: &'static str,
     empty_text: &'static str,
-    time_label: &'static str,
     time_value: fn(&TodoItem) -> Option<String>,
 }
 
@@ -323,15 +322,17 @@ fn todo_detail_body(output: &Value) -> CommandBody {
     let display_time = string_value(item, "display_time").filter(|value| !value.trim().is_empty());
     let detail = string_value(item, "detail");
 
-    let mut lines = vec![format!("📌 {title}"), format!("状态：{status_label}")];
-    let mut markdown_lines = vec![format!("# 📌 {title}"), format!("**状态**：{status_label}")];
+    let mut lines = vec![title];
+    let mut markdown_lines = vec![format!("# {}", lines[0])];
+    lines.push(format!("状态：{status_label}"));
+    markdown_lines.push(format!("**状态**：{status_label}"));
     if let Some(time) = display_time {
         lines.push(format!("时间：{time}"));
         markdown_lines.push(format!("**时间**：{time}"));
     }
     if let Some(detail) = detail {
-        lines.push(format!("详情：{detail}"));
-        markdown_lines.push(format!("**详情**：{detail}"));
+        lines.push(format_todo_full_detail_line(&detail, false));
+        markdown_lines.push(format_todo_full_detail_line(&detail, true));
     }
     CommandBody::dual(lines.join("\n"), markdown_lines.join("\n"))
 }
@@ -755,27 +756,13 @@ fn append_related_list(
         format!("{} · 共 {} 项", spec.title, total_count)
     });
     for (index, item) in items.iter().enumerate() {
-        if markdown {
-            rows.push(format_todo_list_line(
-                index,
-                item,
-                spec.time_label,
-                (spec.time_value)(item),
-                true,
-                None,
-            ));
-            append_related_detail(rows, item, true);
-        } else {
-            rows.push(format_todo_list_line(
-                index,
-                item,
-                spec.time_label,
-                (spec.time_value)(item),
-                false,
-                None,
-            ));
-            append_related_detail(rows, item, false);
-        }
+        rows.push(format_todo_natural_list_item(
+            index,
+            item,
+            (spec.time_value)(item),
+            markdown,
+            None,
+        ));
     }
     if truncated {
         let (range_label, command) = collapse_prompt_for_related_spec(spec);
@@ -786,17 +773,6 @@ fn append_related_list(
             command,
         );
     }
-}
-
-fn append_related_detail(rows: &mut Vec<String>, item: &TodoItem, markdown: bool) {
-    let Some(detail) = item
-        .detail
-        .as_deref()
-        .and_then(|value| clean_string(value.to_owned()))
-    else {
-        return;
-    };
-    rows.push(format_todo_detail_quote(&detail, markdown));
 }
 
 fn collapse_prompt_for_related_spec(
@@ -861,7 +837,6 @@ fn pending_list_spec() -> RelatedListSpec {
         due_date: None,
         title: "🚧 当前进行中",
         empty_text: "当前没有进行中的待办。",
-        time_label: "时间",
         time_value: todo_due_chip,
     }
 }
@@ -874,7 +849,6 @@ fn completed_list_spec() -> RelatedListSpec {
         due_date: None,
         title: "✅ 当前已完成",
         empty_text: "当前没有已完成待办。",
-        time_label: "完成时间",
         time_value: display_todo_completed_at,
     }
 }
@@ -887,7 +861,6 @@ fn cancelled_list_spec() -> RelatedListSpec {
         due_date: None,
         title: "⛔ 当前已取消",
         empty_text: "当前没有已取消待办。",
-        time_label: "取消时间",
         time_value: display_todo_cancelled_at,
     }
 }
@@ -920,7 +893,6 @@ fn all_list_spec() -> RelatedListSpec {
         due_date: None,
         title: "📋 全部待办",
         empty_text: "当前没有待办。",
-        time_label: "时间",
         time_value: todo_due_chip,
     }
 }
@@ -1014,25 +986,11 @@ fn success_count_markdown_lines(
 }
 
 fn affected_item_line(item: &TodoItem) -> String {
-    let mut line = format!("- {}", format_todo_inline(item));
-    if let Some(time) = todo_due_chip(item) {
-        line.push_str(&format!(" · 时间：{time}"));
-    }
-    if let Some(reminder) = todo_reminder_chip(item) {
-        line.push_str(&format!("（提醒: {reminder}）"));
-    }
-    line
+    format_todo_receipt_item_line(item, false).join("\n")
 }
 
 fn affected_item_line_markdown(item: &TodoItem) -> String {
-    let mut line = format!("- {}", format_todo_inline_markdown(item));
-    if let Some(time) = todo_due_chip(item) {
-        line.push_str(&format!(" · **时间**：{time}"));
-    }
-    if let Some(reminder) = todo_reminder_chip(item) {
-        line.push_str(&format!("（提醒: {reminder}）"));
-    }
-    line
+    format_todo_receipt_item_line(item, true).join("\n")
 }
 
 #[derive(Debug, Clone)]
@@ -1146,13 +1104,13 @@ fn append_todo_detail_card_lines(
         && let Some(reminder) = todo_timestamp_chip(reminder_at)
     {
         lines.push(if markdown {
-            format!("**提醒时间**：{reminder}")
+            format!("**提醒**：{reminder}")
         } else {
-            format!("提醒时间：{reminder}")
+            format!("提醒：{reminder}")
         });
     }
     if let Some(detail) = item.detail.as_deref() {
-        lines.push(format_todo_detail_quote(detail, markdown));
+        lines.push(format_todo_full_detail_line(detail, markdown));
     }
     if item.status.as_deref() == Some("completed")
         && let Some(completed_at) = item.completed_at.as_deref()


### PR DESCRIPTION
## 变更
- 待办时间 chip 不再使用 Markdown 行内 code 反引号，改为纯文本日期和星期展示。
- 更新公共时间格式测试和 Core 待办回执测试断言。

## 原因
Todo 列表和回执会把时间字段作为动态文本走 escape_markdown_inline，反引号会被转义，和 RSS 模板中直接拼接 Markdown code 的路径不同。改为纯文本后避免依赖 QQ Markdown 对行内 code 的处理。

## 验证
- cargo fmt --all -- --check
- cargo test -p qq-maid-common formats_and_parses_local_timestamp_dates
- cargo test -p qq-maid-core todo_create_receipt_shows_full_user_visible_card
- cargo test -p qq-maid-core todo_edit_receipt_shows_final_detail_card
- cargo test -p qq-maid-core todo_complete_receipt_reuses_full_user_visible_card

未跑完整 workspace CI。