### PR TITLE
test(#300): 群聊引用快照 owner/scope 不匹配不 fallback 回归

### DIFF
--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -965,8 +965,6 @@ pub(super) fn recent_session_messages(session: &SessionRecord, limit: usize) -> 
 #[cfg(test)]
 mod prompt_protection_tests {
     use super::*;
-    use crate::service::{ToolsVisibleItem, ToolsVisibleSnapshot};
-    use qq_maid_common::input_part::QuotedMessageContext;
 
     #[test]
     fn prompt_extraction_detection_covers_system_prompt_requests() {
@@ -1000,6 +998,55 @@ mod prompt_protection_tests {
             assert!(!is_prompt_extraction_request(input), "{input}");
         }
     }
+}
+
+#[cfg(test)]
+mod selection_scope_tests {
+    use super::*;
+    use crate::service::{ToolsVisibleItem, ToolsVisibleSnapshot};
+    use qq_maid_common::input_part::QuotedMessageContext;
+
+    fn quoted_from_bot(summary: &str, ref_id: &str) -> QuotedMessageContext {
+        QuotedMessageContext {
+            current_message_id: Some("current-msg".to_owned()),
+            current_msg_idx: Some("current-idx".to_owned()),
+            reference_id: Some(ref_id.to_owned()),
+            ref_msg_idx: Some(ref_id.to_owned()),
+            lookup_found: true,
+            text_summary: Some(summary.to_owned()),
+            media_summaries: Vec::new(),
+            input_parts: Vec::new(),
+            from_bot: Some(true),
+            fallback_reason: None,
+        }
+    }
+
+    fn todo_item(entity_id: &str, visible_number: usize) -> ToolsVisibleItem {
+        ToolsVisibleItem {
+            domain: "todo".to_owned(),
+            entity_kind: "todo".to_owned(),
+            entity_id: entity_id.to_owned(),
+            visible_number,
+            label: None,
+            status: Some("pending".to_owned()),
+        }
+    }
+
+    fn snapshot(
+        scope_key: &str,
+        owner_key: Option<String>,
+        account_id: Option<&str>,
+        items: Vec<ToolsVisibleItem>,
+    ) -> ToolsVisibleSnapshot {
+        ToolsVisibleSnapshot {
+            platform: "qq_official".to_owned(),
+            account_id: account_id.map(str::to_owned),
+            scope_key: scope_key.to_owned(),
+            owner_key,
+            created_at: crate::runtime::session::now_iso_cn(),
+            items,
+        }
+    }
 
     #[test]
     fn quoted_snapshot_scope_mismatch_blocks_without_fallback() {
@@ -1008,39 +1055,81 @@ mod prompt_protection_tests {
         req.user_id = Some("u1".to_owned());
         req.platform = "qq_official".to_owned();
         req.account_id = Some("app-a".to_owned());
-        req.quoted = Some(QuotedMessageContext {
-            current_message_id: Some("current-msg".to_owned()),
-            current_msg_idx: Some("current-idx".to_owned()),
-            reference_id: Some("msg-a".to_owned()),
-            ref_msg_idx: Some("ref-a".to_owned()),
-            lookup_found: true,
-            text_summary: Some("1. A".to_owned()),
-            media_summaries: Vec::new(),
-            input_parts: Vec::new(),
-            from_bot: Some(true),
-            fallback_reason: None,
-        });
-        req.tools_visible_snapshot = Some(ToolsVisibleSnapshot {
-            platform: "qq_official".to_owned(),
-            account_id: Some("app-b".to_owned()),
-            scope_key: "private:u1".to_owned(),
-            owner_key: Some("private:u1::u1".to_owned()),
-            created_at: crate::runtime::session::now_iso_cn(),
-            items: vec![ToolsVisibleItem {
-                domain: "todo".to_owned(),
-                entity_kind: "todo".to_owned(),
-                entity_id: "todo-a-1".to_owned(),
-                visible_number: 1,
-                label: None,
-                status: Some("pending".to_owned()),
-            }],
-        });
+        req.quoted = Some(quoted_from_bot("1. A", "msg-a"));
+        req.tools_visible_snapshot = Some(snapshot(
+            "private:u1",
+            Some("private:u1::u1".to_owned()),
+            Some("app-b"),
+            vec![todo_item("todo-a-1", 1)],
+        ));
 
         let owner = crate::runtime::todo::TodoStore::owner(Some("u1"), "private:u1");
-
         assert!(matches!(
             todo_selection_scope_from_tools_visible_snapshot(&req, &owner),
             Some(SelectionScope::Blocked)
         ));
+    }
+
+    /// 群聊中 user B 引用机器人消息，但快照 owner_key 属于 user A 时，
+    /// 必须直接 Blocked，不能回退到 user B 自己的 `last_todo_query`，
+    /// 否则 B 会用 A 的可见列表编号误操作 A 的待办。
+    #[test]
+    fn quoted_snapshot_group_owner_mismatch_blocks_without_fallback() {
+        let group_scope = "platform:qq_official:account:app-1:group:g1";
+        let owner_user_a = crate::runtime::todo::TodoStore::owner(Some("u1"), group_scope);
+        let owner_user_b = crate::runtime::todo::TodoStore::owner(Some("u2"), group_scope);
+
+        let mut req = empty_respond_request();
+        req.scope_key = group_scope.to_owned();
+        req.user_id = Some("u2".to_owned());
+        req.platform = "qq_official".to_owned();
+        req.account_id = Some("app-1".to_owned());
+        req.group_id = Some("g1".to_owned());
+        req.quoted = Some(quoted_from_bot("1. 买票", "msg-a"));
+        req.tools_visible_snapshot = Some(snapshot(
+            group_scope,
+            Some(owner_user_a.key.clone()),
+            Some("app-1"),
+            vec![todo_item("todo-a-1", 1)],
+        ));
+
+        assert!(
+            matches!(
+                todo_selection_scope_from_tools_visible_snapshot(&req, &owner_user_b),
+                Some(SelectionScope::Blocked)
+            ),
+            "跨人 owner 的引用快照必须 Blocked，避免 B 用 A 的可见编号"
+        );
+    }
+
+    /// 引用快照的 scope_key 与当前请求 scope_key 不一致（跨群 / 跨会话）时必须 Blocked，
+    /// 不能回退到当前会话的 `last_todo_query`，避免跨群编号串用。
+    #[test]
+    fn quoted_snapshot_group_scope_mismatch_blocks_without_fallback() {
+        let group_a = "platform:qq_official:account:app-1:group:g1";
+        let group_b = "platform:qq_official:account:app-1:group:g2";
+        let owner_in_b = crate::runtime::todo::TodoStore::owner(Some("u1"), group_b);
+
+        let mut req = empty_respond_request();
+        req.scope_key = group_b.to_owned();
+        req.user_id = Some("u1".to_owned());
+        req.platform = "qq_official".to_owned();
+        req.account_id = Some("app-1".to_owned());
+        req.group_id = Some("g2".to_owned());
+        req.quoted = Some(quoted_from_bot("1. 买票", "msg-g1"));
+        req.tools_visible_snapshot = Some(snapshot(
+            group_a,
+            Some(owner_in_b.key.clone()),
+            Some("app-1"),
+            vec![todo_item("todo-g1-1", 1)],
+        ));
+
+        assert!(
+            matches!(
+                todo_selection_scope_from_tools_visible_snapshot(&req, &owner_in_b),
+                Some(SelectionScope::Blocked)
+            ),
+            "跨群 scope 的引用快照必须 Blocked，避免跨群编号串用"
+        );
     }
 }


### PR DESCRIPTION
## 关联

- 父 Epic：#294
- 本子任务：#300
- 依赖已合并：PR #309 已把 #297 引用快照链路回灌到 master，base 已改回 master。

## 范围

#300 验收共 5 条：

1. 同一群 user A / B 创建个人 Todo，owner 不同 —— 现有 `stable_group_visible_todo_snapshots_are_isolated_by_actor`（pending.rs）已覆盖，本 PR 不重复。
2. user A 查询 Todo 后，user B 回复"第一条完成"不能用 A 的列表快照 —— 同上 Tool 层隔离测试已覆盖（u2 `complete_todos` 编号 1 只完成 u2 自己的）。
3. user A 的"刚才那个 / 这个"不会引用 B 的最近操作 —— `stable_group_todo_clarify_is_isolated_by_actor_interaction_session` 已覆盖。
4. **quoted visible snapshot 的 owner / account / scope 不匹配时不 fallback 到错误列表** —— 本 PR 补齐。
5. 原有私聊 Todo 续指行为不回归 —— 隐含在已有私聊记忆 / Todo 套件，无新实现改动。

## 本 PR 做的

只补回归测试，不改实现（`+117 / -28`，单文件）。

把 `quoted_snapshot_*` 三条回归测试从 `prompt_protection_tests` 抽出，单独成 `selection_scope_tests` 子模块（同在 `chat_flow.rs`）：

- `quoted_snapshot_scope_mismatch_blocks_without_fallback`（已有，account_id 跨账号 → Blocked）
- `quoted_snapshot_group_owner_mismatch_blocks_without_fallback`（新增，群聊 user B 引用但快照 owner 属于 user A → Blocked）
- `quoted_snapshot_group_scope_mismatch_blocks_without_fallback`（新增，跨群 g1 vs g2 → Blocked）

抽出来的理由：引用快照作用域构造（`todo_selection_scope_from_tools_visible_snapshot`）与 prompt 提取保护（`is_prompt_extraction_request`）语义无关。原来的 3 条测试混在 `prompt_protection_tests` 里，模块名和被测对象对不上，后续维护找测试要绕一层。独立成块后测试边界与被测函数语义对齐；共用 `quoted_from_bot` / `todo_item` / `snapshot` 三个 helper 去重复样板。

验收第 4 条 owner / account / scope 三个维度全覆盖。

## 为什么只补测试不补实现

实现链路在 PR #297 已收敛：

- `todo_selection_scope_from_tools_visible_snapshot`（chat_flow.rs）对 `snapshot.scope_key != req.scope_key`、`snapshot.owner_key != owner.key`、`snapshot.platform != req.platform`、`snapshot.account_id != req.account_id`、以及 TTL 失效，逐一短路返回 `SelectionScope::Blocked`，不回退 `last_todo_query`。
- `TodoToolScope::resolve_numbers`（tools/todo/scope.rs）在 `SelectionScope::Blocked` 时直接返回 `TODO_VISIBLE_NUMBERS_UNAVAILABLE_CODE`。
- `TodoToolScope::load` 在群聊 + stable scope 下用 `interaction_scope_key(user_id, scope_id)` 加载 session，owner 用 `TodoStore::owner(user_id, scope_id)`，actor 与 owner 双隔离。

#301 已为 Pending / active session 落地 actor interaction scope；本子任务不重写 storage / schema，不删 `last_todo_query` / `TodoToolScope`，符合 #300 非目标。

## 关于测试位置

本想按"工具与响应解耦"方向把测试挪到 `runtime/tools/todo/tests.rs`，但 `todo_selection_scope_from_tools_visible_snapshot` 现是 `chat_flow.rs` 私有函数，且消费 `RespondRequest` + `ToolsVisibleSnapshot`（属 respond / service 层）。把函数搬进 `tools/todo/scope.rs` 会引入 `tools → respond` / `tools → service` 的反向依赖，违反现有 crate 依赖方向，超出 #300「只补测试」边界。因此本 PR 走最小改动：测试留在 `chat_flow.rs`（被测函数实现所在），但独立成 `selection_scope_tests` 子模块，与 prompt 保护测试分块。真正的"工具与响应解耦"留到后续 agent loop 重构 Epic 处理。

## 验证

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo test --workspace --all-features`：
  - `qq-maid-core` 687 passed（含 3 条 `quoted_snapshot_*` 不匹配回归）✅
  - `qq-maid-gateway-rs` 311 passed ✅
  - `qq-maid-llm` 184 passed ✅
  - `qq-maid-common` 27 passed ✅

## 残余风险

- 全量 `cargo test --workspace --all-features` 偶发 2-4 条 `todo_tool_loop::*` 时间相关 flaky 失败，在 master 上同样存在，与本 PR 无关；单跑稳定通过。
- 端到端"群聊里 user B 自然语言回复'第一条完成'"的 e2e 路径未单测，因为群聊 Tool Loop 默认关闭，现有 Tool 层直接调用 `CompleteTodoTool::execute` 的隔离测试已等价覆盖编号绑定逻辑。
- 引用快照的 `platform` 维度跨账号阻断已有旧测试，本 PR 不重复。
