### PR TITLE
[codex] 兼容 OpenAI 流式结束帧

### DIFF
--- a/qq-maid-llm/src/provider/openai/chat.rs
+++ b/qq-maid-llm/src/provider/openai/chat.rs
@@ -328,21 +328,27 @@ fn handle_chat_stream_event(
     };
     let mut finish_reason = None;
     for choice in choices {
-        if let Some(delta) = choice
-            .get("delta")
-            .and_then(|delta| extract_content_value(delta.get("content")))
-            && !delta.is_empty()
-        {
-            recorder.mark_token();
-            answer.push_str(&delta);
-            events.push(LlmStreamEvent::TextDelta(delta));
+        if let Some(delta_value) = choice.get("delta") {
+            let content = delta_value.get("content");
+            if let Some(delta) = extract_content_value(content)
+                && !delta.is_empty()
+            {
+                recorder.mark_token();
+                answer.push_str(&delta);
+                events.push(LlmStreamEvent::TextDelta(delta));
+            } else if content.is_some_and(|value| !value.is_null()) {
+                trace_ignored_chat_stream_content("delta.content", content);
+            }
         }
-        if let Some(message) = choice
-            .get("message")
-            .and_then(|message| extract_content_value(message.get("content")))
-            && !message.is_empty()
-        {
-            final_message.push_str(&message);
+        if let Some(message_value) = choice.get("message") {
+            let content = message_value.get("content");
+            if let Some(message) = extract_content_value(content)
+                && !message.is_empty()
+            {
+                final_message.push_str(&message);
+            } else if content.is_some_and(|value| !value.is_null()) {
+                trace_ignored_chat_stream_content("message.content", content);
+            }
         }
         if let Some(reason) = choice.get("finish_reason").and_then(Value::as_str)
             && !reason.trim().is_empty()
@@ -521,6 +527,25 @@ fn extract_content_value(value: Option<&Value>) -> Option<String> {
     }
 }
 
+fn trace_ignored_chat_stream_content(field: &str, value: Option<&Value>) {
+    let Some(value) = value else {
+        return;
+    };
+    let kind = match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array_without_text",
+        Value::Object(_) => "object",
+    };
+    tracing::trace!(
+        field,
+        kind,
+        "ignored non-text Chat Completions stream content"
+    );
+}
+
 pub(super) fn extract_chat_completion_usage(body: &Value) -> Option<TokenUsage> {
     let usage = body.get("usage")?;
     let input_tokens = usage
@@ -675,6 +700,36 @@ mod tests {
         .unwrap();
 
         assert_eq!(outcome.reply, "你好");
+        assert_eq!(outcome.usage.unwrap().total_tokens, Some(3));
+    }
+
+    #[tokio::test]
+    async fn stream_chat_completion_skips_null_and_non_body_chunks() {
+        let body = concat!(
+            "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":null}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n\n",
+            "data: {\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2,\"total_tokens\":3}}\n\n",
+            "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"content\":\"可以\"}}]}\n\n",
+            "data: [DONE]\n\n",
+        )
+        .to_owned();
+        let (base_url, _state) = spawn_mock_chat(vec![body], StatusCode::OK).await;
+        let client =
+            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+
+        let outcome = stream_completion(
+            &client,
+            "openai",
+            "gpt-test",
+            1200,
+            &[ChatMessage::user("hi")],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome.reply, "可以");
+        assert!(!outcome.reply.starts_with("null"));
         assert_eq!(outcome.usage.unwrap().total_tokens, Some(3));
     }
 

--- a/qq-maid-llm/src/provider/openai/responses.rs
+++ b/qq-maid-llm/src/provider/openai/responses.rs
@@ -178,6 +178,9 @@ async fn next_responses_stream_event(
             }) else {
                 continue;
             };
+            if is_openai_stream_done_sentinel(&event.data) {
+                continue;
+            }
             state.recorder.mark_event();
             match handle_openai_chat_stream_event(
                 event,
@@ -210,17 +213,19 @@ async fn next_responses_stream_event(
                         continue;
                     };
                     state.frame_buffer.clear();
-                    state.recorder.mark_event();
-                    match handle_openai_chat_stream_event(
-                        event,
-                        &mut state.recorder,
-                        &mut state.answer,
-                        &mut state.completed_response,
-                        &mut state.saw_completed,
-                    ) {
-                        Ok(Some(delta)) => return Some(Ok(LlmStreamEvent::TextDelta(delta))),
-                        Ok(None) => {}
-                        Err(err) => return Some(Err(err)),
+                    if !is_openai_stream_done_sentinel(&event.data) {
+                        state.recorder.mark_event();
+                        match handle_openai_chat_stream_event(
+                            event,
+                            &mut state.recorder,
+                            &mut state.answer,
+                            &mut state.completed_response,
+                            &mut state.saw_completed,
+                        ) {
+                            Ok(Some(delta)) => return Some(Ok(LlmStreamEvent::TextDelta(delta))),
+                            Ok(None) => {}
+                            Err(err) => return Some(Err(err)),
+                        }
                     }
                 }
                 if state.answer.trim().is_empty()
@@ -260,6 +265,11 @@ async fn next_responses_stream_event(
             }
         }
     }
