### PR TITLE
feat: 入站身份上下文增强 Phase 2

### DIFF
--- a/qq-maid-common/src/identity_context.rs
+++ b/qq-maid-common/src/identity_context.rs
@@ -2,17 +2,32 @@
 //!
 //! 这些结构只承载 Gateway 已知的入站身份事实。服务端权限、owner 和 session scope
 //! 仍应使用各业务模块自己的稳定字段，不能让 LLM 基于本上下文反向决定真实身份。
+//!
+//! # 字段来源与优先级
+//!
+//! - `IdentitySource::Event`：来自平台入站事件的结构化字段，最高优先级。
+//! - `IdentitySource::MemberApi` / `Cache`：Phase 3 接入 #229 成员详情补全后使用。
+//! - `IdentitySource::LegacyFallback`：旧字段兼容兜底（如不可信的 author.id），
+//!   仅作展示，不得用于强权限或数据归属。
+//! - `IdentitySource::TextWeak`：仅来自文本 `@昵称`，无稳定 ID，不可当强身份。
+//!
+//! 缺失字段一律留空并如实标注来源，不得伪造稳定 ID 或 is_bot。
 
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum IdentitySource {
+    /// 平台入站事件直接给出的结构化身份字段，最高优先级。
     #[default]
     Event,
+    /// 成员详情接口补全（Phase 3 接入 #229）。
     MemberApi,
+    /// 成员详情缓存命中（Phase 3 接入 #229）。
     Cache,
+    /// 旧字段兼容兜底，仅作展示，不可用于强权限或数据归属。
     LegacyFallback,
+    /// 仅来自文本 `@昵称`，无稳定 ID，不可当强身份。
     TextWeak,
 }
 
