### PR TITLE
docs(#302): 梳理业务 owner 策略与群共享入口

### DIFF
--- a/docs/design/business-owner-strategy.md
+++ b/docs/design/business-owner-strategy.md
@@ -1,0 +1,35 @@
+# 业务 Owner 策略与群共享入口
+
+本文补充 #294 Phase 3 / #302 的业务归属规则，说明 Todo、Memory、Session、RSS、Notification 和 Push 如何区分 owner scope 与 delivery target。本文只收口当前实现语义，不新增群共享 Todo 能力，不改变 SQLite schema，不迁移历史数据。
+
+## 总体规则
+
+- 消息来自群聊不等于业务数据归属群；默认归属必须由业务入口明确决定。
+- 个人业务状态优先绑定 actor；群共享状态必须通过明确的 group 命令、权限或业务路径进入。
+- `scope_key` / `owner_key` 是业务隔离键，不是平台发送目标。
+- 主动推送必须使用 `PushTarget` / 通知 outbox 中保存的 platform、account、target type 和 target id。
+- `parse_stable_scope_key` 只能辅助继承 platform / account，不能用其中的 raw target 替换当前可投递目标。
+
+## 当前业务策略
+
+| 业务 | 默认归属 | 群共享入口 | 投递目标规则 |
+| --- | --- | --- | --- |
+| Todo | `TodoStore::owner(user_id, conversation_scope)`；群聊中仍是发言人的个人 Todo | 当前没有隐式群共享 Todo；未来必须新增明确命令和权限策略 | 单次提醒按创建时的 conversation scope 推送，owner 不因此变成群 owner；每日提醒只从可解析私聊 target 的 owner 候选发送 |
+| Memory | 普通 `/memory` / `/记忆` 使用 personal scope，由 `SessionMeta::personal_scope_id()` 生成 | 只有 `/memory group ...` / `/记忆 group ...` / `/memory 群 ...` 进入 group scope；群写入先过群主/管理员 guard，编辑/删除还受创建者权限约束 | Memory 不直接生成主动推送；聊天上下文读取 personal + 当前 group 可访问记忆 |
+| Session | 普通聊天 active session 使用 conversation scope | 群聊个人 pending、Tool Loop 和可见编号快照使用 interaction scope | Session 不作为发送目标 |
+| RSS | 当前 conversation target 的订阅；群订阅属于群目标，私聊订阅属于私聊目标 | `/rss add/delete` 在群聊中需要群主或管理员；list 可供群成员查看 | `RssSubscription.target_id` 是真实投递目标；`scope_key` 只用于订阅过滤和继承 platform/account |
+| Notification | 不拥有业务数据，只保存业务事件的通知快照 | 由上游业务显式传入 `NotificationUpsert.target` | outbox 持久化 `platform/account_id/target_type/target_id`，发送方只按这些字段投递 |
+| Push | 不表达 owner，只表达目标平台账号和目标 ID | 无 | `PushTarget::from_scope_key_or_qq_official` 只从 stable scope 继承 platform/account，目标 ID 必须来自调用方传入的当前 target |
+
+## 代码入口
+
+- Todo owner：`qq-maid-core/src/storage/todo/mod.rs::TodoStore::owner`。
+- Todo Tool Loop：`qq-maid-core/src/runtime/tools/todo/scope.rs::TodoToolScope::load`。
+- Memory scope：`qq-maid-core/src/runtime/respond/memory_flow/scope.rs::memory_command_scope`。
+- RSS target：`qq-maid-core/src/runtime/respond/rss_flow.rs::rss_target_from_meta` 和 `qq-maid-core/src/runtime/rss/scheduler.rs::push_item`。
+- Notification target：`qq-maid-core/src/storage/notification.rs::NotificationUpsert`。
+- Push target：`qq-maid-core/src/runtime/push.rs::PushTarget::from_scope_key_or_qq_official`。
+
+## 兼容性结论
+
+本阶段不改变持久化 key 或数据格式，因此不需要 migration。旧 `private:` / `group:` scope 继续按现有兼容路径读取；stable scope 继续用于新入口的平台/account 命名空间。无法证明归属的旧 Memory 已由既有 migration 放入 `legacy_unassigned`，不在本阶段重新归类。

--- a/docs/design/scope-identity-boundary.md
+++ b/docs/design/scope-identity-boundary.md
@@ -1,6 +1,6 @@
 # Scope 与 Identity 边界
 
-本文定义多入口场景下的业务隔离键和平台投递目标语义。它只约束术语、helper 和调用边界，不迁移历史数据，不改变 session / pending / todo 持久化 key。
+本文定义多入口场景下的业务隔离键和平台投递目标语义。它只约束术语、helper 和调用边界，不迁移历史数据，不改变 session / pending / todo 持久化 key。各业务默认 owner 策略和群共享入口见 [业务 Owner 策略与群共享入口](./business-owner-strategy.md)。
 
 ## 术语
 

--- a/qq-maid-core/src/runtime/respond/memory_flow/scope.rs
+++ b/qq-maid-core/src/runtime/respond/memory_flow/scope.rs
@@ -39,6 +39,7 @@ pub(super) fn memory_command_scope(
     command: &ParsedCommand,
     meta: &SessionMeta,
 ) -> Option<MemoryCommandScope> {
+    // 群记忆必须由显式 group/群 参数进入；普通 /memory 在群里仍写个人记忆。
     let group_command = memory_command_targets_group(command);
     if group_command {
         let group_id = meta.group_scope_id()?;

--- a/qq-maid-core/src/runtime/respond/rss_flow.rs
+++ b/qq-maid-core/src/runtime/respond/rss_flow.rs
@@ -219,6 +219,7 @@ pub(super) fn parse_rss_command(text: &str) -> Option<ParsedCommand> {
 }
 
 fn rss_target_from_meta(meta: &SessionMeta) -> Option<RssTarget> {
+    // RSS 订阅跟随当前可投递会话目标；scope_key 只用于订阅过滤，不能替代 target_id。
     if meta.scope == "group" || meta.scope_key.starts_with("group:") {
         let target_id = meta
             .group_id
@@ -364,6 +365,26 @@ mod tests {
         let target = rss_target_from_meta(&meta).unwrap();
         assert_eq!(target.target_type, RssTargetType::Group);
         assert_eq!(target.target_id, "g1");
+    }
+
+    #[test]
+    fn stable_group_target_keeps_raw_delivery_target_separate() {
+        let meta = SessionMeta::new_with_account(
+            "platform:qq_official:account:app-1:group:stale-gid",
+            Some("u1".to_owned()),
+            Some("current-gid".to_owned()),
+            None,
+            None,
+            "qq_official",
+            Some("app-1".to_owned()),
+        );
+        let target = rss_target_from_meta(&meta).unwrap();
+        assert_eq!(target.target_type, RssTargetType::Group);
+        assert_eq!(target.target_id, "current-gid");
+        assert_eq!(
+            target.scope_key,
+            "platform:qq_official:account:app-1:group:stale-gid"
+        );
     }
 
     #[test]

--- a/qq-maid-core/src/runtime/respond/tests/todo.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo.rs
@@ -298,6 +298,34 @@ async fn todo_root_aliases_list_pending_items() {
 }
 
 #[tokio::test]
+async fn group_todo_defaults_to_actor_personal_owner() {
+    let service = test_service();
+    let owner_a = TodoStore::owner(Some("u1"), "group:g1");
+    let owner_b = TodoStore::owner(Some("u2"), "group:g1");
+    service
+        .todo_store
+        .create(&owner_a, draft("A 的个人待办"))
+        .unwrap();
+    service
+        .todo_store
+        .create(&owner_b, draft("B 的个人待办"))
+        .unwrap();
+
+    let a_list = service.respond(message("/todo")).await.unwrap();
+    let a_text = a_list.text.unwrap();
+    assert!(a_text.contains("A 的个人待办"));
+    assert!(!a_text.contains("B 的个人待办"));
+
+    let b_list = service
+        .respond(message_in_scope("/todo", "group:g1", "u2", "g1"))
+        .await
+        .unwrap();
+    let b_text = b_list.text.unwrap();
+    assert!(b_text.contains("B 的个人待办"));
+    assert!(!b_text.contains("A 的个人待办"));
+}
+
+#[tokio::test]
 async fn todo_query_writes_visible_snapshot_for_tool_followup() {
     let service = test_service();
     let owner = TodoStore::owner(Some("u1"), "group:g1");

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -167,6 +167,7 @@ impl RustRespondService {
         meta: &SessionMeta,
         session: &mut SessionRecord,
     ) -> Result<Option<RespondResponse>, LlmError> {
+        // Todo 默认归属当前 actor；即使消息来自群聊，也不能隐式写入群共享 Todo。
         let owner = TodoStore::owner(meta.user_id.as_deref(), &meta.scope_key);
         if is_full_todo_result_request(user_text) {
             let (reply, command_name) = self.full_todo_result_from_last_query(&owner, session)?;

--- a/qq-maid-core/src/runtime/rss/scheduler.rs
+++ b/qq-maid-core/src/runtime/rss/scheduler.rs
@@ -765,6 +765,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rss_notification_uses_subscription_target_not_scope_payload() {
+        let provider = MockTranslationProvider::new(Vec::new());
+        let database = SqliteDatabase::open(
+            std::env::temp_dir().join(format!("qq-maid-rss-target-{}.db", uuid::Uuid::new_v4())),
+            APP_MIGRATIONS,
+        )
+        .unwrap();
+        let store = RssStore::new(database.clone());
+        let notification_store = NotificationOutboxStore::new(database);
+        let subscription = RssSubscription {
+            scope_key: "platform:qq_official:account:app-1:group:stale-group".to_owned(),
+            target_id: "current-group".to_owned(),
+            ..subscription()
+        };
+        let item = pending_item("中文标题", Some("中文摘要"));
+        let scheduler = RssScheduler::new(
+            store,
+            RssFetcher::new(RssFetchConfig::default()).unwrap(),
+            notification_store.clone(),
+            TranslationService::new(Arc::new(provider), None),
+            RssSchedulerConfig {
+                enabled: true,
+                interval_seconds: 300,
+                max_push_per_subscription: 3,
+                summary_max_chars: 500,
+                seen_retention: 500,
+                push_max_failures: 3,
+                push_message_type: "markdown".to_owned(),
+            },
+        );
+
+        scheduler.push_item(&subscription, &item).await;
+        let task = notification_store
+            .get_by_dedupe_key(&rss_dedupe_key(&subscription, &item))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(task.target.platform, "qq_official");
+        assert_eq!(task.target.account_id.as_deref(), Some("app-1"));
+        assert_eq!(task.target.target_type, PushTargetType::Group);
+        assert_eq!(task.target.target_id, "current-group");
+    }
+
+    #[tokio::test]
     async fn rss_notification_uses_stable_dedupe_key_for_same_revision() {
         let provider = MockTranslationProvider::new(Vec::new());
         let database = SqliteDatabase::open(


### PR DESCRIPTION
## 关联

- 父 Epic：#294
- 本子任务：#302
- Phase：Phase 3，业务 owner 策略整理。

## 修改

- 新增 `docs/design/business-owner-strategy.md`，明确 Todo、Memory、Session、RSS、Notification、Push 的默认 owner / 群共享入口 / 投递目标规则。
- 在 `scope-identity-boundary.md` 补充 Phase 3 文档入口。
- 给 Todo、Memory、RSS 的关键入口补充语义注释：群聊 Todo 默认仍是 actor 个人 owner，群记忆必须显式 group 命令进入，RSS scope_key 不能替代 target_id。
- 补充回归测试：
  - 群聊里 user A / user B 的 Todo 默认按 actor 个人 owner 隔离。
  - stable group scope 下 RSS 命令入口使用当前原始 group target。
  - RSS 调度入 outbox 时使用订阅保存的真实 target_id，只从 stable scope 继承 platform/account。

## 边界

- 不新增群共享 Todo 产品能力。
- 不修改发送层 DeliveryTarget / PushTarget 语义。
- 不改变 session / todo / memory / rss / notification 持久化 key 或 schema。
- 不需要历史数据迁移；旧 `private:` / `group:` scope 继续走现有兼容路径。
- 不引入 QQ 官方特定逻辑到 Core 通用 owner 策略。

## 验证

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p qq-maid-core runtime::respond::tests::todo::group_todo_defaults_to_actor_personal_owner`
- `cargo test -p qq-maid-core runtime::respond::rss_flow::tests::stable_group_target_keeps_raw_delivery_target_separate`
- `cargo test -p qq-maid-core runtime::rss::scheduler::tests::rss_notification_uses_subscription_target_not_scope_payload`
- `cargo test -p qq-maid-core`
- `cargo check -p qq-maid-core`
- `cargo clippy -p qq-maid-core --all-targets --all-features -- -D warnings`

## 后续

#303 继续评估 scope key 历史数据迁移与兼容策略。本 PR 的结论是 Phase 3 未改变持久化 key 或数据格式。