+}
+
+fn is_openai_stream_done_sentinel(data: &str) -> bool {
+    // OpenAI/兼容网关会用非 JSON 的 `[DONE]` 作为 SSE 结束哨兵，不能交给 JSON parser。
+    data.trim() == "[DONE]"
 }
 
 pub(crate) fn incomplete_stream_eof_error(message: &str, answer: &str) -> LlmError {
@@ -408,5 +418,99 @@ mod tests {
         let outcome = openai_responses_stream_chat(&req).await.unwrap();
 
         assert_eq!(outcome.reply, "你好");
+    }
+
+    #[tokio::test]
+    async fn openai_responses_stream_skips_done_between_delta_and_completed() {
+        let (base_url, _state) = spawn_mock_responses(
+            concat!(
+                "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"你好\"}\n\n",
+                "data: [DONE]\n\n",
+                "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"output_text\":\"你好\"}}\n\n",
+            )
+            .to_owned(),
+            StatusCode::OK,
+        )
+        .await;
+        let client = reqwest::Client::new();
+        let messages = [ChatMessage::user("hi")];
+        let req = stream_req(&client, &base_url, &messages);
+
+        let outcome = openai_responses_stream_chat(&req).await.unwrap();
+
+        assert_eq!(outcome.reply, "你好");
+    }
+
+    #[tokio::test]
+    async fn openai_responses_stream_skips_done_after_completed_at_eof() {
+        let (base_url, _state) = spawn_mock_responses(
+            concat!(
+                "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"你好\"}\n\n",
+                "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"output_text\":\"你好\"}}\n\n",
+                "data: [DONE]",
+            )
+            .to_owned(),
+            StatusCode::OK,
+        )
+        .await;
+        let client = reqwest::Client::new();
+        let messages = [ChatMessage::user("hi")];
+        let req = stream_req(&client, &base_url, &messages);
+
+        let outcome = openai_responses_stream_chat(&req).await.unwrap();
+
+        assert_eq!(outcome.reply, "你好");
+    }
+
+    #[tokio::test]
+    async fn openai_responses_stream_skips_null_and_metadata_before_text() {
+        let (base_url, _state) = spawn_mock_responses(
+            concat!(
+                "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_test\"}}\n\n",
+                "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":null}\n\n",
+                "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\"}\n\n",
+                "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"可以\"}\n\n",
+                "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"output_text\":\"可以\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n",
+            )
+            .to_owned(),
+            StatusCode::OK,
+        )
+        .await;
+        let client = reqwest::Client::new();
+        let messages = [ChatMessage::user("hi")];
+        let req = stream_req(&client, &base_url, &messages);
+
+        let outcome = openai_responses_stream_chat(&req).await.unwrap();
+
+        assert_eq!(outcome.reply, "可以");
+        assert!(!outcome.reply.starts_with("null"));
+        assert_eq!(outcome.usage.unwrap().total_tokens, Some(2));
+    }
+
+    #[tokio::test]
+    async fn openai_responses_non_stream_still_extracts_text_and_usage() {
+        let (base_url, state) = spawn_mock_responses(
+            serde_json::json!({
+                "output_text": "non stream ok",
+                "usage": {
+                    "input_tokens": 1,
+                    "output_tokens": 2,
+                    "total_tokens": 3
+                }
+            })
+            .to_string(),
+            StatusCode::OK,
+        )
+        .await;
+        let client = reqwest::Client::new();
+        let messages = [ChatMessage::user("hi")];
+        let mut req = stream_req(&client, &base_url, &messages);
+        req.stream = false;
+
+        let outcome = openai_responses_non_stream_chat(&req).await.unwrap();
+
+        assert_eq!(outcome.reply, "non stream ok");
+        assert_eq!(outcome.usage.unwrap().total_tokens, Some(3));
+        assert_eq!(state.lock().await.calls, 1);
     }
 }

--- a/qq-maid-llm/src/provider/openai/stream.rs
+++ b/qq-maid-llm/src/provider/openai/stream.rs
@@ -35,6 +35,8 @@ pub(crate) fn handle_openai_chat_stream_event(
                 recorder.mark_token();
                 answer.push_str(delta);
                 return Ok(Some(delta.to_owned()));
+            } else if value.get("delta").is_some_and(|delta| !delta.is_null()) {
+                trace_ignored_responses_stream_delta(event_type, value.get("delta"));
             }
         }
         "response.completed" => {
@@ -50,6 +52,25 @@ pub(crate) fn handle_openai_chat_stream_event(
     }
 
     Ok(None)
+}
+
+fn trace_ignored_responses_stream_delta(event_type: &str, delta: Option<&Value>) {
+    let Some(delta) = delta else {
+        return;
+    };
+    let kind = match delta {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "empty_string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    };
+    tracing::trace!(
+        event_type,
+        kind,
+        "ignored non-text OpenAI Responses stream delta"
+    );
 }
 
 fn stream_error_message(value: &Value) -> Option<String> {


### PR DESCRIPTION
## 变更

- 兼容 OpenAI/兼容网关在 SSE 中发送的 `[DONE]` 结束哨兵，避免非 JSON 帧被当作错误解析。
- 跳过 Chat Completions / Responses 流里的 `null`、metadata 或非文本 delta/content，不再把它们拼进用户回复。
- 补充 OpenAI stream 相关回归测试，覆盖 `[DONE]`、空 delta、非流式 usage 提取等情况。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p qq-maid-llm openai`
- `git diff --cached --check`