### PR TITLE
[codex] 修复 QQ 群聊引用上下文索引

### DIFF
--- a/qq-maid-gateway-rs/src/api/mod.rs
+++ b/qq-maid-gateway-rs/src/api/mod.rs
@@ -138,7 +138,6 @@ impl SendMessageIds {
     pub fn ref_index_lookup_id(&self) -> Option<&str> {
         self.ref_index_id
             .as_deref()
-            .or(self.message_id.as_deref())
             .map(str::trim)
             .filter(|value| !value.is_empty())
     }

--- a/qq-maid-gateway-rs/src/api/mod.rs
+++ b/qq-maid-gateway-rs/src/api/mod.rs
@@ -108,7 +108,43 @@ struct GroupTextPayload<'a> {
     msg_seq: u32,
 }
 
-pub type SendResult = Result<Option<String>, ApiError>;
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SendMessageIds {
+    /// QQ OpenAPI 返回的真实平台消息 ID，用于 outbound cache、去重和平台消息操作。
+    pub message_id: Option<String>,
+    /// QQ 引用上下文索引，如 `REFIDX_*`，只用于 ref_index/quoted lookup。
+    pub ref_index_id: Option<String>,
+}
+
+impl SendMessageIds {
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    pub fn message_id(message_id: impl Into<String>) -> Self {
+        Self {
+            message_id: Some(message_id.into()),
+            ref_index_id: None,
+        }
+    }
+
+    pub fn ref_index_id(ref_index_id: impl Into<String>) -> Self {
+        Self {
+            message_id: None,
+            ref_index_id: Some(ref_index_id.into()),
+        }
+    }
+
+    pub fn ref_index_lookup_id(&self) -> Option<&str> {
+        self.ref_index_id
+            .as_deref()
+            .or(self.message_id.as_deref())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+    }
+}
+
+pub type SendResult = Result<SendMessageIds, ApiError>;
 pub type SendFuture<'a> = Pin<Box<dyn Future<Output = SendResult> + Send + 'a>>;
 
 /// QQ C2C Markdown 流式消息载荷。
@@ -546,15 +582,16 @@ impl QqApiClient {
         }
 
         let body = response.text().await.map_err(ApiError::Http)?;
-        let sent_message_id = extract_sent_message_id(&body);
+        let sent_ids = extract_sent_message_ids(&body);
         info!(
             user = %masked_user,
             source_message_id = msg_id.unwrap_or(""),
-            sent_message_id = sent_message_id.as_deref().unwrap_or(""),
+            sent_message_id = sent_ids.message_id.as_deref().unwrap_or(""),
+            sent_ref_index_id = sent_ids.ref_index_id.as_deref().unwrap_or(""),
             message_type = message_type,
             "qq send success"
         );
-        Ok(sent_message_id)
+        Ok(sent_ids)
     }
 
     async fn post_group_message(
@@ -598,15 +635,16 @@ impl QqApiClient {
         }
 
         let body = response.text().await.map_err(ApiError::Http)?;
-        let sent_message_id = extract_sent_message_id(&body);
+        let sent_ids = extract_sent_message_ids(&body);
         info!(
             group = %masked_group,
             source_message_id = msg_id.unwrap_or(""),
-            sent_message_id = sent_message_id.as_deref().unwrap_or(""),
+            sent_message_id = sent_ids.message_id.as_deref().unwrap_or(""),
+            sent_ref_index_id = sent_ids.ref_index_id.as_deref().unwrap_or(""),
             message_type = message_type,
             "qq group send success"
         );
-        Ok(sent_message_id)
+        Ok(sent_ids)
     }
 }
 
@@ -801,6 +839,36 @@ pub(crate) fn extract_sent_message_id(body: &str) -> Option<String> {
         .map(str::trim)
         .find(|value| !value.is_empty())
         .map(str::to_owned)
+}
+
+pub(crate) fn extract_sent_ref_index_id(body: &str) -> Option<String> {
+    let value = serde_json::from_str::<Value>(body).ok()?;
+    let candidates = [
+        value.get("msg_idx"),
+        value.get("ref_msg_idx"),
+        value.get("d").and_then(|item| item.get("msg_idx")),
+        value.get("d").and_then(|item| item.get("ref_msg_idx")),
+        value.get("data").and_then(|item| item.get("msg_idx")),
+        value.get("data").and_then(|item| item.get("ref_msg_idx")),
+        value.get("message").and_then(|item| item.get("msg_idx")),
+        value
+            .get("message")
+            .and_then(|item| item.get("ref_msg_idx")),
+    ];
+    candidates
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .find(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+pub(crate) fn extract_sent_message_ids(body: &str) -> SendMessageIds {
+    SendMessageIds {
+        message_id: extract_sent_message_id(body),
+        ref_index_id: extract_sent_ref_index_id(body),
+    }
 }
 
 pub async fn send_outbound_with_fallback<S: OutboundSender + ?Sized>(

--- a/qq-maid-gateway-rs/src/api/tests.rs
+++ b/qq-maid-gateway-rs/src/api/tests.rs
@@ -25,6 +25,28 @@ fn extracts_sent_message_id_from_common_response_shapes() {
 }
 
 #[test]
+fn extracts_message_id_and_refidx_without_mixing_semantics() {
+    let ids = extract_sent_message_ids(r#"{"id":"bot-msg-1","msg_idx":"REFIDX_bot_1"}"#);
+    assert_eq!(
+        ids,
+        SendMessageIds {
+            message_id: Some("bot-msg-1".to_owned()),
+            ref_index_id: Some("REFIDX_bot_1".to_owned()),
+        }
+    );
+
+    let nested = extract_sent_message_ids(
+        r#"{"data":{"message_id":"bot-msg-2","ref_msg_idx":"REFIDX_bot_2"}}"#,
+    );
+    assert_eq!(nested.message_id.as_deref(), Some("bot-msg-2"));
+    assert_eq!(nested.ref_index_id.as_deref(), Some("REFIDX_bot_2"));
+    assert_eq!(
+        extract_sent_message_id(r#"{"id":"bot-msg-1","msg_idx":"REFIDX_bot_1"}"#).as_deref(),
+        Some("bot-msg-1")
+    );
+}
+
+#[test]
 fn c2c_text_payload_matches_qq_shape() {
     let payload = build_c2c_text_payload("hello", Some("msg-1"), 7);
 
@@ -298,7 +320,7 @@ impl OutboundSender for MockSender {
     fn send_text<'a>(&'a self, _target: &'a C2cReplyTarget, text: &'a str) -> SendFuture<'a> {
         Box::pin(async move {
             self.calls.lock().unwrap().push(format!("text:{text}"));
-            Ok(None)
+            Ok(SendMessageIds::none())
         })
     }
 
@@ -332,7 +354,7 @@ impl GroupOutboundSender for MockSender {
                 .lock()
                 .unwrap()
                 .push(format!("group-text:{text}"));
-            Ok(None)
+            Ok(SendMessageIds::none())
         })
     }
 

--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -807,8 +807,8 @@ mod tests {
         let mut message = c2c_message();
         message.message_id = "msg-quote".to_owned();
         message.reply = Some(crate::gateway::event::MessageReply {
-            message_id: ref_id.to_owned(),
-            ref_msg_idx: None,
+            message_id: "qq-reply-message-id".to_owned(),
+            ref_msg_idx: Some(ref_id.to_owned()),
             content: None,
         });
         let mut inbound = platform::qq_official::inbound_from_c2c(&message);
@@ -922,6 +922,28 @@ mod tests {
         );
         assert_eq!(
             quoted_lookup_found(&ref_index, &config, "markdown-id"),
+            None
+        );
+    }
+
+    #[test]
+    fn complete_c2c_reply_does_not_record_message_id_as_ref_index() {
+        let config = test_config();
+        let ref_index = crate::gateway::ref_index::ref_index();
+
+        record_c2c_bot_outbound_refs(
+            &ref_index,
+            &c2c_message(),
+            &config,
+            [SendMessageIds {
+                message_id: Some("markdown-id-only".to_owned()),
+                ref_index_id: None,
+            }],
+            "完整回复",
+        );
+
+        assert_eq!(
+            quoted_lookup_found(&ref_index, &config, "markdown-id-only"),
             None
         );
     }

--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -26,7 +26,7 @@ use super::{
     typing::{C2cTypingStatusGuard, TypingStopReason},
 };
 use crate::{
-    api::{OutboundSender, QqApiClient, send_outbound_with_fallback},
+    api::{OutboundSender, QqApiClient, SendMessageIds, send_outbound_with_fallback},
     auth::AccessTokenManager,
     config::AppConfig,
     markdown::MarkdownPayload,
@@ -98,17 +98,17 @@ pub(super) fn record_c2c_bot_outbound_refs(
     ref_index: &SharedRefIndex,
     message: &C2cMessage,
     config: &AppConfig,
-    sent_ids: impl IntoIterator<Item = Option<String>>,
+    sent_ids: impl IntoIterator<Item = SendMessageIds>,
     text: &str,
 ) {
     let inbound = platform::qq_official::inbound_from_c2c(message);
     let mut index = ref_index.lock().unwrap();
-    for sent_id in sent_ids.into_iter().flatten() {
+    for sent_id in sent_ids.into_iter() {
         index.insert_bot_outbound(
             platform::Platform::QqOfficial,
             Some(&config.app_id),
             &inbound.conversation,
-            Some(sent_id),
+            sent_id.ref_index_lookup_id().map(str::to_owned),
             text,
         );
     }
@@ -124,7 +124,7 @@ pub(super) async fn send_c2c_respond_response_with_sender<S: OutboundSender + ?S
     response: &RespondResponse,
     config: &AppConfig,
     capability: &ReplyCapability,
-) -> anyhow::Result<Vec<Option<String>>> {
+) -> anyhow::Result<Vec<SendMessageIds>> {
     let masked_user = mask_openid(&message.user_openid);
     let outbound = match render_respond_response_for_profile(response, &capability.render) {
         Some(outbound) => outbound,
@@ -734,7 +734,10 @@ mod tests {
                     content: text.to_owned(),
                     msg_id: target.msg_id.clone(),
                 });
-                Ok(Some("text-id".to_owned()))
+                Ok(SendMessageIds {
+                    message_id: Some("text-id".to_owned()),
+                    ref_index_id: Some("REFIDX_text_id".to_owned()),
+                })
             })
         }
 
@@ -748,7 +751,10 @@ mod tests {
                     content: markdown.content.clone(),
                     msg_id: target.msg_id.clone(),
                 });
-                Ok(Some("markdown-id".to_owned()))
+                Ok(SendMessageIds {
+                    message_id: Some("markdown-id".to_owned()),
+                    ref_index_id: Some("REFIDX_markdown_id".to_owned()),
+                })
             })
         }
 
