### PR TITLE
[codex] 收紧 Tool Loop 模糊路由

### DIFF
--- a/qq-maid-core/src/runtime/respond.rs
+++ b/qq-maid-core/src/runtime/respond.rs
@@ -16,7 +16,10 @@ use crate::{
         prompt::PromptConfig,
         query::DynQueryExecutor,
         rss::{RssFetcher, RssStore},
-        session::{SessionMeta, SessionRecord, SessionStore},
+        session::{
+            LAST_QUERY_TTL_SECONDS, SessionMeta, SessionRecord, SessionStore, query_is_fresh,
+            valid_last_visible_todo_query,
+        },
         todo::TodoStore,
         tools::{
             CancelTodoTool, CompleteTodoTool, CreateTodoTool, DeleteTodoTool, EditTodoTool,
@@ -307,8 +310,13 @@ impl RustRespondService {
             return Ok(StatusHint::model());
         }
         let policy = self.resolve_agent_policy(req)?;
+        let meta = respond_meta(req);
+        let active_session = self
+            .session_store
+            .get_active(&meta)
+            .map_err(session_error)?;
         Ok(self
-            .route_tool_loop(req, &policy)
+            .route_tool_loop_with_active(req, &policy, active_session.as_ref())
             .status_hint
             .unwrap_or_else(StatusHint::default_tool))
     }
@@ -349,7 +357,7 @@ impl RustRespondService {
         }
 
         let policy = self.resolve_agent_policy(req)?;
-        let tool_decision = self.route_tool_loop(req, &policy);
+        let tool_decision = self.route_tool_loop_with_active(req, &policy, active_session.as_ref());
         let plan = if matches!(tool_decision.route, ToolLoopRoute::CompleteToolLoop) {
             RespondPlan::CompleteToolLoop
         } else {
@@ -359,6 +367,7 @@ impl RustRespondService {
             respond_plan = ?plan,
             tool_loop_route = ?tool_decision.route,
             semantic_route = ?tool_decision.semantic_route,
+            tool_domain = ?tool_decision.domain,
             route_reason = tool_decision.reason,
             is_group = req
                 .group_id
@@ -375,10 +384,11 @@ impl RustRespondService {
         }
     }
 
-    fn route_tool_loop(
+    fn route_tool_loop_with_active(
         &self,
         req: &RespondRequest,
         policy: &ResolvedAgentPolicy,
+        active_session: Option<&SessionRecord>,
     ) -> tool_route::ToolRouteDecision {
         tool_route::route_tool_loop(
             req,
@@ -391,6 +401,7 @@ impl RustRespondService {
                     .tool_calling_protocol(Some(&policy.main_model))
                     .is_some(),
                 enabled_tools_available: !policy.enabled_tools.is_empty(),
+                has_recent_todo_context: has_recent_todo_context(req, active_session),
             },
         )
     }
@@ -631,6 +642,24 @@ fn pending_blocks_immediate(user_text: &str, active_session: Option<&SessionReco
         && active_session
             .and_then(|session| session.pending_operation.as_ref())
             .is_some()
+}
+
+fn has_recent_todo_context(req: &RespondRequest, active_session: Option<&SessionRecord>) -> bool {
+    let Some(session) = active_session else {
+        return false;
+    };
+    let owner = TodoStore::owner(req.user_id.as_deref(), &req.scope_key);
+
+    let mut snapshot = session.clone();
+    let has_visible_snapshot = valid_last_visible_todo_query(&mut snapshot, &owner.key)
+        .is_some_and(|query| !query.result_ids.is_empty());
+    if has_visible_snapshot {
+        return true;
+    }
+
+    session.last_todo_action.as_ref().is_some_and(|action| {
+        action.owner_key == owner.key && query_is_fresh(&action.created_at, LAST_QUERY_TTL_SECONDS)
+    })
 }
 
 fn classify_inbound_with_active(

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -996,7 +996,7 @@ async fn todo_tool_ok_false_without_error_code_is_failed_outcome() {
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
 
     let response = service
-        .respond(private_message("把第一条改一下"))
+        .respond(private_message("把第一条待办改成新标题"))
         .await
         .unwrap();
 
@@ -1028,7 +1028,7 @@ async fn todo_clarification_is_not_marked_as_write_success() {
         );
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
 
-    let response = service.respond(private_message("完成一下")).await.unwrap();
+    let response = service.respond(private_message("完成待办")).await.unwrap();
 
     assert_eq!(response.command.as_deref(), Some("todo_clarify_wait"));
     let text = response.text.unwrap();
@@ -1432,7 +1432,7 @@ async fn unadapted_success_with_todo_success_is_not_silently_dropped() {
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
 
     let response = service
-        .respond(private_message("执行两个工具"))
+        .respond(private_message("新增待办并执行两个工具"))
         .await
         .unwrap();
 
@@ -1545,7 +1545,7 @@ async fn only_list_todos_success_does_not_claim_todo_write_success() {
         .unwrap();
 
     let response = service
-        .respond(private_message("今天安排如何"))
+        .respond(private_message("检查待办状态"))
         .await
         .unwrap();
 
@@ -1616,7 +1616,7 @@ async fn list_todos_due_date_receipt_preserves_filtered_visible_snapshot() {
         .unwrap();
 
     let response = service
-        .respond(private_message("帮我看看安排"))
+        .respond(private_message("检查今天待办状态"))
         .await
         .unwrap();
     let text = response.text.unwrap();
@@ -2170,7 +2170,7 @@ async fn todo_internal_list_before_write_is_not_user_visible_query() {
 
     service.respond(private_message("/todo")).await.unwrap();
     let response = service
-        .respond(private_message("处理第一项"))
+        .respond(private_message("完成第一项待办"))
         .await
         .unwrap();
 
@@ -3673,7 +3673,7 @@ async fn cancelled_query_then_delete_all_creates_bulk_pending_and_confirm_delete
     assert_eq!(snapshot.result_ids, expected_cancelled_ids);
 
     let delete = service
-        .respond(private_message("都删除了吧"))
+        .respond(private_message("把这些已取消待办都删除了吧"))
         .await
         .unwrap();
     assert!(
@@ -3920,9 +3920,9 @@ async fn non_todo_chat_phrase_does_not_mutate_when_model_calls_no_tool() {
         diagnostics["tool_loop_executed_tools"],
         serde_json::json!([])
     );
-    // 私聊普通消息统一进入 Tool Loop，但模型未调用 Todo 工具时不应修改待办。
-    assert_eq!(inspector.tool_call_count(), 1);
-    assert_eq!(inspector.requests().len(), 0);
+    // 不确定的私聊文本默认走普通聊天；不能仅因 provider 支持工具而进入 Tool Loop。
+    assert_eq!(inspector.tool_call_count(), 0);
+    assert_eq!(inspector.requests().len(), 1);
     // 待办不应被误修改。
     assert_eq!(
         service.todo_store.list_pending(&owner).unwrap()[0].status,

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -120,6 +120,74 @@ async fn private_general_chat_with_tool_capability_uses_plain_chat() {
 }
 
 #[tokio::test]
+async fn private_generation_and_explanation_requests_keep_plain_chat() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    for input in ["帮我写个文案", "解释一下这个问题", "刚刚没看到，再来一条"]
+    {
+        let response = service.respond(private_message(input)).await.unwrap();
+        assert!(
+            response
+                .text
+                .as_deref()
+                .unwrap()
+                .contains(&format!("回复：{input}")),
+            "{input}"
+        );
+    }
+
+    assert_eq!(inspector.tool_call_count(), 0);
+    assert_eq!(inspector.requests().len(), 3);
+}
+
+#[tokio::test]
+async fn private_strong_todo_reference_without_context_enters_tool_loop_and_clarifies() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json(
+            "complete_todos",
+            r#"{"numbers":[1]}"#,
+            "我需要先确认是哪一条待办。",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("完成第一条"))
+        .await
+        .unwrap();
+
+    assert_eq!(inspector.tool_call_count(), 1);
+    assert_eq!(inspector.requests().len(), 0);
+    assert!(
+        response
+            .text
+            .as_deref()
+            .is_some_and(|text| !text.is_empty())
+    );
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(
+        diagnostics["tool_loop_executed_tools"],
+        serde_json::json!(["complete_todos"])
+    );
+
+    let session = service
+        .session_store
+        .get_or_create_active(&private_test_meta())
+        .unwrap();
+    match session.pending_operation {
+        Some(PendingOperation::TodoClarify { request, .. }) => {
+            assert_eq!(request.tool_name, "complete_todos");
+            assert_eq!(
+                request.error_code.as_str(),
+                "todo_visible_numbers_unavailable"
+            );
+        }
+        other => panic!("expected todo clarification pending, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn private_tool_loop_registers_todo_tools_and_keeps_internal_ids_hidden() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);

--- a/qq-maid-core/src/runtime/respond/tool_route.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route.rs
@@ -2,8 +2,8 @@
 //!
 //! slash 命令、pending 和确定性 Todo 查询仍在更外层保持原有路径。这里仅判断
 //! 普通聊天是否需要进入受控工具 Agent：明显闲聊、创作、解释和流式测试保留
-//! 原生聊天路径；明确工具任务才进入 Tool Loop。不确定的私聊仍保守交给 Agent，
-//! 群聊不确定则默认保持普通聊天，避免群聊闲聊频繁阻塞在工具循环。
+//! 原生聊天路径；只有明确工具任务才进入 Tool Loop。不确定请求默认保持普通聊天，
+//! 避免普通文本生成和上下文延续被工具循环阻塞。
 
 use super::{
     RespondRequest,
@@ -57,7 +57,7 @@ const TODO_WRITE_MARKERS: &[&str] = &[
     "改成",
 ];
 const TODO_CONFIRM_MARKERS: &[&str] = &["完成", "做完", "恢复", "取消", "删除", "删掉", "移除"];
-const TODO_QUERY_MARKERS: &[&str] = &["查看", "看一下", "列出", "有哪些"];
+const TODO_QUERY_MARKERS: &[&str] = &["查看", "看一下", "列出", "有哪些", "检查"];
 
 pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> ToolRouteDecision {
     if !ctx.scene_enabled
@@ -116,17 +116,11 @@ pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> To
             "deterministic_or_empty",
             None,
         ),
-        SemanticRoute::Ambiguous if is_group => decision(
+        SemanticRoute::Ambiguous => decision(
             ToolLoopRoute::PlainChat,
             SemanticRoute::Ambiguous,
-            "semantic_ambiguous_group_plain",
+            "semantic_ambiguous_plain",
             None,
-        ),
-        SemanticRoute::Ambiguous => decision(
-            ToolLoopRoute::CompleteToolLoop,
-            SemanticRoute::Ambiguous,
-            "semantic_ambiguous_private_tool_loop",
-            Some(StatusHint::default_tool()),
         ),
     }
 }
@@ -153,6 +147,7 @@ fn classify_semantic_route(text: &str) -> SemanticRoute {
 
     // 明确工具意图优先，避免“写一个待办”“讲一下今天待办”被创作/解释词误判为闲聊。
     if has_todo_intent(text, &lower)
+        || has_reminder_intent(text)
         || has_memory_intent(text, &lower)
         || has_weather_intent(text, &lower)
         || has_train_intent(text, &lower)
@@ -178,7 +173,7 @@ fn classify_semantic_route(text: &str) -> SemanticRoute {
 
 fn classify_status_hint(text: &str) -> Option<StatusHint> {
     let lower = text.to_ascii_lowercase();
-    if has_todo_intent(text, &lower) {
+    if has_todo_intent(text, &lower) || has_reminder_intent(text) {
         return Some(StatusHint::new(
             StatusSubject::Todo,
             todo_status_action(text),
@@ -223,6 +218,27 @@ fn has_todo_intent(text: &str, lower: &str) -> bool {
 
     (contains_any(text, TODO_CONFIRM_MARKERS) || contains_any(text, &["编辑", "修改", "改成"]))
         && (has_ordinal_reference(text) || contains_any(text, &["它", "这个", "那个", "刚才那条"]))
+}
+
+fn has_reminder_intent(text: &str) -> bool {
+    let has_reminder_action = contains_any(
+        text,
+        &[
+            "提醒我",
+            "提醒一下",
+            "帮我提醒",
+            "回头提醒",
+            "别忘",
+            "别忘了",
+        ],
+    );
+    has_reminder_action
+        && contains_any(
+            text,
+            &[
+                "今天", "明天", "后天", "今晚", "下午", "上午", "晚上", "回头",
+            ],
+        )
 }
 
 fn has_memory_intent(text: &str, lower: &str) -> bool {
@@ -540,11 +556,59 @@ mod tests {
     }
 
     #[test]
-    fn ambiguous_private_defaults_to_tool_loop() {
-        let decision = route_tool_loop(&request("明天别忘了"), context());
-        assert_eq!(decision.route, ToolLoopRoute::CompleteToolLoop);
+    fn ambiguous_private_defaults_to_plain_chat() {
+        let decision = route_tool_loop(&request("安排一下"), context());
+        assert_eq!(decision.route, ToolLoopRoute::PlainChat);
         assert_eq!(decision.semantic_route, SemanticRoute::Ambiguous);
-        assert_eq!(decision.status_hint, Some(StatusHint::default_tool()));
+        assert_eq!(decision.reason, "semantic_ambiguous_plain");
+        assert_eq!(decision.status_hint, None);
+    }
+
+    #[test]
+    fn plain_text_generation_without_tool_affordance_keeps_plain_chat() {
+        for input in [
+            "能不能给我发一条，三行的信息",
+            "刚刚没看到，再来一条",
+            "帮我写个文案",
+            "解释一下这个问题",
+            "我好烦，陪我聊会",
+        ] {
+            let decision = route_tool_loop(&request(input), context());
+            assert_eq!(decision.route, ToolLoopRoute::PlainChat, "{input}");
+            assert_ne!(decision.reason, "semantic_tool_intent", "{input}");
+        }
+    }
+
+    #[test]
+    fn enabled_tools_alone_do_not_force_tool_loop() {
+        let decision = route_tool_loop(&request("安排一下"), context());
+        assert_eq!(decision.route, ToolLoopRoute::PlainChat);
+        assert_eq!(decision.semantic_route, SemanticRoute::Ambiguous);
+    }
+
+    #[test]
+    fn provider_tool_support_alone_do_not_force_tool_loop() {
+        let decision = route_tool_loop(&request("普通说两句"), context());
+        assert_eq!(decision.route, ToolLoopRoute::PlainChat);
+        assert_eq!(decision.semantic_route, SemanticRoute::Ambiguous);
+    }
+
+    #[test]
+    fn reminder_like_text_is_tool_loop_only_when_classified_as_explicit_intent() {
+        for input in ["明天别忘了", "回头提醒我检查日志"] {
+            let decision = route_tool_loop(&request(input), context());
+            assert_eq!(decision.route, ToolLoopRoute::CompleteToolLoop, "{input}");
+            assert_eq!(decision.semantic_route, SemanticRoute::ToolLoop, "{input}");
+            assert_eq!(
+                decision.status_hint,
+                Some(StatusHint::new(StatusSubject::Todo, StatusAction::Write)),
+                "{input}"
+            );
+        }
+
+        let ambiguous = route_tool_loop(&request("帮我处理一下"), context());
+        assert_eq!(ambiguous.route, ToolLoopRoute::PlainChat);
+        assert_eq!(ambiguous.semantic_route, SemanticRoute::Ambiguous);
     }
 
     #[test]

--- a/qq-maid-core/src/runtime/respond/tool_route.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route.rs
@@ -73,6 +73,15 @@ const TODO_WRITE_MARKERS: &[&str] = &[
 ];
 const TODO_CONFIRM_MARKERS: &[&str] = &["完成", "做完", "恢复", "取消", "删除", "删掉", "移除"];
 const TODO_QUERY_MARKERS: &[&str] = &["查看", "看一下", "列出", "有哪些", "检查"];
+const REMINDER_ACTION_MARKERS: &[&str] = &[
+    "提醒我",
+    "提醒一下",
+    "提醒下",
+    "帮我提醒",
+    "回头提醒",
+    "别忘",
+    "别忘了",
+];
 
 pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> ToolRouteDecision {
     if !ctx.scene_enabled
@@ -292,8 +301,10 @@ fn classify_semantic_route(text: &str, has_recent_todo_context: bool) -> Semanti
 
 fn classify_status_hint(text: &str, has_recent_todo_context: bool) -> Option<StatusHint> {
     let lower = text.to_ascii_lowercase();
+    if has_reminder_intent(text) {
+        return Some(StatusHint::new(StatusSubject::Todo, StatusAction::Write));
+    }
     if has_todo_intent(text, &lower)
-        || has_reminder_intent(text)
         || is_strong_todo_reference_operation(text)
         || (has_recent_todo_context && is_weak_todo_context_reference(text))
     {
@@ -331,6 +342,10 @@ fn todo_status_action(text: &str) -> StatusAction {
 }
 
 fn has_todo_intent(text: &str, lower: &str) -> bool {
+    if has_reminder_action(text) && !has_reminder_intent(text) {
+        return false;
+    }
+
     let has_todo_object = contains_any(text, TODO_OBJECT_MARKERS) || lower.contains("todo");
     let has_todo_action = contains_any(text, TODO_WRITE_MARKERS)
         || contains_any(text, TODO_CONFIRM_MARKERS)
@@ -344,18 +359,12 @@ fn has_todo_intent(text: &str, lower: &str) -> bool {
 }
 
 fn has_reminder_intent(text: &str) -> bool {
-    let has_reminder_action = contains_any(
-        text,
-        &[
-            "提醒我",
-            "提醒一下",
-            "帮我提醒",
-            "回头提醒",
-            "别忘",
-            "别忘了",
-        ],
-    );
-    has_reminder_action && looks_like_temporal_expression(text)
+    has_reminder_action(text)
+        && (looks_like_temporal_expression(text) || has_reminder_payload(text))
+}
+
+fn has_reminder_action(text: &str) -> bool {
+    contains_any(text, REMINDER_ACTION_MARKERS)
 }
 
 fn looks_like_temporal_expression(text: &str) -> bool {
@@ -386,6 +395,62 @@ fn looks_like_temporal_expression(text: &str) -> bool {
             "下个月",
         ],
     )
+}
+
+fn has_reminder_payload(text: &str) -> bool {
+    let mut payload = text.to_owned();
+    for marker in REMINDER_ACTION_MARKERS {
+        payload = payload.replace(marker, "");
+    }
+    // 只清掉明显的提示/时间壳，剩余内容仍交给 Todo Tool 解析和澄清。
+    for filler in [
+        "帮我",
+        "请",
+        "麻烦",
+        "一下",
+        "一下子",
+        "到时候",
+        "记得",
+        "记着",
+        "回头",
+        "今天",
+        "明天",
+        "后天",
+        "今晚",
+        "明早",
+        "明晚",
+        "早上",
+        "上午",
+        "中午",
+        "下午",
+        "晚上",
+        "凌晨",
+        "傍晚",
+        "月底",
+        "月末",
+        "下个月初",
+        "下个月",
+        "周一",
+        "周二",
+        "周三",
+        "周四",
+        "周五",
+        "周六",
+        "周日",
+        "星期一",
+        "星期二",
+        "星期三",
+        "星期四",
+        "星期五",
+        "星期六",
+        "星期日",
+    ] {
+        payload = payload.replace(filler, "");
+    }
+    let meaningful = payload.trim_matches(|ch: char| {
+        ch.is_whitespace() || ch.is_ascii_punctuation() || is_cjk_punctuation(ch)
+    });
+    meaningful.chars().count() >= 2
 }
 
 fn has_memory_intent(text: &str, lower: &str) -> bool {
@@ -485,9 +550,6 @@ fn has_plain_chat_intent(text: &str, lower: &str) -> bool {
                 "讲故事",
                 "小说",
                 "文案",
-                "没看到",
-                "再来一条",
-                "发一条",
             ],
         )
         || contains_any(
@@ -670,12 +732,9 @@ mod tests {
             "晚上好",
             "你在吗",
             "能试试输出一段长文本，我试试流式输出",
-            "帮我写个文案",
             "写一段长文本测试流式",
             "讲个故事",
             "解释一下 Rust 所有权",
-            "解释一下这个问题",
-            "刚刚没看到，再来一条",
             "C2C 流式还有问题",
             "C2C 消息发送失败",
             "T3 架构怎么设计",
@@ -706,6 +765,13 @@ mod tests {
             "新增待办，明天接老公",
             "编辑第三条，其他不动",
             "记一下我喜欢少糖",
+            "别忘了买菜",
+            "别忘了交水电费",
+            "提醒我续费",
+            "帮我提醒一下检查日志",
+            "回头提醒我检查日志",
+            "明天别忘了买菜",
+            "下周五提醒我验收",
             "周五别忘了开会",
             "月底提醒我续费",
             "月末提醒我续费",
@@ -768,11 +834,13 @@ mod tests {
 
     #[test]
     fn ambiguous_private_defaults_to_plain_chat() {
-        let decision = route_tool_loop(&request("安排一下"), context());
-        assert_eq!(decision.route, ToolLoopRoute::PlainChat);
-        assert_eq!(decision.semantic_route, SemanticRoute::Ambiguous);
-        assert_eq!(decision.reason, "semantic_ambiguous_plain");
-        assert_eq!(decision.status_hint, None);
+        for input in ["安排一下", "帮我处理一下", "刚刚没看到，再来一条"] {
+            let decision = route_tool_loop(&request(input), context());
+            assert_eq!(decision.route, ToolLoopRoute::PlainChat, "{input}");
+            assert_eq!(decision.semantic_route, SemanticRoute::Ambiguous, "{input}");
+            assert_eq!(decision.reason, "semantic_ambiguous_plain", "{input}");
+            assert_eq!(decision.status_hint, None, "{input}");
+        }
     }
 
     #[test]
@@ -836,6 +904,14 @@ mod tests {
             let decision = route_tool_loop(&request(input), context());
             assert_eq!(decision.route, ToolLoopRoute::PlainChat, "{input}");
             assert_ne!(decision.reason, "semantic_tool_intent", "{input}");
+            assert_ne!(decision.semantic_route, SemanticRoute::ToolLoop, "{input}");
+            assert_eq!(decision.status_hint, None, "{input}");
+        }
+
+        for input in ["能不能给我发一条，三行的信息", "刚刚没看到，再来一条"]
+        {
+            let decision = route_tool_loop(&request(input), context());
+            assert_eq!(decision.semantic_route, SemanticRoute::Ambiguous, "{input}");
         }
     }
 
@@ -854,21 +930,54 @@ mod tests {
     }
 
     #[test]
-    fn reminder_like_text_is_tool_loop_only_when_classified_as_explicit_intent() {
-        for input in ["明天别忘了", "回头提醒我检查日志"] {
+    fn reminder_without_date_but_with_payload_routes_to_todo_write_tool_loop() {
+        for input in [
+            "别忘了买菜",
+            "别忘了交水电费",
+            "提醒我续费",
+            "帮我提醒一下检查日志",
+            "回头提醒我检查日志",
+        ] {
             let decision = route_tool_loop(&request(input), context());
             assert_eq!(decision.route, ToolLoopRoute::CompleteToolLoop, "{input}");
             assert_eq!(decision.semantic_route, SemanticRoute::ToolLoop, "{input}");
+            assert_eq!(decision.domain, ToolDomain::Todo, "{input}");
             assert_eq!(
                 decision.status_hint,
                 Some(StatusHint::new(StatusSubject::Todo, StatusAction::Write)),
                 "{input}"
             );
         }
+    }
 
-        let ambiguous = route_tool_loop(&request("帮我处理一下"), context());
-        assert_eq!(ambiguous.route, ToolLoopRoute::PlainChat);
-        assert_eq!(ambiguous.semantic_route, SemanticRoute::Ambiguous);
+    #[test]
+    fn reminder_with_date_still_routes_to_todo_write_tool_loop() {
+        for input in [
+            "明天别忘了",
+            "明天别忘了买菜",
+            "下周五提醒我验收",
+            "月底提醒我续费",
+        ] {
+            let decision = route_tool_loop(&request(input), context());
+            assert_eq!(decision.route, ToolLoopRoute::CompleteToolLoop, "{input}");
+            assert_eq!(decision.semantic_route, SemanticRoute::ToolLoop, "{input}");
+            assert_eq!(decision.domain, ToolDomain::Todo, "{input}");
+            assert_eq!(
+                decision.status_hint,
+                Some(StatusHint::new(StatusSubject::Todo, StatusAction::Write)),
+                "{input}"
+            );
+        }
+    }
+
+    #[test]
+    fn reminder_action_without_date_or_payload_stays_ambiguous_plain() {
+        for input in ["别忘了", "提醒我"] {
+            let decision = route_tool_loop(&request(input), context());
+            assert_eq!(decision.route, ToolLoopRoute::PlainChat, "{input}");
+            assert_eq!(decision.semantic_route, SemanticRoute::Ambiguous, "{input}");
+            assert_eq!(decision.status_hint, None, "{input}");
+        }
     }
 
     #[test]

--- a/qq-maid-core/src/runtime/respond/tool_route.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route.rs
@@ -2,8 +2,10 @@
 //!
 //! slash 命令、pending 和确定性 Todo 查询仍在更外层保持原有路径。这里仅判断
 //! 普通聊天是否需要进入受控工具 Agent：明显闲聊、创作、解释和流式测试保留
-//! 原生聊天路径；只有明确工具任务才进入 Tool Loop。不确定请求默认保持普通聊天，
-//! 避免普通文本生成和上下文延续被工具循环阻塞。
+//! 原生聊天路径；明确工具任务进入 Tool Loop；依赖 Todo 最近可见快照/最近操作
+//! 的上下文续指由调用方传入 session 信号后再进入 Todo Tool Loop。
+
+use crate::util::time_context;
 
 use super::{
     RespondRequest,
@@ -24,10 +26,21 @@ pub(super) enum SemanticRoute {
     Ambiguous,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ToolDomain {
+    Todo,
+    Weather,
+    Train,
+    Rss,
+    Memory,
+    Unknown,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(super) struct ToolRouteDecision {
     pub route: ToolLoopRoute,
     pub semantic_route: SemanticRoute,
+    pub domain: ToolDomain,
     pub reason: &'static str,
     pub status_hint: Option<StatusHint>,
 }
@@ -39,6 +52,8 @@ pub(super) struct ToolRouteContext {
     pub group_tool_calling_enabled: bool,
     pub provider_supports_tool_calling: bool,
     pub enabled_tools_available: bool,
+    /// 是否存在仍在有效期内的 Todo 可见列表快照或最近单项操作。
+    pub has_recent_todo_context: bool,
 }
 
 const TODO_OBJECT_MARKERS: &[&str] = &["待办", "代办", "任务", "提醒", "事项"];
@@ -68,6 +83,7 @@ pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> To
         return decision(
             ToolLoopRoute::PlainChat,
             SemanticRoute::PlainChat,
+            ToolDomain::Unknown,
             "tool_loop_unavailable",
             None,
         );
@@ -78,6 +94,7 @@ pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> To
         return decision(
             ToolLoopRoute::PlainChat,
             SemanticRoute::Deterministic,
+            ToolDomain::Unknown,
             "deterministic_or_empty",
             None,
         );
@@ -90,36 +107,48 @@ pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> To
         return decision(
             ToolLoopRoute::PlainChat,
             SemanticRoute::PlainChat,
+            ToolDomain::Unknown,
             "group_tool_loop_disabled",
             None,
         );
     }
 
-    let semantic = classify_semantic_route(trimmed);
-    let status_hint = classify_status_hint(trimmed);
-    match semantic {
+    let assessment = classify_semantic_route(trimmed, ctx.has_recent_todo_context);
+    let status_hint = classify_status_hint(trimmed, ctx.has_recent_todo_context);
+    match assessment.semantic_route {
         SemanticRoute::PlainChat => decision(
             ToolLoopRoute::PlainChat,
             SemanticRoute::PlainChat,
-            "semantic_plain_chat",
+            assessment.domain,
+            assessment.reason,
             None,
         ),
         SemanticRoute::ToolLoop => decision(
             ToolLoopRoute::CompleteToolLoop,
             SemanticRoute::ToolLoop,
-            "semantic_tool_intent",
+            assessment.domain,
+            assessment.reason,
             status_hint,
         ),
         SemanticRoute::Deterministic => decision(
             ToolLoopRoute::PlainChat,
             SemanticRoute::Deterministic,
+            assessment.domain,
             "deterministic_or_empty",
+            None,
+        ),
+        SemanticRoute::Ambiguous if is_group => decision(
+            ToolLoopRoute::PlainChat,
+            SemanticRoute::Ambiguous,
+            assessment.domain,
+            "semantic_ambiguous_group_plain",
             None,
         ),
         SemanticRoute::Ambiguous => decision(
             ToolLoopRoute::PlainChat,
             SemanticRoute::Ambiguous,
-            "semantic_ambiguous_plain",
+            assessment.domain,
+            assessment.reason,
             None,
         ),
     }
@@ -128,52 +157,146 @@ pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> To
 fn decision(
     route: ToolLoopRoute,
     semantic_route: SemanticRoute,
+    domain: ToolDomain,
     reason: &'static str,
     status_hint: Option<StatusHint>,
 ) -> ToolRouteDecision {
     ToolRouteDecision {
         route,
         semantic_route,
+        domain,
         reason,
         status_hint,
     }
 }
 
-fn classify_semantic_route(text: &str) -> SemanticRoute {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SemanticAssessment {
+    semantic_route: SemanticRoute,
+    domain: ToolDomain,
+    reason: &'static str,
+}
+
+fn assessment(
+    semantic_route: SemanticRoute,
+    domain: ToolDomain,
+    reason: &'static str,
+) -> SemanticAssessment {
+    SemanticAssessment {
+        semantic_route,
+        domain,
+        reason,
+    }
+}
+
+fn classify_semantic_route(text: &str, has_recent_todo_context: bool) -> SemanticAssessment {
     let lower = text.to_ascii_lowercase();
     if text.starts_with('/') || text.starts_with('／') {
-        return SemanticRoute::Deterministic;
+        return assessment(
+            SemanticRoute::Deterministic,
+            ToolDomain::Unknown,
+            "deterministic_or_empty",
+        );
     }
 
-    // 明确工具意图优先，避免“写一个待办”“讲一下今天待办”被创作/解释词误判为闲聊。
-    if has_todo_intent(text, &lower)
-        || has_reminder_intent(text)
-        || has_memory_intent(text, &lower)
-        || has_weather_intent(text, &lower)
-        || has_train_intent(text, &lower)
-        || has_rss_intent(text, &lower)
-    {
-        return SemanticRoute::ToolLoop;
+    // 硬规则负责确定性工具请求；session/context 规则只处理 Todo 快照续指。
+    // 剩余模糊场景后续可替换为轻量模型/主模型输出结构化路由，不继续扩散关键词表。
+    if has_todo_intent(text, &lower) || has_reminder_intent(text) {
+        return assessment(
+            SemanticRoute::ToolLoop,
+            ToolDomain::Todo,
+            "semantic_tool_intent",
+        );
+    }
+    if is_strong_todo_reference_operation(text) {
+        return assessment(
+            SemanticRoute::ToolLoop,
+            ToolDomain::Todo,
+            "todo_reference_strong",
+        );
+    }
+    if is_weak_todo_context_reference(text) && has_recent_todo_context {
+        return assessment(
+            SemanticRoute::ToolLoop,
+            ToolDomain::Todo,
+            "todo_reference_context",
+        );
+    }
+    if has_memory_intent(text, &lower) {
+        return assessment(
+            SemanticRoute::ToolLoop,
+            ToolDomain::Memory,
+            "semantic_tool_intent",
+        );
+    }
+    if has_weather_intent(text, &lower) {
+        return assessment(
+            SemanticRoute::ToolLoop,
+            ToolDomain::Weather,
+            "semantic_tool_intent",
+        );
+    }
+    if has_train_intent(text, &lower) {
+        return assessment(
+            SemanticRoute::ToolLoop,
+            ToolDomain::Train,
+            "semantic_tool_intent",
+        );
+    }
+    if has_rss_intent(text, &lower) {
+        return assessment(
+            SemanticRoute::ToolLoop,
+            ToolDomain::Rss,
+            "semantic_tool_intent",
+        );
     }
 
     if mentions_inert_weather_topic(text) {
-        return SemanticRoute::PlainChat;
+        return assessment(
+            SemanticRoute::PlainChat,
+            ToolDomain::Unknown,
+            "semantic_plain_chat",
+        );
     }
 
     if has_plain_chat_intent(text, &lower) {
-        return SemanticRoute::PlainChat;
+        return assessment(
+            SemanticRoute::PlainChat,
+            ToolDomain::Unknown,
+            "semantic_plain_chat",
+        );
+    }
+
+    if is_weak_todo_context_reference(text) {
+        return assessment(
+            SemanticRoute::PlainChat,
+            ToolDomain::Todo,
+            "todo_reference_context_missing",
+        );
     }
 
     if has_ambiguous_toolish_intent(text) {
-        return SemanticRoute::Ambiguous;
+        return assessment(
+            SemanticRoute::Ambiguous,
+            ToolDomain::Unknown,
+            "semantic_ambiguous_plain",
+        );
     }
 
-    SemanticRoute::Ambiguous
+    assessment(
+        SemanticRoute::Ambiguous,
+        ToolDomain::Unknown,
+        "semantic_ambiguous_plain",
+    )
 }
 
-fn classify_status_hint(text: &str) -> Option<StatusHint> {
+fn classify_status_hint(text: &str, has_recent_todo_context: bool) -> Option<StatusHint> {
     let lower = text.to_ascii_lowercase();
-    if has_todo_intent(text, &lower) || has_reminder_intent(text) {
+    if has_todo_intent(text, &lower)
+        || has_reminder_intent(text)
+        || is_strong_todo_reference_operation(text)
+        || (has_recent_todo_context && is_weak_todo_context_reference(text))
+    {
         return Some(StatusHint::new(
             StatusSubject::Todo,
             todo_status_action(text),
@@ -232,13 +355,37 @@ fn has_reminder_intent(text: &str) -> bool {
             "别忘了",
         ],
     );
-    has_reminder_action
-        && contains_any(
-            text,
-            &[
-                "今天", "明天", "后天", "今晚", "下午", "上午", "晚上", "回头",
-            ],
-        )
+    has_reminder_action && looks_like_temporal_expression(text)
+}
+
+fn looks_like_temporal_expression(text: &str) -> bool {
+    // 路由层只判断“是否存在时间线索”，不消费推断出的日期，也不改变 Todo Tool
+    // 内部基于模型/时间上下文生成的最终 due_date/due_at。
+    let ctx = time_context::request_time_context();
+    let compact = text.split_whitespace().collect::<String>();
+    if time_context::infer_due_date_from_text(text, &ctx).is_some()
+        || compact != text && time_context::infer_due_date_from_text(&compact, &ctx).is_some()
+    {
+        return true;
+    }
+    contains_any(
+        text,
+        &[
+            "今晚",
+            "明早",
+            "明晚",
+            "早上",
+            "上午",
+            "中午",
+            "下午",
+            "晚上",
+            "凌晨",
+            "傍晚",
+            "回头",
+            "月末",
+            "下个月",
+        ],
+    )
 }
 
 fn has_memory_intent(text: &str, lower: &str) -> bool {
@@ -338,6 +485,9 @@ fn has_plain_chat_intent(text: &str, lower: &str) -> bool {
                 "讲故事",
                 "小说",
                 "文案",
+                "没看到",
+                "再来一条",
+                "发一条",
             ],
         )
         || contains_any(
@@ -369,12 +519,54 @@ fn has_ambiguous_toolish_intent(text: &str) -> bool {
     )
 }
 
+fn is_strong_todo_reference_operation(text: &str) -> bool {
+    let has_reference = has_ordinal_reference(text) || has_context_pronoun_reference(text);
+    if !has_reference {
+        return false;
+    }
+
+    let has_lifecycle_action = contains_any(text, TODO_CONFIRM_MARKERS);
+    let has_numbered_edit_or_process =
+        has_ordinal_reference(text) && contains_any(text, &["处理", "改一下", "修改", "编辑"]);
+    has_lifecycle_action || has_numbered_edit_or_process
+}
+
+fn is_weak_todo_context_reference(text: &str) -> bool {
+    (has_context_pronoun_reference(text)
+        && contains_any(text, &["处理", "改一下", "修改", "编辑", "改成"]))
+        || is_bulk_todo_context_reference(text)
+}
+
+fn is_bulk_todo_context_reference(text: &str) -> bool {
+    contains_any(text, &["都", "全部", "全"]) && contains_any(text, TODO_CONFIRM_MARKERS)
+}
+
 fn has_ordinal_reference(text: &str) -> bool {
     contains_any(
         text,
         &[
             "第一", "第二", "第三", "第四", "第五", "第六", "第七", "第八", "第九", "第十", "第 1",
-            "第 2", "第 3", "第 4", "第 5", "第 6", "第 7", "第 8", "第 9",
+            "第 2", "第 3", "第 4", "第 5", "第 6", "第 7", "第 8", "第 9", "第1", "第2", "第3",
+            "第4", "第5", "第6", "第7", "第8", "第9",
+        ],
+    )
+}
+
+fn has_context_pronoun_reference(text: &str) -> bool {
+    contains_any(
+        text,
+        &[
+            "它",
+            "这个",
+            "那个",
+            "这条",
+            "那条",
+            "这些",
+            "它们",
+            "刚才那条",
+            "刚刚那条",
+            "刚才那个",
+            "刚刚那个",
         ],
     )
 }
@@ -461,6 +653,14 @@ mod tests {
             group_tool_calling_enabled: false,
             provider_supports_tool_calling: true,
             enabled_tools_available: true,
+            has_recent_todo_context: false,
+        }
+    }
+
+    fn context_with_recent_todo() -> ToolRouteContext {
+        ToolRouteContext {
+            has_recent_todo_context: true,
+            ..context()
         }
     }
 
@@ -470,9 +670,12 @@ mod tests {
             "晚上好",
             "你在吗",
             "能试试输出一段长文本，我试试流式输出",
+            "帮我写个文案",
             "写一段长文本测试流式",
             "讲个故事",
             "解释一下 Rust 所有权",
+            "解释一下这个问题",
+            "刚刚没看到，再来一条",
             "C2C 流式还有问题",
             "C2C 消息发送失败",
             "T3 架构怎么设计",
@@ -497,9 +700,17 @@ mod tests {
     fn private_tool_intent_uses_tool_loop_when_tool_calling_enabled() {
         for input in [
             "删除第二条",
+            "处理第一项",
+            "处理第一条",
+            "把第一条改一下",
             "新增待办，明天接老公",
             "编辑第三条，其他不动",
             "记一下我喜欢少糖",
+            "周五别忘了开会",
+            "月底提醒我续费",
+            "月末提醒我续费",
+            "下个月初提醒我看账单",
+            "7 月 10 号提醒我验收",
             "杭州天气",
             "杭州天气如何",
             "杭州明天要带伞吗",
@@ -562,6 +773,55 @@ mod tests {
         assert_eq!(decision.semantic_route, SemanticRoute::Ambiguous);
         assert_eq!(decision.reason, "semantic_ambiguous_plain");
         assert_eq!(decision.status_hint, None);
+    }
+
+    #[test]
+    fn private_todo_reference_routes_by_strength_and_recent_context() {
+        for input in [
+            "完成第一条",
+            "处理第一项",
+            "取消它",
+            "删掉这个",
+            "这些完成了",
+        ] {
+            let decision = route_tool_loop(&request(input), context());
+            assert_eq!(decision.route, ToolLoopRoute::CompleteToolLoop, "{input}");
+            assert_eq!(decision.semantic_route, SemanticRoute::ToolLoop, "{input}");
+            assert_eq!(decision.domain, ToolDomain::Todo, "{input}");
+        }
+
+        for input in ["这个改一下", "都删除了吧"] {
+            let weak_without_context = route_tool_loop(&request(input), context());
+            assert_eq!(
+                weak_without_context.route,
+                ToolLoopRoute::PlainChat,
+                "{input}"
+            );
+            assert_eq!(
+                weak_without_context.semantic_route,
+                SemanticRoute::PlainChat,
+                "{input}"
+            );
+            assert_eq!(
+                weak_without_context.reason, "todo_reference_context_missing",
+                "{input}"
+            );
+        }
+
+        for input in ["这个改一下", "都删除了吧"] {
+            let weak_with_context = route_tool_loop(&request(input), context_with_recent_todo());
+            assert_eq!(
+                weak_with_context.route,
+                ToolLoopRoute::CompleteToolLoop,
+                "{input}"
+            );
+            assert_eq!(
+                weak_with_context.semantic_route,
+                SemanticRoute::ToolLoop,
+                "{input}"
+            );
+            assert_eq!(weak_with_context.domain, ToolDomain::Todo, "{input}");
+        }
     }
 
     #[test]
@@ -628,6 +888,7 @@ mod tests {
                     group_tool_calling_enabled: false,
                     provider_supports_tool_calling: true,
                     enabled_tools_available: true,
+                    has_recent_todo_context: false,
                 },
             )
             .route,

--- a/qq-maid-core/src/service/tests.rs
+++ b/qq-maid-core/src/service/tests.rs
@@ -200,6 +200,9 @@ fn core_plan_routes_private_todo_like_messages_to_agent_tool_loop() {
     for input in [
         "提醒我明天下午三点开会",
         "明天别忘了",
+        "周五别忘了开会",
+        "月底提醒我续费",
+        "下个月初提醒我看账单",
         "完成第一条",
         "恢复第 1 个",
         "取消它",
@@ -208,6 +211,59 @@ fn core_plan_routes_private_todo_like_messages_to_agent_tool_loop() {
         assert_eq!(
             service.plan_core_respond(&req).unwrap(),
             RespondPlan::CompleteToolLoop,
+            "{input}"
+        );
+    }
+}
+
+#[test]
+fn core_plan_routes_todo_context_reference_after_recent_list_to_tool_loop() {
+    let provider =
+        TestProvider::replying("工具回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let state = test_state_with_tool_calling(provider, 5, true);
+    let session_store = state.session_store.clone();
+    let meta = SessionMeta::new(
+        "private:u1",
+        Some("u1".to_owned()),
+        None,
+        None,
+        None,
+        "qq_official",
+    );
+    let mut session = session_store.get_or_create_active(&meta).unwrap();
+    // 等同用户刚通过 /todo 或自然语言列表看到了可见编号，路由只消费 fresh session 快照信号。
+    session.remember_last_todo_query("u1", "list", "进行中列表", vec!["todo-1".to_owned()]);
+    session_store.save(&mut session).unwrap();
+
+    let service = CoreHandle::new(state).respond_service();
+    for input in ["处理第一项", "这个改一下", "都删除了吧"] {
+        let req: RespondRequest = private_request(input).into();
+        assert_eq!(
+            service.plan_core_respond(&req).unwrap(),
+            RespondPlan::CompleteToolLoop,
+            "{input}"
+        );
+    }
+}
+
+#[test]
+fn core_plan_keeps_weak_todo_reference_plain_without_recent_context() {
+    let provider =
+        TestProvider::replying("聊天回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let state = test_state_with_tool_calling(provider, 5, true);
+    let service = CoreHandle::new(state).respond_service();
+
+    for input in [
+        "这个改一下",
+        "都删除了吧",
+        "帮我写个文案",
+        "解释一下这个问题",
+        "刚刚没看到，再来一条",
+    ] {
+        let req: RespondRequest = private_request(input).into();
+        assert_eq!(
+            service.plan_core_respond(&req).unwrap(),
+            RespondPlan::StreamingChat,
             "{input}"
         );
     }

--- a/qq-maid-core/src/service/tests.rs
+++ b/qq-maid-core/src/service/tests.rs
@@ -137,6 +137,30 @@ fn core_plan_routes_general_private_chat_to_streaming_when_tools_available() {
 }
 
 #[test]
+fn core_plan_routes_ambiguous_private_chat_to_streaming_when_tools_available() {
+    let provider =
+        TestProvider::replying("普通回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let state = test_state_with_tool_calling(provider, 5, true);
+    let service = CoreHandle::new(state).respond_service();
+
+    for input in [
+        "安排一下",
+        "能不能给我发一条，三行的信息",
+        "刚刚没看到，再来一条",
+        "帮我写个文案",
+        "解释一下这个问题",
+        "我好烦，陪我聊会",
+    ] {
+        let req: RespondRequest = private_request(input).into();
+        assert_eq!(
+            service.plan_core_respond(&req).unwrap(),
+            RespondPlan::StreamingChat,
+            "{input}"
+        );
+    }
+}
+
+#[test]
 fn core_plan_routes_private_weather_message_to_complete_tool_loop_when_tools_available() {
     let provider =
         TestProvider::replying("工具回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
@@ -175,6 +199,7 @@ fn core_plan_routes_private_todo_like_messages_to_agent_tool_loop() {
     let service = CoreHandle::new(state).respond_service();
     for input in [
         "提醒我明天下午三点开会",
+        "明天别忘了",
         "完成第一条",
         "恢复第 1 个",
         "取消它",


### PR DESCRIPTION
## 背景

Fixes #234。

当前私聊 Tool Loop 路由里，`SemanticRoute::Ambiguous` 会默认进入 `CompleteToolLoop`。这会让普通聊天、文本生成和上下文延续请求在 provider 支持工具且工具白名单非空时误进工具循环，失去普通 C2C 流式路径。

## 修改

- 将 `SemanticRoute::Ambiguous` 统一改为普通聊天路径，并使用 `semantic_ambiguous_plain` reason。
- 保持明确工具意图继续进入 Tool Loop，包括天气、列车、RSS、Todo 操作等。
- 将 `明天别忘了`、`回头提醒我检查日志` 这类 reminder 表达升级为明确 Todo 工具意图，而不是依赖 Ambiguous 兜底。
- 更新 `tool_route`、Core plan 和 chat response 测试，避免测试继续依赖模糊表达触发 Tool Loop。

## 影响

不确定请求现在默认走 `StreamingChat / PlainChat`。`enabled_tools_available` 和 provider tool support 只作为进入 Tool Loop 的门禁，不再单独推动请求进入工具循环。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p qq-maid-core tool_route`
- `cargo test -p qq-maid-core core_plan`
- `cargo test -p qq-maid-core respond`
- `cargo check -p qq-maid-core`
- `git diff --check`
