### PR TITLE
feat: 引入 SQLite 连接池

### DIFF
--- a/qq-maid-core/README.md
+++ b/qq-maid-core/README.md
@@ -99,6 +99,7 @@ runtime/.env
 - `TOOL_CALLING_ENABLED`、`TOOL_CALLING_GROUP_ENABLED`、`TOOL_CALLING_MAX_ROUNDS`：旧兼容开关。存在 `agent.toml` 时，请优先使用 `[scenes.*].tool_calling_enabled`、`enabled_tools` 和 profile 的 `max_tool_rounds`；群聊默认仍不会进入 Tool Loop，显式开启后默认也只开放天气、列车时刻和 RSS 最近条目工具。该能力依赖 provider Tool Calling 能力，`OPENAI_API_MODE=chat_only` 时 OpenAI Responses 原生 Tool Loop 不会执行。
 - `WEB_CONSOLE_ENABLED`、`WEB_CONSOLE_ALLOWED_ORIGINS`：本地控制台和跨域 allowlist；默认关闭且不允许任意来源。
 - `APP_DB_FILE`：统一 SQLite 文件，承载业务数据和知识检索索引。
+- `QQ_MAID_DB_POOL_MAX_SIZE`：本地 SQLite 连接池大小，默认 8，合法范围 1～32；独立于 `MAX_CONCURRENT_RESPONSES`。
 - `PROMPT_DIR`：固定 prompt 目录。
 - `KNOWLEDGE_DIR`：Markdown 知识目录；留空时使用 `config/knowledge`，启动时自动同步到 SQLite FTS5，普通聊天按需检索片段。
 - `RSS_*`：RSS / Atom 轮询、去重、推送和 SSRF 防护相关配置。

--- a/qq-maid-core/src/app/mod.rs
+++ b/qq-maid-core/src/app/mod.rs
@@ -91,8 +91,12 @@ impl LlmRuntime {
         let train_executor = build_train_executor(&config)?;
         let radar_executor = build_radar_executor()?;
         // 通用数据库在应用启动阶段统一打开并执行项目级 migration；
-        // RSS、Todo、Session 和 Memory 共用同一 SQLite 句柄，避免各业务模块重复打开数据库。
-        let database = SqliteDatabase::open(config.app_db_file.clone(), APP_MIGRATIONS)?;
+        // SQLite pool size 独立于 LLM / Web Search 上游并发限制。
+        let database = SqliteDatabase::open_with_pool_size(
+            config.app_db_file.clone(),
+            APP_MIGRATIONS,
+            config.sqlite_pool_size,
+        )?;
         let session_store = SessionStore::new(database.clone());
         let rss_store = RssStore::new(database.clone());
         let todo_store = TodoStore::new(database.clone());

--- a/qq-maid-core/src/config/mod.rs
+++ b/qq-maid-core/src/config/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     runtime::weather::{
         default_qweather_api_host, default_qweather_geo_host, qweather_geo_host_from_api_host,
     },
+    storage::database::{DEFAULT_SQLITE_POOL_SIZE, MAX_SQLITE_POOL_SIZE, MIN_SQLITE_POOL_SIZE},
 };
 use qq_maid_llm::config::{HttpAuthConfig, OpenAiCompatibleProviderConfig};
 use qq_maid_llm::context_budget::ContextBudgetConfig;
