### PR TITLE
[codex] 支持多模态输入链路

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,6 +1454,7 @@ version = "0.1.2"
 dependencies = [
  "chrono",
  "regex",
+ "serde",
 ]
 
 [[package]]

--- a/qq-maid-common/Cargo.toml
+++ b/qq-maid-common/Cargo.toml
@@ -9,3 +9,5 @@ publish = false
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 # 中文自然语言日期表达解析。
 regex = "1"
+# 跨 crate 输入块需要在 Core 请求和 LLM 请求中序列化。
+serde = { version = "1", features = ["derive"] }

--- a/qq-maid-common/src/input_part.rs
+++ b/qq-maid-common/src/input_part.rs
@@ -1,0 +1,185 @@
+//! 平台无关的入站消息内容块。
+//!
+//! 一次用户输入可能由多段文字、图片或文件组成。本模块只描述顺序和元信息，
+//! 不承载 OCR、票据识别或任何业务语义，便于 gateway、core 和 LLM 层复用。
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MessageInputPart {
+    Text {
+        text: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<TextSource>,
+    },
+    Image {
+        media: MessageMedia,
+    },
+    File {
+        media: MessageMedia,
+    },
+    Unknown {
+        media: MessageMedia,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TextSource {
+    Body,
+    Caption,
+    Quote,
+    Supplement,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct MessageMedia {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub media_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attachment_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub platform: Option<String>,
+    #[serde(default)]
+    pub status: MediaStatus,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MediaStatus {
+    #[default]
+    Available,
+    SizeExceeded,
+    UnsupportedType,
+    DownloadFailed,
+    Expired,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MediaKind {
+    Image,
+    File,
+    Unknown,
+}
+
+impl MessageInputPart {
+    pub fn text(text: impl Into<String>) -> Self {
+        Self::Text {
+            text: text.into(),
+            source: Some(TextSource::Body),
+        }
+    }
+
+    pub fn image(media: MessageMedia) -> Self {
+        Self::Image { media }
+    }
+
+    pub fn file(media: MessageMedia) -> Self {
+        Self::File { media }
+    }
+
+    pub fn unknown(media: MessageMedia, reason: impl Into<String>) -> Self {
+        Self::Unknown {
+            media,
+            reason: Some(reason.into()),
+        }
+    }
+
+    pub fn text_content(&self) -> Option<&str> {
+        match self {
+            Self::Text { text, .. } => Some(text),
+            Self::Image { .. } | Self::File { .. } | Self::Unknown { .. } => None,
+        }
+    }
+
+    pub fn media_kind(&self) -> Option<MediaKind> {
+        match self {
+            Self::Text { .. } => None,
+            Self::Image { .. } => Some(MediaKind::Image),
+            Self::File { .. } => Some(MediaKind::File),
+            Self::Unknown { .. } => Some(MediaKind::Unknown),
+        }
+    }
+
+    pub fn media(&self) -> Option<&MessageMedia> {
+        match self {
+            Self::Text { .. } => None,
+            Self::Image { media } | Self::File { media } | Self::Unknown { media, .. } => {
+                Some(media)
+            }
+        }
+    }
+
+    pub fn is_non_text(&self) -> bool {
+        !matches!(self, Self::Text { .. })
+    }
+
+    pub fn fallback_text(&self) -> String {
+        match self {
+            Self::Text { text, .. } => text.clone(),
+            Self::Image { media } => format_media_note("图片", media),
+            Self::File { media } => format_media_note("文件", media),
+            Self::Unknown { media, .. } => format_media_note("附件", media),
+        }
+    }
+}
+
+impl MessageMedia {
+    pub fn remote_url(&self) -> Option<&str> {
+        self.url
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+    }
+
+    pub fn has_fetchable_reference(&self) -> bool {
+        self.remote_url().is_some()
+            || self
+                .media_id
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            || self
+                .file_id
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+    }
+}
+
+fn format_media_note(label: &str, media: &MessageMedia) -> String {
+    let mime = media.mime_type.as_deref().unwrap_or("unknown");
+    let filename = media.filename.as_deref().unwrap_or("unnamed");
+    format!("[{label} {mime}: {filename}]")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fallback_text_omits_sensitive_url() {
+        let media = MessageMedia {
+            mime_type: Some("image/jpeg".to_owned()),
+            filename: Some("ticket.jpg".to_owned()),
+            url: Some("https://example.test/secret-token".to_owned()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            MessageInputPart::image(media).fallback_text(),
+            "[图片 image/jpeg: ticket.jpg]"
+        );
+    }
+}

--- a/qq-maid-common/src/lib.rs
+++ b/qq-maid-common/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! 这里只放 gateway 和 LLM 都可能复用、且不依赖业务状态的通用逻辑。
 
+pub mod input_part;
 pub mod markdown_strip;
 pub mod redaction;
 pub mod text;

--- a/qq-maid-core/src/runtime/respond.rs
+++ b/qq-maid-core/src/runtime/respond.rs
@@ -335,7 +335,7 @@ impl RustRespondService {
     pub(crate) fn plan_core_respond(&self, req: &RespondRequest) -> Result<RespondPlan, LlmError> {
         let user_text = req.effective_user_text();
         let trimmed = user_text.trim();
-        if trimmed.is_empty() {
+        if trimmed.is_empty() && req.effective_input_parts().is_empty() {
             return Ok(RespondPlan::Immediate);
         }
 
@@ -364,7 +364,9 @@ impl RustRespondService {
 
         let policy = self.resolve_agent_policy(req)?;
         let tool_decision = self.route_tool_loop_with_active(req, &policy, active_session.as_ref());
-        let plan = if matches!(tool_decision.route, ToolLoopRoute::CompleteToolLoop) {
+        let plan = if !req.has_non_text_input_parts()
+            && matches!(tool_decision.route, ToolLoopRoute::CompleteToolLoop)
+        {
             RespondPlan::CompleteToolLoop
         } else {
             RespondPlan::StreamingChat

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -56,7 +56,7 @@ impl RustRespondService {
         mut session: SessionRecord,
         chat_tool_plan: ChatToolPlan,
     ) -> Result<RespondResponse, LlmError> {
-        if user_text.trim().is_empty() {
+        if user_text.trim().is_empty() && req.effective_input_parts().is_empty() {
             let reply = "唔，我在。可以直接说要我看哪一块。";
             self.session_store
                 .append_exchange(&mut session, &user_text, reply)
@@ -91,6 +91,7 @@ impl RustRespondService {
             session_id: session.session_id.clone(),
             purpose: RespondPurpose::Chat,
             user_text: user_text.clone(),
+            input_parts: req.effective_input_parts(),
             system_prompts,
             memory_context,
             knowledge_context: knowledge_context.text.clone(),
@@ -330,7 +331,7 @@ impl RustRespondService {
             .session_store
             .get_or_create_active(&meta)
             .map_err(session_error)?;
-        if user_text.trim().is_empty() {
+        if user_text.trim().is_empty() && req.effective_input_parts().is_empty() {
             return self
                 .handle_chat(req, user_text, meta, session, ChatToolPlan::Plain)
                 .await;
@@ -363,6 +364,7 @@ impl RustRespondService {
                     session_id: session.session_id.clone(),
                     purpose: RespondPurpose::Chat,
                     user_text: user_text.clone(),
+                    input_parts: req.effective_input_parts(),
                     system_prompts,
                     memory_context,
                     knowledge_context: knowledge_context.text.clone(),
@@ -711,10 +713,12 @@ pub(super) fn recent_session_messages(session: &SessionRecord, limit: usize) -> 
             "user" => Some(ChatMessage {
                 role: ChatRole::User,
                 content: message.content.clone(),
+                content_parts: Vec::new(),
             }),
             "assistant" => Some(ChatMessage {
                 role: ChatRole::Assistant,
                 content: message.content.clone(),
+                content_parts: Vec::new(),
             }),
             _ => None,
         })

--- a/qq-maid-core/src/runtime/respond/common.rs
+++ b/qq-maid-core/src/runtime/respond/common.rs
@@ -107,6 +107,7 @@ pub(super) fn empty_respond_request() -> RespondRequest {
         purpose: RespondPurpose::Chat,
         user_text: String::new(),
         content: String::new(),
+        input_parts: Vec::new(),
         scope_key: String::new(),
         user_id: None,
         group_member_role: None,

--- a/qq-maid-core/src/runtime/respond/llm_service/mod.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service/mod.rs
@@ -579,7 +579,10 @@ fn build_chat_messages(req: &RespondRequest) -> Vec<ChatMessage> {
             .filter(|message| !message.content.trim().is_empty())
             .cloned(),
     );
-    messages.push(ChatMessage::user(req.user_text.clone()));
+    messages.push(ChatMessage::user_with_parts(
+        req.user_text.clone(),
+        req.effective_input_parts(),
+    ));
     messages
 }
 
@@ -647,7 +650,7 @@ fn budget_chat_messages(
     push_message_item(
         &mut items,
         BudgetItemKind::Required,
-        ChatMessage::user(req.user_text.clone()),
+        ChatMessage::user_with_parts(req.user_text.clone(), req.effective_input_parts()),
     )?;
 
     let budgeted = apply_context_budget(items, config)?;

--- a/qq-maid-core/src/runtime/respond/llm_service/tests.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service/tests.rs
@@ -4,6 +4,7 @@ use super::*;
 use super::strip_markdown_for_chat;
 use crate::{provider::types::TokenUsage, util::metrics::LlmMetrics};
 use chrono::TimeZone;
+use qq_maid_common::input_part::{MessageInputPart, MessageMedia};
 
 fn message_contents_with_time_marker(messages: &[ChatMessage]) -> Vec<String> {
     messages
@@ -44,6 +45,31 @@ fn plain_chat_reply_only_returns_text_channel() {
 
     assert_eq!(text, "普通回复");
     assert_eq!(markdown.as_deref(), Some("普通回复"));
+}
+
+#[test]
+fn build_chat_messages_preserves_current_user_input_parts() {
+    let req = RespondRequest {
+        purpose: RespondPurpose::Chat,
+        user_text: "看图说明".to_owned(),
+        input_parts: vec![
+            MessageInputPart::text("看这张"),
+            MessageInputPart::image(MessageMedia {
+                mime_type: Some("image/png".to_owned()),
+                url: Some("https://example.test/a.png".to_owned()),
+                ..Default::default()
+            }),
+            MessageInputPart::text("按顺序解释"),
+        ],
+        ..Default::default()
+    };
+
+    let messages = build_respond_messages(&req);
+    let current = messages.last().unwrap();
+
+    assert_eq!(current.role, ChatRole::User);
+    assert_eq!(current.content, "看图说明");
+    assert_eq!(current.content_parts, req.input_parts);
 }
 
 #[test]
@@ -208,6 +234,7 @@ fn chat_messages_keep_stable_system_prefix_before_time_context() {
             ChatMessage {
                 role: ChatRole::Assistant,
                 content: "上一轮助手".to_owned(),
+                content_parts: Vec::new(),
             },
         ],
         ..Default::default()
@@ -250,6 +277,7 @@ fn budgeted_chat_messages_keep_order_when_under_limit() {
             ChatMessage {
                 role: ChatRole::Assistant,
                 content: "历史助手".to_owned(),
+                content_parts: Vec::new(),
             },
         ],
         ..Default::default()
@@ -295,11 +323,13 @@ fn budgeted_chat_messages_evict_old_history_before_recent_turns() {
             ChatMessage {
                 role: ChatRole::Assistant,
                 content: format!("旧助手 {long_text}"),
+                content_parts: Vec::new(),
             },
             ChatMessage::user("最近用户".to_owned()),
             ChatMessage {
                 role: ChatRole::Assistant,
                 content: "最近助手".to_owned(),
+                content_parts: Vec::new(),
             },
         ],
         ..Default::default()
@@ -350,16 +380,19 @@ fn budgeted_chat_messages_evict_old_turns_from_oldest_to_newest() {
             ChatMessage {
                 role: ChatRole::Assistant,
                 content: format!("旧一助手 {long_text}"),
+                content_parts: Vec::new(),
             },
             ChatMessage::user(format!("旧二用户 {long_text}")),
             ChatMessage {
                 role: ChatRole::Assistant,
                 content: format!("旧二助手 {long_text}"),
+                content_parts: Vec::new(),
             },
             ChatMessage::user("最近用户".to_owned()),
             ChatMessage {
                 role: ChatRole::Assistant,
                 content: "最近助手".to_owned(),
+                content_parts: Vec::new(),
             },
         ],
         ..Default::default()
@@ -484,12 +517,14 @@ fn budgeted_chat_messages_handles_non_standard_history_sequences() {
             ChatMessage {
                 role: ChatRole::Assistant,
                 content: "孤立助手".to_owned(),
+                content_parts: Vec::new(),
             },
             ChatMessage::user("连续用户一"),
             ChatMessage::user("连续用户二"),
             ChatMessage {
                 role: ChatRole::Assistant,
                 content: "连续用户后的助手".to_owned(),
+                content_parts: Vec::new(),
             },
         ],
         ..Default::default()

--- a/qq-maid-core/src/runtime/respond/tool_route.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route.rs
@@ -97,6 +97,15 @@ pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> To
             None,
         );
     }
+    if req.has_non_text_input_parts() {
+        return decision(
+            ToolLoopRoute::PlainChat,
+            SemanticRoute::PlainChat,
+            ToolDomain::Unknown,
+            "multimodal_plain_chat",
+            None,
+        );
+    }
     let text = req.effective_user_text();
     let trimmed = text.trim();
     if trimmed.is_empty() || trimmed.starts_with('/') || trimmed.starts_with('／') {

--- a/qq-maid-core/src/runtime/respond/types.rs
+++ b/qq-maid-core/src/runtime/respond/types.rs
@@ -11,6 +11,7 @@ use crate::{
     provider::types::{ChatMessage, ReasoningEffort, TokenUsage},
     util::metrics::LlmMetrics,
 };
+use qq_maid_common::input_part::MessageInputPart;
 use serde::{Deserialize, Serialize};
 
 /// 请求用途标记，用于区分当前请求的业务语义。
@@ -58,6 +59,9 @@ pub struct RespondRequest {
     /// 原始消息内容（当 user_text 为空时作为 fallback）
     #[serde(default)]
     pub content: String,
+    /// 当前用户输入的有序内容块。为空时按旧纯文本消息兼容。
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub input_parts: Vec<MessageInputPart>,
     /// 作用域键，用于隔离不同群 / 频道的会话
     #[serde(default)]
     pub scope_key: String,
@@ -126,6 +130,23 @@ impl RespondRequest {
         self.content.clone()
     }
 
+    /// LLM 可见的有序内容块；旧纯文本请求自动转换为单个 text part。
+    pub fn effective_input_parts(&self) -> Vec<MessageInputPart> {
+        if !self.input_parts.is_empty() {
+            return self.input_parts.clone();
+        }
+        let text = self.effective_user_text();
+        if text.trim().is_empty() {
+            Vec::new()
+        } else {
+            vec![MessageInputPart::text(text)]
+        }
+    }
+
+    pub fn has_non_text_input_parts(&self) -> bool {
+        self.input_parts.iter().any(MessageInputPart::is_non_text)
+    }
+
     /// 判断是否为"标准"消息（具有 scope_key 或 content）。
     pub fn is_standard_message(&self) -> bool {
         !self.scope_key.trim().is_empty() || !self.content.trim().is_empty()
@@ -142,6 +163,7 @@ impl Default for RespondRequest {
             purpose: RespondPurpose::Chat,
             user_text: String::new(),
             content: String::new(),
+            input_parts: Vec::new(),
             scope_key: String::new(),
             user_id: None,
             group_member_role: None,

--- a/qq-maid-core/src/service/handle.rs
+++ b/qq-maid-core/src/service/handle.rs
@@ -182,6 +182,7 @@ impl CoreService for CoreHandle {
             messages: vec![ChatMessage {
                 role: ChatRole::User,
                 content: "这是连通性检查。请只回复 OK。".to_owned(),
+                content_parts: Vec::new(),
             }],
             context_budget: None,
             max_output_tokens: None,
@@ -238,6 +239,7 @@ impl From<CoreRequest> for RespondRequest {
         };
         Self {
             content: value.text,
+            input_parts: value.input_parts,
             scope_key,
             user_id: value.actor.user_id,
             group_member_role: value

--- a/qq-maid-core/src/service/tests.rs
+++ b/qq-maid-core/src/service/tests.rs
@@ -40,6 +40,7 @@ use crate::{
 fn private_conversation_derives_private_scope() {
     let req = CoreRequest {
         text: "hello".to_owned(),
+        input_parts: Vec::new(),
         platform: Platform::QqOfficial,
         account_id: Some("app-1".to_owned()),
         actor: CoreActor {
@@ -66,6 +67,7 @@ fn private_conversation_derives_private_scope() {
 fn group_conversation_derives_group_scope_without_member_split() {
     let req = CoreRequest {
         text: "/todo".to_owned(),
+        input_parts: Vec::new(),
         platform: Platform::QqOfficial,
         account_id: Some("app-1".to_owned()),
         actor: CoreActor {
@@ -1079,6 +1081,7 @@ impl RadarExecutor for EmptyRadarExecutor {
 fn private_request(text: &str) -> CoreRequest {
     CoreRequest {
         text: text.to_owned(),
+        input_parts: Vec::new(),
         platform: Platform::QqOfficial,
         account_id: Some("app-1".to_owned()),
         actor: CoreActor {
@@ -1098,6 +1101,7 @@ fn private_scope() -> &'static str {
 fn group_request(text: &str) -> CoreRequest {
     CoreRequest {
         text: text.to_owned(),
+        input_parts: Vec::new(),
         platform: Platform::QqOfficial,
         account_id: Some("app-1".to_owned()),
         actor: CoreActor {
@@ -1113,6 +1117,7 @@ fn group_request(text: &str) -> CoreRequest {
 fn wechat_service_request(text: &str) -> CoreRequest {
     CoreRequest {
         text: text.to_owned(),
+        input_parts: Vec::new(),
         platform: Platform::WechatService,
         account_id: Some("gh-service".to_owned()),
         actor: CoreActor {

--- a/qq-maid-core/src/service/types.rs
+++ b/qq-maid-core/src/service/types.rs
@@ -4,6 +4,7 @@ use std::sync::{
 };
 
 use async_trait::async_trait;
+use qq_maid_common::input_part::MessageInputPart;
 use tokio::sync::mpsc;
 
 use crate::identity::stable_scope_key;
@@ -27,6 +28,7 @@ pub trait CoreService: Send + Sync {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CoreRequest {
     pub text: String,
+    pub input_parts: Vec<MessageInputPart>,
     pub platform: Platform,
     pub account_id: Option<String>,
     pub actor: CoreActor,

--- a/qq-maid-gateway-rs/src/gateway/aggregator/actor.rs
+++ b/qq-maid-gateway-rs/src/gateway/aggregator/actor.rs
@@ -3,6 +3,7 @@ use std::{
     sync::Arc,
 };
 
+use qq_maid_common::input_part::MessageInputPart;
 use qq_maid_core::service::CoreInboundKind;
 use tokio::{
     sync::{mpsc, oneshot},
@@ -41,6 +42,8 @@ use crate::{
 use super::types::BarrierDebugState;
 
 const AGGREGATION_FAILURE_TEXT: &str = "当前服务暂时不可用，请稍后再试。";
+const AGGREGATION_CANCELLED_TEXT: &str = "已取消本次图片/文件处理。";
+const AGGREGATION_NOTHING_TO_CANCEL_TEXT: &str = "当前没有待取消的图片/文件处理。";
 
 pub(super) struct AggregatorActor {
     pub(super) config: MessageAggregationConfig,
@@ -165,7 +168,38 @@ impl AggregatorActor {
         };
         resolve_signals(&mut message, &self.reply_cache);
         self.drain_ready_barrier_events().await;
+        if is_aggregation_cancel_command(&message.content)
+            && self.batches.get(&key).is_some_and(batch_has_non_text_input)
+        {
+            return self
+                .cancel_pending_aggregation(key, &message, reservation)
+                .await;
+        }
         self.process_reserved_c2c(key, message, reservation).await
+    }
+
+    async fn cancel_pending_aggregation(
+        &mut self,
+        key: AggregationKey,
+        message: &C2cMessage,
+        reservation: MessageReservation,
+    ) -> anyhow::Result<()> {
+        let had_batch = self
+            .batches
+            .remove(&key)
+            .map(|batch| {
+                commit_reservations(batch.reservations);
+                true
+            })
+            .unwrap_or(false);
+        reservation.commit();
+        let text = if had_batch {
+            AGGREGATION_CANCELLED_TEXT
+        } else {
+            AGGREGATION_NOTHING_TO_CANCEL_TEXT
+        };
+        self.dispatcher.notify_c2c_failure(message, text).await?;
+        Ok(())
     }
 
     async fn process_reserved_c2c(
@@ -203,8 +237,7 @@ impl AggregatorActor {
 
     async fn classify(&self, message: &C2cMessage) -> AggregationDecision {
         if !self.config.private_enabled
-            || message.content.trim().is_empty()
-            || !message.attachments.is_empty()
+            || (message.content.trim().is_empty() && message.input_parts.is_empty())
             || message.reply.is_some()
             || is_ping_command(&message.content)
         {
@@ -715,6 +748,19 @@ impl AggregatorActor {
     }
 }
 
+fn is_aggregation_cancel_command(content: &str) -> bool {
+    matches!(content.trim(), "取消" | "/取消" | "／取消")
+}
+
+fn batch_has_non_text_input(batch: &PendingAggregation) -> bool {
+    batch.messages.iter().any(|message| {
+        message
+            .input_parts
+            .iter()
+            .any(MessageInputPart::is_non_text)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -877,6 +923,7 @@ mod tests {
             timestamp: None,
             first_message_timestamp: None,
             last_message_timestamp: None,
+            input_parts: vec![qq_maid_common::input_part::MessageInputPart::text("hello")],
             attachments: Vec::new(),
         });
         assert_eq!(key.bot_instance, "appid");

--- a/qq-maid-gateway-rs/src/gateway/aggregator/batch.rs
+++ b/qq-maid-gateway-rs/src/gateway/aggregator/batch.rs
@@ -95,8 +95,17 @@ pub(super) fn merge_batch(batch: &PendingAggregation, reason: FlushReason) -> C2
     merged.content = all_messages
         .iter()
         .map(|message| message.content.as_str())
+        .filter(|content| !content.trim().is_empty())
         .collect::<Vec<_>>()
         .join("\n");
+    merged.input_parts = all_messages
+        .iter()
+        .flat_map(|message| message.input_parts.clone())
+        .collect();
+    merged.attachments = all_messages
+        .iter()
+        .flat_map(|message| message.attachments.clone())
+        .collect();
     merged.source_message_ids = all_messages.iter().flat_map(message_id_values).collect();
     merged.source_event_ids = all_messages.iter().flat_map(event_id_values).collect();
     merged.first_message_timestamp = all_messages.first().and_then(|message| {

--- a/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
@@ -9,6 +9,7 @@ use crate::{
     respond::{RespondClient, scope_key_from_c2c_message},
 };
 use async_trait::async_trait;
+use qq_maid_common::input_part::MessageInputPart;
 use qq_maid_core::service::{
     CoreActor, CoreConversation, CoreError, CoreHealthSnapshot, CoreInboundClassification,
     CoreInboundKind, CoreRequest, CoreRespondOutput, CoreResponse, CoreService, Platform,
@@ -360,8 +361,29 @@ fn c2c(id: &str, user: &str, content: &str) -> C2cMessage {
         timestamp: Some(format!("2026-06-10T12:00:0{id}+08:00")),
         first_message_timestamp: Some(format!("2026-06-10T12:00:0{id}+08:00")),
         last_message_timestamp: Some(format!("2026-06-10T12:00:0{id}+08:00")),
+        input_parts: if content.trim().is_empty() {
+            Vec::new()
+        } else {
+            vec![MessageInputPart::text(content)]
+        },
         attachments: Vec::new(),
     }
+}
+
+fn c2c_image(id: &str, user: &str, url: &str) -> C2cMessage {
+    let attachment = crate::gateway::event::Attachment {
+        content_type: Some("image/jpeg".to_owned()),
+        filename: Some(format!("{id}.jpg")),
+        url: Some(url.to_owned()),
+        size_bytes: None,
+        media_id: None,
+        file_id: None,
+        attachment_id: None,
+    };
+    let mut message = c2c(id, user, "");
+    message.input_parts = vec![attachment.to_input_part("qq_official")];
+    message.attachments = vec![attachment];
+    message
 }
 
 async fn yield_actor() {
@@ -670,6 +692,48 @@ async fn multiple_messages_merge_in_order() {
     assert_eq!(
         messages[0].last_message_timestamp.as_deref(),
         Some("2026-06-10T12:00:02+08:00")
+    );
+    h.aggregator.shutdown().await;
+}
+
+#[tokio::test]
+async fn image_then_text_aggregation_preserves_ordered_input_parts() {
+    pause();
+    let h = harness();
+    let handle = h.aggregator.handle();
+    enqueue(&handle, c2c_image("1", "u1", "https://example.test/a.jpg")).await;
+    enqueue(&handle, c2c("2", "u1", "帮我看下这个")).await;
+    advance(Duration::from_millis(101)).await;
+    wait_for_messages(&h.dispatcher, 1).await;
+
+    let messages = h.dispatcher.messages();
+    assert_eq!(messages[0].attachments.len(), 1);
+    assert_eq!(messages[0].input_parts.len(), 2);
+    assert!(matches!(
+        messages[0].input_parts[0],
+        MessageInputPart::Image { .. }
+    ));
+    assert_eq!(
+        messages[0].input_parts[1].text_content(),
+        Some("帮我看下这个")
+    );
+    h.aggregator.shutdown().await;
+}
+
+#[tokio::test]
+async fn cancel_clears_pending_image_aggregation_without_dispatching_to_core() {
+    pause();
+    let h = harness();
+    let handle = h.aggregator.handle();
+    enqueue(&handle, c2c_image("1", "u1", "https://example.test/a.jpg")).await;
+    enqueue(&handle, c2c("2", "u1", "/取消")).await;
+    advance(Duration::from_millis(101)).await;
+    yield_actor().await;
+
+    assert!(h.dispatcher.messages().is_empty());
+    assert_eq!(
+        h.dispatcher.failure_notifications(),
+        vec![("2".to_owned(), "已取消本次图片/文件处理。".to_owned())]
     );
     h.aggregator.shutdown().await;
 }
@@ -1091,6 +1155,7 @@ async fn classification_failure_dispatches_immediately() {
 fn request_scope_key_matches_private_message() {
     let request = CoreRequest {
         text: "hello".to_owned(),
+        input_parts: Vec::new(),
         platform: Platform::QqOfficial,
         account_id: None,
         actor: CoreActor {

--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -695,6 +695,7 @@ mod tests {
             timestamp: None,
             first_message_timestamp: None,
             last_message_timestamp: None,
+            input_parts: vec![qq_maid_common::input_part::MessageInputPart::text("晚上好")],
             attachments: Vec::new(),
         }
     }

--- a/qq-maid-gateway-rs/src/gateway/cache.rs
+++ b/qq-maid-gateway-rs/src/gateway/cache.rs
@@ -98,6 +98,11 @@ mod tests {
             timestamp: None,
             first_message_timestamp: None,
             last_message_timestamp: None,
+            input_parts: if content.trim().is_empty() {
+                Vec::new()
+            } else {
+                vec![qq_maid_common::input_part::MessageInputPart::text(content)]
+            },
             attachments: Vec::new(),
         }
     }

--- a/qq-maid-gateway-rs/src/gateway/dispatcher/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/dispatcher/tests.rs
@@ -177,6 +177,7 @@ fn c2c(id: &str, user: &str) -> C2cMessage {
         timestamp: None,
         first_message_timestamp: None,
         last_message_timestamp: None,
+        input_parts: vec![qq_maid_common::input_part::MessageInputPart::text("hello")],
         attachments: Vec::new(),
     }
 }
@@ -191,6 +192,7 @@ fn group(id: &str, group_openid: &str) -> GroupMessage {
         mentions: Vec::new(),
         reply: None,
         timestamp: None,
+        input_parts: vec![qq_maid_common::input_part::MessageInputPart::text("hello")],
         attachments: Vec::new(),
         event_type: super::super::event::GroupEventType::GroupAtMessage,
         author_is_bot: false,

--- a/qq-maid-gateway-rs/src/gateway/event.rs
+++ b/qq-maid-gateway-rs/src/gateway/event.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 use tracing::warn;
 
 use crate::gateway::logging::mask_openid;
+use qq_maid_common::input_part::{MessageInputPart, MessageMedia};
 
 pub const EVENT_C2C_MESSAGE_CREATE: &str = "C2C_MESSAGE_CREATE";
 pub const EVENT_GROUP_AT_MESSAGE_CREATE: &str = "GROUP_AT_MESSAGE_CREATE";
@@ -49,6 +50,7 @@ pub struct C2cMessage {
     pub timestamp: Option<String>,
     pub first_message_timestamp: Option<String>,
     pub last_message_timestamp: Option<String>,
+    pub input_parts: Vec<MessageInputPart>,
     pub attachments: Vec<Attachment>,
 }
 
@@ -62,6 +64,7 @@ pub struct GroupMessage {
     pub mentions: Vec<GroupMention>,
     pub reply: Option<MessageReply>,
     pub timestamp: Option<String>,
+    pub input_parts: Vec<MessageInputPart>,
     pub attachments: Vec<Attachment>,
     pub event_type: GroupEventType,
     pub author_is_bot: bool,
@@ -107,6 +110,14 @@ pub struct Attachment {
     pub filename: Option<String>,
     #[serde(default, alias = "url", alias = "file_url", alias = "image_url")]
     pub url: Option<String>,
+    #[serde(default, alias = "size", alias = "file_size")]
+    pub size_bytes: Option<u64>,
+    #[serde(default, alias = "media_id")]
+    pub media_id: Option<String>,
+    #[serde(default, alias = "file_id")]
+    pub file_id: Option<String>,
+    #[serde(default, alias = "attachment_id", alias = "id")]
+    pub attachment_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -244,6 +255,8 @@ pub fn parse_c2c_message(envelope: &GatewayEnvelope) -> Result<Option<C2cMessage
     let base_content = raw.content.unwrap_or_default().trim().to_owned();
     let reply = extract_message_reply(&base_content, raw.reply.as_ref(), raw.quote.as_ref());
     let timestamp = raw.timestamp;
+    let input_parts =
+        input_parts_from_content_and_attachments(&base_content, &raw.attachments, "qq_official");
     Ok(Some(C2cMessage {
         source_message_ids: vec![message_id.clone()],
         source_event_ids: event_id.iter().cloned().collect(),
@@ -255,6 +268,7 @@ pub fn parse_c2c_message(envelope: &GatewayEnvelope) -> Result<Option<C2cMessage
         first_message_timestamp: timestamp.clone(),
         last_message_timestamp: timestamp.clone(),
         timestamp,
+        input_parts,
         attachments: raw.attachments,
     }))
 }
@@ -301,6 +315,8 @@ pub fn parse_group_message(envelope: &GatewayEnvelope) -> Result<Option<GroupMes
             .unwrap_or(false);
     let base_content = raw.content.unwrap_or_default().trim().to_owned();
     let reply = extract_message_reply(&base_content, raw.reply.as_ref(), raw.quote.as_ref());
+    let input_parts =
+        input_parts_from_content_and_attachments(&base_content, &raw.attachments, "qq_official");
     Ok(Some(GroupMessage {
         message_id,
         group_openid,
@@ -314,6 +330,7 @@ pub fn parse_group_message(envelope: &GatewayEnvelope) -> Result<Option<GroupMes
             .collect::<Vec<_>>(),
         reply,
         timestamp: raw.timestamp,
+        input_parts,
         attachments: raw.attachments,
         event_type,
         author_is_bot,
@@ -443,8 +460,71 @@ impl Attachment {
     pub fn note(&self) -> String {
         let content_type = self.content_type.as_deref().unwrap_or("unknown");
         let filename = self.filename.as_deref().unwrap_or("unnamed");
-        let url = self.url.as_deref().unwrap_or("no-url");
-        format!("[附件 {content_type}: {filename} {url}]")
+        format!("[附件 {content_type}: {filename}]")
+    }
+
+    pub fn to_input_part(&self, platform: &str) -> MessageInputPart {
+        let media = MessageMedia {
+            mime_type: self.content_type.clone(),
+            filename: self.filename.clone(),
+            size_bytes: self.size_bytes,
+            url: self.url.clone(),
+            media_id: self.media_id.clone(),
+            file_id: self.file_id.clone(),
+            attachment_id: self.attachment_id.clone(),
+            platform: Some(platform.to_owned()),
+            status: Default::default(),
+        };
+        match attachment_kind(self.content_type.as_deref(), self.filename.as_deref()) {
+            AttachmentKind::Image => MessageInputPart::image(media),
+            AttachmentKind::File => MessageInputPart::file(media),
+            AttachmentKind::Unknown => MessageInputPart::unknown(media, "unsupported_media_type"),
+        }
+    }
+}
+
+fn input_parts_from_content_and_attachments(
+    content: &str,
+    attachments: &[Attachment],
+    platform: &str,
+) -> Vec<MessageInputPart> {
+    let mut parts = Vec::new();
+    if !content.trim().is_empty() {
+        parts.push(MessageInputPart::text(content.to_owned()));
+    }
+    parts.extend(
+        attachments
+            .iter()
+            .map(|attachment| attachment.to_input_part(platform)),
+    );
+    parts
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AttachmentKind {
+    Image,
+    File,
+    Unknown,
+}
+
+fn attachment_kind(content_type: Option<&str>, filename: Option<&str>) -> AttachmentKind {
+    let content_type = content_type.unwrap_or("").trim().to_ascii_lowercase();
+    if content_type.starts_with("image/") || content_type == "image" {
+        return AttachmentKind::Image;
+    }
+    if !content_type.is_empty() {
+        return AttachmentKind::File;
+    }
+    let filename = filename.unwrap_or("").trim().to_ascii_lowercase();
+    if matches!(
+        filename.rsplit('.').next(),
+        Some("jpg" | "jpeg" | "png" | "gif" | "webp" | "bmp")
+    ) {
+        AttachmentKind::Image
+    } else if filename.is_empty() {
+        AttachmentKind::Unknown
+    } else {
+        AttachmentKind::File
     }
 }
 

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -374,6 +374,11 @@ mod tests {
             mentions: Vec::new(),
             reply: None,
             timestamp: None,
+            input_parts: if content.trim().is_empty() {
+                Vec::new()
+            } else {
+                vec![qq_maid_common::input_part::MessageInputPart::text(content)]
+            },
             attachments: Vec::new(),
             event_type,
             author_is_bot: false,

--- a/qq-maid-gateway-rs/src/gateway/group_filter.rs
+++ b/qq-maid-gateway-rs/src/gateway/group_filter.rs
@@ -201,6 +201,11 @@ mod tests {
             mentions: Vec::new(),
             reply: None,
             timestamp: None,
+            input_parts: if content.trim().is_empty() {
+                Vec::new()
+            } else {
+                vec![qq_maid_common::input_part::MessageInputPart::text(content)]
+            },
             attachments: Vec::new(),
             event_type,
             author_is_bot: false,

--- a/qq-maid-gateway-rs/src/gateway/logging.rs
+++ b/qq-maid-gateway-rs/src/gateway/logging.rs
@@ -271,6 +271,11 @@ mod tests {
             timestamp: None,
             first_message_timestamp: None,
             last_message_timestamp: None,
+            input_parts: if content.trim().is_empty() {
+                Vec::new()
+            } else {
+                vec![qq_maid_common::input_part::MessageInputPart::text(content)]
+            },
             attachments: Vec::new(),
         }
     }
@@ -360,6 +365,10 @@ mod tests {
                     content_type: Some("image/jpeg".to_owned()),
                     filename: Some("a.jpg".to_owned()),
                     url: Some("https://example.test/a.jpg".to_owned()),
+                    size_bytes: None,
+                    media_id: None,
+                    file_id: None,
+                    attachment_id: None,
                 }],
                 verbose: false,
                 expected_extracted: None,

--- a/qq-maid-gateway-rs/src/gateway/ping/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/ping/tests.rs
@@ -74,6 +74,7 @@ fn message() -> C2cMessage {
         timestamp: Some("2026-06-10T12:00:00+08:00".to_owned()),
         first_message_timestamp: Some("2026-06-10T12:00:00+08:00".to_owned()),
         last_message_timestamp: Some("2026-06-10T12:00:00+08:00".to_owned()),
+        input_parts: vec![qq_maid_common::input_part::MessageInputPart::text("/ping")],
         attachments: Vec::new(),
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/platform/core.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/core.rs
@@ -1,7 +1,8 @@
 //! 统一入站模型到 CoreService 的映射和 Core 文本协议渲染。
 //!
-//! 这里仍属于 Gateway 边界：Core 不理解平台原始协议，也不接收附件/reply 的结构化字段。
+//! 这里仍属于 Gateway 边界：Core 不理解平台原始协议，只接收平台无关的有序 input parts。
 
+use qq_maid_common::input_part::MessageInputPart;
 use qq_maid_core::service::{
     CoreActor, CoreConversation, CoreGroupMemberRole, CoreRequest, Platform as CorePlatform,
 };
@@ -41,6 +42,7 @@ pub(crate) fn to_core_request(
 
     Ok(CoreRequest {
         text,
+        input_parts: effective_input_parts(inbound),
         platform,
         account_id: inbound.account_id.clone(),
         actor: CoreActor {
@@ -67,14 +69,44 @@ pub(crate) fn render_text_for_core(inbound: &InboundMessage) -> String {
         }
         content.push_str("\n[/reply]\n");
     }
-    content.push_str(&inbound.text);
-    for attachment in &inbound.attachments {
-        if !content.is_empty() {
-            content.push('\n');
+    let parts = effective_input_parts(inbound);
+    if parts.is_empty() {
+        content.push_str(&inbound.text);
+    } else {
+        content.push_str(
+            &parts
+                .iter()
+                .map(MessageInputPart::fallback_text)
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
+    }
+    if parts.is_empty() {
+        for attachment in &inbound.attachments {
+            if !content.is_empty() {
+                content.push('\n');
+            }
+            content.push_str(&attachment_note(attachment));
         }
-        content.push_str(&attachment_note(attachment));
     }
     content
+}
+
+fn effective_input_parts(inbound: &InboundMessage) -> Vec<MessageInputPart> {
+    if !inbound.input_parts.is_empty() {
+        return inbound.input_parts.clone();
+    }
+    let mut parts = Vec::new();
+    if !inbound.text.trim().is_empty() {
+        parts.push(MessageInputPart::text(inbound.text.clone()));
+    }
+    parts.extend(
+        inbound
+            .attachments
+            .iter()
+            .map(|attachment| attachment.to_input_part(inbound.platform)),
+    );
+    parts
 }
 
 fn core_platform(platform: Platform) -> Option<CorePlatform> {
@@ -91,8 +123,7 @@ fn attachment_note(attachment: &Attachment) -> String {
     }
     let content_type = attachment.content_type.as_deref().unwrap_or("unknown");
     let filename = attachment.filename.as_deref().unwrap_or("unnamed");
-    let url = attachment.url.as_deref().unwrap_or("no-url");
-    format!("[附件 {content_type}: {filename} {url}]")
+    format!("[附件 {content_type}: {filename}]")
 }
 
 impl From<GroupMemberRoleKind> for CoreGroupMemberRole {
@@ -129,10 +160,15 @@ mod tests {
             message_id: "msg-1".to_owned(),
             timestamp: None,
             text: "看一下".to_owned(),
+            input_parts: Vec::new(),
             attachments: vec![Attachment {
                 content_type: None,
                 filename: None,
                 url: None,
+                size_bytes: None,
+                media_id: None,
+                file_id: None,
+                attachment_id: None,
                 placeholder: Some("[图片]".to_owned()),
             }],
             reply: Some(ReplyReference {

--- a/qq-maid-gateway-rs/src/gateway/platform/core.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/core.rs
@@ -62,14 +62,10 @@ pub(crate) fn core_scope_key(inbound: &InboundMessage) -> Result<String, Inbound
 
 pub(crate) fn render_text_for_core(inbound: &InboundMessage) -> String {
     let mut content = String::new();
-    if let Some(reply) = &inbound.reply {
-        content.push_str(&format!("[reply message_id={}]\n", reply.message_id));
-        if let Some(reply_content) = reply.content.as_deref() {
-            content.push_str(reply_content);
-        }
-        content.push_str("\n[/reply]\n");
+    if let Some(reply_block) = reply_block_for_core(inbound) {
+        content.push_str(&reply_block);
     }
-    let parts = effective_input_parts(inbound);
+    let parts = body_input_parts(inbound);
     if parts.is_empty() {
         content.push_str(&inbound.text);
     } else {
@@ -93,6 +89,15 @@ pub(crate) fn render_text_for_core(inbound: &InboundMessage) -> String {
 }
 
 fn effective_input_parts(inbound: &InboundMessage) -> Vec<MessageInputPart> {
+    let mut parts = Vec::new();
+    if let Some(reply_block) = reply_block_for_core(inbound) {
+        parts.push(MessageInputPart::text(reply_block));
+    }
+    parts.extend(body_input_parts(inbound));
+    parts
+}
+
+fn body_input_parts(inbound: &InboundMessage) -> Vec<MessageInputPart> {
     if !inbound.input_parts.is_empty() {
         return inbound.input_parts.clone();
     }
@@ -107,6 +112,16 @@ fn effective_input_parts(inbound: &InboundMessage) -> Vec<MessageInputPart> {
             .map(|attachment| attachment.to_input_part(inbound.platform)),
     );
     parts
+}
+
+fn reply_block_for_core(inbound: &InboundMessage) -> Option<String> {
+    let reply = inbound.reply.as_ref()?;
+    let mut block = format!("[reply message_id={}]\n", reply.message_id);
+    if let Some(reply_content) = reply.content.as_deref() {
+        block.push_str(reply_content);
+    }
+    block.push_str("\n[/reply]\n");
+    Some(block)
 }
 
 fn core_platform(platform: Platform) -> Option<CorePlatform> {
@@ -143,6 +158,7 @@ mod tests {
         Actor, Attachment, ConversationTarget, InboundMessage, Platform, ReplyReference,
     };
     use super::*;
+    use qq_maid_common::input_part::MessageMedia;
 
     #[test]
     fn core_render_uses_attachment_placeholder_without_platform_protocol() {
@@ -182,5 +198,58 @@ mod tests {
             render_text_for_core(&inbound),
             "[reply message_id=quoted-1]\n上一条\n[/reply]\n看一下\n[图片]"
         );
+    }
+
+    #[test]
+    fn core_mapping_includes_reply_block_in_input_parts_before_ordered_body_parts() {
+        let inbound = InboundMessage {
+            platform: Platform::QqOfficial,
+            account_id: None,
+            conversation: ConversationTarget::Private {
+                target_id: "user-1".to_owned(),
+            },
+            actor: Actor {
+                sender_id: Some("user-1".to_owned()),
+                display_name: None,
+                group_member_role: None,
+            },
+            message_id: "msg-1".to_owned(),
+            timestamp: None,
+            text: "看一下".to_owned(),
+            input_parts: vec![
+                MessageInputPart::text("看一下"),
+                MessageInputPart::image(MessageMedia {
+                    mime_type: Some("image/png".to_owned()),
+                    filename: Some("a.png".to_owned()),
+                    url: Some("https://example.test/a.png".to_owned()),
+                    ..Default::default()
+                }),
+            ],
+            attachments: Vec::new(),
+            reply: Some(ReplyReference {
+                message_id: "quoted-1".to_owned(),
+                content: Some("上一条".to_owned()),
+            }),
+            mentioned_bot: false,
+        };
+
+        let rendered = render_text_for_core(&inbound);
+        let request = to_core_request(&inbound, rendered.clone()).unwrap();
+
+        assert_eq!(
+            rendered,
+            "[reply message_id=quoted-1]\n上一条\n[/reply]\n看一下\n[图片 image/png: a.png]"
+        );
+        assert_eq!(request.text, rendered);
+        assert_eq!(request.input_parts.len(), 3);
+        assert_eq!(
+            request.input_parts[0].text_content(),
+            Some("[reply message_id=quoted-1]\n上一条\n[/reply]\n")
+        );
+        assert_eq!(request.input_parts[1].text_content(), Some("看一下"));
+        assert!(matches!(
+            request.input_parts[2],
+            MessageInputPart::Image { .. }
+        ));
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/platform/model.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/model.rs
@@ -3,6 +3,8 @@
 //! 本文件不依赖 QQ 官方、OneBot 或微信协议类型；所有协议字段都必须先在 adapter
 //! 层转换为这些通用结构，再进入 Core 映射和回复编排。
 
+use qq_maid_common::input_part::{MessageInputPart, MessageMedia};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Platform {
     QqOfficial,
@@ -33,6 +35,7 @@ pub(crate) struct InboundMessage {
     pub(crate) message_id: String,
     pub(crate) timestamp: Option<String>,
     pub(crate) text: String,
+    pub(crate) input_parts: Vec<MessageInputPart>,
     pub(crate) attachments: Vec<Attachment>,
     pub(crate) reply: Option<ReplyReference>,
     pub(crate) mentioned_bot: bool,
@@ -78,6 +81,10 @@ pub(crate) struct Attachment {
     pub(crate) content_type: Option<String>,
     pub(crate) filename: Option<String>,
     pub(crate) url: Option<String>,
+    pub(crate) size_bytes: Option<u64>,
+    pub(crate) media_id: Option<String>,
+    pub(crate) file_id: Option<String>,
+    pub(crate) attachment_id: Option<String>,
     pub(crate) placeholder: Option<String>,
 }
 
@@ -85,6 +92,59 @@ pub(crate) struct Attachment {
 pub(crate) struct ReplyReference {
     pub(crate) message_id: String,
     pub(crate) content: Option<String>,
+}
+
+impl Attachment {
+    pub(crate) fn to_input_part(&self, platform: Platform) -> MessageInputPart {
+        if let Some(placeholder) = self.placeholder.as_deref() {
+            return MessageInputPart::text(placeholder.to_owned());
+        }
+        let media = MessageMedia {
+            mime_type: self.content_type.clone(),
+            filename: self.filename.clone(),
+            size_bytes: self.size_bytes,
+            url: self.url.clone(),
+            media_id: self.media_id.clone(),
+            file_id: self.file_id.clone(),
+            attachment_id: self.attachment_id.clone(),
+            platform: Some(platform.as_str().to_owned()),
+            status: Default::default(),
+        };
+        match attachment_kind(self.content_type.as_deref(), self.filename.as_deref()) {
+            AttachmentKind::Image => MessageInputPart::image(media),
+            AttachmentKind::File => MessageInputPart::file(media),
+            AttachmentKind::Unknown => MessageInputPart::unknown(media, "unsupported_media_type"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AttachmentKind {
+    Image,
+    File,
+    Unknown,
+}
+
+fn attachment_kind(content_type: Option<&str>, filename: Option<&str>) -> AttachmentKind {
+    let content_type = content_type.unwrap_or("").trim().to_ascii_lowercase();
+    if content_type.starts_with("image/") || content_type == "image" {
+        return AttachmentKind::Image;
+    }
+    if !content_type.is_empty() {
+        return AttachmentKind::File;
+    }
+    let filename = filename.unwrap_or("").trim().to_ascii_lowercase();
+    if matches!(
+        filename.rsplit('.').next(),
+        Some("jpg" | "jpeg" | "png" | "gif" | "webp" | "bmp")
+    ) {
+        return AttachmentKind::Image;
+    }
+    if filename.is_empty() {
+        AttachmentKind::Unknown
+    } else {
+        AttachmentKind::File
+    }
 }
 
 impl InboundMessage {
@@ -155,6 +215,7 @@ mod tests {
             message_id: "msg-1".to_owned(),
             timestamp: Some("2026-07-04T20:00:00+08:00".to_owned()),
             text: "你好".to_owned(),
+            input_parts: vec![MessageInputPart::text("你好")],
             attachments: Vec::new(),
             reply: None,
             mentioned_bot: false,
@@ -188,10 +249,21 @@ mod tests {
             message_id: "msg-2".to_owned(),
             timestamp: None,
             text: "看图".to_owned(),
+            input_parts: vec![
+                MessageInputPart::text("看图"),
+                MessageInputPart::image(MessageMedia {
+                    mime_type: Some("image/png".to_owned()),
+                    ..Default::default()
+                }),
+            ],
             attachments: vec![Attachment {
-                content_type: Some("image".to_owned()),
+                content_type: Some("image/png".to_owned()),
                 filename: None,
                 url: None,
+                size_bytes: None,
+                media_id: None,
+                file_id: None,
+                attachment_id: None,
                 placeholder: Some("[图片]".to_owned()),
             }],
             reply: Some(ReplyReference {
@@ -230,6 +302,7 @@ mod tests {
             message_id: "same-msg".to_owned(),
             timestamp: None,
             text: "私聊".to_owned(),
+            input_parts: vec![MessageInputPart::text("私聊")],
             attachments: Vec::new(),
             reply: None,
             mentioned_bot: false,
@@ -244,6 +317,7 @@ mod tests {
             message_id: "same-msg".to_owned(),
             timestamp: None,
             text: "群聊".to_owned(),
+            input_parts: vec![MessageInputPart::text("群聊")],
             attachments: Vec::new(),
             reply: None,
             mentioned_bot: true,
@@ -272,6 +346,7 @@ mod tests {
             message_id: "  ".to_owned(),
             timestamp: None,
             text: "空 id".to_owned(),
+            input_parts: vec![MessageInputPart::text("空 id")],
             attachments: Vec::new(),
             reply: None,
             mentioned_bot: false,

--- a/qq-maid-gateway-rs/src/gateway/platform/qq_official.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/qq_official.rs
@@ -26,6 +26,7 @@ pub(crate) fn inbound_from_c2c(message: &C2cMessage) -> InboundMessage {
         message_id: message.message_id.clone(),
         timestamp: message.timestamp.clone(),
         text: message.content.clone(),
+        input_parts: message.input_parts.clone(),
         attachments: message.attachments.iter().map(attachment_from_qq).collect(),
         reply: message.reply.as_ref().map(reply_from_qq),
         mentioned_bot: false,
@@ -47,6 +48,7 @@ pub(crate) fn inbound_from_group(message: &GroupMessage) -> InboundMessage {
         message_id: message.message_id.clone(),
         timestamp: message.timestamp.clone(),
         text: message.content.clone(),
+        input_parts: message.input_parts.clone(),
         attachments: message.attachments.iter().map(attachment_from_qq).collect(),
         reply: message.reply.as_ref().map(reply_from_qq),
         mentioned_bot: message.event_type == GroupEventType::GroupAtMessage
@@ -59,6 +61,10 @@ fn attachment_from_qq(value: &QqAttachment) -> Attachment {
         content_type: value.content_type.clone(),
         filename: value.filename.clone(),
         url: value.url.clone(),
+        size_bytes: value.size_bytes,
+        media_id: value.media_id.clone(),
+        file_id: value.file_id.clone(),
+        attachment_id: value.attachment_id.clone(),
         placeholder: None,
     }
 }
@@ -99,6 +105,7 @@ mod tests {
             timestamp: Some("2026-07-04T20:00:00+08:00".to_owned()),
             first_message_timestamp: Some("2026-07-04T20:00:00+08:00".to_owned()),
             last_message_timestamp: Some("2026-07-04T20:00:00+08:00".to_owned()),
+            input_parts: vec![qq_maid_common::input_part::MessageInputPart::text("你好")],
             attachments: Vec::new(),
         }
     }
@@ -116,6 +123,7 @@ mod tests {
             }],
             reply: None,
             timestamp: None,
+            input_parts: vec![qq_maid_common::input_part::MessageInputPart::text("/rss")],
             attachments: Vec::new(),
             event_type: GroupEventType::GroupMessage,
             author_is_bot: false,
@@ -181,7 +189,14 @@ mod tests {
             content_type: Some("image/jpeg".to_owned()),
             filename: Some("a.jpg".to_owned()),
             url: Some("https://example.test/a.jpg".to_owned()),
+            size_bytes: None,
+            media_id: None,
+            file_id: None,
+            attachment_id: None,
         }];
+        message
+            .input_parts
+            .push(message.attachments[0].to_input_part("qq_official"));
 
         let inbound = inbound_from_c2c(&message);
         let rendered = super::super::render_text_for_core(&inbound);
@@ -195,6 +210,6 @@ mod tests {
         );
         assert_eq!(inbound.attachments[0].filename.as_deref(), Some("a.jpg"));
         assert!(rendered.starts_with("[reply message_id=quoted-1]\n上一条\n[/reply]\n你好"));
-        assert!(rendered.contains("[附件 image/jpeg: a.jpg https://example.test/a.jpg]"));
+        assert!(rendered.contains("[图片 image/jpeg: a.jpg]"));
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/platform/wechat_service.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/wechat_service.rs
@@ -83,6 +83,13 @@ pub(crate) fn inbound_from_text_message(message: &WechatTextMessage) -> InboundM
         message_id: message.msg_id.clone(),
         timestamp: message.create_time.clone(),
         text: message.content.clone(),
+        input_parts: if message.content.trim().is_empty() {
+            Vec::new()
+        } else {
+            vec![qq_maid_common::input_part::MessageInputPart::text(
+                message.content.clone(),
+            )]
+        },
         attachments: Vec::new(),
         reply: None,
         mentioned_bot: false,

--- a/qq-maid-gateway-rs/src/gateway/stream/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests.rs
@@ -199,6 +199,7 @@ fn c2c_message() -> C2cMessage {
         timestamp: None,
         first_message_timestamp: None,
         last_message_timestamp: None,
+        input_parts: vec![qq_maid_common::input_part::MessageInputPart::text("晚上好")],
         attachments: Vec::new(),
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/typing.rs
+++ b/qq-maid-gateway-rs/src/gateway/typing.rs
@@ -356,6 +356,7 @@ mod tests {
             timestamp: None,
             first_message_timestamp: None,
             last_message_timestamp: None,
+            input_parts: vec![qq_maid_common::input_part::MessageInputPart::text("晚上好")],
             attachments: Vec::new(),
         }
     }

--- a/qq-maid-gateway-rs/src/respond.rs
+++ b/qq-maid-gateway-rs/src/respond.rs
@@ -324,7 +324,16 @@ fn clean_optional(value: String) -> Option<String> {
 pub fn build_group_respond_content(message: &GroupMessage, active_keywords: &[String]) -> String {
     let content = normalize_group_command_content(&message.content, active_keywords);
     let mut inbound = platform::qq_official::inbound_from_group(message);
-    inbound.text = content;
+    inbound.text = content.clone();
+    if inbound.attachments.is_empty() {
+        inbound.input_parts = if content.trim().is_empty() {
+            Vec::new()
+        } else {
+            vec![qq_maid_common::input_part::MessageInputPart::text(
+                content.clone(),
+            )]
+        };
+    }
     platform::render_text_for_core(&inbound)
 }
 
@@ -413,6 +422,9 @@ fn respond_error_info_to_qq_text(code: &str, stage: &str, message: &str) -> Stri
         "safety_blocked" => {
             "这条消息触发了上游安全拦截，我没法按原样继续。可以换个说法再试。".to_owned()
         }
+        "unsupported_input_part" => safe_message.unwrap_or_else(|| {
+            "我收到图片或文件了，但当前模型暂时不支持图片/文件理解。你可以补充文字说明，我先帮你记录。".to_owned()
+        }),
         "invalid_request" | "bad_request" => safe_message
             .map(|message| format!("请求格式有误：{message}"))
             .unwrap_or_else(|| "请求格式有误，请调整后再试".to_owned()),
@@ -524,6 +536,11 @@ mod tests {
             timestamp: Some("2026-06-10T12:00:00+08:00".to_owned()),
             first_message_timestamp: Some("2026-06-10T12:00:00+08:00".to_owned()),
             last_message_timestamp: Some("2026-06-10T12:00:00+08:00".to_owned()),
+            input_parts: if content.trim().is_empty() {
+                Vec::new()
+            } else {
+                vec![qq_maid_common::input_part::MessageInputPart::text(content)]
+            },
             attachments: Vec::new(),
         }
     }
@@ -538,6 +555,11 @@ mod tests {
             mentions: Vec::new(),
             reply: None,
             timestamp: None,
+            input_parts: if content.trim().is_empty() {
+                Vec::new()
+            } else {
+                vec![qq_maid_common::input_part::MessageInputPart::text(content)]
+            },
             attachments: Vec::new(),
             event_type: GroupEventType::GroupAtMessage,
             author_is_bot: false,
@@ -686,12 +708,19 @@ mod tests {
             content_type: Some("image/png".to_owned()),
             filename: Some("a.png".to_owned()),
             url: Some("https://example.test/a.png".to_owned()),
+            size_bytes: None,
+            media_id: None,
+            file_id: None,
+            attachment_id: None,
         }];
+        message
+            .input_parts
+            .push(message.attachments[0].to_input_part("qq_official"));
 
         let content = build_respond_content(&message);
 
         assert!(content.starts_with("[reply message_id=reply-1]\n被回复内容\n[/reply]\n正文"));
-        assert!(content.contains("[附件 image/png: a.png https://example.test/a.png]"));
+        assert!(content.contains("[图片 image/png: a.png]"));
     }
 
     #[test]

--- a/qq-maid-llm/src/provider/bigmodel.rs
+++ b/qq-maid-llm/src/provider/bigmodel.rs
@@ -23,6 +23,9 @@ use crate::{
     },
 };
 
+const MULTIMODAL_UNSUPPORTED_MESSAGE: &str =
+    "我收到图片或文件了，但当前模型暂时不支持图片/文件理解。你可以补充文字说明，我先帮你记录。";
+
 /// 智谱 BigModel 提供商实现。
 pub struct BigModelProvider {
     /// OpenAI 兼容 Chat Completions 客户端。
@@ -66,6 +69,7 @@ impl BigModelProvider {
 #[async_trait]
 impl LlmProvider for BigModelProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatOutcome, LlmError> {
+        reject_multimodal_if_needed(&req)?;
         let effective_model = effective_bigmodel_model(req.model.as_deref(), &self.model)?;
         chat_completions_with_stream_fallback(
             self.stream,
@@ -79,6 +83,7 @@ impl LlmProvider for BigModelProvider {
     }
 
     async fn stream_chat(&self, req: ChatRequest) -> Result<LlmStream, LlmError> {
+        reject_multimodal_if_needed(&req)?;
         let effective_model = effective_bigmodel_model(req.model.as_deref(), &self.model)?;
         if !self.stream {
             let outcome = chat_completions_with_stream_fallback(
@@ -142,6 +147,17 @@ impl LlmProvider for BigModelProvider {
     fn stream_enabled(&self) -> bool {
         self.stream
     }
+}
+
+fn reject_multimodal_if_needed(req: &ChatRequest) -> Result<(), LlmError> {
+    if req.has_non_text_parts() {
+        return Err(LlmError::new(
+            "unsupported_input_part",
+            MULTIMODAL_UNSUPPORTED_MESSAGE,
+            "request",
+        ));
+    }
+    Ok(())
 }
 
 /// 验证并解析 BigModel 的配置模型名。

--- a/qq-maid-llm/src/provider/deepseek.rs
+++ b/qq-maid-llm/src/provider/deepseek.rs
@@ -22,6 +22,9 @@ use crate::{
     },
 };
 
+const MULTIMODAL_UNSUPPORTED_MESSAGE: &str =
+    "我收到图片或文件了，但当前模型暂时不支持图片/文件理解。你可以补充文字说明，我先帮你记录。";
+
 /// DeepSeek 提供商实现。
 pub struct DeepSeekProvider {
     /// OpenAI 兼容 Chat Completions 客户端。
@@ -65,6 +68,7 @@ impl DeepSeekProvider {
 #[async_trait]
 impl LlmProvider for DeepSeekProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatOutcome, LlmError> {
+        reject_multimodal_if_needed(&req)?;
         let effective_model = effective_deepseek_model(req.model.as_deref(), &self.model)?;
         chat_completions_with_stream_fallback(
             self.stream,
@@ -78,6 +82,7 @@ impl LlmProvider for DeepSeekProvider {
     }
 
     async fn stream_chat(&self, req: ChatRequest) -> Result<LlmStream, LlmError> {
+        reject_multimodal_if_needed(&req)?;
         let effective_model = effective_deepseek_model(req.model.as_deref(), &self.model)?;
         if !self.stream {
             let outcome = chat_completions_with_stream_fallback(
@@ -141,6 +146,17 @@ impl LlmProvider for DeepSeekProvider {
     fn stream_enabled(&self) -> bool {
         self.stream
     }
+}
+
+fn reject_multimodal_if_needed(req: &ChatRequest) -> Result<(), LlmError> {
+    if req.has_non_text_parts() {
+        return Err(LlmError::new(
+            "unsupported_input_part",
+            MULTIMODAL_UNSUPPORTED_MESSAGE,
+            "request",
+        ));
+    }
+    Ok(())
 }
 
 /// 验证并解析 DeepSeek 的配置模型名。

--- a/qq-maid-llm/src/provider/openai/chat.rs
+++ b/qq-maid-llm/src/provider/openai/chat.rs
@@ -707,6 +707,7 @@ mod tests {
         response::IntoResponse,
         routing::post,
     };
+    use qq_maid_common::input_part::MessageMedia;
     use std::sync::Arc;
     use tokio::{net::TcpListener, sync::Mutex};
 
@@ -751,6 +752,40 @@ mod tests {
             axum::serve(listener, app).await.unwrap();
         });
         (format!("http://{addr}/v1"), state)
+    }
+
+    #[test]
+    fn chat_completions_payload_keeps_reply_context_before_image_parts() {
+        let payload = chat_completions_payload(
+            &[ChatMessage::user_with_parts(
+                "[reply message_id=quoted-1]\n上一条\n[/reply]\n看图",
+                vec![
+                    MessageInputPart::text("[reply message_id=quoted-1]\n上一条\n[/reply]\n"),
+                    MessageInputPart::text("看图"),
+                    MessageInputPart::image(MessageMedia {
+                        mime_type: Some("image/jpeg".to_owned()),
+                        filename: Some("a.jpg".to_owned()),
+                        url: Some("https://example.test/a.jpg".to_owned()),
+                        ..Default::default()
+                    }),
+                ],
+            )],
+            "gpt-test",
+            1200,
+            false,
+        )
+        .unwrap();
+        let content = payload["messages"][0]["content"].as_array().unwrap();
+
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(
+            content[0]["text"],
+            "[reply message_id=quoted-1]\n上一条\n[/reply]\n"
+        );
+        assert_eq!(content[1]["type"], "text");
+        assert_eq!(content[1]["text"], "看图");
+        assert_eq!(content[2]["type"], "image_url");
+        assert_eq!(content[2]["image_url"]["url"], "https://example.test/a.jpg");
     }
 
     #[tokio::test]

--- a/qq-maid-llm/src/provider/openai/chat.rs
+++ b/qq-maid-llm/src/provider/openai/chat.rs
@@ -21,6 +21,7 @@ use crate::{
     },
     sse::{parse_sse_frame, take_sse_frame},
 };
+use qq_maid_common::input_part::{MediaStatus, MessageInputPart};
 
 use super::fallback::{
     should_retry_non_stream_after_empty_stream, should_retry_non_stream_after_stream_error,
@@ -140,9 +141,9 @@ pub(super) fn chat_completions_messages(messages: &[ChatMessage]) -> Result<Vec<
     }
     let converted = messages
         .iter()
-        .filter(|message| !message.content.trim().is_empty())
+        .filter(|message| message_has_payload(message))
         .map(chat_completions_message)
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, _>>()?;
     if converted.is_empty() {
         return Err(LlmError::new(
             "bad_request",
@@ -153,16 +154,101 @@ pub(super) fn chat_completions_messages(messages: &[ChatMessage]) -> Result<Vec<
     Ok(converted)
 }
 
-fn chat_completions_message(message: &ChatMessage) -> Value {
+fn chat_completions_message(message: &ChatMessage) -> Result<Value, LlmError> {
     let role = match message.role {
         ChatRole::System => "system",
         ChatRole::User => "user",
         ChatRole::Assistant => "assistant",
     };
-    json!({
+    Ok(json!({
         "role": role,
-        "content": [{"type": "text", "text": message.content.as_str()}],
-    })
+        "content": chat_completions_content(message)?,
+    }))
+}
+
+fn message_has_payload(message: &ChatMessage) -> bool {
+    !message.content.trim().is_empty() || !message.content_parts.is_empty()
+}
+
+fn chat_completions_content(message: &ChatMessage) -> Result<Vec<Value>, LlmError> {
+    if message.role != ChatRole::User || message.content_parts.is_empty() {
+        return Ok(vec![
+            json!({"type": "text", "text": message.content.as_str()}),
+        ]);
+    }
+    let mut content = Vec::new();
+    for part in message.effective_content_parts() {
+        match part {
+            MessageInputPart::Text { text, .. } => {
+                if !text.trim().is_empty() {
+                    content.push(json!({"type": "text", "text": text}));
+                }
+            }
+            MessageInputPart::Image { media } => {
+                ensure_media_available(media.status, "图片")?;
+                let Some(url) = media.remote_url() else {
+                    return Err(image_reference_error());
+                };
+                content.push(json!({
+                    "type": "image_url",
+                    "image_url": {"url": url},
+                }));
+            }
+            MessageInputPart::File { .. } | MessageInputPart::Unknown { .. } => {
+                return Err(file_unsupported_error());
+            }
+        }
+    }
+    if content.is_empty() {
+        return Err(LlmError::new(
+            "bad_request",
+            "messages must contain non-empty content",
+            "request",
+        ));
+    }
+    Ok(content)
+}
+
+fn ensure_media_available(status: MediaStatus, label: &str) -> Result<(), LlmError> {
+    match status {
+        MediaStatus::Available => Ok(()),
+        MediaStatus::SizeExceeded => Err(LlmError::new(
+            "unsupported_input_part",
+            format!("{label}太大了，暂时无法处理。"),
+            "request",
+        )),
+        MediaStatus::UnsupportedType => Err(LlmError::new(
+            "unsupported_input_part",
+            format!("我收到这个{label}了，但目前还不能读取这种类型。"),
+            "request",
+        )),
+        MediaStatus::DownloadFailed => Err(LlmError::new(
+            "unsupported_input_part",
+            format!("{label}已收到，但下载失败，请重新发送一次。"),
+            "request",
+        )),
+        MediaStatus::Expired => Err(LlmError::new(
+            "unsupported_input_part",
+            format!("{label}已收到，但访问地址已过期，请重新发送一次。"),
+            "request",
+        )),
+    }
+}
+
+pub(crate) fn image_reference_error() -> LlmError {
+    LlmError::new(
+        "unsupported_input_part",
+        "我收到图片了，但当前入口还没有提供可读取的图片地址。你可以补充文字说明，我先帮你记录。",
+        "request",
+    )
+}
+
+pub(crate) fn file_unsupported_error() -> LlmError {
+    LlmError::new(
+        "unsupported_input_part",
+        "我收到这个文件了，但目前还不能读取这种文件类型。",
+        "request",
+    )
 }
 
 pub(super) async fn send_chat_completions_request(

--- a/qq-maid-llm/src/provider/openai/mod.rs
+++ b/qq-maid-llm/src/provider/openai/mod.rs
@@ -728,6 +728,7 @@ mod tests {
             ChatMessage {
                 role: crate::provider::types::ChatRole::Assistant,
                 content: "old reply".to_owned(),
+                content_parts: Vec::new(),
             },
             ChatMessage::user("again"),
         ];

--- a/qq-maid-llm/src/provider/openai/payload.rs
+++ b/qq-maid-llm/src/provider/openai/payload.rs
@@ -265,4 +265,39 @@ mod tests {
         assert_eq!(content[2]["type"], "input_text");
         assert_eq!(content[2]["text"], "再结合这句");
     }
+
+    #[test]
+    fn openai_responses_payload_keeps_reply_context_before_image_parts() {
+        let payload = openai_responses_payload(
+            &[ChatMessage::user_with_parts(
+                "[reply message_id=quoted-1]\n上一条\n[/reply]\n看图",
+                vec![
+                    MessageInputPart::text("[reply message_id=quoted-1]\n上一条\n[/reply]\n"),
+                    MessageInputPart::text("看图"),
+                    MessageInputPart::image(MessageMedia {
+                        mime_type: Some("image/jpeg".to_owned()),
+                        filename: Some("a.jpg".to_owned()),
+                        url: Some("https://example.test/a.jpg".to_owned()),
+                        ..Default::default()
+                    }),
+                ],
+            )],
+            "gpt-5.5",
+            1200,
+            None,
+            false,
+        )
+        .unwrap();
+        let content = payload["input"][0]["content"].as_array().unwrap();
+
+        assert_eq!(content[0]["type"], "input_text");
+        assert_eq!(
+            content[0]["text"],
+            "[reply message_id=quoted-1]\n上一条\n[/reply]\n"
+        );
+        assert_eq!(content[1]["type"], "input_text");
+        assert_eq!(content[1]["text"], "看图");
+        assert_eq!(content[2]["type"], "input_image");
+        assert_eq!(content[2]["image_url"], "https://example.test/a.jpg");
+    }
 }

--- a/qq-maid-llm/src/provider/openai/payload.rs
+++ b/qq-maid-llm/src/provider/openai/payload.rs
@@ -10,6 +10,9 @@ use crate::{
     error::LlmError,
     provider::types::{ChatMessage, ChatRole, ReasoningEffort},
 };
+use qq_maid_common::input_part::{MediaStatus, MessageInputPart};
+
+use super::chat::{file_unsupported_error, image_reference_error};
 
 /// 构造 OpenAI Responses API 请求体。
 pub(crate) fn openai_responses_payload(
@@ -37,9 +40,9 @@ pub(crate) fn openai_responses_payload(
 fn openai_responses_input(messages: &[ChatMessage]) -> Result<Vec<Value>, LlmError> {
     let input = messages
         .iter()
-        .filter(|message| !message.content.trim().is_empty())
+        .filter(|message| message_has_payload(message))
         .map(openai_responses_message)
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, _>>()?;
 
     if input.is_empty() {
         return Err(LlmError::new(
@@ -52,26 +55,95 @@ fn openai_responses_input(messages: &[ChatMessage]) -> Result<Vec<Value>, LlmErr
 }
 
 /// 将单条聊天消息映射成 OpenAI Responses message item。
-pub(crate) fn openai_responses_message(message: &ChatMessage) -> Value {
+pub(crate) fn openai_responses_message(message: &ChatMessage) -> Result<Value, LlmError> {
     match message.role {
-        ChatRole::System => json!({
+        ChatRole::System => Ok(json!({
             "type": "message",
             "role": "system",
             "content": [{"type": "input_text", "text": message.content.as_str()}],
-        }),
-        ChatRole::User => json!({
+        })),
+        ChatRole::User => Ok(json!({
             "type": "message",
             "role": "user",
-            "content": [{"type": "input_text", "text": message.content.as_str()}],
-        }),
-        ChatRole::Assistant => json!({
+            "content": openai_responses_user_content(message)?,
+        })),
+        ChatRole::Assistant => Ok(json!({
             "type": "message",
             "role": "assistant",
             "status": "completed",
             // Responses API 回放 assistant 历史时必须使用 output_text/refusal；
             // input_text 只用于用户/系统输入，兼容网关会按角色严格校验。
             "content": [{"type": "output_text", "text": message.content.as_str()}],
-        }),
+        })),
+    }
+}
+
+fn message_has_payload(message: &ChatMessage) -> bool {
+    !message.content.trim().is_empty() || !message.content_parts.is_empty()
+}
+
+fn openai_responses_user_content(message: &ChatMessage) -> Result<Vec<Value>, LlmError> {
+    if message.content_parts.is_empty() {
+        return Ok(vec![
+            json!({"type": "input_text", "text": message.content.as_str()}),
+        ]);
+    }
+    let mut content = Vec::new();
+    for part in message.effective_content_parts() {
+        match part {
+            MessageInputPart::Text { text, .. } => {
+                if !text.trim().is_empty() {
+                    content.push(json!({"type": "input_text", "text": text}));
+                }
+            }
+            MessageInputPart::Image { media } => {
+                ensure_media_available(media.status, "图片")?;
+                let Some(url) = media.remote_url() else {
+                    return Err(image_reference_error());
+                };
+                content.push(json!({
+                    "type": "input_image",
+                    "image_url": url,
+                }));
+            }
+            MessageInputPart::File { .. } | MessageInputPart::Unknown { .. } => {
+                return Err(file_unsupported_error());
+            }
+        }
+    }
+    if content.is_empty() {
+        return Err(LlmError::new(
+            "bad_request",
+            "messages must contain non-empty content",
+            "request",
+        ));
+    }
+    Ok(content)
+}
+
+fn ensure_media_available(status: MediaStatus, label: &str) -> Result<(), LlmError> {
+    match status {
+        MediaStatus::Available => Ok(()),
+        MediaStatus::SizeExceeded => Err(LlmError::new(
+            "unsupported_input_part",
+            format!("{label}太大了，暂时无法处理。"),
+            "request",
+        )),
+        MediaStatus::UnsupportedType => Err(LlmError::new(
+            "unsupported_input_part",
+            format!("我收到这个{label}了，但目前还不能读取这种类型。"),
+            "request",
+        )),
+        MediaStatus::DownloadFailed => Err(LlmError::new(
+            "unsupported_input_part",
+            format!("{label}已收到，但下载失败，请重新发送一次。"),
+            "request",
+        )),
+        MediaStatus::Expired => Err(LlmError::new(
+            "unsupported_input_part",
+            format!("{label}已收到，但访问地址已过期，请重新发送一次。"),
+            "request",
+        )),
     }
 }
 
@@ -91,6 +163,7 @@ pub(crate) fn openai_model_supports_reasoning(model: &str) -> bool {
 mod tests {
     use super::*;
     use crate::provider::types::ChatMessage;
+    use qq_maid_common::input_part::{MessageInputPart, MessageMedia};
 
     #[test]
     fn openai_responses_payload_replays_assistant_history_as_output_text() {
@@ -100,6 +173,7 @@ mod tests {
             ChatMessage {
                 role: ChatRole::Assistant,
                 content: "old reply".to_owned(),
+                content_parts: Vec::new(),
             },
             ChatMessage::user("again"),
         ];
@@ -159,5 +233,36 @@ mod tests {
             openai_responses_payload(&[ChatMessage::user(" \n\t ")], "gpt-5.5", 1200, None, false)
                 .unwrap_err();
         assert_eq!(err.code, "bad_request");
+    }
+
+    #[test]
+    fn openai_responses_payload_preserves_ordered_text_and_image_parts() {
+        let payload = openai_responses_payload(
+            &[ChatMessage::user_with_parts(
+                "看图",
+                vec![
+                    MessageInputPart::text("先看这张"),
+                    MessageInputPart::image(MessageMedia {
+                        mime_type: Some("image/jpeg".to_owned()),
+                        url: Some("https://example.test/a.jpg".to_owned()),
+                        ..Default::default()
+                    }),
+                    MessageInputPart::text("再结合这句"),
+                ],
+            )],
+            "gpt-5.5",
+            1200,
+            None,
+            false,
+        )
+        .unwrap();
+        let content = payload["input"][0]["content"].as_array().unwrap();
+
+        assert_eq!(content[0]["type"], "input_text");
+        assert_eq!(content[0]["text"], "先看这张");
+        assert_eq!(content[1]["type"], "input_image");
+        assert_eq!(content[1]["image_url"], "https://example.test/a.jpg");
+        assert_eq!(content[2]["type"], "input_text");
+        assert_eq!(content[2]["text"], "再结合这句");
     }
 }

--- a/qq-maid-llm/src/provider/openai/tool_loop.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop.rs
@@ -179,9 +179,9 @@ fn enforce_tool_loop_budget(
 fn openai_tool_loop_input(messages: &[ChatMessage]) -> Result<Vec<Value>, LlmError> {
     let input = messages
         .iter()
-        .filter(|message| !message.content.trim().is_empty())
+        .filter(|message| !message.content.trim().is_empty() || !message.content_parts.is_empty())
         .map(openai_responses_message)
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, _>>()?;
     if input.is_empty() {
         return Err(LlmError::new(
             "bad_request",

--- a/qq-maid-llm/src/provider/openai_compatible.rs
+++ b/qq-maid-llm/src/provider/openai_compatible.rs
@@ -23,6 +23,9 @@ use crate::{
     },
 };
 
+const MULTIMODAL_UNSUPPORTED_MESSAGE: &str =
+    "我收到图片或文件了，但当前模型暂时不支持图片/文件理解。你可以补充文字说明，我先帮你记录。";
+
 /// 配置驱动的 OpenAI-compatible provider。
 pub struct OpenAiCompatibleProvider {
     id: ModelProvider,
@@ -96,6 +99,7 @@ impl OpenAiCompatibleProvider {
 #[async_trait]
 impl LlmProvider for OpenAiCompatibleProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatOutcome, LlmError> {
+        reject_multimodal_if_needed(&req)?;
         let effective_model = self.effective_model(req.model.as_deref())?;
         chat_completions_with_stream_fallback(
             self.stream,
@@ -110,6 +114,7 @@ impl LlmProvider for OpenAiCompatibleProvider {
     }
 
     async fn stream_chat(&self, req: ChatRequest) -> Result<LlmStream, LlmError> {
+        reject_multimodal_if_needed(&req)?;
         let effective_model = self.effective_model(req.model.as_deref())?;
         if !self.stream {
             let outcome = chat_completions_with_stream_fallback(
@@ -179,6 +184,17 @@ impl LlmProvider for OpenAiCompatibleProvider {
     fn stream_enabled(&self) -> bool {
         self.stream
     }
+}
+
+fn reject_multimodal_if_needed(req: &ChatRequest) -> Result<(), LlmError> {
+    if req.has_non_text_parts() {
+        return Err(LlmError::new(
+            "unsupported_input_part",
+            MULTIMODAL_UNSUPPORTED_MESSAGE,
+            "request",
+        ));
+    }
+    Ok(())
 }
 
 struct AuthMappingAgentSession {

--- a/qq-maid-llm/src/provider/route_error.rs
+++ b/qq-maid-llm/src/provider/route_error.rs
@@ -53,7 +53,12 @@ impl ModelAttemptFailure {
 pub(crate) fn should_try_next_model(err: &LlmError) -> bool {
     matches!(
         err.code.as_str(),
-        "timeout" | "provider_error" | "http_error" | "rate_limited" | "upstream_unavailable"
+        "timeout"
+            | "provider_error"
+            | "http_error"
+            | "rate_limited"
+            | "upstream_unavailable"
+            | "unsupported_input_part"
     )
 }
 
@@ -110,6 +115,16 @@ pub(crate) fn model_task_name(req: &ChatRequest) -> &str {
 /// 文案格式与原实现保持一致：`#<index> <provider>:<model> -> <code>@<stage>`，
 /// 用 `; ` 分隔，便于在调用方日志中一次性看到整条链的失败原因。
 pub(crate) fn aggregate_route_error(task: &str, failures: Vec<ModelAttemptFailure>) -> LlmError {
+    if failures
+        .iter()
+        .all(|failure| failure.error.code == "unsupported_input_part")
+    {
+        return failures
+            .into_iter()
+            .next()
+            .expect("unsupported_input_part failures should not be empty")
+            .error;
+    }
     let details = failures
         .into_iter()
         .map(|failure| {

--- a/qq-maid-llm/src/provider/types.rs
+++ b/qq-maid-llm/src/provider/types.rs
@@ -4,6 +4,7 @@
 
 use std::collections::HashMap;
 
+use qq_maid_common::input_part::MessageInputPart;
 use serde::{Deserialize, Serialize};
 
 use crate::{context_budget::ContextBudgetConfig, error::LlmError};
@@ -109,6 +110,9 @@ pub struct ChatMessage {
     pub role: ChatRole,
     /// 消息文本内容。
     pub content: String,
+    /// 有序多模态内容块。为空时按 `content` 兼容为单个文本块。
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub content_parts: Vec<MessageInputPart>,
 }
 
 /// LLM 聊天请求。
@@ -133,6 +137,12 @@ pub struct ChatRequest {
     /// 附加元数据（透传，可用于日志追踪等）。
     #[serde(default)]
     pub metadata: HashMap<String, String>,
+}
+
+impl ChatRequest {
+    pub fn has_non_text_parts(&self) -> bool {
+        self.messages.iter().any(ChatMessage::has_non_text_parts)
+    }
 }
 
 impl ReasoningEffort {
@@ -291,6 +301,7 @@ impl ChatMessage {
         Self {
             role: ChatRole::System,
             content: content.into(),
+            content_parts: Vec::new(),
         }
     }
 
@@ -299,7 +310,37 @@ impl ChatMessage {
         Self {
             role: ChatRole::User,
             content: content.into(),
+            content_parts: Vec::new(),
         }
+    }
+
+    /// 创建一条带有有序内容块的用户消息。
+    pub fn user_with_parts(
+        content: impl Into<String>,
+        content_parts: Vec<MessageInputPart>,
+    ) -> Self {
+        Self {
+            role: ChatRole::User,
+            content: content.into(),
+            content_parts,
+        }
+    }
+
+    /// 返回 provider 应发送的内容块；旧纯文本消息自动兼容为 text part。
+    pub fn effective_content_parts(&self) -> Vec<MessageInputPart> {
+        if !self.content_parts.is_empty() {
+            return self.content_parts.clone();
+        }
+        let text = self.content.trim();
+        if text.is_empty() {
+            Vec::new()
+        } else {
+            vec![MessageInputPart::text(self.content.clone())]
+        }
+    }
+
+    pub fn has_non_text_parts(&self) -> bool {
+        self.content_parts.iter().any(MessageInputPart::is_non_text)
     }
 }
 


### PR DESCRIPTION
## 背景

Closes #273。

实现第一阶段有序多模态输入链路，让文本、图片和文件元数据从 Gateway 透传到 Core，再交给 LLM provider 处理。当前不做 OCR、文件读取、自动工单或自动 Todo。

## 主要变更

- 新增统一 MessageInputPart 模型，支持 Text / Image / File / Unknown 和安全降级文案。
- Gateway 解析 QQ / WeChat 入站消息并生成 input_parts，C2C 聚合保留跨消息顺序，支持取消待处理的图片/文件聚合。
- Core 普通聊天保留 input_parts，非文本输入绕过 Tool Loop，避免图片/文件误触发 Todo / Memory 工具。
- OpenAI Responses / Chat Completions 支持有序 text + image；DeepSeek、BigModel 和 custom OpenAI-compatible 对非文本输入返回明确 unsupported_input_part，并允许 candidate fallback。
- 补充 common、core、gateway、llm 相关单元测试。

## 验证

- cargo fmt --all -- --check
- cargo check --workspace
- cargo test --workspace
- git diff --check

## 未验证

- 未跑 clippy 和 release build。
- 未做真实 QQ / OpenAI 多模态联调。
- 文件输入目前只透传元数据并明确降级，不读取文件内容。