### PR TITLE
[codex] 补齐 QQ 群聊引用索引覆盖

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 本文档基于 [keep a changelog](https://keepachangelog.com/zh-CN/1.0.0/) 格式，记录每个已发布版本的变更。
 
+## [v0.13.2] - 2026-07-06
+
+### Fixed
+
+* **QQ 群聊引用索引热修复**（PR #290）：收口真实平台 `message_id` 与 QQ 引用索引 `REFIDX_* / ref_msg_idx` 的字段边界，避免 `REFIDX_*` 污染 outbound cache、主动推送缓存或 Core 公共推送结果；群聊 quoted context 只使用引用索引恢复上下文，`reply.message_id` 不再被伪造成 `ref_msg_idx`。
+
+* **群聊回复机器人判定修正**（PR #290）：支持通过命中的 bot outbound `ref_msg_idx` 识别“回复机器人”，但不会仅凭 `ref_msg_idx` 存在或仅凭长得像 `REFIDX_*` 的 `reply.message_id` 误判；只有真实 `message_id` 的主动推送仍可成功投递，但不会写入伪造 ref_index。
+
 ## [v0.13.1] - 2026-07-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 本文档基于 [keep a changelog](https://keepachangelog.com/zh-CN/1.0.0/) 格式，记录每个已发布版本的变更。
 
-## [v0.13.2] - 2026-07-06
-
-### Fixed
-
-* **QQ 群聊引用索引热修复**（PR #290）：收口真实平台 `message_id` 与 QQ 引用索引 `REFIDX_* / ref_msg_idx` 的字段边界，避免 `REFIDX_*` 污染 outbound cache、主动推送缓存或 Core 公共推送结果；群聊 quoted context 只使用引用索引恢复上下文，`reply.message_id` 不再被伪造成 `ref_msg_idx`。
-
-* **群聊回复机器人判定修正**（PR #290）：支持通过命中的 bot outbound `ref_msg_idx` 识别“回复机器人”，但不会仅凭 `ref_msg_idx` 存在或仅凭长得像 `REFIDX_*` 的 `reply.message_id` 误判；只有真实 `message_id` 的主动推送仍可成功投递，但不会写入伪造 ref_index。
-
 ## [v0.13.1] - 2026-07-06
 
 ### Added

--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -810,6 +810,8 @@ mod tests {
             message_id: "qq-reply-message-id".to_owned(),
             ref_msg_idx: Some(ref_id.to_owned()),
             content: None,
+            input_parts: Vec::new(),
+            media_summaries: Vec::new(),
         });
         let mut inbound = platform::qq_official::inbound_from_c2c(&message);
         inbound.account_id = Some(config.app_id.clone());

--- a/qq-maid-gateway-rs/src/gateway/event.rs
+++ b/qq-maid-gateway-rs/src/gateway/event.rs
@@ -4,8 +4,10 @@ use thiserror::Error;
 use tracing::warn;
 
 use crate::gateway::logging::mask_openid;
-use crate::gateway::ref_index::qq::{RawMessageScene, RawMsgElement, parse_ref_indices};
-use qq_maid_common::input_part::{MediaStatus, MessageInputPart, MessageMedia};
+use crate::gateway::ref_index::qq::{
+    MSG_TYPE_QUOTE, RawMessageScene, RawMsgElement, parse_ref_indices,
+};
+use qq_maid_common::input_part::{MediaStatus, MessageInputPart, MessageMedia, QuotedMediaSummary};
 
 pub const EVENT_C2C_MESSAGE_CREATE: &str = "C2C_MESSAGE_CREATE";
 pub const EVENT_GROUP_AT_MESSAGE_CREATE: &str = "GROUP_AT_MESSAGE_CREATE";
