### PR TITLE
[codex] 修复群聊触发与工具路由

### DIFF
--- a/qq-maid-core/src/runtime/respond/agent_outcome.rs
+++ b/qq-maid-core/src/runtime/respond/agent_outcome.rs
@@ -229,6 +229,15 @@ impl AgentTurnOutcome {
                 .all(|outcome| outcome.presentation != OutcomePresentation::Unhandled)
     }
 
+    pub(in crate::runtime::respond) fn should_preserve_model_reply(&self) -> bool {
+        !self.blocks.is_empty()
+            && self.outcomes.iter().all(|outcome| {
+                outcome.effect == ToolEffect::ReadOnly
+                    && outcome.status == ToolOutcomeStatus::Succeeded
+                    && outcome.presentation != OutcomePresentation::Unhandled
+            })
+    }
+
     pub(in crate::runtime::respond) fn has_unhandled_outcome(&self) -> bool {
         self.outcomes
             .iter()
@@ -567,5 +576,37 @@ mod tests {
         let fact_pos = body.text.find("🚄 已查到车次").unwrap();
         let todo_pos = body.text.find("✅ 已新增待办").unwrap();
         assert!(fact_pos < todo_pos);
+    }
+
+    #[test]
+    fn readonly_success_preserves_model_reply() {
+        let turn = AgentTurnOutcome::from_outcomes(vec![outcome(
+            "get_weather",
+            "weather",
+            ToolOutcomeStatus::Succeeded,
+            ToolEffect::ReadOnly,
+            vec![ResponseBlock::FactCard(CommandBody::plain(
+                "🌦 岱山天气\n当前多云",
+            ))],
+        )]);
+
+        assert!(turn.can_replace_model_reply());
+        assert!(turn.should_preserve_model_reply());
+    }
+
+    #[test]
+    fn mutation_success_still_replaces_model_reply() {
+        let turn = AgentTurnOutcome::from_outcomes(vec![outcome(
+            "create_todo",
+            "todo",
+            ToolOutcomeStatus::Succeeded,
+            ToolEffect::Created,
+            vec![ResponseBlock::MutationReceipt(CommandBody::plain(
+                "✅ 已新增待办",
+            ))],
+        )]);
+
+        assert!(turn.can_replace_model_reply());
+        assert!(!turn.should_preserve_model_reply());
     }
 }

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -165,7 +165,11 @@ impl RustRespondService {
             let turn_outcome =
                 build_agent_turn_outcome(&self.todo_store, &mut session, &owner, &output)?;
             let validation = if turn_outcome.can_replace_model_reply() {
-                apply_agent_turn_outcome(&mut output, &turn_outcome);
+                if turn_outcome.should_preserve_model_reply() {
+                    apply_agent_turn_outcome_with_model_reply(&mut output, &turn_outcome);
+                } else {
+                    apply_agent_turn_outcome(&mut output, &turn_outcome);
+                }
                 todo_success_validation_from_agent_outcome(&turn_outcome)
             } else if turn_outcome.has_unhandled_outcome() && !turn_outcome.outcomes.is_empty() {
                 apply_agent_turn_compat_output(&mut output, &turn_outcome);
@@ -588,6 +592,33 @@ fn apply_agent_turn_outcome(
     output.reply = body.markdown.clone().unwrap_or_else(|| body.text.clone());
     output.text = body.text;
     output.markdown = body.markdown;
+    output.chat.reply = Some(output.reply.clone());
+}
+
+fn apply_agent_turn_outcome_with_model_reply(
+    output: &mut super::llm_service::RespondOutput,
+    outcome: &AgentTurnOutcome,
+) {
+    let body = outcome.render_body();
+    let model_text = output.reply.trim();
+    if model_text.is_empty() {
+        apply_agent_turn_outcome(output, outcome);
+        return;
+    }
+
+    let text = if body.text.trim().is_empty() {
+        model_text.to_owned()
+    } else {
+        format!("{}\n\n{}", body.text.trim(), model_text)
+    };
+    let markdown = body
+        .markdown
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .map(|markdown| format!("{}\n\n{}", markdown.trim(), model_text));
+    output.reply = markdown.clone().unwrap_or_else(|| text.clone());
+    output.text = text;
+    output.markdown = markdown;
     output.chat.reply = Some(output.reply.clone());
 }
 

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -218,7 +218,7 @@ async fn private_tool_loop_can_query_train_schedule_with_trusted_rendering() {
         .with_tool_call_json(
             "get_train_schedule",
             r#"{"train_code":"g1","travel_date":"2026-06-28"}"#,
-            "模型原始火车回复不应直接展示",
+            "这趟车早上发车，适合当天安排。",
         );
     let train = MockTrainExecutor::new();
     let train_inspector = train.clone();
@@ -257,7 +257,7 @@ async fn private_tool_loop_can_query_train_schedule_with_trusted_rendering() {
     assert!(text.contains("G1 列车时刻"));
     assert!(text.contains("北京南"));
     assert!(text.contains("上海虹桥"));
-    assert!(!text.contains("模型原始火车回复不应直接展示"));
+    assert!(text.contains("这趟车早上发车，适合当天安排。"));
     assert_eq!(response.command.as_deref(), Some("train"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(
@@ -268,13 +268,100 @@ async fn private_tool_loop_can_query_train_schedule_with_trusted_rendering() {
 }
 
 #[tokio::test]
+async fn mixed_train_and_todo_request_is_not_captured_by_todo_date_query() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_calls_json(
+            vec![
+                (
+                    "get_train_schedule",
+                    r#"{"train_code":"g1","travel_date":"明天"}"#,
+                ),
+                (
+                    "create_todo",
+                    r#"{"content":"查看明天 G1 车次","title":null,"detail":null,"due_date":null,"due_at":null,"time_precision":null}"#,
+                ),
+            ],
+            "G1 可查，已新增待办",
+        );
+    let train = MockTrainExecutor::new();
+    let train_inspector = train.clone();
+    let (service, _) = test_service_with_provider_base_title_query_weather_train_models_and_options(
+        inspector.clone(),
+        None,
+        std::sync::Arc::new(MockQueryExecutor),
+        std::sync::Arc::new(MockWeatherExecutor::new()),
+        std::sync::Arc::new(train),
+        TestModelOptions {
+            todo_model: None,
+            memory_model: None,
+            compact_model: None,
+            translation_model: None,
+        },
+        TestToolCallingOptions {
+            enabled: true,
+            group_enabled: false,
+        },
+    );
+
+    let response = service
+        .respond(private_message(
+            "明天有没有g1，我想看看，如果有车，我要加个待办，是上海到北京么",
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(inspector.tool_call_count(), 1);
+    assert_ne!(response.command.as_deref(), Some("todo_due_date"));
+    let text = response.text.as_deref().unwrap();
+    assert!(!text.contains("这一天暂无未完成待办"));
+    assert!(text.contains("G1 列车时刻"));
+    assert!(text.contains("✅ 已新增待办"));
+    let train_requests = train_inspector.requests();
+    assert_eq!(train_requests.len(), 1);
+    assert_eq!(train_requests[0].train_code, "G1");
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let todos = service.todo_store.list_pending(&owner).unwrap();
+    assert_eq!(todos.len(), 1);
+    assert_eq!(todos[0].title, "查看明天 G1 车次");
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(
+        diagnostics["tool_loop_executed_tools"],
+        serde_json::json!(["get_train_schedule", "create_todo"])
+    );
+}
+
+#[tokio::test]
+async fn conditional_external_query_is_not_captured_by_todo_date_query() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_loop_reply_without_tool("需要先确认具体车次或可查询来源。");
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("明天上海到北京有高铁吗，有的话提醒我"))
+        .await
+        .unwrap();
+
+    assert_eq!(inspector.tool_call_count(), 1);
+    assert_ne!(response.command.as_deref(), Some("todo_due_date"));
+    assert!(
+        !response
+            .text
+            .as_deref()
+            .unwrap()
+            .contains("这一天暂无未完成待办")
+    );
+}
+
+#[tokio::test]
 async fn private_tool_loop_can_query_recent_rss_items_with_trusted_rendering() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
         .with_tool_call_json(
             "get_rss_recent_items",
             r#"{"query":"codex","limit":1}"#,
-            "模型原始 RSS 回复不应直接展示",
+            "这条更新主要值得关注工具调用改进。",
         );
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
     let target = RssTarget {
@@ -322,7 +409,7 @@ async fn private_tool_loop_can_query_recent_rss_items_with_trusted_rendering() {
     assert!(text.contains("Codex CLI 0.42 发布"));
     assert!(text.contains("这次发布改进了工具调用和日志展示"));
     assert!(text.contains("本地已轮询入库记录"));
-    assert!(!text.contains("模型原始 RSS 回复不应直接展示"));
+    assert!(text.contains("这条更新主要值得关注工具调用改进。"));
     assert_eq!(response.command.as_deref(), Some("rss"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(
@@ -1123,6 +1210,58 @@ async fn weather_success_and_todo_success_are_both_rendered_in_order() {
     assert_eq!(diagnostics["tool_outcomes"][0]["presentation"], "trusted");
     assert_eq!(diagnostics["tool_outcomes"][1]["domain"], "todo");
     assert_eq!(diagnostics["tool_outcomes"][1]["presentation"], "trusted");
+}
+
+#[tokio::test]
+async fn readonly_weather_result_preserves_model_advice() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json(
+            "get_weather",
+            r#"{"city":"杭州","forecast_days":3}"#,
+            "湿度偏高，户外运动建议降低强度，优先选清晨或室内。",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("杭州天气怎么样，是不是要运动"))
+        .await
+        .unwrap();
+
+    assert_eq!(inspector.tool_call_count(), 1);
+    let text = response.text.as_deref().unwrap();
+    assert!(text.contains("杭州天气"));
+    assert!(text.contains("湿度偏高，户外运动建议降低强度"));
+    assert_eq!(response.command.as_deref(), Some("weather"));
+}
+
+#[tokio::test]
+async fn conditional_weather_and_todo_request_uses_tool_loop() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_calls_json(
+            vec![
+                ("get_weather", r#"{"city":"杭州","forecast_days":3}"#),
+                (
+                    "create_todo",
+                    r#"{"content":"明天带伞","title":null,"detail":null,"due_date":null,"due_at":null,"time_precision":null}"#,
+                ),
+            ],
+            "明天可能有雨，已新增带伞待办",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("如果明天下雨，帮我加个带伞的待办"))
+        .await
+        .unwrap();
+
+    assert_eq!(inspector.tool_call_count(), 1);
+    assert_ne!(response.command.as_deref(), Some("todo_due_date"));
+    let text = response.text.as_deref().unwrap();
+    assert!(!text.contains("这一天暂无未完成待办"));
+    assert!(text.contains("杭州天气"));
+    assert!(text.contains("✅ 已新增待办"));
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tests/todo.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo.rs
@@ -374,11 +374,23 @@ async fn natural_todo_date_query_filters_pending_by_local_due_date() {
     assert_eq!(snapshot.condition, today_text);
     assert_eq!(snapshot.result_ids, vec![today_date.id, today_datetime.id]);
 
-    let tomorrow_response = service.respond(message("明天要做什么")).await.unwrap();
+    let tomorrow_response = service.respond(message("明天有什么待办")).await.unwrap();
     assert_eq!(tomorrow_response.command.as_deref(), Some("todo_due_date"));
     let tomorrow_text_reply = tomorrow_response.text.unwrap();
     assert!(tomorrow_text_reply.contains("明天事项"));
     assert!(!tomorrow_text_reply.contains("今天日期型"));
+
+    let plain_chat_response = service.respond(message("明天要做什么")).await.unwrap();
+    assert_ne!(
+        plain_chat_response.command.as_deref(),
+        Some("todo_due_date")
+    );
+
+    let short_response = service.respond(message("明天待办")).await.unwrap();
+    assert_eq!(short_response.command.as_deref(), Some("todo_due_date"));
+    let short_text_reply = short_response.text.unwrap();
+    assert!(short_text_reply.contains("明天事项"));
+    assert!(!short_text_reply.contains("今天日期型"));
 
     let explicit_response = service
         .respond(message(&format!(

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -849,7 +849,7 @@ fn normalize_pure_todo_query_pattern(text: &str) -> String {
         .chars()
         .filter(|ch| !ch.is_whitespace() && !is_query_punctuation(*ch))
         .collect::<String>();
-    while normalized.ends_with(|ch| matches!(ch, '吗' | '呢' | '啊' | '呀' | '吧' | '嘛')) {
+    while normalized.ends_with(['吗', '呢', '啊', '呀', '吧', '嘛']) {
         normalized.pop();
     }
     normalized

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -98,8 +98,10 @@ const TODO_QUERY_WRITE_MARKERS: &[&str] = &[
     "增加",
     "创建",
     "记下",
+    "加个",
     "加一个",
     "加一条",
+    "加一项",
     "加到",
     "完成",
     "取消",
@@ -707,6 +709,11 @@ fn detect_natural_todo_query(user_text: &str) -> Option<NaturalTodoQuery> {
         || mentions_pending
         || mentions_pending_by_negated_completed
         || mentions_negated_cancelled;
+    if contains_todo_due_date_write_marker(&text, mentions_pending_by_negated_completed)
+        && !mentions_state
+    {
+        return None;
+    }
     if !(mentions_todo || mentions_list && mentions_state) {
         return None;
     }
@@ -779,28 +786,96 @@ fn detect_natural_todo_due_date_query(text: &str) -> Option<TodoDueDateQuery> {
     if mentions_cancelled || mentions_completed && !mentions_pending_by_negated_completed {
         return None;
     }
-    let mentions_todo = contains_any(text, TODO_QUERY_NOUNS);
-    let asks_list = TODO_QUERY_LIST_VERBS
-        .iter()
-        .any(|needle| text.contains(needle));
-    let asks_daily_work = [
-        "要做什么",
-        "要做啥",
-        "有什么事",
-        "有哪些事",
-        "有什么安排",
-        "有哪些安排",
-    ]
-    .iter()
-    .any(|needle| text.contains(needle));
-    if mentions_todo
-        || asks_list && (text.contains("有哪些") || text.contains("有什么"))
-        || asks_daily_work
-    {
+    // 日期待办查询是 Tool Loop 前的确定性短路，只允许少量完整句式命中。
+    // 不再用“日期 + 通用疑问词”猜测，避免普通聊天和跨工具任务被抢走。
+    if is_pure_todo_due_date_query(text, &date_query) {
         Some(date_query)
     } else {
         None
     }
+}
+
+fn is_pure_todo_due_date_query(text: &str, date_query: &TodoDueDateQuery) -> bool {
+    let text = normalize_pure_todo_query_pattern(text);
+    pure_todo_due_date_query_patterns(date_query)
+        .into_iter()
+        .any(|pattern| text == pattern)
+}
+
+fn pure_todo_due_date_query_patterns(date_query: &TodoDueDateQuery) -> Vec<String> {
+    let mut patterns = Vec::new();
+    for date in todo_due_date_query_date_tokens(date_query) {
+        for pattern in [
+            format!("{date}待办"),
+            format!("我的{date}待办"),
+            format!("查看{date}待办"),
+            format!("查询{date}待办"),
+            format!("列出{date}待办"),
+            format!("查看{date}的待办"),
+            format!("查询{date}的待办"),
+            format!("列出{date}的待办"),
+            format!("{date}未完成待办"),
+            format!("查看{date}未完成待办"),
+            format!("{date}有什么待办"),
+            format!("{date}有哪些待办"),
+            format!("{date}有什么任务"),
+            format!("{date}有哪些任务"),
+            format!("{date}有什么未完成待办"),
+            format!("{date}有哪些未完成待办"),
+            format!("{date}有什么未完成任务"),
+            format!("{date}有哪些未完成任务"),
+        ] {
+            patterns.push(pattern);
+        }
+    }
+    patterns
+}
+
+fn todo_due_date_query_date_tokens(date_query: &TodoDueDateQuery) -> Vec<String> {
+    let mut tokens = Vec::new();
+    for value in [&date_query.label, &date_query.condition] {
+        let token = normalize_pure_todo_query_pattern(value);
+        if !token.is_empty() && !tokens.contains(&token) {
+            tokens.push(token);
+        }
+    }
+    tokens
+}
+
+fn normalize_pure_todo_query_pattern(text: &str) -> String {
+    let mut normalized = text
+        .trim()
+        .replace("代办", "待办")
+        .chars()
+        .filter(|ch| !ch.is_whitespace() && !is_query_punctuation(*ch))
+        .collect::<String>();
+    while normalized.ends_with(|ch| matches!(ch, '吗' | '呢' | '啊' | '呀' | '吧' | '嘛')) {
+        normalized.pop();
+    }
+    normalized
+}
+
+fn is_query_punctuation(ch: char) -> bool {
+    ch.is_ascii_punctuation()
+        || matches!(
+            ch,
+            '，' | '。'
+                | '、'
+                | '：'
+                | '；'
+                | '？'
+                | '！'
+                | '（'
+                | '）'
+                | '【'
+                | '】'
+                | '《'
+                | '》'
+                | '“'
+                | '”'
+                | '‘'
+                | '’'
+        )
 }
 
 fn contains_todo_due_date_write_marker(

--- a/qq-maid-core/src/runtime/respond/tool_route.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route.rs
@@ -127,6 +127,10 @@ fn classify_semantic_route(text: &str) -> SemanticRoute {
         return SemanticRoute::ToolLoop;
     }
 
+    if mentions_inert_weather_topic(text) {
+        return SemanticRoute::PlainChat;
+    }
+
     if has_plain_chat_intent(text, &lower) {
         return SemanticRoute::PlainChat;
     }
@@ -188,21 +192,61 @@ fn has_memory_intent(text: &str, lower: &str) -> bool {
 }
 
 fn has_weather_intent(text: &str, _lower: &str) -> bool {
-    contains_any(
+    if contains_any(
         text,
         &[
-            "天气",
             "下雨",
             "有雨",
             "带伞",
-            "气温",
-            "温度",
             "冷吗",
             "热吗",
             "穿什么",
+            "几度",
+            "预报",
+            "预警",
             "台风",
         ],
-    )
+    ) {
+        return true;
+    }
+    if looks_like_city_weather_query(text) {
+        return true;
+    }
+    contains_any(text, &["天气", "气温", "温度"])
+        && contains_any(
+            text,
+            &[
+                "查",
+                "查询",
+                "看看",
+                "看下",
+                "看一下",
+                "怎么样",
+                "如何",
+                "多少",
+                "会不会",
+                "有没有",
+            ],
+        )
+}
+
+fn mentions_inert_weather_topic(text: &str) -> bool {
+    contains_any(text, &["天气", "气温", "温度"]) && !has_weather_intent(text, "")
+}
+
+fn looks_like_city_weather_query(text: &str) -> bool {
+    let compact = text.split_whitespace().collect::<String>();
+    let Some(city) = compact.strip_suffix("天气") else {
+        return false;
+    };
+    !city.is_empty()
+        && city.chars().count() <= 12
+        && !contains_any(
+            city,
+            &[
+                "聊聊", "讨论", "关于", "这个", "那个", "一说", "说到", "如果", "因为",
+            ],
+        )
 }
 
 fn has_train_intent(text: &str, _lower: &str) -> bool {
@@ -380,6 +424,11 @@ mod tests {
             "T3架构怎么设计",
             "D1版本说明",
             "GPT-5 怎么选模型",
+            "天气",
+            "今天天气真好",
+            "天气怎么设计",
+            "聊聊天气",
+            "温度参数怎么设计",
         ] {
             let decision = route_tool_loop(&request(input), context());
             assert_eq!(decision.route, ToolLoopRoute::PlainChat, "{input}");
@@ -394,10 +443,16 @@ mod tests {
             "新增待办，明天接老公",
             "编辑第三条，其他不动",
             "记一下我喜欢少糖",
+            "杭州天气",
+            "杭州天气如何",
             "杭州明天要带伞吗",
+            "明天会不会下雨",
             "查一下 G1 时刻",
             "G1 明天几点",
             "高铁 G1 时刻",
+            "明天有没有g1，我想看看，如果有车，我要加个待办，是上海到北京么",
+            "明天上海到北京有高铁吗，有的话提醒我",
+            "如果明天下雨，帮我加个带伞的待办",
             "查看上次 codex 发布的 rss",
         ] {
             let decision = route_tool_loop(&request(input), context());

--- a/qq-maid-gateway-rs/README.md
+++ b/qq-maid-gateway-rs/README.md
@@ -76,6 +76,7 @@ QQ_MAID_ENABLE_IMAGE=false
 QQ_MAID_GATEWAY_VERBOSE_LOG=false
 QQ_MAID_GROUP_MESSAGE_MODE=mention
 QQ_MAID_GROUP_ACTIVE_KEYWORDS=小女仆
+QQ_MAID_BOT_MENTION_IDS=
 RUST_LOG=info,qq_maid_gateway_rs=debug
 ```
 
@@ -87,6 +88,8 @@ QQ_SECRET=你的QQ机器人AppSecret
 ```
 
 普通群消息由 `QQ_MAID_GROUP_MESSAGE_MODE` 控制，默认 `mention` 保持有限触发；`off` 完全关闭普通群消息，`command` 只处理 `/` 或全角 `／` 开头的命令，`mention` 额外处理平台 @ 标记和回复机器人消息，`active` 只处理包含 `QQ_MAID_GROUP_ACTIVE_KEYWORDS` 指定提示词的普通群消息，提示词默认 `小女仆`，多个用英文逗号分隔。旧变量 `QQ_MAID_ENABLE_GROUP_MESSAGES` 仅在未设置新变量时兼容，`false` 映射为 `off`，`true` 映射为 `active`，未设置时默认 `mention`。群聊不会开放通用 Harness、文件处理或代码执行；Tool Calling 由 Core 的 `TOOL_CALLING_GROUP_ENABLED` 控制且默认关闭。gateway 只负责把群聊目标传给 Core，由 Core 按既有命令和普通聊天边界处理。
+
+普通群事件里的结构化 @ 目标不一定等于 AppID。Gateway 默认使用 `QQ_BOT_APP_ID`，并从 Gateway `READY` 事件里自动学习机器人自身 ID；如果线上观察到 `mention_count > 0` 仍被模式策略忽略，可临时用 `QQ_MAID_BOT_MENTION_IDS` 追加机器人 openid / member_openid 等稳定 mention 目标，多个用英文逗号分隔。不要把这些 ID 写入公开文档或提交到仓库。
 
 普通群消息会过滤自己发送的消息、可识别的其它机器人消息、空内容/无附件消息和重复 `message_id`，并使用群级与群成员级内存冷却避免刷屏；但发送给 Core 的 `scope_key` 仍保持 `group:<group_openid>`，避免把 RSS、会话等按当前 QQ 目标建模的能力意外拆成成员分片。
 

--- a/qq-maid-gateway-rs/src/config/mod.rs
+++ b/qq-maid-gateway-rs/src/config/mod.rs
@@ -39,6 +39,7 @@ pub enum GroupMessageMode {
 pub struct AppConfig {
     pub app_id: String,
     pub app_secret: String,
+    pub bot_mention_ids: Vec<String>,
     pub sandbox: bool,
     pub api_base: String,
     pub token_refresh_margin: Duration,
@@ -116,6 +117,7 @@ impl AppConfig {
     pub fn from_map(env: &HashMap<String, String>) -> Result<Self, ConfigError> {
         let app_id = required(env, "QQ_BOT_APP_ID", Some("QQ_APPID"))?;
         let app_secret = required(env, "QQ_BOT_APP_SECRET", Some("QQ_SECRET"))?;
+        let bot_mention_ids = parse_csv(env, "QQ_MAID_BOT_MENTION_IDS", &[]);
         let sandbox = parse_bool(env, "QQ_BOT_SANDBOX")?.unwrap_or(false);
         let default_api_base = if sandbox {
             DEFAULT_SANDBOX_API_BASE
@@ -182,6 +184,7 @@ impl AppConfig {
         Ok(Self {
             app_id,
             app_secret,
+            bot_mention_ids,
             sandbox,
             api_base,
             token_refresh_margin: Duration::from_secs(margin_seconds),
@@ -433,6 +436,7 @@ mod tests {
         );
         assert!(config.enable_markdown);
         assert!(!config.enable_image);
+        assert!(config.bot_mention_ids.is_empty());
         assert!(!config.enable_group_messages);
         assert!(!config.verbose_log);
         assert_eq!(config.group_message_mode, GroupMessageMode::Mention);
@@ -543,6 +547,17 @@ mod tests {
     }
 
     #[test]
+    fn bot_mention_ids_parse_csv() {
+        let config = AppConfig::from_map(&env_with_creds(&[(
+            "QQ_MAID_BOT_MENTION_IDS",
+            " bot-openid, member-openid , ",
+        )]))
+        .unwrap();
+
+        assert_eq!(config.bot_mention_ids, vec!["bot-openid", "member-openid"]);
+    }
+
+    #[test]
     fn supports_legacy_qq_variable_aliases() {
         let config = AppConfig::from_map(&env(&[
             ("QQ_APPID", "old-appid"),
@@ -574,6 +589,7 @@ mod tests {
             ("QQ_BOT_SANDBOX", "yes"),
             ("QQ_BOT_API_BASE", "https://example.test/"),
             ("QQ_BOT_TOKEN_REFRESH_MARGIN_SECONDS", "120"),
+            ("QQ_MAID_BOT_MENTION_IDS", "bot-openid,member-openid"),
             ("QQ_MAID_ENABLE_MARKDOWN", "true"),
             ("QQ_MAID_ENABLE_IMAGE", "1"),
             ("QQ_MAID_ENABLE_GROUP_MESSAGES", "yes"),
@@ -598,6 +614,7 @@ mod tests {
         assert!(config.sandbox);
         assert_eq!(config.api_base, "https://example.test");
         assert_eq!(config.token_refresh_margin, Duration::from_secs(120));
+        assert_eq!(config.bot_mention_ids, vec!["bot-openid", "member-openid"]);
         assert!(config.enable_markdown);
         assert!(config.enable_image);
         assert!(config.enable_group_messages);

--- a/qq-maid-gateway-rs/src/gateway/aggregator/actor.rs
+++ b/qq-maid-gateway-rs/src/gateway/aggregator/actor.rs
@@ -817,6 +817,7 @@ mod tests {
         let config = AppConfig {
             app_id: "appid".to_owned(),
             app_secret: "secret".to_owned(),
+            bot_mention_ids: Vec::new(),
             sandbox: false,
             api_base: "https://example.test".to_owned(),
             token_refresh_margin: Duration::from_secs(60),

--- a/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
@@ -283,6 +283,7 @@ fn test_config() -> AppConfig {
     AppConfig {
         app_id: "appid".to_owned(),
         app_secret: "secret".to_owned(),
+        bot_mention_ids: Vec::new(),
         sandbox: false,
         api_base: "https://example.test".to_owned(),
         token_refresh_margin: Duration::from_secs(60),

--- a/qq-maid-gateway-rs/src/gateway/bot_identity.rs
+++ b/qq-maid-gateway-rs/src/gateway/bot_identity.rs
@@ -1,0 +1,120 @@
+//! Gateway 侧机器人身份匹配。
+//!
+//! QQ 普通群消息里的 mention 目标不一定等于 AppID；运行时从 READY 事件里学习
+//! 当前机器人可比对的稳定 ID，并与配置中的兜底 ID 一起用于群消息 @ 判定。
+
+use std::{
+    collections::HashSet,
+    sync::{Arc, RwLock},
+};
+
+use serde_json::Value;
+use tracing::info;
+
+#[derive(Debug)]
+pub(crate) struct BotIdentity {
+    ids: RwLock<HashSet<String>>,
+}
+
+pub(crate) type SharedBotIdentity = Arc<BotIdentity>;
+
+impl BotIdentity {
+    pub(crate) fn new(app_id: &str, configured_ids: &[String]) -> Self {
+        let mut ids = HashSet::new();
+        insert_id(&mut ids, app_id);
+        for id in configured_ids {
+            insert_id(&mut ids, id);
+        }
+        Self {
+            ids: RwLock::new(ids),
+        }
+    }
+
+    pub(crate) fn contains(&self, value: &str) -> bool {
+        let value = value.trim();
+        !value.is_empty() && self.ids.read().unwrap().contains(value)
+    }
+
+    pub(crate) fn absorb_ready_payload(&self, payload: &Value) {
+        let mut learned = HashSet::new();
+        collect_ready_identity_candidates(payload, &mut learned);
+        if learned.is_empty() {
+            return;
+        }
+
+        let mut ids = self.ids.write().unwrap();
+        let before = ids.len();
+        ids.extend(learned);
+        let added = ids.len().saturating_sub(before);
+        if added > 0 {
+            info!(
+                learned_bot_identity_count = added,
+                total_bot_identity_count = ids.len(),
+                "learned QQ bot identity candidates from READY"
+            );
+        }
+    }
+}
+
+fn insert_id(ids: &mut HashSet<String>, value: &str) {
+    let value = value.trim();
+    if !value.is_empty() {
+        ids.insert(value.to_owned());
+    }
+}
+
+fn collect_ready_identity_candidates(payload: &Value, output: &mut HashSet<String>) {
+    for key in ["user", "bot", "self", "application", "bot_info"] {
+        if let Some(value) = payload.get(key) {
+            collect_identity_object(value, output);
+        }
+    }
+}
+
+fn collect_identity_object(value: &Value, output: &mut HashSet<String>) {
+    match value {
+        Value::Object(map) => {
+            for key in ["id", "openid", "user_openid", "member_openid", "bot_openid"] {
+                if let Some(id) = map.get(key).and_then(Value::as_str) {
+                    insert_id(output, id);
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_identity_object(item, output);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn identity_includes_configured_app_and_extra_ids() {
+        let identity = BotIdentity::new("appid", &["bot-openid".to_owned()]);
+
+        assert!(identity.contains("appid"));
+        assert!(identity.contains("bot-openid"));
+        assert!(!identity.contains("other"));
+    }
+
+    #[test]
+    fn identity_learns_ready_candidates_without_session_id() {
+        let identity = BotIdentity::new("appid", &[]);
+        identity.absorb_ready_payload(&json!({
+            "session_id": "session-should-not-match",
+            "user": {"id": "bot-id", "openid": "bot-openid"},
+            "application": {"id": "app-from-ready"}
+        }));
+
+        assert!(identity.contains("bot-id"));
+        assert!(identity.contains("bot-openid"));
+        assert!(identity.contains("app-from-ready"));
+        assert!(!identity.contains("session-should-not-match"));
+    }
+}

--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -598,6 +598,7 @@ mod tests {
         AppConfig {
             app_id: "app".to_owned(),
             app_secret: "secret".to_owned(),
+            bot_mention_ids: Vec::new(),
             sandbox: false,
             api_base: "https://example.test".to_owned(),
             token_refresh_margin: Duration::from_secs(60),

--- a/qq-maid-gateway-rs/src/gateway/dispatcher/actor.rs
+++ b/qq-maid-gateway-rs/src/gateway/dispatcher/actor.rs
@@ -28,8 +28,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use super::super::{
-    BotOutboundCache, ReplyCache, dedupe::MessageDedupe, group_filter::GroupCooldowns,
-    handle_c2c_message, handle_group_message, logging::mask_scope_key, ping::GatewayRuntimeStatus,
+    BotOutboundCache, ReplyCache, bot_identity::SharedBotIdentity, dedupe::MessageDedupe,
+    group_filter::GroupCooldowns, handle_c2c_message, handle_group_message,
+    logging::mask_scope_key, ping::GatewayRuntimeStatus,
 };
 use super::reject::run_reject_worker;
 use super::types::{
@@ -61,6 +62,7 @@ pub(super) struct RealMessageHandler {
     reply_cache: ReplyCache,
     group_outbound_cache: Arc<std::sync::Mutex<BotOutboundCache>>,
     group_cooldowns: Arc<std::sync::Mutex<GroupCooldowns>>,
+    bot_identity: SharedBotIdentity,
     runtime: GatewayRuntimeStatus,
 }
 
@@ -78,6 +80,7 @@ impl RealMessageHandler {
         reply_cache: ReplyCache,
         group_outbound_cache: Arc<std::sync::Mutex<BotOutboundCache>>,
         group_cooldowns: Arc<std::sync::Mutex<GroupCooldowns>>,
+        bot_identity: SharedBotIdentity,
         runtime: GatewayRuntimeStatus,
     ) -> Arc<dyn MessageHandler> {
         Arc::new(Self {
@@ -89,6 +92,7 @@ impl RealMessageHandler {
             reply_cache,
             group_outbound_cache,
             group_cooldowns,
+            bot_identity,
             runtime,
         })
     }
@@ -120,6 +124,7 @@ impl MessageHandler for RealMessageHandler {
                         &self.dedupe,
                         &self.group_outbound_cache,
                         &self.group_cooldowns,
+                        &self.bot_identity,
                         &self.runtime,
                     )
                     .await

--- a/qq-maid-gateway-rs/src/gateway/dispatcher/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/dispatcher/mod.rs
@@ -55,6 +55,7 @@ use tracing::warn;
 
 use super::{
     BotOutboundCache, ReplyCache,
+    bot_identity::SharedBotIdentity,
     dedupe::MessageDedupe,
     event::{C2cMessage, GroupMessage},
     group_filter::GroupCooldowns,
@@ -200,6 +201,7 @@ impl MessageDispatcher {
         reply_cache: ReplyCache,
         group_outbound_cache: Arc<std::sync::Mutex<BotOutboundCache>>,
         group_cooldowns: Arc<std::sync::Mutex<GroupCooldowns>>,
+        bot_identity: SharedBotIdentity,
         runtime: GatewayRuntimeStatus,
         shutdown_token: CancellationToken,
     ) -> Self {
@@ -221,6 +223,7 @@ impl MessageDispatcher {
             reply_cache,
             group_outbound_cache,
             group_cooldowns,
+            bot_identity,
             runtime.clone(),
         );
         let actor = DispatcherActor::new(

--- a/qq-maid-gateway-rs/src/gateway/dispatcher/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/dispatcher/tests.rs
@@ -91,6 +91,7 @@ fn test_config() -> AppConfig {
     AppConfig {
         app_id: "appid".to_owned(),
         app_secret: "secret".to_owned(),
+        bot_mention_ids: Vec::new(),
         sandbox: false,
         api_base: "https://example.test".to_owned(),
         token_refresh_margin: Duration::from_secs(60),

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -11,6 +11,7 @@ use std::{
 use tracing::{debug, info, warn};
 
 use super::{
+    bot_identity::SharedBotIdentity,
     cache::BotOutboundCache,
     dedupe::MessageDedupe,
     event::{GroupEventType, GroupMessage},
@@ -85,6 +86,7 @@ pub(super) async fn handle_group_message(
     dedupe: &MessageDedupe,
     group_outbound_cache: &Arc<Mutex<BotOutboundCache>>,
     group_cooldowns: &Arc<Mutex<GroupCooldowns>>,
+    bot_identity: &SharedBotIdentity,
     runtime: &GatewayRuntimeStatus,
 ) -> anyhow::Result<()> {
     log_group_message_received(&message, config.verbose_log);
@@ -107,7 +109,7 @@ pub(super) async fn handle_group_message(
         &config.group_active_keywords,
         &message,
         &respond_content,
-        &config.app_id,
+        bot_identity,
         group_outbound_cache,
     ) {
         let active_keyword_count = config.group_active_keywords.len();

--- a/qq-maid-gateway-rs/src/gateway/group_filter.rs
+++ b/qq-maid-gateway-rs/src/gateway/group_filter.rs
@@ -1,7 +1,7 @@
 //! 群消息过滤与冷却判定。
 //!
 //! 从 `gateway/mod.rs` 提取的纯判定逻辑，负责：
-//! - 自身 / bot 消息和空内容过滤（`should_ignore_group_message`）；
+//! - 自身 / bot 消息和普通空内容过滤（`should_ignore_group_message`）；
 //! - 按群消息模式（Off / Command / Mention / Active）决定是否处理（`should_process_group_message`）；
 //! - 群级和用户级冷却（`GroupCooldowns`）。
 //!
@@ -18,6 +18,7 @@ use tracing::debug;
 
 use super::{
     BotOutboundCache,
+    bot_identity::SharedBotIdentity,
     event::{GroupEventType, GroupMessage},
 };
 use crate::config::GroupMessageMode;
@@ -64,7 +65,7 @@ impl GroupCooldowns {
     }
 }
 
-/// 判断群消息是否应被忽略（自身消息、bot 消息、空内容）。
+/// 判断群消息是否应被忽略（自身消息、bot 消息、普通空内容）。
 ///
 /// `masked_group` 仅用于日志脱敏展示，不影响判定结果。
 pub(crate) fn should_ignore_group_message(
@@ -88,7 +89,7 @@ pub(crate) fn should_ignore_group_message(
         );
         return true;
     }
-    if respond_content.trim().is_empty() {
+    if message.event_type != GroupEventType::GroupAtMessage && respond_content.trim().is_empty() {
         debug!(
             message_id = %message.message_id,
             group = %masked_group,
@@ -101,8 +102,8 @@ pub(crate) fn should_ignore_group_message(
 
 /// 按群消息模式策略判断是否应处理该消息。
 ///
-/// `GroupAtMessage` 事件在没有结构化 mention 目标时兼容视为 @ 机器人；
-/// 若事件携带 mention 目标，则必须明确命中当前 bot app id。其余按模式：
+/// `GroupAtMessage` 是 QQ 官方“机器人被 @”事件，直接视为 @ 机器人。
+/// 其余普通群消息按模式：
 /// - Off：不处理；
 /// - Command：仅斜杠命令；
 /// - Mention：命令、@机器人、回复机器人；
@@ -112,17 +113,15 @@ pub(crate) fn should_process_group_message(
     active_keywords: &[String],
     message: &GroupMessage,
     respond_content: &str,
-    bot_app_id: &str,
+    bot_identity: &SharedBotIdentity,
     bot_outbound_cache: &Arc<Mutex<BotOutboundCache>>,
 ) -> bool {
-    let mentions_current_bot = mentions_bot(message, bot_app_id)
-        || content_mentions_bot_by_stable_id(&message.content, bot_app_id);
-    let content_has_stable_mention = content_has_stable_mention_target(&message.content);
-    if message.event_type == GroupEventType::GroupAtMessage
-        && (mentions_current_bot || message.mention_ids.is_empty() && !content_has_stable_mention)
-    {
+    if message.event_type == GroupEventType::GroupAtMessage {
         return true;
     }
+
+    let mentions_current_bot =
+        mentions_bot(message, bot_identity) || content_mentions_bot(&message.content, bot_identity);
 
     // QQ 有时把 `@机器人 /help` 作为普通群消息下发；
     // 此时原始 content 不是斜杠开头，需要使用 gateway 已归一化的 Core 文本判断命令。
@@ -154,27 +153,17 @@ fn is_group_command(content: &str) -> bool {
     trimmed.starts_with('/') || trimmed.starts_with('／')
 }
 
-fn mentions_bot(message: &GroupMessage, bot_app_id: &str) -> bool {
-    let bot_app_id = bot_app_id.trim();
-    !bot_app_id.is_empty()
-        && message
-            .mention_ids
-            .iter()
-            .any(|mention_id| mention_id.trim() == bot_app_id)
+fn mentions_bot(message: &GroupMessage, bot_identity: &SharedBotIdentity) -> bool {
+    message
+        .mention_ids
+        .iter()
+        .any(|mention_id| bot_identity.contains(mention_id))
 }
 
 /// 只信任 CQ/angle mention 里可比对的稳定目标 ID；显示昵称不参与触发判定。
-fn content_mentions_bot_by_stable_id(content: &str, bot_app_id: &str) -> bool {
-    let bot_app_id = bot_app_id.trim();
-    if bot_app_id.is_empty() {
-        return false;
-    }
-    cq_at_targets(content).any(|target| target == bot_app_id)
-        || angle_mention_targets(content).any(|target| target == bot_app_id)
-}
-
-fn content_has_stable_mention_target(content: &str) -> bool {
-    cq_at_targets(content).next().is_some() || angle_mention_targets(content).next().is_some()
+fn content_mentions_bot(content: &str, bot_identity: &SharedBotIdentity) -> bool {
+    cq_at_targets(content).any(|target| bot_identity.contains(target))
+        || angle_mention_targets(content).any(|target| bot_identity.contains(target))
 }
 
 fn cq_at_targets(content: &str) -> impl Iterator<Item = &str> {
@@ -237,7 +226,16 @@ pub(crate) fn group_user_key(message: &GroupMessage) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::gateway::bot_identity::BotIdentity;
     use crate::gateway::event::MessageReply;
+
+    fn bot_identity() -> SharedBotIdentity {
+        Arc::new(BotIdentity::new("appid", &[]))
+    }
+
+    fn bot_identity_with_extra(extra: &str) -> SharedBotIdentity {
+        Arc::new(BotIdentity::new("appid", &[extra.to_owned()]))
+    }
 
     fn group_message(content: &str, event_type: GroupEventType) -> GroupMessage {
         GroupMessage {
@@ -271,7 +269,7 @@ mod tests {
             &active_keywords,
             &ordinary,
             &ordinary.content,
-            "appid",
+            &bot_identity(),
             &cache
         ));
         assert!(should_process_group_message(
@@ -279,7 +277,7 @@ mod tests {
             &active_keywords,
             &at_event,
             &at_event.content,
-            "appid",
+            &bot_identity(),
             &cache
         ));
         assert!(should_process_group_message(
@@ -287,7 +285,7 @@ mod tests {
             &active_keywords,
             &command,
             &command.content,
-            "appid",
+            &bot_identity(),
             &cache
         ));
         assert!(!should_process_group_message(
@@ -295,7 +293,7 @@ mod tests {
             &active_keywords,
             &other_mention,
             &other_mention.content,
-            "appid",
+            &bot_identity(),
             &cache
         ));
         assert!(!should_process_group_message(
@@ -303,7 +301,7 @@ mod tests {
             &active_keywords,
             &other_mention,
             &other_mention.content,
-            "appid",
+            &bot_identity(),
             &cache
         ));
         assert!(should_process_group_message(
@@ -311,7 +309,7 @@ mod tests {
             &active_keywords,
             &bot_mention,
             &bot_mention.content,
-            "appid",
+            &bot_identity(),
             &cache
         ));
         assert!(!should_process_group_message(
@@ -319,7 +317,7 @@ mod tests {
             &active_keywords,
             &ordinary,
             &ordinary.content,
-            "appid",
+            &bot_identity(),
             &cache
         ));
         assert!(should_process_group_message(
@@ -327,7 +325,7 @@ mod tests {
             &active_keywords,
             &active_keyword,
             &active_keyword.content,
-            "appid",
+            &bot_identity(),
             &cache
         ));
     }
@@ -351,7 +349,7 @@ mod tests {
                     &active_keywords,
                     &message,
                     respond_content,
-                    "appid",
+                    &bot_identity(),
                     &cache
                 ),
                 "{mode:?} should accept structured mention slash command"
@@ -378,7 +376,7 @@ mod tests {
                     &active_keywords,
                     &message,
                     respond_content,
-                    "appid",
+                    &bot_identity(),
                     &cache
                 ),
                 "{mode:?} should ignore slash command aimed at another structured mention"
@@ -399,7 +397,7 @@ mod tests {
             &active_keywords,
             &structured,
             &structured.content,
-            "appid",
+            &bot_identity(),
             &cache
         ));
 
@@ -409,9 +407,33 @@ mod tests {
             &active_keywords,
             &display,
             &display.content,
-            "appid",
+            &bot_identity(),
             &cache
         ));
+    }
+
+    #[test]
+    fn active_mode_accepts_configured_bot_mention_id() {
+        let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        let active_keywords = vec!["小女仆".to_owned()];
+        let identity = bot_identity_with_extra("bot-openid");
+        let mut message =
+            group_message("@脸脸家的小女仆 实在是睡不着", GroupEventType::GroupMessage);
+        message.mention_ids = vec!["bot-openid".to_owned()];
+
+        for mode in [GroupMessageMode::Mention, GroupMessageMode::Active] {
+            assert!(
+                should_process_group_message(
+                    mode,
+                    &active_keywords,
+                    &message,
+                    &message.content,
+                    &identity,
+                    &cache
+                ),
+                "{mode:?} should accept configured bot mention id"
+            );
+        }
     }
 
     #[test]
@@ -432,7 +454,7 @@ mod tests {
                         &active_keywords,
                         &message,
                         &message.content,
-                        "appid",
+                        &bot_identity(),
                         &cache
                     ),
                     "{mode:?} should ignore non-bot mention: {input}"
@@ -449,7 +471,7 @@ mod tests {
                         &active_keywords,
                         &message,
                         &message.content,
-                        "appid",
+                        &bot_identity(),
                         &cache
                     ),
                     "{mode:?} should accept bot mention: {input}"
@@ -459,57 +481,51 @@ mod tests {
     }
 
     #[test]
-    fn group_at_event_with_other_structured_mention_falls_back_to_mode_policy() {
+    fn group_at_event_trusts_official_event_type() {
         let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
         let active_keywords = vec!["小女仆".to_owned()];
         let mut message = group_message("@其他成员 hello", GroupEventType::GroupAtMessage);
         message.mention_ids = vec!["other-user".to_owned()];
 
-        assert!(!should_process_group_message(
+        assert!(should_process_group_message(
             GroupMessageMode::Mention,
             &active_keywords,
             &message,
             &message.content,
-            "appid",
-            &cache
-        ));
-
-        message.content = "小女仆 hello".to_owned();
-        assert!(should_process_group_message(
-            GroupMessageMode::Active,
-            &active_keywords,
-            &message,
-            &message.content,
-            "appid",
+            &bot_identity(),
             &cache
         ));
     }
 
     #[test]
-    fn group_at_event_with_other_content_mention_falls_back_to_mode_policy() {
+    fn group_at_event_with_empty_content_is_not_ignored() {
+        let message = group_message("", GroupEventType::GroupAtMessage);
+
+        assert!(!should_ignore_group_message(&message, "", "masked-group"));
+    }
+
+    #[test]
+    fn plain_group_message_with_empty_content_is_ignored() {
+        let message = group_message("", GroupEventType::GroupMessage);
+
+        assert!(should_ignore_group_message(&message, "", "masked-group"));
+    }
+
+    #[test]
+    fn group_at_event_with_other_content_mention_trusts_official_event_type() {
         let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
         let active_keywords = vec!["小女仆".to_owned()];
-        let mut message = group_message(
+        let message = group_message(
             "[CQ:at,qq=other-user] hello",
             GroupEventType::GroupAtMessage,
         );
 
-        assert!(!should_process_group_message(
+        assert!(should_process_group_message(
             GroupMessageMode::Mention,
             &active_keywords,
             &message,
             &message.content,
-            "appid",
-            &cache
-        ));
-
-        message.content = "[CQ:at,qq=other-user] 小女仆 hello".to_owned();
-        assert!(should_process_group_message(
-            GroupMessageMode::Active,
-            &active_keywords,
-            &message,
-            &message.content,
-            "appid",
+            &bot_identity(),
             &cache
         ));
     }
@@ -525,7 +541,7 @@ mod tests {
             &[],
             &message,
             &message.content,
-            "appid",
+            &bot_identity(),
             &cache
         ));
 
@@ -535,7 +551,7 @@ mod tests {
             &[],
             &message,
             &message.content,
-            "appid",
+            &bot_identity(),
             &cache
         ));
     }
@@ -555,7 +571,7 @@ mod tests {
             &[],
             &message,
             &message.content,
-            "appid",
+            &bot_identity(),
             &cache
         ));
     }

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -1,6 +1,7 @@
 //! QQ gateway 运行域。负责 WebSocket 主循环、事件分发、去重、诊断与回发编排。
 
 mod aggregator;
+mod bot_identity;
 mod c2c;
 mod cache;
 pub mod dedupe;
@@ -24,6 +25,7 @@ use std::{
 
 use aggregator::MessageAggregator;
 use anyhow::Context;
+use bot_identity::BotIdentity;
 use dispatcher::MessageDispatcher;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -69,6 +71,7 @@ pub async fn run(
     // reply 只需要一个极简 HashMap 缓存，不引入额外抽象层或持久化。
     let reply_cache: ReplyCache = Arc::new(Mutex::new(HashMap::new()));
     let group_cooldowns = Arc::new(Mutex::new(GroupCooldowns::default()));
+    let bot_identity = Arc::new(BotIdentity::new(&config.app_id, &config.bot_mention_ids));
     // 断线续连所需的状态（session_id + seq）
     let mut resume = ResumeState::default();
     // 聚合器必须先 flush 到 Dispatcher，不能让全局 shutdown 同时取消两者。
@@ -84,6 +87,7 @@ pub async fn run(
         reply_cache.clone(),
         group_outbound_cache.clone(),
         group_cooldowns.clone(),
+        bot_identity.clone(),
         runtime.clone(),
         dispatcher_shutdown,
     );
@@ -125,6 +129,7 @@ pub async fn run(
             &runtime,
             &mut resume,
             aggregator_handle.clone(),
+            bot_identity.clone(),
             shutdown_token.clone(),
         )
         .await

--- a/qq-maid-gateway-rs/src/gateway/ping/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/ping/tests.rs
@@ -18,6 +18,7 @@ fn config() -> AppConfig {
     AppConfig {
         app_id: "appid".to_owned(),
         app_secret: "app-secret-value".to_owned(),
+        bot_mention_ids: Vec::new(),
         sandbox: false,
         api_base: "https://api.sgroup.qq.com".to_owned(),
         token_refresh_margin: Duration::from_secs(60),

--- a/qq-maid-gateway-rs/src/gateway/protocol.rs
+++ b/qq-maid-gateway-rs/src/gateway/protocol.rs
@@ -14,6 +14,7 @@ use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
+use super::bot_identity::SharedBotIdentity;
 use super::{aggregator::MessageAggregatorHandle, ping::GatewayRuntimeStatus};
 use crate::{
     auth::AccessTokenManager,
@@ -84,6 +85,7 @@ pub(super) async fn run_gateway_once(
     runtime: &GatewayRuntimeStatus,
     resume: &mut ResumeState,
     dispatcher: MessageAggregatorHandle,
+    bot_identity: SharedBotIdentity,
     shutdown_token: CancellationToken,
 ) -> anyhow::Result<()> {
     info!(
@@ -145,6 +147,7 @@ pub(super) async fn run_gateway_once(
                             resume,
                             &mut write,
                             &dispatcher,
+                            &bot_identity,
                         )
                         .await?;
                     }
@@ -158,6 +161,7 @@ pub(super) async fn run_gateway_once(
                             resume,
                             &mut write,
                             &dispatcher,
+                            &bot_identity,
                         )
                         .await?;
                     }
@@ -186,6 +190,7 @@ async fn handle_envelope<S>(
     resume: &mut ResumeState,
     write: &mut S,
     dispatcher: &MessageAggregatorHandle,
+    bot_identity: &SharedBotIdentity,
 ) -> anyhow::Result<()>
 where
     S: futures_util::Sink<Message, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
@@ -206,6 +211,7 @@ where
                     session_id_present = resume.session_id.is_some(),
                     "QQ gateway ready"
                 );
+                bot_identity.absorb_ready_payload(&envelope.d);
                 runtime.record_ready();
                 return Ok(());
             }

--- a/qq-maid-gateway-rs/src/gateway/stream/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests.rs
@@ -197,6 +197,7 @@ fn test_config() -> AppConfig {
     AppConfig {
         app_id: "app".to_owned(),
         app_secret: "secret".to_owned(),
+        bot_mention_ids: Vec::new(),
         sandbox: false,
         api_base: "https://example.test".to_owned(),
         token_refresh_margin: Duration::from_secs(60),

--- a/runtime/config/.env.example
+++ b/runtime/config/.env.example
@@ -43,6 +43,9 @@ QQ_TEXT_CHUNK_SOFT_LIMIT=5000
 # active=额外处理包含指定提示词的普通群消息。
 QQ_MAID_GROUP_MESSAGE_MODE=mention
 QQ_MAID_GROUP_ACTIVE_KEYWORDS=小女仆
+# 普通群事件里的 @ 目标有时不是 AppID。默认会从 Gateway READY 自动学习；
+# 若线上日志显示 mention_count>0 仍未命中，可临时填入机器人 openid/member_openid，逗号分隔。
+QQ_MAID_BOT_MENTION_IDS=
 
 # =============================================================================
 # 会话排队与消息聚合


### PR DESCRIPTION
## 变更内容

- 修复群聊 @ 机器人识别，支持 READY 学习到的 bot 身份和显式配置的 mention id，并允许官方 GroupAtMessage 空内容进入处理。
- 收窄自然语言 Todo 日期查询前置拦截，只保留极窄完整句式，避免混合列车/天气/RSS/条件待办任务被误判为 Todo 查询。
- 收窄天气工具路由，普通天气话题保持聊天，明确天气查询才进入 Tool Loop。
- 调整只读工具结果编排：天气、火车、RSS 事实卡保留，同时保留模型基于事实给出的判断；Todo 写入仍以真实工具回执为准。

## 根因

- 旧的自然语言 Todo 查询逻辑在 Tool Loop 前使用宽泛关键词短路，看到日期和待办相关词就可能直接执行待办查询。
- Tool Loop 的可信只读工具展示会替换模型最终回复，导致天气/火车/RSS 后续判断被事实卡吞掉。
- 群聊 @ 目标在实际事件中可能不是 AppID，原匹配方式对部分官方事件和空 @ 内容不够稳。

## 验证

- cargo fmt --all -- --check
- git diff --check
- cargo test -p qq-maid-core -- --test-threads=1
- cargo test -p qq-maid-gateway-rs
