### PR TITLE
[codex] 收敛引用快照待办编号链路

### DIFF
--- a/qq-maid-core/src/config/agent.rs
+++ b/qq-maid-core/src/config/agent.rs
@@ -28,6 +28,7 @@ const DEFAULT_PRIVATE_ENABLED_TOOLS: &[&str] = &[
     "cancel_todo",
     "restore_todos",
     "delete_todos",
+    "merge_todos",
 ];
 const DEFAULT_GROUP_ENABLED_TOOLS: &[&str] =
     &["get_weather", "get_train_schedule", "get_rss_recent_items"];

--- a/qq-maid-core/src/runtime/respond.rs
+++ b/qq-maid-core/src/runtime/respond.rs
@@ -23,8 +23,8 @@ use crate::{
         todo::TodoStore,
         tools::{
             CancelTodoTool, CompleteTodoTool, CreateTodoTool, DeleteTodoTool, DynRadarExecutor,
-            EditTodoTool, GetTodoTool, ListTodoTool, RestoreTodoTool, RssRecentItemsTool,
-            TrainScheduleTool, WeatherTool,
+            EditTodoTool, GetTodoTool, ListTodoTool, MergeTodoTool, RestoreTodoTool,
+            RssRecentItemsTool, TrainScheduleTool, WeatherTool,
         },
         train::DynTrainExecutor,
         translation::TranslationService,
@@ -38,6 +38,7 @@ use qq_maid_llm::{
 };
 
 mod types;
+use crate::service::ToolsVisibleSnapshot;
 use crate::service::{CoreInboundClassification, CoreInboundKind};
 pub use types::{ChatResponse, RespondPurpose, RespondRequest, RespondResponse};
 
@@ -263,6 +264,11 @@ impl RustRespondService {
                 stores.notification_store.clone(),
             )),
             std::sync::Arc::new(DeleteTodoTool::new(
+                stores.todo_store.clone(),
+                stores.session_store.clone(),
+                stores.notification_store.clone(),
+            )),
+            std::sync::Arc::new(MergeTodoTool::new(
                 stores.todo_store.clone(),
                 stores.session_store.clone(),
                 stores.notification_store.clone(),
@@ -661,6 +667,10 @@ fn pending_blocks_immediate(user_text: &str, active_session: Option<&SessionReco
 }
 
 fn has_recent_todo_context(req: &RespondRequest, active_session: Option<&SessionRecord>) -> bool {
+    if tools_visible_snapshot_has_todo_items(req.tools_visible_snapshot.as_ref()) {
+        return true;
+    }
+
     let Some(session) = active_session else {
         return false;
     };
@@ -675,6 +685,15 @@ fn has_recent_todo_context(req: &RespondRequest, active_session: Option<&Session
 
     session.last_todo_action.as_ref().is_some_and(|action| {
         action.owner_key == owner.key && query_is_fresh(&action.created_at, LAST_QUERY_TTL_SECONDS)
+    })
+}
+
+fn tools_visible_snapshot_has_todo_items(snapshot: Option<&ToolsVisibleSnapshot>) -> bool {
+    snapshot.is_some_and(|snapshot| {
+        snapshot
+            .items
+            .iter()
+            .any(|item| item.domain == "todo" && item.entity_kind == "todo")
     })
 }
 

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -25,7 +25,9 @@ use crate::{
 
 use super::{
     ChatToolPlan, RespondPurpose, RespondRequest, RespondResponse, RustRespondService,
-    agent_outcome::{AgentTurnOutcome, AgentTurnStatus, ToolEffect, ToolOutcomeStatus},
+    agent_outcome::{
+        AgentTurnOutcome, AgentTurnStatus, ResponseBlock, ToolEffect, ToolOutcomeStatus,
+    },
     common::{
         SESSION_HISTORY_MESSAGE_LIMIT, command_response, empty_respond_request, memory_error,
         merge_metadata, session_error,
@@ -321,8 +323,12 @@ impl RustRespondService {
                 Value::Null
             },
         }));
-        response.tools_visible_snapshot =
-            super::todo_flow::todo_tools_visible_snapshot(&session, Some(&meta));
+        // 只有本轮确定性渲染了 Todo 可见编号列表，才把当前快照绑定到出站消息。
+        // 普通聊天不能继承旧 last_todo_query，否则引用普通回复会误恢复上一条列表。
+        if agent_turn_shows_todo_visible_list(agent_turn_outcome.as_ref()) {
+            response.tools_visible_snapshot =
+                super::todo_flow::todo_tools_visible_snapshot(&session, Some(&meta));
+        }
         Ok(response)
     }
 
@@ -912,6 +918,19 @@ fn generic_agent_error_code(
         };
     }
     (use_tool_loop && !todo_success_validation.passed()).then_some("todo_success_not_verified")
+}
+
+fn agent_turn_shows_todo_visible_list(outcome: Option<&AgentTurnOutcome>) -> bool {
+    outcome.is_some_and(|outcome| {
+        outcome.outcomes.iter().any(|item| {
+            item.domain == "todo"
+                && item.status == ToolOutcomeStatus::Succeeded
+                && item
+                    .blocks
+                    .iter()
+                    .any(|block| matches!(block, ResponseBlock::RelatedList(_)))
+        })
+    })
 }
 
 /// 从会话历史中截取最近的 N 条消息，转换为 LLM `ChatMessage` 格式。

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -3,7 +3,7 @@
 //! 承担 `RustRespondService` 中"兜底聊天"路径的实现：
 //! 组装 LLM 请求、发起调用、保存对话记录、自动生成会话标题等。
 
-use std::{future::Future, pin::Pin};
+use std::{future::Future, pin::Pin, sync::Arc};
 
 use serde_json::{Value, json};
 
