### PR TITLE
docs: 澄清 QQ 群关键词触发边界

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Windows 下程序以前台方式运行，关闭终端即停止。如需长期后
 | 启动后立即退出 | 查看日志最后几十行。通常是 `config/.env` 缺少必填项或 API Key 无效。 |
 | QQ 收不到消息 | 确认 QQ 开放平台已启用机器人事件权限；查看 Gateway 是否成功鉴权并建立 WebSocket 连接。 |
 | 模型调用报错 | 确认 `LLM_PROVIDER` 与 `LLM_MODEL` 前缀匹配，自定义前缀需先在 `agent.toml [providers.*]` 声明。用 GLM / Qwen / Ollama 等 OpenAI 兼容网关时，需要设 `OPENAI_API_MODE=chat_only`。 |
-| 群聊不回复 | 默认 `mention` 模式只响应 @ 和回复机器人。主动响应需设 `QQ_MAID_GROUP_MESSAGE_MODE=active` 和 `QQ_MAID_GROUP_ACTIVE_KEYWORDS`。 |
+| 群聊不回复 | 默认 `mention` 模式只响应 @ 和回复机器人。主动响应可设 `QQ_MAID_GROUP_MESSAGE_MODE=active` 和 `QQ_MAID_GROUP_ACTIVE_KEYWORDS`；但 QQ 官方只能处理平台实际推送到 Gateway 的群消息，普通非 @ 消息平台不一定推送。 |
 | 图片没有被理解 | 确认 `QQ_MAID_ENABLE_IMAGE=true`，媒体目录可写，图片大小没有超过 `QQ_MAID_MEDIA_MAX_BYTES`，并且当前模型支持图片输入。 |
 | 怎么诊断 | `./botctl.sh health` 确认服务存活；`./diagnose-network.sh` 检查配置、网络和模型连通性。 |
 | 升级后启动失败 | 对比新版 `config/.env.example` 是否新增必填项；检查 `PROMPT_DIR` 等路径是否仍然有效。 |

--- a/qq-maid-gateway-rs/README.md
+++ b/qq-maid-gateway-rs/README.md
@@ -68,7 +68,7 @@ flowchart LR
 
 ## 当前范围
 
-- 处理 `C2C_MESSAGE_CREATE`、`GROUP_AT_MESSAGE_CREATE` 和普通 `GROUP_MESSAGE_CREATE` 文本消息；普通群消息默认采用 `mention` 模式，仅响应命令、@ 和回复机器人消息，可按配置关闭或改为提示词触发模式。
+- 处理 `C2C_MESSAGE_CREATE`、`GROUP_AT_MESSAGE_CREATE` 和平台实际推送到 Gateway 的普通 `GROUP_MESSAGE_CREATE` 文本消息；普通群消息默认采用 `mention` 模式，仅响应命令、@ 和回复机器人消息，可按配置关闭或改为提示词触发模式。QQ 官方通道只能处理平台实际推送的事件，关键词不会让平台额外推送不可见的普通非 @ 消息。
 - `/ping` 会在 gateway 本地返回诊断信息，直接读取 Core 进程内健康快照；`/ping check` 会调用 `CoreService::upstream_check()` 执行一次不写会话的最小上游检查。
 - 文本回复使用 QQ C2C `msg_type: 0`、原消息 `msg_id` 和递增 `msg_seq`。
 - 入站附件不会改 Core 稳定请求模型；图片等附件信息会追加到文本末尾，例如 `[附件 image/jpeg: a.jpg https://example.test/a.jpg]`。