@@ -104,6 +106,8 @@ pub struct MessageReply {
     pub message_id: String,
     pub ref_msg_idx: Option<String>,
     pub content: Option<String>,
+    pub input_parts: Vec<MessageInputPart>,
+    pub media_summaries: Vec<QuotedMediaSummary>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -235,6 +239,13 @@ struct RawMessageReply {
     message_id: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct QuotedPayloadFallback {
+    content: Option<String>,
+    input_parts: Vec<MessageInputPart>,
+    media_summaries: Vec<QuotedMediaSummary>,
+}
+
 #[derive(Debug, Error)]
 pub enum EventError {
     #[error("invalid C2C message event: {0}")]
@@ -280,6 +291,7 @@ pub fn parse_c2c_message(envelope: &GatewayEnvelope) -> Result<Option<C2cMessage
         raw.reply.as_ref(),
         raw.quote.as_ref(),
         ref_indices.ref_msg_idx.clone(),
+        quoted_payload_fallback(raw.message_type, &raw.msg_elements),
     );
     let timestamp = raw.timestamp;
     let input_parts = input_parts_from_content_and_attachments(
@@ -357,6 +369,7 @@ pub fn parse_group_message(envelope: &GatewayEnvelope) -> Result<Option<GroupMes
         raw.reply.as_ref(),
         raw.quote.as_ref(),
         ref_indices.ref_msg_idx.clone(),
+        quoted_payload_fallback(raw.message_type, &raw.msg_elements),
     );
     let input_parts = input_parts_from_content_and_attachments(
         &base_content,
@@ -422,6 +435,7 @@ fn extract_message_reply(
     reply: Option<&RawMessageReply>,
     quote: Option<&RawMessageReply>,
     ref_msg_idx: Option<String>,
+    fallback: QuotedPayloadFallback,
 ) -> Option<MessageReply> {
     let reference_id = reply
         .and_then(|item| item.message_id.as_deref())
@@ -434,8 +448,41 @@ fn extract_message_reply(
     reference_id.map(|message_id| MessageReply {
         message_id,
         ref_msg_idx,
-        content: None,
+        content: fallback.content,
+        input_parts: fallback.input_parts,
+        media_summaries: fallback.media_summaries,
     })
+}
+
+fn quoted_payload_fallback(
+    message_type: Option<u64>,
+    msg_elements: &[RawMsgElement],
+) -> QuotedPayloadFallback {
+    if message_type != Some(MSG_TYPE_QUOTE) {
+        return QuotedPayloadFallback::default();
+    }
+    let Some(element) = msg_elements.first() else {
+        return QuotedPayloadFallback::default();
+    };
+    let raw_content = element.content.as_deref().unwrap_or_default();
+    let parsed = parse_safe_content_parts(raw_content, "qq_official");
+    let content = parsed.text.trim().to_owned();
+    let input_parts = input_parts_from_content_and_attachments(
+        &content,
+        parsed.input_parts,
+        &element.attachments,
+        "qq_official",
+    );
+    let media_summaries = input_parts
+        .iter()
+        .filter_map(QuotedMediaSummary::from_input_part)
+        .collect::<Vec<_>>();
+
+    QuotedPayloadFallback {
+        content: (!content.is_empty()).then_some(content),
+        input_parts,
+        media_summaries,
+    }
 }
 
 fn extract_cq_reply_message_id(content: &str) -> Option<&str> {
@@ -1211,6 +1258,8 @@ mod tests {
                 message_id: "quoted-1".to_owned(),
                 ref_msg_idx: None,
                 content: None,
+                input_parts: Vec::new(),
+                media_summaries: Vec::new(),
             })
         );
     }
@@ -1240,6 +1289,8 @@ mod tests {
                 message_id: "quoted-2".to_owned(),
                 ref_msg_idx: None,
                 content: None,
+                input_parts: Vec::new(),
+                media_summaries: Vec::new(),
             })
         );
     }
@@ -1269,6 +1320,8 @@ mod tests {
                 message_id: "quoted-3".to_owned(),
                 ref_msg_idx: None,
                 content: None,
+                input_parts: Vec::new(),
+                media_summaries: Vec::new(),
             })
         );
     }
@@ -1303,7 +1356,52 @@ mod tests {
                 message_id: "REFIDX_quoted".to_owned(),
                 ref_msg_idx: Some("REFIDX_quoted".to_owned()),
                 content: None,
+                input_parts: Vec::new(),
+                media_summaries: Vec::new(),
             })
         );