@@ -11,7 +11,16 @@ use crate::{
     config::agent::AgentConfigSource,
     error::LlmError,
     provider::types::{ChatMessage, ChatRole},
-    runtime::session::{DEFAULT_SESSION_TITLE, SessionMeta, SessionRecord},
+    runtime::{
+        session::{
+            DEFAULT_SESSION_TITLE, LAST_QUERY_TTL_SECONDS, SessionMeta, SessionRecord,
+            query_is_fresh,
+        },
+        tools::{
+            CancelTodoTool, CompleteTodoTool, DeleteTodoTool, EditTodoTool, GetTodoTool,
+            MergeTodoTool, RestoreTodoTool, SelectionScope,
+        },
+    },
 };
 
 use super::{
@@ -98,6 +107,10 @@ impl RustRespondService {
             system_prompts
         };
         let policy = self.resolve_agent_policy(&req)?;
+        let owner =
+            crate::runtime::todo::TodoStore::owner(meta.user_id.as_deref(), &meta.scope_key);
+        let quoted_todo_selection_scope =
+            todo_selection_scope_from_tools_visible_snapshot(&req, &owner);
         let chat_req = RespondRequest {
             session_id: session.session_id.clone(),
             purpose: RespondPurpose::Chat,
@@ -149,7 +162,8 @@ impl RustRespondService {
             LlmChatService::with_context_budget(self.provider.clone(), self.context_budget);
         let use_tool_loop = matches!(chat_tool_plan, ChatToolPlan::ForceCompleteToolLoop);
         let (output, todo_success_validation, agent_turn_outcome) = if use_tool_loop {
-            let tools = self.tool_registry_for_chat(&policy)?;
+            let tools =
+                self.tool_registry_for_chat(&policy, quoted_todo_selection_scope.clone())?;
             let mut output = service
                 .respond_with_tools(chat_req, tools, policy.max_tool_rounds)
                 .await?;
@@ -173,8 +187,6 @@ impl RustRespondService {
             latest_session.state = session.state.clone();
             session = latest_session;
 
-            let owner =
-                crate::runtime::todo::TodoStore::owner(meta.user_id.as_deref(), &meta.scope_key);
             let turn_outcome =
                 build_agent_turn_outcome(&self.todo_store, &mut session, &owner, &output)?;
             let validation = if turn_outcome.can_replace_model_reply() {
@@ -253,7 +265,7 @@ impl RustRespondService {
         self.schedule_auto_title(session.clone());
 
         let mut response = response_from_output(output);
-        response.session_id = Some(session.session_id);
+        response.session_id = Some(session.session_id.clone());
         response.command = agent_turn_outcome
             .as_ref()
             .and_then(AgentTurnOutcome::primary_command);
@@ -309,6 +321,8 @@ impl RustRespondService {
                 Value::Null
             },
         }));
+        response.tools_visible_snapshot =
+            super::todo_flow::todo_tools_visible_snapshot(&session, Some(&meta));
         Ok(response)
     }
 
@@ -319,13 +333,18 @@ impl RustRespondService {
     fn tool_registry_for_chat(
         &self,
         policy: &crate::config::ResolvedAgentPolicy,
+        todo_selection_scope: Option<SelectionScope>,
     ) -> Result<qq_maid_llm::tool::ToolRegistry, LlmError> {
         let tool_names = policy
             .enabled_tools
             .iter()
             .map(String::as_str)
             .collect::<Vec<_>>();
-        self.tool_registry.subset(&tool_names)
+        let mut registry = self.tool_registry.subset(&tool_names)?;
+        if let Some(scope) = todo_selection_scope {
+            replace_scoped_todo_tools(&mut registry, self, &policy.enabled_tools, scope)?;
+        }
+        Ok(registry)
     }
 
     /// 普通聊天真流式路径：复用非流式聊天的上下文构造和后处理，只替换 LLM 调用方式。
@@ -545,6 +564,128 @@ impl RustRespondService {
             }
         });
     }
+}
+
+fn todo_selection_scope_from_tools_visible_snapshot(
+    req: &RespondRequest,
+    owner: &crate::runtime::todo::TodoOwner,
+) -> Option<SelectionScope> {
+    let had_quoted_lookup = req
+        .quoted
+        .as_ref()
+        .is_some_and(|quoted| quoted.lookup_found && quoted.from_bot == Some(true));
+    let Some(snapshot) = req.tools_visible_snapshot.as_ref() else {
+        return had_quoted_lookup.then_some(SelectionScope::Blocked);
+    };
+    if snapshot.scope_key != req.scope_key
+        || snapshot
+            .owner_key
+            .as_deref()
+            .is_some_and(|key| key != owner.key)
+        || snapshot.platform != req.platform
+        || snapshot.account_id != req.account_id
+        || !query_is_fresh(&snapshot.created_at, LAST_QUERY_TTL_SECONDS)
+    {
+        return Some(SelectionScope::Blocked);
+    }
+    let mut todo_items = snapshot
+        .items
+        .iter()
+        .filter(|item| item.domain == "todo" && item.entity_kind == "todo")
+        .collect::<Vec<_>>();
+    if todo_items.is_empty() {
+        return had_quoted_lookup.then_some(SelectionScope::Blocked);
+    }
+    todo_items.sort_by_key(|item| item.visible_number);
+    if todo_items
+        .iter()
+        .enumerate()
+        .any(|(index, item)| item.visible_number != index + 1 || item.entity_id.trim().is_empty())
+    {
+        return Some(SelectionScope::Blocked);
+    }
+    Some(SelectionScope::Scoped(Arc::from(
+        todo_items
+            .into_iter()
+            .map(|item| item.entity_id.clone())
+            .collect::<Vec<_>>(),
+    )))
+}
+
+fn replace_scoped_todo_tools(
+    registry: &mut qq_maid_llm::tool::ToolRegistry,
+    service: &RustRespondService,
+    enabled_tools: &[String],
+    scope: SelectionScope,
+) -> Result<(), LlmError> {
+    let enabled = |name: &str| enabled_tools.iter().any(|tool| tool == name);
+    if enabled("get_todo") {
+        registry.replace(Arc::new(
+            GetTodoTool::new(service.todo_store.clone(), service.session_store.clone())
+                .with_selection_scope(scope.clone()),
+        ))?;
+    }
+    if enabled("complete_todos") {
+        registry.replace(Arc::new(
+            CompleteTodoTool::new(
+                service.todo_store.clone(),
+                service.session_store.clone(),
+                service.notification_store.clone(),
+            )
+            .with_selection_scope(scope.clone()),
+        ))?;
+    }
+    if enabled("edit_todo") {
+        registry.replace(Arc::new(
+            EditTodoTool::new(
+                service.todo_store.clone(),
+                service.session_store.clone(),
+                service.notification_store.clone(),
+            )
+            .with_selection_scope(scope.clone()),
+        ))?;
+    }
+    if enabled("cancel_todo") {
+        registry.replace(Arc::new(
+            CancelTodoTool::new(
+                service.todo_store.clone(),
+                service.session_store.clone(),
+                service.notification_store.clone(),
+            )
+            .with_selection_scope(scope.clone()),
+        ))?;
+    }
+    if enabled("restore_todos") {
+        registry.replace(Arc::new(
+            RestoreTodoTool::new(
+                service.todo_store.clone(),
+                service.session_store.clone(),
+                service.notification_store.clone(),
+            )
+            .with_selection_scope(scope.clone()),
+        ))?;
+    }
+    if enabled("delete_todos") {
+        registry.replace(Arc::new(
+            DeleteTodoTool::new(
+                service.todo_store.clone(),
+                service.session_store.clone(),
+                service.notification_store.clone(),
+            )
+            .with_selection_scope(scope.clone()),
+        ))?;
+    }
+    if enabled("merge_todos") {
+        registry.replace(Arc::new(
+            MergeTodoTool::new(
+                service.todo_store.clone(),
+                service.session_store.clone(),
+                service.notification_store.clone(),
+            )
+            .with_selection_scope(scope),
+        ))?;
+    }
+    Ok(())
 }
 
 fn is_prompt_extraction_request(text: &str) -> bool {
@@ -805,6 +946,8 @@ pub(super) fn recent_session_messages(session: &SessionRecord, limit: usize) -> 
 #[cfg(test)]
 mod prompt_protection_tests {
     use super::*;
+    use crate::service::{ToolsVisibleItem, ToolsVisibleSnapshot};
+    use qq_maid_common::input_part::QuotedMessageContext;
 
     #[test]
     fn prompt_extraction_detection_covers_system_prompt_requests() {
@@ -837,5 +980,48 @@ mod prompt_protection_tests {
         ] {
             assert!(!is_prompt_extraction_request(input), "{input}");
         }
+    }
+
+    #[test]
+    fn quoted_snapshot_scope_mismatch_blocks_without_fallback() {
+        let mut req = empty_respond_request();
+        req.scope_key = "private:u1".to_owned();
+        req.user_id = Some("u1".to_owned());
+        req.platform = "qq_official".to_owned();
+        req.account_id = Some("app-a".to_owned());
+        req.quoted = Some(QuotedMessageContext {
+            current_message_id: Some("current-msg".to_owned()),
+            current_msg_idx: Some("current-idx".to_owned()),
+            reference_id: Some("msg-a".to_owned()),
+            ref_msg_idx: Some("ref-a".to_owned()),
+            lookup_found: true,
+            text_summary: Some("1. A".to_owned()),
+            media_summaries: Vec::new(),
+            input_parts: Vec::new(),
+            from_bot: Some(true),
+            fallback_reason: None,
+        });
+        req.tools_visible_snapshot = Some(ToolsVisibleSnapshot {
+            platform: "qq_official".to_owned(),
+            account_id: Some("app-b".to_owned()),
+            scope_key: "private:u1".to_owned(),
+            owner_key: Some("private:u1::u1".to_owned()),
+            created_at: crate::runtime::session::now_iso_cn(),
+            items: vec![ToolsVisibleItem {
+                domain: "todo".to_owned(),
+                entity_kind: "todo".to_owned(),
+                entity_id: "todo-a-1".to_owned(),
+                visible_number: 1,
+                label: None,
+                status: Some("pending".to_owned()),
+            }],
+        });
+
+        let owner = crate::runtime::todo::TodoStore::owner(Some("u1"), "private:u1");
+
+        assert!(matches!(
+            todo_selection_scope_from_tools_visible_snapshot(&req, &owner),
+            Some(SelectionScope::Blocked)
+        ));
     }
 }

--- a/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/todo_guard.rs
@@ -102,6 +102,7 @@ fn successful_todo_write_result(result: &ToolExecutionResult) -> bool {
         "cancel_todo" => non_empty_array_field(&result.output, "cancelled"),
         "delete_todos" => pending_action_matches(&result.output, "delete"),
         "edit_todo" => result.output.get("updated").is_some(),
+        "merge_todos" => result.output.get("merged").is_some(),
         "complete_todos" => non_empty_array_field(&result.output, "completed"),
         "restore_todos" => non_empty_array_field(&result.output, "restored"),
         _ => false,
@@ -188,6 +189,7 @@ fn is_todo_tool(name: &str) -> bool {
         "create_todo"
             | "cancel_todo"
             | "delete_todos"
+            | "merge_todos"
             | "edit_todo"
             | "complete_todos"
             | "restore_todos"
@@ -366,7 +368,7 @@ fn is_explanatory_clear_success_usage(text: &str, pos: usize, marker: &str) -> b
 }
 
 pub(super) fn todo_success_not_verified_reply() -> String {
-    "我这次没有收到待办工具的成功回执，所以不能确认已经完成该待办操作。请再说一次，或使用 /todo 查看当前待办状态。".to_owned()
+    "这次没有确认改动成功。请先查看最新待办列表，再按编号操作一次。".to_owned()
 }
 
 pub(super) fn todo_success_not_verified_reply_for_output(output: &RespondOutput) -> String {
@@ -391,7 +393,7 @@ pub(super) fn todo_success_not_verified_reply_for_output(output: &RespondOutput)
     if let Some(summary) = best_failure_summary(&summaries) {
         return todo_tool_failure_reply(summary);
     }
-    "待办工具已返回结果，但这次回复没有通过成功验真。请使用 /todo 查看当前待办状态。".to_owned()
+    "这次没有确认改动成功。请先查看最新待办列表，再按编号操作一次。".to_owned()
 }
 
 fn best_failure_summary(summaries: &[TodoToolResultSummary]) -> Option<&TodoToolResultSummary> {
@@ -435,14 +437,14 @@ fn todo_tool_failure_reply(summary: &TodoToolResultSummary) -> String {
         Some("bad_tool_arguments") if summary.requires_clarification => {
             "目标不明确，请选择具体待办。".to_owned()
         }
-        Some("bad_tool_arguments") => "这次待办工具参数不完整，请换个说法说明目标。".to_owned(),
+        Some("bad_tool_arguments") => "这次待办目标不完整，请换个说法说明目标。".to_owned(),
         Some(_) if summary.exception => {
-            "待办工具执行时发生异常，未确认完成操作。请稍后重试或先查看当前待办状态。".to_owned()
+            "这次没有确认改动成功。请稍后重试，或先查看最新待办列表。".to_owned()
         }
-        Some(_) => "待办工具返回业务失败，未确认完成操作。请先查看当前待办状态。".to_owned(),
+        Some(_) => "这次没有确认改动成功。请先查看最新待办列表，再试一次。".to_owned(),
         None if summary.requires_clarification => "目标不明确，请选择具体待办。".to_owned(),
         None if summary.skipped => {
-            "前一个待办工具没有成功，后续待办工具已跳过；本轮未确认完成操作。".to_owned()
+            "前一步没有确认成功，本次没有继续修改待办。请先查看最新待办列表。".to_owned()
         }
         None => todo_success_not_verified_reply(),
     }
@@ -510,7 +512,7 @@ mod tests {
     fn explicit_non_success_explanation_passes_without_tool_result() {
         assert_eq!(
             validate_todo_success_reply(&output(
-                "没有收到待办工具的成功回执，不能确认已经新增待办。",
+                "这次没有确认改动成功。请先查看最新待办列表，再按编号操作一次。",
                 Vec::new()
             )),
             TodoSuccessValidation::Passed {

--- a/qq-maid-core/src/runtime/respond/common.rs
+++ b/qq-maid-core/src/runtime/respond/common.rs
@@ -109,6 +109,7 @@ pub(super) fn empty_respond_request() -> RespondRequest {
         content: String::new(),
         input_parts: Vec::new(),
         quoted: None,
+        tools_visible_snapshot: None,
         scope_key: String::new(),
         user_id: None,
         group_member_role: None,
@@ -175,6 +176,7 @@ pub(super) fn command_response_with_stream(
         },
         usage: None,
         error: None,
+        tools_visible_snapshot: None,
     }
 }
 

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -1791,7 +1791,7 @@ async fn todo_create_intent_without_tool_call_does_not_leak_fake_success_reply()
         .unwrap();
 
     let text = response.text.unwrap();
-    assert!(text.contains("没有收到待办工具的成功回执"));
+    assert!(text.contains("这次没有确认改动成功"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["todo_success_claimed"], true);
     assert_eq!(diagnostics["todo_success_verified"], false);
@@ -1955,7 +1955,7 @@ async fn todo_fake_success_with_followup_instruction_is_still_blocked() {
         .unwrap();
 
     let text = response.text.unwrap();
-    assert!(text.contains("没有收到待办工具的成功回执"));
+    assert!(text.contains("这次没有确认改动成功"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["todo_success_claimed"], true);
     assert_eq!(diagnostics["todo_success_verified"], false);
@@ -1980,7 +1980,7 @@ async fn todo_mixed_unsupported_and_fake_success_reply_is_still_blocked() {
         .unwrap();
 
     let text = response.text.unwrap();
-    assert!(text.contains("没有收到待办工具的成功回执"));
+    assert!(text.contains("这次没有确认改动成功"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["todo_success_claimed"], true);
     assert_eq!(diagnostics["todo_success_verified"], false);
@@ -3484,7 +3484,7 @@ async fn last_reference_complete_without_tool_blocks_fake_success_reply() {
         .unwrap();
 
     let text = response.text.unwrap();
-    assert!(text.contains("没有收到待办工具的成功回执"));
+    assert!(text.contains("这次没有确认改动成功"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["todo_success_claimed"], true);
     assert_eq!(diagnostics["todo_success_verified"], false);

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -1439,6 +1439,14 @@ async fn only_list_todos_success_does_not_claim_todo_write_success() {
         .await
         .unwrap();
 
+    let visible_snapshot = response
+        .tools_visible_snapshot
+        .as_ref()
+        .expect("visible list response should carry snapshot");
+    assert_eq!(visible_snapshot.items.len(), 1);
+    assert_eq!(visible_snapshot.items[0].visible_number, 1);
+    assert_eq!(visible_snapshot.items[0].domain, "todo");
+
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["agent_turn_status"], "succeeded");
     assert_eq!(diagnostics["todo_success_claimed"], false);
@@ -1446,6 +1454,28 @@ async fn only_list_todos_success_does_not_claim_todo_write_success() {
     assert_eq!(diagnostics["tool_outcomes"][0]["domain"], "todo");
     assert_eq!(diagnostics["tool_outcomes"][0]["effect"], "read_only");
     assert_eq!(diagnostics["tool_outcomes"][0]["status"], "succeeded");
+}
+
+#[tokio::test]
+async fn ordinary_chat_response_does_not_inherit_old_todo_visible_snapshot() {
+    let service = test_service();
+    create_private_todo(&service, "旧列表第一条");
+
+    let list_response = service.respond(private_message("/todo")).await.unwrap();
+    assert!(
+        list_response.tools_visible_snapshot.is_some(),
+        "deterministic todo list should bind its own snapshot"
+    );
+
+    let chat_response = service
+        .respond(private_message("普通聊一句，不展示待办编号"))
+        .await
+        .unwrap();
+
+    assert!(
+        chat_response.tools_visible_snapshot.is_none(),
+        "ordinary chat response must not bind stale last_todo_query"
+    );
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tests/pending.rs
+++ b/qq-maid-core/src/runtime/respond/tests/pending.rs
@@ -135,7 +135,7 @@ async fn todo_add_pending_confirm_and_cancel_are_supported_for_tool_path() {
 }
 
 #[tokio::test]
-async fn legacy_todo_delete_pending_item_confirm_soft_cancels() {
+async fn legacy_todo_delete_pending_item_confirm_asks_to_restart_without_cancel() {
     let service = test_service();
     let owner = TodoStore::owner(Some("u1"), "group:g1");
     let item = service.todo_store.create(&owner, draft("买牛奶")).unwrap();
@@ -171,7 +171,7 @@ async fn legacy_todo_delete_pending_item_confirm_soft_cancels() {
         },
     );
     let confirmed = service.respond(message("确认")).await.unwrap();
-    assert!(confirmed.text.unwrap().contains("已取消待办 1 条"));
+    assert!(confirmed.text.unwrap().contains("旧版待确认操作已失效"));
     assert_eq!(
         service
             .todo_store
@@ -179,7 +179,7 @@ async fn legacy_todo_delete_pending_item_confirm_soft_cancels() {
             .unwrap()
             .unwrap()
             .status,
-        TodoStatus::Cancelled
+        TodoStatus::Pending
     );
 }
 

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -10,6 +10,7 @@ use crate::{
         session::{SessionMeta, SessionRecord},
         todo::{TodoItem, TodoOwner, TodoStatus, TodoStore},
     },
+    service::{ToolsVisibleItem, ToolsVisibleSnapshot},
     storage::session::valid_last_visible_todo_query,
     util::time_context::{parse_single_date_expression, request_time_context},
 };
@@ -137,6 +138,7 @@ fn remember_todo_query(
 impl RustRespondService {
     fn append_todo_query_response(
         &self,
+        meta: &SessionMeta,
         session: &mut SessionRecord,
         user_text: &str,
         reply: impl Into<CommandBody>,
@@ -152,11 +154,10 @@ impl RustRespondService {
                 latest.last_todo_query = current.last_todo_query.clone();
             })
             .map_err(super::common::session_error)?;
-        Ok(super::common::command_response(
-            reply,
-            Some(session.session_id.clone()),
-            Some(command),
-        ))
+        let mut response =
+            super::common::command_response(reply, Some(session.session_id.clone()), Some(command));
+        response.tools_visible_snapshot = todo_tools_visible_snapshot(session, Some(meta));
+        Ok(response)
     }
 
     /// 处理待办指令的主入口。解析 `/todo` 子命令并分派到对应的处理逻辑。
@@ -170,6 +171,7 @@ impl RustRespondService {
         if is_full_todo_result_request(user_text) {
             let (reply, command_name) = self.full_todo_result_from_last_query(&owner, session)?;
             return Ok(Some(self.append_todo_query_response(
+                meta,
                 session,
                 user_text,
                 reply,
@@ -182,6 +184,7 @@ impl RustRespondService {
             self.try_handle_natural_todo_query(user_text, &owner, session)?
         {
             return Ok(Some(self.append_todo_query_response(
+                meta,
                 session,
                 user_text,
                 reply,
@@ -362,7 +365,7 @@ impl RustRespondService {
         };
 
         let response = if visible_query_shown {
-            self.append_todo_query_response(session, user_text, reply, command_name)?
+            self.append_todo_query_response(meta, session, user_text, reply, command_name)?
         } else {
             self.append_pending_response(session, user_text, reply, command_name)?
         };
@@ -618,6 +621,40 @@ impl RustRespondService {
             )),
         }
     }
+}
+
+pub(in crate::runtime::respond) fn todo_tools_visible_snapshot(
+    session: &SessionRecord,
+    meta: Option<&SessionMeta>,
+) -> Option<ToolsVisibleSnapshot> {
+    let query = session.last_todo_query.as_ref()?;
+    if query.result_ids.is_empty() {
+        return None;
+    }
+    Some(ToolsVisibleSnapshot {
+        platform: meta
+            .map(|meta| meta.platform.clone())
+            .unwrap_or_else(|| session.platform.clone()),
+        account_id: meta.and_then(|meta| meta.account_id.clone()),
+        scope_key: meta
+            .map(|meta| meta.scope_key.clone())
+            .unwrap_or_else(|| session.scope_key.clone()),
+        owner_key: Some(query.owner_key.clone()),
+        created_at: query.created_at.clone(),
+        items: query
+            .result_ids
+            .iter()
+            .enumerate()
+            .map(|(index, id)| ToolsVisibleItem {
+                domain: "todo".to_owned(),
+                entity_kind: "todo".to_owned(),
+                entity_id: id.clone(),
+                visible_number: index + 1,
+                label: None,
+                status: Some(query.query_type.clone()),
+            })
+            .collect(),
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
@@ -22,6 +22,7 @@ use qq_maid_llm::tool::{DynTool, Tool, ToolContext, ToolMetadata, ToolOutput, To
 use serde_json::{Value, json};
 use uuid::Uuid;
 
+use crate::runtime::tools::SelectionScope;
 use crate::{
     config::ChatScene,
     error::LlmError,
@@ -117,40 +118,15 @@ impl RustRespondService {
                 }
                 if matches!(reply_kind, PendingReplyKind::Confirm) {
                     if item.status == TodoStatus::Pending {
-                        // 旧版本的 `TodoDelete` + Pending 表示“确认后软取消待办”。
-                        // 该变体没有持久化 delete/cancel 意图，升级后必须保留旧语义，
-                        // 避免把用户原本确认取消的旧 pending 解释成永久删除。
-                        let outcome = crate::runtime::todo::ops::cancel_many(
-                            &self.todo_store,
-                            session,
-                            owner,
-                            std::slice::from_ref(&item.id),
-                        )
-                        .map_err(todo_error)?;
-                        if outcome.cancelled.is_empty() {
-                            return Ok(Some(self.clear_pending_response(
-                                session,
-                                user_text,
-                                CommandBody::plain("这条待办已不存在或状态已变化，没有执行取消。"),
-                                "todo_cancel",
-                            )?));
-                        }
-                        for cancelled in &outcome.cancelled {
-                            cancel_reminder_task(&self.notification_store, cancelled).map_err(
-                                |message| {
-                                    LlmError::new(
-                                        "todo_reminder_cancel_failed",
-                                        message,
-                                        "todo_pending",
-                                    )
-                                },
-                            )?;
-                        }
+                        // legacy only：旧版 `TodoDelete + Pending` 曾表示软取消。
+                        // 新版删除/取消已严格分离，不能再把确认删除解释成取消。
                         return Ok(Some(self.clear_pending_response(
                             session,
                             user_text,
-                            CommandBody::plain("⛔ 已取消待办 1 条。"),
-                            "todo_cancel",
+                            CommandBody::plain(
+                                "这条旧版待确认操作已失效。请重新发起删除或取消操作。",
+                            ),
+                            "todo_legacy_delete",
                         )?));
                     }
                     let outcome = delete_by_ids_with_pending_status(
@@ -538,6 +514,7 @@ impl RustRespondService {
     }
 
     fn scoped_todo_tool(&self, tool_name: &str, scope: Arc<[String]>) -> Result<DynTool, LlmError> {
+        let scope = SelectionScope::Scoped(scope);
         match tool_name {
             "complete_todos" => Ok(Arc::new(
                 CompleteTodoTool::new(

--- a/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
@@ -51,6 +51,7 @@ enum TodoWriteOperation {
     Complete,
     Cancel,
     Restore,
+    Merge,
     DeletePending,
 }
 
@@ -543,6 +544,19 @@ fn receipt_from_tool_result_with_status(
                 "todo_restore",
             )?
         }
+        TodoWriteOperation::Merge => {
+            let target = result
+                .output
+                .get("merged")
+                .and_then(|value| value.get("target"))
+                .and_then(|value| item_from_value(Some(value)));
+            let lines = success_lines("🔀 已合并待办", target.as_ref());
+            let markdown_lines = success_markdown_lines("🔀 已合并待办", target.as_ref());
+            mutation_receipt(
+                CommandBody::dual(lines.join("\n"), markdown_lines.join("\n")),
+                "todo_merge",
+            )?
+        }
         TodoWriteOperation::DeletePending => pending_confirmation_receipt(&result.output),
     };
     Ok(receipt)
@@ -565,6 +579,7 @@ fn tool_effect_for_operation(operation: TodoWriteOperation) -> ToolEffect {
         TodoWriteOperation::Complete => ToolEffect::Completed,
         TodoWriteOperation::Cancel => ToolEffect::Cancelled,
         TodoWriteOperation::Restore => ToolEffect::Updated,
+        TodoWriteOperation::Merge => ToolEffect::Updated,
         TodoWriteOperation::DeletePending => ToolEffect::Deleted,
     }
 }
@@ -863,6 +878,7 @@ fn todo_write_operation(name: &str) -> Option<TodoWriteOperation> {
         "complete_todos" => Some(TodoWriteOperation::Complete),
         "cancel_todo" => Some(TodoWriteOperation::Cancel),
         "restore_todos" => Some(TodoWriteOperation::Restore),
+        "merge_todos" => Some(TodoWriteOperation::Merge),
         "delete_todos" => Some(TodoWriteOperation::DeletePending),
         _ => None,
     }

--- a/qq-maid-core/src/runtime/respond/tool_route.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route.rs
@@ -240,6 +240,20 @@ fn classify_semantic_route(text: &str, has_recent_todo_context: bool) -> Semanti
             "todo_reference_context",
         );
     }
+    if is_bare_number_todo_operation(text) {
+        if has_recent_todo_context {
+            return assessment(
+                SemanticRoute::ToolLoop,
+                ToolDomain::Todo,
+                "todo_number_context",
+            );
+        }
+        return assessment(
+            SemanticRoute::PlainChat,
+            ToolDomain::Todo,
+            "todo_number_context_missing",
+        );
+    }
     if has_memory_intent(text, &lower) {
         return assessment(
             SemanticRoute::ToolLoop,
@@ -316,6 +330,7 @@ fn classify_status_hint(text: &str, has_recent_todo_context: bool) -> Option<Sta
     if has_todo_intent(text, &lower)
         || is_strong_todo_reference_operation(text)
         || (has_recent_todo_context && is_weak_todo_context_reference(text))
+        || (has_recent_todo_context && is_bare_number_todo_operation(text))
     {
         return Some(StatusHint::new(
             StatusSubject::Todo,
@@ -612,6 +627,17 @@ fn is_bulk_todo_context_reference(text: &str) -> bool {
     contains_any(text, &["都", "全部", "全"]) && contains_any(text, TODO_CONFIRM_MARKERS)
 }
 
+fn is_bare_number_todo_operation(text: &str) -> bool {
+    let compact = text.split_whitespace().collect::<String>();
+    has_ascii_digit(&compact)
+        && (contains_any(&compact, TODO_CONFIRM_MARKERS)
+            || contains_any(&compact, &["删", "清掉", "作废", "合并"]))
+}
+
+fn has_ascii_digit(text: &str) -> bool {
+    text.bytes().any(|byte| byte.is_ascii_digit())
+}
+
 fn has_ordinal_reference(text: &str) -> bool {
     contains_any(
         text,
@@ -898,6 +924,53 @@ mod tests {
                 "{input}"
             );
             assert_eq!(weak_with_context.domain, ToolDomain::Todo, "{input}");
+        }
+    }
+
+    #[test]
+    fn bare_number_todo_operations_require_recent_context() {
+        for input in [
+            "7删除",
+            "删除7",
+            "7取消",
+            "取消7",
+            "7完成",
+            "把7合并到6",
+            "6和7合并",
+        ] {
+            let without_context = route_tool_loop(&request(input), context());
+            assert_eq!(without_context.route, ToolLoopRoute::PlainChat, "{input}");
+            assert_eq!(
+                without_context.reason, "todo_number_context_missing",
+                "{input}"
+            );
+
+            let with_context = route_tool_loop(&request(input), context_with_recent_todo());
+            assert_eq!(
+                with_context.route,
+                ToolLoopRoute::CompleteToolLoop,
+                "{input}"
+            );
+            assert_eq!(
+                with_context.semantic_route,
+                SemanticRoute::ToolLoop,
+                "{input}"
+            );
+            assert_eq!(with_context.domain, ToolDomain::Todo, "{input}");
+        }
+    }
+
+    #[test]
+    fn bare_numbers_without_todo_action_do_not_route_to_tools() {
+        for input in [
+            "407 笑死我了",
+            "T3 架构怎么设计",
+            "D1 版本说明",
+            "2026 年计划",
+        ] {
+            let decision = route_tool_loop(&request(input), context_with_recent_todo());
+            assert_eq!(decision.route, ToolLoopRoute::PlainChat, "{input}");
+            assert_ne!(decision.domain, ToolDomain::Todo, "{input}");
         }
     }
 

--- a/qq-maid-core/src/runtime/respond/types.rs
+++ b/qq-maid-core/src/runtime/respond/types.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use crate::{
     error::ErrorInfo,
     provider::types::{ChatMessage, ReasoningEffort, TokenUsage},
+    service::ToolsVisibleSnapshot,
     util::metrics::LlmMetrics,
 };
 use qq_maid_common::input_part::{MessageInputPart, QuotedMessageContext};
@@ -65,6 +66,10 @@ pub struct RespondRequest {
     /// 当前消息引用 / 回复的上下文，由 Gateway 归一化，Core 负责组装为 LLM 可见上下文。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub quoted: Option<QuotedMessageContext>,
+    /// 引用消息绑定的工具可见实体快照。仅服务端内部用于 Tool selection scope，
+    /// 不进入模型 prompt，也不作为用户可见响应序列化。
+    #[serde(default, skip)]
+    pub tools_visible_snapshot: Option<ToolsVisibleSnapshot>,
     /// 作用域键，用于隔离不同群 / 频道的会话
     #[serde(default)]
     pub scope_key: String,
@@ -168,6 +173,7 @@ impl Default for RespondRequest {
             content: String::new(),
             input_parts: Vec::new(),
             quoted: None,
+            tools_visible_snapshot: None,
             scope_key: String::new(),
             user_id: None,
             group_member_role: None,
@@ -241,6 +247,10 @@ pub struct RespondResponse {
     pub usage: Option<TokenUsage>,
     /// 错误信息
     pub error: Option<ErrorInfo>,
+    /// 当前回复绑定的工具可见实体快照。该字段只供 Gateway 写入引用索引，
+    /// 序列化时跳过，避免内部实体 ID 暴露到 HTTP/诊断面。
+    #[serde(default, skip)]
+    pub tools_visible_snapshot: Option<ToolsVisibleSnapshot>,
 }
 
 impl ChatResponse {
@@ -281,6 +291,7 @@ impl RespondResponse {
             metrics: chat.metrics,
             usage: chat.usage,
             error: chat.error,
+            tools_visible_snapshot: None,
         }
     }
 }

--- a/qq-maid-core/src/runtime/tools/mod.rs
+++ b/qq-maid-core/src/runtime/tools/mod.rs
@@ -15,9 +15,10 @@ pub use radar::{
     RadarTarget, build_radar_executor, radar_feedback_url, radar_site_url,
 };
 pub use rss::RssRecentItemsTool;
+pub(crate) use todo::SelectionScope;
 pub use todo::{
     CancelTodoTool, CompleteTodoTool, CreateTodoTool, DeleteTodoTool, EditTodoTool, GetTodoTool,
-    ListTodoTool, RestoreTodoTool,
+    ListTodoTool, MergeTodoTool, RestoreTodoTool,
 };
 pub use train::TrainScheduleTool;
 pub use weather::WeatherTool;

--- a/qq-maid-core/src/runtime/tools/todo/cancel.rs
+++ b/qq-maid-core/src/runtime/tools/todo/cancel.rs
@@ -45,7 +45,7 @@ impl CancelTodoTool {
     }
 
     /// 注入受限 Tool Loop 专属的请求级选择作用域，返回新实例。
-    pub fn with_selection_scope(mut self, scope: SelectionScope) -> Self {
+    pub(crate) fn with_selection_scope(mut self, scope: SelectionScope) -> Self {
         self.selection_scope = Some(scope);
         self
     }

--- a/qq-maid-core/src/runtime/tools/todo/common.rs
+++ b/qq-maid-core/src/runtime/tools/todo/common.rs
@@ -22,6 +22,7 @@ pub(super) const EDIT_TODO_TOOL_NAME: &str = "edit_todo";
 pub(super) const CANCEL_TODO_TOOL_NAME: &str = "cancel_todo";
 pub(super) const RESTORE_TODOS_TOOL_NAME: &str = "restore_todos";
 pub(super) const DELETE_TODOS_TOOL_NAME: &str = "delete_todos";
+pub(super) const MERGE_TODOS_TOOL_NAME: &str = "merge_todos";
 
 // 输入上限；超长直接拒绝，避免把异常长参数带进 pending / 存储。
 pub(super) const TODO_TOOL_MAX_NUMBERS: usize = 20;

--- a/qq-maid-core/src/runtime/tools/todo/complete.rs
+++ b/qq-maid-core/src/runtime/tools/todo/complete.rs
@@ -48,7 +48,7 @@ impl CompleteTodoTool {
     ///
     /// 该作用域不写入 Session / 数据库，仅用于本次受限 Loop 把模型给的可见编号映射到
     /// 本次澄清候选。
-    pub fn with_selection_scope(mut self, scope: SelectionScope) -> Self {
+    pub(crate) fn with_selection_scope(mut self, scope: SelectionScope) -> Self {
         self.selection_scope = Some(scope);
         self
     }

--- a/qq-maid-core/src/runtime/tools/todo/delete.rs
+++ b/qq-maid-core/src/runtime/tools/todo/delete.rs
@@ -49,7 +49,7 @@ impl DeleteTodoTool {
     }
 
     /// 注入受限 Tool Loop 专属的请求级选择作用域，返回新实例。
-    pub fn with_selection_scope(mut self, scope: SelectionScope) -> Self {
+    pub(crate) fn with_selection_scope(mut self, scope: SelectionScope) -> Self {
         self.selection_scope = Some(scope);
         self
     }

--- a/qq-maid-core/src/runtime/tools/todo/edit.rs
+++ b/qq-maid-core/src/runtime/tools/todo/edit.rs
@@ -49,7 +49,7 @@ impl EditTodoTool {
     }
 
     /// 注入受限 Tool Loop 专属的请求级选择作用域，返回新实例。
-    pub fn with_selection_scope(mut self, scope: SelectionScope) -> Self {
+    pub(crate) fn with_selection_scope(mut self, scope: SelectionScope) -> Self {
         self.selection_scope = Some(scope);
         self
     }

--- a/qq-maid-core/src/runtime/tools/todo/get.rs
+++ b/qq-maid-core/src/runtime/tools/todo/get.rs
@@ -9,12 +9,13 @@ use crate::error::LlmError;
 
 use super::common::{GET_TODO_TOOL_NAME, single_number_or_reference_schema};
 use super::json::todo_selected_item_json;
-use super::scope::{TodoToolScope, TodoToolSingleItemResolution};
+use super::scope::{SelectionScope, TodoToolScope, TodoToolSingleItemResolution};
 use super::selection::{prepare_selection_arguments, resolved_selection_from_arguments};
 
 pub struct GetTodoTool {
     todo_store: crate::runtime::todo::TodoStore,
     session_store: crate::runtime::session::SessionStore,
+    selection_scope: Option<SelectionScope>,
 }
 
 impl GetTodoTool {
@@ -25,7 +26,13 @@ impl GetTodoTool {
         Self {
             todo_store,
             session_store,
+            selection_scope: None,
         }
+    }
+
+    pub(crate) fn with_selection_scope(mut self, scope: SelectionScope) -> Self {
+        self.selection_scope = Some(scope);
+        self
     }
 }
 
@@ -50,7 +57,7 @@ impl Tool for GetTodoTool {
             context,
             arguments,
             false,
-            None,
+            self.selection_scope.clone(),
         )
     }
 
@@ -59,7 +66,8 @@ impl Tool for GetTodoTool {
         context: ToolContext,
         arguments: serde_json::Value,
     ) -> Result<ToolOutput, LlmError> {
-        let mut scope = TodoToolScope::load(&self.session_store, &context, None)?;
+        let mut scope =
+            TodoToolScope::load(&self.session_store, &context, self.selection_scope.clone())?;
         let resolved =
             resolved_selection_from_arguments(&mut scope, &self.todo_store, &arguments, false)?;
         let label = resolved.single_label();

--- a/qq-maid-core/src/runtime/tools/todo/merge.rs
+++ b/qq-maid-core/src/runtime/tools/todo/merge.rs
@@ -186,8 +186,21 @@ impl Tool for MergeTodoTool {
             .todo_store
             .edit(&scope.owner, &target.id, draft)
             .map_err(todo_tool_error)?;
-        sync_reminder_task(&self.notification_store, &scope.owner, &updated)
-            .map_err(|message| LlmError::new("todo_reminder_sync_failed", message, "todo_tool"))?;
+        if let Err(message) = sync_reminder_task(&self.notification_store, &scope.owner, &updated) {
+            scope.session.last_todo_query = None;
+            scope
+                .session
+                .remember_last_todo_action(&scope.owner.key, &updated, "merged_partial");
+            scope.save()?;
+            return Ok(ToolOutput::json(json!({
+                "ok": false,
+                "partial_failure": true,
+                "error_code": "todo_merge_reminder_sync_failed",
+                "message": message,
+                "target": todo_plain_item_json(&updated),
+                "source": todo_plain_item_json(&source),
+            })));
+        }
 
         let delete_outcome = self
             .todo_store

--- a/qq-maid-core/src/runtime/tools/todo/merge.rs
+++ b/qq-maid-core/src/runtime/tools/todo/merge.rs
@@ -1,0 +1,296 @@
+//! `merge_todos` Tool。
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use qq_maid_llm::tool::{Tool, ToolContext, ToolMetadata, ToolOutput, ToolPreparation};
+
+use crate::{
+    error::LlmError,
+    runtime::todo::{TodoItem, TodoItemDraft, TodoStatus, reminder_task::sync_reminder_task},
+    storage::notification::NotificationOutboxStore,
+};
+
+use super::common::{
+    MERGE_TODOS_TOOL_NAME, TODO_REFERENCE_INVALID_STATE_CODE, TODO_SELECTION_NOT_FOUND_CODE,
+    TodoSelectionRequest, bad_tool_arguments, todo_tool_error, todo_tool_error_output,
+};
+use super::json::todo_plain_item_json;
+use super::scope::{SelectionScope, TodoToolScope, TodoToolSelectionResolution};
+
+pub struct MergeTodoTool {
+    todo_store: crate::runtime::todo::TodoStore,
+    session_store: crate::runtime::session::SessionStore,
+    notification_store: NotificationOutboxStore,
+    selection_scope: Option<SelectionScope>,
+}
+
+impl MergeTodoTool {
+    pub fn new(
+        todo_store: crate::runtime::todo::TodoStore,
+        session_store: crate::runtime::session::SessionStore,
+        notification_store: NotificationOutboxStore,
+    ) -> Self {
+        Self {
+            todo_store,
+            session_store,
+            notification_store,
+            selection_scope: None,
+        }
+    }
+
+    pub(crate) fn with_selection_scope(mut self, scope: SelectionScope) -> Self {
+        self.selection_scope = Some(scope);
+        self
+    }
+}
+
+#[async_trait]
+impl Tool for MergeTodoTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            name: MERGE_TODOS_TOOL_NAME.to_owned(),
+            description: "合并两个未完成待办。source_number 是要被合入并物理删除的 visible_number，target_number 是保留并更新的 visible_number。用户说“把 7 合并到 6”时 source_number=7,target_number=6；用户说“6 和 7 合并”且未明确方向时，保守追问，不要调用本工具。".to_owned(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "source_number": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "源待办 visible_number；合并后会物理删除。"
+                    },
+                    "target_number": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "目标待办 visible_number；合并后保留。"
+                    }
+                },
+                "required": ["source_number", "target_number"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn prepare(
+        &self,
+        context: &ToolContext,
+        arguments: Value,
+    ) -> Result<ToolPreparation, LlmError> {
+        let source = required_number(&arguments, "source_number")?;
+        let target = required_number(&arguments, "target_number")?;
+        let mut scope =
+            TodoToolScope::load(&self.session_store, context, self.selection_scope.clone())?;
+        let resolved = match scope.resolve_selection(
+            &TodoSelectionRequest::Numbers(vec![target, source]),
+            &self.todo_store,
+        )? {
+            TodoToolSelectionResolution::Resolved(resolved) => resolved,
+            TodoToolSelectionResolution::Output(output) => {
+                let mut prepared = arguments;
+                prepared["_error_output"] = output.value;
+                return Ok(ToolPreparation::ready(prepared));
+            }
+        };
+        let mut prepared = arguments;
+        let object = prepared
+            .as_object_mut()
+            .ok_or_else(|| bad_tool_arguments("tool arguments must be a JSON object"))?;
+        if let Some(id) = resolved
+            .matched
+            .iter()
+            .find(|(label, _)| label_visible_number(label) == Some(target))
+            .map(|(_, id)| json!(id))
+        {
+            object.insert("_target_id".to_owned(), id);
+        }
+        if let Some(id) = resolved
+            .matched
+            .iter()
+            .find(|(label, _)| label_visible_number(label) == Some(source))
+            .map(|(_, id)| json!(id))
+        {
+            object.insert("_source_id".to_owned(), id);
+        }
+        if !resolved.missing.is_empty() || resolved.error_output.is_some() {
+            object.insert(
+                "_error_output".to_owned(),
+                json!({
+                    "ok": false,
+                    "error_code": TODO_SELECTION_NOT_FOUND_CODE,
+                    "message": "visible number not found"
+                }),
+            );
+        }
+        Ok(ToolPreparation::ready(prepared))
+    }
+
+    async fn execute(
+        &self,
+        context: ToolContext,
+        arguments: Value,
+    ) -> Result<ToolOutput, LlmError> {
+        let mut scope =
+            TodoToolScope::load(&self.session_store, &context, self.selection_scope.clone())?;
+        if let Some(output) = arguments.get("_error_output").cloned() {
+            return Ok(ToolOutput::json(output));
+        }
+        let target_id =
+            match prepared_id_or_resolve(&mut scope, &self.todo_store, &arguments, "target")? {
+                PreparedMergeId::Resolved(id) => id,
+                PreparedMergeId::Output(output) => return Ok(output),
+            };
+        let source_id =
+            match prepared_id_or_resolve(&mut scope, &self.todo_store, &arguments, "source")? {
+                PreparedMergeId::Resolved(id) => id,
+                PreparedMergeId::Output(output) => return Ok(output),
+            };
+        if target_id == source_id {
+            return Ok(todo_tool_error_output(
+                TODO_SELECTION_NOT_FOUND_CODE,
+                "source and target must be different todos",
+            ));
+        }
+
+        let Some(target) = self
+            .todo_store
+            .get_by_id(&scope.owner, &target_id)
+            .map_err(todo_tool_error)?
+        else {
+            return Ok(todo_tool_error_output(
+                TODO_SELECTION_NOT_FOUND_CODE,
+                "target todo no longer exists",
+            ));
+        };
+        let Some(source) = self
+            .todo_store
+            .get_by_id(&scope.owner, &source_id)
+            .map_err(todo_tool_error)?
+        else {
+            return Ok(todo_tool_error_output(
+                TODO_SELECTION_NOT_FOUND_CODE,
+                "source todo no longer exists",
+            ));
+        };
+        if target.status != TodoStatus::Pending || source.status != TodoStatus::Pending {
+            return Ok(todo_tool_error_output(
+                TODO_REFERENCE_INVALID_STATE_CODE,
+                "merge_todos only accepts pending todos",
+            ));
+        }
+
+        let mut draft =
+            TodoItemDraft::from_item(&target, target.raw_text.clone().unwrap_or_default());
+        draft.detail = Some(merged_detail(&target, &source));
+        draft.raw_text = Some(format!("{}\n{}", target.title.trim(), source.title.trim()));
+        let updated = self
+            .todo_store
+            .edit(&scope.owner, &target.id, draft)
+            .map_err(todo_tool_error)?;
+        sync_reminder_task(&self.notification_store, &scope.owner, &updated)
+            .map_err(|message| LlmError::new("todo_reminder_sync_failed", message, "todo_tool"))?;
+
+        let delete_outcome = self
+            .todo_store
+            .delete_pending_by_ids(&scope.owner, std::slice::from_ref(&source.id))
+            .map_err(todo_tool_error)?;
+        if delete_outcome.deleted_count == 0 {
+            scope.session.last_todo_query = None;
+            scope
+                .session
+                .remember_last_todo_action(&scope.owner.key, &updated, "merged");
+            scope.save()?;
+            return Ok(ToolOutput::json(json!({
+                "ok": false,
+                "partial_failure": true,
+                "error_code": "todo_merge_source_delete_failed",
+                "message": "target updated but source was not deleted",
+                "target": todo_plain_item_json(&updated),
+                "source": todo_plain_item_json(&source),
+            })));
+        }
+
+        scope.session.last_todo_query = None;
+        scope
+            .session
+            .remember_last_todo_action(&scope.owner.key, &updated, "merged");
+        scope.clear_clarification_if_scoped();
+        scope.save()?;
+        Ok(ToolOutput::json(json!({
+            "ok": true,
+            "merged": {
+                "target": todo_plain_item_json(&updated),
+                "source_deleted": todo_plain_item_json(&source),
+            },
+            "message": "已合并待办；源项已物理删除。",
+        })))
+    }
+}
+
+fn required_number(arguments: &Value, field: &str) -> Result<usize, LlmError> {
+    let value = arguments
+        .get(field)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| bad_tool_arguments(format!("{field} must be a positive integer")))?;
+    usize::try_from(value).map_err(|_| bad_tool_arguments(format!("{field} is too large")))
+}
+
+fn label_visible_number(label: &super::common::TodoSelectionLabel) -> Option<usize> {
+    match label {
+        super::common::TodoSelectionLabel::Number(number) => Some(*number),
+        super::common::TodoSelectionLabel::Reference(_) => None,
+    }
+}
+
+fn prepared_id_or_resolve(
+    scope: &mut TodoToolScope,
+    todo_store: &crate::runtime::todo::TodoStore,
+    arguments: &Value,
+    role: &str,
+) -> Result<PreparedMergeId, LlmError> {
+    let id_key = format!("_{role}_id");
+    if let Some(id) = arguments.get(&id_key).and_then(Value::as_str) {
+        return Ok(PreparedMergeId::Resolved(id.to_owned()));
+    }
+    let number = required_number(arguments, &format!("{role}_number"))?;
+    let resolved =
+        match scope.resolve_selection(&TodoSelectionRequest::Numbers(vec![number]), todo_store)? {
+            TodoToolSelectionResolution::Resolved(resolved) => resolved,
+            TodoToolSelectionResolution::Output(output) => {
+                return Ok(PreparedMergeId::Output(output));
+            }
+        };
+    if let Some((_, id)) = resolved.matched.first() {
+        return Ok(PreparedMergeId::Resolved(id.clone()));
+    }
+    Ok(PreparedMergeId::Output(todo_tool_error_output(
+        TODO_SELECTION_NOT_FOUND_CODE,
+        "visible number not found",
+    )))
+}
+
+enum PreparedMergeId {
+    Resolved(String),
+    Output(ToolOutput),
+}
+
+fn merged_detail(target: &TodoItem, source: &TodoItem) -> String {
+    let mut parts = Vec::new();
+    if let Some(detail) = target
+        .detail
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        parts.push(detail.to_owned());
+    }
+    parts.push(format!("合并来源：{}", source.title.trim()));
+    if let Some(detail) = source
+        .detail
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        parts.push(detail.to_owned());
+    }
+    parts.join("\n")
+}

--- a/qq-maid-core/src/runtime/tools/todo/mod.rs
+++ b/qq-maid-core/src/runtime/tools/todo/mod.rs
@@ -23,6 +23,7 @@ mod delete;
 mod edit;
 mod get;
 mod list;
+mod merge;
 mod restore;
 
 pub use cancel::CancelTodoTool;
@@ -32,7 +33,9 @@ pub use delete::DeleteTodoTool;
 pub use edit::EditTodoTool;
 pub use get::GetTodoTool;
 pub use list::ListTodoTool;
+pub use merge::MergeTodoTool;
 pub use restore::RestoreTodoTool;
+pub(crate) use scope::SelectionScope;
 
 #[cfg(test)]
 mod tests;

--- a/qq-maid-core/src/runtime/tools/todo/restore.rs
+++ b/qq-maid-core/src/runtime/tools/todo/restore.rs
@@ -44,7 +44,7 @@ impl RestoreTodoTool {
     }
 
     /// 注入受限 Tool Loop 专属的请求级选择作用域，返回新实例。
-    pub fn with_selection_scope(mut self, scope: SelectionScope) -> Self {
+    pub(crate) fn with_selection_scope(mut self, scope: SelectionScope) -> Self {
         self.selection_scope = Some(scope);
         self
     }

--- a/qq-maid-core/src/runtime/tools/todo/scope.rs
+++ b/qq-maid-core/src/runtime/tools/todo/scope.rs
@@ -32,13 +32,17 @@ use super::common::{
     TodoToolDedupEntry, session_tool_error, todo_tool_error, todo_tool_error_output,
 };
 
-/// 受限 Tool Loop 专属的请求级选择作用域：按展示顺序排列的内部 ID 列表。
+/// 受限 Tool Loop / 引用消息专属的请求级选择作用域。
 ///
-/// 该作用域是运行时内存态覆盖，由澄清恢复路径在构造受限 TodoTool 实例时注入，
+/// 该作用域是运行时内存态覆盖，由澄清恢复或引用消息路径在构造 TodoTool 实例时注入，
 /// **不写入 Session / 数据库 / 全局共享状态**。`resolve_numbers` 优先用它把模型
-/// 给的 `numbers=[n]` 映射到本次澄清候选，只有它为空时才回退到会话默认的
-/// `last_todo_query` 快照，避免澄清候选污染后续“第二条”“刚刚列表”等语义。
-pub(crate) type SelectionScope = Arc<[String]>;
+/// 给的 `numbers=[n]` 映射到本次可见快照；引用快照存在但校验失败时会注入
+/// `Blocked`，明确禁止 fallback 到 `last_todo_query`，避免跨 owner/account 误操作。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SelectionScope {
+    Scoped(Arc<[String]>),
+    Blocked,
+}
 
 const TODO_TASK_QUERY_HISTORY_KEY: &str = "tool_todo_task_query_history";
 const TODO_TASK_QUERY_HISTORY_LIMIT: usize = 16;
@@ -270,23 +274,27 @@ impl TodoToolScope {
         numbers: &[usize],
         todo_store: &TodoStore,
     ) -> Result<ResolvedTodoSelection, LlmError> {
-        // 受限 Tool Loop 注入了请求级选择作用域时优先用它，把模型给的可见编号映射到
-        // 本次澄清候选；只有未注入时才回退会话默认 `last_todo_query` 快照。
-        let scoped_ids = self.selection_scope.as_deref();
-        let scoped_match = |number: usize| -> Option<String> {
-            scoped_ids?
-                .get(number.saturating_sub(1))
-                .filter(|_| number > 0)
-                .cloned()
-        };
-        if scoped_ids.is_some() {
+        // 优先级：quoted visible snapshot / pending clarification candidate scope
+        // > Tool Loop 本轮临时 list_todos scope > session.last_todo_query > last_todo_action。
+        // 引用快照存在但 scope/owner/account 校验失败时，必须显式阻断 fallback。
+        if matches!(self.selection_scope, Some(SelectionScope::Blocked)) {
+            return Ok(ResolvedTodoSelection::error(
+                TODO_VISIBLE_NUMBERS_UNAVAILABLE_CODE,
+                "quoted visible snapshot is unavailable for this request",
+            ));
+        }
+        if let Some(SelectionScope::Scoped(scoped_ids)) = self.selection_scope.as_ref() {
             let mut matched = Vec::new();
             let mut missing = Vec::new();
             let mut labels = Vec::new();
             for number in numbers {
                 let label = TodoSelectionLabel::Number(*number);
                 labels.push(label.clone());
-                if let Some(id) = scoped_match(*number) {
+                if let Some(id) = scoped_ids
+                    .get(number.saturating_sub(1))
+                    .filter(|_| *number > 0)
+                    .cloned()
+                {
                     matched.push((label, id));
                 } else {
                     missing.push(label);

--- a/qq-maid-core/src/runtime/tools/todo/tests.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests.rs
@@ -2554,6 +2554,81 @@ async fn merge_numbers_use_quoted_snapshot_and_physically_delete_source() {
 }
 
 #[tokio::test]
+async fn merge_reminder_sync_failure_returns_structured_partial_failure() {
+    let (todo_store, session_store, notification_store, owner) = test_stores();
+    let mut target_draft = tool_test_draft("目标待办");
+    target_draft.reminder_at = Some("not-a-valid-reminder".to_owned());
+    let target = todo_store.create(&owner, target_draft).unwrap();
+    let source = todo_store
+        .create(&owner, tool_test_draft("来源待办"))
+        .unwrap();
+    let mut session = session_store
+        .get_or_create_active(&SessionMeta::new(
+            "private:u1",
+            Some("u1".to_owned()),
+            None,
+            None,
+            None,
+            "qq_official",
+        ))
+        .unwrap();
+    session.remember_last_todo_query(
+        &owner.key,
+        "list",
+        "待办列表",
+        vec![target.id.clone(), source.id.clone()],
+    );
+    session_store.save(&mut session).unwrap();
+
+    let merge_tool = MergeTodoTool::new(
+        todo_store.clone(),
+        session_store.clone(),
+        notification_store,
+    );
+    let output = merge_tool
+        .execute(
+            test_context(),
+            json!({"source_number": 2, "target_number": 1}),
+        )
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(output["ok"], false);
+    assert_eq!(output["partial_failure"], true);
+    assert_eq!(output["error_code"], "todo_merge_reminder_sync_failed");
+    let updated_target = todo_store.get_by_id(&owner, &target.id).unwrap().unwrap();
+    assert!(
+        updated_target
+            .detail
+            .unwrap_or_default()
+            .contains("来源待办")
+    );
+    assert!(
+        todo_store.get_by_id(&owner, &source.id).unwrap().is_some(),
+        "source should not be deleted after reminder sync partial failure"
+    );
+    let saved = session_store
+        .get_or_create_active(&SessionMeta::new(
+            "private:u1",
+            Some("u1".to_owned()),
+            None,
+            None,
+            None,
+            "qq_official",
+        ))
+        .unwrap();
+    assert!(saved.last_todo_query.is_none());
+    assert_eq!(
+        saved
+            .last_todo_action
+            .as_ref()
+            .map(|action| action.action.as_str()),
+        Some("merged_partial")
+    );
+}
+
+#[tokio::test]
 async fn delete_tool_rejects_mixed_status_bulk_selection_without_pending() {
     let (todo_store, session_store, notification_store, owner) = test_stores();
     let pending = todo_store

--- a/qq-maid-core/src/runtime/tools/todo/tests.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests.rs
@@ -1,4 +1,6 @@
 // 拆分后这些不再随 `super::*` 自动进入命名空间，测试体里仍直接引用完整类型/宏。
+use std::sync::Arc;
+
 use serde_json::{Value, json};
 
 use qq_maid_llm::tool::{Tool, ToolContext};
@@ -9,10 +11,10 @@ use crate::runtime::todo::{
     TodoItem, TodoItemDraft, TodoOwner, TodoStatus, TodoStore, TodoTimePrecision,
 };
 
-use super::scope::TodoToolScope;
+use super::scope::{SelectionScope, TodoToolScope};
 use super::{
     CancelTodoTool, CompleteTodoTool, CreateTodoTool, DeleteTodoTool, EditTodoTool, GetTodoTool,
-    ListTodoTool,
+    ListTodoTool, MergeTodoTool,
 };
 use crate::storage::{APP_MIGRATIONS, database::SqliteDatabase};
 
@@ -2310,6 +2312,245 @@ async fn delete_numbers_prefer_current_task_query_over_stale_visible_snapshot() 
         }
         other => panic!("expected single delete pending, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn delete_numbers_prefer_quoted_snapshot_over_latest_last_todo_query() {
+    let (todo_store, session_store, notification_store, owner) = test_stores();
+    let mut list_a_ids = Vec::new();
+    let mut list_b_ids = Vec::new();
+    for index in 1..=7 {
+        let item = todo_store
+            .create(&owner, tool_test_draft(&format!("列表 A 第 {index} 条")))
+            .unwrap();
+        list_a_ids.push(item.id);
+    }
+    for index in 1..=7 {
+        let item = todo_store
+            .create(&owner, tool_test_draft(&format!("列表 B 第 {index} 条")))
+            .unwrap();
+        list_b_ids.push(item.id);
+    }
+    let mut session = session_store
+        .get_or_create_active(&SessionMeta::new(
+            "private:u1",
+            Some("u1".to_owned()),
+            None,
+            None,
+            None,
+            "qq_official",
+        ))
+        .unwrap();
+    session.remember_last_todo_query(&owner.key, "list", "列表 B", list_b_ids.clone());
+    session_store.save(&mut session).unwrap();
+
+    let delete_tool = DeleteTodoTool::new(todo_store, session_store.clone(), notification_store)
+        .with_selection_scope(SelectionScope::Scoped(Arc::from(list_a_ids.clone())));
+    let output = delete_tool
+        .execute(
+            test_context(),
+            json!({"numbers": [7], "reference": null, "query": null, "all_status": null}),
+        )
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(output["ok"], true);
+    let session = session_store
+        .get_or_create_active(&SessionMeta::new(
+            "private:u1",
+            Some("u1".to_owned()),
+            None,
+            None,
+            None,
+            "qq_official",
+        ))
+        .unwrap();
+    match session.pending_operation {
+        Some(PendingOperation::TodoBulkDelete { item_ids, .. }) => {
+            assert_eq!(item_ids, vec![list_a_ids[6].clone()]);
+            assert_ne!(item_ids, vec![list_b_ids[6].clone()]);
+        }
+        other => panic!("expected bulk delete pending from quoted snapshot, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn blocked_quoted_snapshot_does_not_fallback_to_last_todo_query() {
+    let (todo_store, session_store, notification_store, owner) = test_stores();
+    let fallback = todo_store
+        .create(&owner, tool_test_draft("不应被 fallback 删除"))
+        .unwrap();
+    let mut session = session_store
+        .get_or_create_active(&SessionMeta::new(
+            "private:u1",
+            Some("u1".to_owned()),
+            None,
+            None,
+            None,
+            "qq_official",
+        ))
+        .unwrap();
+    session.remember_last_todo_query(&owner.key, "list", "列表 B", vec![fallback.id]);
+    session_store.save(&mut session).unwrap();
+
+    let delete_tool = DeleteTodoTool::new(todo_store, session_store.clone(), notification_store)
+        .with_selection_scope(SelectionScope::Blocked);
+    let output = delete_tool
+        .execute(
+            test_context(),
+            json!({"numbers": [1], "reference": null, "query": null, "all_status": null}),
+        )
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(output["ok"], false);
+    let session = session_store
+        .get_or_create_active(&SessionMeta::new(
+            "private:u1",
+            Some("u1".to_owned()),
+            None,
+            None,
+            None,
+            "qq_official",
+        ))
+        .unwrap();
+    assert!(session.pending_operation.is_none());
+}
+
+#[tokio::test]
+async fn cancel_numbers_use_quoted_snapshot_and_do_not_delete() {
+    let (todo_store, session_store, notification_store, owner) = test_stores();
+    let mut list_a_ids = Vec::new();
+    let mut list_b_ids = Vec::new();
+    for index in 1..=7 {
+        list_a_ids.push(
+            todo_store
+                .create(
+                    &owner,
+                    tool_test_draft(&format!("取消列表 A 第 {index} 条")),
+                )
+                .unwrap()
+                .id,
+        );
+        list_b_ids.push(
+            todo_store
+                .create(
+                    &owner,
+                    tool_test_draft(&format!("取消列表 B 第 {index} 条")),
+                )
+                .unwrap()
+                .id,
+        );
+    }
+    let mut session = session_store
+        .get_or_create_active(&SessionMeta::new(
+            "private:u1",
+            Some("u1".to_owned()),
+            None,
+            None,
+            None,
+            "qq_official",
+        ))
+        .unwrap();
+    session.remember_last_todo_query(&owner.key, "list", "列表 B", list_b_ids.clone());
+    session_store.save(&mut session).unwrap();
+
+    let cancel_tool = CancelTodoTool::new(todo_store.clone(), session_store, notification_store)
+        .with_selection_scope(SelectionScope::Scoped(Arc::from(list_a_ids.clone())));
+    let output = cancel_tool
+        .execute(
+            test_context(),
+            json!({"numbers": [7], "selection_text": null, "reference": null}),
+        )
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(output["ok"], true);
+    assert_eq!(output["cancelled"].as_array().unwrap().len(), 1);
+    let cancelled = todo_store.list_cancelled(&owner).unwrap();
+    assert_eq!(cancelled.len(), 1);
+    assert_eq!(cancelled[0].id, list_a_ids[6]);
+    assert_eq!(
+        todo_store
+            .get_by_id(&owner, &list_b_ids[6])
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
+}
+
+#[tokio::test]
+async fn merge_numbers_use_quoted_snapshot_and_physically_delete_source() {
+    let (todo_store, session_store, notification_store, owner) = test_stores();
+    let mut list_a_ids = Vec::new();
+    let mut list_b_ids = Vec::new();
+    for index in 1..=7 {
+        let mut draft = tool_test_draft(&format!("合并列表 A 第 {index} 条"));
+        draft.detail = Some(format!("A detail {index}"));
+        list_a_ids.push(todo_store.create(&owner, draft).unwrap().id);
+        list_b_ids.push(
+            todo_store
+                .create(
+                    &owner,
+                    tool_test_draft(&format!("合并列表 B 第 {index} 条")),
+                )
+                .unwrap()
+                .id,
+        );
+    }
+    let mut session = session_store
+        .get_or_create_active(&SessionMeta::new(
+            "private:u1",
+            Some("u1".to_owned()),
+            None,
+            None,
+            None,
+            "qq_official",
+        ))
+        .unwrap();
+    session.remember_last_todo_query(&owner.key, "list", "列表 B", list_b_ids.clone());
+    session_store.save(&mut session).unwrap();
+
+    let merge_tool = MergeTodoTool::new(todo_store.clone(), session_store, notification_store)
+        .with_selection_scope(SelectionScope::Scoped(Arc::from(list_a_ids.clone())));
+    let output = merge_tool
+        .execute(
+            test_context(),
+            json!({"source_number": 7, "target_number": 6}),
+        )
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(output["ok"], true);
+    let target = todo_store
+        .get_by_id(&owner, &list_a_ids[5])
+        .unwrap()
+        .unwrap();
+    assert!(target.detail.unwrap_or_default().contains("A detail 7"));
+    assert!(
+        todo_store
+            .get_by_id(&owner, &list_a_ids[6])
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        todo_store
+            .list_cancelled(&owner)
+            .unwrap()
+            .iter()
+            .all(|item| item.id != list_a_ids[6])
+    );
+    assert!(
+        todo_store
+            .get_by_id(&owner, &list_b_ids[6])
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/service/handle.rs
+++ b/qq-maid-core/src/service/handle.rs
@@ -135,7 +135,9 @@ impl CoreService for CoreHandle {
         .await;
 
         match result {
-            Ok(Ok(response)) if response.ok => Ok(CoreRespondOutput::Complete(response.into())),
+            Ok(Ok(response)) if response.ok => {
+                Ok(CoreRespondOutput::Complete(Box::new(response.into())))
+            }
             Ok(Ok(response)) => {
                 let err = response.error.map(CoreError::from).unwrap_or_else(|| {
                     CoreError::new("internal_error", "respond", "处理失败，请稍后再试")

--- a/qq-maid-core/src/service/handle.rs
+++ b/qq-maid-core/src/service/handle.rs
@@ -241,6 +241,7 @@ impl From<CoreRequest> for RespondRequest {
             content: value.text,
             input_parts: value.input_parts,
             quoted: value.quoted,
+            tools_visible_snapshot: value.tools_visible_snapshot,
             scope_key,
             user_id: value.actor.user_id,
             group_member_role: value
@@ -267,6 +268,7 @@ impl From<RespondResponse> for CoreResponse {
             session_id: value.session_id,
             command: value.command,
             diagnostics: value.diagnostics,
+            tools_visible_snapshot: value.tools_visible_snapshot,
         }
     }
 }

--- a/qq-maid-core/src/service/streaming.rs
+++ b/qq-maid-core/src/service/streaming.rs
@@ -72,7 +72,7 @@ pub(crate) fn start_core_response_stream(
             return;
         }
         let event = match result {
-            Ok(response) if response.ok => CoreResponseEvent::Completed(response.into()),
+            Ok(response) if response.ok => CoreResponseEvent::Completed(Box::new(response.into())),
             Ok(response) => {
                 let err = response.error.map(CoreError::from).unwrap_or_else(|| {
                     CoreError::new("internal_error", "respond", "处理失败，请稍后再试")

--- a/qq-maid-core/src/service/tests.rs
+++ b/qq-maid-core/src/service/tests.rs
@@ -714,6 +714,7 @@ async fn core_private_simple_todo_queries_use_deterministic_path() {
         let CoreRespondOutput::Complete(response) = output else {
             panic!("expected complete output for deterministic todo query");
         };
+        let response = *response;
         assert_eq!(response.command.as_deref(), Some("todo_list"), "{input}");
         assert!(response.text.as_deref().unwrap().contains("待查看项目"));
         responses.push(response.text);
@@ -826,7 +827,7 @@ async fn collect_stream_completed(output: Result<CoreRespondOutput, CoreError>) 
     let mut stream = expect_stream(output.unwrap());
     while let Some(event) = stream.recv().await {
         if let CoreResponseEvent::Completed(response) = event {
-            return response;
+            return *response;
         }
     }
     panic!("stream ended without completed response");
@@ -836,7 +837,7 @@ async fn collect_completed_without_text_delta(stream: &mut CoreResponseStream) -
     while let Some(event) = stream.recv().await {
         match event {
             CoreResponseEvent::Status(_) => {}
-            CoreResponseEvent::Completed(response) => return response,
+            CoreResponseEvent::Completed(response) => return *response,
             CoreResponseEvent::TextDelta(delta) => {
                 panic!("unexpected text delta before completed response: {delta}");
             }

--- a/qq-maid-core/src/service/tests.rs
+++ b/qq-maid-core/src/service/tests.rs
@@ -42,6 +42,7 @@ fn private_conversation_derives_private_scope() {
         text: "hello".to_owned(),
         input_parts: Vec::new(),
         quoted: None,
+        tools_visible_snapshot: None,
         platform: Platform::QqOfficial,
         account_id: Some("app-1".to_owned()),
         actor: CoreActor {
@@ -70,6 +71,7 @@ fn group_conversation_derives_group_scope_without_member_split() {
         text: "/todo".to_owned(),
         input_parts: Vec::new(),
         quoted: None,
+        tools_visible_snapshot: None,
         platform: Platform::QqOfficial,
         account_id: Some("app-1".to_owned()),
         actor: CoreActor {
@@ -115,6 +117,7 @@ fn core_response_keeps_public_fields_from_respond_response() {
         session_id: Some("session-1".to_owned()),
         command: Some("chat".to_owned()),
         diagnostics: Some(serde_json::json!({"k":"v"})),
+        tools_visible_snapshot: None,
         metrics: LlmMetrics {
             provider: "test".to_owned(),
             model: "test".to_owned(),
@@ -1085,6 +1088,7 @@ fn private_request(text: &str) -> CoreRequest {
         text: text.to_owned(),
         input_parts: Vec::new(),
         quoted: None,
+        tools_visible_snapshot: None,
         platform: Platform::QqOfficial,
         account_id: Some("app-1".to_owned()),
         actor: CoreActor {
@@ -1106,6 +1110,7 @@ fn group_request(text: &str) -> CoreRequest {
         text: text.to_owned(),
         input_parts: Vec::new(),
         quoted: None,
+        tools_visible_snapshot: None,
         platform: Platform::QqOfficial,
         account_id: Some("app-1".to_owned()),
         actor: CoreActor {
@@ -1123,6 +1128,7 @@ fn wechat_service_request(text: &str) -> CoreRequest {
         text: text.to_owned(),
         input_parts: Vec::new(),
         quoted: None,
+        tools_visible_snapshot: None,
         platform: Platform::WechatService,
         account_id: Some("gh-service".to_owned()),
         actor: CoreActor {

--- a/qq-maid-core/src/service/types.rs
+++ b/qq-maid-core/src/service/types.rs
@@ -132,7 +132,7 @@ pub struct CoreResponse {
 
 #[derive(Debug)]
 pub enum CoreRespondOutput {
-    Complete(CoreResponse),
+    Complete(Box<CoreResponse>),
     Stream(CoreResponseStream),
 }
 
@@ -176,7 +176,7 @@ pub enum CoreResponseEvent {
     /// Tool Loop 路径只会在工具循环完成、业务校验通过并生成最终回复后发送该事件；
     /// 工具参数、工具结果原文和模型中间候选文本不得通过此事件外发。
     TextDelta(String),
-    Completed(CoreResponse),
+    Completed(Box<CoreResponse>),
     Failed(CoreRespondFailure),
 }
 

--- a/qq-maid-core/src/service/types.rs
+++ b/qq-maid-core/src/service/types.rs
@@ -30,10 +30,36 @@ pub struct CoreRequest {
     pub text: String,
     pub input_parts: Vec<MessageInputPart>,
     pub quoted: Option<QuotedMessageContext>,
+    pub tools_visible_snapshot: Option<ToolsVisibleSnapshot>,
     pub platform: Platform,
     pub account_id: Option<String>,
     pub actor: CoreActor,
     pub conversation: CoreConversation,
+}
+
+/// 工具输出绑定到出站消息的通用可见实体快照。
+///
+/// Gateway 只负责按消息引用索引保存和回填本结构，不理解具体业务域。
+/// Core 内各 Tool 消费自己认识的 `domain`，例如 Todo Tool 使用 `todo` 项把
+/// visible number 映射回服务端内部实体 ID。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolsVisibleSnapshot {
+    pub platform: String,
+    pub account_id: Option<String>,
+    pub scope_key: String,
+    pub owner_key: Option<String>,
+    pub items: Vec<ToolsVisibleItem>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolsVisibleItem {
+    pub domain: String,
+    pub entity_kind: String,
+    pub entity_id: String,
+    pub visible_number: usize,
+    pub label: Option<String>,
+    pub status: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -101,6 +127,7 @@ pub struct CoreResponse {
     pub session_id: Option<String>,
     pub command: Option<String>,
     pub diagnostics: Option<serde_json::Value>,
+    pub tools_visible_snapshot: Option<ToolsVisibleSnapshot>,
 }
 
 #[derive(Debug)]

--- a/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
@@ -38,7 +38,7 @@ struct MockCore {
 #[async_trait]
 impl CoreService for MockCore {
     async fn respond(&self, _request: CoreRequest) -> Result<CoreRespondOutput, CoreError> {
-        Ok(CoreRespondOutput::Complete(CoreResponse {
+        Ok(CoreRespondOutput::Complete(Box::new(CoreResponse {
             text: Some("ok".to_owned()),
             markdown: None,
             handled: Some(true),
@@ -46,7 +46,7 @@ impl CoreService for MockCore {
             command: None,
             diagnostics: None,
             tools_visible_snapshot: None,
-        }))
+        })))
     }
 
     async fn classify_inbound(

--- a/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
@@ -45,6 +45,7 @@ impl CoreService for MockCore {
             session_id: None,
             command: None,
             diagnostics: None,
+            tools_visible_snapshot: None,
         }))
     }
 
@@ -1160,6 +1161,7 @@ fn request_scope_key_matches_private_message() {
         text: "hello".to_owned(),
         input_parts: Vec::new(),
         quoted: None,
+        tools_visible_snapshot: None,
         platform: Platform::QqOfficial,
         account_id: None,
         actor: CoreActor {

--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -90,7 +90,14 @@ async fn send_c2c_respond_response(
         .as_deref()
         .or(response.text.as_deref())
         .unwrap_or("");
-    record_c2c_bot_outbound_refs(ref_index, message, config, sent_ids, text);
+    record_c2c_bot_outbound_refs(
+        ref_index,
+        message,
+        config,
+        sent_ids,
+        text,
+        response.tools_visible_snapshot.clone(),
+    );
     Ok(())
 }
 
@@ -100,6 +107,7 @@ pub(super) fn record_c2c_bot_outbound_refs(
     config: &AppConfig,
     sent_ids: impl IntoIterator<Item = SendMessageIds>,
     text: &str,
+    tools_visible_snapshot: Option<qq_maid_core::service::ToolsVisibleSnapshot>,
 ) {
     let inbound = platform::qq_official::inbound_from_c2c(message);
     let mut index = ref_index.lock().unwrap();
@@ -110,6 +118,7 @@ pub(super) fn record_c2c_bot_outbound_refs(
             &inbound.conversation,
             sent_id.ref_index_lookup_id().map(str::to_owned),
             text,
+            tools_visible_snapshot.clone(),
         );
     }
 }
@@ -510,7 +519,14 @@ where
                         .as_deref()
                         .or(response.text.as_deref())
                         .unwrap_or("");
-                    record_c2c_bot_outbound_refs(ref_index, message, config, sent_ids, text);
+                    record_c2c_bot_outbound_refs(
+                        ref_index,
+                        message,
+                        config,
+                        sent_ids,
+                        text,
+                        response.tools_visible_snapshot.clone(),
+                    );
                 }
                 return Ok(DisabledStreamOutcome::Completed);
             }
@@ -796,6 +812,7 @@ mod tests {
             session_id: None,
             command: None,
             diagnostics: None,
+            tools_visible_snapshot: None,
         }
     }
 
@@ -916,6 +933,7 @@ mod tests {
                 ref_index_id: Some("REFIDX_markdown_id".to_owned()),
             }],
             "完整回复",
+            None,
         );
 
         assert_eq!(
@@ -942,6 +960,7 @@ mod tests {
                 ref_index_id: None,
             }],
             "完整回复",
+            None,
         );
 
         assert_eq!(

--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -973,7 +973,7 @@ mod tests {
     async fn disabled_stream_completed_sends_single_ordinary_reply() {
         let events = FakeEventStream::new([
             RespondEvent::TextDelta("不应外发".to_owned()),
-            RespondEvent::Completed(respond_response("最终回复")),
+            RespondEvent::Completed(Box::new(respond_response("最终回复"))),
         ]);
         let sender = FakeOutboundSender::default();
         let mut typing = None;
@@ -1002,7 +1002,9 @@ mod tests {
     #[tokio::test]
     async fn disabled_stream_completed_records_ref_index() {
         let config = test_config();
-        let events = FakeEventStream::new([RespondEvent::Completed(respond_response("最终回复"))]);
+        let events = FakeEventStream::new([RespondEvent::Completed(Box::new(respond_response(
+            "最终回复",
+        )))]);
         let sender = FakeOutboundSender::default();
         let mut typing = None;
         let ref_index = crate::gateway::ref_index::ref_index();
@@ -1036,7 +1038,7 @@ mod tests {
                 kind: CoreResponseStatusKind::ToolLoopStarted,
                 text: "正在处理".to_owned(),
             }),
-            RespondEvent::Completed(respond_response("最终回复")),
+            RespondEvent::Completed(Box::new(respond_response("最终回复"))),
         ]);
         let sender = FakeOutboundSender::default();
         let mut typing = None;
@@ -1073,7 +1075,7 @@ mod tests {
                 kind: CoreResponseStatusKind::ToolLoopFinalizing,
                 text: "小女仆正在确认结果…".to_owned(),
             }),
-            RespondEvent::Completed(respond_response("最终回复")),
+            RespondEvent::Completed(Box::new(respond_response("最终回复"))),
         ])
         .with_policy(CoreOutputPolicy::ProgressThenComplete);
         let sender = FakeOutboundSender::default();
@@ -1113,7 +1115,7 @@ mod tests {
                 kind: CoreResponseStatusKind::ToolLoopStarted,
                 text: "小女仆正在处理…".to_owned(),
             }),
-            RespondEvent::Completed(respond_response("最终回复")),
+            RespondEvent::Completed(Box::new(respond_response("最终回复"))),
         ])
         .with_policy(CoreOutputPolicy::ProgressThenComplete);
         let sender = FakeOutboundSender::default();

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -360,6 +360,7 @@ fn record_group_bot_outbound_send(
         &inbound.conversation,
         sent_ids.ref_index_lookup_id().map(str::to_owned),
         text,
+        response.tools_visible_snapshot.clone(),
     );
 }
 
@@ -584,6 +585,7 @@ mod tests {
                 session_id: None,
                 command: None,
                 diagnostics: None,
+                tools_visible_snapshot: None,
             },
             respond_calls,
         }))
@@ -1000,6 +1002,7 @@ mod tests {
             session_id: None,
             command: None,
             diagnostics: None,
+            tools_visible_snapshot: None,
         };
         let sent_ids = SendMessageIds {
             message_id: Some("qq_msg_1".to_owned()),
@@ -1048,6 +1051,7 @@ mod tests {
             session_id: None,
             command: None,
             diagnostics: None,
+            tools_visible_snapshot: None,
         };
 
         let message_only_cache = Arc::new(Mutex::new(BotOutboundCache::default()));

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -394,7 +394,7 @@ async fn consume_respond_stream(
                     status_event_count,
                     "group stream collapsed into single Completed response"
                 );
-                return Some(response);
+                return Some(*response);
             }
             RespondEvent::Failed(failure) => {
                 warn!(
@@ -547,7 +547,7 @@ mod tests {
     impl CoreService for MockCore {
         async fn respond(&self, _request: CoreRequest) -> Result<CoreRespondOutput, CoreError> {
             self.respond_calls.fetch_add(1, Ordering::SeqCst);
-            Ok(CoreRespondOutput::Complete(self.response.clone()))
+            Ok(CoreRespondOutput::Complete(Box::new(self.response.clone())))
         }
 
         async fn classify_inbound(

--- a/qq-maid-gateway-rs/src/gateway/platform/core.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/core.rs
@@ -44,6 +44,7 @@ pub(crate) fn to_core_request(
         text,
         input_parts: effective_input_parts(inbound),
         quoted: inbound.quoted.clone(),
+        tools_visible_snapshot: inbound.tools_visible_snapshot.clone(),
         platform,
         account_id: inbound.account_id.clone(),
         actor: CoreActor {
@@ -177,6 +178,7 @@ mod tests {
                 ..Default::default()
             }),
             mentioned_bot: false,
+            tools_visible_snapshot: None,
         };
 
         assert_eq!(render_text_for_core(&inbound), "看一下\n[图片]");
@@ -217,6 +219,7 @@ mod tests {
                 ..Default::default()
             }),
             mentioned_bot: false,
+            tools_visible_snapshot: None,
         };
 
         let rendered = render_text_for_core(&inbound);

--- a/qq-maid-gateway-rs/src/gateway/platform/model.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/model.rs
@@ -4,6 +4,7 @@
 //! 层转换为这些通用结构，再进入 Core 映射和回复编排。
 
 use qq_maid_common::input_part::{MessageInputPart, MessageMedia, QuotedMessageContext};
+use qq_maid_core::service::ToolsVisibleSnapshot;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Platform {
@@ -39,6 +40,8 @@ pub(crate) struct InboundMessage {
     pub(crate) input_parts: Vec<MessageInputPart>,
     pub(crate) attachments: Vec<Attachment>,
     pub(crate) quoted: Option<QuotedMessageContext>,
+    /// 引用消息关联的工具可见实体快照。Gateway 只透传，不解析具体 domain。
+    pub(crate) tools_visible_snapshot: Option<ToolsVisibleSnapshot>,
     pub(crate) mentioned_bot: bool,
 }
 
@@ -219,6 +222,7 @@ mod tests {
             attachments: Vec::new(),
             quoted: None,
             mentioned_bot: false,
+            tools_visible_snapshot: None,
         };
 
         assert_eq!(
@@ -273,6 +277,7 @@ mod tests {
                 ..Default::default()
             }),
             mentioned_bot: true,
+            tools_visible_snapshot: None,
         };
 
         assert_eq!(
@@ -309,6 +314,7 @@ mod tests {
             attachments: Vec::new(),
             quoted: None,
             mentioned_bot: false,
+            tools_visible_snapshot: None,
         };
         let group = InboundMessage {
             platform: Platform::QqOfficial,
@@ -325,6 +331,7 @@ mod tests {
             attachments: Vec::new(),
             quoted: None,
             mentioned_bot: true,
+            tools_visible_snapshot: None,
         };
 
         assert_eq!(
@@ -355,6 +362,7 @@ mod tests {
             attachments: Vec::new(),
             quoted: None,
             mentioned_bot: false,
+            tools_visible_snapshot: None,
         };
 
         assert_eq!(inbound.dedupe_message_key(), None);

--- a/qq-maid-gateway-rs/src/gateway/platform/qq_official.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/qq_official.rs
@@ -36,6 +36,7 @@ pub(crate) fn inbound_from_c2c(message: &C2cMessage) -> InboundMessage {
                 message.current_msg_idx.as_deref(),
             )
         }),
+        tools_visible_snapshot: None,
         mentioned_bot: false,
     }
 }
@@ -66,6 +67,7 @@ pub(crate) fn inbound_from_group(message: &GroupMessage) -> InboundMessage {
                 message.current_msg_idx.as_deref(),
             )
         }),
+        tools_visible_snapshot: None,
         mentioned_bot: message.event_type == GroupEventType::GroupAtMessage
             || message.mentions.iter().any(|mention| mention.is_you),
     }

--- a/qq-maid-gateway-rs/src/gateway/platform/wechat_service.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/wechat_service.rs
@@ -94,6 +94,7 @@ pub(crate) fn inbound_from_text_message(message: &WechatTextMessage) -> InboundM
         },
         attachments: Vec::new(),
         quoted: None,
+        tools_visible_snapshot: None,
         mentioned_bot: false,
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/push.rs
+++ b/qq-maid-gateway-rs/src/gateway/push.rs
@@ -239,6 +239,7 @@ impl GatewayPushRuntime {
             &conversation,
             Some(ref_index_id.to_owned()),
             delivered_text,
+            None,
         );
     }
 }
@@ -469,6 +470,7 @@ mod tests {
                 group_member_role: None,
                 is_bot: false,
             },
+            tools_visible_snapshot: None,
             message_id: "gm-quote".to_owned(),
             current_msg_idx: None,
             timestamp: None,

--- a/qq-maid-gateway-rs/src/gateway/ref_index/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/ref_index/mod.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use qq_maid_common::input_part::{MediaStatus, MessageInputPart, MessageMedia, QuotedMediaSummary};
+use qq_maid_core::service::ToolsVisibleSnapshot;
 use tracing::{debug, warn};
 
 use super::{
@@ -39,6 +40,7 @@ pub(crate) struct RefIndexEntry {
     pub(crate) input_parts: Vec<MessageInputPart>,
     pub(crate) from_bot: bool,
     pub(crate) timestamp: Option<String>,
+    pub(crate) tools_visible_snapshot: Option<ToolsVisibleSnapshot>,
 }
 
 #[derive(Debug, Default)]
@@ -62,6 +64,7 @@ impl RefIndex {
         conversation: &ConversationTarget,
         ref_index_id: Option<String>,
         text: &str,
+        tools_visible_snapshot: Option<ToolsVisibleSnapshot>,
     ) {
         let Some(ref_index_id) = clean_optional(ref_index_id) else {
             return;
@@ -76,6 +79,7 @@ impl RefIndex {
             },
             from_bot: true,
             timestamp: None,
+            tools_visible_snapshot,
         };
         let key = key_for(platform, account_id, conversation, &ref_index_id);
         self.insert_key(key, entry);
@@ -103,6 +107,7 @@ impl RefIndex {
             quoted.input_parts = entry.input_parts.clone();
             quoted.from_bot = Some(entry.from_bot);
             quoted.fallback_reason = None;
+            inbound.tools_visible_snapshot = entry.tools_visible_snapshot.clone();
             log_ref_index_hit("quoted_lookup", &key, entry);
         } else {
             log_ref_index_miss(&self.entries, &key);
@@ -180,6 +185,7 @@ fn entry_from_inbound(inbound: &InboundMessage) -> RefIndexEntry {
         input_parts,
         from_bot: inbound.actor.is_bot,
         timestamp: inbound.timestamp.clone(),
+        tools_visible_snapshot: None,
     }
 }
 
@@ -351,6 +357,25 @@ fn sanitize_index_media(mut media: MessageMedia) -> MessageMedia {
 mod tests {
     use super::*;
     use qq_maid_common::input_part::{MessageMedia, QuotedMessageContext};
+    use qq_maid_core::service::{ToolsVisibleItem, ToolsVisibleSnapshot};
+
+    fn test_snapshot(entity_id: &str) -> ToolsVisibleSnapshot {
+        ToolsVisibleSnapshot {
+            platform: "qq_official".to_owned(),
+            account_id: Some("app".to_owned()),
+            scope_key: "private:u1".to_owned(),
+            owner_key: Some("private:u1".to_owned()),
+            created_at: "2026-07-06T10:00:00+08:00".to_owned(),
+            items: vec![ToolsVisibleItem {
+                domain: "todo".to_owned(),
+                entity_kind: "todo".to_owned(),
+                entity_id: entity_id.to_owned(),
+                visible_number: 1,
+                label: None,
+                status: Some("list".to_owned()),
+            }],
+        }
+    }
 
     fn inbound(message_id: &str, msg_idx: Option<&str>, text: &str) -> InboundMessage {
         InboundMessage {
@@ -373,6 +398,7 @@ mod tests {
             attachments: Vec::new(),
             quoted: None,
             mentioned_bot: false,
+            tools_visible_snapshot: None,
         }
     }
 
@@ -581,6 +607,7 @@ mod tests {
             },
             Some("bot-private-1".to_owned()),
             "私聊回复",
+            None,
         );
         store.insert_bot_outbound(
             super::super::platform::Platform::QqOfficial,
@@ -590,6 +617,7 @@ mod tests {
             },
             Some("bot-group-1".to_owned()),
             "群聊回复",
+            None,
         );
 
         let mut private_current = inbound("m2", None, "继续");
@@ -637,6 +665,43 @@ mod tests {
     }
 
     #[test]
+    fn bot_outbound_tools_visible_snapshot_binds_to_refidx_not_latest_message() {
+        let mut store = RefIndex::default();
+        let conversation = ConversationTarget::Private {
+            target_id: "user-1".to_owned(),
+        };
+        store.insert_bot_outbound(
+            super::super::platform::Platform::QqOfficial,
+            Some("app"),
+            &conversation,
+            Some("REFIDX_A".to_owned()),
+            "列表 A",
+            Some(test_snapshot("todo-a-1")),
+        );
+        store.insert_bot_outbound(
+            super::super::platform::Platform::QqOfficial,
+            Some("app"),
+            &conversation,
+            Some("REFIDX_B".to_owned()),
+            "列表 B",
+            Some(test_snapshot("todo-b-1")),
+        );
+
+        let mut quoted_a = inbound("current", None, "1删除");
+        quoted_a.quoted = Some(QuotedMessageContext {
+            ref_msg_idx: Some("REFIDX_A".to_owned()),
+            ..Default::default()
+        });
+        store.enrich_inbound(&mut quoted_a);
+
+        assert!(quoted_a.quoted.as_ref().unwrap().lookup_found);
+        assert_eq!(
+            quoted_a.tools_visible_snapshot.as_ref().unwrap().items[0].entity_id,
+            "todo-a-1"
+        );
+    }
+
+    #[test]
     fn qq_group_quote_bot_outbound_by_refidx_hits_after_account_normalization() {
         let mut store = RefIndex::default();
         let conversation = ConversationTarget::Group {
@@ -648,6 +713,7 @@ mod tests {
             &conversation,
             Some("REFIDX_bot_group_reply".to_owned()),
             "机器人上一条群回复",
+            None,
         );
 
         let mut current = group_inbound("gm2", Some("REFIDX_current"), "继续解释");
@@ -791,6 +857,7 @@ mod tests {
                 &conversation,
                 Some(format!("bot-{index}")),
                 &format!("回复 {index}"),
+                None,
             );
         }
 

--- a/qq-maid-gateway-rs/src/gateway/stream/delivery.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/delivery.rs
@@ -687,6 +687,7 @@ where
                                 config,
                                 sent_ids,
                                 final_content,
+                                response.tools_visible_snapshot.clone(),
                             );
                         }
                         return Ok(C2cStreamingPhase::Completed);
@@ -781,7 +782,14 @@ where
             )
             .await?;
             if let Some(ref_index) = ref_index {
-                record_c2c_bot_outbound_refs(ref_index, message, config, sent_ids, &accumulated);
+                record_c2c_bot_outbound_refs(
+                    ref_index,
+                    message,
+                    config,
+                    sent_ids,
+                    &accumulated,
+                    None,
+                );
             }
         }
         C2cStreamingPhase::Pending(_) | C2cStreamingPhase::Completed => {}

--- a/qq-maid-gateway-rs/src/gateway/stream/send.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/send.rs
@@ -28,6 +28,7 @@ pub(crate) fn response_from_incomplete_stream_text(content: &str) -> RespondResp
         session_id: None,
         command: None,
         diagnostics: None,
+        tools_visible_snapshot: None,
     }
 }
 

--- a/qq-maid-gateway-rs/src/gateway/stream/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests.rs
@@ -296,7 +296,7 @@ async fn stream_first_send_error_falls_back_to_completed_response() {
     let events = FakeEventStream::new([
         RespondEvent::TextDelta("晚上".to_owned()),
         RespondEvent::TextDelta("好".to_owned()),
-        RespondEvent::Completed(respond_response("晚上好")),
+        RespondEvent::Completed(Box::new(respond_response("晚上好"))),
     ]);
     let sender = FakeStreamSender::new([Err(ApiError::Unsupported("stream"))]);
 
@@ -328,7 +328,7 @@ async fn stream_pending_fallback_records_ref_index() {
     let config = test_config();
     let events = FakeEventStream::new([
         RespondEvent::TextDelta("晚上".to_owned()),
-        RespondEvent::Completed(respond_response("晚上好")),
+        RespondEvent::Completed(Box::new(respond_response("晚上好"))),
     ]);
     let sender = FakeStreamSender::new([Err(ApiError::Unsupported("stream"))]);
     let ref_index = crate::gateway::ref_index::ref_index();
@@ -358,7 +358,7 @@ async fn active_stream_does_not_fake_ref_index_from_stream_id() {
     let config = test_config();
     let events = FakeEventStream::new([
         RespondEvent::TextDelta("晚上好".to_owned()),
-        RespondEvent::Completed(respond_response("晚上好")),
+        RespondEvent::Completed(Box::new(respond_response("晚上好"))),
     ]);
     let sender = FakeStreamSender::new([Ok(Some("stream-1".to_owned())), Ok(None)]);
     let ref_index = crate::gateway::ref_index::ref_index();
@@ -384,7 +384,7 @@ async fn stream_status_event_does_not_start_qq_stream_or_extra_send() {
             kind: CoreResponseStatusKind::ToolLoopStarted,
             text: "正在处理".to_owned(),
         }),
-        RespondEvent::Completed(respond_response("最终回复")),
+        RespondEvent::Completed(Box::new(respond_response("最终回复"))),
     ]);
     let sender = FakeStreamSender::new([]);
 
@@ -412,7 +412,7 @@ async fn progress_policy_status_sends_one_visible_hint_then_final_reply() {
             kind: CoreResponseStatusKind::ToolLoopFinalizing,
             text: "小女仆正在确认结果…".to_owned(),
         }),
-        RespondEvent::Completed(respond_response("最终回复")),
+        RespondEvent::Completed(Box::new(respond_response("最终回复"))),
     ])
     .with_policy(CoreOutputPolicy::ProgressThenComplete);
     let sender = FakeStreamSender::new([]);
@@ -441,7 +441,7 @@ async fn stream_first_send_without_id_falls_back_to_completed_response() {
     let events = FakeEventStream::new([
         RespondEvent::TextDelta("晚上".to_owned()),
         RespondEvent::TextDelta("好".to_owned()),
-        RespondEvent::Completed(respond_response("晚上好")),
+        RespondEvent::Completed(Box::new(respond_response("晚上好"))),
     ]);
     let sender = FakeStreamSender::new([Ok(None)]);
 
@@ -475,7 +475,7 @@ async fn progress_policy_status_respects_visible_progress_config() {
             kind: CoreResponseStatusKind::ToolLoopStarted,
             text: "小女仆正在处理…".to_owned(),
         }),
-        RespondEvent::Completed(respond_response("最终回复")),
+        RespondEvent::Completed(Box::new(respond_response("最终回复"))),
     ])
     .with_policy(CoreOutputPolicy::ProgressThenComplete);
     let sender = FakeStreamSender::new([]);
@@ -499,7 +499,7 @@ async fn progress_policy_status_respects_visible_progress_config() {
 async fn stream_single_content_packet_then_final_keeps_stream_id() {
     let events = FakeEventStream::new([
         RespondEvent::TextDelta("测试成功".to_owned()),
-        RespondEvent::Completed(respond_response("测试成功")),
+        RespondEvent::Completed(Box::new(respond_response("测试成功"))),
     ]);
     let sender = FakeStreamSender::new([Ok(Some("stream-1".to_owned())), Ok(None)]);
 
@@ -541,7 +541,7 @@ async fn stream_active_path_reuses_id_and_increments_content_index() {
         ),
         (
             Duration::ZERO,
-            RespondEvent::Completed(respond_response("晚上好")),
+            RespondEvent::Completed(Box::new(respond_response("晚上好"))),
         ),
     ]);
     let sender = FakeStreamSender::new([Ok(Some("stream-1".to_owned())), Ok(None), Ok(None)]);
@@ -586,7 +586,7 @@ async fn stream_empty_delta_does_not_consume_index() {
     let events = FakeEventStream::new([
         RespondEvent::TextDelta(String::new()),
         RespondEvent::TextDelta("好".to_owned()),
-        RespondEvent::Completed(respond_response("好")),
+        RespondEvent::Completed(Box::new(respond_response("好"))),
     ]);
     let sender = FakeStreamSender::new([Ok(Some("stream-1".to_owned())), Ok(None)]);
 
@@ -627,7 +627,7 @@ async fn stream_middle_returned_id_does_not_replace_first_stream_id() {
         ),
         (
             Duration::ZERO,
-            RespondEvent::Completed(respond_response("晚上")),
+            RespondEvent::Completed(Box::new(respond_response("晚上"))),
         ),
     ]);
     let sender = FakeStreamSender::new([
@@ -682,7 +682,7 @@ async fn stream_middle_chunks_coalesce_only_unsent_delta() {
         ),
         (
             Duration::ZERO,
-            RespondEvent::Completed(respond_response("晚上好")),
+            RespondEvent::Completed(Box::new(respond_response("晚上好"))),
         ),
     ]);
     let sender = FakeStreamSender::new([Ok(Some("stream-1".to_owned())), Ok(None), Ok(None)]);
@@ -726,7 +726,7 @@ async fn stream_middle_chunks_coalesce_only_unsent_delta() {
 async fn stream_final_failure_does_not_send_ordinary_fallback_after_active() {
     let events = FakeEventStream::new([
         RespondEvent::TextDelta("晚上".to_owned()),
-        RespondEvent::Completed(respond_response("晚上好")),
+        RespondEvent::Completed(Box::new(respond_response("晚上好"))),
     ]);
     let sender = FakeStreamSender::new([
         Ok(Some("stream-1".to_owned())),
@@ -765,7 +765,7 @@ async fn stream_completed_flushes_pending_delta_before_final() {
     let events = FakeEventStream::new([
         RespondEvent::TextDelta("晚".to_owned()),
         RespondEvent::TextDelta("上".to_owned()),
-        RespondEvent::Completed(respond_response("晚上")),
+        RespondEvent::Completed(Box::new(respond_response("晚上"))),
     ]);
     let sender = FakeStreamSender::new([Ok(Some("stream-1".to_owned())), Ok(None), Ok(None)]);
 
@@ -806,7 +806,9 @@ async fn stream_completed_flushes_pending_delta_before_final() {
 
 #[tokio::test]
 async fn stream_completed_without_delta_uses_ordinary_reply_path() {
-    let events = FakeEventStream::new([RespondEvent::Completed(respond_response("晚上好"))]);
+    let events = FakeEventStream::new([RespondEvent::Completed(Box::new(respond_response(
+        "晚上好",
+    )))]);
     let sender = FakeStreamSender::new([]);
 
     let phase = stream_respond_c2c_with_sender(events, &sender, &c2c_message(), &test_config())
@@ -825,7 +827,9 @@ async fn stream_completed_without_delta_uses_ordinary_reply_path() {
 
 #[tokio::test]
 async fn stream_pending_completed_stops_typing_with_final_reply_before_ordinary_reply() {
-    let events = FakeEventStream::new([RespondEvent::Completed(respond_response("晚上好"))]);
+    let events = FakeEventStream::new([RespondEvent::Completed(Box::new(respond_response(
+        "晚上好",
+    )))]);
     let sender = FakeStreamSender::new([]);
     let typing = C2cTypingStatusGuard::schedule_with_sender(
         &AgentTypingConfig {
@@ -865,8 +869,8 @@ async fn stream_pending_completed_stops_typing_with_final_reply_before_ordinary_
 #[tokio::test]
 async fn stream_pending_completed_sends_ordinary_reply_once() {
     let events = FakeEventStream::new([
-        RespondEvent::Completed(respond_response("晚上好")),
-        RespondEvent::Completed(respond_response("不应重复发送")),
+        RespondEvent::Completed(Box::new(respond_response("晚上好"))),
+        RespondEvent::Completed(Box::new(respond_response("不应重复发送"))),
     ]);
     let sender = FakeStreamSender::new([]);
 
@@ -887,8 +891,8 @@ async fn stream_pending_completed_sends_ordinary_reply_once() {
 async fn stream_completed_sends_single_final_chunk() {
     let events = FakeEventStream::new([
         RespondEvent::TextDelta("好".to_owned()),
-        RespondEvent::Completed(respond_response("好")),
-        RespondEvent::Completed(respond_response("好")),
+        RespondEvent::Completed(Box::new(respond_response("好"))),
+        RespondEvent::Completed(Box::new(respond_response("好"))),
     ]);
     let sender = FakeStreamSender::new([Ok(Some("stream-1".to_owned())), Ok(None)]);
 
@@ -1008,7 +1012,7 @@ async fn stream_middle_failure_does_not_send_ordinary_fallback_on_completed() {
         ),
         (
             Duration::ZERO,
-            RespondEvent::Completed(respond_response("晚上")),
+            RespondEvent::Completed(Box::new(respond_response("晚上"))),
         ),
     ]);
     let sender = FakeStreamSender::new([

--- a/qq-maid-gateway-rs/src/gateway/stream/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests.rs
@@ -222,6 +222,7 @@ fn respond_response(text: &str) -> RespondResponse {
         session_id: None,
         command: None,
         diagnostics: None,
+        tools_visible_snapshot: None,
     }
 }
 

--- a/qq-maid-gateway-rs/src/gateway/wechat_service/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/wechat_service/tests.rs
@@ -179,6 +179,7 @@ impl CoreService for MockCore {
             session_id: None,
             command: None,
             diagnostics: None,
+            tools_visible_snapshot: None,
         }))
     }
 

--- a/qq-maid-gateway-rs/src/gateway/wechat_service/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/wechat_service/tests.rs
@@ -172,7 +172,7 @@ impl CoreService for MockCore {
         if let Some(delay) = delay {
             tokio::time::sleep(delay).await;
         }
-        Ok(CoreRespondOutput::Complete(CoreResponse {
+        Ok(CoreRespondOutput::Complete(Box::new(CoreResponse {
             text: Some("hello <wx> & user".to_owned()),
             markdown: Some("**hello**".to_owned()),
             handled: Some(true),
@@ -180,7 +180,7 @@ impl CoreService for MockCore {
             command: None,
             diagnostics: None,
             tools_visible_snapshot: None,
-        }))
+        })))
     }
 
     async fn classify_inbound(

--- a/qq-maid-gateway-rs/src/render.rs
+++ b/qq-maid-gateway-rs/src/render.rs
@@ -122,6 +122,7 @@ mod tests {
             session_id: None,
             command: None,
             diagnostics: None,
+            tools_visible_snapshot: None,
         }
     }
 

--- a/qq-maid-gateway-rs/src/respond.rs
+++ b/qq-maid-gateway-rs/src/respond.rs
@@ -898,6 +898,7 @@ mod tests {
             session_id: None,
             command: None,
             diagnostics: None,
+            tools_visible_snapshot: None,
         };
 
         let text = respond_error_to_qq_text(&RespondError::Core(CoreError::new(

--- a/qq-maid-gateway-rs/src/respond.rs
+++ b/qq-maid-gateway-rs/src/respond.rs
@@ -29,7 +29,7 @@ pub type RespondResponse = CoreResponse;
 
 #[derive(Debug)]
 pub enum RespondTransport {
-    Complete(CoreResponse),
+    Complete(Box<CoreResponse>),
     Stream(CoreResponseStream),
 }
 

--- a/runtime/config/agent.toml
+++ b/runtime/config/agent.toml
@@ -98,6 +98,7 @@ tool_calling_enabled = true
 #   "cancel_todo",
 #   "restore_todos",
 #   "delete_todos",
+#   "merge_todos",
 # ]
 
 # 群聊普通聊天：默认 fast，Tool Loop 默认关闭。


### PR DESCRIPTION
## 变更
- 增加通用 `ToolsVisibleSnapshot` sidecar，Gateway 只按最终可引用出站 ref 绑定和回填，Core/Tool 结构化消费。
- Todo 编号解析改为 quoted snapshot 优先，scope/account/owner/platform 不匹配或引用到无 snapshot 的 bot 消息时阻断 fallback；无引用时保留 `last_todo_query` fallback。
- 收口普通聊天 snapshot 绑定语义：只有本轮实际展示 Todo 可见编号列表的回复才携带 snapshot，普通聊天、prompt guard 和失败提示不继承旧列表。
- 收敛删除/取消语义，旧 TodoDelete + Pending 不再自动取消；新增 `merge_todos`，合并源项物理删除。
- `merge_todos` 在 target edit 后 reminder sync 失败时返回结构化 `partial_failure`，避免把已发生的部分写入伪装成普通失败。
- 将 `CoreRespondOutput::Complete` 和 `CoreResponseEvent::Completed` 改为 `Box<CoreResponse>`，修复 clippy `large_enum_variant`。
- 补充 snapshot 绑定、quoted snapshot 优先/阻断和 merge partial failure 回归测试。

## 验证
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo check --workspace --all-features`
- `cargo test --workspace --all-features`
- `cargo build --workspace --release --all-features`
- `git diff --check`

Closes #296
