### PR TITLE
fix(#299): 隔离群聊 Tool Loop Todo 聚合状态

### DIFF
--- a/qq-maid-core/src/config/agent.rs
+++ b/qq-maid-core/src/config/agent.rs
@@ -546,6 +546,16 @@ impl AgentRuntimeConfig {
     }
 }
 
+#[cfg(test)]
+impl AgentRuntimeConfig {
+    pub(crate) fn with_group_enabled_tools_for_test(mut self, tools: &[&str]) -> Self {
+        self.scenes.group.enabled_tools =
+            Some(tools.iter().map(|tool| (*tool).to_owned()).collect());
+        self.scenes.group.tool_calling_enabled = Some(true);
+        self
+    }
+}
+
 impl ResolvedAgentPolicy {
     pub fn diagnostic_summary(&self) -> serde_json::Value {
         serde_json::json!({

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -109,6 +109,13 @@ impl RustRespondService {
             system_prompts
         };
         let policy = self.resolve_agent_policy(&req)?;
+        // 群聊 Tool Loop 中 Todo 可见列表快照属于发起人个人交互状态：
+        // #301 已让 Pending / TodoToolScope 落到 interaction session，但聚合层
+        // `build_agent_turn_outcome` 和出站快照读取仍走 conversation session，
+        // 会让群里 A 列待办后 B 的"第一条"沿用 A 的列表。这里先依据请求计算
+        // interaction meta，随后在 Tool Loop 分支按该 meta 加载独立 interaction
+        // session 承载写/读。`req.metadata` 会在 `chat_req` 中被 move，提前计算。
+        let interaction_meta = super::respond_interaction_meta(&req);
         let owner =
             crate::runtime::todo::TodoStore::owner(meta.user_id.as_deref(), &meta.scope_key);
         let quoted_todo_selection_scope =
@@ -163,64 +170,98 @@ impl RustRespondService {
         let service =
             LlmChatService::with_context_budget(self.provider.clone(), self.context_budget);
         let use_tool_loop = matches!(chat_tool_plan, ChatToolPlan::ForceCompleteToolLoop);
-        let (output, todo_success_validation, agent_turn_outcome) = if use_tool_loop {
-            let tools =
-                self.tool_registry_for_chat(&policy, quoted_todo_selection_scope.clone())?;
-            let mut output = service
-                .respond_with_tools(chat_req, tools, policy.max_tool_rounds)
-                .await?;
+        let (output, todo_success_validation, agent_turn_outcome, standalone_interaction) =
+            if use_tool_loop {
+                let tools =
+                    self.tool_registry_for_chat(&policy, quoted_todo_selection_scope.clone())?;
+                let mut output = service
+                    .respond_with_tools(chat_req, tools, policy.max_tool_rounds)
+                    .await?;
 
-            let mut latest_session = self
-                .session_store
-                .get(&session.session_id)
-                .map_err(session_error)?
-                .ok_or_else(|| {
-                    LlmError::new(
-                        "session_missing",
-                        format!(
-                            "session `{}` disappeared after tool loop",
-                            session.session_id
-                        ),
-                        "session",
+                let mut latest_session = self
+                    .session_store
+                    .get(&session.session_id)
+                    .map_err(session_error)?
+                    .ok_or_else(|| {
+                        LlmError::new(
+                            "session_missing",
+                            format!(
+                                "session `{}` disappeared after tool loop",
+                                session.session_id
+                            ),
+                            "session",
+                        )
+                    })?;
+                // conversation session 只承载群聊公开历史与普通聊天状态；Todo 工具执行
+                // 自身会经 TodoToolScope 写 interaction session。这里刷新 conversation 记录，
+                // 只把本轮聊天在调用模型前更新的状态合并回最新记录，避免旧 SessionRecord 覆盖工具结果。
+                latest_session.state = session.state.clone();
+                session = latest_session;
+
+                // 群聊且 actor 可隔离时加载独立 interaction session 承载 Todo 聚合写/读；
+                // 私聊与无 actor 隔离的群聊保持原行为（interaction meta 与 conversation meta
+                // 指向同一 session）。`interaction_meta` 已在 `chat_req` 构造前计算。
+                let actor_isolated = interaction_meta.scope_key != meta.scope_key;
+                let mut standalone_interaction: Option<SessionRecord> = if actor_isolated {
+                    Some(
+                        self.session_store
+                            .get_or_create_active(&interaction_meta)
+                            .map_err(session_error)?,
                     )
-                })?;
-            // Tool 执行会基于同一 active session 保存 pending/最近 Todo 查询等字段；
-            // 这里只把本轮聊天在调用模型前更新的状态合并回最新记录，避免旧 SessionRecord 覆盖工具结果。
-            latest_session.state = session.state.clone();
-            session = latest_session;
-
-            let turn_outcome =
-                build_agent_turn_outcome(&self.todo_store, &mut session, &owner, &output)?;
-            let validation = if turn_outcome.can_replace_model_reply() {
-                if turn_outcome.should_preserve_model_reply() {
-                    apply_agent_turn_outcome_with_model_reply(&mut output, &turn_outcome);
                 } else {
-                    apply_agent_turn_outcome(&mut output, &turn_outcome);
+                    None
+                };
+                let todo_state_session: &mut SessionRecord =
+                    standalone_interaction.as_mut().unwrap_or(&mut session);
+
+                let turn_outcome = build_agent_turn_outcome(
+                    &self.todo_store,
+                    todo_state_session,
+                    &owner,
+                    &output,
+                )?;
+                if let Some(interaction) = standalone_interaction.as_mut() {
+                    self.session_store
+                        .save(interaction)
+                        .map_err(session_error)?;
                 }
-                todo_success_validation_from_agent_outcome(&turn_outcome)
-            } else if turn_outcome.has_unhandled_outcome() && !turn_outcome.outcomes.is_empty() {
-                apply_agent_turn_compat_output(&mut output, &turn_outcome);
-                todo_success_validation_from_agent_outcome(&turn_outcome)
+                let validation = if turn_outcome.can_replace_model_reply() {
+                    if turn_outcome.should_preserve_model_reply() {
+                        apply_agent_turn_outcome_with_model_reply(&mut output, &turn_outcome);
+                    } else {
+                        apply_agent_turn_outcome(&mut output, &turn_outcome);
+                    }
+                    todo_success_validation_from_agent_outcome(&turn_outcome)
+                } else if turn_outcome.has_unhandled_outcome() && !turn_outcome.outcomes.is_empty()
+                {
+                    apply_agent_turn_compat_output(&mut output, &turn_outcome);
+                    todo_success_validation_from_agent_outcome(&turn_outcome)
+                } else {
+                    let validation = todo_guard::validate_todo_success_reply(&output);
+                    if !validation.passed() {
+                        output = todo_success_not_verified_output(
+                            output,
+                            todo_guard::todo_success_not_verified_reply_for_output,
+                        );
+                    }
+                    validation
+                };
+                (
+                    output,
+                    validation,
+                    Some(turn_outcome),
+                    standalone_interaction,
+                )
             } else {
-                let validation = todo_guard::validate_todo_success_reply(&output);
-                if !validation.passed() {
-                    output = todo_success_not_verified_output(
-                        output,
-                        todo_guard::todo_success_not_verified_reply_for_output,
-                    );
-                }
-                validation
+                (
+                    service.respond(chat_req).await?,
+                    todo_guard::TodoSuccessValidation::Passed {
+                        claimed_success: false,
+                    },
+                    None,
+                    None,
+                )
             };
-            (output, validation, Some(turn_outcome))
-        } else {
-            (
-                service.respond(chat_req).await?,
-                todo_guard::TodoSuccessValidation::Passed {
-                    claimed_success: false,
-                },
-                None,
-            )
-        };
 
         let reply = output.reply.clone();
         let executed_tools = output.executed_tools.clone();
@@ -323,11 +364,15 @@ impl RustRespondService {
                 Value::Null
             },
         }));
-        // 只有本轮确定性渲染了 Todo 可见编号列表，才把当前快照绑定到出站消息。
-        // 普通聊天不能继承旧 last_todo_query，否则引用普通回复会误恢复上一条列表。
+        // 只有本轮确定性渲染了工具可见实体快照，才把当前快照绑定到出站消息。
+        // 当前只有 Todo 会产出该快照；普通聊天不能继承旧 last_todo_query，
+        // 否则引用普通回复会误恢复上一条列表。
+        // 群聊时本轮快照写在发起人的 interaction session，这里必须从同一 session 读取，
+        // 避免回读到 conversation session 的旧快照导致跨人串用。
+        let snapshot_session = standalone_interaction.as_ref().unwrap_or(&session);
         if agent_turn_shows_todo_visible_list(agent_turn_outcome.as_ref()) {
             response.tools_visible_snapshot =
-                super::todo_flow::todo_tools_visible_snapshot(&session, Some(&meta));
+                super::todo_flow::todo_tools_visible_snapshot(snapshot_session, Some(&meta));
         }
         Ok(response)
     }

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -206,6 +206,7 @@ async fn private_tool_loop_can_query_train_schedule_with_trusted_rendering() {
         TestToolCallingOptions {
             enabled: true,
             group_enabled: false,
+            group_enabled_tools: None,
         },
     );
 
@@ -270,6 +271,7 @@ async fn mixed_train_and_todo_request_is_not_captured_by_todo_date_query() {
         TestToolCallingOptions {
             enabled: true,
             group_enabled: false,
+            group_enabled_tools: None,
         },
     );
 

--- a/qq-maid-core/src/runtime/respond/tests/support.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support.rs
@@ -130,6 +130,7 @@ pub(super) struct TestModelOptions {
 pub(super) struct TestToolCallingOptions {
     pub(super) enabled: bool,
     pub(super) group_enabled: bool,
+    pub(super) group_enabled_tools: Option<Vec<String>>,
 }
 
 #[derive(Clone)]
@@ -1714,6 +1715,20 @@ pub(super) fn test_service_with_provider_and_group_tool_calling(
     tool_calling_enabled: bool,
     tool_calling_group_enabled: bool,
 ) -> RustRespondService {
+    test_service_with_provider_and_group_tool_calling_tools(
+        provider,
+        tool_calling_enabled,
+        tool_calling_group_enabled,
+        None,
+    )
+}
+
+pub(super) fn test_service_with_provider_and_group_tool_calling_tools(
+    provider: MockProvider,
+    tool_calling_enabled: bool,
+    tool_calling_group_enabled: bool,
+    group_enabled_tools: Option<Vec<String>>,
+) -> RustRespondService {
     test_service_with_provider_base_title_query_weather_train_models_and_options(
         provider,
         None,
@@ -1729,6 +1744,7 @@ pub(super) fn test_service_with_provider_and_group_tool_calling(
         TestToolCallingOptions {
             enabled: tool_calling_enabled,
             group_enabled: tool_calling_group_enabled,
+            group_enabled_tools,
         },
     )
     .0
@@ -1917,7 +1933,15 @@ pub(super) fn test_service_with_provider_base_title_query_weather_train_models_a
             },
             tool_result_max_chars: crate::config::DEFAULT_AGENT_TOOL_RESULT_CHAR_LIMIT as usize,
             status_display_name: crate::config::DEFAULT_STATUS_DISPLAY_NAME.to_owned(),
-            agent_config: test_agent_config(tool_calling.enabled, tool_calling.group_enabled),
+            agent_config: {
+                let config = test_agent_config(tool_calling.enabled, tool_calling.group_enabled);
+                if let Some(tools) = tool_calling.group_enabled_tools.as_ref() {
+                    let refs = tools.iter().map(String::as_str).collect::<Vec<_>>();
+                    config.with_group_enabled_tools_for_test(&refs)
+                } else {
+                    config
+                }
+            },
         },
     );
     (service, base)

--- a/qq-maid-core/src/runtime/respond/tests/todo_tool_loop.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo_tool_loop.rs
@@ -1,7 +1,68 @@
-use crate::provider::ToolCallingProtocol;
-use crate::runtime::todo::TodoStatus;
+use serde_json::json;
+
+use crate::provider::{ToolCallingProtocol, ToolExecutionResult};
+use crate::runtime::respond::{RespondRequest, common::empty_respond_request};
+use crate::runtime::session::SessionMeta;
+use crate::runtime::todo::{TodoItemDraft, TodoStatus, TodoTimePrecision};
 
 use super::support::*;
+
+fn stable_group_scope() -> &'static str {
+    "platform:qq_official:account:app-1:group:g1"
+}
+
+fn stable_group_message(text: &str, user_id: &str) -> RespondRequest {
+    RespondRequest {
+        content: text.to_owned(),
+        scope_key: stable_group_scope().to_owned(),
+        user_id: Some(user_id.to_owned()),
+        group_id: Some("g1".to_owned()),
+        platform: "qq_official".to_owned(),
+        account_id: Some("app-1".to_owned()),
+        event_type: "FakeEvent".to_owned(),
+        ..empty_respond_request()
+    }
+}
+
+fn stable_group_interaction_meta(user_id: &str) -> SessionMeta {
+    SessionMeta::new_with_account(
+        format!("{}:actor:{user_id}", stable_group_scope()),
+        Some(user_id.to_owned()),
+        Some("g1".to_owned()),
+        None,
+        None,
+        "qq_official",
+        Some("app-1".to_owned()),
+    )
+}
+
+fn stable_group_conversation_meta(user_id: &str) -> SessionMeta {
+    SessionMeta::new_with_account(
+        stable_group_scope(),
+        Some(user_id.to_owned()),
+        Some("g1".to_owned()),
+        None,
+        None,
+        "qq_official",
+        Some("app-1".to_owned()),
+    )
+}
+
+fn group_todo_draft(title: &str) -> TodoItemDraft {
+    TodoItemDraft {
+        title: title.to_owned(),
+        detail: None,
+        raw_text: None,
+        due_date: None,
+        due_at: None,
+        reminder_at: None,
+        time_precision: TodoTimePrecision::None,
+        recurrence_kind: crate::runtime::todo::TodoRecurrenceKind::None,
+        recurrence_interval_days: 0,
+        recurrence_interval: 0,
+        recurrence_unit: crate::runtime::todo::TodoRecurrenceUnit::Day,
+    }
+}
 
 #[tokio::test]
 async fn private_tool_loop_registers_todo_tools_and_keeps_internal_ids_hidden() {
@@ -41,6 +102,149 @@ async fn private_tool_loop_registers_todo_tools_and_keeps_internal_ids_hidden() 
     assert_eq!(last_action.title, "检查机器人日志");
     assert_eq!(last_action.action, "restored");
     assert_eq!(last_action.resulting_status, TodoStatus::Pending);
+}
+
+#[tokio::test]
+async fn group_tool_loop_todo_visible_snapshot_uses_actor_interaction_session() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_raw_tool_results(
+            vec![ToolExecutionResult {
+                name: "list_todos".to_owned(),
+                output: json!({"ok": true, "status": "pending"}),
+                succeeded: true,
+            }],
+            "已列出待办",
+        )
+        .with_tool_call_json(
+            "complete_todos",
+            r#"{"numbers":[1],"reference":null}"#,
+            "尝试完成第一条",
+        )
+        .with_tool_call_json(
+            "complete_todos",
+            r#"{"numbers":[1],"reference":null}"#,
+            "完成第一条",
+        );
+    let service = test_service_with_provider_and_group_tool_calling_tools(
+        inspector,
+        true,
+        true,
+        Some(vec!["list_todos".to_owned(), "complete_todos".to_owned()]),
+    );
+    let owner_a = crate::runtime::todo::TodoStore::owner(Some("u1"), stable_group_scope());
+    let owner_b = crate::runtime::todo::TodoStore::owner(Some("u2"), stable_group_scope());
+    let todo_a = service
+        .todo_store
+        .create(&owner_a, group_todo_draft("A 的待办"))
+        .unwrap();
+    let todo_b = service
+        .todo_store
+        .create(&owner_b, group_todo_draft("B 的待办"))
+        .unwrap();
+
+    let list_response = service
+        .respond(stable_group_message("检查待办", "u1"))
+        .await
+        .unwrap();
+
+    let conversation = service
+        .session_store
+        .get_or_create_active(&stable_group_conversation_meta("u1"))
+        .unwrap();
+    assert_eq!(
+        list_response.session_id.as_deref(),
+        Some(conversation.session_id.as_str())
+    );
+    assert!(
+        conversation
+            .history
+            .iter()
+            .any(|message| message.role == "user" && message.content == "检查待办"),
+        "群聊 Tool Loop 后 conversation session 仍应保留公开聊天历史"
+    );
+    assert!(
+        conversation.last_todo_query.is_none(),
+        "群聊 Tool Loop 的 Todo 可见快照不能写入 conversation session"
+    );
+    let interaction_a = service
+        .session_store
+        .get_or_create_active(&stable_group_interaction_meta("u1"))
+        .unwrap();
+    assert_eq!(
+        interaction_a
+            .last_todo_query
+            .as_ref()
+            .expect("missing user A visible snapshot")
+            .result_ids,
+        vec![todo_a.id.clone()]
+    );
+    assert!(
+        service
+            .session_store
+            .get_active(&stable_group_interaction_meta("u2"))
+            .unwrap()
+            .is_none(),
+        "user A 的工具快照不能提前创建 user B 的 interaction session"
+    );
+
+    service
+        .respond(stable_group_message("第一条完成", "u2"))
+        .await
+        .unwrap();
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner_a, &todo_a.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending,
+        "user B 不能沿用 user A 的可见编号完成 A 的待办"
+    );
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner_b, &todo_b.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending,
+        "user B 没有自己的可见快照时也不能误完成自己的待办"
+    );
+    assert!(
+        service
+            .session_store
+            .get_or_create_active(&stable_group_interaction_meta("u2"))
+            .unwrap()
+            .pending_operation
+            .is_some(),
+        "user B 缺少可见编号时应进入自己的澄清 pending"
+    );
+
+    service
+        .respond(stable_group_message("第一条完成", "u1"))
+        .await
+        .unwrap();
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner_a, &todo_a.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Completed,
+        "user A 仍能使用自己的 interaction session 快照继续操作"
+    );
+    assert_eq!(
+        service
+            .todo_store
+            .get_by_id(&owner_b, &todo_b.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## 关联

- 父 Epic：#294
- 本子任务：#299
- 承接：#301 已让 pending / active session 具备 actor-aware interaction scope；#300 已补齐 Todo 最近上下文和引用快照不 fallback 回归。

## 问题

群聊 Tool Loop 中，`TodoToolScope::load` 已经会按 `interaction_scope_key(user_id, scope_id)` 加载发起人的 interaction session，pending / 澄清 / 工具内部状态不会串。

但外层 Tool Loop 聚合仍存在缺口：

- `handle_chat` 使用 conversation session 作为普通群聊上下文；
- Tool Loop 结束后调用 `build_agent_turn_outcome(&mut session, ...)`；
- `aggregate_todo_tool_results` 会把最终用户可见 `list_todos` 结果写入传入 session 的 `last_todo_query`；
- 出站 `ToolsVisibleSnapshot` 也从同一个 session 读取；
- 结果是群聊里 A 的 Tool Loop 可见列表快照可能写进 group conversation session，B 后续“第一条 / 刚才那个”有机会沿用 A 的快照。

这正是 #299 要收口的 Tool Loop 聚合层 actor-aware interaction scope 缺口。

## 修改

### Core 行为

`qq-maid-core/src/runtime/respond/chat_flow.rs`

- `chat_req.session_id` 仍然使用 conversation session，不改变模型上下文和群聊公开历史。
- 普通聊天历史、最终 `append_exchange`、自动标题仍写 conversation session。
- Tool Loop 分支在进入模型前提前计算 `interaction_meta`。
- Tool Loop 完成后：
  - conversation session 仍刷新公开聊天状态；
  - 若 `interaction_meta.scope_key != meta.scope_key`，加载独立 interaction session；
  - `build_agent_turn_outcome` / `aggregate_todo_tool_results` 使用 interaction session 写 Todo 可见列表快照；
  - interaction session 显式 `save`；
  - 出站 `ToolsVisibleSnapshot` 从同一 interaction session 读取；
  - 私聊或无法 actor 隔离的旧 scope 保持原 conversation session 行为。

同时把快照注释从“Todo 可见编号列表”修正为“工具可见实体快照（当前只有 Todo 产出）”，避免未来快照扩展时注释误导。

### 测试

`qq-maid-core/src/runtime/respond/tests/todo_tool_loop.rs`

新增 `group_tool_loop_todo_visible_snapshot_uses_actor_interaction_session`：

- 开启群聊 Tool Loop，并在测试配置中显式开放 `list_todos` / `complete_todos`（不改变生产默认白名单）。
- user A 触发 Tool Loop `list_todos`：
  - conversation session 保留公开聊天历史；
  - conversation session 不写 `last_todo_query`；
  - user A interaction session 写入 A 的可见列表快照；
  - user B interaction session 不被提前创建。
- user B 随后执行 `complete_todos(numbers=[1])`：
  - 不能沿用 A 的可见快照；
  - A / B 的待办都不会被误完成；
  - B 进入自己的澄清 pending。
- user A 再执行 `complete_todos(numbers=[1])`：
  - 仍能使用 A 自己 interaction session 中的快照；
  - A 的待办完成；B 的待办不变。

### 测试辅助

`qq-maid-core/src/config/agent.rs` / `tests/support.rs`

- 增加 `#[cfg(test)] AgentRuntimeConfig::with_group_enabled_tools_for_test`，只用于测试显式开放群聊 Todo 工具。
- 扩展 `TestToolCallingOptions.group_enabled_tools`，生产默认配置不变。
- 补齐已有两个 `TestToolCallingOptions` 初始化中的新字段。

## 边界

- 不打开群聊 Tool Calling 默认开关。
- 不扩大生产群聊工具白名单。
- 不改 Provider / Tool Loop 协议。
- 不移动 #309 / #310 的引用快照实现与测试结构。
- 不引入 tools → respond / tools → service 的反向依赖。
- 不改变非工具聊天路径。

## 验证

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo test -p qq-maid-core --lib 'group_tool_loop_todo_visible_snapshot_uses_actor_interaction_session'` ✅
- `cargo test -p qq-maid-core --lib 'todo_tool_loop'` ✅
- `cargo test --workspace --all-features`：
  - `qq-maid-core` 689 passed ✅
  - `qq-maid-gateway-rs` 311 passed ✅
  - `qq-maid-llm` 184 passed ✅
  - `qq-maid-common` 27 passed ✅

## 后续

agent loop 与 respond/tool 的进一步解耦仍建议后续单独 Epic 处理。本 PR 只做 #299 最小兼容修复：conversation history 保持 conversation scope，Todo 工具聚合状态落 actor-aware interaction scope。