+    }
+
+    #[test]
+    fn parses_qq_quote_msg_element_as_payload_fallback() {
+        let envelope = GatewayEnvelope {
+            op: 0,
+            s: Some(42),
+            t: Some(EVENT_GROUP_AT_MESSAGE_CREATE.to_owned()),
+            id: None,
+            d: json!({
+                "id": "msg-current",
+                "group_openid": "group-1",
+                "author": {"member_openid": "member-1"},
+                "content": "查看这条",
+                "message_type": 103,
+                "message_scene": {
+                    "ext": ["msg_idx=REFIDX_current"]
+                },
+                "msg_elements": [{
+                    "msg_idx": "REFIDX_quoted",
+                    "content": "被引用原文",
+                    "attachments": [{
+                        "content_type": "image/png",
+                        "filename": "quoted.png",
+                        "url": "https://example.test/quoted.png"
+                    }]
+                }]
+            }),
+        };
+
+        let message = parse_group_message(&envelope).unwrap().unwrap();
+        let reply = message.reply.unwrap();
+
+        assert_eq!(message.current_msg_idx.as_deref(), Some("REFIDX_current"));
+        assert_eq!(reply.ref_msg_idx.as_deref(), Some("REFIDX_quoted"));
+        assert_eq!(reply.message_id, "REFIDX_quoted");
+        assert_eq!(reply.content.as_deref(), Some("被引用原文"));
+        assert_eq!(reply.input_parts.len(), 2);
+        assert_eq!(reply.media_summaries.len(), 1);
+        assert!(matches!(
+            reply.input_parts[1],
+            MessageInputPart::Image { .. }
+        ));
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -113,6 +113,7 @@ pub(super) async fn handle_group_message(
     let masked_group = mask_openid(&message.group_openid);
     let respond_content =
         crate::respond::build_group_respond_content(&message, &config.group_active_keywords);
+    observe_group_message_ref_index(&message, respond, ref_index);
     if should_ignore_group_message(
         &message,
         &respond_content,
@@ -258,6 +259,25 @@ pub(super) async fn handle_group_message(
         }
     }
     Ok(())
+}
+
+fn observe_group_message_ref_index(
+    message: &GroupMessage,
+    respond: &RespondClient,
+    ref_index: &SharedRefIndex,
+) {
+    if message.author_is_self || message.author_is_bot || message.current_msg_idx.is_none() {
+        return;
+    }
+    let inbound = respond.prepare_inbound(platform::qq_official::inbound_from_group(message));
+    match ref_index.lock() {
+        Ok(mut index) => index.insert_inbound(&inbound),
+        Err(_) => warn!(
+            message_id = %message.message_id,
+            group = %mask_openid(&message.group_openid),
+            "group inbound ref_index observe skipped because index lock is poisoned"
+        ),
+    }
 }
 
 async fn send_group_respond_response(
@@ -526,11 +546,13 @@ mod tests {
 
     struct MockCore {
         response: RespondResponse,
+        respond_calls: Arc<AtomicUsize>,
     }
 
     #[async_trait::async_trait]
     impl CoreService for MockCore {
         async fn respond(&self, _request: CoreRequest) -> Result<CoreRespondOutput, CoreError> {
+            self.respond_calls.fetch_add(1, Ordering::SeqCst);
             Ok(CoreRespondOutput::Complete(self.response.clone()))
         }
 
@@ -557,6 +579,10 @@ mod tests {
     }
 
     fn respond_client() -> RespondClient {
+        respond_client_with_counter(Arc::new(AtomicUsize::new(0)))
+    }
+
+    fn respond_client_with_counter(respond_calls: Arc<AtomicUsize>) -> RespondClient {
         RespondClient::new(Arc::new(MockCore {
             response: RespondResponse {
                 text: None,
@@ -566,6 +592,7 @@ mod tests {
                 command: None,
                 diagnostics: None,
             },
+            respond_calls,
         }))
     }
 
@@ -790,6 +817,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn plain_group_message_observes_ref_index_before_mode_policy_without_core_call() {
+        let config = test_config();
+        let mut message = group_message("普通群友消息", GroupEventType::GroupMessage);
+        message.message_id = "group-observed".to_owned();
+        message.current_msg_idx = Some("REFIDX_user_observed".to_owned());
+        let respond_calls = Arc::new(AtomicUsize::new(0));
+        let ref_index = crate::gateway::ref_index::ref_index();
+
+        handle_group_message(
+            message,
+            &config,
+            &respond_client_with_counter(respond_calls.clone()),
+            &api_client(),
+            &crate::gateway::dedupe::MessageDedupe::new(Duration::from_secs(60)),
+            &Arc::new(Mutex::new(BotOutboundCache::default())),
+            &Arc::new(Mutex::new(GroupCooldowns::default())),
+            &bot_identity(),
+            &GatewayRuntimeStatus::new(),
+            &ref_index,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(respond_calls.load(Ordering::SeqCst), 0);
+
+        let mut quoted = group_message("查看这条", GroupEventType::GroupAtMessage);
+        quoted.message_id = "group-quote".to_owned();
+        quoted.reply = Some(crate::gateway::event::MessageReply {
+            message_id: "qq_reply_payload_id".to_owned(),
+            ref_msg_idx: Some("REFIDX_user_observed".to_owned()),
+            content: None,
+            input_parts: Vec::new(),
+            media_summaries: Vec::new(),
+        });
+        let mut inbound =
+            respond_client().prepare_inbound(platform::qq_official::inbound_from_group(&quoted));
+        ref_index.lock().unwrap().enrich_inbound(&mut inbound);
+
+        let quoted_context = inbound.quoted.as_ref().unwrap();
+        assert!(quoted_context.lookup_found);
+        assert_eq!(quoted_context.text_summary.as_deref(), Some("普通群友消息"));
+        assert_eq!(quoted_context.from_bot, Some(false));
+    }
+
+    #[tokio::test]
     async fn cooldown_and_dedupe_blocked_group_messages_do_not_download_media() {
         let mut config = test_config();
         config.group_message_mode = GroupMessageMode::Active;
@@ -938,6 +1010,8 @@ mod tests {
             message_id: "qq_reply_payload_id".to_owned(),
             ref_msg_idx: Some("REFIDX_1".to_owned()),
             content: None,
+            input_parts: Vec::new(),
+            media_summaries: Vec::new(),
         });
         assert!(should_process_group_message(
             crate::config::GroupMessageMode::Mention,

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -60,26 +60,16 @@ fn group_reply_mention_prefix(
         .map(|member_openid| format!("<@{member_openid}>"))
 }
 
-fn prefix_group_reply_text(
-    message: &GroupMessage,
-    text: &str,
-    capability: &ReplyCapability,
-) -> String {
-    let Some(prefix) = group_reply_mention_prefix(message, capability) else {
-        return text.to_owned();
-    };
-    if text.trim().is_empty() {
-        prefix
-    } else {
-        format!("{prefix}\n{text}")
-    }
-}
-
 fn prefix_group_reply_outbound(
     message: &GroupMessage,
     outbound: OutboundMessage,
     capability: &ReplyCapability,
 ) -> OutboundMessage {
+    // QQ 官方群文本消息不会把 `<@openid>` 渲染成昵称，会直接暴露 openid。
+    // 只有 markdown 出站消息保留显式 at；纯文本命令依靠 reply target 关联原消息。
+    if !matches!(outbound, OutboundMessage::Markdown { .. }) {
+        return outbound;
+    }
     let Some(prefix) = group_reply_mention_prefix(message, capability) else {
         return outbound;
     };
@@ -87,13 +77,13 @@ fn prefix_group_reply_outbound(
 }
 
 fn group_respond_error_texts(
-    message: &GroupMessage,
+    _message: &GroupMessage,
     err: &crate::respond::RespondError,
-    capability: &ReplyCapability,
+    _capability: &ReplyCapability,
 ) -> (String, String) {
     let log_text = respond_error_to_qq_text(err);
-    // 群 at fallback 的实际 QQ 文本需要保留 <@openid>，但日志字段只能使用未加前缀的安全文案。
-    let qq_text = prefix_group_reply_text(message, &log_text, capability);
+    // 本地错误 fallback 是纯文本发送，不能拼 `<@openid>`，否则 QQ 会原样展示 openid。
+    let qq_text = log_text.clone();
     (qq_text, log_text)
 }
 
@@ -713,17 +703,6 @@ mod tests {
     }
 
     #[test]
-    fn group_at_reply_text_mentions_sender_when_member_openid_exists() {
-        let message = group_message("hello", GroupEventType::GroupAtMessage);
-        let capability = qq_group_capability();
-
-        assert_eq!(
-            prefix_group_reply_text(&message, "回复正文", &capability),
-            "<@member-1>\n回复正文"
-        );
-    }
-
-    #[test]
     fn group_at_respond_error_log_text_keeps_member_openid_out() {
         let message = group_message("hello", GroupEventType::GroupAtMessage);
         let error = crate::respond::RespondError::Core(qq_maid_core::service::CoreError::new(
@@ -735,36 +714,14 @@ mod tests {
 
         let (qq_text, log_text) = group_respond_error_texts(&message, &error, &capability);
 
-        assert!(qq_text.starts_with("<@member-1>\n"));
+        assert!(!qq_text.contains("member-1"));
+        assert!(!qq_text.contains("<@"));
         assert!(!log_text.contains("member-1"));
         assert!(!log_text.contains("<@"));
     }
 
     #[test]
-    fn group_reply_text_skips_mention_for_plain_group_message() {
-        let message = group_message("hello", GroupEventType::GroupMessage);
-        let capability = qq_group_capability();
-
-        assert_eq!(
-            prefix_group_reply_text(&message, "回复正文", &capability),
-            "回复正文"
-        );
-    }
-
-    #[test]
-    fn group_at_reply_text_skips_mention_without_member_openid() {
-        let mut message = group_message("hello", GroupEventType::GroupAtMessage);
-        message.member_openid = None;
-        let capability = qq_group_capability();
-
-        assert_eq!(
-            prefix_group_reply_text(&message, "回复正文", &capability),
-            "回复正文"
-        );
-    }
-
-    #[test]
-    fn group_at_reply_outbound_mentions_sender() {
+    fn group_at_reply_text_outbound_keeps_plain_text_without_openid_mention() {
         let message = group_message("hello", GroupEventType::GroupAtMessage);
         let capability = qq_group_capability();
         let outbound = OutboundMessage::Text {
@@ -774,23 +731,48 @@ mod tests {
         assert_eq!(
             prefix_group_reply_outbound(&message, outbound, &capability),
             OutboundMessage::Text {
-                text: "<@member-1>\n回复正文".to_owned(),
+                text: "回复正文".to_owned(),
             }
         );
     }
 
     #[test]
-    fn structured_group_mention_reply_mentions_sender_like_at_event() {
+    fn group_at_reply_markdown_outbound_mentions_sender() {
+        let message = group_message("hello", GroupEventType::GroupAtMessage);
+        let capability = qq_group_capability();
+        let outbound = OutboundMessage::Markdown {
+            markdown: crate::markdown::MarkdownPayload::new("**回复正文**"),
+            fallback_text: "回复正文".to_owned(),
+        };
+
+        assert_eq!(
+            prefix_group_reply_outbound(&message, outbound, &capability),
+            OutboundMessage::Markdown {
+                markdown: crate::markdown::MarkdownPayload::new("<@member-1>\n**回复正文**"),
+                fallback_text: "<@member-1>\n回复正文".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn structured_group_mention_markdown_reply_mentions_sender_like_at_event() {
         let mut message = group_message("hello", GroupEventType::GroupMessage);
         message.mentions = vec![crate::gateway::event::GroupMention {
             is_you: true,
             member_role: None,
         }];
         let capability = qq_group_capability();
+        let outbound = OutboundMessage::Markdown {
+            markdown: crate::markdown::MarkdownPayload::new("**回复正文**"),
+            fallback_text: "回复正文".to_owned(),
+        };
 
         assert_eq!(
-            prefix_group_reply_text(&message, "回复正文", &capability),
-            "<@member-1>\n回复正文"
+            prefix_group_reply_outbound(&message, outbound, &capability),
+            OutboundMessage::Markdown {
+                markdown: crate::markdown::MarkdownPayload::new("<@member-1>\n**回复正文**"),
+                fallback_text: "<@member-1>\n回复正文".to_owned(),
+            }
         );
     }
 
@@ -799,10 +781,17 @@ mod tests {
         let message = group_message("hello", GroupEventType::GroupAtMessage);
         let mut capability = qq_group_capability();
         capability.supports_at_mention = false;
+        let outbound = OutboundMessage::Markdown {
+            markdown: crate::markdown::MarkdownPayload::new("**回复正文**"),
+            fallback_text: "回复正文".to_owned(),
+        };
 
         assert_eq!(
-            prefix_group_reply_text(&message, "回复正文", &capability),
-            "回复正文"
+            prefix_group_reply_outbound(&message, outbound, &capability),
+            OutboundMessage::Markdown {
+                markdown: crate::markdown::MarkdownPayload::new("**回复正文**"),
+                fallback_text: "回复正文".to_owned(),
+            }
         );
     }
 

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -17,7 +17,10 @@ use super::{
     cache::BotOutboundCache,
     dedupe::MessageDedupe,
     event::{GroupEventType, GroupMessage},
-    group_filter::{GroupCooldowns, should_ignore_group_message, should_process_group_message},
+    group_filter::{
+        GroupCooldowns, mentions_current_bot, should_ignore_group_message,
+        should_process_group_message,
+    },
     logging::{group_message_log_summary, mask_openid},
     media_fetch::{MediaFetchContext, fetch_qq_official_image_attachments},
     outbound::{
@@ -41,12 +44,12 @@ fn group_reply_mention_prefix(
     message: &GroupMessage,
     capability: &ReplyCapability,
 ) -> Option<String> {
-    // 只有用户显式 @ 机器人触发的官方群 at 事件，才在回复正文里 @ 回发起人；
+    // 只有官方确认提到当前机器人时，才在回复正文里 @ 回发起人；
     // 普通群命令、关键词触发和回复机器人消息继续只挂原消息 msg_id，避免额外打扰。
     if !capability.supports_at_mention {
         return None;
     }
-    if message.event_type != GroupEventType::GroupAtMessage {
+    if !mentions_current_bot(message) {
         return None;
     }
     message
@@ -773,6 +776,21 @@ mod tests {
             OutboundMessage::Text {
                 text: "<@member-1>\n回复正文".to_owned(),
             }
+        );
+    }
+
+    #[test]
+    fn structured_group_mention_reply_mentions_sender_like_at_event() {
+        let mut message = group_message("hello", GroupEventType::GroupMessage);
+        message.mentions = vec![crate::gateway::event::GroupMention {
+            is_you: true,
+            member_role: None,
+        }];
+        let capability = qq_group_capability();
+
+        assert_eq!(
+            prefix_group_reply_text(&message, "回复正文", &capability),
+            "<@member-1>\n回复正文"
         );
     }
 

--- a/qq-maid-gateway-rs/src/gateway/group_filter.rs
+++ b/qq-maid-gateway-rs/src/gateway/group_filter.rs
@@ -494,6 +494,8 @@ mod tests {
             message_id: "bot-msg-1".to_owned(),
             ref_msg_idx: None,
             content: None,
+            input_parts: Vec::new(),
+            media_summaries: Vec::new(),
         });
 
         assert!(!should_ignore_group_message(
@@ -524,6 +526,8 @@ mod tests {
             message_id: "msg-current-or-unknown".to_owned(),
             ref_msg_idx: Some("REFIDX_bot_msg_1".to_owned()),
             content: None,
+            input_parts: Vec::new(),
+            media_summaries: Vec::new(),
         });
 
         assert!(!should_ignore_group_message(
@@ -555,6 +559,8 @@ mod tests {
             message_id: "REFIDX_bot_msg_1".to_owned(),
             ref_msg_idx: None,
             content: None,
+            input_parts: Vec::new(),
+            media_summaries: Vec::new(),
         });
 
         assert!(should_ignore_group_message(
@@ -630,6 +636,8 @@ mod tests {
             message_id: "bot-msg-1".to_owned(),
             ref_msg_idx: None,
             content: None,
+            input_parts: Vec::new(),
+            media_summaries: Vec::new(),
         });
 
         assert!(should_process_group_message(
@@ -654,6 +662,8 @@ mod tests {
             message_id: "msg-current-or-unknown".to_owned(),
             ref_msg_idx: Some("REFIDX_bot_msg_1".to_owned()),
             content: None,
+            input_parts: Vec::new(),
+            media_summaries: Vec::new(),
         });
 
         assert!(should_process_group_message(
@@ -679,6 +689,8 @@ mod tests {
             message_id: "REFIDX_bot_msg_1".to_owned(),
             ref_msg_idx: None,
             content: None,
+            input_parts: Vec::new(),
+            media_summaries: Vec::new(),
         });
 
         assert!(!should_process_group_message(

--- a/qq-maid-gateway-rs/src/gateway/group_filter.rs
+++ b/qq-maid-gateway-rs/src/gateway/group_filter.rs
@@ -90,7 +90,7 @@ pub(crate) fn should_ignore_group_message(
         );
         return true;
     }
-    if message.event_type != GroupEventType::GroupAtMessage
+    if !mentions_current_bot(message)
         && respond_content.trim().is_empty()
         && !is_reply_to_bot(message, bot_outbound_cache)
     {
@@ -106,12 +106,12 @@ pub(crate) fn should_ignore_group_message(
 
 /// 按群消息模式策略判断是否应处理该消息。
 ///
-/// `GroupAtMessage` 是 QQ 官方“机器人被 @”事件，直接视为 @ 机器人。
-/// 其余普通群消息按模式：
+/// QQ 官方 at 事件和普通群消息中的结构化 `is_you` 都归一为“提到当前机器人”。
+/// 后续只按群消息模式决定是否进入 Core：
 /// - Off：不处理；
 /// - Command：仅斜杠命令；
-/// - Mention：命令、官方 `is_you` @机器人、回复机器人；
-/// - Active：仅处理命中配置提示词的普通群消息。
+/// - Mention：命令、提到机器人、回复机器人；
+/// - Active：提到机器人或命中配置提示词。
 pub(crate) fn should_process_group_message(
     mode: GroupMessageMode,
     active_keywords: &[String],
@@ -120,11 +120,7 @@ pub(crate) fn should_process_group_message(
     _bot_identity: &SharedBotIdentity,
     bot_outbound_cache: &Arc<Mutex<BotOutboundCache>>,
 ) -> bool {
-    if message.event_type == GroupEventType::GroupAtMessage {
-        return true;
-    }
-
-    let mentions_current_bot = message.mentions.iter().any(|mention| mention.is_you);
+    let mentions_current_bot = mentions_current_bot(message);
 
     // QQ 有时把 `@机器人 /help` 作为普通群消息下发；
     // 此时原始 content 不是斜杠开头，需要使用 gateway 已归一化的 Core 文本判断命令。
@@ -148,6 +144,11 @@ pub(crate) fn should_process_group_message(
                 || contains_active_keyword(&message.content, active_keywords)
         }
     }
+}
+
+pub(crate) fn mentions_current_bot(message: &GroupMessage) -> bool {
+    message.event_type == GroupEventType::GroupAtMessage
+        || message.mentions.iter().any(|mention| mention.is_you)
 }
 
 /// 判断内容是否以 `/` 或全角 `／` 开头（群命令）。
@@ -246,7 +247,7 @@ mod tests {
             &bot_identity(),
             &cache
         ));
-        assert!(should_process_group_message(
+        assert!(!should_process_group_message(
             GroupMessageMode::Off,
             &active_keywords,
             &at_event,
@@ -299,6 +300,14 @@ mod tests {
             &active_keywords,
             &active_keyword,
             &active_keyword.content,
+            &bot_identity(),
+            &cache
+        ));
+        assert!(should_process_group_message(
+            GroupMessageMode::Active,
+            &active_keywords,
+            &at_event,
+            &at_event.content,
             &bot_identity(),
             &cache
         ));

--- a/qq-maid-gateway-rs/src/gateway/platform/qq_official.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/qq_official.rs
@@ -97,11 +97,15 @@ fn quoted_from_qq(
         // 保留为原始引用字段，不伪造成 ref_index lookup key。
         ref_msg_idx: value.ref_msg_idx.clone(),
         text_summary: value.content.clone(),
-        lookup_found: value.content.is_some(),
-        fallback_reason: value
-            .content
-            .is_none()
-            .then(|| "pending_ref_index_lookup".to_owned()),
+        media_summaries: value.media_summaries.clone(),
+        input_parts: value.input_parts.clone(),
+        lookup_found: value.content.is_some()
+            || !value.media_summaries.is_empty()
+            || !value.input_parts.is_empty(),
+        fallback_reason: (value.content.is_none()
+            && value.media_summaries.is_empty()
+            && value.input_parts.is_empty())
+        .then(|| "pending_ref_index_lookup".to_owned()),
         ..Default::default()
     }
 }
@@ -217,6 +221,8 @@ mod tests {
             message_id: "quoted-1".to_owned(),
             ref_msg_idx: None,
             content: Some("上一条".to_owned()),
+            input_parts: Vec::new(),
+            media_summaries: Vec::new(),
         });
         message.attachments = vec![QqAttachment {
             content_type: Some("image/jpeg".to_owned()),

--- a/qq-maid-gateway-rs/src/gateway/ref_index/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/ref_index/mod.rs
@@ -105,9 +105,15 @@ impl RefIndex {
             quoted.fallback_reason = None;
             log_ref_index_hit("quoted_lookup", &key, entry);
         } else {
-            quoted.lookup_found = false;
-            quoted.fallback_reason = Some("ref_index_miss".to_owned());
             log_ref_index_miss(&self.entries, &key);
+            if quoted_has_payload_fallback(quoted) {
+                quoted.lookup_found = true;
+                quoted.from_bot = None;
+                quoted.fallback_reason = Some("quoted_payload".to_owned());
+            } else {
+                quoted.lookup_found = false;
+                quoted.fallback_reason = Some("ref_index_miss".to_owned());
+            }
         }
     }
 
@@ -150,6 +156,15 @@ fn ref_ids_for_current_message(inbound: &InboundMessage) -> Vec<String> {
             (!value.is_empty()).then(|| value.to_owned())
         })
         .collect()
+}
+
+fn quoted_has_payload_fallback(quoted: &qq_maid_common::input_part::QuotedMessageContext) -> bool {
+    quoted
+        .text_summary
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty())
+        || !quoted.media_summaries.is_empty()
+        || !quoted.input_parts.is_empty()
 }
 
 fn entry_from_inbound(inbound: &InboundMessage) -> RefIndexEntry {
@@ -508,6 +523,28 @@ mod tests {
         let quoted = current.quoted.unwrap();
         assert!(!quoted.lookup_found);
         assert_eq!(quoted.fallback_reason.as_deref(), Some("ref_index_miss"));
+    }
+
+    #[test]
+    fn missing_quote_uses_current_payload_fallback_when_available() {
+        let store = RefIndex::default();
+        let mut current = group_inbound("gm-current", Some("REFIDX_current"), "查看这条");
+        current.quoted = Some(QuotedMessageContext {
+            ref_msg_idx: Some("REFIDX_missing".to_owned()),
+            text_summary: Some("payload 原文".to_owned()),
+            input_parts: vec![MessageInputPart::text("payload 原文")],
+            lookup_found: true,
+            fallback_reason: Some("pending_ref_index_lookup".to_owned()),
+            ..Default::default()
+        });
+
+        store.enrich_inbound(&mut current);
+
+        let quoted = current.quoted.as_ref().unwrap();
+        assert!(quoted.lookup_found);
+        assert_eq!(quoted.text_summary.as_deref(), Some("payload 原文"));
+        assert_eq!(quoted.from_bot, None);
+        assert_eq!(quoted.fallback_reason.as_deref(), Some("quoted_payload"));
     }
 
     #[test]

--- a/qq-maid-gateway-rs/src/gateway/ref_index/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/ref_index/mod.rs
@@ -391,6 +391,29 @@ mod tests {
         }
     }
 
+    fn group_inbound_from(
+        message_id: &str,
+        msg_idx: Option<&str>,
+        text: &str,
+        sender_id: &str,
+        is_bot: bool,
+    ) -> InboundMessage {
+        let mut message = group_inbound(message_id, msg_idx, text);
+        message.actor.sender_id = Some(sender_id.to_owned());
+        message.actor.is_bot = is_bot;
+        message
+    }
+
+    fn quoted_group_lookup(store: &RefIndex, ref_id: &str) -> QuotedMessageContext {
+        let mut current = group_inbound("gm-current", Some("REFIDX_current"), "查看引用");
+        current.quoted = Some(QuotedMessageContext {
+            ref_msg_idx: Some(ref_id.to_owned()),
+            ..Default::default()
+        });
+        store.enrich_inbound(&mut current);
+        current.quoted.unwrap()
+    }
+
     #[test]
     fn index_isolated_by_peer_and_fills_quote_context() {
         let mut store = RefIndex::default();
@@ -697,6 +720,62 @@ mod tests {
             quoted.input_parts[1],
             MessageInputPart::Image { .. }
         ));
+    }
+
+    #[test]
+    fn qq_group_ref_index_cross_quotes_exact_ref_id_without_latest_overwrite() {
+        let mut message_a =
+            group_inbound_from("gm-a", Some("REFIDX_A"), "内容 A", "member-a", false);
+        let mut message_b =
+            group_inbound_from("gm-b", Some("REFIDX_B"), "内容 B", "member-bot", true);
+        message_b
+            .input_parts
+            .push(MessageInputPart::image(MessageMedia {
+                mime_type: Some("image/png".to_owned()),
+                filename: Some("b.png".to_owned()),
+                url: Some("https://example.test/b.png".to_owned()),
+                ..Default::default()
+            }));
+
+        let mut store = RefIndex::default();
+        store.insert_inbound(&message_a);
+        store.insert_inbound(&message_b);
+
+        let quoted_a_first = quoted_group_lookup(&store, "REFIDX_A");
+        let quoted_b = quoted_group_lookup(&store, "REFIDX_B");
+        let quoted_a_again = quoted_group_lookup(&store, "REFIDX_A");
+
+        assert!(quoted_a_first.lookup_found);
+        assert_eq!(quoted_a_first.text_summary.as_deref(), Some("内容 A"));
+        assert_eq!(quoted_a_first.from_bot, Some(false));
+        assert!(quoted_a_first.media_summaries.is_empty());
+        assert_eq!(quoted_a_first.input_parts.len(), 1);
+        assert_eq!(quoted_a_first.input_parts[0].text_content(), Some("内容 A"));
+
+        assert!(quoted_b.lookup_found);
+        assert_eq!(quoted_b.text_summary.as_deref(), Some("内容 B"));
+        assert_eq!(quoted_b.from_bot, Some(true));
+        assert_eq!(quoted_b.media_summaries.len(), 1);
+        assert!(matches!(
+            quoted_b.input_parts[1],
+            MessageInputPart::Image { .. }
+        ));
+
+        assert!(quoted_a_again.lookup_found);
+        assert_eq!(quoted_a_again.text_summary.as_deref(), Some("内容 A"));
+        assert_eq!(quoted_a_again.from_bot, Some(false));
+        assert!(quoted_a_again.media_summaries.is_empty());
+        assert_eq!(quoted_a_again.input_parts.len(), 1);
+
+        message_a.actor.sender_id = Some("member-a-updated".to_owned());
+        store.insert_inbound(&message_a);
+        let quoted_b_after_a_update = quoted_group_lookup(&store, "REFIDX_B");
+        assert_eq!(
+            quoted_b_after_a_update.text_summary.as_deref(),
+            Some("内容 B")
+        );
+        assert_eq!(quoted_b_after_a_update.from_bot, Some(true));
+        assert_eq!(quoted_b_after_a_update.media_summaries.len(), 1);
     }
 
     #[test]

--- a/qq-maid-gateway-rs/src/gateway/ref_index/qq.rs
+++ b/qq-maid-gateway-rs/src/gateway/ref_index/qq.rs
@@ -5,7 +5,7 @@
 
 use serde::Deserialize;
 
-const MSG_TYPE_QUOTE: u64 = 103;
+pub(crate) const MSG_TYPE_QUOTE: u64 = 103;
 
 #[derive(Debug, Clone, Deserialize, Default)]
 pub(crate) struct RawMessageScene {
@@ -17,6 +17,10 @@ pub(crate) struct RawMessageScene {
 pub(crate) struct RawMsgElement {
     #[serde(default)]
     pub(crate) msg_idx: Option<String>,
+    #[serde(default)]
+    pub(crate) content: Option<String>,
+    #[serde(default)]
+    pub(crate) attachments: Vec<crate::gateway::event::Attachment>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -82,6 +86,8 @@ mod tests {
         };
         let elements = vec![RawMsgElement {
             msg_idx: Some("REFIDX_element".to_owned()),
+            content: None,
+            attachments: Vec::new(),
         }];
 
         let indices = parse_ref_indices(Some(&scene), Some(MSG_TYPE_QUOTE), &elements);

--- a/qq-maid-gateway-rs/src/gateway/stream/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests.rs
@@ -236,6 +236,8 @@ fn quoted_lookup_found(
         message_id: "qq-reply-message-id".to_owned(),
         ref_msg_idx: Some(ref_id.to_owned()),
         content: None,
+        input_parts: Vec::new(),
+        media_summaries: Vec::new(),
     });
     let mut inbound = crate::gateway::platform::qq_official::inbound_from_c2c(&message);
     inbound.account_id = Some(config.app_id.clone());

--- a/qq-maid-gateway-rs/src/respond.rs
+++ b/qq-maid-gateway-rs/src/respond.rs
@@ -825,6 +825,8 @@ mod tests {
             message_id: "reply-1".to_owned(),
             ref_msg_idx: None,
             content: Some("被回复内容".to_owned()),
+            input_parts: Vec::new(),
+            media_summaries: Vec::new(),
         });
         message.attachments = vec![Attachment {
             content_type: Some("image/png".to_owned()),


### PR DESCRIPTION
## 变更内容

目标发布：`v0.13.2`

本 PR 同时覆盖两个 QQ 官方群链路问题：

1. QQ 群引用索引覆盖（#291）
   - 在 QQ 入站解析中保留 quoted payload 的 `msg_elements[0]` 内容和附件元信息，用于 `ref_index` miss 时即时兜底。
   - Gateway 收到且带 `current_msg_idx/msg_idx` 的群消息时提前登记 `ref_index`；登记只用于后续引用恢复，不代表触发 Core 回复。
   - `ref_index` 查找 miss 时，如果当前 quoted context 已带 payload 内容，则保留为可用引用上下文；缓存命中仍优先使用缓存并恢复 `from_bot`。
   - 补充普通群消息提前登记、quoted payload 兜底、交叉引用精确命中、REFIDX 字段边界等测试。

2. QQ 官方群回复展示边界修复
   - 避免纯文本群回复和本地错误 fallback 拼显式 `<@openid>`，防止 QQ 文本消息原样展示 openid。
   - Markdown 出站消息仍保留显式 mention 前缀，用于 `/rss` 等 markdown 响应保持正常 at 展示。

## 修复原因

#291 的现场现象是 QQ 引用事件已解析出 `ref_msg_idx`，但本地 `ref_index` 未登记普通群友消息，所以最终只能给出 `ref_index_miss`。本次改动补齐已被 Gateway 观察到的非机器人群消息登记，并在当前 QQ payload 自带 quoted element 时提供一次性上下文。

后续线上验证又发现 `/new` 等纯文本群命令回复会把 `<@openid>` 原样展示出来，而 `/rss` 等 markdown 回复正常。因此本 PR 追加限制：显式 mention 只进入 markdown 出站路径，纯文本和错误 fallback 依靠 reply target 关联原消息。

## 字段边界

- `current_msg_idx/msg_idx` 只用于登记当前消息。
- `ref_msg_idx` 只用于查引用目标。
- `message_id` 不参与 `ref_index` lookup。
- `reply.message_id` 不填进 `ref_msg_idx`。
- `msg_elements[0]` 只作为 quoted payload 兜底，不反向登记成当前消息。
- 不重新引入 `message_id` fallback。

## 不在本 PR 处理

- 不删除或废弃 group policy mode。
- policy mode 的整体清理放到 #293。

## 验证

- `cargo fmt --all -- --check`
- `cargo check -p qq-maid-gateway-rs`
- `cargo clippy -p qq-maid-gateway-rs --all-targets --all-features -- -D warnings`
- `cargo test -p qq-maid-gateway-rs`
- `cargo test -p qq-maid-core rss`
- `git diff --check`

GitHub Actions: `Rust checks` 已通过。

## 备注

- 未新增持久化 `ref_index`；仍是进程内短时索引。
- QQ 官方群消息权限和可见性主要由平台推送决定；Gateway 能观察到且带 `current_msg_idx/msg_idx` 的消息才会提前登记。
- payload 兜底无法确认发送者时仍保持 `from=unknown`。