@@ -903,13 +909,20 @@ mod tests {
             &ref_index,
             &c2c_message(),
             &config,
-            [Some("markdown-id".to_owned())],
+            [SendMessageIds {
+                message_id: Some("markdown-id".to_owned()),
+                ref_index_id: Some("REFIDX_markdown_id".to_owned()),
+            }],
             "完整回复",
         );
 
         assert_eq!(
-            quoted_lookup_found(&ref_index, &config, "markdown-id").as_deref(),
+            quoted_lookup_found(&ref_index, &config, "REFIDX_markdown_id").as_deref(),
             Some("完整回复")
+        );
+        assert_eq!(
+            quoted_lookup_found(&ref_index, &config, "markdown-id"),
+            None
         );
     }
 
@@ -964,8 +977,12 @@ mod tests {
 
         assert_eq!(outcome, DisabledStreamOutcome::Completed);
         assert_eq!(
-            quoted_lookup_found(&ref_index, &config, "markdown-id").as_deref(),
+            quoted_lookup_found(&ref_index, &config, "REFIDX_markdown_id").as_deref(),
             Some("最终回复")
+        );
+        assert_eq!(
+            quoted_lookup_found(&ref_index, &config, "markdown-id"),
+            None
         );
     }
 

--- a/qq-maid-gateway-rs/src/gateway/cache.rs
+++ b/qq-maid-gateway-rs/src/gateway/cache.rs
@@ -1,6 +1,7 @@
 //! Gateway 短时缓存。
 //!
-//! 这里只保存用于群聊触发策略的 bot 出站消息 id；引用上下文统一走 `ref_index`。
+//! 这里只保存用于群聊触发策略的 bot 出站真实消息 ID 和独立 ref_index ID；
+//! 引用上下文内容统一走 `ref_index`。
 
 use std::collections::HashSet;
 

--- a/qq-maid-gateway-rs/src/gateway/cache.rs
+++ b/qq-maid-gateway-rs/src/gateway/cache.rs
@@ -7,6 +7,7 @@ use std::collections::HashSet;
 #[derive(Debug, Default)]
 pub(crate) struct BotOutboundCache {
     message_ids: HashSet<String>,
+    ref_index_ids: HashSet<String>,
 }
 
 impl BotOutboundCache {
@@ -16,7 +17,17 @@ impl BotOutboundCache {
         }
     }
 
+    pub(crate) fn insert_ref_index_id(&mut self, ref_index_id: Option<String>) {
+        if let Some(ref_index_id) = ref_index_id.filter(|value| !value.trim().is_empty()) {
+            self.ref_index_ids.insert(ref_index_id);
+        }
+    }
+
     pub(crate) fn contains(&self, message_id: &str) -> bool {
         self.message_ids.contains(message_id)
+    }
+
+    pub(crate) fn contains_ref_index_id(&self, ref_index_id: &str) -> bool {
+        self.ref_index_ids.contains(ref_index_id)
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/event.rs
+++ b/qq-maid-gateway-rs/src/gateway/event.rs
@@ -1272,4 +1272,38 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn parses_group_refidx_from_message_scene_ext() {
+        let envelope = GatewayEnvelope {
+            op: 0,
+            s: Some(42),
+            t: Some(EVENT_GROUP_MESSAGE_CREATE.to_owned()),
+            id: None,
+            d: json!({
+                "id": "msg-current",
+                "group_openid": "group-1",
+                "author": {"member_openid": "member-1"},
+                "content": "这条是什么意思",
+                "message_scene": {
+                    "ext": [
+                        "msg_idx=REFIDX_current",
+                        "ref_msg_idx=REFIDX_quoted"
+                    ]
+                }
+            }),
+        };
+
+        let message = parse_group_message(&envelope).unwrap().unwrap();
+
+        assert_eq!(message.current_msg_idx.as_deref(), Some("REFIDX_current"));
+        assert_eq!(
+            message.reply,
+            Some(MessageReply {
+                message_id: "REFIDX_quoted".to_owned(),
+                ref_msg_idx: Some("REFIDX_quoted".to_owned()),
+                content: None,
+            })
+        );
+    }
 }

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -990,6 +990,17 @@ mod tests {
                 .unwrap()
                 .contains_ref_index_id("qq_msg_only")
         );
+        let mut message_only_quote = platform::qq_official::inbound_from_group(&message);
+        message_only_quote.account_id = Some(config.app_id.clone());
+        message_only_quote.quoted = Some(qq_maid_common::input_part::QuotedMessageContext {
+            ref_msg_idx: Some("qq_msg_only".to_owned()),
+            ..Default::default()
+        });
+        message_only_index
+            .lock()
+            .unwrap()
+            .enrich_inbound(&mut message_only_quote);
+        assert!(!message_only_quote.quoted.as_ref().unwrap().lookup_found);
 
         let refidx_only_cache = Arc::new(Mutex::new(BotOutboundCache::default()));
         let refidx_only_index = crate::gateway::ref_index::ref_index();

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -28,7 +28,7 @@ use super::{
     ref_index::SharedRefIndex,
 };
 use crate::{
-    api::QqApiClient,
+    api::{QqApiClient, SendMessageIds},
     config::AppConfig,
     message_chunk::{ChunkLimits, OutboundSendError, send_group_outbound_chunked},
     render::{OutboundMessage, render_respond_response_for_profile},
@@ -217,7 +217,14 @@ pub(super) async fn handle_group_message(
                 &qq_text,
             )
             .await?;
-            group_outbound_cache.lock().unwrap().insert(sent_message_id);
+            group_outbound_cache
+                .lock()
+                .unwrap()
+                .insert(sent_message_id.message_id.clone());
+            group_outbound_cache
+                .lock()
+                .unwrap()
+                .insert_ref_index_id(sent_message_id.ref_index_id);
             return Ok(());
         }
     };
@@ -294,31 +301,16 @@ async fn send_group_respond_response(
     );
     // 普通群回复统一走分段编排：每个成功发送并返回 message id 的分段写入
     // `BotOutboundCache`；失败分段不写，错误向上传递为 PartiallySent / NotSent。
-    match send_group_outbound_chunked(
-        &sender,
-        &target,
-        &outbound,
-        &limits,
-        |_, sent_message_id| {
-            group_outbound_cache
-                .lock()
-                .unwrap()
-                .insert(sent_message_id.clone());
-            let inbound = platform::qq_official::inbound_from_group(message);
-            let text = response
-                .markdown
-                .as_deref()
-                .or(response.text.as_deref())
-                .unwrap_or("");
-            ref_index.lock().unwrap().insert_bot_outbound(
-                platform::Platform::QqOfficial,
-                Some(&config.app_id),
-                &inbound.conversation,
-                sent_message_id.clone(),
-                text,
-            );
-        },
-    )
+    match send_group_outbound_chunked(&sender, &target, &outbound, &limits, |_, sent_ids| {
+        record_group_bot_outbound_send(
+            group_outbound_cache,
+            ref_index,
+            message,
+            response,
+            config,
+            sent_ids,
+        );
+    })
     .await
     {
         Ok(_) => Ok(()),
@@ -328,6 +320,34 @@ async fn send_group_respond_response(
             Err(source.into())
         }
     }
