### PR TITLE
docs: 明确 scope 与 identity 边界

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,8 @@ SQLite 留档
 `scope_key` / `owner_key` 是 Session、Pending、Memory、Todo 等业务状态的隔离键；
 `DeliveryTarget` 才是平台真实投递目标。RSS、Notification 和 Push 这种主动投递链路必须
 保留平台原始发送目标，不能把 `target_id` 简化替换为 namespaced 业务 key。
+conversation / actor / interaction / owner / delivery target 的详细边界见
+[docs/design/scope-identity-boundary.md](./docs/design/scope-identity-boundary.md)。
 
 ```mermaid
 flowchart TB

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -17,7 +17,7 @@
 
 QQ、OneBot、微信等入口接入相关能力优先在 gateway 的平台 adapter / sender 边界演进；模型协议、provider fallback 和 Tool Loop 协议优先在 `qq-maid-llm/` 演进；普通聊天、查询命令、记忆、session、待办、会话命令、prompt 和具体业务 Tool 等业务逻辑优先在 `qq-maid-core/` 内部维护。
 
-多平台入口维护时必须区分三类 ID：平台原始 ID 是 `ReplyTarget` / `DeliveryTarget` 的真实投递目标；`scope_key` / `owner_key` 是 Session、Pending、Memory、Todo 的业务隔离键；Core、LLM 和 Tool Loop 不应理解 QQ、OneBot 或微信协议字段。RSS、Notification、Todo 提醒和 Push 需要保留平台原始发送目标，不允许发送逻辑从 `scope_key` / `owner_key` 反解析 raw target。
+多平台入口维护时必须区分三类 ID：平台原始 ID 是 `ReplyTarget` / `DeliveryTarget` 的真实投递目标；`scope_key` / `owner_key` 是 Session、Pending、Memory、Todo 的业务隔离键；Core、LLM 和 Tool Loop 不应理解 QQ、OneBot 或微信协议字段。RSS、Notification、Todo 提醒和 Push 需要保留平台原始发送目标，不允许发送逻辑从 `scope_key` / `owner_key` 反解析 raw target。conversation / actor / interaction / owner / delivery target 的术语边界见 [scope-identity-boundary.md](./design/scope-identity-boundary.md)。
 
 ## 项目结构
 

--- a/docs/design/scope-identity-boundary.md
+++ b/docs/design/scope-identity-boundary.md
@@ -1,0 +1,53 @@
+# Scope 与 Identity 边界
+
+本文定义多入口场景下的业务隔离键和平台投递目标语义。它只约束术语、helper 和调用边界，不迁移历史数据，不改变 session / pending / todo 持久化 key。
+
+## 术语
+
+| 术语 | 含义 | 典型用途 | 不应用于 |
+| --- | --- | --- | --- |
+| conversation scope | 消息发生的对话空间 | session、会话级 pending、ref_index、群聊聚合串行 | 判断自然人身份、平台发送 |
+| actor scope | 当前对话空间里的实际操作者 | 权限、审计、群聊成员身份判断 | 替代 conversation scope |
+| interaction scope | 一次个人交互状态的隔离键 | 群聊多人 pending、visible snapshot、“第 N 条”引用解析 | 跨会话合并长期数据 |
+| owner scope | Todo / Memory 等业务数据归属 | Todo owner、长期数据归属 | 平台投递目标 |
+| delivery target | 平台真实投递目标 | ReplyTarget、DeliveryTarget、PushTarget、sender | Session / Todo / Memory 归属 |
+
+## Helper 边界
+
+`qq-maid-core/src/identity.rs` 是业务隔离键 helper 的主入口：
+
+- `conversation_scope_key(...)` / `stable_scope_key(...)`：构造 conversation scope。新代码优先使用 `conversation_scope_key`，旧名保留兼容。
+- `actor_scope_key(user_id, scope_key)`：表达当前 conversation scope 内的操作者；缺少 actor 时返回 `None`。
+- `interaction_scope_key(user_id, scope_key)`：优先使用 conversation + actor，缺少 actor 时回退 conversation scope，用于 pending / visible snapshot 等个人交互状态。
+- `owner_scope_key(user_id, scope_key)` / `actor_owner_key(...)`：构造 Todo / Memory 等业务 owner key。旧名保留兼容。
+- `parse_stable_scope_key(...)`：只解析业务 key 中的平台、账号和目标类型信息；不得把解析结果当作最新投递目标。
+
+`scope_key` / `owner_key` 可包含平台和账号命名空间，但仍是业务 key。发送阶段必须使用 `ReplyTarget` / `DeliveryTarget` / `PushTarget` 携带的真实目标，不允许从业务 key 反推出 raw openid、group_id 或微信 FromUserName。
+
+## QQ 官方示例
+
+私聊：
+
+```text
+conversation scope = platform:qq_official:account:{appid}:private:{user_openid}
+actor scope        = platform:qq_official:account:{appid}:private:{user_openid}:actor:{user_openid}
+delivery target    = qq_official + appid + private + 当前可投递 openid
+```
+
+群聊：
+
+```text
+conversation scope = platform:qq_official:account:{appid}:group:{group_openid}
+actor scope        = platform:qq_official:account:{appid}:group:{group_openid}:actor:{member_openid}
+delivery target    = qq_official + appid + group + 当前可投递 group_openid
+```
+
+同一个自然人在私聊和群聊里可能出现相同或不同的用户标识。即使 actor 可疑似归一，conversation scope 也必须按实际对话空间分开，避免 session、pending、visible snapshot 和 ref_index 串用。
+
+## 维护规则
+
+- Gateway adapter 负责把平台协议字段归一化为 `InboundMessage` 的 `ConversationTarget` 与 `Actor`。
+- Core 根据 `CoreConversation` 生成 conversation scope；Core、LLM 和 Tool Loop 不理解 QQ `msg_seq`、OneBot CQ 片段或微信 XML 字段。
+- 群聊内个人 pending、visible snapshot 或 Todo Tool 选择状态应使用 interaction scope 或 owner scope，不要只用裸 `user_id`。
+- Todo / Memory 等长期业务数据可以使用 owner scope 归属，但不要反向影响当前消息的 conversation scope。
+- RSS、Notification、Todo 提醒和 Push 必须显式保存或携带平台投递目标；业务 key 只能辅助继承平台 / account 信息，不能替代最新 raw target。

--- a/qq-maid-core/README.md
+++ b/qq-maid-core/README.md
@@ -55,6 +55,8 @@ qq-maid-core/src/
 
 Gateway 调用 Core 的唯一业务入口是 `CoreService::respond(CoreRequest)`。Gateway 只传入最终拼接后的文本、平台、成员身份和私聊 / 群聊目标；`scope_key` 由 Core 根据目标派生。私聊普通聊天在 `TOOL_CALLING_ENABLED=true` 时可进入完整 Tool Loop；群聊普通聊天还需要 `TOOL_CALLING_GROUP_ENABLED=true` 或 `agent.toml` 场景开关，并按 `enabled_tools` 白名单裁剪模型可见工具。明确定义的 slash 前缀命令和 pending 确认流程继续走既有分支。`/ping check` 调用 `CoreService::upstream_check()`，该分支不进入 respond 业务 flow，不创建 session，也不触发标题、记忆、Todo、查询或 Tool Calling。
 
+`scope_key` 表示 conversation scope，只描述消息发生的对话空间；`actor.user_id` 表示发言人；Todo / Memory 等业务 owner 由 `qq-maid-core/src/identity.rs` helper 在 conversation scope 上叠加 actor 推导。详细术语见 [Scope 与 Identity 边界](../docs/design/scope-identity-boundary.md)。
+
 ### `GET /console/` 与 `POST /api/v1/markdown/render`
 
 仅当 `WEB_CONSOLE_ENABLED=true` 时注册。控制台用于本机 Markdown 预览，默认不暴露；Markdown 渲染接口限制请求体 64 KiB，并使用 HTML sanitizer 清理脚本、事件属性和危险链接。

--- a/qq-maid-core/src/identity.rs
+++ b/qq-maid-core/src/identity.rs
@@ -1,7 +1,15 @@
 //! 跨平台身份与业务隔离键 helper。
 //!
-//! 这里的 key 只用于 session、pending、Memory、Todo 等业务状态隔离；
-//! 平台真实发送目标仍由各业务的 target/raw id 字段保存，发送阶段不得反解析这些 key。
+//! 本模块只负责生成和解析业务隔离键，不负责平台投递目标。几个术语需要分清：
+//!
+//! - conversation scope：消息发生的对话空间，用于 session、ref_index 等会话状态隔离；
+//! - actor scope：对话空间内的实际操作者，用于权限、审计和群聊内个人交互归属；
+//! - interaction scope：一次个人交互状态的隔离键，例如 pending 和 visible snapshot；
+//! - owner scope：Todo / Memory 等业务数据归属；
+//! - delivery target：平台真实投递目标，必须由 ReplyTarget / DeliveryTarget 等发送链路携带。
+//!
+//! 这里生成的 key 可包含平台和账号命名空间，但仍然是业务 key。发送阶段不得把它们当作
+//! raw openid / group_id 反解析出平台投递目标。
 
 const UNKNOWN_ACCOUNT: &str = "-";
 
@@ -13,7 +21,11 @@ pub struct ParsedScopeKey<'a> {
     pub raw_target_id: &'a str,
 }
 
-pub fn stable_scope_key(
+/// 构造 conversation scope。
+///
+/// 该 key 描述“消息发生在哪个对话空间”。私聊和群聊即使 actor 相同，也必须生成不同
+/// conversation scope，避免 session / pending / visible snapshot / ref_index 串用。
+pub fn conversation_scope_key(
     platform: &str,
     account_id: Option<&str>,
     target_type: &str,
@@ -28,12 +40,51 @@ pub fn stable_scope_key(
     format!("platform:{platform}:account:{account}:{target_type}:{target}")
 }
 
-pub fn actor_owner_key(user_id: Option<&str>, scope_key: &str) -> String {
+/// 兼容旧命名的 stable scope 构造入口。
+///
+/// 新代码优先使用 [`conversation_scope_key`] 表达语义；保留该函数是为了稳定既有调用点
+/// 和测试中的历史术语。
+pub fn stable_scope_key(
+    platform: &str,
+    account_id: Option<&str>,
+    target_type: &str,
+    raw_target_id: &str,
+) -> String {
+    conversation_scope_key(platform, account_id, target_type, raw_target_id)
+}
+
+/// 构造 actor scope。
+///
+/// actor scope 描述“当前对话空间里的谁”，不是独立会话空间，也不是发送目标。
+pub fn actor_scope_key(user_id: Option<&str>, scope_key: &str) -> Option<String> {
     let scope_key = clean_string(scope_key).unwrap_or_else(|| "unknown".to_owned());
-    match user_id.and_then(clean_string) {
-        Some(user_id) => format!("{scope_key}:actor:{user_id}"),
-        None => scope_key,
-    }
+    user_id
+        .and_then(clean_string)
+        .map(|user_id| format!("{scope_key}:actor:{user_id}"))
+}
+
+/// 构造 interaction scope。
+///
+/// 群聊多人场景下，pending、可见编号快照和“刚刚那条”等个人交互状态应优先使用
+/// conversation + actor；缺少 actor 时才退回 conversation scope，保持旧入口兼容。
+pub fn interaction_scope_key(user_id: Option<&str>, scope_key: &str) -> String {
+    actor_scope_key(user_id, scope_key)
+        .unwrap_or_else(|| clean_string(scope_key).unwrap_or_else(|| "unknown".to_owned()))
+}
+
+/// 构造 owner scope。
+///
+/// Todo / Memory 等业务数据归属可以复用 interaction scope 的隔离方式，但仍不等同于
+/// delivery target，不能从它反推出平台发送参数。
+pub fn owner_scope_key(user_id: Option<&str>, scope_key: &str) -> String {
+    interaction_scope_key(user_id, scope_key)
+}
+
+/// 兼容旧命名的 owner key 构造入口。
+///
+/// 新代码优先使用 [`owner_scope_key`] 或 [`interaction_scope_key`] 表达真实用途。
+pub fn actor_owner_key(user_id: Option<&str>, scope_key: &str) -> String {
+    owner_scope_key(user_id, scope_key)
 }
 
 pub fn parse_stable_scope_key(value: &str) -> Option<ParsedScopeKey<'_>> {
@@ -121,9 +172,13 @@ mod tests {
 
     #[test]
     fn stable_scope_key_preserves_raw_target_as_business_key_payload() {
-        let key = stable_scope_key("qq_official", Some("app-1"), "private", "openid-1");
+        let key = conversation_scope_key("qq_official", Some("app-1"), "private", "openid-1");
 
         assert_eq!(key, "platform:qq_official:account:app-1:private:openid-1");
+        assert_eq!(
+            stable_scope_key("qq_official", Some("app-1"), "private", "openid-1"),
+            key
+        );
         assert_eq!(
             private_raw_target_from_scope_key(&key).as_deref(),
             Some("openid-1")
@@ -131,14 +186,23 @@ mod tests {
     }
 
     #[test]
-    fn actor_owner_key_keeps_actor_and_conversation_scope_separate() {
+    fn actor_interaction_and_owner_scopes_keep_actor_and_conversation_separate() {
+        let conversation = "platform:qq_official:account:app-1:group:group-1";
+
         assert_eq!(
-            actor_owner_key(
-                Some("member-1"),
-                "platform:qq_official:account:app-1:group:group-1"
-            ),
+            actor_scope_key(Some("member-1"), conversation).as_deref(),
+            Some("platform:qq_official:account:app-1:group:group-1:actor:member-1")
+        );
+        assert_eq!(actor_scope_key(None, conversation), None);
+        assert_eq!(
+            interaction_scope_key(Some("member-1"), conversation),
             "platform:qq_official:account:app-1:group:group-1:actor:member-1"
         );
+        assert_eq!(
+            owner_scope_key(Some("member-1"), conversation),
+            "platform:qq_official:account:app-1:group:group-1:actor:member-1"
+        );
+        assert_eq!(interaction_scope_key(None, "group:g1"), "group:g1");
         assert_eq!(actor_owner_key(None, "group:g1"), "group:g1");
     }
 }

--- a/qq-maid-core/src/service/types.rs
+++ b/qq-maid-core/src/service/types.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use qq_maid_common::input_part::{MessageInputPart, QuotedMessageContext};
 use tokio::sync::mpsc;
 
-use crate::identity::stable_scope_key;
+use crate::identity::conversation_scope_key;
 
 use super::UpstreamStatusSnapshot;
 
@@ -56,6 +56,7 @@ pub enum Platform {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CoreActor {
+    /// 当前消息的实际操作者。群聊中它只表示发言人，不参与 conversation scope 拆分。
     pub user_id: Option<String>,
     pub group_member_role: Option<CoreGroupMemberRole>,
 }
@@ -81,12 +82,10 @@ impl CoreGroupMemberRole {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CoreConversation {
-    Private {
-        peer_id: String,
-    },
-    Group {
-        group_id: String,
-    },
+    /// 私聊 conversation scope，session / pending / ref_index 等会话状态以该空间隔离。
+    Private { peer_id: String },
+    /// 群聊 conversation scope，按群空间隔离；群内个人状态需再叠加 actor/owner scope。
+    Group { group_id: String },
     ServiceAccount {
         account_id: Option<String>,
         peer_id: String,
@@ -220,15 +219,19 @@ impl CoreRespondOutput {
 }
 
 impl CoreRequest {
+    /// 生成 conversation scope。
+    ///
+    /// 该值是业务隔离键，不是平台发送地址；Gateway 回复和 Core 主动推送必须使用显式的
+    /// ReplyTarget / DeliveryTarget / PushTarget。
     pub fn scope_key(&self) -> String {
         match &self.conversation {
-            CoreConversation::Private { peer_id } => stable_scope_key(
+            CoreConversation::Private { peer_id } => conversation_scope_key(
                 self.platform.as_str(),
                 self.account_id.as_deref(),
                 "private",
                 peer_id,
             ),
-            CoreConversation::Group { group_id } => stable_scope_key(
+            CoreConversation::Group { group_id } => conversation_scope_key(
                 self.platform.as_str(),
                 self.account_id.as_deref(),
                 "group",
@@ -237,7 +240,7 @@ impl CoreRequest {
             CoreConversation::ServiceAccount {
                 account_id,
                 peer_id,
-            } => stable_scope_key(
+            } => conversation_scope_key(
                 self.platform.as_str(),
                 self.account_id.as_deref().or(account_id.as_deref()),
                 "private",

--- a/qq-maid-core/src/storage/todo/mod.rs
+++ b/qq-maid-core/src/storage/todo/mod.rs
@@ -10,7 +10,7 @@ use rusqlite::{Connection, params};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    identity::{actor_owner_key, parse_stable_scope_key},
+    identity::{owner_scope_key, parse_stable_scope_key},
     storage::{
         database::{DatabaseError, SqliteDatabase, SqliteMigration},
         session::now_iso_cn,
@@ -423,7 +423,7 @@ impl TodoStore {
             .map(str::to_owned);
         let scope_key = clean_optional(scope_key).unwrap_or_else(|| "unknown".to_owned());
         let key = if parse_stable_scope_key(&scope_key).is_some() {
-            actor_owner_key(user_id.as_deref(), &scope_key)
+            owner_scope_key(user_id.as_deref(), &scope_key)
         } else {
             user_id.clone().unwrap_or_else(|| scope_key.clone())
         };


### PR DESCRIPTION
## 变更内容

- 新增 `docs/design/scope-identity-boundary.md`，明确 conversation scope、actor scope、interaction scope、owner scope 与 delivery target 的边界。
- 在 `qq-maid-core/src/identity.rs` 中补充语义化 helper：
  - `conversation_scope_key`
  - `actor_scope_key`
  - `interaction_scope_key`
  - `owner_scope_key`
- 保留 `stable_scope_key` / `actor_owner_key` 旧入口兼容，不改现有 key 格式。
- 在 Core request 与 Todo owner 构造处改用更明确的 helper 名称，并补充注释。
- README / DEVELOPMENT / Core README 链接到新的术语文档。

## 边界

本 PR 只建立术语和 helper 边界，不迁移历史数据，不改变 session / pending / todo 持久化 key，不重写 Core / Gateway 架构。

## 验证

- `cargo fmt --all -- --check`
- `cargo check -p qq-maid-core`
- `cargo test -p qq-maid-core`
- `cargo clippy -p qq-maid-core --all-targets --all-features -- -D warnings`
- `git diff --check`

Refs #298
