### PR TITLE
[codex] 建立 Gateway 出站能力抽象

### DIFF
--- a/qq-maid-gateway-rs/src/api/mod.rs
+++ b/qq-maid-gateway-rs/src/api/mod.rs
@@ -864,6 +864,10 @@ pub async fn send_outbound_with_fallback<S: OutboundSender + ?Sized>(
             }
             Err(err) => Err(err),
         },
+        OutboundMessage::ImagePlaceholder { fallback_text }
+        | OutboundMessage::AttachmentPlaceholder { fallback_text } => {
+            sender.send_text(target, fallback_text).await
+        }
     }
 }
 
@@ -901,7 +905,9 @@ pub async fn send_group_outbound_with_fallback<S: GroupOutboundSender + ?Sized>(
             }
             Err(err) => Err(err),
         },
-        OutboundMessage::Image { fallback_text, .. } => {
+        OutboundMessage::Image { fallback_text, .. }
+        | OutboundMessage::ImagePlaceholder { fallback_text }
+        | OutboundMessage::AttachmentPlaceholder { fallback_text } => {
             sender.send_text(target, fallback_text).await
         }
     }

--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -12,7 +12,10 @@ use super::{
     dedupe::MessageDedupe,
     event::C2cMessage,
     logging::{c2c_message_log_summary, mask_openid},
-    outbound::{RuntimeRecordingSender, send_c2c_text_with_status},
+    outbound::{
+        DeliveryMode, ReplyCapability, ReplyTarget, RuntimeRecordingSender,
+        send_c2c_text_with_status,
+    },
     ping::{
         GatewayRuntimeStatus, build_c2c_ping_reply_with_check_failure, is_ping_check_command,
         is_ping_command,
@@ -21,12 +24,12 @@ use super::{
     typing::{C2cTypingStatusGuard, TypingStopReason},
 };
 use crate::{
-    api::{C2cReplyTarget, OutboundSender, QqApiClient, send_outbound_with_fallback},
+    api::{OutboundSender, QqApiClient, send_outbound_with_fallback},
     auth::AccessTokenManager,
     config::AppConfig,
     markdown::MarkdownPayload,
     message_chunk::{ChunkLimits, OutboundSendError, send_c2c_outbound_chunked},
-    render::{OutboundMessage, render_respond_response},
+    render::{OutboundMessage, render_respond_response_for_profile},
     respond::{
         RespondClient, RespondEvent, RespondResponse, RespondTransport, build_respond_content,
         respond_error_to_qq_text,
@@ -67,7 +70,8 @@ async fn send_c2c_respond_response(
         inner: api,
         runtime,
     };
-    send_c2c_respond_response_with_sender(&sender, message, response, config).await
+    let capability = ReplyCapability::qq_official_c2c(config);
+    send_c2c_respond_response_with_sender(&sender, message, response, config, &capability).await
 }
 
 /// 普通 C2C 回复发送的共享实现。
@@ -79,11 +83,10 @@ pub(super) async fn send_c2c_respond_response_with_sender<S: OutboundSender + ?S
     message: &C2cMessage,
     response: &RespondResponse,
     config: &AppConfig,
+    capability: &ReplyCapability,
 ) -> anyhow::Result<()> {
     let masked_user = mask_openid(&message.user_openid);
-    let Some(outbound) =
-        render_respond_response(response, config.enable_markdown, config.enable_image)
-    else {
+    let Some(outbound) = render_respond_response_for_profile(response, &capability.render) else {
         debug!(
             message_id = %message.message_id,
             user = %masked_user,
@@ -92,10 +95,12 @@ pub(super) async fn send_c2c_respond_response_with_sender<S: OutboundSender + ?S
         return Ok(());
     };
 
-    let target = C2cReplyTarget {
-        user_openid: message.user_openid.clone(),
-        msg_id: Some(message.message_id.clone()),
-    };
+    let target = ReplyTarget::qq_c2c(
+        message.user_openid.clone(),
+        Some(message.message_id.clone()),
+    )
+    .to_qq_c2c_target()
+    .expect("QQ C2C reply target should adapt to QQ API target");
     debug!(
         message_id = target.msg_id.as_deref().unwrap_or(""),
         user = %masked_user,
@@ -197,11 +202,11 @@ pub(super) async fn handle_c2c_message(
             check_failure.as_deref(),
         )
         .await;
-        let target = C2cReplyTarget {
-            user_openid: message.user_openid,
-            msg_id: Some(message.message_id),
-        };
-        let outbound = render_local_ping_reply(reply, config.enable_markdown);
+        let target = ReplyTarget::qq_c2c(message.user_openid, Some(message.message_id))
+            .to_qq_c2c_target()
+            .expect("QQ C2C reply target should adapt to QQ API target");
+        let capability = ReplyCapability::qq_official_c2c(config);
+        let outbound = render_local_ping_reply(reply, &capability);
         debug!(
             message_id = target.msg_id.as_deref().unwrap_or(""),
             user = %mask_openid(&target.user_openid),
@@ -285,7 +290,8 @@ pub(super) async fn handle_c2c_message(
             send_c2c_respond_response(api, runtime, &message, &response, config).await?;
         }
         RespondTransport::Stream(stream) => {
-            if config.c2c_final_reply_stream_enabled {
+            let capability = ReplyCapability::qq_official_c2c(config);
+            if should_use_c2c_streaming(&capability) {
                 stream_respond_c2c(stream, api, runtime, &message, config, typing).await?;
             } else {
                 let sender = RuntimeRecordingSender {
@@ -376,31 +382,38 @@ where
             }
             RespondEvent::Completed(response) => {
                 stop_typing(typing, TypingStopReason::FinalReply);
-                send_c2c_respond_response_with_sender(sender, message, &response, config)
-                    .await
-                    .inspect(|_| {
-                        debug!(
-                            message_id = %message.message_id,
-                            user = %mask_openid(&message.user_openid),
-                            response_delivery_mode = "ordinary_complete",
-                            final_send_exit = "ordinary_reply",
-                            text_delta_count,
-                            status_event_count,
-                            "C2C stream disabled; ordinary final reply sent"
-                        );
-                    })
-                    .inspect_err(|send_err| {
-                        warn!(
-                            message_id = %message.message_id,
-                            user = %mask_openid(&message.user_openid),
-                            response_delivery_mode = "ordinary_complete",
-                            final_send_exit = "ordinary_reply",
-                            text_delta_count,
-                            status_event_count,
-                            error = %send_err,
-                            "C2C stream disabled; ordinary final reply failed"
-                        );
-                    })?;
+                let capability = ReplyCapability::qq_official_c2c(config);
+                send_c2c_respond_response_with_sender(
+                    sender,
+                    message,
+                    &response,
+                    config,
+                    &capability,
+                )
+                .await
+                .inspect(|_| {
+                    debug!(
+                        message_id = %message.message_id,
+                        user = %mask_openid(&message.user_openid),
+                        response_delivery_mode = "ordinary_complete",
+                        final_send_exit = "ordinary_reply",
+                        text_delta_count,
+                        status_event_count,
+                        "C2C stream disabled; ordinary final reply sent"
+                    );
+                })
+                .inspect_err(|send_err| {
+                    warn!(
+                        message_id = %message.message_id,
+                        user = %mask_openid(&message.user_openid),
+                        response_delivery_mode = "ordinary_complete",
+                        final_send_exit = "ordinary_reply",
+                        text_delta_count,
+                        status_event_count,
+                        error = %send_err,
+                        "C2C stream disabled; ordinary final reply failed"
+                    );
+                })?;
                 return Ok(DisabledStreamOutcome::Completed);
             }
             RespondEvent::Failed(failure) => {
@@ -434,10 +447,12 @@ async fn send_local_c2c_failure_text<S: OutboundSender + ?Sized>(
     message: &C2cMessage,
     text: &str,
 ) -> anyhow::Result<()> {
-    let target = C2cReplyTarget {
-        user_openid: message.user_openid.clone(),
-        msg_id: Some(message.message_id.clone()),
-    };
+    let target = ReplyTarget::qq_c2c(
+        message.user_openid.clone(),
+        Some(message.message_id.clone()),
+    )
+    .to_qq_c2c_target()
+    .expect("QQ C2C reply target should adapt to QQ API target");
     sender.send_text(&target, text).await?;
     Ok(())
 }
@@ -449,8 +464,17 @@ fn failure_stop_reason(failure: &CoreRespondFailure) -> TypingStopReason {
     }
 }
 
-fn render_local_ping_reply(reply: String, enable_markdown: bool) -> OutboundMessage {
-    if enable_markdown {
+fn should_use_c2c_streaming(capability: &ReplyCapability) -> bool {
+    debug_assert!(
+        capability.supports_delivery_mode(DeliveryMode::AsynchronousReply)
+            || capability.supports_delivery_mode(DeliveryMode::SynchronousReply),
+        "reply capability must expose at least one non-stream delivery mode"
+    );
+    capability.supports_delivery_mode(DeliveryMode::Streaming)
+}
+
+fn render_local_ping_reply(reply: String, capability: &ReplyCapability) -> OutboundMessage {
+    if capability.render.supports_markdown {
         // `/ping` 本地生成的状态报告本身就是 Markdown；发送层复用现有 fallback，
         // 避免 QQ Markdown 权限或平台兼容问题导致诊断消息完全丢失。
         return OutboundMessage::Markdown {
@@ -489,7 +513,7 @@ fn log_c2c_message_received(message: &C2cMessage, verbose_log: bool) {
 mod tests {
     use super::*;
     use crate::{
-        api::{ApiError, SendFuture},
+        api::{ApiError, C2cReplyTarget, SendFuture},
         config::{
             AgentTypingConfig, DEFAULT_CONVERSATION_QUEUE_CAPACITY,
             DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT, DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS,
@@ -648,7 +672,10 @@ mod tests {
 
     #[test]
     fn local_ping_reply_respects_markdown_config() {
-        let markdown = render_local_ping_reply("# 状态\n\n| A | B |".to_owned(), true);
+        let markdown_config = test_config();
+        let markdown_capability = ReplyCapability::qq_official_c2c(&markdown_config);
+        let markdown =
+            render_local_ping_reply("# 状态\n\n| A | B |".to_owned(), &markdown_capability);
         assert_eq!(
             markdown,
             OutboundMessage::Markdown {
@@ -657,13 +684,28 @@ mod tests {
             }
         );
 
-        let text = render_local_ping_reply("# 状态".to_owned(), false);
+        let mut text_config = test_config();
+        text_config.enable_markdown = false;
+        let text_capability = ReplyCapability::qq_official_c2c(&text_config);
+        let text = render_local_ping_reply("# 状态".to_owned(), &text_capability);
         assert_eq!(
             text,
             OutboundMessage::Text {
                 text: "# 状态".to_owned(),
             }
         );
+    }
+
+    #[test]
+    fn c2c_stream_branch_requires_stream_capability() {
+        let mut config = test_config();
+        config.c2c_final_reply_stream_enabled = true;
+        let streaming = ReplyCapability::qq_official_c2c(&config);
+        assert!(should_use_c2c_streaming(&streaming));
+
+        config.c2c_final_reply_stream_enabled = false;
+        let ordinary = ReplyCapability::qq_official_c2c(&config);
+        assert!(!should_use_c2c_streaming(&ordinary));
     }
 
     #[tokio::test]

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -17,22 +17,30 @@ use super::{
     event::{GroupEventType, GroupMessage},
     group_filter::{GroupCooldowns, should_ignore_group_message, should_process_group_message},
     logging::{group_message_log_summary, mask_openid},
-    outbound::{RuntimeRecordingGroupSender, send_group_text_with_status},
+    outbound::{
+        ReplyCapability, ReplyTarget, RuntimeRecordingGroupSender, send_group_text_with_status,
+    },
     ping::GatewayRuntimeStatus,
 };
 use crate::{
-    api::{GroupReplyTarget, QqApiClient},
+    api::QqApiClient,
     config::AppConfig,
     message_chunk::{ChunkLimits, OutboundSendError, send_group_outbound_chunked},
-    render::{OutboundMessage, render_respond_response},
+    render::{OutboundMessage, render_respond_response_for_profile},
     respond::{
         RespondClient, RespondEvent, RespondResponse, RespondTransport, respond_error_to_qq_text,
     },
 };
 
-fn group_reply_mention_prefix(message: &GroupMessage) -> Option<String> {
+fn group_reply_mention_prefix(
+    message: &GroupMessage,
+    capability: &ReplyCapability,
+) -> Option<String> {
     // 只有用户显式 @ 机器人触发的官方群 at 事件，才在回复正文里 @ 回发起人；
     // 普通群命令、关键词触发和回复机器人消息继续只挂原消息 msg_id，避免额外打扰。
+    if !capability.supports_at_mention {
+        return None;
+    }
     if message.event_type != GroupEventType::GroupAtMessage {
         return None;
     }
@@ -44,8 +52,12 @@ fn group_reply_mention_prefix(message: &GroupMessage) -> Option<String> {
         .map(|member_openid| format!("<@{member_openid}>"))
 }
 
-fn prefix_group_reply_text(message: &GroupMessage, text: &str) -> String {
-    let Some(prefix) = group_reply_mention_prefix(message) else {
+fn prefix_group_reply_text(
+    message: &GroupMessage,
+    text: &str,
+    capability: &ReplyCapability,
+) -> String {
+    let Some(prefix) = group_reply_mention_prefix(message, capability) else {
         return text.to_owned();
     };
     if text.trim().is_empty() {
@@ -58,8 +70,9 @@ fn prefix_group_reply_text(message: &GroupMessage, text: &str) -> String {
 fn prefix_group_reply_outbound(
     message: &GroupMessage,
     outbound: OutboundMessage,
+    capability: &ReplyCapability,
 ) -> OutboundMessage {
-    let Some(prefix) = group_reply_mention_prefix(message) else {
+    let Some(prefix) = group_reply_mention_prefix(message, capability) else {
         return outbound;
     };
     outbound.prefix_text(&prefix)
@@ -68,10 +81,11 @@ fn prefix_group_reply_outbound(
 fn group_respond_error_texts(
     message: &GroupMessage,
     err: &crate::respond::RespondError,
+    capability: &ReplyCapability,
 ) -> (String, String) {
     let log_text = respond_error_to_qq_text(err);
     // 群 at fallback 的实际 QQ 文本需要保留 <@openid>，但日志字段只能使用未加前缀的安全文案。
-    let qq_text = prefix_group_reply_text(message, &log_text);
+    let qq_text = prefix_group_reply_text(message, &log_text, capability);
     (qq_text, log_text)
 }
 
@@ -150,7 +164,8 @@ pub(super) async fn handle_group_message(
         }
         Err(err) => {
             runtime.record_respond_failure(err.log_summary());
-            let (qq_text, log_text) = group_respond_error_texts(&message, &err);
+            let capability = ReplyCapability::qq_official_group(config);
+            let (qq_text, log_text) = group_respond_error_texts(&message, &err, &capability);
             warn!(
                 message_id = %message.message_id,
                 group = %masked_group,
@@ -210,9 +225,8 @@ async fn send_group_respond_response(
     message: &GroupMessage,
     response: &RespondResponse,
 ) -> anyhow::Result<()> {
-    let Some(outbound) =
-        render_respond_response(response, config.enable_markdown, config.enable_image)
-    else {
+    let capability = ReplyCapability::qq_official_group(config);
+    let Some(outbound) = render_respond_response_for_profile(response, &capability.render) else {
         debug!(
             message_id = %message.message_id,
             group = %mask_openid(&message.group_openid),
@@ -220,15 +234,17 @@ async fn send_group_respond_response(
         );
         return Ok(());
     };
-    let outbound = prefix_group_reply_outbound(message, outbound);
+    let outbound = prefix_group_reply_outbound(message, outbound, &capability);
     let sender = RuntimeRecordingGroupSender {
         inner: api,
         runtime,
     };
-    let target = GroupReplyTarget {
-        group_openid: message.group_openid.clone(),
-        msg_id: Some(message.message_id.clone()),
-    };
+    let target = ReplyTarget::qq_group(
+        message.group_openid.clone(),
+        Some(message.message_id.clone()),
+    )
+    .to_qq_group_target()
+    .expect("QQ group reply target should adapt to QQ API target");
     let limits = ChunkLimits::new(
         config.markdown_chunk_soft_limit,
         config.text_chunk_soft_limit,
@@ -339,6 +355,14 @@ fn log_group_message_received(message: &GroupMessage, verbose_log: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{
+        AgentTypingConfig, DEFAULT_CONVERSATION_QUEUE_CAPACITY, DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT,
+        DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS, DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS,
+        DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS, DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES,
+        DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS, DEFAULT_MESSAGE_AGGREGATION_QUIET_MS,
+        DEFAULT_TEXT_CHUNK_SOFT_LIMIT, GroupMessageMode, MessageAggregationConfig,
+    };
+    use std::time::Duration;
 
     fn group_message(content: &str, event_type: GroupEventType) -> GroupMessage {
         GroupMessage {
@@ -357,12 +381,53 @@ mod tests {
         }
     }
 
+    fn test_config() -> AppConfig {
+        AppConfig {
+            app_id: "app".to_owned(),
+            app_secret: "secret".to_owned(),
+            bot_mention_ids: Vec::new(),
+            sandbox: false,
+            api_base: "https://example.test".to_owned(),
+            token_refresh_margin: Duration::from_secs(60),
+            enable_markdown: true,
+            enable_image: false,
+            enable_group_messages: true,
+            verbose_log: false,
+            group_message_mode: GroupMessageMode::Mention,
+            group_active_keywords: vec!["小女仆".to_owned()],
+            conversation_queue_capacity: DEFAULT_CONVERSATION_QUEUE_CAPACITY,
+            max_active_conversation_workers: DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS,
+            conversation_worker_idle_timeout: Duration::from_secs(300),
+            message_aggregation: MessageAggregationConfig {
+                private_enabled: true,
+                group_enabled: false,
+                quiet: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_QUIET_MS),
+                max_wait: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS),
+                max_messages: DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES,
+                max_chars: DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS,
+                max_active_keys: DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS,
+            },
+            c2c_final_reply_stream_enabled: false,
+            agent_typing: AgentTypingConfig {
+                enabled: false,
+                delay: Duration::from_secs(1),
+            },
+            markdown_chunk_soft_limit: DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT,
+            text_chunk_soft_limit: DEFAULT_TEXT_CHUNK_SOFT_LIMIT,
+        }
+    }
+
+    fn qq_group_capability() -> ReplyCapability {
+        ReplyCapability::qq_official_group(&test_config())
+    }
+
     #[test]
     fn group_at_reply_text_mentions_sender_when_member_openid_exists() {
         let message = group_message("hello", GroupEventType::GroupAtMessage);
+        let capability = qq_group_capability();
 
         assert_eq!(
-            prefix_group_reply_text(&message, "回复正文"),
+            prefix_group_reply_text(&message, "回复正文", &capability),
             "<@member-1>\n回复正文"
         );
     }
@@ -375,8 +440,9 @@ mod tests {
             "respond",
             "backend down",
         ));
+        let capability = qq_group_capability();
 
-        let (qq_text, log_text) = group_respond_error_texts(&message, &error);
+        let (qq_text, log_text) = group_respond_error_texts(&message, &error, &capability);
 
         assert!(qq_text.starts_with("<@member-1>\n"));
         assert!(!log_text.contains("member-1"));
@@ -386,30 +452,51 @@ mod tests {
     #[test]
     fn group_reply_text_skips_mention_for_plain_group_message() {
         let message = group_message("hello", GroupEventType::GroupMessage);
+        let capability = qq_group_capability();
 
-        assert_eq!(prefix_group_reply_text(&message, "回复正文"), "回复正文");
+        assert_eq!(
+            prefix_group_reply_text(&message, "回复正文", &capability),
+            "回复正文"
+        );
     }
 
     #[test]
     fn group_at_reply_text_skips_mention_without_member_openid() {
         let mut message = group_message("hello", GroupEventType::GroupAtMessage);
         message.member_openid = None;
+        let capability = qq_group_capability();
 
-        assert_eq!(prefix_group_reply_text(&message, "回复正文"), "回复正文");
+        assert_eq!(
+            prefix_group_reply_text(&message, "回复正文", &capability),
+            "回复正文"
+        );
     }
 
     #[test]
     fn group_at_reply_outbound_mentions_sender() {
         let message = group_message("hello", GroupEventType::GroupAtMessage);
+        let capability = qq_group_capability();
         let outbound = OutboundMessage::Text {
             text: "回复正文".to_owned(),
         };
 
         assert_eq!(
-            prefix_group_reply_outbound(&message, outbound),
+            prefix_group_reply_outbound(&message, outbound, &capability),
             OutboundMessage::Text {
                 text: "<@member-1>\n回复正文".to_owned(),
             }
+        );
+    }
+
+    #[test]
+    fn group_at_reply_respects_platform_mention_capability() {
+        let message = group_message("hello", GroupEventType::GroupAtMessage);
+        let mut capability = qq_group_capability();
+        capability.supports_at_mention = false;
+
+        assert_eq!(
+            prefix_group_reply_text(&message, "回复正文", &capability),
+            "回复正文"
         );
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -10,7 +10,7 @@ pub mod event;
 mod group;
 mod group_filter;
 pub mod logging;
-mod outbound;
+pub(crate) mod outbound;
 pub mod ping;
 pub(crate) mod platform;
 mod protocol;

--- a/qq-maid-gateway-rs/src/gateway/outbound.rs
+++ b/qq-maid-gateway-rs/src/gateway/outbound.rs
@@ -3,16 +3,231 @@
 //! 这里集中维护“真实 QQ 发送 -> runtime 状态记录”的约束，
 //! 避免不同调用点各自实现后出现重复记录或遗漏记录。
 
+use std::time::Duration;
+
 use crate::{
     api::{
         C2cReplyTarget, GroupOutboundSender, GroupReplyTarget, OutboundSender, QqApiClient,
         SendFuture, SendResult,
     },
+    config::AppConfig,
     markdown::MarkdownPayload,
     media::ImagePayload,
 };
 
-use super::ping::GatewayRuntimeStatus;
+use super::{ping::GatewayRuntimeStatus, platform::Platform};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DeliveryMode {
+    SynchronousReply,
+    AsynchronousReply,
+    Streaming,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UnsupportedCapabilityFallback {
+    UseText,
+    UsePlaceholderText,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LongRunningReplyStrategy {
+    KeepAsyncDelivery,
+    RequireAsyncFollowUp,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ReplyTarget {
+    Private {
+        platform: Platform,
+        target_id: String,
+        source_message_id: Option<String>,
+    },
+    Group {
+        platform: Platform,
+        target_id: String,
+        source_message_id: Option<String>,
+    },
+    #[allow(dead_code)]
+    ServiceAccount {
+        platform: Platform,
+        target_id: String,
+        source_message_id: Option<String>,
+    },
+}
+
+impl ReplyTarget {
+    pub(crate) fn qq_c2c(target_id: impl Into<String>, source_message_id: Option<String>) -> Self {
+        Self::Private {
+            platform: Platform::QqOfficial,
+            target_id: target_id.into(),
+            source_message_id,
+        }
+    }
+
+    pub(crate) fn qq_group(
+        target_id: impl Into<String>,
+        source_message_id: Option<String>,
+    ) -> Self {
+        Self::Group {
+            platform: Platform::QqOfficial,
+            target_id: target_id.into(),
+            source_message_id,
+        }
+    }
+
+    pub(crate) fn to_qq_c2c_target(&self) -> Option<C2cReplyTarget> {
+        match self {
+            Self::Private {
+                platform: Platform::QqOfficial,
+                target_id,
+                source_message_id,
+            } => Some(C2cReplyTarget {
+                user_openid: target_id.clone(),
+                msg_id: source_message_id.clone(),
+            }),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn to_qq_group_target(&self) -> Option<GroupReplyTarget> {
+        match self {
+            Self::Group {
+                platform: Platform::QqOfficial,
+                target_id,
+                source_message_id,
+            } => Some(GroupReplyTarget {
+                group_openid: target_id.clone(),
+                msg_id: source_message_id.clone(),
+            }),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RenderProfile {
+    pub(crate) supports_text: bool,
+    pub(crate) supports_markdown: bool,
+    pub(crate) supports_image: bool,
+    pub(crate) supports_attachment: bool,
+    pub(crate) unsupported_fallback: UnsupportedCapabilityFallback,
+}
+
+impl RenderProfile {
+    pub(crate) fn qq_official(config: &AppConfig, supports_image: bool) -> Self {
+        Self {
+            supports_text: true,
+            supports_markdown: config.enable_markdown,
+            supports_image: supports_image && config.enable_image,
+            supports_attachment: false,
+            unsupported_fallback: UnsupportedCapabilityFallback::UseText,
+        }
+    }
+
+    pub(crate) fn text_only_sync() -> Self {
+        Self {
+            supports_text: true,
+            supports_markdown: false,
+            supports_image: false,
+            supports_attachment: false,
+            unsupported_fallback: UnsupportedCapabilityFallback::UsePlaceholderText,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ReplyLimits {
+    pub(crate) single_message_chars: Option<usize>,
+    pub(crate) reply_timeout: Option<Duration>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ReplyCapability {
+    pub(crate) platform: Platform,
+    pub(crate) render: RenderProfile,
+    pub(crate) supports_quote_original: bool,
+    pub(crate) supports_at_mention: bool,
+    pub(crate) supports_multi_part: bool,
+    pub(crate) supports_synchronous_reply: bool,
+    pub(crate) supports_asynchronous_reply: bool,
+    pub(crate) supports_streaming: bool,
+    pub(crate) limits: ReplyLimits,
+    pub(crate) long_running_strategy: LongRunningReplyStrategy,
+}
+
+impl ReplyCapability {
+    pub(crate) fn qq_official_c2c(config: &AppConfig) -> Self {
+        Self {
+            platform: Platform::QqOfficial,
+            render: RenderProfile::qq_official(config, true),
+            supports_quote_original: true,
+            supports_at_mention: false,
+            supports_multi_part: true,
+            supports_synchronous_reply: false,
+            supports_asynchronous_reply: true,
+            supports_streaming: config.c2c_final_reply_stream_enabled,
+            limits: ReplyLimits {
+                single_message_chars: Some(
+                    config
+                        .markdown_chunk_soft_limit
+                        .max(config.text_chunk_soft_limit),
+                ),
+                reply_timeout: None,
+            },
+            long_running_strategy: LongRunningReplyStrategy::KeepAsyncDelivery,
+        }
+    }
+
+    pub(crate) fn qq_official_group(config: &AppConfig) -> Self {
+        Self {
+            platform: Platform::QqOfficial,
+            render: RenderProfile::qq_official(config, false),
+            supports_quote_original: true,
+            supports_at_mention: true,
+            supports_multi_part: true,
+            supports_synchronous_reply: false,
+            supports_asynchronous_reply: true,
+            supports_streaming: false,
+            limits: ReplyLimits {
+                single_message_chars: Some(
+                    config
+                        .markdown_chunk_soft_limit
+                        .max(config.text_chunk_soft_limit),
+                ),
+                reply_timeout: None,
+            },
+            long_running_strategy: LongRunningReplyStrategy::KeepAsyncDelivery,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn wechat_service_text_sync(reply_timeout: Duration) -> Self {
+        Self {
+            platform: Platform::WechatService,
+            render: RenderProfile::text_only_sync(),
+            supports_quote_original: false,
+            supports_at_mention: false,
+            supports_multi_part: false,
+            supports_synchronous_reply: true,
+            supports_asynchronous_reply: true,
+            supports_streaming: false,
+            limits: ReplyLimits {
+                single_message_chars: None,
+                reply_timeout: Some(reply_timeout),
+            },
+            long_running_strategy: LongRunningReplyStrategy::RequireAsyncFollowUp,
+        }
+    }
+
+    pub(crate) fn supports_delivery_mode(self, mode: DeliveryMode) -> bool {
+        match mode {
+            DeliveryMode::SynchronousReply => self.supports_synchronous_reply,
+            DeliveryMode::AsynchronousReply => self.supports_asynchronous_reply,
+            DeliveryMode::Streaming => self.supports_streaming,
+        }
+    }
+}
 
 pub(crate) async fn send_c2c_text_with_status(
     api: &QqApiClient,
@@ -130,6 +345,49 @@ impl GroupOutboundSender for RuntimeRecordingGroupSender<'_> {
 mod tests {
     use super::*;
     use crate::api::ApiError;
+    use crate::config::{
+        AgentTypingConfig, DEFAULT_CONVERSATION_QUEUE_CAPACITY, DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT,
+        DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS, DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS,
+        DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS, DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES,
+        DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS, DEFAULT_MESSAGE_AGGREGATION_QUIET_MS,
+        DEFAULT_TEXT_CHUNK_SOFT_LIMIT, GroupMessageMode, MessageAggregationConfig,
+    };
+
+    fn test_config() -> AppConfig {
+        AppConfig {
+            app_id: "app".to_owned(),
+            app_secret: "secret".to_owned(),
+            bot_mention_ids: Vec::new(),
+            sandbox: false,
+            api_base: "https://example.test".to_owned(),
+            token_refresh_margin: Duration::from_secs(60),
+            enable_markdown: true,
+            enable_image: false,
+            enable_group_messages: true,
+            verbose_log: false,
+            group_message_mode: GroupMessageMode::Mention,
+            group_active_keywords: vec!["小女仆".to_owned()],
+            conversation_queue_capacity: DEFAULT_CONVERSATION_QUEUE_CAPACITY,
+            max_active_conversation_workers: DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS,
+            conversation_worker_idle_timeout: Duration::from_secs(300),
+            message_aggregation: MessageAggregationConfig {
+                private_enabled: true,
+                group_enabled: false,
+                quiet: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_QUIET_MS),
+                max_wait: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS),
+                max_messages: DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES,
+                max_chars: DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS,
+                max_active_keys: DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS,
+            },
+            c2c_final_reply_stream_enabled: true,
+            agent_typing: AgentTypingConfig {
+                enabled: false,
+                delay: Duration::from_secs(1),
+            },
+            markdown_chunk_soft_limit: DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT,
+            text_chunk_soft_limit: DEFAULT_TEXT_CHUNK_SOFT_LIMIT,
+        }
+    }
 
     #[test]
     fn record_qq_send_result_updates_runtime_status() {
@@ -149,6 +407,68 @@ mod tests {
         assert_eq!(
             snapshot.last_qq_send_failure_summary.as_deref(),
             Some("text sending is unsupported")
+        );
+    }
+
+    #[test]
+    fn qq_official_c2c_capability_expresses_text_markdown_stream_and_multipart() {
+        let capability = ReplyCapability::qq_official_c2c(&test_config());
+
+        assert_eq!(capability.platform, Platform::QqOfficial);
+        assert!(capability.render.supports_text);
+        assert!(capability.render.supports_markdown);
+        assert!(capability.supports_multi_part);
+        assert!(capability.supports_quote_original);
+        assert!(!capability.supports_at_mention);
+        assert!(capability.supports_delivery_mode(DeliveryMode::AsynchronousReply));
+        assert!(capability.supports_delivery_mode(DeliveryMode::Streaming));
+    }
+
+    #[test]
+    fn reply_target_adapts_qq_private_and_group_targets() {
+        let private = ReplyTarget::qq_c2c("user-1", Some("msg-1".to_owned()))
+            .to_qq_c2c_target()
+            .unwrap();
+        assert_eq!(private.user_openid, "user-1");
+        assert_eq!(private.msg_id.as_deref(), Some("msg-1"));
+
+        let group = ReplyTarget::qq_group("group-1", Some("group-msg-1".to_owned()))
+            .to_qq_group_target()
+            .unwrap();
+        assert_eq!(group.group_openid, "group-1");
+        assert_eq!(group.msg_id.as_deref(), Some("group-msg-1"));
+    }
+
+    #[test]
+    fn qq_official_markdown_capability_follows_runtime_config() {
+        let mut config = test_config();
+        config.enable_markdown = false;
+        let capability = ReplyCapability::qq_official_c2c(&config);
+
+        assert!(!capability.render.supports_markdown);
+        assert_eq!(
+            capability.render.unsupported_fallback,
+            UnsupportedCapabilityFallback::UseText
+        );
+    }
+
+    #[test]
+    fn wechat_service_capability_is_text_sync_without_streaming() {
+        let capability = ReplyCapability::wechat_service_text_sync(Duration::from_secs(5));
+
+        assert_eq!(capability.platform, Platform::WechatService);
+        assert!(capability.render.supports_text);
+        assert!(!capability.render.supports_markdown);
+        assert!(capability.supports_delivery_mode(DeliveryMode::SynchronousReply));
+        assert!(capability.supports_delivery_mode(DeliveryMode::AsynchronousReply));
+        assert!(!capability.supports_delivery_mode(DeliveryMode::Streaming));
+        assert_eq!(
+            capability.long_running_strategy,
+            LongRunningReplyStrategy::RequireAsyncFollowUp
+        );
+        assert_eq!(
+            capability.limits.reply_timeout,
+            Some(Duration::from_secs(5))
         );
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/platform/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/mod.rs
@@ -8,3 +8,4 @@ mod model;
 pub(crate) mod qq_official;
 
 pub(crate) use core::{core_scope_key, render_text_for_core, to_core_request};
+pub(crate) use model::Platform;

--- a/qq-maid-gateway-rs/src/gateway/stream/delivery.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/delivery.rs
@@ -17,7 +17,7 @@ use crate::{
         c2c::send_c2c_respond_response_with_sender,
         event::C2cMessage,
         logging::{mask_identifier, mask_openid},
-        outbound::RuntimeRecordingSender,
+        outbound::{ReplyCapability, RuntimeRecordingSender},
         ping::GatewayRuntimeStatus,
         typing::{C2cTypingStatusGuard, TypingStopReason},
     },
@@ -570,43 +570,50 @@ where
                         } else {
                             output_policy.as_str()
                         };
-                        send_c2c_respond_response_with_sender(sender, message, &response, config)
-                            .await
-                            .inspect(|_| {
-                                info!(
-                                    user = %masked_user,
-                                    reply_msg_id = %masked_reply_msg_id,
-                                    phase = "ordinary_fallback_on_completed",
-                                    response_delivery_mode,
-                                    stream_state = stream_state_name,
-                                    text_delta_count,
-                                    status_event_count,
-                                    stream_entered_active = false,
-                                    final_send_exit = "ordinary_reply",
-                                    qq_stream_send_count = 0_u32,
-                                    accumulated_chars = accumulated.chars().count(),
-                                    elapsed_ms = started_at.elapsed().as_millis(),
-                                    fallback_used = stream_first_attempted,
-                                    final_chars,
-                                    "QQ C2C stream response completed"
-                                );
-                            })
-                            .inspect_err(|fallback_err| {
-                                warn!(
-                                    user = %masked_user,
-                                    reply_msg_id = %masked_reply_msg_id,
-                                    phase = "ordinary_fallback_on_completed",
-                                    response_delivery_mode,
-                                    stream_state = stream_state_name,
-                                    error = %fallback_err,
-                                    text_delta_count,
-                                    status_event_count,
-                                    stream_entered_active = false,
-                                    final_send_exit = "ordinary_reply",
-                                    final_chars,
-                                    "QQ ordinary fallback send failed"
-                                );
-                            })?;
+                        let capability = ReplyCapability::qq_official_c2c(config);
+                        send_c2c_respond_response_with_sender(
+                            sender,
+                            message,
+                            &response,
+                            config,
+                            &capability,
+                        )
+                        .await
+                        .inspect(|_| {
+                            info!(
+                                user = %masked_user,
+                                reply_msg_id = %masked_reply_msg_id,
+                                phase = "ordinary_fallback_on_completed",
+                                response_delivery_mode,
+                                stream_state = stream_state_name,
+                                text_delta_count,
+                                status_event_count,
+                                stream_entered_active = false,
+                                final_send_exit = "ordinary_reply",
+                                qq_stream_send_count = 0_u32,
+                                accumulated_chars = accumulated.chars().count(),
+                                elapsed_ms = started_at.elapsed().as_millis(),
+                                fallback_used = stream_first_attempted,
+                                final_chars,
+                                "QQ C2C stream response completed"
+                            );
+                        })
+                        .inspect_err(|fallback_err| {
+                            warn!(
+                                user = %masked_user,
+                                reply_msg_id = %masked_reply_msg_id,
+                                phase = "ordinary_fallback_on_completed",
+                                response_delivery_mode,
+                                stream_state = stream_state_name,
+                                error = %fallback_err,
+                                text_delta_count,
+                                status_event_count,
+                                stream_entered_active = false,
+                                final_send_exit = "ordinary_reply",
+                                final_chars,
+                                "QQ ordinary fallback send failed"
+                            );
+                        })?;
                         return Ok(C2cStreamingPhase::Completed);
                     }
                 }
@@ -689,7 +696,9 @@ where
         }
         C2cStreamingPhase::Pending(_) if !accumulated.is_empty() && !stream_first_attempted => {
             let response = response_from_incomplete_stream_text(&accumulated);
-            send_c2c_respond_response_with_sender(sender, message, &response, config).await?;
+            let capability = ReplyCapability::qq_official_c2c(config);
+            send_c2c_respond_response_with_sender(sender, message, &response, config, &capability)
+                .await?;
         }
         C2cStreamingPhase::Pending(_) | C2cStreamingPhase::Completed => {}
     }

--- a/qq-maid-gateway-rs/src/message_chunk.rs
+++ b/qq-maid-gateway-rs/src/message_chunk.rs
@@ -575,7 +575,9 @@ pub fn chunk_outbound(message: &OutboundMessage, limits: &ChunkLimits) -> Vec<Ou
             fallback_text,
         } => chunk_markdown_with_fallback(&markdown.content, fallback_text, limits),
         // Image 不做文本分段；发送编排走单段图片链路，fallback 用作纯文本占位。
-        OutboundMessage::Image { fallback_text, .. } => {
+        OutboundMessage::Image { fallback_text, .. }
+        | OutboundMessage::ImagePlaceholder { fallback_text }
+        | OutboundMessage::AttachmentPlaceholder { fallback_text } => {
             chunk_plain_text(fallback_text, limits.text_soft_limit)
         }
     }
@@ -989,6 +991,8 @@ fn outbound_kind(message: &OutboundMessage) -> &'static str {
         OutboundMessage::Text { .. } => "text",
         OutboundMessage::Markdown { .. } => "markdown",
         OutboundMessage::Image { .. } => "image",
+        OutboundMessage::ImagePlaceholder { .. } => "image_placeholder",
+        OutboundMessage::AttachmentPlaceholder { .. } => "attachment_placeholder",
     }
 }
 

--- a/qq-maid-gateway-rs/src/render.rs
+++ b/qq-maid-gateway-rs/src/render.rs
@@ -1,4 +1,7 @@
-use crate::{markdown::MarkdownPayload, media::ImagePayload, respond::RespondResponse};
+use crate::{
+    gateway::outbound::RenderProfile, markdown::MarkdownPayload, media::ImagePayload,
+    respond::RespondResponse,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OutboundMessage {
@@ -13,15 +16,22 @@ pub enum OutboundMessage {
         image: ImagePayload,
         fallback_text: String,
     },
+    ImagePlaceholder {
+        fallback_text: String,
+    },
+    AttachmentPlaceholder {
+        fallback_text: String,
+    },
 }
 
 impl OutboundMessage {
     pub fn fallback_text(&self) -> &str {
         match self {
             Self::Text { text } => text,
-            Self::Markdown { fallback_text, .. } | Self::Image { fallback_text, .. } => {
-                fallback_text
-            }
+            Self::Markdown { fallback_text, .. }
+            | Self::Image { fallback_text, .. }
+            | Self::ImagePlaceholder { fallback_text }
+            | Self::AttachmentPlaceholder { fallback_text } => fallback_text,
         }
     }
 
@@ -53,6 +63,12 @@ impl OutboundMessage {
                 image,
                 fallback_text: join(prefix, fallback_text),
             },
+            Self::ImagePlaceholder { fallback_text } => Self::ImagePlaceholder {
+                fallback_text: join(prefix, fallback_text),
+            },
+            Self::AttachmentPlaceholder { fallback_text } => Self::AttachmentPlaceholder {
+                fallback_text: join(prefix, fallback_text),
+            },
         }
     }
 }
@@ -60,13 +76,27 @@ impl OutboundMessage {
 pub fn render_respond_response(
     response: &RespondResponse,
     enable_markdown: bool,
-    _enable_image: bool,
+    enable_image: bool,
+) -> Option<OutboundMessage> {
+    let profile = RenderProfile {
+        supports_text: true,
+        supports_markdown: enable_markdown,
+        supports_image: enable_image,
+        supports_attachment: false,
+        unsupported_fallback: crate::gateway::outbound::UnsupportedCapabilityFallback::UseText,
+    };
+    render_respond_response_for_profile(response, &profile)
+}
+
+pub(crate) fn render_respond_response_for_profile(
+    response: &RespondResponse,
+    profile: &RenderProfile,
 ) -> Option<OutboundMessage> {
     let text = response.text.as_ref()?;
     if text.trim().is_empty() {
         return None;
     }
-    if enable_markdown
+    if profile.supports_markdown
         && let Some(markdown) = response.markdown.as_ref()
         && !markdown.trim().is_empty()
     {
@@ -75,7 +105,9 @@ pub fn render_respond_response(
             fallback_text: text.clone(),
         });
     }
-    Some(OutboundMessage::Text { text: text.clone() })
+    profile
+        .supports_text
+        .then(|| OutboundMessage::Text { text: text.clone() })
 }
 
 #[cfg(test)]
@@ -154,6 +186,19 @@ mod tests {
                 case.name
             );
         }
+    }
+
+    #[test]
+    fn profile_without_markdown_degrades_to_text() {
+        let profile = RenderProfile::text_only_sync();
+        let response = response_with_body(Some("hello"), Some("**hello**"));
+
+        assert_eq!(
+            render_respond_response_for_profile(&response, &profile),
+            Some(OutboundMessage::Text {
+                text: "hello".to_owned()
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 变更内容

- 在 Gateway 层新增平台无关的出站目标、内容渲染画像和回复能力画像。
- 明确 QQ 官方 C2C / 群回复能力，包括 text、markdown、群 at、多段、异步回复和 C2C stream。
- 让 C2C / 群普通回复先基于能力画像渲染，再适配到现有 QQ API target 和 chunk sender。
- 让 C2C stream 入口通过 `DeliveryMode::Streaming` 能力判断，保留原有 QQ stream 状态机行为。
- 为微信服务号预留同步文本回复和长耗时异步策略表达，不实现微信协议接入。

## 影响

Core / LLM / Tool Loop 语义不变。QQ 官方现有发送链路、markdown/text fallback、群 at 前缀、分段发送和 C2C 流式策略保持兼容。

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy -p qq-maid-gateway-rs --all-targets --all-features -- -D warnings`
- `make test-gateway`
- `cargo test -p qq-maid-gateway-rs --all-features`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace --release --all-features`
- `git diff --check`
