### PR TITLE
[codex] 修复微信回调重试去重与入站日志上下文

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@
 | 联网查询 | Web Search、天气、列车时刻和翻译 |
 | 消息体验 | 私聊最终回复流、QQ 原生 typing、普通消息自动降级 |
 | 模型基础设施 | Provider 路由、候选链、fallback、SSE、usage、健康观测和 Agent Loop 观测 |
-| 运维诊断 | `/healthz`、`/ping`、部署脚本、服务控制和网络诊断 |
+| 多入口接入 | QQ 官方 Gateway；可选微信服务号明文 text-only 同步回调，默认关闭 |
+| 运维诊断 | `/healthz`、`/ping`、部署脚本、服务控制和网络诊断；`/ping all` 会展示微信入口安全摘要 |
 
 ## 使用示例
 
@@ -328,7 +329,7 @@ QQ 消息
   → Gateway 以流式或普通消息发送
 ```
 
-Gateway 与 Core 由同一进程装配，聊天、命令、`/ping check`、RSS 和 Todo 主动推送都走进程内强类型接口；外部 HTTP 默认仅保留 `GET /healthz`，以及运行和 Markdown 渲染所需的少量辅助接口。显式启用 `WECHAT_SERVICE_ENABLED=true` 时，Gateway 会额外启动微信服务号回调监听器，只处理 URL 验证和文本消息同步 XML 回复。
+Gateway 与 Core 由同一进程装配，聊天、命令、`/ping check`、RSS 和 Todo 主动推送都走进程内强类型接口；外部 HTTP 默认仅保留 `GET /healthz`，以及运行和 Markdown 渲染所需的少量辅助接口。显式启用 `WECHAT_SERVICE_ENABLED=true` 时，Gateway 会额外启动微信服务号回调监听器，只处理 GET URL 验证、POST 明文 `text` XML 和同步文本 XML 回复，Markdown 会降级为 text。当前不支持加密 XML、客服消息、模板消息、图片语音视频、事件、异步 follow-up 或流式输出，配置步骤见 [runtime/README.md#微信服务号文本回调配置](./runtime/README.md#微信服务号文本回调配置)。
 
 项目内部通过根目录 Cargo Workspace 统一管理，保持明确的模块边界：
 
@@ -364,6 +365,7 @@ Tool Calling 不等于把宿主机交给模型。
 * 群聊默认不进入 Tool Loop；即使配置了群聊 profile，也必须显式允许群聊 Tool Calling，开启后仍按 `enabled_tools` 白名单暴露工具，默认不含 Todo
 * slash 命令、文件处理和宿主机代码执行不会进入普通聊天 Tool Loop
 * 工具成功与否以真实执行结果为准，不以模型自述为准
+* 微信服务号入口默认关闭；启用时只支持明文 text-only 同步回复，不记录 Token、AppSecret、OpenID 或消息正文到诊断输出
 
 ## 开发调试
 

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ QQ 消息
   → Gateway 以流式或普通消息发送
 ```
 