@@ -141,11 +141,11 @@ QQ_APPID=你的QQ机器人AppID
 QQ_SECRET=你的QQ机器人AppSecret
 ```
 
-普通群消息由 `QQ_MAID_GROUP_MESSAGE_MODE` 控制，默认 `mention` 保持有限触发；`off` 完全关闭普通群消息，`command` 只处理 `/` 或全角 `／` 开头的命令，`mention` 额外处理平台 @ 标记和回复机器人消息，`active` 只处理包含 `QQ_MAID_GROUP_ACTIVE_KEYWORDS` 指定提示词的普通群消息，提示词默认 `小女仆`，多个用英文逗号分隔。旧变量 `QQ_MAID_ENABLE_GROUP_MESSAGES` 仅在未设置新变量时兼容，`false` 映射为 `off`，`true` 映射为 `active`，未设置时默认 `mention`。群聊不会开放通用 Harness、文件处理或代码执行；Tool Calling 由 Core 的 `TOOL_CALLING_GROUP_ENABLED` 控制且默认关闭。gateway 只负责把群聊目标传给 Core，由 Core 按既有命令和普通聊天边界处理。
+普通群消息由 `QQ_MAID_GROUP_MESSAGE_MODE` 控制，默认 `mention` 保持有限触发；`off` 完全关闭普通群消息，`command` 只处理 `/` 或全角 `／` 开头的命令，`mention` 额外处理平台 @ 标记和回复机器人消息，`active` 只处理包含 `QQ_MAID_GROUP_ACTIVE_KEYWORDS` 指定提示词的普通群消息，提示词默认 `小女仆`，多个用英文逗号分隔。旧变量 `QQ_MAID_ENABLE_GROUP_MESSAGES` 仅在未设置新变量时兼容，`false` 映射为 `off`，`true` 映射为 `active`，未设置时默认 `mention`。这些策略只对 QQ 官方已经推送到 Gateway 的群事件生效；如果平台没有推送普通非 @ 群消息，Gateway 无法通过关键词提前收到或登记该消息。群聊不会开放通用 Harness、文件处理或代码执行；Tool Calling 由 Core 的 `TOOL_CALLING_GROUP_ENABLED` 控制且默认关闭。gateway 只负责把群聊目标传给 Core，由 Core 按既有命令和普通聊天边界处理。
 
 普通群事件是否 @ 当前机器人只信任官方结构化 `mentions[].is_you == true`；旧的 AppID、openid、member_openid、CQ 文本和 `<@...>` 文本不再作为触发依据。`QQ_MAID_BOT_MENTION_IDS` 仅保留为旧配置兼容，不应再用于修正普通群 @ 判定。不要把真实 ID 写入公开文档或提交到仓库。
 
-普通群消息会过滤自己发送的消息、可识别的其它机器人消息、空内容/无附件消息和重复 `message_id`，并使用群级与群成员级内存冷却避免刷屏；但发送给 Core 的 `scope_key` 仍保持 `group:<group_openid>`，避免把 RSS、会话等按当前 QQ 目标建模的能力意外拆成成员分片。
+普通群消息会过滤自己发送的消息、可识别的其它机器人消息、空内容/无附件消息和重复 `message_id`，并使用群级与群成员级内存冷却避免刷屏；但发送给 Core 的 `scope_key` 仍保持群会话维度，actor 仅表示群内发言人，避免同一个用户的私聊与群聊 session / pending / visible snapshot / ref_index 串用。只有 QQ 官方实际推送且 payload 带 `current_msg_idx / msg_idx` 的群消息，才能提前登记到运行期 ref_index；平台未推送或缺字段时，后续引用只能依赖当前引用事件 payload 兜底或已有索引。
 
 `QQ_MAID_C2C_VISIBLE_PROGRESS_STATUS_ENABLED` 控制私聊 Tool Loop 的可见进度文本，默认开启，只在 Core 输出策略为 `progress_then_complete` / `progress_then_stream` 时发送一次受控短提示。它不是 QQ 原生 typing 状态；原生 typing 由 `QQ_MAID_AGENT_TYPING_ENABLED` / `QQ_MAID_AGENT_TYPING_DELAY_MS` 单独控制。
 

--- a/qq-maid-gateway-rs/src/gateway/group_filter.rs
+++ b/qq-maid-gateway-rs/src/gateway/group_filter.rs
@@ -112,6 +112,9 @@ pub(crate) fn should_ignore_group_message(
 /// - Command：仅斜杠命令；
 /// - Mention：命令、提到机器人、回复机器人；
 /// - Active：提到机器人或命中配置提示词。
+///
+/// 这些本地策略只对 QQ 官方已经推送到 Gateway 的群事件生效，关键词不能让平台额外推送
+/// 原本不可见的普通非 @ 消息。
 pub(crate) fn should_process_group_message(
     mode: GroupMessageMode,
     active_keywords: &[String],

--- a/qq-maid-gateway-rs/src/respond.rs
+++ b/qq-maid-gateway-rs/src/respond.rs
@@ -729,6 +729,28 @@ mod tests {
     }
 
     #[test]
+    fn same_qq_actor_keeps_private_and_group_conversation_scopes_separate() {
+        let client = RespondClient::new(Arc::new(NoopCore)).with_qq_official_account_id("app-123");
+        let private = c2c_message("继续");
+        let group = group_message("继续", Some("u1"));
+
+        let private_request = client.core_request_from_c2c_message(&private, "继续".to_owned());
+        let group_request = client.core_request_from_group_message(&group, "继续".to_owned());
+
+        assert_eq!(private_request.actor.user_id.as_deref(), Some("u1"));
+        assert_eq!(group_request.actor.user_id.as_deref(), Some("u1"));
+        assert_eq!(
+            private_request.scope_key(),
+            "platform:qq_official:account:app-123:private:u1"
+        );
+        assert_eq!(
+            group_request.scope_key(),
+            "platform:qq_official:account:app-123:group:g1"
+        );
+        assert_ne!(private_request.scope_key(), group_request.scope_key());
+    }
+
+    #[test]
     fn prepare_inbound_injects_account_before_core_scope_mapping() {
         let client = RespondClient::new(Arc::new(NoopCore)).with_qq_official_account_id("app-123");
         let c2c = client.prepare_inbound(platform::qq_official::inbound_from_c2c(&c2c_message(

--- a/runtime/config/.env.example
+++ b/runtime/config/.env.example
@@ -52,6 +52,7 @@ QQ_MAID_MEDIA_MAX_BYTES=10485760
 # 群消息处理策略：
 # off=忽略；command=只处理 / 命令；mention=命令/@/回复机器人；
 # active=额外处理包含指定提示词的普通群消息。
+# 注意：QQ 官方通道只能处理平台实际推送到 Gateway 的群事件，关键词不会让平台额外推送不可见消息。
 QQ_MAID_GROUP_MESSAGE_MODE=mention
 QQ_MAID_GROUP_ACTIVE_KEYWORDS=小女仆
 # 普通群事件里的 @ 目标有时不是 AppID。默认会从 Gateway READY 自动学习；


### PR DESCRIPTION
## 变更内容

- 澄清 QQ 官方群聊关键词触发只对已经推送到 Gateway 的群事件生效。
- 保留现有 `active` / `QQ_MAID_GROUP_ACTIVE_KEYWORDS` 行为，不移除、不废弃、不改成忽略。
- 补充同一 QQ actor 在私聊和群聊中保持不同 conversation scope 的回归测试。

## 背景

关联 #293。

这次改动只修正文档、注释和最小回归测试，避免用户误解“配置关键词后 QQ 官方平台就会额外推送普通非 @ 群消息”。实际行为仍然是：如果平台已经把群事件推送到 Gateway，`active` 模式和关键词判断继续按原逻辑生效。

## 验证

- `cargo fmt --all -- --check`
- `cargo check -p qq-maid-gateway-rs`
- `cargo test -p qq-maid-gateway-rs`
- `cargo clippy -p qq-maid-gateway-rs --all-targets --all-features -- -D warnings`
- `git diff --check HEAD~1..HEAD`