@@ -204,6 +205,8 @@ pub struct AppConfig {
     pub server_port: u16,
     /// 项目通用 SQLite 文件路径；RSS、Todo、Session 和 Memory 共用该数据库。
     pub app_db_file: String,
+    /// 本地 SQLite 连接池大小，独立于 LLM / Web Search 并发限制。
+    pub sqlite_pool_size: usize,
     /// 是否启用 RSS 后台轮询
     pub rss_enabled: bool,
     /// RSS 轮询间隔（秒）
@@ -360,6 +363,7 @@ impl AppConfig {
             server_host: env_string("LLM_SERVER_HOST", DEFAULT_SERVER_HOST),
             server_port: env_u16("LLM_SERVER_PORT", DEFAULT_SERVER_PORT)?,
             app_db_file: env_optional("APP_DB_FILE").unwrap_or_else(default_app_db_file),
+            sqlite_pool_size: sqlite_pool_size_from_env()?,
             rss_enabled: env_bool("RSS_ENABLED", true)?,
             rss_poll_interval_seconds: env_u64(
                 "RSS_POLL_INTERVAL_SECONDS",
@@ -478,6 +482,15 @@ impl AppConfig {
 /// 默认项目通用 SQLite 文件路径。
 fn default_app_db_file() -> String {
     DEFAULT_APP_DB_FILE.to_owned()
+}
+
+fn sqlite_pool_size_from_env() -> Result<usize, LlmError> {
+    Ok(env_u64_bounded_range(
+        "QQ_MAID_DB_POOL_MAX_SIZE",
+        DEFAULT_SQLITE_POOL_SIZE as u64,
+        MIN_SQLITE_POOL_SIZE as u64,
+        MAX_SQLITE_POOL_SIZE as u64,
+    )? as usize)
 }
 
 /// 默认提示词模板目录。

--- a/qq-maid-core/src/config/tests.rs
+++ b/qq-maid-core/src/config/tests.rs
@@ -367,6 +367,42 @@ fn max_concurrent_responses_allows_zero_and_rejects_large_values() {
 }
 
 #[test]
+fn sqlite_pool_size_uses_independent_bounded_config() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let snapshot = EnvSnapshot::capture(&["QQ_MAID_DB_POOL_MAX_SIZE", "MAX_CONCURRENT_RESPONSES"]);
+
+    restore_env("QQ_MAID_DB_POOL_MAX_SIZE", None);
+    unsafe {
+        env::set_var("MAX_CONCURRENT_RESPONSES", "0");
+    }
+    assert_eq!(
+        sqlite_pool_size_from_env().unwrap(),
+        crate::storage::database::DEFAULT_SQLITE_POOL_SIZE
+    );
+
+    unsafe {
+        env::set_var("QQ_MAID_DB_POOL_MAX_SIZE", "9");
+    }
+    assert_eq!(sqlite_pool_size_from_env().unwrap(), 9);
+
+    unsafe {
+        env::set_var("QQ_MAID_DB_POOL_MAX_SIZE", "0");
+    }
+    let err = sqlite_pool_size_from_env().unwrap_err();
+    assert_eq!(err.code, "config");
+    assert!(err.message.contains("between 1 and 32"));
+
+    unsafe {
+        env::set_var("QQ_MAID_DB_POOL_MAX_SIZE", "33");
+    }
+    let err = sqlite_pool_size_from_env().unwrap_err();
+    assert_eq!(err.code, "config");
+    assert!(err.message.contains("between 1 and 32"));
+
+    snapshot.restore();
+}
+
+#[test]
 fn context_budget_config_uses_default_values() {
     let _guard = ENV_LOCK.lock().unwrap();
     let names = [

--- a/qq-maid-core/src/http/routes.rs
+++ b/qq-maid-core/src/http/routes.rs
@@ -564,6 +564,7 @@ mod tests {
                 server_host: "127.0.0.1".to_owned(),
                 server_port: 8787,
                 app_db_file: app_db_file.to_string_lossy().into_owned(),
+                sqlite_pool_size: crate::storage::database::DEFAULT_SQLITE_POOL_SIZE,
                 rss_enabled: true,
                 rss_poll_interval_seconds: 300,
                 rss_http_timeout_seconds: 15,

--- a/qq-maid-core/src/service/tests.rs
+++ b/qq-maid-core/src/service/tests.rs
@@ -1361,6 +1361,7 @@ fn test_state_with_group_tool_calling(
             server_host: "127.0.0.1".to_owned(),
             server_port: 8787,
             app_db_file: app_db_file.to_string_lossy().into_owned(),
+            sqlite_pool_size: crate::storage::database::DEFAULT_SQLITE_POOL_SIZE,
             rss_enabled: false,
             rss_poll_interval_seconds: 300,
             rss_http_timeout_seconds: 15,

--- a/qq-maid-core/src/storage/database.rs
+++ b/qq-maid-core/src/storage/database.rs
@@ -5,8 +5,10 @@
 
 use std::{
     fmt, fs,
+    marker::PhantomData,
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
+    rc::Rc,
     sync::{Arc, Condvar, Mutex},
 };
 
@@ -51,6 +53,7 @@ struct SqliteDatabaseInner {
 pub struct PooledSqliteConnection {
     connection: Option<Connection>,
     database: Arc<SqliteDatabaseInner>,
+    _not_send: PhantomData<Rc<()>>,
 }
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
@@ -116,6 +119,7 @@ impl SqliteDatabase {
                 return Ok(PooledSqliteConnection {
                     connection: Some(connection),
                     database: Arc::clone(&self.inner),
+                    _not_send: PhantomData,
                 });
             }
             connections = self
@@ -394,6 +398,9 @@ mod tests {
             let synchronous: i64 = conn
                 .query_row("PRAGMA synchronous", [], |row| row.get(0))
                 .unwrap();
+            let journal_mode: String = conn
+                .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+                .unwrap();
             let cleaned: String = conn
                 .query_row(
                     "SELECT qq_maid_json_remove_object_keys(?1, ?2)",
@@ -405,6 +412,7 @@ mod tests {
             assert_eq!(foreign_keys, 1);
             assert_eq!(busy_timeout, 3000);
             assert_eq!(synchronous, 1);
+            assert_eq!(journal_mode.to_ascii_lowercase(), "wal");
             assert_eq!(cleaned, r#"{"keep":1}"#);
         }
     }

--- a/qq-maid-core/src/storage/database.rs
+++ b/qq-maid-core/src/storage/database.rs
@@ -4,9 +4,10 @@
 //! 业务表结构由各业务模块提供 migration 定义，避免通用层反向依赖 RSS/Todo 等语义。
 
 use std::{
-    fs,
+    fmt, fs,
+    ops::{Deref, DerefMut},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex, MutexGuard},
+    sync::{Arc, Condvar, Mutex},
 };
 
 use rusqlite::{
@@ -15,6 +16,14 @@ use rusqlite::{
 };
 use serde_json::Value;
 use thiserror::Error;
+
+/// SQLite 连接池默认大小。
+///
+/// 这是本地 SQLite 连接数，独立于 LLM / Web Search 的上游并发限制；
+/// 运行时可通过 `QQ_MAID_DB_POOL_MAX_SIZE` 覆盖。
+pub const DEFAULT_SQLITE_POOL_SIZE: usize = 8;
+pub const MIN_SQLITE_POOL_SIZE: usize = 1;
+pub const MAX_SQLITE_POOL_SIZE: usize = 32;
 
 /// 单个 SQLite migration。
 ///
@@ -34,7 +43,14 @@ pub struct SqliteDatabase {
 #[derive(Debug)]
 struct SqliteDatabaseInner {
     path: PathBuf,
-    connection: Mutex<Connection>,
+    pool_size: usize,
+    connections: Mutex<Vec<Connection>>,
+    available: Condvar,
+}
+
+pub struct PooledSqliteConnection {
+    connection: Option<Connection>,
+    database: Arc<SqliteDatabaseInner>,
 }
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
@@ -50,32 +66,77 @@ impl SqliteDatabase {
         db_path: impl Into<PathBuf>,
         migrations: &[SqliteMigration],
     ) -> Result<Self, DatabaseError> {
+        Self::open_with_pool_size(db_path, migrations, DEFAULT_SQLITE_POOL_SIZE)
+    }
+
+    /// 打开数据库文件，串行执行 migration 后创建固定大小的连接池。
+    pub fn open_with_pool_size(
+        db_path: impl Into<PathBuf>,
+        migrations: &[SqliteMigration],
+        pool_size: usize,
+    ) -> Result<Self, DatabaseError> {
+        if !(MIN_SQLITE_POOL_SIZE..=MAX_SQLITE_POOL_SIZE).contains(&pool_size) {
+            return Err(DatabaseError::io(format!(
+                "sqlite pool size must be between {MIN_SQLITE_POOL_SIZE} and {MAX_SQLITE_POOL_SIZE}"
+            )));
+        }
+
         let db_path = db_path.into();
         ensure_parent_dir(&db_path)?;
-        let mut connection = Connection::open(&db_path).map_err(DatabaseError::from_sql)?;
-        configure_connection(&connection)?;
-        run_migrations(&mut connection, migrations)?;
+        let mut migration_connection = open_configured_connection(&db_path)?;
+        run_migrations(&mut migration_connection, migrations)?;
+        drop(migration_connection);
+
+        let mut connections = Vec::with_capacity(pool_size);
+        for _ in 0..pool_size {
+            connections.push(open_configured_connection(&db_path)?);
+        }
+
         Ok(Self {
             inner: Arc::new(SqliteDatabaseInner {
                 path: db_path,
-                connection: Mutex::new(connection),
+                pool_size,
+                connections: Mutex::new(connections),
+                available: Condvar::new(),
             }),
         })
     }
 
-    /// 获取共享 SQLite 连接。
+    /// 从连接池借出 SQLite 连接。
     ///
-    /// 当前机器人是单实例低并发场景，使用单连接加互斥锁可以保持 RSS 命令和后台轮询
-    /// 的写入顺序，同时避免业务模块重复打开数据库或自行配置 PRAGMA。
-    pub fn connection(&self) -> Result<MutexGuard<'_, Connection>, DatabaseError> {
-        self.inner
-            .connection
+    /// guard 释放时连接会归还池中；调用方不得把它跨 `.await` 保存。
+    pub fn connection(&self) -> Result<PooledSqliteConnection, DatabaseError> {
+        let mut connections = self
+            .inner
+            .connections
             .lock()
-            .map_err(|_| DatabaseError::io("sqlite connection lock poisoned"))
+            .map_err(|_| DatabaseError::io("sqlite connection pool lock poisoned"))?;
+        loop {
+            if let Some(connection) = connections.pop() {
+                return Ok(PooledSqliteConnection {
+                    connection: Some(connection),
+                    database: Arc::clone(&self.inner),
+                });
+            }
+            connections = self
+                .inner
+                .available
+                .wait(connections)
+                .map_err(|_| DatabaseError::io("sqlite connection pool lock poisoned"))?;
+        }
     }
 
     pub fn path(&self) -> &Path {
         &self.inner.path
+    }
+
+    pub fn pool_size(&self) -> usize {
+        self.inner.pool_size
+    }
+
+    #[cfg(test)]
+    fn idle_connection_count(&self) -> usize {
+        self.inner.connections.lock().unwrap().len()
     }
 
     #[cfg(test)]
@@ -84,6 +145,46 @@ impl SqliteDatabase {
             std::env::temp_dir().join(format!("{prefix}-{}.db", uuid::Uuid::new_v4())),
             migrations,
         )
+    }
+}
+
+impl fmt::Debug for PooledSqliteConnection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PooledSqliteConnection")
+            .field("path", &self.database.path)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Deref for PooledSqliteConnection {
+    type Target = Connection;
+
+    fn deref(&self) -> &Self::Target {
+        self.connection
+            .as_ref()
+            .expect("pooled sqlite connection missing before drop")
+    }
+}
+
+impl DerefMut for PooledSqliteConnection {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.connection
+            .as_mut()
+            .expect("pooled sqlite connection missing before drop")
+    }
+}
+
+impl Drop for PooledSqliteConnection {
+    fn drop(&mut self) {
+        let Some(connection) = self.connection.take() else {
+            return;
+        };
+        let mut connections = match self.database.connections.lock() {
+            Ok(connections) => connections,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        connections.push(connection);
+        self.database.available.notify_one();
     }
 }
 
@@ -123,11 +224,19 @@ fn ensure_parent_dir(path: &Path) -> Result<(), DatabaseError> {
     Ok(())
 }
 
+fn open_configured_connection(path: &Path) -> Result<Connection, DatabaseError> {
+    let connection = Connection::open(path).map_err(DatabaseError::from_sql)?;
+    configure_connection(&connection)?;
+    Ok(connection)
+}
+
 fn configure_connection(conn: &Connection) -> Result<(), DatabaseError> {
     register_json_remove_object_keys_function(conn)?;
     conn.execute_batch(
         "PRAGMA foreign_keys = ON;
-         PRAGMA busy_timeout = 3000;",
+         PRAGMA busy_timeout = 3000;
+         PRAGMA journal_mode = WAL;
+         PRAGMA synchronous = NORMAL;",
     )
     .map_err(DatabaseError::from_sql)
 }
@@ -228,6 +337,92 @@ mod tests {
             .unwrap();
 
         assert_eq!(value, "first");
+    }
+
+    #[test]
+    fn creates_configured_connection_pool_after_migration() {
+        let path = std::env::temp_dir().join(format!(
+            "qq-maid-sqlite-pool-test-{}.db",
+            uuid::Uuid::new_v4()
+        ));
+        let db = SqliteDatabase::open_with_pool_size(&path, TEST_MIGRATIONS, 2).unwrap();
+
+        assert_eq!(db.pool_size(), 2);
+        assert_eq!(db.idle_connection_count(), 2);
+
+        let first = db.connection().unwrap();
+        let second = db.connection().unwrap();
+        assert_eq!(db.idle_connection_count(), 0);
+
+        first
+            .execute(
+                "INSERT INTO test_items (id, value) VALUES (?1, ?2)",
+                rusqlite::params!["pooled", "ok"],
+            )
+            .unwrap();
+        let value: String = second
+            .query_row(
+                "SELECT value FROM test_items WHERE id = 'pooled'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(value, "ok");
+
+        drop(first);
+        drop(second);
+        assert_eq!(db.idle_connection_count(), 2);
+    }
+
+    #[test]
+    fn every_pooled_connection_has_common_initialization() {
+        let path = std::env::temp_dir().join(format!(
+            "qq-maid-sqlite-config-test-{}.db",
+            uuid::Uuid::new_v4()
+        ));
+        let db = SqliteDatabase::open_with_pool_size(&path, TEST_MIGRATIONS, 2).unwrap();
+        let first = db.connection().unwrap();
+        let second = db.connection().unwrap();
+
+        for conn in [&first, &second] {
+            let foreign_keys: i64 = conn
+                .query_row("PRAGMA foreign_keys", [], |row| row.get(0))
+                .unwrap();
+            let busy_timeout: i64 = conn
+                .query_row("PRAGMA busy_timeout", [], |row| row.get(0))
+                .unwrap();
+            let synchronous: i64 = conn
+                .query_row("PRAGMA synchronous", [], |row| row.get(0))
+                .unwrap();
+            let cleaned: String = conn
+                .query_row(
+                    "SELECT qq_maid_json_remove_object_keys(?1, ?2)",
+                    rusqlite::params![r#"{"keep":1,"remove":2}"#, "remove"],
+                    |row| row.get(0),
+                )
+                .unwrap();
+
+            assert_eq!(foreign_keys, 1);
+            assert_eq!(busy_timeout, 3000);
+            assert_eq!(synchronous, 1);
+            assert_eq!(cleaned, r#"{"keep":1}"#);
+        }
+    }
+
+    #[test]
+    fn rejects_pool_size_outside_supported_range() {
+        let path = std::env::temp_dir().join(format!(
+            "qq-maid-sqlite-zero-pool-{}.db",
+            uuid::Uuid::new_v4()
+        ));
+        let err = SqliteDatabase::open_with_pool_size(&path, TEST_MIGRATIONS, 0).unwrap_err();
+
+        assert_eq!(err.code(), "io_error");
+        assert!(err.message().contains("between 1 and 32"));
+
+        let err = SqliteDatabase::open_with_pool_size(&path, TEST_MIGRATIONS, 33).unwrap_err();
+        assert_eq!(err.code(), "io_error");
+        assert!(err.message().contains("between 1 and 32"));
     }
 
     #[test]

--- a/qq-maid-core/src/storage/display_name.rs
+++ b/qq-maid-core/src/storage/display_name.rs
@@ -10,7 +10,7 @@
 //!
 //! 同一用户在不同群 / 私聊中各自独立，互不污染；缺少稳定 `user_id` 时不允许设置。
 
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{OptionalExtension, params};
 
 use crate::storage::{
     database::{DatabaseError, SqliteDatabase, SqliteMigration},
@@ -101,7 +101,9 @@ impl DisplayNameStore {
         Self { database }
     }
 
-    fn connection(&self) -> Result<std::sync::MutexGuard<'_, Connection>, DisplayNameError> {
+    fn connection(
+        &self,
+    ) -> Result<crate::storage::database::PooledSqliteConnection, DisplayNameError> {
         self.database
             .connection()
             .map_err(DisplayNameError::from_database)

--- a/qq-maid-core/src/storage/memory/mod.rs
+++ b/qq-maid-core/src/storage/memory/mod.rs
@@ -5,7 +5,7 @@
 //! 也不保留 JSONL 回退，避免写入失败时出现“表面成功、实际未保存”的状态。
 
 use qq_maid_common::redaction::redact_sensitive_text;
-use rusqlite::{Connection, params};
+use rusqlite::params;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -477,7 +477,7 @@ impl MemoryStore {
         Ok(id)
     }
 
-    fn connection(&self) -> Result<std::sync::MutexGuard<'_, Connection>, MemoryError> {
+    fn connection(&self) -> Result<crate::storage::database::PooledSqliteConnection, MemoryError> {
         self.database
             .connection()
             .map_err(MemoryError::from_database)

--- a/qq-maid-core/src/storage/notification.rs
+++ b/qq-maid-core/src/storage/notification.rs
@@ -383,7 +383,9 @@ impl NotificationOutboxStore {
             .map_err(NotificationError::from_sql)
     }
 
-    fn connection(&self) -> Result<std::sync::MutexGuard<'_, Connection>, NotificationError> {
+    fn connection(
+        &self,
+    ) -> Result<crate::storage::database::PooledSqliteConnection, NotificationError> {
         self.database
             .connection()
             .map_err(NotificationError::from_database)

--- a/qq-maid-core/src/storage/rss/mod.rs
+++ b/qq-maid-core/src/storage/rss/mod.rs
@@ -592,7 +592,9 @@ impl RssStore {
         .map_err(RssStoreError::from_sql)
     }
 
-    fn connection(&self) -> Result<std::sync::MutexGuard<'_, Connection>, RssStoreError> {
+    fn connection(
+        &self,
+    ) -> Result<crate::storage::database::PooledSqliteConnection, RssStoreError> {
         self.database
             .connection()
             .map_err(RssStoreError::from_database)

--- a/qq-maid-core/src/storage/session/mod.rs
+++ b/qq-maid-core/src/storage/session/mod.rs
@@ -440,7 +440,7 @@ impl SessionStore {
         self.save(session)
     }
 
-    fn connection(&self) -> Result<std::sync::MutexGuard<'_, Connection>, SessionError> {
+    fn connection(&self) -> Result<crate::storage::database::PooledSqliteConnection, SessionError> {
         self.database
             .connection()
             .map_err(SessionError::from_database)

--- a/qq-maid-core/src/storage/todo/mod.rs
+++ b/qq-maid-core/src/storage/todo/mod.rs
@@ -1316,7 +1316,7 @@ impl TodoStore {
             .ok_or_else(|| TodoError::not_found("todo not found"))
     }
 
-    fn connection(&self) -> Result<std::sync::MutexGuard<'_, Connection>, TodoError> {
+    fn connection(&self) -> Result<crate::storage::database::PooledSqliteConnection, TodoError> {
         self.database.connection().map_err(TodoError::from_database)
     }
 

--- a/runtime/config/.env.example
+++ b/runtime/config/.env.example
@@ -211,6 +211,8 @@ WEB_CONSOLE_ALLOWED_ORIGINS=
 # =============================================================================
 # 相对路径按 runtime 运行目录解析；生产建议使用外部绝对路径。
 APP_DB_FILE=data/storage/app.db
+# SQLite 本地连接池大小，独立于 MAX_CONCURRENT_RESPONSES；合法范围 1～32。
+QQ_MAID_DB_POOL_MAX_SIZE=8
 
 # PROMPT_DIR 留空时使用默认 config/prompts；默认目录缺文件会回退内置通用 prompt。
 # 显式配置 PROMPT_DIR 后，缺文件或空文件会作为配置错误处理。


### PR DESCRIPTION
## 完成范围

本 PR 完成 #328 的 Phase 1：SQLite 连接池与存储基础设施。

- 将 `SqliteDatabase` 从单个 `Arc<Mutex<Connection>>` 改为固定大小连接池，新增 pooled connection guard，Drop 时自动归还。
- migration 仍在 `open/open_with_pool_size` 阶段用单个临时连接串行执行，完成后再创建连接池。
- 每个池连接统一初始化 `foreign_keys`、`busy_timeout`、`journal_mode=WAL`、`synchronous=NORMAL`，并注册 `qq_maid_json_remove_object_keys`。
- 新增 `QQ_MAID_DB_POOL_MAX_SIZE`，默认 8，合法范围 1..=32；与 `MAX_CONCURRENT_RESPONSES` 完全独立。
- 迁移现有 Store 连接 guard 类型，保持事务边界和业务语义不变。
- 更新 `.env.example`、Core README 和相关测试。

## 并发模型说明

- `MAX_CONCURRENT_RESPONSES` 继续只控制 LLM / Web Search semaphore。
- `QQ_MAID_DB_POOL_MAX_SIZE` 只控制本地 SQLite 连接池大小。
- 未新增阻塞线程池；当前 SQL 路径仍是同步 Store 方法内的短 SQL 调用。
- 没有新增跨 `.await` 持有数据库连接的路径。
- SQLite 写事务仍是单 writer 语义；连接池主要减少 Rust 侧单连接全局锁争用。

## 未完成范围

本 PR 不包含 #328 的 Phase 2～5：

- Core runtime 装配边界拆分
- Respond 编排层拆分
- Todo 交互状态通用化
- Gateway ref_index 抽象调整

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo build --workspace --release --all-features`

## 风险说明

如果后续出现 `SQLITE_BUSY`、连接获取等待变长或写入 p95/p99 上升，应优先分析事务范围、写锁等待和调用链，不应单纯增大连接池。


Closes #330
Part of #328