+}
+
+fn record_group_bot_outbound_send(
+    group_outbound_cache: &Arc<Mutex<BotOutboundCache>>,
+    ref_index: &SharedRefIndex,
+    message: &GroupMessage,
+    response: &RespondResponse,
+    config: &AppConfig,
+    sent_ids: &SendMessageIds,
+) {
+    {
+        let mut cache = group_outbound_cache.lock().unwrap();
+        cache.insert(sent_ids.message_id.clone());
+        cache.insert_ref_index_id(sent_ids.ref_index_id.clone());
+    }
+    let inbound = platform::qq_official::inbound_from_group(message);
+    let text = response
+        .markdown
+        .as_deref()
+        .or(response.text.as_deref())
+        .unwrap_or("");
+    ref_index.lock().unwrap().insert_bot_outbound(
+        platform::Platform::QqOfficial,
+        Some(&config.app_id),
+        &inbound.conversation,
+        sent_ids.ref_index_lookup_id().map(str::to_owned),
+        text,
+    );
 }
 
 async fn consume_respond_stream(
@@ -886,5 +906,110 @@ mod tests {
 
         assert_eq!(hits.load(Ordering::SeqCst), 1);
         assert_eq!(media_file_count(&config.media_dir), 1);
+    }
+
+    #[test]
+    fn group_send_records_message_id_for_cache_and_refidx_for_ref_index() {
+        let config = test_config();
+        let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        let ref_index = crate::gateway::ref_index::ref_index();
+        let message = group_message("小女仆 你好", GroupEventType::GroupMessage);
+        let response = RespondResponse {
+            text: Some("机器人回复".to_owned()),
+            markdown: Some("机器人回复".to_owned()),
+            handled: Some(true),
+            session_id: None,
+            command: None,
+            diagnostics: None,
+        };
+        let sent_ids = SendMessageIds {
+            message_id: Some("qq_msg_1".to_owned()),
+            ref_index_id: Some("REFIDX_1".to_owned()),
+        };
+
+        record_group_bot_outbound_send(&cache, &ref_index, &message, &response, &config, &sent_ids);
+
+        assert!(cache.lock().unwrap().contains("qq_msg_1"));
+        assert!(!cache.lock().unwrap().contains("REFIDX_1"));
+        assert!(cache.lock().unwrap().contains_ref_index_id("REFIDX_1"));
+
+        let mut quoted = group_message("继续", GroupEventType::GroupMessage);
+        quoted.reply = Some(crate::gateway::event::MessageReply {
+            message_id: "qq_reply_payload_id".to_owned(),
+            ref_msg_idx: Some("REFIDX_1".to_owned()),
+            content: None,
+        });
+        assert!(should_process_group_message(
+            crate::config::GroupMessageMode::Mention,
+            &[],
+            &quoted,
+            &quoted.content,
+            &bot_identity(),
+            &cache
+        ));
+
+        let mut inbound = platform::qq_official::inbound_from_group(&quoted);
+        inbound.account_id = Some(config.app_id.clone());
+        ref_index.lock().unwrap().enrich_inbound(&mut inbound);
+        let quoted_context = inbound.quoted.as_ref().unwrap();
+        assert!(quoted_context.lookup_found);
+        assert_eq!(quoted_context.text_summary.as_deref(), Some("机器人回复"));
+        assert_eq!(quoted_context.from_bot, Some(true));
+    }
+
+    #[test]
+    fn group_send_does_not_cross_use_message_id_and_refidx_when_one_is_missing() {
+        let config = test_config();
+        let response = RespondResponse {
+            text: Some("机器人回复".to_owned()),
+            markdown: None,
+            handled: Some(true),
+            session_id: None,
+            command: None,
+            diagnostics: None,
+        };
+
+        let message_only_cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        let message_only_index = crate::gateway::ref_index::ref_index();
+        let message = group_message("小女仆 你好", GroupEventType::GroupMessage);
+        record_group_bot_outbound_send(
+            &message_only_cache,
+            &message_only_index,
+            &message,
+            &response,
+            &config,
+            &SendMessageIds {
+                message_id: Some("qq_msg_only".to_owned()),
+                ref_index_id: None,
+            },
+        );
+        assert!(message_only_cache.lock().unwrap().contains("qq_msg_only"));
+        assert!(
+            !message_only_cache
+                .lock()
+                .unwrap()
+                .contains_ref_index_id("qq_msg_only")
+        );
+
+        let refidx_only_cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        let refidx_only_index = crate::gateway::ref_index::ref_index();
+        record_group_bot_outbound_send(
+            &refidx_only_cache,
+            &refidx_only_index,
+            &message,
+            &response,
+            &config,
+            &SendMessageIds {
+                message_id: None,
+                ref_index_id: Some("REFIDX_only".to_owned()),
+            },
+        );
+        assert!(!refidx_only_cache.lock().unwrap().contains("REFIDX_only"));
+        assert!(
+            refidx_only_cache
+                .lock()
+                .unwrap()
+                .contains_ref_index_id("REFIDX_only")
+        );
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/group_filter.rs
+++ b/qq-maid-gateway-rs/src/gateway/group_filter.rs
@@ -544,6 +544,36 @@ mod tests {
     }
 
     #[test]
+    fn quote_only_reply_message_id_does_not_match_refidx_cache_without_ref_msg_idx() {
+        let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        cache
+            .lock()
+            .unwrap()
+            .insert_ref_index_id(Some("REFIDX_bot_msg_1".to_owned()));
+        let mut message = group_message("", GroupEventType::GroupMessage);
+        message.reply = Some(MessageReply {
+            message_id: "REFIDX_bot_msg_1".to_owned(),
+            ref_msg_idx: None,
+            content: None,
+        });
+
+        assert!(should_ignore_group_message(
+            &message,
+            "",
+            "masked-group",
+            &cache
+        ));
+        assert!(!should_process_group_message(
+            GroupMessageMode::Mention,
+            &[],
+            &message,
+            "",
+            &bot_identity(),
+            &cache
+        ));
+    }
+
+    #[test]
     fn group_at_event_with_other_content_mention_trusts_official_event_type() {
         let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
         let active_keywords = vec!["小女仆".to_owned()];
@@ -635,6 +665,30 @@ mod tests {
             &cache
         ));
         assert!(!cache.lock().unwrap().contains("REFIDX_bot_msg_1"));
+    }
+
+    #[test]
+    fn reply_message_id_does_not_trigger_mention_mode_from_refidx_cache_without_ref_msg_idx() {
+        let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        cache
+            .lock()
+            .unwrap()
+            .insert_ref_index_id(Some("REFIDX_bot_msg_1".to_owned()));
+        let mut message = group_message("继续", GroupEventType::GroupMessage);
+        message.reply = Some(MessageReply {
+            message_id: "REFIDX_bot_msg_1".to_owned(),
+            ref_msg_idx: None,
+            content: None,
+        });
+
+        assert!(!should_process_group_message(
+            GroupMessageMode::Mention,
+            &[],
+            &message,
+            &message.content,
+            &bot_identity(),
+            &cache
+        ));
     }
 
     #[test]

--- a/qq-maid-gateway-rs/src/gateway/group_filter.rs
+++ b/qq-maid-gateway-rs/src/gateway/group_filter.rs
@@ -172,10 +172,12 @@ fn is_reply_to_bot(
     bot_outbound_cache: &Arc<Mutex<BotOutboundCache>>,
 ) -> bool {
     message.reply.as_ref().is_some_and(|reply| {
-        bot_outbound_cache
-            .lock()
-            .unwrap()
-            .contains(&reply.message_id)
+        let cache = bot_outbound_cache.lock().unwrap();
+        cache.contains(&reply.message_id)
+            || reply
+                .ref_msg_idx
+                .as_deref()
+                .is_some_and(|ref_msg_idx| cache.contains_ref_index_id(ref_msg_idx))
     })
 }
 
@@ -511,6 +513,37 @@ mod tests {
     }
 
     #[test]
+    fn quote_only_reply_to_cached_bot_refidx_is_not_ignored() {
+        let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        cache
+            .lock()
+            .unwrap()
+            .insert_ref_index_id(Some("REFIDX_bot_msg_1".to_owned()));
+        let mut message = group_message("", GroupEventType::GroupMessage);
+        message.reply = Some(MessageReply {
+            message_id: "msg-current-or-unknown".to_owned(),
+            ref_msg_idx: Some("REFIDX_bot_msg_1".to_owned()),
+            content: None,
+        });
+
+        assert!(!should_ignore_group_message(
+            &message,
+            "",
+            "masked-group",
+            &cache
+        ));
+        assert!(should_process_group_message(
+            GroupMessageMode::Mention,
+            &[],
+            &message,
+            "",
+            &bot_identity(),
+            &cache
+        ));
+        assert!(!cache.lock().unwrap().contains("REFIDX_bot_msg_1"));
+    }
+
+    #[test]
     fn group_at_event_with_other_content_mention_trusts_official_event_type() {
         let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
         let active_keywords = vec!["小女仆".to_owned()];
@@ -577,6 +610,31 @@ mod tests {
             &bot_identity(),
             &cache
         ));
+    }
+
+    #[test]
+    fn reply_to_cached_bot_refidx_triggers_mention_mode() {
+        let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        cache
+            .lock()
+            .unwrap()
+            .insert_ref_index_id(Some("REFIDX_bot_msg_1".to_owned()));
+        let mut message = group_message("继续", GroupEventType::GroupMessage);
+        message.reply = Some(MessageReply {
+            message_id: "msg-current-or-unknown".to_owned(),
+            ref_msg_idx: Some("REFIDX_bot_msg_1".to_owned()),
+            content: None,
+        });
+
+        assert!(should_process_group_message(
+            GroupMessageMode::Mention,
+            &[],
+            &message,
+            &message.content,
+            &bot_identity(),
+            &cache
+        ));
+        assert!(!cache.lock().unwrap().contains("REFIDX_bot_msg_1"));
     }
 
     #[test]

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -91,6 +91,7 @@ pub async fn run(
         config.app_id.clone(),
         runtime.clone(),
         group_outbound_cache.clone(),
+        ref_index.clone(),
     );
     let group_cooldowns = Arc::new(Mutex::new(GroupCooldowns::default()));
     let bot_identity = Arc::new(BotIdentity::new(&config.app_id, &config.bot_mention_ids));

