### PR TITLE
[codex] 隔离群聊 pending 交互状态

### DIFF
--- a/qq-maid-core/src/runtime/respond.rs
+++ b/qq-maid-core/src/runtime/respond.rs
@@ -327,14 +327,13 @@ impl RustRespondService {
             .session_store
             .get_active(&meta)
             .map_err(session_error)?;
+        let route_session = route_context_session(
+            req,
+            active_interaction_session.as_ref(),
+            active_conversation_session.as_ref(),
+        );
         Ok(self
-            .route_tool_loop_with_active(
-                req,
-                &policy,
-                active_interaction_session
-                    .as_ref()
-                    .or(active_conversation_session.as_ref()),
-            )
+            .route_tool_loop_with_active(req, &policy, route_session)
             .status_hint
             .unwrap_or_else(StatusHint::default_tool))
     }
@@ -361,6 +360,11 @@ impl RustRespondService {
             .session_store
             .get_active(&meta)
             .map_err(session_error)?;
+        let route_session = route_context_session(
+            req,
+            active_interaction_session.as_ref(),
+            active_conversation_session.as_ref(),
+        );
         if pending_blocks_immediate(
             &user_text,
             active_interaction_session.as_ref(),
@@ -390,13 +394,7 @@ impl RustRespondService {
         }
 
         let policy = self.resolve_agent_policy(req)?;
-        let tool_decision = self.route_tool_loop_with_active(
-            req,
-            &policy,
-            active_interaction_session
-                .as_ref()
-                .or(active_conversation_session.as_ref()),
-        );
+        let tool_decision = self.route_tool_loop_with_active(req, &policy, route_session);
         let plan = if !req.has_non_text_input_parts()
             && matches!(tool_decision.route, ToolLoopRoute::CompleteToolLoop)
         {
@@ -814,6 +812,22 @@ fn has_recent_todo_context(req: &RespondRequest, active_session: Option<&Session
     session.last_todo_action.as_ref().is_some_and(|action| {
         action.owner_key == owner.key && query_is_fresh(&action.created_at, LAST_QUERY_TTL_SECONDS)
     })
+}
+
+fn route_context_session<'a>(
+    req: &RespondRequest,
+    active_interaction_session: Option<&'a SessionRecord>,
+    active_conversation_session: Option<&'a SessionRecord>,
+) -> Option<&'a SessionRecord> {
+    // 新 session 状态以 interaction scope 为准；旧 conversation 可见快照只作为路由提示
+    // 兼容读取，不迁移、不回写，实际 Todo/Memory 状态仍落在 interaction session。
+    if has_recent_todo_context(req, active_interaction_session) {
+        return active_interaction_session;
+    }
+    if has_recent_todo_context(req, active_conversation_session) {
+        return active_conversation_session;
+    }
+    active_interaction_session.or(active_conversation_session)
 }
 
 fn classify_inbound_with_active(

--- a/qq-maid-core/src/runtime/respond.rs
+++ b/qq-maid-core/src/runtime/respond.rs
@@ -9,6 +9,7 @@ use std::{future::Future, pin::Pin};
 use crate::{
     config::{AgentRuntimeConfig, ChatScene, ResolvedAgentPolicy},
     error::LlmError,
+    identity::{interaction_scope_key, parse_stable_scope_key},
     provider::DynLlmProvider,
     runtime::{
         knowledge::KnowledgeIndex,
@@ -317,12 +318,23 @@ impl RustRespondService {
         }
         let policy = self.resolve_agent_policy(req)?;
         let meta = respond_meta(req);
-        let active_session = self
+        let interaction_meta = respond_interaction_meta(req);
+        let active_interaction_session = self
+            .session_store
+            .get_active(&interaction_meta)
+            .map_err(session_error)?;
+        let active_conversation_session = self
             .session_store
             .get_active(&meta)
             .map_err(session_error)?;
         Ok(self
-            .route_tool_loop_with_active(req, &policy, active_session.as_ref())
+            .route_tool_loop_with_active(
+                req,
+                &policy,
+                active_interaction_session
+                    .as_ref()
+                    .or(active_conversation_session.as_ref()),
+            )
             .status_hint
             .unwrap_or_else(StatusHint::default_tool))
     }
@@ -340,11 +352,21 @@ impl RustRespondService {
         }
 
         let meta = respond_meta(req);
-        let active_session = self
+        let interaction_meta = respond_interaction_meta(req);
+        let active_interaction_session = self
+            .session_store
+            .get_active(&interaction_meta)
+            .map_err(session_error)?;
+        let active_conversation_session = self
             .session_store
             .get_active(&meta)
             .map_err(session_error)?;
-        if pending_blocks_immediate(&user_text, active_session.as_ref()) {
+        if pending_blocks_immediate(
+            &user_text,
+            active_interaction_session.as_ref(),
+            active_conversation_session.as_ref(),
+            meta.user_id.as_deref(),
+        ) {
             return Ok(RespondPlan::Immediate);
         }
 
@@ -357,13 +379,24 @@ impl RustRespondService {
 
         // 先保护已有确定性命令和自然语言 Todo 查询，避免简单列表查询绕过
         // `handle_todo_flow()` 进入模型 Tool Loop，回归同义词和默认过滤语义。
-        let classification = classify_inbound_with_active(&user_text, active_session.as_ref());
+        let classification = classify_inbound_with_active(
+            &user_text,
+            active_interaction_session.as_ref(),
+            active_conversation_session.as_ref(),
+            meta.user_id.as_deref(),
+        );
         if matches!(classification.kind, CoreInboundKind::Immediate) {
             return Ok(RespondPlan::Immediate);
         }
 
         let policy = self.resolve_agent_policy(req)?;
-        let tool_decision = self.route_tool_loop_with_active(req, &policy, active_session.as_ref());
+        let tool_decision = self.route_tool_loop_with_active(
+            req,
+            &policy,
+            active_interaction_session
+                .as_ref()
+                .or(active_conversation_session.as_ref()),
+        );
         let plan = if !req.has_non_text_input_parts()
             && matches!(tool_decision.route, ToolLoopRoute::CompleteToolLoop)
         {
@@ -454,8 +487,14 @@ impl RustRespondService {
     ) -> Result<RespondResponse, LlmError> {
         let user_text = req.effective_user_text();
         let meta = respond_meta(&req);
+        let interaction_meta = respond_interaction_meta(&req);
 
-        // 尝试获取当前会话的活跃记录
+        // pending、Todo 可见编号和 Memory 列表序号属于群内个人交互状态；
+        // 普通聊天历史仍保留在 conversation session，避免把群聊上下文强制拆成私聊。
+        let mut active_interaction_session = self
+            .session_store
+            .get_active(&interaction_meta)
+            .map_err(session_error)?;
         let mut active_session = self
             .session_store
             .get_active(&meta)
@@ -464,13 +503,25 @@ impl RustRespondService {
         // 若用户输入不是跳等待办的会话指令，则先检查是否有待处理操作（pending）
         let bypass_pending_for_session_command =
             session_flow::parse_pending_bypass_session_command(&user_text).is_some();
-        if !bypass_pending_for_session_command
-            && let Some(session) = active_session.as_mut()
-            && let Some(response) = self
-                .handle_pending_operation(&req, &user_text, &meta, session)
-                .await?
-        {
-            return Ok(response);
+        if !bypass_pending_for_session_command {
+            if let Some(session) = active_interaction_session
+                .as_mut()
+                .filter(|session| session.pending_operation.is_some())
+                && let Some(response) = self
+                    .handle_pending_operation(&req, &user_text, &meta, session)
+                    .await?
+            {
+                return Ok(response);
+            }
+            if let Some(session) = active_session
+                .as_mut()
+                .filter(|session| session_pending_visible_to_user(session, meta.user_id.as_deref()))
+                && let Some(response) = self
+                    .handle_pending_operation(&req, &user_text, &meta, session)
+                    .await?
+            {
+                return Ok(response);
+            }
         }
 
         // 检查是否为会话管理指令（/new, /clear, /state 等）
@@ -535,21 +586,39 @@ impl RustRespondService {
         // slash 命令、pending 和确定性 Todo 查询已在前面保持原路径。
         if !force_tool_loop {
             // 检查是否为待办相关操作（新增、查看、完成、编辑、删除等）
-            if let Some(response) = self
-                .handle_todo_flow(&user_text, &meta, &mut session)
-                .await?
-            {
-                return Ok(response);
+            if should_try_todo_flow(&user_text) {
+                let mut interaction_session = match active_interaction_session.take() {
+                    Some(session) => session,
+                    None => self
+                        .session_store
+                        .get_or_create_active(&interaction_meta)
+                        .map_err(session_error)?,
+                };
+                if let Some(response) = self
+                    .handle_todo_flow(&user_text, &meta, &mut interaction_session)
+                    .await?
+                {
+                    return Ok(response);
+                }
+                active_interaction_session = Some(interaction_session);
             }
         }
 
         // 检查是否为长期记忆相关操作（记忆新增、查看、更新、删除等）
-        if !force_tool_loop
-            && let Some(response) = self
-                .handle_memory_flow(&req, &user_text, &meta, &mut session)
+        if !force_tool_loop && memory_flow::parse_memory_command(&user_text).is_some() {
+            let mut interaction_session = match active_interaction_session.take() {
+                Some(session) => session,
+                None => self
+                    .session_store
+                    .get_or_create_active(&interaction_meta)
+                    .map_err(session_error)?,
+            };
+            if let Some(response) = self
+                .handle_memory_flow(&req, &user_text, &meta, &mut interaction_session)
                 .await?
-        {
-            return Ok(response);
+            {
+                return Ok(response);
+            }
         }
 
         // 兜底：进入普通 LLM 聊天流程
@@ -571,12 +640,22 @@ impl RustRespondService {
     ) -> Result<CoreInboundClassification, LlmError> {
         let user_text = req.effective_user_text();
         let meta = respond_meta(&req);
-        let active_session = self
+        let interaction_meta = respond_interaction_meta(&req);
+        let active_interaction_session = self
+            .session_store
+            .get_active(&interaction_meta)
+            .map_err(session_error)?;
+        let active_conversation_session = self
             .session_store
             .get_active(&meta)
             .map_err(session_error)?;
 
-        if pending_blocks_immediate(&user_text, active_session.as_ref()) {
+        if pending_blocks_immediate(
+            &user_text,
+            active_interaction_session.as_ref(),
+            active_conversation_session.as_ref(),
+            meta.user_id.as_deref(),
+        ) {
             return Ok(CoreInboundClassification {
                 kind: CoreInboundKind::Immediate,
             });
@@ -584,7 +663,9 @@ impl RustRespondService {
 
         Ok(classify_inbound_with_active(
             &user_text,
-            active_session.as_ref(),
+            active_interaction_session.as_ref(),
+            active_conversation_session.as_ref(),
+            meta.user_id.as_deref(),
         ))
     }
 
@@ -601,6 +682,11 @@ impl RustRespondService {
     {
         let user_text = req.effective_user_text();
         let meta = respond_meta(&req);
+        let interaction_meta = respond_interaction_meta(&req);
+        let mut active_interaction_session = self
+            .session_store
+            .get_active(&interaction_meta)
+            .map_err(session_error)?;
         let mut active_session = self
             .session_store
             .get_active(&meta)
@@ -608,13 +694,25 @@ impl RustRespondService {
 
         let bypass_pending_for_session_command =
             session_flow::parse_pending_bypass_session_command(&user_text).is_some();
-        if !bypass_pending_for_session_command
-            && let Some(session) = active_session.as_mut()
-            && let Some(response) = self
-                .handle_pending_operation(&req, &user_text, &meta, session)
-                .await?
-        {
-            return Ok(response);
+        if !bypass_pending_for_session_command {
+            if let Some(session) = active_interaction_session
+                .as_mut()
+                .filter(|session| session.pending_operation.is_some())
+                && let Some(response) = self
+                    .handle_pending_operation(&req, &user_text, &meta, session)
+                    .await?
+            {
+                return Ok(response);
+            }
+            if let Some(session) = active_session
+                .as_mut()
+                .filter(|session| session_pending_visible_to_user(session, meta.user_id.as_deref()))
+                && let Some(response) = self
+                    .handle_pending_operation(&req, &user_text, &meta, session)
+                    .await?
+            {
+                return Ok(response);
+            }
         }
 
         if let Some(command) = session_flow::parse_session_command(&user_text) {
@@ -651,13 +749,53 @@ fn respond_meta(req: &RespondRequest) -> SessionMeta {
     )
 }
 
-fn pending_blocks_immediate(user_text: &str, active_session: Option<&SessionRecord>) -> bool {
+fn respond_interaction_meta(req: &RespondRequest) -> SessionMeta {
+    let mut meta = respond_meta(req);
+    if req
+        .group_id
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty())
+        && req
+            .user_id
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty())
+        && parse_stable_scope_key(&req.scope_key).is_some()
+    {
+        meta.scope_key = interaction_scope_key(req.user_id.as_deref(), &req.scope_key);
+    }
+    meta
+}
+
+fn pending_blocks_immediate(
+    user_text: &str,
+    active_interaction_session: Option<&SessionRecord>,
+    active_conversation_session: Option<&SessionRecord>,
+    user_id: Option<&str>,
+) -> bool {
     let bypass_pending_for_session_command =
         session_flow::parse_pending_bypass_session_command(user_text).is_some();
     !bypass_pending_for_session_command
-        && active_session
+        && (active_interaction_session
             .and_then(|session| session.pending_operation.as_ref())
             .is_some()
+            || active_conversation_session
+                .is_some_and(|session| session_pending_visible_to_user(session, user_id)))
+}
+
+fn session_pending_visible_to_user(session: &SessionRecord, user_id: Option<&str>) -> bool {
+    let Some(pending) = session.pending_operation.as_ref() else {
+        return false;
+    };
+    match pending.initiator_user_id() {
+        Some(initiator) => user_id == Some(initiator),
+        None => true,
+    }
+}
+
+fn should_try_todo_flow(user_text: &str) -> bool {
+    todo_flow::parse_todo_command(user_text).is_some()
+        || todo_flow::is_natural_todo_query_text(user_text)
+        || todo_flow::is_full_todo_result_request(user_text)
 }
 
 fn has_recent_todo_context(req: &RespondRequest, active_session: Option<&SessionRecord>) -> bool {
@@ -680,9 +818,16 @@ fn has_recent_todo_context(req: &RespondRequest, active_session: Option<&Session
 
 fn classify_inbound_with_active(
     user_text: &str,
-    active_session: Option<&SessionRecord>,
+    active_interaction_session: Option<&SessionRecord>,
+    active_conversation_session: Option<&SessionRecord>,
+    user_id: Option<&str>,
 ) -> CoreInboundClassification {
-    if pending_blocks_immediate(user_text, active_session) {
+    if pending_blocks_immediate(
+        user_text,
+        active_interaction_session,
+        active_conversation_session,
+        user_id,
+    ) {
         return CoreInboundClassification {
             kind: CoreInboundKind::Immediate,
         };

--- a/qq-maid-core/src/runtime/respond/tests/pending.rs
+++ b/qq-maid-core/src/runtime/respond/tests/pending.rs
@@ -3,8 +3,10 @@ use crate::runtime::{
     pending::{ClarificationCandidate, PendingOperation, PendingTodoClarification},
     session::{SessionMeta, now_iso_cn},
     todo::{TodoItemDraft, TodoStatus, TodoStore, TodoTimePrecision},
+    tools::CompleteTodoTool,
 };
 use crate::service::CoreInboundKind;
+use qq_maid_llm::tool::{Tool, ToolContext};
 use serde_json::json;
 
 fn draft(title: &str) -> TodoItemDraft {
@@ -39,6 +41,18 @@ fn stable_group_scope() -> &'static str {
 fn stable_group_interaction_meta(user_id: &str) -> SessionMeta {
     SessionMeta::new_with_account(
         format!("{}:actor:{user_id}", stable_group_scope()),
+        Some(user_id.to_owned()),
+        Some("g1".to_owned()),
+        None,
+        None,
+        "qq_official",
+        Some("app-1".to_owned()),
+    )
+}
+
+fn stable_group_conversation_meta(user_id: &str) -> SessionMeta {
+    SessionMeta::new_with_account(
+        stable_group_scope(),
         Some(user_id.to_owned()),
         Some("g1".to_owned()),
         None,
@@ -535,6 +549,142 @@ async fn stable_group_todo_clarify_is_isolated_by_actor_interaction_session() {
             .get_or_create_active(&stable_group_interaction_meta("u1"))
             .unwrap()
             .pending_operation
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn stable_group_visible_todo_snapshots_are_isolated_by_actor() {
+    let service = test_service();
+    let owner_u1 = TodoStore::owner(Some("u1"), stable_group_scope());
+    let owner_u2 = TodoStore::owner(Some("u2"), stable_group_scope());
+    let u1_item = service
+        .todo_store
+        .create(&owner_u1, draft("u1 的待办"))
+        .unwrap();
+    let u2_item = service
+        .todo_store
+        .create(&owner_u2, draft("u2 的待办"))
+        .unwrap();
+
+    service
+        .respond(stable_group_message("看一下待办", "u1"))
+        .await
+        .unwrap();
+    service
+        .respond(stable_group_message("看一下待办", "u2"))
+        .await
+        .unwrap();
+
+    let u1_session = service
+        .session_store
+        .get_or_create_active(&stable_group_interaction_meta("u1"))
+        .unwrap();
+    let u2_session = service
+        .session_store
+        .get_or_create_active(&stable_group_interaction_meta("u2"))
+        .unwrap();
+    assert_eq!(
+        u1_session
+            .last_todo_query
+            .as_ref()
+            .expect("missing u1 snapshot")
+            .result_ids,
+        vec![u1_item.id.clone()]
+    );
+    assert_eq!(
+        u2_session
+            .last_todo_query
+            .as_ref()
+            .expect("missing u2 snapshot")
+            .result_ids,
+        vec![u2_item.id.clone()]
+    );
+
+    let complete_tool = CompleteTodoTool::new(
+        service.todo_store.clone(),
+        service.session_store.clone(),
+        service.notification_store.clone(),
+    );
+    let output = complete_tool
+        .execute(
+            ToolContext {
+                task_id: "stable-group-u2-complete".to_owned(),
+                user_id: Some("u2".to_owned()),
+                scope_id: stable_group_scope().to_owned(),
+                tool_call_id: Some("call-u2-complete".to_owned()),
+            },
+            json!({"numbers": [1], "reference": null}),
+        )
+        .await
+        .unwrap();
+    assert_eq!(output.value["ok"], true);
+
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner_u1, &u1_item.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner_u2, &u2_item.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Completed
+    );
+}
+
+#[tokio::test]
+async fn stable_group_plain_chat_keeps_conversation_session_without_actor_split() {
+    let service = test_service();
+
+    let first = service
+        .respond(stable_group_message("聊聊 Rust", "u1"))
+        .await
+        .unwrap();
+    let second = service
+        .respond(stable_group_message("继续聊所有权", "u2"))
+        .await
+        .unwrap();
+
+    let conversation = service
+        .session_store
+        .get_active(&stable_group_conversation_meta("u1"))
+        .unwrap()
+        .expect("missing group conversation session");
+    assert_eq!(
+        first.session_id.as_deref(),
+        Some(conversation.session_id.as_str())
+    );
+    assert_eq!(
+        second.session_id.as_deref(),
+        Some(conversation.session_id.as_str())
+    );
+    let user_messages = conversation
+        .history
+        .iter()
+        .filter(|message| message.role == "user")
+        .map(|message| message.content.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(user_messages, vec!["聊聊 Rust", "继续聊所有权"]);
+    assert!(
+        service
+            .session_store
+            .get_active(&stable_group_interaction_meta("u1"))
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        service
+            .session_store
+            .get_active(&stable_group_interaction_meta("u2"))
+            .unwrap()
             .is_none()
     );
 }

--- a/qq-maid-core/src/runtime/respond/tests/pending.rs
+++ b/qq-maid-core/src/runtime/respond/tests/pending.rs
@@ -1,10 +1,11 @@
 use super::support::*;
 use crate::runtime::{
-    pending::PendingOperation,
-    session::now_iso_cn,
+    pending::{ClarificationCandidate, PendingOperation, PendingTodoClarification},
+    session::{SessionMeta, now_iso_cn},
     todo::{TodoItemDraft, TodoStatus, TodoStore, TodoTimePrecision},
 };
 use crate::service::CoreInboundKind;
+use serde_json::json;
 
 fn draft(title: &str) -> TodoItemDraft {
     TodoItemDraft {
@@ -29,6 +30,36 @@ fn save_pending(service: &crate::runtime::respond::RustRespondService, pending: 
         .unwrap();
     session.pending_operation = Some(pending);
     service.session_store.save(&mut session).unwrap();
+}
+
+fn stable_group_scope() -> &'static str {
+    "platform:qq_official:account:app-1:group:g1"
+}
+
+fn stable_group_interaction_meta(user_id: &str) -> SessionMeta {
+    SessionMeta::new_with_account(
+        format!("{}:actor:{user_id}", stable_group_scope()),
+        Some(user_id.to_owned()),
+        Some("g1".to_owned()),
+        None,
+        None,
+        "qq_official",
+        Some("app-1".to_owned()),
+    )
+}
+
+fn stable_group_message(text: &str, user_id: &str) -> crate::runtime::respond::RespondRequest {
+    crate::runtime::respond::RespondRequest {
+        content: text.to_owned(),
+        scope_key: stable_group_scope().to_owned(),
+        user_id: Some(user_id.to_owned()),
+        group_member_role: Some("owner".to_owned()),
+        group_id: Some("g1".to_owned()),
+        platform: "qq_official".to_owned(),
+        account_id: Some("app-1".to_owned()),
+        event_type: "FakeEvent".to_owned(),
+        ..crate::runtime::respond::RespondRequest::default()
+    }
 }
 
 #[test]
@@ -415,6 +446,95 @@ async fn todo_bulk_delete_confirm_keeps_items_whose_status_changed_after_pending
             .todo_store
             .get_by_id(&owner, &delete.id)
             .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn stable_group_todo_clarify_is_isolated_by_actor_interaction_session() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), stable_group_scope());
+    let item = service.todo_store.create(&owner, draft("买票")).unwrap();
+    let created_at = now_iso_cn();
+    let mut session = service
+        .session_store
+        .get_or_create_active(&stable_group_interaction_meta("u1"))
+        .unwrap();
+    session.pending_operation = Some(PendingOperation::TodoClarify {
+        initiator_user_id: Some("u1".to_owned()),
+        owner_key: owner.key.clone(),
+        request: PendingTodoClarification {
+            tool_name: "complete_todos".to_owned(),
+            arguments: json!({"numbers": null, "reference": "last"}),
+            allow_many: true,
+            error_code: "todo_reference_unavailable".to_owned(),
+            question: "请补充要操作哪条待办。".to_owned(),
+            candidates: vec![ClarificationCandidate {
+                id: item.id.clone(),
+                display_number: 1,
+                title: item.title.clone(),
+                status: item.status.clone(),
+            }],
+            created_at: created_at.clone(),
+        },
+        created_at,
+    });
+    service.session_store.save(&mut session).unwrap();
+
+    let other_number = service
+        .respond(stable_group_message("1", "u2"))
+        .await
+        .unwrap();
+    assert_ne!(
+        other_number.command.as_deref(),
+        Some("todo_clarify_resumed")
+    );
+    let other_cancel = service
+        .respond(stable_group_message("取消", "u2"))
+        .await
+        .unwrap();
+    assert_ne!(other_cancel.command.as_deref(), Some("todo_clarify_cancel"));
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
+    assert!(
+        service
+            .session_store
+            .get_or_create_active(&stable_group_interaction_meta("u1"))
+            .unwrap()
+            .pending_operation
+            .is_some()
+    );
+
+    let owner_number = service
+        .respond(stable_group_message("1", "u1"))
+        .await
+        .unwrap();
+    assert_eq!(
+        owner_number.command.as_deref(),
+        Some("todo_clarify_resumed")
+    );
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Completed
+    );
+    assert!(
+        service
+            .session_store
+            .get_or_create_active(&stable_group_interaction_meta("u1"))
+            .unwrap()
+            .pending_operation
             .is_none()
     );
 }

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -919,7 +919,7 @@ fn contains_full_marker(text: &str) -> bool {
     text.contains("全部") || text.contains("所有") || text.contains("完整")
 }
 
-fn is_full_todo_result_request(text: &str) -> bool {
+pub(in crate::runtime::respond) fn is_full_todo_result_request(text: &str) -> bool {
     matches!(
         normalize_natural_todo_text(text).as_str(),
         "查看完整结果" | "显示完整结果" | "看完整结果" | "完整结果"

--- a/qq-maid-core/src/runtime/tools/todo/scope.rs
+++ b/qq-maid-core/src/runtime/tools/todo/scope.rs
@@ -13,7 +13,10 @@ use qq_maid_llm::tool::{ToolContext, ToolOutput};
 
 use crate::{
     error::LlmError,
-    identity::{group_raw_target_from_scope_key, scope_target_type},
+    identity::{
+        group_raw_target_from_scope_key, interaction_scope_key, parse_stable_scope_key,
+        scope_target_type,
+    },
     runtime::{
         pending::{PendingOperation, PendingTodoClarification},
         session::{
@@ -177,7 +180,8 @@ impl TodoToolScope {
     ///
     /// private 和 group Tool Loop 都必须绑定真实 user_id；owner 由当前业务 scope
     /// 与 actor 一起推导，因此群聊中执行 Todo Tool 仍写入个人待办，不写入群共享待办。
-    /// session 则继续使用当前请求 scope，保留用户在该聊天上下文中看到的编号快照。
+    /// session 在 stable 群聊中使用 conversation + actor 的 interaction scope，避免不同
+    /// 成员共享 pending 和可见编号快照；owner 仍使用原 conversation scope 计算。
     /// 未验证的 scope 类型继续拒绝，避免把频道等场景误纳入 Todo 写入口。
     ///
     /// `selection_scope` 为受限 Tool Loop 注入的请求级选择作用域；普通调用传 `None`，
@@ -206,8 +210,14 @@ impl TodoToolScope {
                 "tool",
             )
         })?;
+        let session_scope_id =
+            if group_id.is_some() && parse_stable_scope_key(&context.scope_id).is_some() {
+                interaction_scope_key(Some(user_id), &context.scope_id)
+            } else {
+                context.scope_id.clone()
+            };
         let meta = SessionMeta::new(
-            context.scope_id.clone(),
+            session_scope_id,
             Some(user_id.to_owned()),
             group_id,
             None,


### PR DESCRIPTION
## 变更
- 将 stable 群聊下的 pending、Todo 可见编号快照和 Memory/Todo 命令状态切到 conversation + actor 的 interaction session。
- 保留普通群聊聊天历史使用 conversation session，不把群会话整体拆成个人私聊。
- Todo Tool 在 stable 群聊中也用 interaction session 存取 pending/快照，同时 owner 仍按原 conversation scope 计算。
- 对旧 conversation pending 保留兼容：缺失 initiator 的旧 pending 仍可按历史路径处理；带 initiator 的旧 pending 只对发起人可见。
- route 判断现在同时参考 interaction session 与旧 conversation session 的 recent todo context；旧 conversation visible snapshot / last_todo_action 只作为路由提示兼容读取，不迁移、不回写，实际 Todo/Memory 操作状态仍写入 interaction session。
- 增加 stable group 回归测试，覆盖 TodoClarify pending 隔离、不同成员 visible snapshot 隔离、编号操作不串用、普通聊天仍写入 group conversation session。

## 验证
- cargo test -p qq-maid-core runtime::respond::tests::pending::stable_group
- make test-core
- cargo fmt --all -- --check
- git diff --check

Closes #301