@@ -31,11 +46,14 @@ impl IdentitySource {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum MentionConfidence {
-    /// 平台事件明确给出的结构化 mention。
+    /// 平台事件明确给出的结构化 mention（`mentions[]` / `GROUP_AT_MESSAGE_CREATE`）。
     #[default]
     Event,
+    /// 成员详情接口补全后标注的 mention（Phase 3）。
     MemberApi,
+    /// 成员详情缓存命中后标注的 mention（Phase 3）。
     Cache,
+    /// 仅来自文本 `@昵称`，无稳定 ID，弱候选。
     TextWeak,
 }
 
@@ -51,28 +69,48 @@ impl MentionConfidence {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+/// 单个发言者 / 被提及者的身份摘要。
+///
+/// 稳定身份 key 只取 `user_id` / `union_id`；`display_name` / `group_member_role`
+/// 仅供 LLM 理解和展示，不可单独用于权限或归属判断。
+/// 缺失字段保持 `None` 并通过 `source` 如实标注来源，不伪造。
 pub struct MessageActorContext {
+    /// 平台结构化稳定 ID（member openid / user openid）。程序权威身份来源。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_id: Option<String>,
+    /// 跨群稳定 ID（如 QQ union_openid），事件未提供时为 None。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub union_id: Option<String>,
+    /// 展示名 / 昵称 / 群名片，仅供 LLM 理解，非稳定身份。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+    /// 群角色字符串（owner/admin/member/unknown），仅供 LLM 理解。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub group_member_role: Option<String>,
+    /// 是否机器人；仅平台事件明确给出时为 Some，否则 None 表示未知。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub is_bot: Option<bool>,
+    /// 本条身份字段的来源，见 `IdentitySource` 文档。
     #[serde(default)]
     pub source: IdentitySource,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+/// 一条消息中 `@` 对象的结构化身份。
+///
+/// `target.user_id` 存在时为平台结构化稳定 ID（confidence >= Event/MemberApi/Cache）；
+/// 只有文本 `@昵称` 时 `target.user_id` 为 None、`confidence = TextWeak`，
+/// `target.display_name` 仅作弱线索，不可当稳定身份。
 pub struct MentionIdentity {
+    /// 原始 @ 文本（如 `@当前机器人` / `@小明`），如可用。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub raw_text: Option<String>,
+    /// 被提及者身份摘要。
     pub target: MessageActorContext,
+    /// 是否 @ 的是当前机器人本身。
     #[serde(default)]
     pub is_self: bool,
+    /// 本条 mention 的置信度，见 `MentionConfidence` 文档。
     #[serde(default)]
     pub confidence: MentionConfidence,
 }

--- a/qq-maid-common/src/input_part.rs
+++ b/qq-maid-common/src/input_part.rs
@@ -5,6 +5,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::identity_context::MessageActorContext;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum MessageInputPart {
@@ -81,6 +83,10 @@ pub struct QuotedMessageContext {
     pub input_parts: Vec<MessageInputPart>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub from_bot: Option<bool>,
+    /// 引用消息发送者身份摘要；ref_index 命中时回填，缺失时为 None。
+    /// 与 `from_bot` 并存：`from_bot` 仅区分 bot/user/unknown，`sender` 携带稳定 ID 等更多信息。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender: Option<MessageActorContext>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fallback_reason: Option<String>,
 }
@@ -220,9 +226,33 @@ impl QuotedMessageContext {
             .as_deref()
             .or(self.reference_id.as_deref())
             .unwrap_or("unknown");
+        // 若 ref_index 回填了 sender，优先展示稳定身份摘要；否则回退到 from_bot 摘要。
+        let sender_summary = self.sender.as_ref().map(|sender| {
+            let display = sender
+                .display_name
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or("unknown");
+            let uid = sender
+                .user_id
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or("unknown");
+            let is_bot = sender
+                .is_bot
+                .map(|value| if value { "true" } else { "false" })
+                .unwrap_or("unknown");
+            format!(
+                "昵称={display}，稳定ID={uid}，是否机器人={is_bot}，身份来源={}",
+                sender.source.as_str()
+            )
+        });
         lines.push(format!(
             "Quoted Context: reference={reference}, from={from}"
         ));
+        if let Some(summary) = sender_summary {
+            lines.push(format!("引用发送者：{summary}"));
+        }
         if self.lookup_found {
             if let Some(text) = self
                 .text_summary

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -1064,6 +1064,7 @@ mod selection_scope_tests {
             media_summaries: Vec::new(),
             input_parts: Vec::new(),
             from_bot: Some(true),
+            sender: None,
             fallback_reason: None,
         }
     }

--- a/qq-maid-core/src/runtime/respond/llm_service/tests.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service/tests.rs
@@ -185,6 +185,41 @@ fn build_chat_messages_includes_quoted_text_context() {
 }
 
 #[test]
+fn build_chat_messages_includes_quoted_sender_summary_when_backfilled() {
+    // ref_index 回填 sender 后，LLM 引用上下文应展示发送者稳定身份摘要。
+    use qq_maid_common::identity_context::{IdentitySource, MessageActorContext};
+    let req = RespondRequest {
+        purpose: RespondPurpose::Chat,
+        user_text: "他说的对吗".to_owned(),
+        input_parts: vec![MessageInputPart::text("他说的对吗")],
+        quoted: Some(QuotedMessageContext {
+            reference_id: Some("REFIDX_sender".to_owned()),
+            lookup_found: true,
+            text_summary: Some("用户上一条".to_owned()),
+            from_bot: Some(false),
+            sender: Some(MessageActorContext {
+                user_id: Some("member-9".to_owned()),
+                display_name: Some("小明".to_owned()),
+                is_bot: Some(false),
+                source: IdentitySource::Event,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let messages = build_respond_messages(&req);
+    let current = messages.last().unwrap();
+    let quote_text = current.content_parts[0].fallback_text();
+
+    assert!(quote_text.contains("引用发送者"));
+    assert!(quote_text.contains("小明"));
+    assert!(quote_text.contains("member-9"));
+    assert!(quote_text.contains("身份来源=event"));
+}
+
+#[test]
 fn quoted_image_is_preserved_for_vision_model_and_downgraded_without_vision() {
     let image = MessageInputPart::image(MessageMedia {
         mime_type: Some("image/png".to_owned()),

--- a/qq-maid-gateway-rs/src/gateway/event.rs
+++ b/qq-maid-gateway-rs/src/gateway/event.rs
@@ -80,6 +80,9 @@ pub struct GroupMessage {
 pub struct GroupMention {
     pub is_you: bool,
     pub member_role: Option<GroupMemberRole>,
+    /// 被提及者的平台结构化 ID（群场景优先 member openid，其次 user openid / id）。
+    /// 仅当平台事件未提供任何稳定 ID 时为 None。
+    pub target_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -231,6 +234,15 @@ struct RawMention {
     is_you: Option<bool>,
     #[serde(default)]
     member_role: Option<String>,
+    // QQ mention 对象可能以下任一字段携带被提及者稳定 ID。
+    #[serde(default)]
+    member_openid: Option<String>,
+    #[serde(default)]
+    user_openid: Option<String>,
+    #[serde(default)]
+    openid: Option<String>,
+    #[serde(default, alias = "id")]
+    mention_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -426,6 +438,14 @@ fn raw_group_mention(mention: &RawMention) -> GroupMention {
             .member_role
             .as_deref()
             .map(GroupMemberRole::from_raw),
+        // 群场景优先 member openid，其次 user openid / openid / id；
+        // 都缺失时返回 None，上游据此降级为 TextWeak 弱候选或丢弃。
+        target_id: first_non_empty([
+            mention.member_openid.as_deref(),
+            mention.user_openid.as_deref(),
+            mention.openid.as_deref(),
+            mention.mention_id.as_deref(),
+        ]),
     }
 }
 
@@ -1130,19 +1150,23 @@ mod tests {
             vec![
                 GroupMention {
                     is_you: false,
-                    member_role: Some(GroupMemberRole::Owner)
+                    member_role: Some(GroupMemberRole::Owner),
+                    target_id: Some("owner-id".to_owned())
                 },
                 GroupMention {
                     is_you: true,
-                    member_role: Some(GroupMemberRole::Admin)
+                    member_role: Some(GroupMemberRole::Admin),
+                    target_id: Some("appid".to_owned())
                 },
                 GroupMention {
                     is_you: false,
-                    member_role: Some(GroupMemberRole::Member)
+                    member_role: Some(GroupMemberRole::Member),
+                    target_id: Some("user-openid".to_owned())
                 },
                 GroupMention {
                     is_you: false,
-                    member_role: Some(GroupMemberRole::Unknown)
+                    member_role: Some(GroupMemberRole::Unknown),
+                    target_id: Some("member-openid".to_owned())
                 }
             ]
         );

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -762,6 +762,7 @@ mod tests {
         message.mentions = vec![crate::gateway::event::GroupMention {
             is_you: true,
             member_role: None,
+            target_id: None,
         }];
         let capability = qq_group_capability();
         let outbound = OutboundMessage::Markdown {

--- a/qq-maid-gateway-rs/src/gateway/group_filter.rs
+++ b/qq-maid-gateway-rs/src/gateway/group_filter.rs
@@ -228,6 +228,7 @@ mod tests {
         GroupMention {
             is_you: true,
             member_role: None,
+            target_id: None,
         }
     }
 
@@ -351,6 +352,7 @@ mod tests {
         message.mentions = vec![GroupMention {
             is_you: false,
             member_role: None,
+            target_id: None,
         }];
         let respond_content = "/help";
 
@@ -459,6 +461,7 @@ mod tests {
         message.mentions = vec![GroupMention {
             is_you: false,
             member_role: None,
+            target_id: None,
         }];
 
         assert!(should_process_group_message(
@@ -628,6 +631,7 @@ mod tests {
         message.mentions = vec![GroupMention {
             is_you: false,
             member_role: None,
+            target_id: None,
         }];
         assert!(!should_process_group_message(
             GroupMessageMode::Mention,

--- a/qq-maid-gateway-rs/src/gateway/platform/qq_official.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/qq_official.rs
@@ -10,9 +10,10 @@ use super::model::{
     Actor, Attachment, ConversationTarget, GroupMemberRoleKind, InboundMessage, Platform,
 };
 use crate::gateway::event::{
-    Attachment as QqAttachment, C2cMessage, GroupEventType, GroupMemberRole, GroupMessage,
-    MessageReply,
+    Attachment as QqAttachment, C2cMessage, GroupEventType, GroupMemberRole, GroupMention,
+    GroupMessage, MessageReply,
 };
+use qq_maid_core::service::CoreGroupMemberRole;
 
 pub(crate) fn inbound_from_c2c(message: &C2cMessage) -> InboundMessage {
     InboundMessage {
@@ -77,19 +78,62 @@ pub(crate) fn inbound_from_group(message: &GroupMessage) -> InboundMessage {
             )
         }),
         tools_visible_snapshot: None,
-        mentions: self_mentions_from_group_event(message),
+        mentions: mentions_from_group_event(message),
         mentioned_bot: message.event_type == GroupEventType::GroupAtMessage
             || message.mentions.iter().any(|mention| mention.is_you),
     }
 }
 
-fn self_mentions_from_group_event(message: &GroupMessage) -> Vec<MentionIdentity> {
-    if message.event_type != GroupEventType::GroupAtMessage
-        && !message.mentions.iter().any(|mention| mention.is_you)
-    {
-        return Vec::new();
+/// 把群事件的结构化 mentions 映射为平台无关 `MentionIdentity`。
+///
+/// - `GROUP_AT_MESSAGE_CREATE` 事件本身即代表 @ 当前机器人，补一条 `is_self=true` mention。
+/// - `mentions[]` 中每个条目按事件顺序映射：`is_you` -> `is_self`，`target_id` -> 稳定 ID，
+///   `member_role` -> 角色字符串，`confidence = Event`。
+/// - 非 `is_you` 的 mention `is_bot` 保持 None（事件不提供），不伪造。
+/// - 事件无结构化 mention 但文本出现 `@昵称` 时，由 `text_weak_mentions_from_content` 补 TextWeak 候选。
+fn mentions_from_group_event(message: &GroupMessage) -> Vec<MentionIdentity> {
+    let mut result = Vec::new();
+    // GROUP_AT_MESSAGE_CREATE 事件整体即 @ 当前机器人；即便 mentions 为空也要补一条 self mention。
+    let has_self_event = message.event_type == GroupEventType::GroupAtMessage;
+    let mut saw_self = false;
+    for mention in &message.mentions {
+        let is_self = mention.is_you || has_self_event && !saw_self;
+        if is_self {
+            saw_self = true;
+        }
+        result.push(mention_identity_from_group_mention(mention, is_self));
     }
-    vec![MentionIdentity {
+    if has_self_event && !saw_self {
+        result.push(self_mention());
+    }
+    // 文本 @ 昵称弱候选：仅补充未被结构化 mention 覆盖的文本 @ 对象。
+    result.extend(text_weak_mentions_from_content(&message.content, &result));
+    result
+}
+
+fn mention_identity_from_group_mention(mention: &GroupMention, is_self: bool) -> MentionIdentity {
+    MentionIdentity {
+        raw_text: is_self.then(|| "@当前机器人".to_owned()),
+        target: MessageActorContext {
+            user_id: mention.target_id.clone(),
+            union_id: None,
+            display_name: None,
+            group_member_role: mention.member_role.map(|role| {
+                CoreGroupMemberRole::from(GroupMemberRoleKind::from(role))
+                    .as_str()
+                    .to_owned()
+            }),
+            // 仅 @ 当前机器人时可确定 is_bot=true；其余 mention 事件不提供，保持 None。
+            is_bot: is_self.then_some(true),
+            source: IdentitySource::Event,
+        },
+        is_self,
+        confidence: MentionConfidence::Event,
+    }
+}
+
+fn self_mention() -> MentionIdentity {
+    MentionIdentity {
         raw_text: Some("@当前机器人".to_owned()),
         target: MessageActorContext {
             is_bot: Some(true),
@@ -98,7 +142,95 @@ fn self_mentions_from_group_event(message: &GroupMessage) -> Vec<MentionIdentity
         },
         is_self: true,
         confidence: MentionConfidence::Event,
-    }]
+    }
+}
+
+/// 从消息文本中提取未被结构化 mention 覆盖的 `@昵称` 弱候选。
+///
+/// 仅当 `@` 出现在串首或空白/常见标点后、后跟 1-24 个非终止字符时视为一次 @。
+/// 已被结构化 mention 占用的 `@当前机器人` 不重复生成。生成的弱候选只有 `display_name`，
+/// 不伪造稳定 ID，`confidence = TextWeak`。
+fn text_weak_mentions_from_content(
+    content: &str,
+    structured: &[MentionIdentity],
+) -> Vec<MentionIdentity> {
+    let occupied: Vec<String> = structured
+        .iter()
+        .filter_map(|mention| mention.raw_text.clone())
+        .collect();
+    let mut seen: Vec<String> = Vec::new();
+    let mut result = Vec::new();
+    let chars: Vec<char> = content.chars().collect();
+    let mut index = 0;
+    while index < chars.len() {
+        let is_at = chars[index] == '@';
+        let at_boundary = index == 0 || is_text_weak_boundary(chars[index - 1]);
+        if !(is_at && at_boundary) {
+            index += 1;
+            continue;
+        }
+        // 收集 @ 后的昵称 token：遇空白或终止标点即停。
+        let mut end = index + 1;
+        while end < chars.len() && !is_text_weak_terminator(chars[end]) {
+            end += 1;
+        }
+        let token: String = chars[index + 1..end].iter().collect();
+        let raw = format!("@{token}");
+        index = end;
+        if token.trim().is_empty() || token.chars().count() > 24 {
+            continue;
+        }
+        if occupied.iter().any(|item| item == &raw) || seen.iter().any(|item| item == &raw) {
+            continue;
+        }
+        seen.push(raw.clone());
+        result.push(MentionIdentity {
+            raw_text: Some(raw),
+            target: MessageActorContext {
+                display_name: Some(token),
+                source: IdentitySource::TextWeak,
+                ..Default::default()
+            },
+            is_self: false,
+            confidence: MentionConfidence::TextWeak,
+        });
+    }
+    result
+}
+
+/// `@` 前一个字符是否构成边界（空白或常见中英文标点）。
+fn is_text_weak_boundary(ch: char) -> bool {
+    ch.is_whitespace()
+        || matches!(
+            ch,
+            '，' | '。' | '！' | '？' | '、' | '；' | '：' | ',' | '.' | '!' | '?'
+        )
+}
+
+/// 昵称 token 的终止字符（空白或常见中英文标点 / 括号 / CQ 码分隔符）。
+fn is_text_weak_terminator(ch: char) -> bool {
+    ch.is_whitespace()
+        || matches!(
+            ch,
+            '，' | '。'
+                | '！'
+                | '？'
+                | '、'
+                | '；'
+                | '：'
+                | '['
+                | ']'
+                | '【'
+                | '】'
+                | '('
+                | ')'
+                | '（'
+                | '）'
+                | '<'
+                | '>'
+                | '\n'
+                | '\r'
+        )
 }
 
 fn attachment_from_qq(value: &QqAttachment) -> Attachment {
@@ -186,6 +318,7 @@ mod tests {
             mentions: vec![GroupMention {
                 is_you: true,
                 member_role: Some(GroupMemberRole::Admin),
+                target_id: None,
             }],
             reply: None,
             timestamp: None,
@@ -300,5 +433,84 @@ mod tests {
         assert_eq!(inbound.attachments[0].filename.as_deref(), Some("a.jpg"));
         assert!(rendered.starts_with("你好"));
         assert!(rendered.contains("[图片 image/jpeg: a.jpg]"));
+    }
+
+    #[test]
+    fn qq_group_multi_mention_maps_to_structured_identity_in_order() {
+        // 一条消息同时 @ 当前机器人（is_you）和 @ 普通成员（结构化），顺序与事件一致。
+        let mut message = group_message();
+        message.event_type = GroupEventType::GroupMessage;
+        message.content = "@当前机器人 帮我问一下".to_owned();
+        message.mentions = vec![
+            GroupMention {
+                is_you: true,
+                member_role: Some(GroupMemberRole::Admin),
+                target_id: Some("bot-appid".to_owned()),
+            },
+            GroupMention {
+                is_you: false,
+                member_role: Some(GroupMemberRole::Member),
+                target_id: Some("member-2".to_owned()),
+            },
+        ];
+
+        let inbound = inbound_from_group(&message);
+        let request = super::super::to_core_request(&inbound, inbound.text.clone()).unwrap();
+        let context = request.message_context.as_ref().unwrap();
+
+        // 结构化 mention 按事件顺序进入上下文，第一个是 self，第二个是普通成员。
+        assert_eq!(context.mentions.len(), 2);
+        assert!(context.mentions[0].is_self);
+        assert_eq!(context.mentions[0].target.is_bot, Some(true));
+        assert_eq!(
+            context.mentions[0].target.user_id.as_deref(),
+            Some("bot-appid")
+        );
+        assert_eq!(context.mentions[0].confidence, MentionConfidence::Event);
+        assert!(!context.mentions[1].is_self);
+        // 非 self mention 的 is_bot 事件不提供，保持 None，不伪造。
+        assert_eq!(context.mentions[1].target.is_bot, None);
+        assert_eq!(
+            context.mentions[1].target.user_id.as_deref(),
+            Some("member-2")
+        );
+        assert_eq!(
+            context.mentions[1].target.group_member_role.as_deref(),
+            Some("member")
+        );
+        assert_eq!(context.mentions[1].confidence, MentionConfidence::Event);
+    }
+
+    #[test]
+    fn qq_group_text_mention_without_structured_id_is_text_weak() {
+        // 文本 @昵称 且无对应结构化 mention 时，作为 TextWeak 弱候选，不伪造稳定 ID。
+        let mut message = group_message();
+        message.event_type = GroupEventType::GroupMessage;
+        message.mentions = Vec::new();
+        message.content = "@小明 你觉得呢".to_owned();
+
+        let inbound = inbound_from_group(&message);
+        let context = inbound.mentions.clone();
+
+        assert_eq!(context.len(), 1);
+        assert_eq!(context[0].confidence, MentionConfidence::TextWeak);
+        assert_eq!(context[0].target.user_id, None);
+        assert_eq!(context[0].target.display_name.as_deref(), Some("小明"));
+        assert_eq!(context[0].raw_text.as_deref(), Some("@小明"));
+        assert!(!context[0].is_self);
+    }
+
+    #[test]
+    fn qq_group_at_message_event_always_emits_self_mention() {
+        // GROUP_AT_MESSAGE_CREATE 事件即便 mentions 为空，也代表 @ 当前机器人。
+        let mut message = group_message();
+        message.event_type = GroupEventType::GroupAtMessage;
+        message.mentions = Vec::new();
+        message.content = "/help".to_owned();
+
+        let inbound = inbound_from_group(&message);
+        assert_eq!(inbound.mentions.len(), 1);
+        assert!(inbound.mentions[0].is_self);
+        assert_eq!(inbound.mentions[0].confidence, MentionConfidence::Event);
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/platform/qq_official.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/qq_official.rs
@@ -86,27 +86,32 @@ pub(crate) fn inbound_from_group(message: &GroupMessage) -> InboundMessage {
 
 /// 把群事件的结构化 mentions 映射为平台无关 `MentionIdentity`。
 ///
-/// - `GROUP_AT_MESSAGE_CREATE` 事件本身即代表 @ 当前机器人，补一条 `is_self=true` mention。
 /// - `mentions[]` 中每个条目按事件顺序映射：`is_you` -> `is_self`，`target_id` -> 稳定 ID，
 ///   `member_role` -> 角色字符串，`confidence = Event`。
+/// - `is_self` 只来自平台结构化 `is_you` 字段，不因 `GROUP_AT_MESSAGE_CREATE` 事件类型
+///   把普通 mention 误标为机器人。
+/// - `GROUP_AT_MESSAGE_CREATE` 事件整体即代表 @ 当前机器人；若遍历完 mentions 仍未看到
+///   任何 `is_you=true` 条目，才追加一条 synthetic self mention，避免与结构化普通 mention 混淆。
 /// - 非 `is_you` 的 mention `is_bot` 保持 None（事件不提供），不伪造。
-/// - 事件无结构化 mention 但文本出现 `@昵称` 时，由 `text_weak_mentions_from_content` 补 TextWeak 候选。
+/// - 文本 `@昵称` 弱候选由 `text_weak_mentions_from_content` 补充，采用保守去重策略。
 fn mentions_from_group_event(message: &GroupMessage) -> Vec<MentionIdentity> {
     let mut result = Vec::new();
-    // GROUP_AT_MESSAGE_CREATE 事件整体即 @ 当前机器人；即便 mentions 为空也要补一条 self mention。
     let has_self_event = message.event_type == GroupEventType::GroupAtMessage;
     let mut saw_self = false;
     for mention in &message.mentions {
-        let is_self = mention.is_you || has_self_event && !saw_self;
+        // is_self 只来自平台结构化 is_you；不因事件类型把普通 mention 强制标为 self。
+        let is_self = mention.is_you;
         if is_self {
             saw_self = true;
         }
         result.push(mention_identity_from_group_mention(mention, is_self));
     }
+    // GROUP_AT_MESSAGE_CREATE 整体即 @ 当前机器人；仅当结构化 mentions 中无任何 is_you=true 时
+    // 才追加 synthetic self mention，不与普通 mention 混淆。
     if has_self_event && !saw_self {
         result.push(self_mention());
     }
-    // 文本 @ 昵称弱候选：仅补充未被结构化 mention 覆盖的文本 @ 对象。
+    // 文本 @ 昵称弱候选：保守去重，避免与结构化 mention 拆成两个独立对象。
     result.extend(text_weak_mentions_from_content(&message.content, &result));
     result
 }
@@ -147,13 +152,29 @@ fn self_mention() -> MentionIdentity {
 
 /// 从消息文本中提取未被结构化 mention 覆盖的 `@昵称` 弱候选。
 ///
-/// 仅当 `@` 出现在串首或空白/常见标点后、后跟 1-24 个非终止字符时视为一次 @。
-/// 已被结构化 mention 占用的 `@当前机器人` 不重复生成。生成的弱候选只有 `display_name`，
-/// 不伪造稳定 ID，`confidence = TextWeak`。
+/// # 保守去重策略
+///
+/// QQ 结构化 `mentions[]` 不携带昵称文本，因此无法安全判断正文中的 `@昵称`
+/// 是否与某条结构化 mention 指向同一人。为避免把同一个被 @ 对象拆成
+/// “一个 Event 稳定身份 + 一个 TextWeak 昵称身份”两条独立 mention（会让 LLM 误以为是两个人），
+/// 采用保守策略：
+///
+/// - 当存在任意结构化普通 mention（非 self）时，不再从文本生成 TextWeak 候选。
+///   未被结构化覆盖的真正独立 @对象作为弱信号丢失，可接受；待 Phase 3 接入 #229
+///   成员详情后由 display_name 补全。
+/// - 仅当没有结构化普通 mention（只有 self 或完全无结构化 mention）时，才为正文里
+///   未被 self 的 `@当前机器人` 占用的 `@昵称` 生成 TextWeak 候选。
+///
+/// 生成的弱候选只有 `display_name`，不伪造稳定 ID，`confidence = TextWeak`。
 fn text_weak_mentions_from_content(
     content: &str,
     structured: &[MentionIdentity],
 ) -> Vec<MentionIdentity> {
+    // 存在结构化普通 mention 时直接抑制 TextWeak，避免同对象被拆成两条独立 mention。
+    let has_structured_non_self = structured.iter().any(|mention| !mention.is_self);
+    if has_structured_non_self {
+        return Vec::new();
+    }
     let occupied: Vec<String> = structured
         .iter()
         .filter_map(|mention| mention.raw_text.clone())
@@ -512,5 +533,124 @@ mod tests {
         assert_eq!(inbound.mentions.len(), 1);
         assert!(inbound.mentions[0].is_self);
         assert_eq!(inbound.mentions[0].confidence, MentionConfidence::Event);
+    }
+
+    #[test]
+    fn qq_group_at_message_keeps_plain_mention_order_and_appends_synthetic_self() {
+        // GROUP_AT_MESSAGE_CREATE + mentions 全部 is_you=false：保留普通 mentions，
+        // 并额外追加一条 synthetic self mention，不把首条普通 mention 误标为 self。
+        let mut message = group_message();
+        message.event_type = GroupEventType::GroupAtMessage;
+        message.mentions = vec![
+            GroupMention {
+                is_you: false,
+                member_role: Some(GroupMemberRole::Member),
+                target_id: Some("member-plain".to_owned()),
+            },
+            GroupMention {
+                is_you: false,
+                member_role: Some(GroupMemberRole::Admin),
+                target_id: Some("member-admin".to_owned()),
+            },
+        ];
+        message.content = "/help".to_owned();
+
+        let inbound = inbound_from_group(&message);
+        // 两条普通 mention 保留原序 + 一条 synthetic self mention。
+        assert_eq!(inbound.mentions.len(), 3);
+        assert!(!inbound.mentions[0].is_self);
+        assert_eq!(
+            inbound.mentions[0].target.user_id.as_deref(),
+            Some("member-plain")
+        );
+        assert_eq!(inbound.mentions[0].target.is_bot, None);
+        assert!(!inbound.mentions[1].is_self);
+        assert_eq!(
+            inbound.mentions[1].target.user_id.as_deref(),
+            Some("member-admin")
+        );
+        assert!(inbound.mentions[2].is_self);
+        assert_eq!(inbound.mentions[2].target.is_bot, Some(true));
+        assert_eq!(inbound.mentions[2].confidence, MentionConfidence::Event);
+    }
+
+    #[test]
+    fn qq_group_at_message_with_plain_then_self_keeps_order() {
+        // GROUP_AT_MESSAGE_CREATE + 首条普通 mention、其后 is_you=true 的 self：
+        // 首条保持 is_self=false，第二条 is_self=true，不再追加 synthetic self。
+        let mut message = group_message();
+        message.event_type = GroupEventType::GroupAtMessage;
+        message.mentions = vec![
+            GroupMention {
+                is_you: false,
+                member_role: Some(GroupMemberRole::Member),
+                target_id: Some("member-plain".to_owned()),
+            },
+            GroupMention {
+                is_you: true,
+                member_role: Some(GroupMemberRole::Admin),
+                target_id: Some("bot-appid".to_owned()),
+            },
+        ];
+        message.content = "/help".to_owned();
+
+        let inbound = inbound_from_group(&message);
+        assert_eq!(inbound.mentions.len(), 2);
+        assert!(!inbound.mentions[0].is_self);
+        assert_eq!(inbound.mentions[0].target.is_bot, None);
+        assert!(inbound.mentions[1].is_self);
+        assert_eq!(inbound.mentions[1].target.is_bot, Some(true));
+        assert_eq!(
+            inbound.mentions[1].target.user_id.as_deref(),
+            Some("bot-appid")
+        );
+    }
+
+    #[test]
+    fn qq_group_text_weak_suppressed_when_structured_plain_mention_present() {
+        // 存在结构化普通 mention 时，正文中的 @昵称 不再生成独立 TextWeak，
+        // 避免同对象被拆成 Event + TextWeak 两条独立 mention。
+        let mut message = group_message();
+        message.event_type = GroupEventType::GroupMessage;
+        message.mentions = vec![GroupMention {
+            is_you: false,
+            member_role: Some(GroupMemberRole::Member),
+            target_id: Some("member-2".to_owned()),
+        }];
+        message.content = "@小明 你觉得呢".to_owned();
+
+        let inbound = inbound_from_group(&message);
+        // 仅保留结构化普通 mention，不额外生成 @小明 的 TextWeak。
+        assert_eq!(inbound.mentions.len(), 1);
+        assert_eq!(inbound.mentions[0].confidence, MentionConfidence::Event);
+        assert_eq!(
+            inbound.mentions[0].target.user_id.as_deref(),
+            Some("member-2")
+        );
+    }
+
+    #[test]
+    fn qq_group_text_weak_generated_when_only_self_structured_mention() {
+        // 仅 self 结构化 mention 时，正文里独立的 @昵称 仍生成 TextWeak 弱候选
+        // （@当前机器人 已被 self raw_text 占用，去重后不重复）。
+        let mut message = group_message();
+        message.event_type = GroupEventType::GroupMessage;
+        message.mentions = vec![GroupMention {
+            is_you: true,
+            member_role: Some(GroupMemberRole::Admin),
+            target_id: None,
+        }];
+        message.content = "@当前机器人 帮我叫 @小明".to_owned();
+
+        let inbound = inbound_from_group(&message);
+        // 第一条是 self，其后是 @小明 的 TextWeak 弱候选。
+        assert_eq!(inbound.mentions.len(), 2);
+        assert!(inbound.mentions[0].is_self);
+        assert_eq!(inbound.mentions[1].confidence, MentionConfidence::TextWeak);
+        assert_eq!(
+            inbound.mentions[1].target.display_name.as_deref(),
+            Some("小明")
+        );
+        assert_eq!(inbound.mentions[1].target.user_id, None);
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/ref_index/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/ref_index/mod.rs
@@ -10,8 +10,9 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use qq_maid_common::identity_context::MessageActorContext;
 use qq_maid_common::input_part::{MediaStatus, MessageInputPart, MessageMedia, QuotedMediaSummary};
-use qq_maid_core::service::ToolsVisibleSnapshot;
+use qq_maid_core::service::{CoreGroupMemberRole, ToolsVisibleSnapshot};
 use tracing::{debug, warn};
 
 use super::{
@@ -39,6 +40,8 @@ pub(crate) struct RefIndexEntry {
     pub(crate) media_summaries: Vec<QuotedMediaSummary>,
     pub(crate) input_parts: Vec<MessageInputPart>,
     pub(crate) from_bot: bool,
+    /// 被引用消息发送者身份摘要；insert_inbound 时从 actor 回填，供后续 quote 查询回填 sender。
+    pub(crate) sender: Option<MessageActorContext>,
     pub(crate) timestamp: Option<String>,
     pub(crate) tools_visible_snapshot: Option<ToolsVisibleSnapshot>,
 }
@@ -78,6 +81,12 @@ impl RefIndex {
                 vec![MessageInputPart::text(truncate_summary_text(text))]
             },
             from_bot: true,
+            // 机器人出站消息的发送者即机器人本身；稳定 ID 未知，标注 is_bot=true。
+            sender: Some(MessageActorContext {
+                is_bot: Some(true),
+                source: qq_maid_common::identity_context::IdentitySource::Event,
+                ..Default::default()
+            }),
             timestamp: None,
             tools_visible_snapshot,
         };
@@ -106,6 +115,7 @@ impl RefIndex {
             quoted.media_summaries = entry.media_summaries.clone();
             quoted.input_parts = entry.input_parts.clone();
             quoted.from_bot = Some(entry.from_bot);
+            quoted.sender = entry.sender.clone();
             quoted.fallback_reason = None;
             inbound.tools_visible_snapshot = entry.tools_visible_snapshot.clone();
             log_ref_index_hit("quoted_lookup", &key, entry);
@@ -179,11 +189,25 @@ fn entry_from_inbound(inbound: &InboundMessage) -> RefIndexEntry {
         .iter()
         .filter_map(QuotedMediaSummary::from_input_part)
         .collect::<Vec<_>>();
+    // 保存被索引消息的发送者身份，供后续引用该消息时回填 quoted.sender。
+    // display_name 等展示字段在 Phase 1 阶段常为 None，由 Phase 3 成员详情补全。
+    let sender = Some(MessageActorContext {
+        user_id: inbound.actor.sender_id.clone(),
+        union_id: inbound.actor.union_id.clone(),
+        display_name: inbound.actor.display_name.clone(),
+        group_member_role: inbound
+            .actor
+            .group_member_role
+            .map(|role| CoreGroupMemberRole::from(role).as_str().to_owned()),
+        is_bot: Some(inbound.actor.is_bot),
+        source: inbound.actor.source,
+    });
     RefIndexEntry {
         text_summary,
         media_summaries,
         input_parts,
         from_bot: inbound.actor.is_bot,
+        sender,
         timestamp: inbound.timestamp.clone(),
         tools_visible_snapshot: None,
     }
@@ -356,6 +380,7 @@ fn sanitize_index_media(mut media: MessageMedia) -> MessageMedia {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use qq_maid_common::identity_context::IdentitySource;
     use qq_maid_common::input_part::{MessageMedia, QuotedMessageContext};
     use qq_maid_core::service::{ToolsVisibleItem, ToolsVisibleSnapshot};
 
@@ -737,6 +762,10 @@ mod tests {
         assert!(quoted.lookup_found);
         assert_eq!(quoted.text_summary.as_deref(), Some("机器人上一条群回复"));
         assert_eq!(quoted.from_bot, Some(true));
+        // bot 出站消息回填的 sender 应标注 is_bot=true。
+        let sender = quoted.sender.as_ref().unwrap();
+        assert_eq!(sender.is_bot, Some(true));
+        assert_eq!(sender.source, IdentitySource::Event);
     }
 
     #[test]
@@ -760,6 +789,12 @@ mod tests {
         assert_eq!(quoted.text_summary.as_deref(), Some("用户原文"));
         assert_eq!(quoted.from_bot, Some(false));
         assert!(quoted.fallback_text().contains("from=user"));
+        // 用户入站消息回填的 sender 应携带稳定 ID 与 is_bot=false。
+        let sender = quoted.sender.as_ref().unwrap();
+        assert_eq!(sender.is_bot, Some(false));
+        assert_eq!(sender.user_id.as_deref(), Some("member-1"));
+        assert_eq!(sender.source, IdentitySource::Event);
+        assert!(quoted.fallback_text().contains("引用发送者"));
     }
 
     #[test]


### PR DESCRIPTION
## 变更说明

实现 #320 Phase 2：入站身份上下文增强（普通 mention target 解析 + 引用 sender 回填），并修正审查发现的 mention 边界问题。

### 1. 普通 mention target 完整解析

- 扩展 `event.rs` 的 `RawMention` 捕获被提及者稳定 ID（`member_openid` / `user_openid` / `openid` / `id`），`GroupMention` 新增 `target_id`。
- `qq_official.rs` 新增 `mentions_from_group_event`：把 `mentions[]` 全部条目按事件顺序映射为结构化 `MentionIdentity`。
  - `is_you` → `is_self`，`target_id` → `target.user_id`，`member_role` → 角色字符串，`confidence = Event`。
  - 非 self mention 的 `is_bot` 保持 `None`（事件不提供），不伪造。

### 2. GROUP_AT_MESSAGE_CREATE 边界修正（审查反馈）

- `is_self` **只**来自平台结构化 `is_you` 字段，不再因 `GROUP_AT_MESSAGE_CREATE` 事件类型把首条普通 mention 强制标为 self。
- `GROUP_AT_MESSAGE_CREATE` 事件遍历完 mentions 后，**仅当**没有任何 `is_you=true` 条目时，才追加一条 synthetic self mention。
- 普通 structured mention 不被事件类型误标为机器人。

### 3. TextWeak 与 structured mention 去重（审查反馈）

- 保守策略：当存在任意结构化普通 mention（非 self）时，**不再**从正文生成 TextWeak 候选。
- 原因：QQ 结构化 mention 不携带昵称，无法安全判断正文 `@昵称` 是否与某条结构化 mention 指向同一人。为避免把同一个被 @ 对象拆成"一个 Event 稳定身份 + 一个 TextWeak 昵称身份"两条独立 mention，直接抑制。
- 仅当没有结构化普通 mention（只有 self 或完全无结构化 mention）时，才为正文里未被 self 的 `@当前机器人` 占用的 `@昵称` 生成 TextWeak 候选。
- TextWeak 只有 `display_name`，不伪造稳定 ID。

### 4. 引用消息 sender 回填

- `QuotedMessageContext` 新增 `sender: Option<MessageActorContext>`，与现有 `from_bot` 并存。
- `RefIndexEntry` 新增 `sender` 字段：`entry_from_inbound` 从入站 actor 回填，`insert_bot_outbound` 标注 bot sender。
- `enrich_inbound` 命中时回填 `quoted.sender`；miss / payload fallback 时 `sender` 保持 `None`，不阻断。
- `QuotedMessageContext::fallback_text` 渲染引用发送者稳定身份摘要。

### 5. 字段来源、优先级、缺失行为固化

- `identity_context.rs` 为 `IdentitySource` / `MentionConfidence` / `MessageActorContext` / `MentionIdentity` 补充文档注释。

## 边界

- 不接入 #229 成员详情 API。
- 不改数据库，不做迁移。
- 不影响 session scope / ToolContext / Todo owner。
- `mentioned_bot` 兼容字段保留。
- LLM message_context 仍只用于理解，不作为权限或 owner 判断来源。

## 程序权威身份 vs LLM 理解

- 权威：`user_id` / `union_id`（`source=Event`）。
- LLM 理解：`display_name` / `group_member_role` / `is_bot`（None=未知）。
- TextWeak：仅 `display_name`，无稳定 ID。

## 身份缺失降级

- 结构化 mention 缺 `target_id`：`user_id=None`，仍 `confidence=Event`。
- 非 self mention 缺 `is_bot`：`None`。
- ref_index miss：`quoted.sender=None`，回退 `from_bot`/unknown。
- 文本 `@昵称`：无结构化普通 mention 时生成 TextWeak；有则抑制。

## 验证

```bash
cargo fmt --all -- --check
cargo test -p qq-maid-common -p qq-maid-gateway-rs -p qq-maid-core
cargo clippy -p qq-maid-common -p qq-maid-gateway-rs -p qq-maid-core --all-targets --all-features -- -D warnings
```

新增/修改测试：
- `qq_group_multi_mention_maps_to_structured_identity_in_order`（self + 普通成员共存，顺序保持）
- `qq_group_text_mention_without_structured_id_is_text_weak`
- `qq_group_at_message_event_always_emits_self_mention`
- `qq_group_at_message_keeps_plain_mention_order_and_appends_synthetic_self`（新增，全 is_you=false + GroupAtMessage）
- `qq_group_at_message_with_plain_then_self_keeps_order`（新增，普通在前 self 在后）
- `qq_group_text_weak_suppressed_when_structured_plain_mention_present`（新增，去重抑制）
- `qq_group_text_weak_generated_when_only_self_structured_mention`（新增，仅 self 时仍生成）
- ref_index sender 回填断言（bot 出站 + 用户入站）
- `build_chat_messages_includes_quoted_sender_summary_when_backfilled`

## 关联 Issue

- Closes #320
- Epic：#317
- Phase 1（已合并）：#318
- 成员详情接口（Phase 3 使用）：#229

## 备注

base 已改为 `master`（#318 已合并）。diff 只含 Phase 2 改动。