--- a/qq-maid-gateway-rs/src/gateway/outbound.rs
+++ b/qq-maid-gateway-rs/src/gateway/outbound.rs
@@ -397,7 +397,7 @@ mod tests {
     #[test]
     fn record_qq_send_result_updates_runtime_status() {
         let runtime = GatewayRuntimeStatus::new();
-        let success: SendResult = Ok(None);
+        let success: SendResult = Ok(crate::api::SendMessageIds::none());
 
         record_qq_send_result(&runtime, &success);
         let snapshot = runtime.snapshot();

--- a/qq-maid-gateway-rs/src/gateway/platform/qq_official.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/qq_official.rs
@@ -93,10 +93,9 @@ fn quoted_from_qq(
         current_message_id: Some(current_message_id.to_owned()),
         current_msg_idx: current_msg_idx.map(str::to_owned),
         reference_id: Some(value.message_id.clone()),
-        ref_msg_idx: value
-            .ref_msg_idx
-            .clone()
-            .or_else(|| Some(value.message_id.clone())),
+        // QQ 引用恢复只能使用官方下发的 ref_msg_idx/REFIDX；reply.message_id
+        // 保留为原始引用字段，不伪造成 ref_index lookup key。
+        ref_msg_idx: value.ref_msg_idx.clone(),
         text_summary: value.content.clone(),
         lookup_found: value.content.is_some(),
         fallback_reason: value
@@ -241,6 +240,13 @@ mod tests {
                 .as_ref()
                 .and_then(|quote| quote.reference_id.as_deref()),
             Some("quoted-1")
+        );
+        assert_eq!(
+            inbound
+                .quoted
+                .as_ref()
+                .and_then(|quote| quote.ref_msg_idx.as_deref()),
+            None
         );
         assert_eq!(inbound.attachments[0].filename.as_deref(), Some("a.jpg"));
         assert!(rendered.starts_with("你好"));

--- a/qq-maid-gateway-rs/src/gateway/push.rs
+++ b/qq-maid-gateway-rs/src/gateway/push.rs
@@ -16,10 +16,12 @@ use tokio::{sync::Notify, time::timeout};
 use tracing::{info, warn};
 
 use crate::{
-    api::{QqApiClient, SendResult, build_c2c_text_payload, build_group_text_payload},
+    api::{
+        QqApiClient, SendMessageIds, SendResult, build_c2c_text_payload, build_group_text_payload,
+    },
     gateway::{
-        BotOutboundCache, logging::mask_identifier, outbound::record_qq_send_result,
-        ping::GatewayRuntimeStatus,
+        BotOutboundCache, logging::mask_identifier, ping::GatewayRuntimeStatus,
+        platform::ConversationTarget, ref_index::SharedRefIndex,
     },
     markdown::MarkdownPayload,
 };
@@ -63,6 +65,13 @@ struct GatewayPushRuntime {
     qq_official_account_id: String,
     runtime: GatewayRuntimeStatus,
     group_outbound_cache: Arc<Mutex<BotOutboundCache>>,
+    ref_index: SharedRefIndex,
+}
+
+#[derive(Debug)]
+struct PushSendOutcome {
+    ids: SendMessageIds,
+    delivered_text: String,
 }
 
 impl GatewayPushSink {
@@ -79,6 +88,7 @@ impl GatewayPushSink {
         qq_official_account_id: impl Into<String>,
         runtime: GatewayRuntimeStatus,
         group_outbound_cache: Arc<Mutex<BotOutboundCache>>,
+        ref_index: SharedRefIndex,
     ) {
         // Core scheduler 可能在 Gateway 首次连接 QQ 前启动，因此 sink 需要先存在；
         // 真正发送前必须已绑定运行期上下文，否则返回可观测错误而不是静默丢消息。
@@ -87,6 +97,7 @@ impl GatewayPushSink {
             qq_official_account_id: qq_official_account_id.into(),
             runtime,
             group_outbound_cache,
+            ref_index,
         });
         self.ready.notify_waiters();
     }
@@ -149,25 +160,12 @@ impl GatewayPushRuntime {
                 send_group_push(&self.api, target_id, message_type, text, fallback_text).await
             }
         };
-        record_qq_send_result(&self.runtime, &result);
-        if intent.target.target_type == PushTargetType::Group
-            && let Ok(Some(message_id)) = result.as_ref()
-        {
-            self.group_outbound_cache
-                .lock()
-                .unwrap()
-                .insert(Some(message_id.clone()));
+        match &result {
+            Ok(_) => self.runtime.record_qq_send_success(),
+            Err(err) => self.runtime.record_qq_send_failure(err.log_summary()),
         }
         match result {
-            Ok(message_id) => {
-                info!(
-                    platform = %intent.target.platform,
-                    target_type = %intent.target.target_type.as_str(),
-                    target = %mask_identifier(target_id),
-                    "gateway push sent"
-                );
-                Ok(PushResult { message_id })
-            }
+            Ok(outcome) => Ok(self.record_successful_push(&intent, target_id, outcome)),
             Err(err) => {
                 warn!(
                     platform = %intent.target.platform,
@@ -181,6 +179,67 @@ impl GatewayPushRuntime {
                 })
             }
         }
+    }
+
+    fn record_successful_push(
+        &self,
+        intent: &PushIntent,
+        target_id: &str,
+        outcome: PushSendOutcome,
+    ) -> PushResult {
+        if intent.target.target_type == PushTargetType::Group {
+            let mut cache = self.group_outbound_cache.lock().unwrap();
+            cache.insert(outcome.ids.message_id.clone());
+            cache.insert_ref_index_id(outcome.ids.ref_index_id.clone());
+        }
+        self.record_push_ref_index(intent, &outcome.ids, &outcome.delivered_text);
+        info!(
+            platform = %intent.target.platform,
+            target_type = %intent.target.target_type.as_str(),
+            target = %mask_identifier(target_id),
+            "gateway push sent"
+        );
+        PushResult {
+            message_id: outcome.ids.message_id,
+        }
+    }
+
+    fn record_push_ref_index(
+        &self,
+        intent: &PushIntent,
+        sent_ids: &SendMessageIds,
+        delivered_text: &str,
+    ) {
+        let Some(ref_index_id) = sent_ids.ref_index_id.as_deref() else {
+            return;
+        };
+        let conversation = match intent.target.target_type {
+            PushTargetType::Private => ConversationTarget::Private {
+                target_id: intent.target.target_id.clone(),
+            },
+            PushTargetType::Group => ConversationTarget::Group {
+                target_id: intent.target.target_id.clone(),
+            },
+        };
+        let mut ref_index = match self.ref_index.lock() {
+            Ok(ref_index) => ref_index,
+            Err(_) => {
+                warn!(
+                    target_type = %intent.target.target_type.as_str(),
+                    target = %mask_identifier(&intent.target.target_id),
+                    ref_index_id = %mask_identifier(ref_index_id),
+                    "push ref_index write skipped because index lock is poisoned"
+                );
+                return;
+            }
+        };
+        ref_index.insert_bot_outbound(
+            crate::gateway::platform::Platform::QqOfficial,
+            Some(&self.qq_official_account_id),
+            &conversation,
+            Some(ref_index_id.to_owned()),
+            delivered_text,
+        );
     }
 }
 
@@ -216,26 +275,41 @@ async fn send_private_push<S: PushQqSender + ?Sized>(
     message_type: &str,
     text: &str,
     fallback_text: &str,
-) -> SendResult {
+) -> Result<PushSendOutcome, crate::api::ApiError> {
     match message_type {
         "markdown" => {
             let markdown = MarkdownPayload::new(text.to_owned());
             match sender.send_c2c_markdown(target_id, &markdown).await {
-                Ok(message_id) => Ok(message_id),
+                Ok(ids) => Ok(PushSendOutcome {
+                    ids,
+                    delivered_text: text.to_owned(),
+                }),
                 Err(err) => {
                     warn!(
                         target = %mask_identifier(target_id),
                         error = %err.log_summary(),
                         "markdown push failed; falling back to text"
                     );
-                    sender.send_c2c_text(target_id, fallback_text).await
+                    sender
+                        .send_c2c_text(target_id, fallback_text)
+                        .await
+                        .map(|ids| PushSendOutcome {
+                            ids,
+                            delivered_text: fallback_text.to_owned(),
+                        })
                 }
             }
         }
         "text" | "" => {
             // 主动推送没有原始 QQ msg_id，因此只发送 content/msg_type/msg_seq。
             let _shape = build_c2c_text_payload(text, None, 1);
-            sender.send_c2c_text(target_id, text).await
+            sender
+                .send_c2c_text(target_id, text)
+                .await
+                .map(|ids| PushSendOutcome {
+                    ids,
+                    delivered_text: text.to_owned(),
+                })
         }
         _ => Err(crate::api::ApiError::Unsupported("message_type")),
     }
@@ -247,26 +321,41 @@ async fn send_group_push<S: PushQqSender + ?Sized>(
     message_type: &str,
     text: &str,
     fallback_text: &str,
-) -> SendResult {
+) -> Result<PushSendOutcome, crate::api::ApiError> {
     match message_type {
         "markdown" => {
             let markdown = MarkdownPayload::new(text.to_owned());
             match sender.send_group_markdown(target_id, &markdown).await {
-                Ok(message_id) => Ok(message_id),
+                Ok(ids) => Ok(PushSendOutcome {
+                    ids,
+                    delivered_text: text.to_owned(),
+                }),
                 Err(err) => {
                     warn!(
                         target = %mask_identifier(target_id),
                         error = %err.log_summary(),
                         "group markdown push failed; falling back to text"
                     );
-                    sender.send_group_text(target_id, fallback_text).await
+                    sender
+                        .send_group_text(target_id, fallback_text)
+                        .await
+                        .map(|ids| PushSendOutcome {
+                            ids,
+                            delivered_text: fallback_text.to_owned(),
+                        })
                 }
             }
         }
         "text" | "" => {
             // QQ 群 openid 主动消息使用 /v2/groups/{group_openid}/messages。
             let _shape = build_group_text_payload(text, None, 1);
-            sender.send_group_text(target_id, text).await
+            sender
+                .send_group_text(target_id, text)
+                .await
+                .map(|ids| PushSendOutcome {
+                    ids,
+                    delivered_text: text.to_owned(),
+                })
         }
         _ => Err(crate::api::ApiError::Unsupported("message_type")),
     }
@@ -283,6 +372,7 @@ mod tests {
         fail_markdown: bool,
         fail_text: bool,
         message_id: Option<String>,
+        ref_index_id: Option<String>,
     }
 
     impl MockPushSender {
@@ -301,7 +391,10 @@ mod tests {
             if self.fail_text {
                 Err(crate::api::ApiError::Unsupported("text"))
             } else {
-                Ok(self.message_id.clone())
+                Ok(SendMessageIds {
+                    message_id: self.message_id.clone(),
+                    ref_index_id: self.ref_index_id.clone(),
+                })
             }
         }
 
@@ -317,7 +410,10 @@ mod tests {
             if self.fail_markdown {
                 Err(crate::api::ApiError::Unsupported("markdown"))
             } else {
-                Ok(self.message_id.clone())
+                Ok(SendMessageIds {
+                    message_id: self.message_id.clone(),
+                    ref_index_id: self.ref_index_id.clone(),
+                })
             }
         }
 
@@ -329,7 +425,10 @@ mod tests {
             if self.fail_text {
                 Err(crate::api::ApiError::Unsupported("text"))
             } else {
-                Ok(self.message_id.clone())
+                Ok(SendMessageIds {
+                    message_id: self.message_id.clone(),
+                    ref_index_id: self.ref_index_id.clone(),
+                })
             }
         }
 
@@ -345,9 +444,45 @@ mod tests {
             if self.fail_markdown {
                 Err(crate::api::ApiError::Unsupported("markdown"))
             } else {
-                Ok(self.message_id.clone())
+                Ok(SendMessageIds {
+                    message_id: self.message_id.clone(),
+                    ref_index_id: self.ref_index_id.clone(),
+                })
             }
         }
+    }
+
+    fn quoted_group_context(
+        ref_index: &SharedRefIndex,
+        group_id: &str,
+        ref_id: &str,
+    ) -> qq_maid_common::input_part::QuotedMessageContext {
+        let mut quoted = crate::gateway::platform::InboundMessage {
+            platform: crate::gateway::platform::Platform::QqOfficial,
+            account_id: Some("app".to_owned()),
+            conversation: ConversationTarget::Group {
+                target_id: group_id.to_owned(),
+            },
+            actor: crate::gateway::platform::Actor {
+                sender_id: Some("member-1".to_owned()),
+                display_name: None,
+                group_member_role: None,
+                is_bot: false,
+            },
+            message_id: "gm-quote".to_owned(),
+            current_msg_idx: None,
+            timestamp: None,
+            text: "继续".to_owned(),
+            input_parts: vec![qq_maid_common::input_part::MessageInputPart::text("继续")],
+            attachments: Vec::new(),
+            quoted: Some(qq_maid_common::input_part::QuotedMessageContext {
+                ref_msg_idx: Some(ref_id.to_owned()),
+                ..Default::default()
+            }),
+            mentioned_bot: false,
+        };
+        ref_index.lock().unwrap().enrich_inbound(&mut quoted);
+        quoted.quoted.unwrap()
     }
 
     #[tokio::test]
@@ -357,7 +492,7 @@ mod tests {
             ..MockPushSender::default()
         };
 
-        send_private_push(&sender, "u1", "markdown", "# title", "title")
+        let outcome = send_private_push(&sender, "u1", "markdown", "# title", "title")
             .await
             .unwrap();
 
@@ -365,6 +500,7 @@ mod tests {
             sender.calls(),
             vec!["c2c-markdown:u1:# title", "c2c-text:u1:title"]
         );
+        assert_eq!(outcome.delivered_text, "title");
     }
 
     #[tokio::test]
@@ -374,7 +510,7 @@ mod tests {
             ..MockPushSender::default()
         };
 
-        send_group_push(&sender, "g1", "markdown", "# title", "title")
+        let outcome = send_group_push(&sender, "g1", "markdown", "# title", "title")
             .await
             .unwrap();
 
@@ -382,6 +518,7 @@ mod tests {
             sender.calls(),
             vec!["group-markdown:g1:# title", "group-text:g1:title"]
         );
+        assert_eq!(outcome.delivered_text, "title");
     }
 
     #[tokio::test]
@@ -392,6 +529,7 @@ mod tests {
             qq_official_account_id: "app".to_owned(),
             runtime: GatewayRuntimeStatus::default(),
             group_outbound_cache: cache.clone(),
+            ref_index: crate::gateway::ref_index::ref_index(),
         };
         let sender = MockPushSender {
             message_id: Some("bot-msg-1".to_owned()),
@@ -403,7 +541,7 @@ mod tests {
             .unwrap();
         // `GatewayPushRuntime::push` 的 QQ 发送成功路径会把群消息 ID 写入缓存；
         // 这里直接复用同一个缓存写入分支，证明主动推送仍能触发“回复机器人”识别。
-        if let Some(message_id) = result {
+        if let Some(message_id) = result.ids.message_id {
             runtime
                 .group_outbound_cache
                 .lock()
@@ -415,6 +553,301 @@ mod tests {
             cache.lock().unwrap().contains("bot-msg-1"),
             "group push message_id should be cached for reply detection"
         );
+    }
+
+    #[tokio::test]
+    async fn group_push_cache_uses_message_id_and_ref_index_uses_refidx() {
+        let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        let ref_index = crate::gateway::ref_index::ref_index();
+        let runtime = GatewayPushRuntime {
+            api: panic_api_client(),
+            qq_official_account_id: "app".to_owned(),
+            runtime: GatewayRuntimeStatus::default(),
+            group_outbound_cache: cache.clone(),
+            ref_index: ref_index.clone(),
+        };
+        let intent = PushIntent {
+            target: PushTarget::qq_official(PushTargetType::Group, "g1"),
+            text: "RSS 推送正文".to_owned(),
+            fallback_text: Some("RSS 推送正文".to_owned()),
+            message_type: "text".to_owned(),
+        };
+        let sent_ids = SendMessageIds {
+            message_id: Some("qq_msg_1".to_owned()),
+            ref_index_id: Some("REFIDX_1".to_owned()),
+        };
+
+        let push_result = runtime.record_successful_push(
+            &intent,
+            "g1",
+            PushSendOutcome {
+                ids: sent_ids,
+                delivered_text: "RSS 推送正文".to_owned(),
+            },
+        );
+
+        assert_eq!(push_result.message_id.as_deref(), Some("qq_msg_1"));
+        assert!(cache.lock().unwrap().contains("qq_msg_1"));
+        assert!(!cache.lock().unwrap().contains("REFIDX_1"));
+
+        let quoted = quoted_group_context(&ref_index, "g1", "REFIDX_1");
+        assert!(quoted.lookup_found);
+        assert_eq!(quoted.text_summary.as_deref(), Some("RSS 推送正文"));
+        assert_eq!(quoted.from_bot, Some(true));
+    }
+
+    #[tokio::test]
+    async fn group_markdown_push_success_ref_index_uses_delivered_markdown_text() {
+        let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        let ref_index = crate::gateway::ref_index::ref_index();
+        let runtime = GatewayPushRuntime {
+            api: panic_api_client(),
+            qq_official_account_id: "app".to_owned(),
+            runtime: GatewayRuntimeStatus::default(),
+            group_outbound_cache: cache,
+            ref_index: ref_index.clone(),
+        };
+        let sender = MockPushSender {
+            message_id: Some("qq_md_msg".to_owned()),
+            ref_index_id: Some("REFIDX_md".to_owned()),
+            ..MockPushSender::default()
+        };
+        let intent = PushIntent {
+            target: PushTarget::qq_official(PushTargetType::Group, "g1"),
+            text: "# Markdown 标题".to_owned(),
+            fallback_text: Some("Markdown 标题".to_owned()),
+            message_type: "markdown".to_owned(),
+        };
+
+        let outcome = send_group_push(
+            &sender,
+            "g1",
+            "markdown",
+            "# Markdown 标题",
+            "Markdown 标题",
+        )
+        .await
+        .unwrap();
+        let push_result = runtime.record_successful_push(&intent, "g1", outcome);
+
+        assert_eq!(sender.calls(), vec!["group-markdown:g1:# Markdown 标题"]);
+        assert_eq!(push_result.message_id.as_deref(), Some("qq_md_msg"));
+        let quoted = quoted_group_context(&ref_index, "g1", "REFIDX_md");
+        assert!(quoted.lookup_found);
+        assert_eq!(quoted.text_summary.as_deref(), Some("# Markdown 标题"));
+    }
+
+    #[tokio::test]
+    async fn group_markdown_push_fallback_ref_index_uses_fallback_text() {
+        let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        let ref_index = crate::gateway::ref_index::ref_index();
+        let runtime = GatewayPushRuntime {
+            api: panic_api_client(),
+            qq_official_account_id: "app".to_owned(),
+            runtime: GatewayRuntimeStatus::default(),
+            group_outbound_cache: cache,
+            ref_index: ref_index.clone(),
+        };
+        let sender = MockPushSender {
+            fail_markdown: true,
+            message_id: Some("qq_fallback_msg".to_owned()),
+            ref_index_id: Some("REFIDX_fallback".to_owned()),
+            ..MockPushSender::default()
+        };
+        let intent = PushIntent {
+            target: PushTarget::qq_official(PushTargetType::Group, "g1"),
+            text: "# 失败的 Markdown".to_owned(),
+            fallback_text: Some("降级文本".to_owned()),
+            message_type: "markdown".to_owned(),
+        };
+
+        let outcome = send_group_push(&sender, "g1", "markdown", "# 失败的 Markdown", "降级文本")
+            .await
+            .unwrap();
+        let push_result = runtime.record_successful_push(&intent, "g1", outcome);
+
+        assert_eq!(
+            sender.calls(),
+            vec![
+                "group-markdown:g1:# 失败的 Markdown",
+                "group-text:g1:降级文本"
+            ]
+        );
+        assert_eq!(push_result.message_id.as_deref(), Some("qq_fallback_msg"));
+        let quoted = quoted_group_context(&ref_index, "g1", "REFIDX_fallback");
+        assert!(quoted.lookup_found);
+        assert_eq!(quoted.text_summary.as_deref(), Some("降级文本"));
+    }
+
+    #[test]
+    fn push_segment_outcomes_record_each_delivered_text_by_refidx() {
+        let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        let ref_index = crate::gateway::ref_index::ref_index();
+        let runtime = GatewayPushRuntime {
+            api: panic_api_client(),
+            qq_official_account_id: "app".to_owned(),
+            runtime: GatewayRuntimeStatus::default(),
+            group_outbound_cache: cache.clone(),
+            ref_index: ref_index.clone(),
+        };
+        let intent = PushIntent {
+            target: PushTarget::qq_official(PushTargetType::Group, "g1"),
+            text: "完整推送".to_owned(),
+            fallback_text: Some("完整推送".to_owned()),
+            message_type: "text".to_owned(),
+        };
+
+        let first = runtime.record_successful_push(
+            &intent,
+            "g1",
+            PushSendOutcome {
+                ids: SendMessageIds {
+                    message_id: Some("qq_seg_1".to_owned()),
+                    ref_index_id: Some("REFIDX_seg_1".to_owned()),
+                },
+                delivered_text: "第一段".to_owned(),
+            },
+        );
+        let second = runtime.record_successful_push(
+            &intent,
+            "g1",
+            PushSendOutcome {
+                ids: SendMessageIds {
+                    message_id: Some("qq_seg_2".to_owned()),
+                    ref_index_id: Some("REFIDX_seg_2".to_owned()),
+                },
+                delivered_text: "第二段".to_owned(),
+            },
+        );
+
+        assert_eq!(first.message_id.as_deref(), Some("qq_seg_1"));
+        assert_eq!(second.message_id.as_deref(), Some("qq_seg_2"));
+        assert!(cache.lock().unwrap().contains("qq_seg_1"));
+        assert!(cache.lock().unwrap().contains("qq_seg_2"));
+        assert!(!cache.lock().unwrap().contains("REFIDX_seg_1"));
+        assert!(!cache.lock().unwrap().contains("REFIDX_seg_2"));
+        assert_eq!(
+            quoted_group_context(&ref_index, "g1", "REFIDX_seg_1")
+                .text_summary
+                .as_deref(),
+            Some("第一段")
+        );
+        assert_eq!(
+            quoted_group_context(&ref_index, "g1", "REFIDX_seg_2")
+                .text_summary
+                .as_deref(),
+            Some("第二段")
+        );
+    }
+
+    #[tokio::test]
+    async fn todo_push_refidx_without_message_id_does_not_enter_group_cache() {
+        let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        let ref_index = crate::gateway::ref_index::ref_index();
+        let runtime = GatewayPushRuntime {
+            api: panic_api_client(),
+            qq_official_account_id: "app".to_owned(),
+            runtime: GatewayRuntimeStatus::default(),
+            group_outbound_cache: cache.clone(),
+            ref_index: ref_index.clone(),
+        };
+        let intent = PushIntent {
+            target: PushTarget::qq_official(PushTargetType::Group, "g1"),
+            text: "Todo 提醒正文".to_owned(),
+            fallback_text: Some("Todo 提醒正文".to_owned()),
+            message_type: "text".to_owned(),
+        };
+        let sent_ids = SendMessageIds {
+            message_id: None,
+            ref_index_id: Some("REFIDX_todo_only".to_owned()),
+        };
+
+        let push_result = runtime.record_successful_push(
+            &intent,
+            "g1",
+            PushSendOutcome {
+                ids: sent_ids,
+                delivered_text: "Todo 提醒正文".to_owned(),
+            },
+        );
+
+        assert_eq!(push_result.message_id, None);
+        assert!(!cache.lock().unwrap().contains("REFIDX_todo_only"));
+        let quoted = quoted_group_context(&ref_index, "g1", "REFIDX_todo_only");
+        assert!(quoted.lookup_found);
+        assert_eq!(quoted.text_summary.as_deref(), Some("Todo 提醒正文"));
+    }
+
+    #[tokio::test]
+    async fn push_with_message_id_only_does_not_forge_ref_index_entry() {
+        let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        let ref_index = crate::gateway::ref_index::ref_index();
+        let runtime = GatewayPushRuntime {
+            api: panic_api_client(),
+            qq_official_account_id: "app".to_owned(),
+            runtime: GatewayRuntimeStatus::default(),
+            group_outbound_cache: cache,
+            ref_index: ref_index.clone(),
+        };
+        let intent = PushIntent {
+            target: PushTarget::qq_official(PushTargetType::Group, "g1"),
+            text: "只有 message_id 的推送".to_owned(),
+            fallback_text: Some("只有 message_id 的推送".to_owned()),
+            message_type: "text".to_owned(),
+        };
+
+        let push_result = runtime.record_successful_push(
+            &intent,
+            "g1",
+            PushSendOutcome {
+                ids: SendMessageIds {
+                    message_id: Some("qq_msg_only".to_owned()),
+                    ref_index_id: None,
+                },
+                delivered_text: "只有 message_id 的推送".to_owned(),
+            },
+        );
+        assert_eq!(push_result.message_id.as_deref(), Some("qq_msg_only"));
+
+        let quoted = quoted_group_context(&ref_index, "g1", "qq_msg_only");
+        assert!(!quoted.lookup_found);
+    }
+
+    #[test]
+    fn push_ref_index_write_failure_is_best_effort() {
+        let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        let ref_index = crate::gateway::ref_index::ref_index();
+        let poisoned = ref_index.clone();
+        let _ = std::panic::catch_unwind(move || {
+            let _guard = poisoned.lock().unwrap();
+            panic!("poison ref_index for test");
+        });
+        let runtime = GatewayPushRuntime {
+            api: panic_api_client(),
+            qq_official_account_id: "app".to_owned(),
+            runtime: GatewayRuntimeStatus::default(),
+            group_outbound_cache: cache,
+            ref_index,
+        };
+        let intent = PushIntent {
+            target: PushTarget::qq_official(PushTargetType::Group, "g1"),
+            text: "推送正文".to_owned(),
+            fallback_text: Some("推送正文".to_owned()),
+            message_type: "text".to_owned(),
+        };
+
+        let push_result = runtime.record_successful_push(
+            &intent,
+            "g1",
+            PushSendOutcome {
+                ids: SendMessageIds {
+                    message_id: Some("qq_msg_1".to_owned()),
+                    ref_index_id: Some("REFIDX_poison".to_owned()),
+                },
+                delivered_text: "推送正文".to_owned(),
+            },
+        );
+        assert_eq!(push_result.message_id.as_deref(), Some("qq_msg_1"));
     }
 
     #[tokio::test]

--- a/qq-maid-gateway-rs/src/gateway/ref_index/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/ref_index/mod.rs
@@ -60,10 +60,10 @@ impl RefIndex {
         platform: super::platform::Platform,
         account_id: Option<&str>,
         conversation: &ConversationTarget,
-        message_id: Option<String>,
+        ref_index_id: Option<String>,
         text: &str,
     ) {
-        let Some(message_id) = clean_optional(message_id) else {
+        let Some(ref_index_id) = clean_optional(ref_index_id) else {
             return;
         };
         let entry = RefIndexEntry {
@@ -77,7 +77,7 @@ impl RefIndex {
             from_bot: true,
             timestamp: None,
         };
-        let key = key_for(platform, account_id, conversation, &message_id);
+        let key = key_for(platform, account_id, conversation, &ref_index_id);
         self.insert_key(key, entry);
     }
 
@@ -85,12 +85,7 @@ impl RefIndex {
         let Some(quoted) = inbound.quoted.as_mut() else {
             return;
         };
-        let Some(ref_id) = quoted
-            .ref_msg_idx
-            .as_deref()
-            .or(quoted.reference_id.as_deref())
-            .map(str::to_owned)
-        else {
+        let Some(ref_id) = quoted.ref_msg_idx.as_deref().map(str::to_owned) else {
             quoted.lookup_found = false;
             quoted.fallback_reason = Some("missing_reference_id".to_owned());
             return;
@@ -147,17 +142,14 @@ pub(crate) fn ref_index() -> SharedRefIndex {
 }
 
 fn ref_ids_for_current_message(inbound: &InboundMessage) -> Vec<String> {
-    [
-        Some(inbound.message_id.as_str()),
-        inbound.current_msg_idx.as_deref(),
-    ]
-    .into_iter()
-    .flatten()
-    .filter_map(|value| {
-        let value = value.trim();
-        (!value.is_empty()).then(|| value.to_owned())
-    })
-    .collect()
+    [inbound.current_msg_idx.as_deref()]
+        .into_iter()
+        .flatten()
+        .filter_map(|value| {
+            let value = value.trim();
+            (!value.is_empty()).then(|| value.to_owned())
+        })
+        .collect()
 }
 
 fn entry_from_inbound(inbound: &InboundMessage) -> RefIndexEntry {
@@ -401,6 +393,44 @@ mod tests {
         let quoted = current.quoted.unwrap();
         assert!(quoted.lookup_found);
         assert_eq!(quoted.text_summary.as_deref(), Some("上一条"));
+    }
+
+    #[test]
+    fn inbound_message_id_does_not_become_ref_index_key() {
+        let mut store = RefIndex::default();
+        store.insert_inbound(&inbound("m1", None, "上一条"));
+        let mut current = inbound("m2", None, "继续");
+        current.quoted = Some(QuotedMessageContext {
+            ref_msg_idx: Some("m1".to_owned()),
+            ..Default::default()
+        });
+
+        store.enrich_inbound(&mut current);
+
+        let quoted = current.quoted.unwrap();
+        assert!(!quoted.lookup_found);
+        assert_eq!(quoted.fallback_reason.as_deref(), Some("ref_index_miss"));
+    }
+
+    #[test]
+    fn quoted_reference_id_without_ref_msg_idx_does_not_lookup() {
+        let mut store = RefIndex::default();
+        store.insert_inbound(&inbound("m1", Some("REFIDX_1"), "上一条"));
+        let mut current = inbound("m2", None, "继续");
+        current.quoted = Some(QuotedMessageContext {
+            reference_id: Some("REFIDX_1".to_owned()),
+            ref_msg_idx: None,
+            ..Default::default()
+        });
+
+        store.enrich_inbound(&mut current);
+
+        let quoted = current.quoted.unwrap();
+        assert!(!quoted.lookup_found);
+        assert_eq!(
+            quoted.fallback_reason.as_deref(),
+            Some("missing_reference_id")
+        );
     }
 
     #[test]

--- a/qq-maid-gateway-rs/src/gateway/ref_index/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/ref_index/mod.rs
@@ -11,8 +11,12 @@ use std::{
 };
 
 use qq_maid_common::input_part::{MediaStatus, MessageInputPart, MessageMedia, QuotedMediaSummary};
+use tracing::{debug, warn};
 
-use super::platform::{ConversationTarget, InboundMessage};
+use super::{
+    logging::mask_identifier,
+    platform::{ConversationTarget, InboundMessage},
+};
 
 pub(crate) type SharedRefIndex = Arc<Mutex<RefIndex>>;
 
@@ -104,9 +108,11 @@ impl RefIndex {
             quoted.input_parts = entry.input_parts.clone();
             quoted.from_bot = Some(entry.from_bot);
             quoted.fallback_reason = None;
+            log_ref_index_hit("quoted_lookup", &key, entry);
         } else {
             quoted.lookup_found = false;
             quoted.fallback_reason = Some("ref_index_miss".to_owned());
+            log_ref_index_miss(&self.entries, &key);
         }
     }
 
@@ -124,6 +130,7 @@ impl RefIndex {
         if !self.entries.contains_key(&key) {
             self.order.push_back(key.clone());
         }
+        log_ref_index_insert(&key, &entry);
         self.entries.insert(key, entry);
         while self.entries.len() > MAX_REF_ENTRIES {
             if let Some(oldest) = self.order.pop_front() {
@@ -203,6 +210,68 @@ fn key_for(
         peer_id: conversation.target_id().to_owned(),
         ref_id: ref_id.to_owned(),
     }
+}
+
+fn log_ref_index_insert(key: &RefIndexKey, entry: &RefIndexEntry) {
+    debug!(
+        platform = %key.platform,
+        account = %mask_identifier(&key.app_id),
+        account_present = key.app_id != "-",
+        peer_kind = %key.peer_kind,
+        peer_id = %mask_identifier(&key.peer_id),
+        ref_id = %mask_identifier(&key.ref_id),
+        from_bot = entry.from_bot,
+        text_chars = entry
+            .text_summary
+            .as_deref()
+            .map(|text| text.chars().count())
+            .unwrap_or(0),
+        media_count = entry.media_summaries.len(),
+        input_part_count = entry.input_parts.len(),
+        "ref_index insert"
+    );
+}
+
+fn log_ref_index_hit(reason: &'static str, key: &RefIndexKey, entry: &RefIndexEntry) {
+    debug!(
+        platform = %key.platform,
+        account = %mask_identifier(&key.app_id),
+        account_present = key.app_id != "-",
+        peer_kind = %key.peer_kind,
+        peer_id = %mask_identifier(&key.peer_id),
+        ref_id = %mask_identifier(&key.ref_id),
+        from_bot = entry.from_bot,
+        text_present = entry.text_summary.is_some(),
+        media_count = entry.media_summaries.len(),
+        reason,
+        "ref_index hit"
+    );
+}
+
+fn log_ref_index_miss(entries: &HashMap<RefIndexKey, RefIndexEntry>, query: &RefIndexKey) {
+    let same_ref_candidates = entries
+        .keys()
+        .filter(|key| key.platform == query.platform && key.ref_id == query.ref_id)
+        .collect::<Vec<_>>();
+    let first_candidate = same_ref_candidates.first().copied();
+    warn!(
+        platform = %query.platform,
+        account = %mask_identifier(&query.app_id),
+        account_present = query.app_id != "-",
+        peer_kind = %query.peer_kind,
+        peer_id = %mask_identifier(&query.peer_id),
+        ref_id = %mask_identifier(&query.ref_id),
+        same_ref_candidate_count = same_ref_candidates.len(),
+        candidate_account = %first_candidate
+            .map(|key| mask_identifier(&key.app_id))
+            .unwrap_or_default(),
+        candidate_account_present = first_candidate.is_some_and(|key| key.app_id != "-"),
+        candidate_peer_kind = first_candidate.map(|key| key.peer_kind.as_str()).unwrap_or(""),
+        candidate_peer_id = %first_candidate
+            .map(|key| mask_identifier(&key.peer_id))
+            .unwrap_or_default(),
+        "ref_index miss"
+    );
 }
 
 fn clean_optional(value: Option<String>) -> Option<String> {
@@ -475,6 +544,92 @@ mod tests {
             Some("群聊回复")
         );
         assert!(!missing_account.quoted.as_ref().unwrap().lookup_found);
+    }
+
+    #[test]
+    fn qq_group_quote_bot_outbound_by_refidx_hits_after_account_normalization() {
+        let mut store = RefIndex::default();
+        let conversation = ConversationTarget::Group {
+            target_id: "group-1".to_owned(),
+        };
+        store.insert_bot_outbound(
+            super::super::platform::Platform::QqOfficial,
+            Some("app"),
+            &conversation,
+            Some("REFIDX_bot_group_reply".to_owned()),
+            "机器人上一条群回复",
+        );
+
+        let mut current = group_inbound("gm2", Some("REFIDX_current"), "继续解释");
+        current.account_id = Some("app".to_owned());
+        current.quoted = Some(QuotedMessageContext {
+            current_message_id: Some("gm2".to_owned()),
+            current_msg_idx: Some("REFIDX_current".to_owned()),
+            reference_id: Some("REFIDX_bot_group_reply".to_owned()),
+            ref_msg_idx: Some("REFIDX_bot_group_reply".to_owned()),
+            ..Default::default()
+        });
+
+        store.enrich_inbound(&mut current);
+
+        let quoted = current.quoted.as_ref().unwrap();
+        assert!(quoted.lookup_found);
+        assert_eq!(quoted.text_summary.as_deref(), Some("机器人上一条群回复"));
+        assert_eq!(quoted.from_bot, Some(true));
+    }
+
+    #[test]
+    fn qq_group_quote_user_message_by_refidx_hits_and_marks_user() {
+        let mut store = RefIndex::default();
+        store.insert_inbound(&group_inbound(
+            "gm-user",
+            Some("REFIDX_user_text"),
+            "用户原文",
+        ));
+        let mut current = group_inbound("gm-current", Some("REFIDX_current"), "这句话什么意思");
+        current.quoted = Some(QuotedMessageContext {
+            ref_msg_idx: Some("REFIDX_user_text".to_owned()),
+            ..Default::default()
+        });
+
+        store.enrich_inbound(&mut current);
+
+        let quoted = current.quoted.as_ref().unwrap();
+        assert!(quoted.lookup_found);
+        assert_eq!(quoted.text_summary.as_deref(), Some("用户原文"));
+        assert_eq!(quoted.from_bot, Some(false));
+        assert!(quoted.fallback_text().contains("from=user"));
+    }
+
+    #[test]
+    fn qq_group_mixed_media_quote_by_refidx_keeps_image_part() {
+        let mut message = group_inbound("gm-image", Some("REFIDX_group_image"), "看图");
+        message
+            .input_parts
+            .push(MessageInputPart::image(MessageMedia {
+                mime_type: Some("image/jpeg".to_owned()),
+                filename: Some("group.jpg".to_owned()),
+                url: Some("https://example.test/group.jpg".to_owned()),
+                ..Default::default()
+            }));
+        let mut store = RefIndex::default();
+        store.insert_inbound(&message);
+        let mut current = group_inbound("gm-current", Some("REFIDX_current"), "这张图呢");
+        current.quoted = Some(QuotedMessageContext {
+            ref_msg_idx: Some("REFIDX_group_image".to_owned()),
+            ..Default::default()
+        });
+
+        store.enrich_inbound(&mut current);
+
+        let quoted = current.quoted.as_ref().unwrap();
+        assert!(quoted.lookup_found);
+        assert_eq!(quoted.text_summary.as_deref(), Some("看图"));
+        assert_eq!(quoted.media_summaries.len(), 1);
+        assert!(matches!(
+            quoted.input_parts[1],
+            MessageInputPart::Image { .. }
+        ));
     }
 
     #[test]

--- a/qq-maid-gateway-rs/src/gateway/stream/event_stream.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/event_stream.rs
@@ -1,9 +1,6 @@
 use std::{future::Future, pin::Pin};
 
-use super::super::{
-    outbound::{RuntimeRecordingSender, record_qq_send_result},
-    typing::TypingStopReason,
-};
+use super::super::{outbound::RuntimeRecordingSender, typing::TypingStopReason};
 use crate::{
     api::{C2cStreamState, OutboundSender, StreamSendResult},
     markdown::MarkdownPayload,
@@ -69,7 +66,10 @@ impl C2cStreamSender for RuntimeRecordingSender<'_> {
                     reset,
                 )
                 .await;
-            record_qq_send_result(self.runtime, &result);
+            match &result {
+                Ok(_) => self.runtime.record_qq_send_success(),
+                Err(err) => self.runtime.record_qq_send_failure(err.log_summary()),
+            }
             result
         })
     }

--- a/qq-maid-gateway-rs/src/gateway/stream/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests.rs
@@ -233,8 +233,8 @@ fn quoted_lookup_found(
     let mut message = c2c_message();
     message.message_id = "msg-quote".to_owned();
     message.reply = Some(MessageReply {
-        message_id: ref_id.to_owned(),
-        ref_msg_idx: None,
+        message_id: "qq-reply-message-id".to_owned(),
+        ref_msg_idx: Some(ref_id.to_owned()),
         content: None,
     });
     let mut inbound = crate::gateway::platform::qq_official::inbound_from_c2c(&message);

--- a/qq-maid-gateway-rs/src/gateway/stream/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests.rs
@@ -3,7 +3,10 @@ use crate::gateway::typing::{
     C2cTypingSender, C2cTypingStatusGuard, TypingSendFuture, TypingStopReason,
 };
 use crate::{
-    api::{ApiError, C2cReplyTarget, C2cStreamState, OutboundSender, SendFuture, StreamSendResult},
+    api::{
+        ApiError, C2cReplyTarget, C2cStreamState, OutboundSender, SendFuture, SendMessageIds,
+        StreamSendResult,
+    },
     config::{
         AgentTypingConfig, AppConfig, DEFAULT_CONVERSATION_QUEUE_CAPACITY,
         DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT, DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS,
@@ -105,7 +108,7 @@ impl C2cTypingSender for NoopTypingSender {
         _user_openid: &'a str,
         _msg_id: Option<&'a str>,
     ) -> TypingSendFuture<'a> {
-        Box::pin(async move { Ok(None) })
+        Box::pin(async move { Ok(SendMessageIds::none()) })
     }
 }
 
@@ -129,7 +132,10 @@ impl OutboundSender for FakeStreamSender {
                 content: text.to_owned(),
                 msg_id: target.msg_id.clone(),
             });
-            Ok(Some("ordinary-text-id".to_owned()))
+            Ok(SendMessageIds {
+                message_id: Some("ordinary-text-id".to_owned()),
+                ref_index_id: Some("REFIDX_ordinary_text".to_owned()),
+            })
         })
     }
 
@@ -143,7 +149,10 @@ impl OutboundSender for FakeStreamSender {
                 content: markdown.content.clone(),
                 msg_id: target.msg_id.clone(),
             });
-            Ok(Some("ordinary-markdown-id".to_owned()))
+            Ok(SendMessageIds {
+                message_id: Some("ordinary-markdown-id".to_owned()),
+                ref_index_id: Some("REFIDX_ordinary_markdown".to_owned()),
+            })
         })
     }
 
@@ -332,8 +341,12 @@ async fn stream_pending_fallback_records_ref_index() {
     .unwrap();
 
     assert_eq!(
-        quoted_lookup_found(&ref_index, &config, "ordinary-markdown-id").as_deref(),
+        quoted_lookup_found(&ref_index, &config, "REFIDX_ordinary_markdown").as_deref(),
         Some("晚上好")
+    );
+    assert_eq!(
+        quoted_lookup_found(&ref_index, &config, "ordinary-markdown-id"),
+        None
     );
 }
 

--- a/qq-maid-gateway-rs/src/gateway/typing.rs
+++ b/qq-maid-gateway-rs/src/gateway/typing.rs
@@ -255,7 +255,7 @@ impl Drop for C2cTypingStatusGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::ApiError;
+    use crate::api::{ApiError, SendMessageIds};
     use std::sync::{
         Mutex,
         atomic::{AtomicUsize, Ordering},
@@ -331,7 +331,7 @@ mod tests {
                     Some(rx) => rx
                         .await
                         .unwrap_or_else(|_| Err(ApiError::Unsupported("typing"))),
-                    None => Ok(None),
+                    None => Ok(SendMessageIds::none()),
                 }
             })
         }
