### PR TITLE
[codex] 新增雷达 slash 命令

### DIFF
--- a/qq-maid-core/src/app/mod.rs
+++ b/qq-maid-core/src/app/mod.rs
@@ -26,6 +26,7 @@ use crate::{
         session::SessionStore,
         todo::TodoStore,
         todo_reminder::{TodoReminderScheduler, TodoReminderSchedulerConfig},
+        tools::build_radar_executor,
         train::build_train_executor,
         translation::TranslationService,
         weather::build_weather_executor,
@@ -88,6 +89,7 @@ impl LlmRuntime {
         ));
         let weather_executor = build_weather_executor(&config)?;
         let train_executor = build_train_executor(&config)?;
+        let radar_executor = build_radar_executor()?;
         // 通用数据库在应用启动阶段统一打开并执行项目级 migration；
         // RSS、Todo、Session 和 Memory 共用同一 SQLite 句柄，避免各业务模块重复打开数据库。
         let database = SqliteDatabase::open(config.app_db_file.clone(), APP_MIGRATIONS)?;
@@ -169,6 +171,7 @@ impl LlmRuntime {
             query_executor,
             weather_executor,
             train_executor,
+            radar_executor,
             memory_store,
             session_store,
             todo_store,

--- a/qq-maid-core/src/http/routes.rs
+++ b/qq-maid-core/src/http/routes.rs
@@ -28,6 +28,7 @@ use crate::{
         rss::{RssFetcher, RssStore},
         session::SessionStore,
         todo::TodoStore,
+        tools::DynRadarExecutor,
         train::DynTrainExecutor,
         weather::DynWeatherExecutor,
     },
@@ -49,6 +50,8 @@ pub struct AppState {
     pub weather_executor: DynWeatherExecutor,
     /// 列车时刻查询执行器。
     pub train_executor: DynTrainExecutor,
+    /// Codex / Claude Code Radar 公开数据读取执行器。
+    pub radar_executor: DynRadarExecutor,
     /// 记忆存储。
     pub memory_store: MemoryStore,
     /// 会话存储。
@@ -256,6 +259,7 @@ mod tests {
             query::{QueryExecutor, QueryOutcome, QueryRequest, QuerySource},
             rss::RssFetchConfig,
             session::SessionStore,
+            tools::{RadarExecutor, RadarSnapshot, RadarTarget},
             train::{TrainExecutor, TrainSchedule, TrainScheduleRequest, TrainStop},
             weather::{
                 CurrentWeather, DailyWeather, WeatherExecutor, WeatherLocation, WeatherOutcome,
@@ -291,6 +295,8 @@ mod tests {
     struct MockWeatherExecutor;
 
     struct MockTrainExecutor;
+
+    struct MockRadarExecutor;
 
     #[async_trait]
     impl LlmProvider for MockProvider {
@@ -456,6 +462,17 @@ mod tests {
         }
     }
 
+    #[async_trait]
+    impl RadarExecutor for MockRadarExecutor {
+        async fn radar(&self, _target: RadarTarget) -> Result<RadarSnapshot, LlmError> {
+            Err(LlmError::provider("radar unused", "radar"))
+        }
+
+        fn provider_name(&self) -> &'static str {
+            "mock-radar"
+        }
+    }
+
     fn write_prompt_set(dir: &std::path::Path) {
         fs::create_dir_all(dir).unwrap();
         for file_name in crate::runtime::prompt::PROMPT_FILES {
@@ -569,6 +586,7 @@ mod tests {
             query_executor: Arc::new(MockQueryExecutor),
             weather_executor: Arc::new(MockWeatherExecutor),
             train_executor: Arc::new(MockTrainExecutor),
+            radar_executor: Arc::new(MockRadarExecutor),
             memory_store: MemoryStore::new(database.clone()),
             session_store: SessionStore::new(database.clone()),
             todo_store: TodoStore::new(database.clone()),

--- a/qq-maid-core/src/runtime/command/mod.rs
+++ b/qq-maid-core/src/runtime/command/mod.rs
@@ -55,6 +55,7 @@ fn normalize_command(command: &str) -> Option<String> {
         "查" | "查询" | "search" => "web_search",
         "train" | "火车" => "train",
         "weather" | "天气" => "weather",
+        "rader" | "radar" | "雷达" => "radar",
         _ => return None,
     };
     Some(action.to_owned())

--- a/qq-maid-core/src/runtime/respond.rs
+++ b/qq-maid-core/src/runtime/respond.rs
@@ -22,9 +22,9 @@ use crate::{
         },
         todo::TodoStore,
         tools::{
-            CancelTodoTool, CompleteTodoTool, CreateTodoTool, DeleteTodoTool, EditTodoTool,
-            GetTodoTool, ListTodoTool, RestoreTodoTool, RssRecentItemsTool, TrainScheduleTool,
-            WeatherTool,
+            CancelTodoTool, CompleteTodoTool, CreateTodoTool, DeleteTodoTool, DynRadarExecutor,
+            EditTodoTool, GetTodoTool, ListTodoTool, RestoreTodoTool, RssRecentItemsTool,
+            TrainScheduleTool, WeatherTool,
         },
         train::DynTrainExecutor,
         translation::TranslationService,
@@ -52,6 +52,7 @@ mod llm_service;
 mod markdown_strip;
 mod memory_flow;
 mod pending;
+mod radar_flow;
 mod rss_flow;
 mod search_flow;
 mod session_flow;
@@ -99,6 +100,8 @@ pub struct RespondExecutors {
     pub weather_executor: DynWeatherExecutor,
     /// 列车时刻查询执行器
     pub train_executor: DynTrainExecutor,
+    /// 外部雷达公开数据读取执行器
+    pub radar_executor: DynRadarExecutor,
 }
 
 /// `RustRespondService` 的可选模型和输出配置。
@@ -163,6 +166,8 @@ pub struct RustRespondService {
     weather_executor: DynWeatherExecutor,
     /// 列车时刻查询执行器
     train_executor: DynTrainExecutor,
+    /// Codex / Claude Code Radar 公开数据读取执行器
+    radar_executor: DynRadarExecutor,
     /// 长期记忆存储
     memory_store: MemoryStore,
     /// 会话记录存储
@@ -276,6 +281,7 @@ impl RustRespondService {
             query_executor: executors.query_executor,
             weather_executor: executors.weather_executor,
             train_executor: executors.train_executor,
+            radar_executor: executors.radar_executor,
             memory_store: stores.memory_store,
             session_store: stores.session_store,
             todo_store: stores.todo_store,
@@ -498,6 +504,13 @@ impl RustRespondService {
         if let Some(command) = train_flow::parse_train_command(&user_text) {
             return self
                 .handle_train_command(command, &user_text, &mut session)
+                .await;
+        }
+
+        // 检查是否为雷达看板指令（如 "/rader codex" 或 "/雷达"）
+        if let Some(command) = radar_flow::parse_radar_command(&user_text) {
+            return self
+                .handle_radar_command(command, &user_text, &mut session)
                 .await;
         }
 

--- a/qq-maid-core/src/runtime/respond/help.rs
+++ b/qq-maid-core/src/runtime/respond/help.rs
@@ -87,6 +87,22 @@ const HELP_MODULES: &[HelpModule] = &[
         notes: &["- 城市为空、无法识别或天气服务未配置时，会返回明确提示。"],
     },
     HelpModule {
+        key: "radar",
+        aliases: &["rader", "雷达"],
+        title: "🛰️ 雷达",
+        summary: "查看 Codex Radar 和 Claude Code Radar 的公开摘要卡片。",
+        commands: &[
+            "- `/rader`、`/radar`、`/雷达`：查看两个雷达摘要",
+            "- `/rader codex`：只看 Codex Radar",
+            "- `/rader claude`：只看 Claude Code Radar",
+            "- `/rader issue codex`、`/rader issue claude`：查看反馈入口",
+        ],
+        notes: &[
+            "- 雷达命令只读取公开数据源，不进入普通聊天 Tool Loop。",
+            "- 外部数据失败或字段缺失时，会显示明确降级提示。",
+        ],
+    },
+    HelpModule {
         key: "search",
         aliases: &["查询", "搜索", "火车"],
         title: "🔎 联网查询",
@@ -203,6 +219,10 @@ fn format_help_home(context: HelpContext) -> CommandBody {
     render.push_pair(
         "· 🌤 天气：/天气 杭州".to_owned(),
         "- 🌤 天气：`/天气 杭州`".to_owned(),
+    );
+    render.push_pair(
+        "· 🛰️ 雷达：/rader".to_owned(),
+        "- 🛰️ 雷达：`/rader`".to_owned(),
     );
     render.push_pair(
         "· 🔎 查询：/查 问题、/火车 G1".to_owned(),

--- a/qq-maid-core/src/runtime/respond/radar_flow.rs
+++ b/qq-maid-core/src/runtime/respond/radar_flow.rs
@@ -1,0 +1,450 @@
+//! `/rader` / `/radar` / `/雷达` 指令处理。
+//!
+//! slash 层只解析命令、调用雷达执行器并负责展示；公开数据源读取和字段兼容在
+//! `runtime::tools::radar` 中维护，避免把外部看板接入细节散落到 respond 主流程。
+
+use serde_json::json;
+
+use crate::{
+    error::LlmError,
+    runtime::{
+        command::{ParsedCommand, parse_slash_command},
+        session::SessionRecord,
+        tools::{
+            ClaudeModelMetric, ClaudeRadarSummary, CodexRadarSummary, RadarIssueTarget,
+            RadarSnapshot, RadarSourceFailure, RadarSourceKind, RadarTarget, radar_feedback_url,
+            radar_site_url,
+        },
+    },
+};
+
+use super::{
+    RespondResponse, RustRespondService,
+    command_render::{CommandRender, escape_markdown_inline, escape_markdown_text},
+    common::{CommandBody, command_response, session_error, truncate_chars},
+};
+
+const RADAR_USAGE_REPLY: &str = "用法：/rader [codex|claude]，或 /rader issue [codex|claude]
+别名：/radar、/雷达";
+const RADAR_SUMMARY_MAX_CHARS: usize = 110;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum RadarCommand {
+    Show(RadarTarget),
+    Issue(RadarIssueTarget),
+    Usage,
+}
+
+impl RustRespondService {
+    pub(super) async fn handle_radar_command(
+        &self,
+        command: ParsedCommand,
+        user_text: &str,
+        session: &mut SessionRecord,
+    ) -> Result<RespondResponse, LlmError> {
+        match parse_radar_action(&command.argument) {
+            RadarCommand::Usage => Ok(command_response(
+                RADAR_USAGE_REPLY,
+                Some(session.session_id.clone()),
+                Some(command.action),
+            )),
+            RadarCommand::Issue(target) => {
+                let body = format_radar_issue_reply(target);
+                self.session_store
+                    .append_exchange(session, user_text, &body.text)
+                    .map_err(session_error)?;
+                Ok(command_response(
+                    body,
+                    Some(session.session_id.clone()),
+                    Some(command.action),
+                ))
+            }
+            RadarCommand::Show(target) => {
+                let outcome = match self.radar_executor.radar(target).await {
+                    Ok(outcome) => outcome,
+                    Err(err) => {
+                        tracing::warn!(
+                            error_code = %err.code,
+                            error_stage = %err.stage,
+                            radar_provider = self.radar_executor.provider_name(),
+                            "radar command failed"
+                        );
+                        let body = format_radar_total_failure(&err);
+                        self.session_store
+                            .append_exchange(session, user_text, &body.text)
+                            .map_err(session_error)?;
+                        let mut response = command_response(
+                            body,
+                            Some(session.session_id.clone()),
+                            Some(command.action),
+                        );
+                        response.diagnostics = Some(json!({
+                            "backend": "rust",
+                            "session_backend": "rust",
+                            "used_memory": false,
+                            "used_search": false,
+                            "used_weather": false,
+                            "used_radar": true,
+                            "radar_provider": self.radar_executor.provider_name(),
+                            "radar_error_code": err.code,
+                            "radar_error_stage": err.stage,
+                        }));
+                        return Ok(response);
+                    }
+                };
+                let body = format_radar_reply(&outcome);
+                self.session_store
+                    .append_exchange(session, user_text, &body.text)
+                    .map_err(session_error)?;
+                let mut response =
+                    command_response(body, Some(session.session_id.clone()), Some(command.action));
+                response.diagnostics = Some(json!({
+                    "backend": "rust",
+                    "session_backend": "rust",
+                    "used_memory": false,
+                    "used_search": false,
+                    "used_weather": false,
+                    "used_radar": true,
+                    "radar_provider": self.radar_executor.provider_name(),
+                    "radar_target": radar_target_label(target),
+                    "radar_codex_ok": outcome.codex.is_some(),
+                    "radar_claude_ok": outcome.claude.is_some(),
+                    "radar_failure_count": outcome.failures.len(),
+                }));
+                Ok(response)
+            }
+        }
+    }
+}
+
+pub(super) fn parse_radar_command(text: &str) -> Option<ParsedCommand> {
+    let command = parse_slash_command(text)?;
+    (command.action == "radar").then_some(command)
+}
+
+pub(super) fn parse_radar_action(argument: &str) -> RadarCommand {
+    let mut parts = argument.split_whitespace();
+    let Some(first) = parts.next() else {
+        return RadarCommand::Show(RadarTarget::All);
+    };
+    let first = first.to_ascii_lowercase();
+    if first == "issue" || first == "反馈" {
+        return parts
+            .next()
+            .and_then(parse_issue_target)
+            .map(RadarCommand::Issue)
+            .unwrap_or(RadarCommand::Usage);
+    }
+    parse_show_target(&first)
+        .map(RadarCommand::Show)
+        .unwrap_or(RadarCommand::Usage)
+}
+
+pub(super) fn format_radar_reply(snapshot: &RadarSnapshot) -> CommandBody {
+    let mut render = CommandRender::new();
+    render.title("🛰️ 雷达摘要");
+    if let Some(codex) = snapshot.codex.as_ref() {
+        render.blank();
+        append_codex_card(&mut render, codex);
+    }
+    if let Some(claude) = snapshot.claude.as_ref() {
+        render.blank();
+        append_claude_card(&mut render, claude);
+    }
+    if !snapshot.failures.is_empty() {
+        render.blank();
+        render.subtitle("读取提示");
+        for failure in &snapshot.failures {
+            render.bullet(&format_failure(failure));
+        }
+    }
+    render.build()
+}
+
+fn format_radar_issue_reply(target: RadarIssueTarget) -> CommandBody {
+    let (name, markdown_name) = match target {
+        RadarIssueTarget::Codex => ("Codex Radar", "Codex Radar"),
+        RadarIssueTarget::Claude => ("Claude Code Radar", "Claude Code Radar"),
+    };
+    let site_url = radar_site_url(target);
+    let feedback_url = radar_feedback_url(target);
+    let markdown = format!(
+        "# {markdown_name} 反馈\n\n- 反馈入口：{feedback_url}\n- 来源站点：{site_url}\n\n当前未发现该站点公开 GitHub Issue 仓库或匿名代发 API，请从站点公开反馈入口继续。"
+    );
+    let text = format!(
+        "{name} 反馈\n\n反馈入口：{feedback_url}\n来源站点：{site_url}\n\n当前未发现该站点公开 GitHub Issue 仓库或匿名代发 API，请从站点公开反馈入口继续。"
+    );
+    CommandBody::dual(text, markdown)
+}
+
+fn format_radar_total_failure(err: &LlmError) -> CommandBody {
+    let message = match err.code.as_str() {
+        "timeout" => "雷达数据读取超时了，请稍后再试。",
+        "http_error" => "雷达公开数据源暂时不可用，可能是上游接口或网络异常。",
+        _ => "雷达数据解析失败或字段缺失，请稍后再试。",
+    };
+    let markdown = format!("# 🛰️ 雷达摘要\n\n{message}");
+    CommandBody::dual(message.to_owned(), markdown)
+}
+
+fn append_codex_card(render: &mut CommandRender, summary: &CodexRadarSummary) {
+    render.push_pair(
+        format!(
+            "Codex Radar · {}",
+            display_value(summary.status.as_deref(), "状态未返回")
+        ),
+        format!(
+            "## Codex Radar · {}",
+            escape_markdown_inline(&display_value(summary.status.as_deref(), "状态未返回"))
+        ),
+    );
+    render.bullet(&format!(
+        "更新时间：{}",
+        display_value(summary.updated_at.as_deref(), "未返回")
+    ));
+    render.bullet(&format!(
+        "窗口：{}",
+        display_value(summary.window_message.as_deref(), "未返回窗口说明")
+    ));
+    render.bullet(&format!(
+        "预测：{}{}",
+        display_value(summary.prediction_level.as_deref(), "未返回"),
+        summary
+            .probability_24h
+            .map(|value| format!(" · 24h {:.0}%", value * 100.0))
+            .unwrap_or_default()
+    ));
+    render.bullet(&format!(
+        "IQ：{}",
+        format_score_line(
+            summary.model_score,
+            summary.model_status.as_deref(),
+            summary.model_passed,
+            summary.model_tasks,
+        )
+    ));
+    render.bullet(&format!(
+        "额度：20x Pro 5h {} / 7d {}",
+        format_number(summary.quota_5h_20x),
+        format_number(summary.quota_7d_20x)
+    ));
+    append_link(render, "来源", &summary.source_url);
+}
+
+fn append_claude_card(render: &mut CommandRender, summary: &ClaudeRadarSummary) {
+    render.push_pair(
+        format!(
+            "Claude Code Radar · {}",
+            display_value(summary.status.as_deref(), "状态未返回")
+        ),
+        format!(
+            "## Claude Code Radar · {}",
+            escape_markdown_inline(&display_value(summary.status.as_deref(), "状态未返回"))
+        ),
+    );
+    render.bullet(&format!(
+        "更新时间：{}",
+        display_value(summary.updated_at.as_deref(), "未返回")
+    ));
+    render.bullet(&format!(
+        "额度：5h {} / 7d {}",
+        format_number(summary.quota_5h),
+        format_number(summary.quota_7d)
+    ));
+    if let Some(usage) = summary.usage_5h.as_deref() {
+        render.bullet(&format!(
+            "用量：{}",
+            truncate_chars(usage, RADAR_SUMMARY_MAX_CHARS)
+        ));
+    }
+    if let Some(usage) = summary.usage_7d.as_deref() {
+        render.bullet(&format!(
+            "用量：{}",
+            truncate_chars(usage, RADAR_SUMMARY_MAX_CHARS)
+        ));
+    }
+    render.bullet(&format!(
+        "IQ 最高：{}",
+        format_claude_model(summary.top_iq_model.as_ref(), true)
+    ));
+    render.bullet(&format!(
+        "24h 评分：{}",
+        format_claude_model(summary.top_rating_model.as_ref(), false)
+    ));
+    append_link(render, "来源", &summary.source_url);
+}
+
+fn append_link(render: &mut CommandRender, label: &str, url: &str) {
+    let text = format!("{label}：{url}");
+    let markdown = format!(
+        "- {}：{}",
+        escape_markdown_inline(label),
+        escape_markdown_text(url)
+    );
+    render.push_pair(format!("· {text}"), markdown);
+}
+
+fn format_claude_model(model: Option<&ClaudeModelMetric>, include_pass: bool) -> String {
+    let Some(model) = model else {
+        return "未返回".to_owned();
+    };
+    let score = model
+        .score
+        .map(|score| format_number(Some(score)))
+        .unwrap_or_else(|| "未返回".to_owned());
+    let pass = if include_pass {
+        match (model.passed, model.valid, model.invalid) {
+            (Some(passed), Some(valid), Some(invalid)) if invalid > 0 => {
+                format!(" · {passed}/{valid} · {invalid} invalid")
+            }
+            (Some(passed), Some(valid), _) => format!(" · {passed}/{valid}"),
+            _ => String::new(),
+        }
+    } else {
+        model
+            .valid
+            .map(|count| format!(" · 样本 {count}"))
+            .unwrap_or_default()
+    };
+    format!("{} {score}{pass}", model.name)
+}
+
+fn format_score_line(
+    score: Option<f64>,
+    status: Option<&str>,
+    passed: Option<u64>,
+    tasks: Option<u64>,
+) -> String {
+    let score = score
+        .map(|score| format_number(Some(score)))
+        .unwrap_or_else(|| "未返回".to_owned());
+    let status = status
+        .map(|status| format!(" · {status}"))
+        .unwrap_or_default();
+    let pass = match (passed, tasks) {
+        (Some(passed), Some(tasks)) => format!(" · {passed}/{tasks}"),
+        _ => String::new(),
+    };
+    format!("{score}{status}{pass}")
+}
+
+fn format_failure(failure: &RadarSourceFailure) -> String {
+    let source = match failure.source {
+        RadarSourceKind::Codex => "Codex Radar",
+        RadarSourceKind::Claude => "Claude Code Radar",
+    };
+    let reason = match failure.code.as_str() {
+        "timeout" => "读取超时",
+        "http_error" => "公开接口不可用",
+        _ => "解析失败或字段缺失",
+    };
+    format!("{source}：{reason}（{}）", failure.stage)
+}
+
+fn parse_show_target(token: &str) -> Option<RadarTarget> {
+    match token {
+        "all" | "全部" => Some(RadarTarget::All),
+        "codex" | "code" => Some(RadarTarget::Codex),
+        "claude" | "cc" | "claude-code" => Some(RadarTarget::Claude),
+        _ => None,
+    }
+}
+
+fn parse_issue_target(token: &str) -> Option<RadarIssueTarget> {
+    match token.to_ascii_lowercase().as_str() {
+        "codex" | "code" => Some(RadarIssueTarget::Codex),
+        "claude" | "cc" | "claude-code" => Some(RadarIssueTarget::Claude),
+        _ => None,
+    }
+}
+
+fn radar_target_label(target: RadarTarget) -> &'static str {
+    match target {
+        RadarTarget::All => "all",
+        RadarTarget::Codex => "codex",
+        RadarTarget::Claude => "claude",
+    }
+}
+
+fn display_value(value: Option<&str>, fallback: &str) -> String {
+    value
+        .map(|value| truncate_chars(value, RADAR_SUMMARY_MAX_CHARS))
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| fallback.to_owned())
+}
+
+fn format_number(value: Option<f64>) -> String {
+    let Some(value) = value else {
+        return "未返回".to_owned();
+    };
+    if value.fract().abs() < 0.005 {
+        format!("{value:.0}")
+    } else {
+        format!("{value:.2}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::runtime::tools::{
+        CodexRadarSummary, RadarSnapshot, RadarSourceFailure, RadarSourceKind,
+    };
+
+    use super::*;
+
+    #[test]
+    fn parse_radar_action_accepts_required_variants() {
+        assert_eq!(parse_radar_action(""), RadarCommand::Show(RadarTarget::All));
+        assert_eq!(
+            parse_radar_action("codex"),
+            RadarCommand::Show(RadarTarget::Codex)
+        );
+        assert_eq!(
+            parse_radar_action("claude"),
+            RadarCommand::Show(RadarTarget::Claude)
+        );
+        assert_eq!(
+            parse_radar_action("issue codex"),
+            RadarCommand::Issue(RadarIssueTarget::Codex)
+        );
+        assert_eq!(
+            parse_radar_action("issue claude"),
+            RadarCommand::Issue(RadarIssueTarget::Claude)
+        );
+        assert_eq!(parse_radar_action("unknown"), RadarCommand::Usage);
+    }
+
+    #[test]
+    fn format_radar_reply_surfaces_missing_fields_and_partial_failure() {
+        let body = format_radar_reply(&RadarSnapshot {
+            codex: Some(CodexRadarSummary {
+                status: None,
+                updated_at: None,
+                action: None,
+                window_message: None,
+                prediction_level: None,
+                probability_24h: None,
+                model_score: None,
+                model_status: None,
+                model_passed: None,
+                model_tasks: None,
+                quota_5h_20x: None,
+                quota_7d_20x: None,
+                source_url: "https://codexradar.com/".to_owned(),
+                feedback_url: "https://codexradar.com/".to_owned(),
+            }),
+            claude: None,
+            failures: vec![RadarSourceFailure {
+                source: RadarSourceKind::Claude,
+                code: "timeout".to_owned(),
+                stage: "radar_claude_data".to_owned(),
+            }],
+        });
+
+        assert!(body.text.contains("Codex Radar · 状态未返回"));
+        assert!(body.text.contains("窗口：未返回窗口说明"));
+        assert!(body.text.contains("IQ：未返回"));
+        assert!(body.text.contains("Claude Code Radar：读取超时"));
+        assert!(body.markdown.unwrap().contains("## 读取提示"));
+    }
+}

--- a/qq-maid-core/src/runtime/respond/tests/mod.rs
+++ b/qq-maid-core/src/runtime/respond/tests/mod.rs
@@ -1,6 +1,7 @@
 mod chat;
 mod memory;
 mod pending;
+mod radar;
 mod rss;
 mod search;
 mod session;

--- a/qq-maid-core/src/runtime/respond/tests/radar.rs
+++ b/qq-maid-core/src/runtime/respond/tests/radar.rs
@@ -1,0 +1,121 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use super::support::*;
+
+#[tokio::test]
+async fn radar_command_accepts_rader_alias_and_returns_both_cards() {
+    let provider_calls = Arc::new(AtomicUsize::new(0));
+    let (service, _) = test_service_with_provider_base_title_query_and_models(
+        MockProvider::with_counter(provider_calls.clone()),
+        None,
+        Arc::new(MockQueryExecutor),
+        Arc::new(MockWeatherExecutor::new()),
+        None,
+        None,
+        None,
+    );
+
+    let response = service.respond(message("/rader")).await.unwrap();
+    let text = response.text.clone().unwrap();
+    let markdown = response.markdown.clone().unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("radar"));
+    assert!(text.starts_with("🛰️ 雷达摘要"));
+    assert!(text.contains("Codex Radar · community_confirmed"));
+    assert!(text.contains("Claude Code Radar · ok"));
+    assert!(text.contains("IQ：60 · red · 4/10"));
+    assert!(text.contains("24h 评分：Fable 5 xhigh 9.10 · 样本 9"));
+    assert!(markdown.starts_with("# 🛰️ 雷达摘要"));
+    assert!(markdown.contains("## Codex Radar · community\\_confirmed"));
+    assert!(markdown.contains("## Claude Code Radar · ok"));
+    assert_eq!(provider_calls.load(Ordering::SeqCst), 0);
+
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["used_radar"], true);
+    assert_eq!(diagnostics["radar_target"], "all");
+    assert_eq!(diagnostics["radar_provider"], "mock-radar");
+}
+
+#[tokio::test]
+async fn radar_command_accepts_correct_spelling_alias() {
+    let (service, _) = test_service_with_base();
+
+    let response = service.respond(message("/radar")).await.unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("radar"));
+    assert!(response.text.unwrap().contains("Codex Radar"));
+}
+
+#[tokio::test]
+async fn radar_command_accepts_chinese_alias() {
+    let (service, _) = test_service_with_base();
+
+    let response = service.respond(message("/雷达")).await.unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("radar"));
+    assert!(response.text.unwrap().contains("Claude Code Radar"));
+}
+
+#[tokio::test]
+async fn radar_command_can_show_only_codex() {
+    let (service, _) = test_service_with_base();
+
+    let response = service.respond(message("/rader codex")).await.unwrap();
+    let text = response.text.unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("radar"));
+    assert!(text.contains("Codex Radar · community_confirmed"));
+    assert!(!text.contains("Claude Code Radar"));
+    assert_eq!(response.diagnostics.unwrap()["radar_target"], "codex");
+}
+
+#[tokio::test]
+async fn radar_command_can_show_only_claude() {
+    let (service, _) = test_service_with_base();
+
+    let response = service.respond(message("/rader claude")).await.unwrap();
+    let text = response.text.unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("radar"));
+    assert!(text.contains("Claude Code Radar · ok"));
+    assert!(!text.contains("Codex Radar"));
+    assert_eq!(response.diagnostics.unwrap()["radar_target"], "claude");
+}
+
+#[tokio::test]
+async fn radar_issue_codex_returns_feedback_entry_without_external_call() {
+    let (service, _) = test_service_with_base();
+
+    let response = service
+        .respond(message("/rader issue codex"))
+        .await
+        .unwrap();
+    let text = response.text.clone().unwrap();
+    let markdown = response.markdown.clone().unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("radar"));
+    assert!(text.contains("Codex Radar 反馈"));
+    assert!(text.contains("反馈入口：https://codexradar.com/"));
+    assert!(text.contains("当前未发现该站点公开 GitHub Issue 仓库"));
+    assert!(markdown.starts_with("# Codex Radar 反馈"));
+}
+
+#[tokio::test]
+async fn radar_issue_claude_returns_feedback_entry_without_external_call() {
+    let (service, _) = test_service_with_base();
+
+    let response = service
+        .respond(message("/rader issue claude"))
+        .await
+        .unwrap();
+    let text = response.text.clone().unwrap();
+    let markdown = response.markdown.clone().unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("radar"));
+    assert!(text.contains("Claude Code Radar 反馈"));
+    assert!(text.contains("反馈入口：https://claudecoderadar.com/"));
+    assert!(markdown.starts_with("# Claude Code Radar 反馈"));
+}

--- a/qq-maid-core/src/runtime/respond/tests/support.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support.rs
@@ -32,6 +32,10 @@ use crate::{
         rss::{RssFetchConfig, RssFetcher, RssStore},
         session::{SessionMeta, SessionStore},
         todo::{TodoItem, TodoStatus, TodoStore, TodoTimePrecision},
+        tools::{
+            ClaudeModelMetric, ClaudeRadarSummary, CodexRadarSummary, RadarExecutor, RadarSnapshot,
+            RadarTarget,
+        },
         train::{TrainExecutor, TrainSchedule, TrainScheduleRequest, TrainStop},
         weather::{
             AirQualitySummary, CurrentWeather, DailyWeather, WeatherAlert, WeatherExecutor,
@@ -126,6 +130,21 @@ pub(super) struct TestModelOptions {
 pub(super) struct TestToolCallingOptions {
     pub(super) enabled: bool,
     pub(super) group_enabled: bool,
+}
+
+#[derive(Clone)]
+pub(super) struct MockRadarExecutor {
+    calls: Arc<AtomicUsize>,
+    outcome: Arc<Mutex<Result<RadarSnapshot, LlmError>>>,
+}
+
+impl MockRadarExecutor {
+    pub(super) fn new() -> Self {
+        Self {
+            calls: Arc::new(AtomicUsize::new(0)),
+            outcome: Arc::new(Mutex::new(Ok(mock_radar_snapshot()))),
+        }
+    }
 }
 
 impl MockProvider {
@@ -817,6 +836,98 @@ impl WeatherExecutor for MockWeatherExecutor {
 
     fn provider_name(&self) -> &'static str {
         "mock-weather"
+    }
+}
+
+#[async_trait]
+impl RadarExecutor for MockRadarExecutor {
+    async fn radar(&self, target: RadarTarget) -> Result<RadarSnapshot, LlmError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let snapshot = self.outcome.lock().unwrap().clone()?;
+        Ok(match target {
+            RadarTarget::All => snapshot,
+            RadarTarget::Codex => RadarSnapshot {
+                codex: snapshot.codex,
+                claude: None,
+                failures: snapshot
+                    .failures
+                    .into_iter()
+                    .filter(|failure| {
+                        matches!(
+                            failure.source,
+                            crate::runtime::tools::RadarSourceKind::Codex
+                        )
+                    })
+                    .collect(),
+            },
+            RadarTarget::Claude => RadarSnapshot {
+                codex: None,
+                claude: snapshot.claude,
+                failures: snapshot
+                    .failures
+                    .into_iter()
+                    .filter(|failure| {
+                        matches!(
+                            failure.source,
+                            crate::runtime::tools::RadarSourceKind::Claude
+                        )
+                    })
+                    .collect(),
+            },
+        })
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "mock-radar"
+    }
+}
+
+pub(super) fn mock_radar_snapshot() -> RadarSnapshot {
+    RadarSnapshot {
+        codex: Some(CodexRadarSummary {
+            status: Some("community_confirmed".to_owned()),
+            updated_at: Some("2026-06-30T18:39:12+08:00".to_owned()),
+            action: Some("reset_completed".to_owned()),
+            window_message: Some("社区反馈已完成重置，当前没有开启的速蹬窗口".to_owned()),
+            prediction_level: Some("high".to_owned()),
+            probability_24h: Some(0.36),
+            model_score: Some(60.0),
+            model_status: Some("red".to_owned()),
+            model_passed: Some(4),
+            model_tasks: Some(10),
+            quota_5h_20x: Some(281.91),
+            quota_7d_20x: Some(1691.46),
+            source_url: "https://codexradar.com/".to_owned(),
+            feedback_url: "https://codexradar.com/".to_owned(),
+        }),
+        claude: Some(ClaudeRadarSummary {
+            status: Some("ok".to_owned()),
+            updated_at: Some("2026-07-05T09:37:50+08:00".to_owned()),
+            quota_updated_at: Some("2026-07-04T09:46:15+08:00".to_owned()),
+            quota_5h: Some(332.29),
+            quota_7d: Some(2270.63),
+            usage_5h: Some("当前 5h 共享池 已用 41% · 13:00 重置".to_owned()),
+            usage_7d: Some("当前 7d 额度 已用 60% · 7月4日 16:00 重置".to_owned()),
+            top_iq_model: Some(ClaudeModelMetric {
+                name: "Fable 5 xhigh".to_owned(),
+                score: Some(120.0),
+                passed: Some(8),
+                valid: Some(10),
+                invalid: Some(0),
+                updated_at: Some("2026-07-03T15:25:03+08:00".to_owned()),
+            }),
+            top_rating_model: Some(ClaudeModelMetric {
+                name: "Fable 5 xhigh".to_owned(),
+                score: Some(9.1),
+                passed: None,
+                valid: Some(9),
+                invalid: None,
+                updated_at: None,
+            }),
+            source_url: "https://claudecoderadar.com/".to_owned(),
+            feedback_url: "https://claudecoderadar.com/".to_owned(),
+        }),
+        failures: Vec::new(),
     }
 }
 
@@ -1751,6 +1862,7 @@ pub(super) fn test_service_with_provider_base_title_query_weather_train_models_a
             query_executor,
             weather_executor,
             train_executor,
+            radar_executor: Arc::new(MockRadarExecutor::new()),
         },
         RespondStores {
             memory_store: MemoryStore::new(database.clone()),

--- a/qq-maid-core/src/runtime/tools/mod.rs
+++ b/qq-maid-core/src/runtime/tools/mod.rs
@@ -3,11 +3,17 @@
 //! 本模块只负责把现有业务执行器包装成模型可调用 Tool。未来 Skill 层可以引用这些
 //! Tool 的元数据和说明，但不应让 Tool 依赖 Skill loader 或 SKILL.md 文件。
 
+mod radar;
 mod rss;
 mod todo;
 mod train;
 mod weather;
 
+pub use radar::{
+    ClaudeModelMetric, ClaudeRadarSummary, CodexRadarSummary, DynRadarExecutor, RadarExecutor,
+    RadarIssueTarget, RadarSnapshot, RadarSourceFailure, RadarSourceKind, RadarTarget,
+    build_radar_executor, radar_feedback_url, radar_site_url,
+};
 pub use rss::RssRecentItemsTool;
 pub use todo::{
     CancelTodoTool, CompleteTodoTool, CreateTodoTool, DeleteTodoTool, EditTodoTool, GetTodoTool,

--- a/qq-maid-core/src/runtime/tools/radar.rs
+++ b/qq-maid-core/src/runtime/tools/radar.rs
@@ -1,0 +1,464 @@
+//! Codex / Claude Code Radar 公开数据读取。
+//!
+//! 这里虽然不注册为模型 Tool，但仍放在 `tools` 目录：slash 入口只做解析和展示，
+//! 外部看板接入的 HTTP、字段兼容和错误映射集中在本模块，后续同类雷达可沿用。
+
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::error::LlmError;
+
+const CODEX_CURRENT_URL: &str = "https://codexradar.com/current.json";
+const CODEX_SITE_URL: &str = "https://codexradar.com/";
+const CODEX_FEEDBACK_URL: &str = "https://codexradar.com/";
+const CLAUDE_DATA_URL: &str = "https://claudecoderadar.com/data/claude-code-radar.json";
+const CLAUDE_RATINGS_URL: &str = "https://claudecoderadar.com/api/model-ratings";
+const CLAUDE_SITE_URL: &str = "https://claudecoderadar.com/";
+const CLAUDE_FEEDBACK_URL: &str = "https://claudecoderadar.com/";
+const RADAR_USER_AGENT: &str = concat!("qq-maid-core/", env!("CARGO_PKG_VERSION"));
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RadarTarget {
+    All,
+    Codex,
+    Claude,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RadarIssueTarget {
+    Codex,
+    Claude,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RadarSourceKind {
+    Codex,
+    Claude,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RadarSourceFailure {
+    pub source: RadarSourceKind,
+    pub code: String,
+    pub stage: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RadarSnapshot {
+    pub codex: Option<CodexRadarSummary>,
+    pub claude: Option<ClaudeRadarSummary>,
+    pub failures: Vec<RadarSourceFailure>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CodexRadarSummary {
+    pub status: Option<String>,
+    pub updated_at: Option<String>,
+    pub action: Option<String>,
+    pub window_message: Option<String>,
+    pub prediction_level: Option<String>,
+    pub probability_24h: Option<f64>,
+    pub model_score: Option<f64>,
+    pub model_status: Option<String>,
+    pub model_passed: Option<u64>,
+    pub model_tasks: Option<u64>,
+    pub quota_5h_20x: Option<f64>,
+    pub quota_7d_20x: Option<f64>,
+    pub source_url: String,
+    pub feedback_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClaudeRadarSummary {
+    pub status: Option<String>,
+    pub updated_at: Option<String>,
+    pub quota_updated_at: Option<String>,
+    pub quota_5h: Option<f64>,
+    pub quota_7d: Option<f64>,
+    pub usage_5h: Option<String>,
+    pub usage_7d: Option<String>,
+    pub top_iq_model: Option<ClaudeModelMetric>,
+    pub top_rating_model: Option<ClaudeModelMetric>,
+    pub source_url: String,
+    pub feedback_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClaudeModelMetric {
+    pub name: String,
+    pub score: Option<f64>,
+    pub passed: Option<u64>,
+    pub valid: Option<u64>,
+    pub invalid: Option<u64>,
+    pub updated_at: Option<String>,
+}
+
+#[async_trait]
+pub trait RadarExecutor: Send + Sync {
+    async fn radar(&self, target: RadarTarget) -> Result<RadarSnapshot, LlmError>;
+
+    fn provider_name(&self) -> &'static str {
+        "radar-public"
+    }
+}
+
+pub type DynRadarExecutor = Arc<dyn RadarExecutor>;
+
+pub fn build_radar_executor() -> Result<DynRadarExecutor, LlmError> {
+    Ok(Arc::new(HttpRadarExecutor::new()?))
+}
+
+pub struct HttpRadarExecutor {
+    client: reqwest::Client,
+}
+
+impl HttpRadarExecutor {
+    pub fn new() -> Result<Self, LlmError> {
+        let client = reqwest::Client::builder()
+            .user_agent(RADAR_USER_AGENT)
+            .timeout(Duration::from_secs(10))
+            .build()
+            .map_err(|err| LlmError::provider(err.to_string(), "radar_client"))?;
+        Ok(Self { client })
+    }
+
+    async fn fetch_json(&self, url: &str, stage: &'static str) -> Result<Value, LlmError> {
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(|err| map_radar_request_error(err, stage))?;
+        if !response.status().is_success() {
+            return Err(LlmError::http(format!(
+                "radar upstream returned {} at {stage}",
+                response.status()
+            )));
+        }
+        response
+            .json::<Value>()
+            .await
+            .map_err(|err| LlmError::provider(err.to_string(), stage))
+    }
+
+    async fn fetch_codex(&self) -> Result<CodexRadarSummary, LlmError> {
+        let json = self.fetch_json(CODEX_CURRENT_URL, "radar_codex").await?;
+        Ok(parse_codex_summary(&json))
+    }
+
+    async fn fetch_claude(
+        &self,
+    ) -> Result<(ClaudeRadarSummary, Vec<RadarSourceFailure>), LlmError> {
+        let data = self
+            .fetch_json(CLAUDE_DATA_URL, "radar_claude_data")
+            .await?;
+        let mut failures = Vec::new();
+        let ratings = match self
+            .fetch_json(CLAUDE_RATINGS_URL, "radar_claude_ratings")
+            .await
+        {
+            Ok(ratings) => ratings,
+            Err(err) => {
+                failures.push(failure(RadarSourceKind::Claude, &err));
+                Value::Null
+            }
+        };
+        Ok((parse_claude_summary(&data, &ratings), failures))
+    }
+}
+
+#[async_trait]
+impl RadarExecutor for HttpRadarExecutor {
+    async fn radar(&self, target: RadarTarget) -> Result<RadarSnapshot, LlmError> {
+        let mut snapshot = RadarSnapshot {
+            codex: None,
+            claude: None,
+            failures: Vec::new(),
+        };
+
+        if matches!(target, RadarTarget::All | RadarTarget::Codex) {
+            match self.fetch_codex().await {
+                Ok(summary) => snapshot.codex = Some(summary),
+                Err(err) => snapshot
+                    .failures
+                    .push(failure(RadarSourceKind::Codex, &err)),
+            }
+        }
+        if matches!(target, RadarTarget::All | RadarTarget::Claude) {
+            match self.fetch_claude().await {
+                Ok((summary, failures)) => {
+                    snapshot.claude = Some(summary);
+                    snapshot.failures.extend(failures);
+                }
+                Err(err) => snapshot
+                    .failures
+                    .push(failure(RadarSourceKind::Claude, &err)),
+            }
+        }
+
+        if snapshot.codex.is_none() && snapshot.claude.is_none() {
+            let first = snapshot
+                .failures
+                .first()
+                .cloned()
+                .unwrap_or(RadarSourceFailure {
+                    source: match target {
+                        RadarTarget::Claude => RadarSourceKind::Claude,
+                        RadarTarget::All | RadarTarget::Codex => RadarSourceKind::Codex,
+                    },
+                    code: "radar_empty".to_owned(),
+                    stage: "radar".to_owned(),
+                });
+            return Err(LlmError::new(
+                first.code,
+                "radar data unavailable",
+                first.stage,
+            ));
+        }
+
+        Ok(snapshot)
+    }
+}
+
+pub fn radar_feedback_url(target: RadarIssueTarget) -> &'static str {
+    match target {
+        RadarIssueTarget::Codex => CODEX_FEEDBACK_URL,
+        RadarIssueTarget::Claude => CLAUDE_FEEDBACK_URL,
+    }
+}
+
+pub fn radar_site_url(target: RadarIssueTarget) -> &'static str {
+    match target {
+        RadarIssueTarget::Codex => CODEX_SITE_URL,
+        RadarIssueTarget::Claude => CLAUDE_SITE_URL,
+    }
+}
+
+fn parse_codex_summary(json: &Value) -> CodexRadarSummary {
+    let window = json.get("window").unwrap_or(&Value::Null);
+    let prediction = json.get("prediction").unwrap_or(&Value::Null);
+    let model_latest = json
+        .pointer("/model_iq/latest")
+        .or_else(|| json.pointer("/model_iq/comparisons/gpt_55_high/latest"))
+        .unwrap_or(&Value::Null);
+    let quota = json
+        .pointer("/model_iq/quota_radar")
+        .unwrap_or(&Value::Null);
+    let first_row = quota
+        .get("rows")
+        .and_then(Value::as_array)
+        .and_then(|rows| rows.first())
+        .unwrap_or(&Value::Null);
+
+    CodexRadarSummary {
+        status: str_value(window.get("status")).or_else(|| str_value(json.get("status"))),
+        updated_at: str_value(json.get("monitored_at"))
+            .or_else(|| str_value(prediction.get("updated_at")))
+            .or_else(|| str_value(quota.get("updated_at"))),
+        action: str_value(window.get("action"))
+            .or_else(|| str_value(json.get("recommended_action"))),
+        window_message: str_value(window.get("message")),
+        prediction_level: str_value(prediction.get("level")),
+        probability_24h: f64_value(prediction.get("probability_24h")),
+        model_score: f64_value(model_latest.get("score")),
+        model_status: str_value(model_latest.get("status")),
+        model_passed: u64_value(model_latest.get("passed")),
+        model_tasks: u64_value(model_latest.get("tasks"))
+            .or_else(|| u64_value(model_latest.get("valid_tasks"))),
+        quota_5h_20x: f64_value(first_row.get("five_h")),
+        quota_7d_20x: f64_value(first_row.get("seven_d")),
+        source_url: str_value(json.pointer("/links/html"))
+            .unwrap_or_else(|| CODEX_SITE_URL.to_owned()),
+        feedback_url: CODEX_FEEDBACK_URL.to_owned(),
+    }
+}
+
+fn parse_claude_summary(data: &Value, ratings: &Value) -> ClaudeRadarSummary {
+    let quota = data.get("quota").unwrap_or(&Value::Null);
+    let models = data
+        .pointer("/iq/models")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    let top_iq_model = models
+        .iter()
+        .filter_map(claude_iq_model_metric)
+        .max_by(|left, right| compare_optional_score(left.score, right.score));
+    let top_rating_model = ratings
+        .get("models")
+        .and_then(Value::as_array)
+        .and_then(|models| {
+            models
+                .iter()
+                .filter_map(claude_rating_model_metric)
+                .max_by(|left, right| compare_optional_score(left.score, right.score))
+        });
+
+    ClaudeRadarSummary {
+        status: data
+            .get("ok")
+            .and_then(Value::as_bool)
+            .map(|ok| if ok { "ok" } else { "error" }.to_owned()),
+        updated_at: str_value(data.get("updated_at"))
+            .or_else(|| str_value(ratings.get("updated_at"))),
+        quota_updated_at: str_value(quota.get("updated_at")),
+        quota_5h: f64_value(quota.get("base_h5")),
+        quota_7d: f64_value(quota.get("base_d7")),
+        usage_5h: usage_line(quota, "h5"),
+        usage_7d: usage_line(quota, "d7"),
+        top_iq_model,
+        top_rating_model,
+        source_url: CLAUDE_SITE_URL.to_owned(),
+        feedback_url: CLAUDE_FEEDBACK_URL.to_owned(),
+    }
+}
+
+fn claude_iq_model_metric(value: &Value) -> Option<ClaudeModelMetric> {
+    Some(ClaudeModelMetric {
+        name: str_value(value.get("name"))?,
+        score: f64_value(value.get("score")),
+        passed: latest_array_u64(value.get("pass")).or_else(|| u64_value(value.get("passed"))),
+        valid: latest_array_u64(value.get("valid")).or_else(|| u64_value(value.get("valid"))),
+        invalid: latest_array_u64(value.get("invalid")).or_else(|| u64_value(value.get("invalid"))),
+        updated_at: str_value(value.get("latest_at")),
+    })
+}
+
+fn claude_rating_model_metric(value: &Value) -> Option<ClaudeModelMetric> {
+    Some(ClaudeModelMetric {
+        name: str_value(value.get("label"))?,
+        score: f64_value(value.get("average")),
+        passed: None,
+        valid: u64_value(value.get("count")),
+        invalid: None,
+        updated_at: None,
+    })
+}
+
+fn usage_line(quota: &Value, key: &str) -> Option<String> {
+    let usage = quota.get("usage")?.as_array()?;
+    let item = usage
+        .iter()
+        .find(|item| item.get("key").and_then(Value::as_str) == Some(key))?;
+    let label = str_value(item.get("label_zh"))?;
+    let used = u64_value(item.get("used_pct"))?;
+    let reset = str_value(item.get("reset_text_zh"));
+    Some(match reset {
+        Some(reset) => format!("{label} 已用 {used}% · {reset}"),
+        None => format!("{label} 已用 {used}%"),
+    })
+}
+
+fn latest_array_u64(value: Option<&Value>) -> Option<u64> {
+    value?.as_array()?.iter().rev().find_map(|value| {
+        if value.is_null() {
+            None
+        } else {
+            u64_value(Some(value))
+        }
+    })
+}
+
+fn compare_optional_score(left: Option<f64>, right: Option<f64>) -> std::cmp::Ordering {
+    left.unwrap_or(f64::NEG_INFINITY)
+        .partial_cmp(&right.unwrap_or(f64::NEG_INFINITY))
+        .unwrap_or(std::cmp::Ordering::Equal)
+}
+
+fn str_value(value: Option<&Value>) -> Option<String> {
+    value?
+        .as_str()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn f64_value(value: Option<&Value>) -> Option<f64> {
+    value?.as_f64()
+}
+
+fn u64_value(value: Option<&Value>) -> Option<u64> {
+    value?.as_u64()
+}
+
+fn map_radar_request_error(err: reqwest::Error, stage: &'static str) -> LlmError {
+    if err.is_timeout() {
+        return LlmError::timeout(stage);
+    }
+    LlmError::http(err.to_string())
+}
+
+fn failure(source: RadarSourceKind, err: &LlmError) -> RadarSourceFailure {
+    RadarSourceFailure {
+        source,
+        code: err.code.clone(),
+        stage: err.stage.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn parse_codex_summary_maps_public_current_json_fields() {
+        let summary = parse_codex_summary(&json!({
+            "status": "community_confirmed",
+            "monitored_at": "2026-06-30T18:39:12+08:00",
+            "recommended_action": "reset_completed",
+            "window": {
+                "status": "community_confirmed",
+                "action": "reset_completed",
+                "message": "社区反馈已完成重置"
+            },
+            "prediction": {"level": "high", "probability_24h": 0.36},
+            "links": {"html": "https://codexradar.com/"},
+            "model_iq": {
+                "latest": {"score": 60.0, "status": "red", "passed": 4, "tasks": 10},
+                "quota_radar": {"rows": [{"five_h": 281.91, "seven_d": 1691.46}]}
+            }
+        }));
+
+        assert_eq!(summary.status.as_deref(), Some("community_confirmed"));
+        assert_eq!(summary.action.as_deref(), Some("reset_completed"));
+        assert_eq!(summary.model_score, Some(60.0));
+        assert_eq!(summary.model_passed, Some(4));
+        assert_eq!(summary.quota_5h_20x, Some(281.91));
+    }
+
+    #[test]
+    fn parse_claude_summary_uses_data_and_model_ratings() {
+        let summary = parse_claude_summary(
+            &json!({
+                "ok": true,
+                "updated_at": "2026-07-05T09:37:50+08:00",
+                "quota": {
+                    "updated_at": "2026-07-04T09:46:15+08:00",
+                    "base_h5": 332.29,
+                    "base_d7": 2270.63,
+                    "usage": [{"key": "h5", "label_zh": "当前 5h 共享池", "used_pct": 41, "reset_text_zh": "13:00 重置"}]
+                },
+                "iq": {"models": [
+                    {"name": "Opus", "score": 60.0, "pass": [null, 4], "valid": [null, 10], "latest_at": "2026-07-04T09:46:15+08:00"},
+                    {"name": "Sonnet", "score": 120.0, "pass": [null, 8], "valid": [null, 10], "latest_at": "2026-07-01T13:10:00+08:00"}
+                ]}
+            }),
+            &json!({
+                "models": [
+                    {"label": "Opus 4.8 max", "average": 6.5, "count": 8},
+                    {"label": "Fable 5 xhigh", "average": 9.1, "count": 9}
+                ]
+            }),
+        );
+
+        assert_eq!(summary.status.as_deref(), Some("ok"));
+        assert_eq!(summary.quota_5h, Some(332.29));
+        assert_eq!(summary.top_iq_model.unwrap().name, "Sonnet");
+        assert_eq!(summary.top_rating_model.unwrap().name, "Fable 5 xhigh");
+        assert!(summary.usage_5h.unwrap().contains("已用 41%"));
+    }
+}

--- a/qq-maid-core/src/service/handle.rs
+++ b/qq-maid-core/src/service/handle.rs
@@ -43,6 +43,7 @@ impl CoreHandle {
                 query_executor: state.query_executor.clone(),
                 weather_executor: state.weather_executor.clone(),
                 train_executor: state.train_executor.clone(),
+                radar_executor: state.radar_executor.clone(),
             },
             RespondStores {
                 memory_store: state.memory_store.clone(),

--- a/qq-maid-core/src/service/tests.rs
+++ b/qq-maid-core/src/service/tests.rs
@@ -28,6 +28,7 @@ use crate::{
         rss::{RssFetchConfig, RssFetcher, RssStore},
         session::{SessionMeta, SessionStore},
         todo::{TodoItemDraft, TodoStore, TodoTimePrecision},
+        tools::{RadarExecutor, RadarSnapshot, RadarTarget},
         train::{TrainExecutor, TrainSchedule, TrainScheduleRequest},
         weather::{WeatherExecutor, WeatherOutcome, WeatherRequest},
     },
@@ -1062,6 +1063,19 @@ impl TrainExecutor for EmptyTrainExecutor {
     }
 }
 
+struct EmptyRadarExecutor;
+
+#[async_trait::async_trait]
+impl RadarExecutor for EmptyRadarExecutor {
+    async fn radar(&self, _target: RadarTarget) -> Result<RadarSnapshot, LlmError> {
+        Err(LlmError::provider("radar unused", "radar"))
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "empty-radar"
+    }
+}
+
 fn private_request(text: &str) -> CoreRequest {
     CoreRequest {
         text: text.to_owned(),
@@ -1259,6 +1273,7 @@ fn test_state_with_group_tool_calling(
         query_executor: Arc::new(EmptyQueryExecutor),
         weather_executor: Arc::new(EmptyWeatherExecutor),
         train_executor: Arc::new(EmptyTrainExecutor),
+        radar_executor: Arc::new(EmptyRadarExecutor),
         memory_store: crate::runtime::memory::MemoryStore::new(database.clone()),
         session_store: SessionStore::new(database.clone()),
         todo_store: TodoStore::new(database.clone()),


### PR DESCRIPTION
## 变更
- 新增 `/rader`、`/radar`、`/雷达` slash 入口，支持总览、Codex、Claude 与反馈入口子命令。
- 在 `qq-maid-core/src/runtime/tools/radar.rs` 集中接入公开 Radar 数据源，slash flow 只负责解析和展示，不进入普通聊天 Tool Loop。
- 参考天气卡片输出结构，提供 text 和 markdown 双通道，并对字段缺失、单源失败和接口失败做明确降级提示。
- `/help` 增加雷达命令说明。

## 数据源与字段映射
- Codex Radar：读取 `https://codexradar.com/current.json`，映射 `window.status/message/action`、`prediction.level/probability_24h`、`model_iq.latest`、`model_iq.quota_radar.rows[0]`、`links.html`。
- Claude Code Radar：读取 `https://claudecoderadar.com/data/claude-code-radar.json` 与 `https://claudecoderadar.com/api/model-ratings`，映射 `quota`、`quota.usage`、`iq.models`、`models[].average/count`。
- 已检查两个独立 Radar GitHub 仓库未公开，首页只暴露站点反馈/公众号入口，所以 `/rader issue ...` 返回站点反馈入口，不伪造代发 Issue API。

## 验证
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p qq-maid-core radar --all-features`
- `cargo test -p qq-maid-core --all-features`
- `cargo check --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo build --workspace --release --all-features`

Closes #271