-Gateway 与 Core 由同一进程装配，聊天、命令、`/ping check`、RSS 和 Todo 主动推送都走进程内强类型接口；外部 HTTP 默认仅保留 `GET /healthz`，以及运行和 Markdown 渲染所需的少量辅助接口。显式启用 `WECHAT_SERVICE_ENABLED=true` 时，Gateway 会额外启动微信服务号回调监听器，只处理 GET URL 验证、POST 明文 `text` XML 和同步文本 XML 回复，Markdown 会降级为 text。当前不支持加密 XML、客服消息、模板消息、图片语音视频、事件、异步 follow-up 或流式输出，配置步骤见 [runtime/README.md#微信服务号文本回调配置](./runtime/README.md#微信服务号文本回调配置)。
+Gateway 与 Core 由同一进程装配，聊天、命令、`/ping check`、RSS 和 Todo 主动推送都走进程内强类型接口；外部 HTTP 默认仅保留 `GET /healthz`，以及运行和 Markdown 渲染所需的少量辅助接口。显式启用 `WECHAT_SERVICE_ENABLED=true` 时，Gateway 会额外启动微信服务号回调监听器，只处理 GET URL 验证、POST 明文 `text` XML 和同步文本 XML 回复，Markdown 会降级为 text。当前不支持加密 XML、access_token 获取、客服消息、模板消息、图片语音视频、事件、异步 follow-up 或流式输出，配置步骤见 [runtime/README.md#微信服务号文本回调配置](./runtime/README.md#微信服务号文本回调配置)。
 
 项目内部通过根目录 Cargo Workspace 统一管理，保持明确的模块边界：
 
@@ -365,7 +365,7 @@ Tool Calling 不等于把宿主机交给模型。
 * 群聊默认不进入 Tool Loop；即使配置了群聊 profile，也必须显式允许群聊 Tool Calling，开启后仍按 `enabled_tools` 白名单暴露工具，默认不含 Todo
 * slash 命令、文件处理和宿主机代码执行不会进入普通聊天 Tool Loop
 * 工具成功与否以真实执行结果为准，不以模型自述为准
-* 微信服务号入口默认关闭；启用时只支持明文 text-only 同步回复，不记录 Token、AppSecret、OpenID 或消息正文到诊断输出
+* 微信服务号入口默认关闭；启用时只支持明文 text-only 同步回复，不获取 access_token，也不记录 Token、AppSecret、OpenID 或消息正文到诊断输出
 
 ## 开发调试
 

--- a/qq-maid-gateway-rs/README.md
+++ b/qq-maid-gateway-rs/README.md
@@ -16,6 +16,11 @@ QQ Gateway GROUP_AT_MESSAGE_CREATE
 qq-maid-core RSS scheduler
   -> qq-maid-gateway-rs PushSink
   -> QQ OpenAPI /v2/users 或 /v2/groups 消息发送
+
+WeChat Service Account HTTPS callback
+  -> qq-maid-gateway-rs optional callback listener
+  -> qq-maid-core CoreService::respond
+  -> synchronous text XML reply
 ```
 
 ## 当前范围
@@ -26,7 +31,9 @@ qq-maid-core RSS scheduler
 - 入站附件不会改 Core 稳定请求模型；图片等附件信息会追加到文本末尾，例如 `[附件 image/jpeg: a.jpg https://example.test/a.jpg]`。
 - Markdown 和图片保留独立 outbound 类型、payload 构造和发送入口；发送失败会 warn 并 fallback 到文本。C2C 流式回复当前固定使用 Markdown 流式载荷，首帧成功后不再补发普通全文。
 - Core RSS 调度和 Todo 每日提醒通过进程内 `PushSink` 主动推送，不再暴露本机 HTTP push 入口。
+- 微信服务号入口默认关闭；启用后只处理 GET URL 验证、POST 明文 `text` XML 和同步文本 XML 回复。Markdown 会降级为 text。
 - 不做频道、频道私信、Ark、Embed、Keyboard、多租户或旧接入层兼容。
+- 微信服务号暂不做加密 XML、客服消息、access_token 获取、模板消息、图片语音视频、事件、异步 follow-up、主动推送或流式输出。
 
 ## 开发边界
 
@@ -50,6 +57,8 @@ qq-maid-core RSS scheduler
 - `src/gateway/outbound.rs`：QQ 出站发送包装和 runtime 发送状态记录，保持“真实发送结果再记录状态”的约束。
 - `src/respond.rs`：gateway 到 CoreService 的进程内桥接层，负责 CoreRequest 映射、错误脱敏，以及 reply block / 附件备注拼接。
 - `src/gateway/push.rs`：进程内主动推送实现。
+- `src/gateway/wechat_service.rs`：微信服务号最小文本回调 HTTP 入口，只负责签名校验、明文 XML 解析、Core 调用和同步 XML 回复。
+- `src/gateway/platform/wechat_service.rs`：微信服务号平台字段到统一 `InboundMessage` / `CoreRequest` 的映射，以及 XML 解析和渲染 helper。
 
 维护时应尽量保持这些边界，不要把 WebSocket 协议细节、Core 业务调用和 QQ 发送状态记录重新堆回同一个超长文件。
 
@@ -92,6 +101,22 @@ QQ_SECRET=你的QQ机器人AppSecret
 普通群事件是否 @ 当前机器人只信任官方结构化 `mentions[].is_you == true`；旧的 AppID、openid、member_openid、CQ 文本和 `<@...>` 文本不再作为触发依据。`QQ_MAID_BOT_MENTION_IDS` 仅保留为旧配置兼容，不应再用于修正普通群 @ 判定。不要把真实 ID 写入公开文档或提交到仓库。
 
 普通群消息会过滤自己发送的消息、可识别的其它机器人消息、空内容/无附件消息和重复 `message_id`，并使用群级与群成员级内存冷却避免刷屏；但发送给 Core 的 `scope_key` 仍保持 `group:<group_openid>`，避免把 RSS、会话等按当前 QQ 目标建模的能力意外拆成成员分片。
+
+微信服务号最小配置：
+
+```env
+WECHAT_SERVICE_ENABLED=false
+WECHAT_SERVICE_TOKEN=
+WECHAT_SERVICE_APP_ID=
+WECHAT_SERVICE_APP_SECRET=
+WECHAT_SERVICE_BIND_HOST=127.0.0.1
+WECHAT_SERVICE_BIND_PORT=8788
+WECHAT_SERVICE_CALLBACK_PATH=/wechat/service
+```
+
+生产环境建议保持本机监听 `127.0.0.1`，由 Nginx、Caddy 或 Cloudflare Tunnel 把公网 HTTPS `https://你的域名/wechat/service` 转发到 `http://127.0.0.1:8788/wechat/service`。微信公众平台服务器配置中 URL 填公网 HTTPS 地址，Token 填 `WECHAT_SERVICE_TOKEN`，消息加解密方式选择明文模式，`EncodingAESKey` 当前未使用。详细配置和排障步骤见 [runtime/README.md](../runtime/README.md#微信服务号文本回调配置)。
+
+`/ping all` 的调试详情会展示微信入口安全摘要，包括启用状态、监听地址和端口、callback path、`token` / `app_id` / `app_secret` 是否已配置、当前支持模式和暂不支持能力。secret 类字段只显示 `configured` / `missing`，不输出真实值；未启用时显示 `disabled`，不表示 QQ Gateway 异常。
 
 不要提交真实配置文件、AppSecret、Access Token、openid、私聊内容或截图中的敏感信息。
 

--- a/qq-maid-gateway-rs/README.md
+++ b/qq-maid-gateway-rs/README.md
@@ -116,7 +116,7 @@ WECHAT_SERVICE_CALLBACK_PATH=/wechat/service
 
 生产环境建议保持本机监听 `127.0.0.1`，由 Nginx、Caddy 或 Cloudflare Tunnel 把公网 HTTPS `https://你的域名/wechat/service` 转发到 `http://127.0.0.1:8788/wechat/service`。微信公众平台服务器配置中 URL 填公网 HTTPS 地址，Token 填 `WECHAT_SERVICE_TOKEN`，消息加解密方式选择明文模式，`EncodingAESKey` 当前未使用。详细配置和排障步骤见 [runtime/README.md](../runtime/README.md#微信服务号文本回调配置)。
 
-`/ping all` 的调试详情会展示微信入口安全摘要，包括启用状态、监听地址和端口、callback path、`token` / `app_id` / `app_secret` 是否已配置、当前支持模式和暂不支持能力。secret 类字段只显示 `configured` / `missing`，不输出真实值；未启用时显示 `disabled`，不表示 QQ Gateway 异常。
+`/ping all` 的调试详情会展示微信入口安全摘要，包括启用状态、监听地址和端口、callback path、`token` / `app_id` / `app_secret` 是否已配置、`access_token` 当前是否使用、当前支持模式和暂不支持能力。secret 类字段只显示 `configured` / `missing` / `not_used` 等摘要，不输出真实值；未启用时显示 `disabled`，不表示 QQ Gateway 异常。
 
 不要提交真实配置文件、AppSecret、Access Token、openid、私聊内容或截图中的敏感信息。
 

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -72,6 +72,7 @@ pub async fn run(
             wechat_service::spawn_callback_server(
                 config.wechat_service.clone(),
                 respond.clone(),
+                dedupe.clone(),
                 shutdown_token.clone(),
             )
             .await?,

--- a/qq-maid-gateway-rs/src/gateway/ping/render.rs
+++ b/qq-maid-gateway-rs/src/gateway/ping/render.rs
@@ -330,6 +330,7 @@ fn render_debug_wechat_service(config: &WechatServiceConfig) -> Vec<String> {
             "- app_secret：{}",
             secret_state_text(config.app_secret.as_deref())
         ),
+        "- access_token：not_used（当前 text-only 同步回调不需要获取）".to_owned(),
         "- 支持消息模式：明文 text-only，同步 XML 文本回复；Markdown 会降级为 text".to_owned(),
         "- 暂不支持：加密 XML、客服消息、模板消息、图片/语音/视频、事件、异步 follow-up、流式输出"
             .to_owned(),

--- a/qq-maid-gateway-rs/src/gateway/ping/render.rs
+++ b/qq-maid-gateway-rs/src/gateway/ping/render.rs
@@ -4,7 +4,7 @@ use qq_maid_common::time_context::{
 
 use crate::{
     auth::{AccessTokenSnapshot, AccessTokenSnapshotState},
-    config::AppConfig,
+    config::{AppConfig, WechatServiceConfig},
     gateway::{
         event::C2cMessage,
         logging::{mask_identifier, mask_scope_key},
@@ -132,6 +132,8 @@ fn render_ping_debug_details(
     lines.extend(render_debug_llm(config, llm_health, snapshot));
     lines.push(String::new());
     lines.extend(render_debug_config(config, token_snapshot));
+    lines.push(String::new());
+    lines.extend(render_debug_wechat_service(&config.wechat_service));
     lines
 }
 
@@ -316,6 +318,24 @@ fn render_debug_config(config: &AppConfig, token_snapshot: &AccessTokenSnapshot)
     ]
 }
 
+fn render_debug_wechat_service(config: &WechatServiceConfig) -> Vec<String> {
+    vec![
+        "### 微信服务号".to_owned(),
+        format!("- 入口：{}", bool_text(config.enabled)),
+        format!("- 监听：{}:{}", config.bind_host, config.bind_port),
+        format!("- callback path：{}", config.callback_path),
+        format!("- token：{}", secret_state_text(config.token.as_deref())),
+        format!("- app_id：{}", secret_state_text(config.app_id.as_deref())),
+        format!(
+            "- app_secret：{}",
+            secret_state_text(config.app_secret.as_deref())
+        ),
+        "- 支持消息模式：明文 text-only，同步 XML 文本回复；Markdown 会降级为 text".to_owned(),
+        "- 暂不支持：加密 XML、客服消息、模板消息、图片/语音/视频、事件、异步 follow-up、流式输出"
+            .to_owned(),
+    ]
+}
+
 fn markdown_cell(value: &str) -> String {
     value.replace('|', "\\|").replace(['\r', '\n'], " ")
 }
@@ -356,4 +376,11 @@ fn option_text(value: Option<&str>) -> &str {
 
 fn bool_text(value: bool) -> &'static str {
     if value { "enabled" } else { "disabled" }
+}
+
+fn secret_state_text(value: Option<&str>) -> &'static str {
+    match value {
+        Some(text) if !text.trim().is_empty() => "configured",
+        _ => "missing",
+    }
 }

--- a/qq-maid-gateway-rs/src/gateway/ping/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/ping/tests.rs
@@ -279,6 +279,7 @@ fn renders_ping_all_with_debug_details_without_secrets() {
     assert!(reply.contains("- token：missing"));
     assert!(reply.contains("- app_id：missing"));
     assert!(reply.contains("- app_secret：missing"));
+    assert!(reply.contains("- access_token：not_used（当前 text-only 同步回调不需要获取）"));
     assert!(reply.contains("明文 text-only，同步 XML 文本回复"));
     assert!(
         reply.contains(
@@ -324,9 +325,11 @@ fn renders_ping_all_with_wechat_service_security_summary_without_secrets() {
     assert!(reply.contains("- token：configured"));
     assert!(reply.contains("- app_id：configured"));
     assert!(reply.contains("- app_secret：configured"));
+    assert!(reply.contains("- access_token：not_used（当前 text-only 同步回调不需要获取）"));
     assert!(!reply.contains("real-wechat-token"));
     assert!(!reply.contains("wx-real-app-id"));
     assert!(!reply.contains("wx-real-app-secret"));
+    assert!(!reply.contains("real-access-token"));
 }
 
 #[test]

--- a/qq-maid-gateway-rs/src/gateway/ping/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/ping/tests.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use crate::{
     auth::{AccessTokenManager, AccessTokenSnapshot, AccessTokenSnapshotState},
-    config::{AgentTypingConfig, AppConfig},
+    config::{AgentTypingConfig, AppConfig, WechatServiceConfig},
     gateway::event::C2cMessage,
 };
 use qq_maid_core::service::{CoreHealthSnapshot, UpstreamStatusSnapshot};
@@ -198,6 +198,7 @@ fn renders_summary_ping_reply_without_debug_noise_or_secrets() {
     assert!(reply.contains("- 未发现发送、LLM 或 Session 异常"));
     assert!(reply.contains("| 接收时间 | 2026-06-10 12:00:00 +08:00 |"));
     assert!(!reply.contains("## 调试详情"));
+    assert!(!reply.contains("### 微信服务号"));
     assert!(!reply.contains("pid："));
     assert!(!reply.contains("instance："));
     assert!(!reply.contains("当前用户："));
@@ -271,6 +272,19 @@ fn renders_ping_all_with_debug_details_without_secrets() {
     assert!(reply.contains("当前用户：******123456"));
     assert!(reply.contains("当前 scope_key：private:******123456"));
     assert!(reply.contains("访问令牌缓存：cached, expires_in=120s"));
+    assert!(reply.contains("### 微信服务号"));
+    assert!(reply.contains("- 入口：disabled"));
+    assert!(reply.contains("- 监听：127.0.0.1:8788"));
+    assert!(reply.contains("- callback path：/wechat/service"));
+    assert!(reply.contains("- token：missing"));
+    assert!(reply.contains("- app_id：missing"));
+    assert!(reply.contains("- app_secret：missing"));
+    assert!(reply.contains("明文 text-only，同步 XML 文本回复"));
+    assert!(
+        reply.contains(
+            "加密 XML、客服消息、模板消息、图片/语音/视频、事件、异步 follow-up、流式输出"
+        )
+    );
     assert!(!reply.contains("记忆模块"));
     assert!(!reply.contains("存储"));
     assert!(!reply.contains("user-openid-123456"));
@@ -278,6 +292,41 @@ fn renders_ping_all_with_debug_details_without_secrets() {
     assert!(!reply.contains("real-token"));
     assert!(!reply.contains("app-secret-value"));
     assert!(!reply.contains("Authorization"));
+}
+
+#[test]
+fn renders_ping_all_with_wechat_service_security_summary_without_secrets() {
+    let mut config = config();
+    config.wechat_service = WechatServiceConfig {
+        enabled: true,
+        token: Some("real-wechat-token".to_owned()),
+        app_id: Some("wx-real-app-id".to_owned()),
+        app_secret: Some("wx-real-app-secret".to_owned()),
+        bind_host: "127.0.0.1".to_owned(),
+        bind_port: 8788,
+        callback_path: "/wechat/service".to_owned(),
+    };
+
+    let reply = render_c2c_ping_reply_at(
+        &message_with_content("/ping all"),
+        &config,
+        &GatewayRuntimeStatus::new_for_test(),
+        &token_snapshot(),
+        &health("ok(in-process)", LlmUpstreamSnapshot::Unverified),
+        PingMode::All,
+        1200,
+    );
+
+    assert!(reply.contains("### 微信服务号"));
+    assert!(reply.contains("- 入口：enabled"));
+    assert!(reply.contains("- 监听：127.0.0.1:8788"));
+    assert!(reply.contains("- callback path：/wechat/service"));
+    assert!(reply.contains("- token：configured"));
+    assert!(reply.contains("- app_id：configured"));
+    assert!(reply.contains("- app_secret：configured"));
+    assert!(!reply.contains("real-wechat-token"));
+    assert!(!reply.contains("wx-real-app-id"));
+    assert!(!reply.contains("wx-real-app-secret"));
 }
 
 #[test]

--- a/qq-maid-gateway-rs/src/gateway/wechat_service.rs
+++ b/qq-maid-gateway-rs/src/gateway/wechat_service.rs
@@ -2,7 +2,11 @@
 //!
 //! 当前只实现同步文本回复闭环；客服消息、模板消息、素材和异步 follow-up 均留给后续任务。
 
-use std::{net::SocketAddr, time::Duration};
+use std::{
+    net::SocketAddr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use anyhow::Context;
 use axum::{
@@ -21,6 +25,7 @@ use tracing::{debug, info, warn};
 use crate::{
     config::WechatServiceConfig,
     gateway::{
+        dedupe::MessageDedupe,
         outbound::ReplyCapability,
         platform::{
             self,
@@ -34,15 +39,15 @@ use crate::{
     respond::{RespondClient, RespondError, RespondTransport, respond_error_to_qq_text},
 };
 
-// 微信同步回复窗口有限；这里给 Core 完整回复稍多时间，超时仍返回本地兜底，
-// 长耗时工具调用后的异步补发保持为后续任务。
-const DEFAULT_REPLY_TIMEOUT: Duration = Duration::from_secs(8);
+// 微信同步回复窗口约 5 秒；这里必须提前释放 HTTP 回包，避免平台按同一 MsgId 重试。
+const DEFAULT_REPLY_TIMEOUT: Duration = Duration::from_secs(4);
 const FALLBACK_ERROR_TEXT: &str = "服务暂时不可用，请稍后再试。";
 
 #[derive(Clone)]
 struct WechatServiceState {
     config: WechatServiceConfig,
     respond: RespondClient,
+    dedupe: Arc<MessageDedupe>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -56,6 +61,7 @@ struct VerifyQuery {
 pub(super) async fn spawn_callback_server(
     config: WechatServiceConfig,
     respond: RespondClient,
+    dedupe: Arc<MessageDedupe>,
     shutdown_token: CancellationToken,
 ) -> anyhow::Result<JoinHandle<anyhow::Result<()>>> {
     let addr: SocketAddr = format!("{}:{}", config.bind_host, config.bind_port)
@@ -65,7 +71,11 @@ pub(super) async fn spawn_callback_server(
         .await
         .context("bind wechat service callback listener")?;
     let path = config.callback_path.clone();
-    let state = WechatServiceState { config, respond };
+    let state = WechatServiceState {
+        config,
+        respond,
+        dedupe,
+    };
     let app = Router::new()
         .route(&path, get(verify_url).post(handle_message))
         .with_state(state);
@@ -118,10 +128,15 @@ async fn handle_message(
         // 微信服务号允许同步返回空串表示本轮不回复；空 Content 不进入 Core，避免制造无意义会话。
         return plain(StatusCode::OK, "");
     }
+    let inbound = inbound_from_text_message(&message);
+    let reservation = match reserve_wechat_message(&state, &inbound, &message.msg_id) {
+        Ok(reservation) => reservation,
+        Err(()) => return plain(StatusCode::OK, ""),
+    };
 
     let reply = match tokio::time::timeout(
         DEFAULT_REPLY_TIMEOUT,
-        build_sync_reply(&state.respond, &message),
+        build_sync_reply(&state.respond, &message, &inbound),
     )
     .await
     {
@@ -129,11 +144,15 @@ async fn handle_message(
         Err(_) => {
             warn!(
                 message_id = %message.msg_id,
-                "wechat service respond timed out; returning local sync fallback"
+                timeout_ms = DEFAULT_REPLY_TIMEOUT.as_millis(),
+                "wechat service respond timed out; returning empty sync response"
             );
-            FALLBACK_ERROR_TEXT.to_owned()
+            String::new()
         }
     };
+    if let Some(reservation) = reservation {
+        reservation.commit();
+    }
     if reply.trim().is_empty() {
         return plain(StatusCode::OK, "");
     }
@@ -146,11 +165,34 @@ async fn handle_message(
     xml_response(xml)
 }
 
-async fn build_sync_reply(respond: &RespondClient, message: &WechatTextMessage) -> String {
-    let inbound = inbound_from_text_message(message);
-    let content = platform::render_text_for_core(&inbound);
+fn reserve_wechat_message(
+    state: &WechatServiceState,
+    inbound: &platform::InboundMessage,
+    message_id: &str,
+) -> Result<Option<crate::gateway::dedupe::MessageReservation>, ()> {
+    let Some(key) = inbound.dedupe_message_key() else {
+        return Ok(None);
+    };
+    match state.dedupe.reserve_many([key], Instant::now()) {
+        Ok(reservation) => Ok(Some(reservation)),
+        Err(_) => {
+            info!(
+                message_id = %message_id,
+                "wechat service duplicate message retry ignored"
+            );
+            Err(())
+        }
+    }
+}
+
+async fn build_sync_reply(
+    respond: &RespondClient,
+    message: &WechatTextMessage,
+    inbound: &platform::InboundMessage,
+) -> String {
+    let content = platform::render_text_for_core(inbound);
     let capability = ReplyCapability::wechat_service_text_sync(DEFAULT_REPLY_TIMEOUT);
-    let response = match respond.respond_inbound(&inbound, content).await {
+    let response = match respond.respond_inbound(inbound, content).await {
         Ok(RespondTransport::Complete(response)) => Some(response),
         Ok(RespondTransport::Stream(mut stream)) => {
             // 微信服务号同步回复不支持流式；这里只消费到 Completed，超时由外层统一处理。
@@ -242,7 +284,10 @@ fn now_unix_seconds() -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
+    use std::{
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
 
     use async_trait::async_trait;
     use axum::body::to_bytes;
@@ -250,18 +295,62 @@ mod tests {
         CoreError, CoreHealthSnapshot, CoreInboundClassification, CoreInboundKind, CoreRequest,
         CoreRespondOutput, CoreResponse, CoreService, UpstreamStatusSnapshot,
     };
+    use tokio::sync::Notify;
 
     use super::*;
 
-    #[derive(Default)]
     struct MockCore {
-        last_request: Mutex<Option<CoreRequest>>,
+        requests: Mutex<Vec<CoreRequest>>,
+        response_delay: Mutex<Option<Duration>>,
+        started: Notify,
+    }
+
+    impl Default for MockCore {
+        fn default() -> Self {
+            Self {
+                requests: Mutex::new(Vec::new()),
+                response_delay: Mutex::new(None),
+                started: Notify::new(),
+            }
+        }
+    }
+
+    impl MockCore {
+        fn with_delay(response_delay: Duration) -> Self {
+            Self {
+                response_delay: Mutex::new(Some(response_delay)),
+                ..Self::default()
+            }
+        }
+
+        fn request_count(&self) -> usize {
+            self.requests.lock().unwrap().len()
+        }
+
+        fn last_request(&self) -> Option<CoreRequest> {
+            self.requests.lock().unwrap().last().cloned()
+        }
+
+        async fn wait_for_request_count(&self, expected: usize) {
+            loop {
+                let notified = self.started.notified();
+                if self.request_count() >= expected {
+                    return;
+                }
+                notified.await;
+            }
+        }
     }
 
     #[async_trait]
     impl CoreService for MockCore {
         async fn respond(&self, request: CoreRequest) -> Result<CoreRespondOutput, CoreError> {
-            *self.last_request.lock().unwrap() = Some(request);
+            self.requests.lock().unwrap().push(request);
+            self.started.notify_waiters();
+            let delay = *self.response_delay.lock().unwrap();
+            if let Some(delay) = delay {
+                tokio::time::sleep(delay).await;
+            }
             Ok(CoreRespondOutput::Complete(CoreResponse {
                 text: Some("hello <wx> & user".to_owned()),
                 markdown: Some("**hello**".to_owned()),
@@ -304,6 +393,7 @@ mod tests {
                 ..WechatServiceConfig::default()
             },
             respond: RespondClient::new(core),
+            dedupe: Arc::new(MessageDedupe::new(Duration::from_secs(10 * 60))),
         }
     }
 
@@ -329,6 +419,19 @@ mod tests {
         let status = response.status();
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         (status, String::from_utf8(bytes.to_vec()).unwrap())
+    }
+
+    fn text_xml(message_id: &str, content: &str) -> String {
+        format!(
+            r#"<xml>
+<ToUserName><![CDATA[gh_service]]></ToUserName>
+<FromUserName><![CDATA[user_openid]]></FromUserName>
+<CreateTime>1460537339</CreateTime>
+<MsgType><![CDATA[text]]></MsgType>
+<Content><![CDATA[{content}]]></Content>
+<MsgId>{message_id}</MsgId>
+</xml>"#
+        )
     }
 
     #[tokio::test]
@@ -371,14 +474,7 @@ mod tests {
     #[tokio::test]
     async fn post_text_message_invokes_core_and_returns_sync_xml() {
         let core = Arc::new(MockCore::default());
-        let xml = r#"<xml>
-<ToUserName><![CDATA[gh_service]]></ToUserName>
-<FromUserName><![CDATA[user_openid]]></FromUserName>
-<CreateTime>1460537339</CreateTime>
-<MsgType><![CDATA[text]]></MsgType>
-<Content><![CDATA[你好]]></Content>
-<MsgId>1234567890123456</MsgId>
-</xml>"#;
+        let xml = text_xml("1234567890123456", "你好");
         let response = handle_message(
             State(state(core.clone())),
             Query(signed_post_query()),
@@ -392,12 +488,132 @@ mod tests {
         assert!(body.contains("<FromUserName>gh_service</FromUserName>"));
         assert!(body.contains("<MsgType>text</MsgType>"));
         assert!(body.contains("<Content>hello &lt;wx&gt; &amp; user</Content>"));
-        let request = core.last_request.lock().unwrap().clone().unwrap();
+        let request = core.last_request().unwrap();
         assert_eq!(request.platform.as_str(), "wechat_service");
         assert_eq!(
             request.scope_key(),
             "service_account:gh_service:user_openid"
         );
         assert_eq!(request.text, "你好");
+    }
+
+    #[tokio::test]
+    async fn duplicate_text_message_after_completion_does_not_enter_core_again() {
+        let core = Arc::new(MockCore::default());
+        let state = state(core.clone());
+        let xml = text_xml("1234567890123456", "你好");
+
+        let first = handle_message(
+            State(state.clone()),
+            Query(signed_post_query()),
+            Bytes::from(xml.clone()),
+        )
+        .await;
+        let second =
+            handle_message(State(state), Query(signed_post_query()), Bytes::from(xml)).await;
+        let (first_status, first_body) = response_body(first).await;
+        let (second_status, second_body) = response_body(second).await;
+
+        assert_eq!(first_status, StatusCode::OK);
+        assert!(first_body.contains("<MsgType>text</MsgType>"));
+        assert_eq!(second_status, StatusCode::OK);
+        assert_eq!(second_body, "");
+        assert_eq!(core.request_count(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn duplicate_text_message_while_first_in_flight_does_not_enter_core_again() {
+        let core = Arc::new(MockCore::with_delay(Duration::from_secs(30)));
+        let state = state(core.clone());
+        let xml = text_xml("1234567890123456", "你好");
+
+        let first = tokio::spawn(handle_message(
+            State(state.clone()),
+            Query(signed_post_query()),
+            Bytes::from(xml.clone()),
+        ));
+        core.wait_for_request_count(1).await;
+
+        let duplicate =
+            handle_message(State(state), Query(signed_post_query()), Bytes::from(xml)).await;
+        let (duplicate_status, duplicate_body) = response_body(duplicate).await;
+
+        assert_eq!(duplicate_status, StatusCode::OK);
+        assert_eq!(duplicate_body, "");
+        assert_eq!(core.request_count(), 1);
+
+        tokio::time::advance(DEFAULT_REPLY_TIMEOUT + Duration::from_millis(1)).await;
+        let (first_status, first_body) = response_body(first.await.unwrap()).await;
+        assert_eq!(first_status, StatusCode::OK);
+        assert_eq!(first_body, "");
+        assert_eq!(core.request_count(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn timed_out_text_message_returns_empty_ok_and_later_retry_is_deduped() {
+        let core = Arc::new(MockCore::with_delay(Duration::from_secs(30)));
+        let state = state(core.clone());
+        let xml = text_xml("1234567890123456", "你好");
+
+        let first = tokio::spawn(handle_message(
+            State(state.clone()),
+            Query(signed_post_query()),
+            Bytes::from(xml.clone()),
+        ));
+        core.wait_for_request_count(1).await;
+        tokio::time::advance(DEFAULT_REPLY_TIMEOUT + Duration::from_millis(1)).await;
+        let (first_status, first_body) = response_body(first.await.unwrap()).await;
+
+        assert_eq!(first_status, StatusCode::OK);
+        assert_eq!(first_body, "");
+        assert_eq!(core.request_count(), 1);
+
+        let retry =
+            handle_message(State(state), Query(signed_post_query()), Bytes::from(xml)).await;
+        let (retry_status, retry_body) = response_body(retry).await;
+
+        assert_eq!(retry_status, StatusCode::OK);
+        assert_eq!(retry_body, "");
+        assert_eq!(core.request_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn unsupported_message_type_returns_empty_ok_without_core() {
+        let core = Arc::new(MockCore::default());
+        let xml = r#"<xml>
+<ToUserName><![CDATA[gh_service]]></ToUserName>
+<FromUserName><![CDATA[user_openid]]></FromUserName>
+<CreateTime>1460537339</CreateTime>
+<MsgType><![CDATA[image]]></MsgType>
+<MsgId>image-1</MsgId>
+</xml>"#;
+        let response = handle_message(
+            State(state(core.clone())),
+            Query(signed_post_query()),
+            Bytes::from(xml),
+        )
+        .await;
+        let (status, body) = response_body(response).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "");
+        assert_eq!(core.request_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn empty_text_message_returns_empty_ok_without_core() {
+        let core = Arc::new(MockCore::default());
+        let xml = text_xml("empty-1", "   ");
+        let response = handle_message(
+            State(state(core.clone())),
+            Query(signed_post_query()),
+            Bytes::from(xml),
+        )
+        .await;
+        let (status, body) = response_body(response).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "");
+        assert_eq!(core.request_count(), 0);
     }
 }

--- a/qq-maid-gateway-rs/src/respond.rs
+++ b/qq-maid-gateway-rs/src/respond.rs
@@ -134,19 +134,39 @@ impl RespondClient {
         inbound: &platform::InboundMessage,
         content: String,
     ) -> Result<RespondTransport, RespondError> {
+        let (masked_user, masked_group) = masked_log_context_from_inbound(inbound);
         let request = platform::to_core_request(inbound, content).map_err(|error| {
+            warn!(
+                message_id = %inbound.message_id,
+                user = masked_user.as_deref().unwrap_or(""),
+                group = masked_group.as_deref().unwrap_or(""),
+                platform = %inbound.platform.as_str(),
+                error = %error,
+                "core inbound mapping failed"
+            );
             RespondError::Core(CoreError {
                 code: "invalid_request".to_owned(),
                 stage: "gateway_mapping".to_owned(),
                 message: error.to_string(),
             })
         })?;
-        let output = self
-            .core
-            .respond(request)
-            .await
-            .map_err(RespondError::Core)?;
-        log_core_output_success(&inbound.message_id, None, None, &output);
+        let output = self.core.respond(request).await.map_err(|error| {
+            warn!(
+                message_id = %inbound.message_id,
+                user = masked_user.as_deref().unwrap_or(""),
+                group = masked_group.as_deref().unwrap_or(""),
+                platform = %inbound.platform.as_str(),
+                error = %format!("{}@{}", error.code, error.stage),
+                "core inbound respond request failed"
+            );
+            RespondError::Core(error)
+        })?;
+        log_core_output_success(
+            &inbound.message_id,
+            masked_user.as_deref(),
+            masked_group.as_deref(),
+            &output,
+        );
         Ok(output.into())
     }
 }
@@ -196,6 +216,18 @@ fn log_core_output_success(
                 "core respond stream initialized"
             );
         }
+    }
+}
+
+fn masked_log_context_from_inbound(
+    inbound: &platform::InboundMessage,
+) -> (Option<String>, Option<String>) {
+    match inbound.conversation.kind() {
+        "private" | "service_account" => {
+            (inbound.actor.sender_id.as_deref().map(mask_openid), None)
+        }
+        "group" => (None, Some(mask_openid(inbound.conversation.target_id()))),
+        _ => (None, None),
     }
 }
 
@@ -541,6 +573,48 @@ mod tests {
 
         assert!(content.starts_with("[reply message_id=reply-1]\n被回复内容\n[/reply]\n正文"));
         assert!(content.contains("[附件 image/png: a.png https://example.test/a.png]"));
+    }
+
+    #[test]
+    fn inbound_log_context_masks_private_user() {
+        let inbound = platform::qq_official::inbound_from_c2c(&c2c_message("你好"));
+
+        let (user, group) = masked_log_context_from_inbound(&inbound);
+
+        assert_eq!(user.as_deref(), Some("******"));
+        assert_eq!(group, None);
+    }
+
+    #[test]
+    fn inbound_log_context_masks_wechat_service_user() {
+        let inbound = platform::wechat_service::inbound_from_text_message(
+            &platform::wechat_service::WechatTextMessage {
+                to_user_name: "gh_service".to_owned(),
+                from_user_name: "wechat_user_openid_abcdef".to_owned(),
+                create_time: Some("1460537339".to_owned()),
+                content: "你好".to_owned(),
+                msg_id: "msg-1".to_owned(),
+            },
+        );
+
+        let (user, group) = masked_log_context_from_inbound(&inbound);
+
+        assert_eq!(user.as_deref(), Some("******abcdef"));
+        assert_ne!(user.as_deref(), Some("wechat_user_openid_abcdef"));
+        assert_eq!(group, None);
+    }
+
+    #[test]
+    fn inbound_log_context_masks_group_target_without_member_user() {
+        let mut message = group_message("你好", Some("member_openid_abcdef"));
+        message.group_openid = "group_openid_123456".to_owned();
+        let inbound = platform::qq_official::inbound_from_group(&message);
+
+        let (user, group) = masked_log_context_from_inbound(&inbound);
+
+        assert_eq!(user, None);
+        assert_eq!(group.as_deref(), Some("******123456"));
+        assert_ne!(group.as_deref(), Some("group_openid_123456"));
     }
 
     #[test]

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -69,7 +69,7 @@ APP_DB_FILE=/opt/qqbot/data/app.db
 
 ## 微信服务号文本回调配置
 
-微信服务号入口是 Gateway 的可选能力，默认关闭。它只实现“微信服务号收到文本消息 -> 同步 XML 文本回复”的最小闭环，不支持客服消息、模板消息、素材上传、图片语音视频、流式输出或异步补发。
+微信服务号入口是 Gateway 的可选能力，默认关闭。它只实现“微信服务号收到文本消息 -> 同步 XML 文本回复”的最小闭环，适合先完成公众平台 URL 验证和纯文本消息测试。
 
 最小配置示例：
 
@@ -92,6 +92,8 @@ WECHAT_SERVICE_CALLBACK_PATH=/wechat/service
 - `WECHAT_SERVICE_BIND_HOST` / `WECHAT_SERVICE_BIND_PORT`：机器人本机监听地址。推荐保持 `127.0.0.1:8788`，由 Nginx、Caddy、Cloudflare Tunnel 等反向代理暴露到公网。
 - `WECHAT_SERVICE_CALLBACK_PATH`：回调路径，必须以 `/` 开头。微信公众平台填写的 URL 路径需要和它一致。
 
+`/ping all` 的调试详情会展示微信入口安全摘要：入口是否启用、监听地址和端口、callback path、`token` / `app_id` / `app_secret` 是否已配置、当前支持模式和暂不支持能力。摘要只显示 `configured` / `missing`，不会打印真实 Token、AppSecret、OpenID 或消息正文。未启用时显示 `disabled`，不代表 QQ Gateway 异常。
+
 微信公众平台“服务器配置”中对应填写：
 
 ```text
@@ -107,7 +109,48 @@ EncodingAESKey: 当前未使用
 http://127.0.0.1:8788/wechat/service
 ```
 
-当前实现会校验 GET 验证请求中的 `signature`、`timestamp`、`nonce`、`echostr`；校验通过返回 `echostr` 原文，失败返回拒绝状态。POST 文本消息也会校验签名。非 `text` 消息和空文本会返回空字符串，不进入 Core。
+Nginx 反向代理示例：
+
+```nginx
+location /wechat/service {
+    proxy_pass http://127.0.0.1:8788/wechat/service;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto https;
+}
+```
+
+Caddy 反向代理示例：
+
+```caddy
+你的域名 {
+    reverse_proxy /wechat/service 127.0.0.1:8788
+}
+```
+
+当前已支持：
+
+- GET URL 验证：校验 `signature`、`timestamp`、`nonce`、`echostr`，通过后返回 `echostr` 原文。
+- POST 明文 `text` XML 消息：校验签名后解析文本消息。
+- 同步文本 XML 回复：等待 Core 完整回复后渲染 XML。
+- Markdown 降级为 text：微信同步回复不发送 Markdown。
+
+当前不支持：
+
+- 加密 XML。
+- 客服消息。
+- 模板消息。
+- 图片、语音、视频。
+- subscribe / CLICK / VIEW 等事件。
+- 异步 follow-up 或主动推送。
+- 流式输出。
+
+安全注意事项：
+
+- 不要提交真实 `WECHAT_SERVICE_TOKEN`、`WECHAT_SERVICE_APP_SECRET` 或 access token。
+- 不要在日志、截图或 Issue 中打印 OpenID 和用户消息正文。
+- 生产环境建议只监听 `127.0.0.1`，由 Nginx、Caddy 或 Cloudflare Tunnel 暴露公网 HTTPS。
+- 微信公众平台生产回调 URL 应使用 HTTPS。
+- `EncodingAESKey` 当前未使用；公众平台请先选择明文模式。
 
 ## 知识目录
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -92,7 +92,7 @@ WECHAT_SERVICE_CALLBACK_PATH=/wechat/service
 - `WECHAT_SERVICE_BIND_HOST` / `WECHAT_SERVICE_BIND_PORT`：机器人本机监听地址。推荐保持 `127.0.0.1:8788`，由 Nginx、Caddy、Cloudflare Tunnel 等反向代理暴露到公网。
 - `WECHAT_SERVICE_CALLBACK_PATH`：回调路径，必须以 `/` 开头。微信公众平台填写的 URL 路径需要和它一致。
 
-`/ping all` 的调试详情会展示微信入口安全摘要：入口是否启用、监听地址和端口、callback path、`token` / `app_id` / `app_secret` 是否已配置、当前支持模式和暂不支持能力。摘要只显示 `configured` / `missing`，不会打印真实 Token、AppSecret、OpenID 或消息正文。未启用时显示 `disabled`，不代表 QQ Gateway 异常。
+`/ping all` 的调试详情会展示微信入口安全摘要：入口是否启用、监听地址和端口、callback path、`token` / `app_id` / `app_secret` 是否已配置、`access_token` 当前是否使用、当前支持模式和暂不支持能力。摘要只显示 `configured` / `missing` / `not_used` 等状态，不会打印真实 Token、AppSecret、access token、OpenID 或消息正文。未启用时显示 `disabled`，不代表 QQ Gateway 异常。
 
 微信公众平台“服务器配置”中对应填写：
 
@@ -137,6 +137,7 @@ Caddy 反向代理示例：
 当前不支持：
 
 - 加密 XML。
+- access_token 获取，以及依赖 access_token 的主动接口调用。
 - 客服消息。
 - 模板消息。
 - 图片、语音、视频。

--- a/runtime/config/.env.example
+++ b/runtime/config/.env.example
@@ -58,6 +58,10 @@ QQ_MAID_BOT_MENTION_IDS=
 # - URL: https://你的域名/wechat/service
 # - Token: 与 WECHAT_SERVICE_TOKEN 完全一致
 # - 消息加解密方式: 明文模式（当前不支持加密 XML）
+# - EncodingAESKey: 当前未使用
+# 当前仅支持 GET URL 验证、POST 明文 text 和同步 XML 文本回复；
+# 不支持客服消息、模板消息、图片语音视频、事件、异步 follow-up 或流式输出。
+# /ping all 只会展示 token/app_id/app_secret 是否 configured，不会打印真实值。
 WECHAT_SERVICE_ENABLED=false
 # 自定义 Token，用于 signature 校验；不要提交真实值。
 WECHAT_SERVICE_TOKEN=

--- a/runtime/config/.env.example
+++ b/runtime/config/.env.example
@@ -60,12 +60,13 @@ QQ_MAID_BOT_MENTION_IDS=
 # - 消息加解密方式: 明文模式（当前不支持加密 XML）
 # - EncodingAESKey: 当前未使用
 # 当前仅支持 GET URL 验证、POST 明文 text 和同步 XML 文本回复；
-# 不支持客服消息、模板消息、图片语音视频、事件、异步 follow-up 或流式输出。
-# /ping all 只会展示 token/app_id/app_secret 是否 configured，不会打印真实值。
+# 当前不获取 access_token；不支持依赖 access_token 的客服消息、模板消息、
+# 主动接口调用、图片语音视频、事件、异步 follow-up 或流式输出。
+# /ping all 只会展示 token/app_id/app_secret 是否 configured，以及 access_token=not_used，不会打印真实值。
 WECHAT_SERVICE_ENABLED=false
 # 自定义 Token，用于 signature 校验；不要提交真实值。
 WECHAT_SERVICE_TOKEN=
-# 当前文本同步回复不调用微信 API，AppID / AppSecret 先预留给后续客服消息等能力。
+# 当前文本同步回复不调用微信 API，也不需要配置 access_token；AppID / AppSecret 先预留给后续客服消息等能力。
 WECHAT_SERVICE_APP_ID=
 WECHAT_SERVICE_APP_SECRET=
 # 推荐只监听本地回环地址，由反向代理暴露公网 HTTPS。


### PR DESCRIPTION
## 变更内容

- 将微信服务号同步回复 timeout 从 8 秒调为 4 秒，超时返回微信可接受的空 OK 响应。
- 复用 Gateway 现有 MessageDedupe，对微信统一 InboundMessage 的 dedupe key 做 MsgId reservation，覆盖已完成和 in-flight 重试。
- 重复、超时、非文本、空文本请求均不重复进入 Core。
- 修复 RespondClient::respond_inbound() 成功和错误日志缺少 user/group 上下文的问题，统一按 InboundMessage 派生并脱敏。

## 根因

微信被动回复窗口短于当前 8 秒同步等待，超时后平台会按同一 MsgId 重试；Gateway 微信入口此前没有入站 dedupe / in-flight 保护，可能重复调用 Core。另一个日志问题是 respond_inbound() 固定用 None/None 记录成功日志，导致微信等统一入口日志 user/group 为空。

## 影响

- 同一微信 MsgId 多次 POST 只会进入 Core 一次。
- 超时和重复请求不会返回 500，也不会发送用户可见的重复提示。
- 微信日志会显示脱敏后的 user 摘要；未来统一群聊入口会显示脱敏 group 摘要。
- 不修改 Core / LLM / Tool Loop 语义，不改变 QQ 官方 C2C / 群聊处理逻辑。

## 验证

- cargo fmt --all -- --check
- cargo clippy -p qq-maid-gateway-rs --all-targets --all-features -- -D warnings
- make test-gateway
- cargo test --workspace --all-features
