### PR TITLE
[codex] 准备 v0.13.0 发布

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 本文档基于 [keep a changelog](https://keepachangelog.com/zh-CN/1.0.0/) 格式，记录每个已发布版本的变更。
 
-## [Unreleased]
+## [v0.13.0] - 2026-07-05
 
 ### Added
 
@@ -59,6 +59,10 @@
 * **微信服务号配置文档**：README、Gateway README、runtime README 和 `.env.example` 同步更新微信文本入口、慢请求行为、客服补发前提、诊断摘要和安全注意事项。
 
 * **OneBot 状态说明**：README 和 Gateway README 明确 OneBot 11 目前只有平台模型和边界预留，尚未实现反向 WebSocket server、事件 adapter、API sender 或主动推送路由。
+
+### Internal
+
+* 根包 `qq-maid-bot`：`0.12.1` → `0.13.0`
 
 ## [v0.12.1] - 2026-07-04
 
@@ -839,6 +843,7 @@ bash scripts/deploy-local.sh
 - 移除已废弃的 Python 接入层和旧 Provider
 - rig-core 升级至 0.38.2
 
+[v0.13.0]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.12.1...v0.13.0
 [v0.12.1]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.12.0...v0.12.1
 [v0.12.0]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.11.1...v0.12.0
 [v0.11.1]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.11.0...v0.11.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,7 +1435,7 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "qq-maid-bot"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "qq-maid-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-bot"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2024"
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 > Rust 单进程 · 多平台入口抽象 · Provider 无关 Agent Loop · 受控长期记忆 · 主动推送 · 模型自动降级
 
-当前已发布稳定版本线：**v0.12.1：群聊触发与工具路由修复版本**。当前开发分支在此基础上继续推进微信服务号长任务异步回复：文本入口保留同步 XML 快路径，慢请求可通过客服文本消息补发最终结果。历史版本记录见 [CHANGELOG.md](./CHANGELOG.md)，实际发布包以 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 页面为准。
+当前源码版本线：**v0.13.0：多平台边界与微信服务号增强版本**。这一版在 v0.12.1 的群聊触发与工具路由修复基础上，补齐平台入站 / 出站边界、微信服务号文本入口和长任务客服补发、MiMo / OpenAI-compatible provider 配置，以及 RSS / Todo 统一通知投递目标。历史版本记录见 [CHANGELOG.md](./CHANGELOG.md)，实际发布包以 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 页面为准。
 
 ## 当前版本亮点
 
@@ -504,7 +504,7 @@ QQ 官方机器人功能仍受平台权限、审核和接口规则限制。Linux
 
 ## 版本升级
 
-当前源码版本线为 **v0.12.1：群聊触发与工具路由修复版本**；已发布稳定包请以 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 页面为准。版本升级前请先阅读 [CHANGELOG.md](./CHANGELOG.md)，并对比新版 `runtime/config/.env.example` 和 `runtime/config/agent.toml`。
+当前源码版本线为 **v0.13.0：多平台边界与微信服务号增强版本**；已发布稳定包请以 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 页面为准。版本升级前请先阅读 [CHANGELOG.md](./CHANGELOG.md)，并对比新版 `runtime/config/.env.example` 和 `runtime/config/agent.toml`。
 
 从 v0.11.x 升级到当前版本线时，重点检查：默认 runtime 是否包含 `config/agent.toml`，旧 `.env` 中的 `LLM_MODEL` / `PRIVATE_LLM_MODEL` / `GROUP_LLM_MODEL` 是否仍符合预期，Todo 提醒是否只在明确需要时开启。较早版本从 v0.3.x 升级到 v0.4.0 涉及单进程架构迁移，仍需参考 [v0.4.0 迁移说明](./CHANGELOG.md#v040)。
 


### PR DESCRIPTION
## 变更内容

- 将根包版本从 0.12.1 提升到 0.13.0。
- 将 CHANGELOG 的 v0.12.1 之后累计变更落为 v0.13.0，并补充 compare 链接。
- 同步 README 当前版本线为 v0.13.0：多平台边界与微信服务号增强版本。

## 验证

- git diff --check
- cargo check --workspace

合并后将在 master 合并提交上推送 v0.13.0 tag 触发 Release workflow。