@@ -371,7 +371,7 @@ mod tests {
     #[tokio::test]
     async fn stop_before_delay_threshold_does_not_send_typing() {
         pause();
-        let sender = FakeTypingSender::ready(Ok(None));
+        let sender = FakeTypingSender::ready(Ok(SendMessageIds::none()));
         let mut guard = C2cTypingStatusGuard::schedule_with_sender(
             &typing_config(Duration::from_millis(100)),
             sender.clone(),
@@ -392,7 +392,7 @@ mod tests {
 
     #[tokio::test]
     async fn sends_typing_once_after_delay_threshold() {
-        let sender = FakeTypingSender::ready(Ok(Some("typing-id".to_owned())));
+        let sender = FakeTypingSender::ready(Ok(SendMessageIds::message_id("typing-id")));
         let guard = C2cTypingStatusGuard::schedule_with_sender(
             &typing_config(Duration::from_millis(1)),
             sender.clone(),
@@ -423,7 +423,7 @@ mod tests {
         yield_tasks().await;
         advance(Duration::from_millis(100)).await;
         guard.stop(TypingStopReason::FinalReply);
-        sender.complete(Ok(Some("typing-id".to_owned())));
+        sender.complete(Ok(SendMessageIds::message_id("typing-id")));
         yield_tasks().await;
 
         assert!(!guard.sent_for_test());
@@ -445,7 +445,7 @@ mod tests {
         advance(Duration::from_millis(10)).await;
         sender.wait_started().await;
         guard.stop(TypingStopReason::FirstFrame);
-        sender.complete(Ok(Some("typing-id".to_owned())));
+        sender.complete(Ok(SendMessageIds::message_id("typing-id")));
         yield_tasks().await;
 
         assert_eq!(sender.calls(), 1);
@@ -497,7 +497,7 @@ mod tests {
 
     #[tokio::test]
     async fn different_source_message_ids_are_isolated() {
-        let sender = FakeTypingSender::ready(Ok(None));
+        let sender = FakeTypingSender::ready(Ok(SendMessageIds::none()));
         let mut first = C2cTypingStatusGuard::schedule_with_sender(
             &typing_config(Duration::from_secs(60)),
             sender.clone(),
@@ -529,7 +529,7 @@ mod tests {
     #[tokio::test]
     async fn drop_before_delay_cleans_task_without_late_typing() {
         pause();
-        let sender = FakeTypingSender::ready(Ok(None));
+        let sender = FakeTypingSender::ready(Ok(SendMessageIds::none()));
         let guard = C2cTypingStatusGuard::schedule_with_sender(
             &typing_config(Duration::from_millis(100)),
             sender.clone(),

--- a/qq-maid-gateway-rs/src/message_chunk.rs
+++ b/qq-maid-gateway-rs/src/message_chunk.rs
@@ -15,7 +15,8 @@ use thiserror::Error;
 use tracing::{debug, info, trace, warn};
 
 use crate::api::{
-    ApiError, C2cReplyTarget, GroupOutboundSender, GroupReplyTarget, OutboundSender, SendResult,
+    ApiError, C2cReplyTarget, GroupOutboundSender, GroupReplyTarget, OutboundSender,
+    SendMessageIds, SendResult,
 };
 use crate::logging::mask_openid;
 use crate::markdown::MarkdownPayload;
@@ -788,18 +789,18 @@ fn remaining_chars(chunks: &[OutboundChunk], from_index: usize) -> usize {
 /// 逐段发送，每段成功后才发送下一段；任一段失败立即停止并返回 `OutboundSendError`。
 /// 这里对齐官方非流式长消息发送方式：只 `await` 当前段返回，不额外 `sleep`，
 /// 当前段成功后立即发送下一段。
-/// `on_sent` 仅在分段成功时回调一次（带该段序号与 QQ 返回的 message id），调用方据此
-/// 写入 `BotOutboundCache`；失败段不回调。返回值为各段成功后收集到的 message id 列表。
+/// `on_sent` 仅在分段成功时回调一次（带该段序号与 QQ 返回的 ID 集），调用方按用途选择
+/// `message_id` 或 `ref_index_id`；失败段不回调。返回值为各段成功后收集到的 ID 集列表。
 pub async fn send_c2c_outbound_chunked<S, F>(
     sender: &S,
     target: &C2cReplyTarget,
     message: &OutboundMessage,
     limits: &ChunkLimits,
     mut on_sent: F,
-) -> Result<Vec<Option<String>>, OutboundSendError>
+) -> Result<Vec<SendMessageIds>, OutboundSendError>
 where
     S: OutboundSender + ?Sized,
-    F: FnMut(usize, &Option<String>),
+    F: FnMut(usize, &SendMessageIds),
 {
     let chunks = chunk_outbound(message, limits);
     let total = chunks.len();
@@ -886,10 +887,10 @@ pub async fn send_group_outbound_chunked<S, F>(
     message: &OutboundMessage,
     limits: &ChunkLimits,
     mut on_sent: F,
-) -> Result<Vec<Option<String>>, OutboundSendError>
+) -> Result<Vec<SendMessageIds>, OutboundSendError>
 where
     S: GroupOutboundSender + ?Sized,
-    F: FnMut(usize, &Option<String>),
+    F: FnMut(usize, &SendMessageIds),
 {
     let chunks = chunk_outbound(message, limits);
     let total = chunks.len();

--- a/qq-maid-gateway-rs/src/message_chunk/tests.rs
+++ b/qq-maid-gateway-rs/src/message_chunk/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::api::{C2cReplyTarget, GroupReplyTarget, OutboundSender, SendFuture};
+use crate::api::{C2cReplyTarget, GroupReplyTarget, OutboundSender, SendFuture, SendMessageIds};
 use crate::markdown::MarkdownPayload;
 use crate::render::OutboundMessage;
 use std::sync::Mutex;
@@ -195,10 +195,11 @@ impl OutboundSender for RecordingC2cSender {
     fn send_text<'a>(&'a self, _target: &'a C2cReplyTarget, text: &'a str) -> SendFuture<'a> {
         Box::pin(async move {
             self.text_calls.lock().unwrap().push(text.to_owned());
-            Ok(Some(format!(
-                "tid-{}",
-                self.text_calls.lock().unwrap().len()
-            )))
+            let index = self.text_calls.lock().unwrap().len();
+            Ok(SendMessageIds {
+                message_id: Some(format!("tid-{index}")),
+                ref_index_id: Some(format!("REFIDX_tid_{index}")),
+            })
         })
     }
     fn send_markdown<'a>(
@@ -215,7 +216,10 @@ impl OutboundSender for RecordingC2cSender {
             {
                 return Err(ApiError::Unsupported("markdown"));
             }
-            Ok(Some(format!("mid-{index}")))
+            Ok(SendMessageIds {
+                message_id: Some(format!("mid-{index}")),
+                ref_index_id: Some(format!("REFIDX_mid_{index}")),
+            })
         })
     }
     fn send_image<'a>(
@@ -293,7 +297,10 @@ async fn c2c_partially_sent_returns_error_with_progress() {
                 if i == *self.fail.lock().unwrap() {
                     return Err(ApiError::Unsupported("text"));
                 }
-                Ok(Some(format!("tid-{i}")))
+                Ok(SendMessageIds {
+                    message_id: Some(format!("tid-{i}")),
+                    ref_index_id: Some(format!("REFIDX_tid_{i}")),
+                })
             })
         }
         fn send_markdown<'a>(
@@ -353,7 +360,10 @@ async fn c2c_not_sent_when_first_chunk_fails() {
                 if i == 0 {
                     return Err(ApiError::Unsupported("text"));
                 }
-                Ok(Some(format!("tid-{i}")))
+                Ok(SendMessageIds {
+                    message_id: Some(format!("tid-{i}")),
+                    ref_index_id: Some(format!("REFIDX_tid_{i}")),
+                })
             })
         }
         fn send_markdown<'a>(
@@ -393,7 +403,7 @@ impl crate::api::GroupOutboundSender for RecordingGroupSender {
     fn send_text<'a>(&'a self, _target: &'a GroupReplyTarget, text: &'a str) -> SendFuture<'a> {
         Box::pin(async move {
             self.text_calls.lock().unwrap().push(text.to_owned());
-            Ok(None)
+            Ok(SendMessageIds::none())
         })
     }
     fn send_markdown<'a>(
@@ -406,7 +416,7 @@ impl crate::api::GroupOutboundSender for RecordingGroupSender {
                 .lock()
                 .unwrap()
                 .push(markdown.content.clone());
-            Ok(None)
+            Ok(SendMessageIds::none())
         })
     }
 }


### PR DESCRIPTION
## 概要

- 将 QQ 发送返回 ID 拆分为真实平台 `message_id` 和引用索引 `ref_index_id`
- 修复 QQ 群聊引用上下文写入与查询的 platform/account/conversation/ref key 一致性
- 在 Gateway 主动推送成功后 best-effort 写入 ref_index，不改变 Core `PushResult`、RSS fingerprint 或 Todo reminder 状态语义

## 根因

QQ 群聊引用查询时可能只拿到 `ref_msg_idx` / `REFIDX_*`，而旧 Gateway 发送结果只有一个 ID 字段。这个字段同时服务 outbound cache 和 ref_index，导致真实平台 `message_id` 与 QQ 引用索引语义混用：发送后可能用真实 `message_id` 写入 ref_index，但后续群聊引用用 `REFIDX_*` 查询，于是出现 `ref_index_miss`。

## 主要改动

- `SendMessageIds` 分别保存：
  - `message_id`：真实平台消息 ID，用于 outbound cache、主动推送缓存、平台消息链路
  - `ref_index_id`：QQ `msg_idx/ref_msg_idx/REFIDX_*`，只用于 ref_index / quoted context
- 群聊 reply-to-bot 判断支持 `ref_msg_idx`，但只有命中 bot outbound 的独立 ref_index-id 集合时才认为是回复机器人
- 群聊普通回复、C2C 回复和主动推送成功后，优先用 `ref_index_id` 写入 ref_index
- 主动推送内部新增 outcome，保存发送 ID 和 `delivered_text`，确保 ref_index 内容对应实际投递文本
- ref_index 写入失败只记录脱敏 warn，不影响 RSS/Todo push 成功，也不会导致重复推送
- 增加 ref_index 写入、命中、miss 的脱敏诊断日志

## 边界说明

- Core `PushResult` 仍只暴露真实 `message_id`
- RSS fingerprint / entry 去重逻辑未修改
- Todo reminder / occurrence / planned_at / sent 状态逻辑未修改
- 没有 `ref_index_id` 时，不使用 `message_id` 伪造引用索引
- OneBot / 微信路径不引入 QQ `REFIDX_*` 语义

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p qq-maid-gateway-rs`
- `cargo check -p qq-maid-gateway-rs`
- `cargo clippy -p qq-maid-gateway-rs --all-targets --all-features -- -D warnings`
- `cargo test -p qq-maid-core rss`
- `cargo test -p qq-maid-core todo_reminder`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace --release --all-features`
- `git diff --check`
