### PR TITLE
refactor: 收敛 Core runtime 装配边界

### DIFF
--- a/qq-maid-core/src/app/mod.rs
+++ b/qq-maid-core/src/app/mod.rs
@@ -4,45 +4,27 @@
 use std::{future::Future, net::SocketAddr, sync::Arc};
 
 use time::{UtcOffset, macros::format_description};
-use tokio::sync::Semaphore;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 use crate::{
     config::AppConfig,
-    http::routes::{AppState, build_router},
-    provider::{
-        build_provider,
-        limiter::{LimitingLlmProvider, LimitingWebSearchExecutor},
-        status::{UpstreamStatus, observe_provider},
-    },
-    runtime::{
-        knowledge::KnowledgeIndex,
-        memory::MemoryStore,
-        notification::{NotificationWorker, NotificationWorkerConfig},
-        prompt::PromptConfig,
-        push::PushSink,
-        query::build_query_executor,
-        rss::{RssFetchConfig, RssFetcher, RssScheduler, RssSchedulerConfig, RssStore},
-        session::SessionStore,
-        todo::TodoStore,
-        todo_reminder::{TodoReminderScheduler, TodoReminderSchedulerConfig},
-        tools::build_radar_executor,
-        train::build_train_executor,
-        translation::TranslationService,
-        weather::build_weather_executor,
-    },
-    storage::knowledge::KnowledgeStore,
-    storage::{APP_MIGRATIONS, database::SqliteDatabase},
+    http::routes::{OpsHttpState, build_router},
+    runtime::push::PushSink,
 };
+
+mod runtime;
+mod workers;
+
+pub use runtime::{CoreExecutors, CoreRuntimeState, CoreStores};
+use workers::CoreWorkers;
 
 /// 统一进程入口会先组装 Core 运行时，再决定何时开始监听和何时关停。
 /// 这样既能把聊天调用交给进程内 CoreService，也能避免双入口重复初始化 dotenv 和 tracing。
 pub struct LlmRuntime {
     addr: SocketAddr,
-    state: AppState,
-    rss_scheduler: Option<RssScheduler>,
-    notification_worker: Option<NotificationWorker>,
-    todo_reminder_scheduler: Option<TodoReminderScheduler>,
+    core_state: CoreRuntimeState,
+    http_state: OpsHttpState,
+    workers: CoreWorkers,
 }
 
 /// 应用入口：加载环境变量、初始化日志、构建配置与运行时、启动 HTTP 服务。
@@ -67,139 +49,24 @@ impl LlmRuntime {
         push_sink: Option<Arc<dyn PushSink>>,
     ) -> anyhow::Result<Self> {
         let addr: SocketAddr = format!("{}:{}", config.server_host, config.server_port).parse()?;
-        tracing::info!(
-            agent_policy = %config.agent_config.diagnostic_summary()?,
-            "agent policy loaded"
+        let core_state = CoreRuntimeState::from_config(config)?;
+        let http_state = OpsHttpState::from_parts(
+            (&core_state.config).into(),
+            core_state.provider.clone(),
+            core_state.upstream_status.clone(),
         );
-        let upstream_status = UpstreamStatus::default();
-        let llm_gate = (config.max_concurrent_responses > 0)
-            .then(|| Arc::new(Semaphore::new(config.max_concurrent_responses as usize)));
-        let provider = observe_provider(
-            Arc::new(LimitingLlmProvider::new(
-                build_provider(&config.llm_config())?,
-                llm_gate.clone(),
-            )),
-            upstream_status.clone(),
-        );
-        let translation_service =
-            TranslationService::new(provider.clone(), config.translation_model.clone());
-        let query_executor = Arc::new(LimitingWebSearchExecutor::new(
-            build_query_executor(&config)?,
-            llm_gate.clone(),
-        ));
-        let weather_executor = build_weather_executor(&config)?;
-        let train_executor = build_train_executor(&config)?;
-        let radar_executor = build_radar_executor()?;
-        // 通用数据库在应用启动阶段统一打开并执行项目级 migration；
-        // SQLite pool size 独立于 LLM / Web Search 上游并发限制。
-        let database = SqliteDatabase::open_with_pool_size(
-            config.app_db_file.clone(),
-            APP_MIGRATIONS,
-            config.sqlite_pool_size,
-        )?;
-        let session_store = SessionStore::new(database.clone());
-        let rss_store = RssStore::new(database.clone());
-        let todo_store = TodoStore::new(database.clone());
-        let memory_store = MemoryStore::new(database.clone());
-        let notification_store =
-            crate::storage::notification::NotificationOutboxStore::new(database.clone());
-        let display_name_store =
-            crate::runtime::display_name::DisplayNameStore::new(database.clone());
-        let knowledge_index =
-            KnowledgeIndex::new(KnowledgeStore::new(database), config.knowledge_dir.clone());
-        // 知识目录不存在或为空会正常降级；数据库/FTS 错误必须阻止启动，
-        // 否则会把索引损坏伪装成“没有知识命中”。
-        knowledge_index.sync()?;
-        let rss_fetcher = RssFetcher::new(RssFetchConfig {
-            timeout_seconds: config.rss_http_timeout_seconds,
-            max_body_bytes: config.rss_max_body_bytes as usize,
-            user_agent: "qq-maid-rss/0.1 (+https://github.com/kuliantnt/qqbot)".to_owned(),
-            allow_private_networks: config.rss_allow_private_urls,
-        })?;
-        let prompt_config = PromptConfig::new(config.prompt_dir.clone())
-            .with_builtin_prompt_defaults(config.prompt_dir_uses_builtin_defaults);
-        let push_sink = match (
-            push_sink,
-            config.rss_enabled || config.todo_daily_reminder_enabled,
-        ) {
-            (Some(push_sink), _) => Some(push_sink),
-            (None, true) => {
-                return Err(anyhow::anyhow!(
-                    "RSS 或 Todo 每日提醒已启用，但未注入进程内 PushSink"
-                ));
-            }
-            (None, false) => None,
-        };
-        let notification_worker = push_sink.clone().map(|push_sink| {
-            NotificationWorker::new(
-                notification_store.clone(),
-                push_sink,
-                NotificationWorkerConfig::default(),
-            )
-        });
-        let rss_scheduler = if config.rss_enabled {
-            Some(RssScheduler::new(
-                rss_store.clone(),
-                rss_fetcher.clone(),
-                notification_store.clone(),
-                translation_service.clone(),
-                RssSchedulerConfig {
-                    enabled: config.rss_enabled,
-                    interval_seconds: config.rss_poll_interval_seconds,
-                    max_push_per_subscription: config.rss_max_push_per_feed as usize,
-                    summary_max_chars: config.rss_summary_max_chars as usize,
-                    seen_retention: config.rss_seen_retention as usize,
-                    push_max_failures: config.rss_push_max_failures as u32,
-                    push_message_type: config.rss_push_message_type.clone(),
-                },
-            ))
-        } else {
-            None
-        };
-        let todo_reminder_scheduler = if config.todo_daily_reminder_enabled {
-            Some(TodoReminderScheduler::new(
-                todo_store.clone(),
-                push_sink
-                    .clone()
-                    .expect("push sink must exist when Todo reminder is enabled"),
-                TodoReminderSchedulerConfig {
-                    enabled: true,
-                    reminder_time: config.todo_daily_reminder_time,
-                },
-            ))
-        } else {
-            None
-        };
-        let state = AppState {
-            config,
-            provider,
-            upstream_status,
-            query_executor,
-            weather_executor,
-            train_executor,
-            radar_executor,
-            memory_store,
-            session_store,
-            todo_store,
-            notification_store,
-            rss_store,
-            rss_fetcher,
-            knowledge_index,
-            prompt_config,
-            display_name_store,
-        };
+        let workers = CoreWorkers::from_runtime_state(&core_state, push_sink)?;
 
         Ok(Self {
             addr,
-            state,
-            rss_scheduler,
-            notification_worker,
-            todo_reminder_scheduler,
+            core_state,
+            http_state,
+            workers,
         })
     }
 
     pub fn core_handle(&self) -> crate::service::CoreHandle {
-        crate::service::CoreHandle::new(self.state.clone())
+        crate::service::CoreHandle::new(self.core_state.clone())
     }
 
     /// 返回 Core HTTP 健康检查 URL。
@@ -220,15 +87,7 @@ impl LlmRuntime {
     }
 
     pub fn spawn_schedulers(&self) {
-        if let Some(scheduler) = self.rss_scheduler.clone() {
-            scheduler.spawn();
-        }
-        if let Some(worker) = self.notification_worker.clone() {
-            worker.spawn();
-        }
-        if let Some(scheduler) = self.todo_reminder_scheduler.clone() {
-            scheduler.spawn();
-        }
+        self.workers.spawn();
     }
 
     pub async fn serve_with_shutdown<F>(self, shutdown: F) -> anyhow::Result<()>
@@ -237,25 +96,16 @@ impl LlmRuntime {
     {
         let Self {
             addr,
-            state,
-            rss_scheduler,
-            notification_worker,
-            todo_reminder_scheduler,
+            http_state,
+            workers,
+            ..
         } = self;
         let listener = tokio::net::TcpListener::bind(addr).await?;
 
-        if let Some(scheduler) = rss_scheduler {
-            scheduler.spawn();
-        }
-        if let Some(worker) = notification_worker {
-            worker.spawn();
-        }
-        if let Some(scheduler) = todo_reminder_scheduler {
-            scheduler.spawn();
-        }
+        workers.spawn();
 
         tracing::info!(%addr, "qq-maid-core listening");
-        axum::serve(listener, build_router(state))
+        axum::serve(listener, build_router(http_state))
             .with_graceful_shutdown(shutdown)
             .await?;
         Ok(())

--- a/qq-maid-core/src/app/runtime.rs
+++ b/qq-maid-core/src/app/runtime.rs
@@ -1,0 +1,138 @@
+//! Core 运行时依赖装配。
+//!
+//! 本模块只负责构建进程内 CoreService 需要的 provider、executor、store 和提示词等依赖，
+//! 不承载 HTTP 路由 state，也不启动后台 worker。
+
+use std::sync::Arc;
+
+use tokio::sync::Semaphore;
+
+use crate::{
+    config::AppConfig,
+    provider::{
+        DynLlmProvider, build_provider,
+        limiter::{LimitingLlmProvider, LimitingWebSearchExecutor},
+        status::{UpstreamStatus, observe_provider},
+    },
+    runtime::{
+        display_name::DisplayNameStore,
+        knowledge::KnowledgeIndex,
+        memory::MemoryStore,
+        prompt::PromptConfig,
+        query::{DynQueryExecutor, build_query_executor},
+        rss::{RssFetchConfig, RssFetcher, RssStore},
+        session::SessionStore,
+        todo::TodoStore,
+        tools::{DynRadarExecutor, build_radar_executor},
+        train::{DynTrainExecutor, build_train_executor},
+        weather::{DynWeatherExecutor, build_weather_executor},
+    },
+    storage::notification::NotificationOutboxStore,
+    storage::{APP_MIGRATIONS, database::SqliteDatabase, knowledge::KnowledgeStore},
+};
+
+/// Core 业务 flow 使用的持久化存储集合。
+#[derive(Clone)]
+pub struct CoreStores {
+    pub memory_store: MemoryStore,
+    pub session_store: SessionStore,
+    pub todo_store: TodoStore,
+    pub notification_store: NotificationOutboxStore,
+    pub rss_store: RssStore,
+    /// 手动展示名存储，用于本地昵称兜底（#326）。
+    pub display_name_store: DisplayNameStore,
+}
+
+/// Core 业务 flow 需要的外部执行器集合。
+#[derive(Clone)]
+pub struct CoreExecutors {
+    pub query_executor: DynQueryExecutor,
+    pub weather_executor: DynWeatherExecutor,
+    pub train_executor: DynTrainExecutor,
+    pub radar_executor: DynRadarExecutor,
+}
+
+/// 进程内 CoreService 的运行时依赖容器。
+#[derive(Clone)]
+pub struct CoreRuntimeState {
+    pub config: AppConfig,
+    pub provider: DynLlmProvider,
+    /// 最近一次真实上游调用的脱敏状态。
+    pub upstream_status: UpstreamStatus,
+    pub executors: CoreExecutors,
+    pub stores: CoreStores,
+    pub rss_fetcher: RssFetcher,
+    pub knowledge_index: KnowledgeIndex,
+    pub prompt_config: PromptConfig,
+}
+
+impl CoreRuntimeState {
+    pub fn from_config(config: AppConfig) -> anyhow::Result<Self> {
+        tracing::info!(
+            agent_policy = %config.agent_config.diagnostic_summary()?,
+            "agent policy loaded"
+        );
+        let upstream_status = UpstreamStatus::default();
+        let llm_gate = (config.max_concurrent_responses > 0)
+            .then(|| Arc::new(Semaphore::new(config.max_concurrent_responses as usize)));
+        let provider = observe_provider(
+            Arc::new(LimitingLlmProvider::new(
+                build_provider(&config.llm_config())?,
+                llm_gate.clone(),
+            )),
+            upstream_status.clone(),
+        );
+        let query_executor = Arc::new(LimitingWebSearchExecutor::new(
+            build_query_executor(&config)?,
+            llm_gate.clone(),
+        ));
+        let weather_executor = build_weather_executor(&config)?;
+        let train_executor = build_train_executor(&config)?;
+        let radar_executor = build_radar_executor()?;
+
+        // 通用数据库在应用启动阶段统一打开并执行项目级 migration；
+        // SQLite pool size 独立于 LLM / Web Search 上游并发限制。
+        let database = SqliteDatabase::open_with_pool_size(
+            config.app_db_file.clone(),
+            APP_MIGRATIONS,
+            config.sqlite_pool_size,
+        )?;
+        let stores = CoreStores {
+            memory_store: MemoryStore::new(database.clone()),
+            session_store: SessionStore::new(database.clone()),
+            todo_store: TodoStore::new(database.clone()),
+            notification_store: NotificationOutboxStore::new(database.clone()),
+            rss_store: RssStore::new(database.clone()),
+            display_name_store: DisplayNameStore::new(database.clone()),
+        };
+        let knowledge_index =
+            KnowledgeIndex::new(KnowledgeStore::new(database), config.knowledge_dir.clone());
+        // 知识目录不存在或为空会正常降级；数据库/FTS 错误必须阻止启动，
+        // 否则会把索引损坏伪装成“没有知识命中”。
+        knowledge_index.sync()?;
+        let rss_fetcher = RssFetcher::new(RssFetchConfig {
+            timeout_seconds: config.rss_http_timeout_seconds,
+            max_body_bytes: config.rss_max_body_bytes as usize,
+            user_agent: "qq-maid-rss/0.1 (+https://github.com/kuliantnt/qqbot)".to_owned(),
+            allow_private_networks: config.rss_allow_private_urls,
+        })?;
+        let prompt_config = PromptConfig::new(config.prompt_dir.clone())
+            .with_builtin_prompt_defaults(config.prompt_dir_uses_builtin_defaults);
+
+        Ok(Self {
+            config,
+            provider,
+            upstream_status,
+            executors: CoreExecutors {
+                query_executor,
+                weather_executor,
+                train_executor,
+                radar_executor,
+            },
+            stores,
+            rss_fetcher,
+            knowledge_index,
+            prompt_config,
+        })
+    }
+}

--- a/qq-maid-core/src/app/workers.rs
+++ b/qq-maid-core/src/app/workers.rs
@@ -1,0 +1,104 @@
+//! Core 后台 worker 和 scheduler 装配。
+//!
+//! 这里只根据已经构建好的 CoreRuntimeState 创建后台任务对象；真正 spawn 仍由 LlmRuntime 控制，
+//! 以保持统一入口的启动和 shutdown 顺序稳定。
+
+use std::sync::Arc;
+
+use crate::runtime::{
+    notification::{NotificationWorker, NotificationWorkerConfig},
+    push::PushSink,
+    rss::{RssScheduler, RssSchedulerConfig},
+    todo_reminder::{TodoReminderScheduler, TodoReminderSchedulerConfig},
+    translation::TranslationService,
+};
+
+use super::runtime::CoreRuntimeState;
+
+#[derive(Clone)]
+pub struct CoreWorkers {
+    pub rss_scheduler: Option<RssScheduler>,
+    pub notification_worker: Option<NotificationWorker>,
+    pub todo_reminder_scheduler: Option<TodoReminderScheduler>,
+}
+
+impl CoreWorkers {
+    pub fn from_runtime_state(
+        state: &CoreRuntimeState,
+        push_sink: Option<Arc<dyn PushSink>>,
+    ) -> anyhow::Result<Self> {
+        let config = &state.config;
+        let push_sink = match (
+            push_sink,
+            config.rss_enabled || config.todo_daily_reminder_enabled,
+        ) {
+            (Some(push_sink), _) => Some(push_sink),
+            (None, true) => {
+                return Err(anyhow::anyhow!(
+                    "RSS 或 Todo 每日提醒已启用，但未注入进程内 PushSink"
+                ));
+            }
+            (None, false) => None,
+        };
+        let notification_worker = push_sink.clone().map(|push_sink| {
+            NotificationWorker::new(
+                state.stores.notification_store.clone(),
+                push_sink,
+                NotificationWorkerConfig::default(),
+            )
+        });
+        let translation_service =
+            TranslationService::new(state.provider.clone(), config.translation_model.clone());
+        let rss_scheduler = if config.rss_enabled {
+            Some(RssScheduler::new(
+                state.stores.rss_store.clone(),
+                state.rss_fetcher.clone(),
+                state.stores.notification_store.clone(),
+                translation_service,
+                RssSchedulerConfig {
+                    enabled: config.rss_enabled,
+                    interval_seconds: config.rss_poll_interval_seconds,
+                    max_push_per_subscription: config.rss_max_push_per_feed as usize,
+                    summary_max_chars: config.rss_summary_max_chars as usize,
+                    seen_retention: config.rss_seen_retention as usize,
+                    push_max_failures: config.rss_push_max_failures as u32,
+                    push_message_type: config.rss_push_message_type.clone(),
+                },
+            ))
+        } else {
+            None
+        };
+        let todo_reminder_scheduler = if config.todo_daily_reminder_enabled {
+            Some(TodoReminderScheduler::new(
+                state.stores.todo_store.clone(),
+                push_sink
+                    .clone()
+                    .expect("push sink must exist when Todo reminder is enabled"),
+                TodoReminderSchedulerConfig {
+                    enabled: true,
+                    reminder_time: config.todo_daily_reminder_time,
+                },
+            ))
+        } else {
+            None
+        };
+
+        Ok(Self {
+            rss_scheduler,
+            notification_worker,
+            todo_reminder_scheduler,
+        })
+    }
+
+    pub fn spawn(&self) {
+        if let Some(scheduler) = self.rss_scheduler.clone() {
+            scheduler.spawn();
+        }
+        if let Some(worker) = self.notification_worker.clone() {
+            worker.spawn();
+        }
+        if let Some(scheduler) = self.todo_reminder_scheduler.clone() {
+            scheduler.spawn();
+        }
+    }
+}

--- a/qq-maid-core/src/http/routes.rs
+++ b/qq-maid-core/src/http/routes.rs
@@ -20,61 +20,50 @@ use serde_json::json;
 use crate::{
     config::AppConfig,
     provider::{DynLlmProvider, status::UpstreamStatus},
-    runtime::{
-        display_name::DisplayNameStore,
-        knowledge::KnowledgeIndex,
-        memory::MemoryStore,
-        prompt::PromptConfig,
-        query::DynQueryExecutor,
-        rss::{RssFetcher, RssStore},
-        session::SessionStore,
-        todo::TodoStore,
-        tools::DynRadarExecutor,
-        train::DynTrainExecutor,
-        weather::DynWeatherExecutor,
-    },
-    storage::notification::NotificationOutboxStore,
 };
 
-/// 应用全局状态，通过 Axum 的 State 注入到各处理器中。
+/// 运维 HTTP 接口需要的最小配置。
 #[derive(Clone)]
-pub struct AppState {
-    /// 全局应用配置。
-    pub config: AppConfig,
+pub struct OpsHttpConfig {
+    pub web_console_enabled: bool,
+    pub web_console_allowed_origins: Vec<String>,
+}
+
+impl From<&AppConfig> for OpsHttpConfig {
+    fn from(value: &AppConfig) -> Self {
+        Self {
+            web_console_enabled: value.web_console_enabled,
+            web_console_allowed_origins: value.web_console_allowed_origins.clone(),
+        }
+    }
+}
+
+/// 运维 HTTP 全局状态，通过 Axum 的 State 注入到各处理器中。
+#[derive(Clone)]
+pub struct OpsHttpState {
+    pub config: OpsHttpConfig,
     /// LLM 提供商（可为主备模式）。
     pub provider: DynLlmProvider,
     /// 最近一次真实上游调用的脱敏状态。
     pub upstream_status: UpstreamStatus,
-    /// 联网搜索执行器。
-    pub query_executor: DynQueryExecutor,
-    /// 天气查询执行器。
-    pub weather_executor: DynWeatherExecutor,
-    /// 列车时刻查询执行器。
-    pub train_executor: DynTrainExecutor,
-    /// Codex / Claude Code Radar 公开数据读取执行器。
-    pub radar_executor: DynRadarExecutor,
-    /// 记忆存储。
-    pub memory_store: MemoryStore,
-    /// 会话存储。
-    pub session_store: SessionStore,
-    /// 待办事项存储。
-    pub todo_store: TodoStore,
-    /// 统一通知 Outbox 存储。
-    pub notification_store: NotificationOutboxStore,
-    /// RSS 订阅存储。
-    pub rss_store: RssStore,
-    /// 手动展示名存储，用于本地昵称兜底（#326）。
-    pub display_name_store: DisplayNameStore,
-    /// RSS / Atom 拉取解析器。
-    pub rss_fetcher: RssFetcher,
-    /// 本地 Markdown 知识检索索引。
-    pub knowledge_index: KnowledgeIndex,
-    /// 提示词配置（system prompt 模板等）。
-    pub prompt_config: PromptConfig,
+}
+
+impl OpsHttpState {
+    pub fn from_parts(
+        config: OpsHttpConfig,
+        provider: DynLlmProvider,
+        upstream_status: UpstreamStatus,
+    ) -> Self {
+        Self {
+            config,
+            provider,
+            upstream_status,
+        }
+    }
 }
 
 /// 构建 Axum 路由树，注册所有 HTTP 端点。
-pub fn build_router(state: AppState) -> Router {
+pub fn build_router(state: OpsHttpState) -> Router {
     let console_enabled = state.config.web_console_enabled;
     let router = Router::new().route("/healthz", get(healthz));
     let router = if console_enabled {
@@ -89,7 +78,7 @@ pub fn build_router(state: AppState) -> Router {
 }
 
 /// 健康检查端点，返回当前提供商和模型信息。
-async fn healthz(State(state): State<AppState>) -> Json<serde_json::Value> {
+async fn healthz(State(state): State<OpsHttpState>) -> Json<serde_json::Value> {
     Json(json!({
         "ok": true,
         "provider": state.provider.name(),
@@ -99,7 +88,7 @@ async fn healthz(State(state): State<AppState>) -> Json<serde_json::Value> {
     }))
 }
 
-async fn console_index(State(state): State<AppState>, headers: HeaderMap) -> Response {
+async fn console_index(State(state): State<OpsHttpState>, headers: HeaderMap) -> Response {
     let mut response = with_console_cors(
         Html(include_str!("../../../runtime/static/index.html")).into_response(),
         &state,
@@ -120,7 +109,7 @@ struct MarkdownRenderRequest {
 }
 
 async fn markdown_render(
-    State(state): State<AppState>,
+    State(state): State<OpsHttpState>,
     headers: HeaderMap,
     body: Bytes,
 ) -> Response {
@@ -158,7 +147,10 @@ async fn markdown_render(
     )
 }
 
-async fn markdown_render_preflight(State(state): State<AppState>, headers: HeaderMap) -> Response {
+async fn markdown_render_preflight(
+    State(state): State<OpsHttpState>,
+    headers: HeaderMap,
+) -> Response {
     // 跨站 `application/json` 请求会先发 OPTIONS 预检；这里必须显式返回允许的方法
     // 和请求头，否则 allowlist origin 仍会被浏览器拦下。
     with_console_preflight_cors(StatusCode::NO_CONTENT.into_response(), &state, &headers)
@@ -189,7 +181,11 @@ fn with_console_security(mut response: Response) -> Response {
     response
 }
 
-fn with_console_cors(mut response: Response, state: &AppState, headers: &HeaderMap) -> Response {
+fn with_console_cors(
+    mut response: Response,
+    state: &OpsHttpState,
+    headers: &HeaderMap,
+) -> Response {
     let Some(origin) = allowed_console_origin(state, headers) else {
         return with_console_security(response);
     };
@@ -207,7 +203,7 @@ fn with_console_cors(mut response: Response, state: &AppState, headers: &HeaderM
 
 fn with_console_preflight_cors(
     mut response: Response,
-    state: &AppState,
+    state: &OpsHttpState,
     headers: &HeaderMap,
 ) -> Response {
     let Some(origin) = allowed_console_origin(state, headers) else {
@@ -236,7 +232,7 @@ fn with_console_preflight_cors(
     with_console_security(response)
 }
 
-fn allowed_console_origin<'a>(state: &'a AppState, headers: &'a HeaderMap) -> Option<&'a str> {
+fn allowed_console_origin<'a>(state: &'a OpsHttpState, headers: &'a HeaderMap) -> Option<&'a str> {
     let origin = headers.get(header::ORIGIN)?.to_str().ok()?;
     state
         .config
@@ -250,26 +246,12 @@ fn allowed_console_origin<'a>(state: &'a AppState, headers: &'a HeaderMap) -> Op
 mod tests {
     use super::*;
     use crate::{
-        config::{DEFAULT_DEEPSEEK_BASE_URL, DEFAULT_RSS_SUMMARY_MAX_CHARS, ProviderMode},
         error::LlmError,
         provider::{
             ChatOutcome, LlmProvider,
             status::{UpstreamStatus, observe_provider},
             types::{ChatRequest, TokenUsage},
         },
-        runtime::{
-            prompt::PromptConfig,
-            query::{QueryExecutor, QueryOutcome, QueryRequest, QuerySource},
-            rss::RssFetchConfig,
-            session::SessionStore,
-            tools::{RadarExecutor, RadarSnapshot, RadarTarget},
-            train::{TrainExecutor, TrainSchedule, TrainScheduleRequest, TrainStop},
-            weather::{
-                CurrentWeather, DailyWeather, WeatherExecutor, WeatherLocation, WeatherOutcome,
-                WeatherRequest, WeatherSupplement,
-            },
-        },
-        storage::{APP_MIGRATIONS, database::SqliteDatabase, knowledge::KnowledgeStore},
         util::metrics::LlmMetrics,
     };
     use async_trait::async_trait;
@@ -277,7 +259,6 @@ mod tests {
     use http_body_util::BodyExt;
     use std::{
         convert::Infallible,
-        fs,
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
@@ -292,14 +273,6 @@ mod tests {
     struct CountingProvider {
         calls: Arc<AtomicUsize>,
     }
-
-    struct MockQueryExecutor;
-
-    struct MockWeatherExecutor;
-
-    struct MockTrainExecutor;
-
-    struct MockRadarExecutor;
 
     #[async_trait]
     impl LlmProvider for MockProvider {
@@ -359,257 +332,21 @@ mod tests {
         }
     }
 
-    #[async_trait]
-    impl QueryExecutor for MockQueryExecutor {
-        async fn query(&self, req: QueryRequest) -> Result<QueryOutcome, LlmError> {
-            Ok(QueryOutcome {
-                answer: format!("web answer: {}", req.query),
-                sources: vec![QuerySource {
-                    title: "Source A".to_owned(),
-                    url: "https://a.test".to_owned(),
-                    snippet: "snippet".to_owned(),
-                }],
-                provider: "mock-query".to_owned(),
-                elapsed_ms: 7,
-            })
-        }
-
-        fn provider_name(&self) -> &'static str {
-            "mock-query"
-        }
-    }
-
-    #[async_trait]
-    impl WeatherExecutor for MockWeatherExecutor {
-        async fn weather(&self, req: WeatherRequest) -> Result<WeatherOutcome, LlmError> {
-            Ok(WeatherOutcome {
-                location: WeatherLocation {
-                    id: Some("101210101".to_owned()),
-                    name: req.city,
-                    country: Some("中国".to_owned()),
-                    admin1: Some("浙江".to_owned()),
-                    admin2: Some("杭州".to_owned()),
-                    timezone: Some("Asia/Shanghai".to_owned()),
-                    latitude: 30.29365,
-                    longitude: 120.16142,
-                },
-                current: CurrentWeather {
-                    time: "2026-06-12T20:15".to_owned(),
-                    temperature_c: 27.7,
-                    apparent_temperature_c: Some(28.5),
-                    weather_code: 3,
-                    humidity_percent: None,
-                    precipitation_mm: None,
-                    pressure_hpa: None,
-                    wind_direction: None,
-                    wind_scale: None,
-                    wind_speed_kmh: Some(6.7),
-                },
-                daily: vec![DailyWeather {
-                    date: "2026-06-12".to_owned(),
-                    weather_code: 3,
-                    weather_day: None,
-                    weather_night: None,
-                    temperature_max_c: 32.5,
-                    temperature_min_c: 21.0,
-                    precipitation_probability_max: Some(2),
-                    precipitation_mm: None,
-                    humidity_percent: None,
-                    wind_direction_day: None,
-                    wind_scale_day: None,
-                }],
-                provider: "mock-weather".to_owned(),
-                elapsed_ms: 7,
-                forecast_days: req.forecast_days,
-                alerts: WeatherSupplement::default(),
-                air_quality: WeatherSupplement::default(),
-                life_indices: WeatherSupplement::default(),
-            })
-        }
-
-        fn provider_name(&self) -> &'static str {
-            "mock-weather"
-        }
-    }
-
-    #[async_trait]
-    impl TrainExecutor for MockTrainExecutor {
-        async fn query_train_schedule(
-            &self,
-            req: TrainScheduleRequest,
-        ) -> Result<TrainSchedule, LlmError> {
-            Ok(TrainSchedule {
-                train_code: req.train_code,
-                travel_date: req.travel_date,
-                start_station: "北京南".to_owned(),
-                end_station: "上海虹桥".to_owned(),
-                stops: vec![TrainStop {
-                    station_no: 1,
-                    station_name: "北京南".to_owned(),
-                    arrive_time: None,
-                    departure_time: Some("06:30".to_owned()),
-                    stopover_minutes: None,
-                    day_difference: 0,
-                    day_difference_reliable: true,
-                    station_train_code: "G1".to_owned(),
-                }],
-                full_train_code: None,
-                corporation: None,
-                train_style: None,
-                dept_train: None,
-            })
-        }
-
-        fn provider_name(&self) -> &'static str {
-            "mock-train"
-        }
-    }
-
-    #[async_trait]
-    impl RadarExecutor for MockRadarExecutor {
-        async fn radar(&self, _target: RadarTarget) -> Result<RadarSnapshot, LlmError> {
-            Err(LlmError::provider("radar unused", "radar"))
-        }
-
-        fn provider_name(&self) -> &'static str {
-            "mock-radar"
-        }
-    }
-
-    fn write_prompt_set(dir: &std::path::Path) {
-        fs::create_dir_all(dir).unwrap();
-        for file_name in crate::runtime::prompt::PROMPT_FILES {
-            fs::write(dir.join(file_name), format!("{file_name} content")).unwrap();
-        }
-    }
-
-    fn test_state() -> AppState {
-        let prompt_dir = std::env::temp_dir().join(format!(
-            "qq-maid-route-prompt-test-{}",
-            uuid::Uuid::new_v4()
-        ));
-        write_prompt_set(&prompt_dir);
-        let app_db_file = std::env::temp_dir().join(format!(
-            "qq-maid-route-app-test-{}.db",
-            uuid::Uuid::new_v4()
-        ));
-        let database = SqliteDatabase::open(&app_db_file, APP_MIGRATIONS).unwrap();
-        let knowledge_dir = std::env::temp_dir().join(format!(
-            "qq-maid-route-knowledge-test-{}",
-            uuid::Uuid::new_v4()
-        ));
-        let knowledge_index =
-            KnowledgeIndex::new(KnowledgeStore::new(database.clone()), &knowledge_dir);
-        knowledge_index.sync().unwrap();
-
+    fn test_state() -> OpsHttpState {
         let upstream_status = UpstreamStatus::default();
         let provider = observe_provider(Arc::new(MockProvider), upstream_status.clone());
-        AppState {
-            config: AppConfig {
-                provider: ProviderMode::OpenAi,
-                model: "mock-model".to_owned(),
-                model_route: crate::provider::types::ModelRoute::parse_config(
-                    "mock-model",
-                    "LLM_MODEL",
-                )
-                .unwrap(),
-                agent_config: crate::config::AgentRuntimeConfig::from_legacy(
-                    crate::config::LegacyAgentConfig {
-                        main_model: "mock-model".to_owned(),
-                        max_output_tokens: 1200,
-                        openai_search_model: "mock-search-model".to_owned(),
-                        tool_calling_enabled: false,
-                        group_tool_calling_enabled: false,
-                        tool_calling_max_rounds: 3,
-                        group_llm_model: None,
-                        private_llm_model: None,
-                        group_openai_search_model: None,
-                        private_openai_search_model: None,
-                    },
-                )
-                .unwrap(),
-                title_model: None,
-                todo_model: None,
-                memory_model: None,
-                compact_model: None,
-                translation_model: None,
-                openai_search_model: "mock-search-model".to_owned(),
-                openai_api_key: Some("test".to_owned()),
-                openai_base_url: None,
-                openai_api_mode: crate::config::OpenAiApiMode::Auto,
-                deepseek_api_key: None,
-                deepseek_base_url: DEFAULT_DEEPSEEK_BASE_URL.to_owned(),
-                deepseek_model: "deepseek-chat".to_owned(),
-                bigmodel_api_key: None,
-                bigmodel_base_url: crate::config::DEFAULT_BIGMODEL_BASE_URL.to_owned(),
-                bigmodel_model: "glm-5.2".to_owned(),
-                stream: true,
-                request_timeout_seconds: 5,
-                ttft_warn_seconds: 30,
-                media_max_bytes: crate::config::DEFAULT_MEDIA_MAX_BYTES,
-                max_output_tokens: 1200,
-                max_concurrent_responses: 4,
-                tool_calling_enabled: false,
-                tool_calling_group_enabled: false,
-                tool_calling_max_rounds: 3,
-                context_budget: qq_maid_llm::context_budget::ContextBudgetConfig {
-                    context_window_chars: crate::config::DEFAULT_AGENT_CONTEXT_CHAR_LIMIT as usize,
-                    output_reserve_chars: crate::config::DEFAULT_AGENT_CONTEXT_OUTPUT_RESERVE_CHARS
-                        as usize,
-                    protected_recent_turns:
-                        crate::config::DEFAULT_AGENT_CONTEXT_PROTECTED_RECENT_TURNS as usize,
-                },
-                tool_result_max_chars: crate::config::DEFAULT_AGENT_TOOL_RESULT_CHAR_LIMIT as usize,
-                status_display_name: crate::config::DEFAULT_STATUS_DISPLAY_NAME.to_owned(),
-                server_host: "127.0.0.1".to_owned(),
-                server_port: 8787,
-                app_db_file: app_db_file.to_string_lossy().into_owned(),
-                sqlite_pool_size: crate::storage::database::DEFAULT_SQLITE_POOL_SIZE,
-                rss_enabled: true,
-                rss_poll_interval_seconds: 300,
-                rss_http_timeout_seconds: 15,
-                rss_max_body_bytes: 2 * 1024 * 1024,
-                rss_max_push_per_feed: 3,
-                rss_summary_max_chars: DEFAULT_RSS_SUMMARY_MAX_CHARS,
-                rss_seen_retention: 500,
-                rss_push_max_failures: 3,
-                rss_push_message_type: "markdown".to_owned(),
-                todo_daily_reminder_enabled: false,
-                todo_daily_reminder_time: crate::config::DailyReminderTime { hour: 9, minute: 0 },
-                rss_allow_private_urls: true,
-                prompt_dir: prompt_dir.to_string_lossy().into_owned(),
-                prompt_dir_uses_builtin_defaults: false,
-                knowledge_dir: knowledge_dir.to_string_lossy().into_owned(),
-                qweather_api_key: "test-qweather-key".to_owned(),
-                qweather_api_host: "https://api.qweather.com".to_owned(),
-                qweather_geo_host: "https://geoapi.qweather.com".to_owned(),
+        OpsHttpState::from_parts(
+            OpsHttpConfig {
                 web_console_enabled: false,
                 web_console_allowed_origins: Vec::new(),
             },
             provider,
             upstream_status,
-            query_executor: Arc::new(MockQueryExecutor),
-            weather_executor: Arc::new(MockWeatherExecutor),
-            train_executor: Arc::new(MockTrainExecutor),
-            radar_executor: Arc::new(MockRadarExecutor),
-            memory_store: MemoryStore::new(database.clone()),
-            session_store: SessionStore::new(database.clone()),
-            todo_store: TodoStore::new(database.clone()),
-            notification_store: NotificationOutboxStore::new(database.clone()),
-            rss_store: RssStore::new(database.clone()),
-            rss_fetcher: RssFetcher::new(RssFetchConfig {
-                allow_private_networks: true,
-                ..RssFetchConfig::default()
-            })
-            .unwrap(),
-            knowledge_index,
-            prompt_config: PromptConfig::new(prompt_dir),
-            display_name_store: DisplayNameStore::new(database),
-        }
+        )
     }
 
     async fn request_raw_response(
-        state: AppState,
+        state: OpsHttpState,
         method: &str,
         path: &str,
         value: Option<serde_json::Value>,
@@ -619,7 +356,7 @@ mod tests {
     }
 
     async fn request_raw_response_with_origin(
-        state: AppState,
+        state: OpsHttpState,
         method: &str,
         path: &str,
         value: Option<serde_json::Value>,
@@ -654,7 +391,7 @@ mod tests {
     }
 
     async fn request_response(
-        state: AppState,
+        state: OpsHttpState,
         method: &str,
         path: &str,
         value: Option<serde_json::Value>,
@@ -665,7 +402,7 @@ mod tests {
     }
 
     async fn request_text_response(
-        state: AppState,
+        state: OpsHttpState,
         method: &str,
         path: &str,
         value: Option<serde_json::Value>,

--- a/qq-maid-core/src/service/handle.rs
+++ b/qq-maid-core/src/service/handle.rs
@@ -5,9 +5,9 @@ use tokio::time::timeout;
 use tracing::warn;
 
 use crate::{
+    app::CoreRuntimeState,
     config::AppConfig,
     error::LlmError,
-    http::routes::AppState,
     provider::types::{ChatMessage, ChatRequest, ChatRole},
     runtime::respond::{
         RespondExecutors, RespondPlan, RespondRequest, RespondResponse, RespondServiceOptions,
@@ -25,11 +25,11 @@ use super::{
 
 #[derive(Clone)]
 pub struct CoreHandle {
-    state: Arc<AppState>,
+    state: Arc<CoreRuntimeState>,
 }
 
 impl CoreHandle {
-    pub fn new(state: AppState) -> Self {
+    pub fn new(state: CoreRuntimeState) -> Self {
         Self {
             state: Arc::new(state),
         }
@@ -40,18 +40,18 @@ impl CoreHandle {
         RustRespondService::new(
             state.provider.clone(),
             RespondExecutors {
-                query_executor: state.query_executor.clone(),
-                weather_executor: state.weather_executor.clone(),
-                train_executor: state.train_executor.clone(),
-                radar_executor: state.radar_executor.clone(),
+                query_executor: state.executors.query_executor.clone(),
+                weather_executor: state.executors.weather_executor.clone(),
+                train_executor: state.executors.train_executor.clone(),
+                radar_executor: state.executors.radar_executor.clone(),
             },
             RespondStores {
-                memory_store: state.memory_store.clone(),
-                session_store: state.session_store.clone(),
-                todo_store: state.todo_store.clone(),
-                notification_store: state.notification_store.clone(),
-                rss_store: state.rss_store.clone(),
-                display_name_store: state.display_name_store.clone(),
+                memory_store: state.stores.memory_store.clone(),
+                session_store: state.stores.session_store.clone(),
+                todo_store: state.stores.todo_store.clone(),
+                notification_store: state.stores.notification_store.clone(),
+                rss_store: state.stores.rss_store.clone(),
+                display_name_store: state.stores.display_name_store.clone(),
             },
             state.rss_fetcher.clone(),
             state.knowledge_index.clone(),

--- a/qq-maid-core/src/service/tests/mod.rs
+++ b/qq-maid-core/src/service/tests/mod.rs
@@ -1,42 +1,22 @@
 use super::*;
-use std::{
-    fs,
-    sync::{
-        Arc, Mutex,
-        atomic::{AtomicUsize, Ordering},
-    },
-    time::Duration,
-};
+use std::{sync::atomic::Ordering, time::Duration};
 
 use qq_maid_common::identity_context::IdentitySource;
 
 use crate::{
-    config::{
-        AppConfig, DEFAULT_BIGMODEL_BASE_URL, DEFAULT_DEEPSEEK_BASE_URL,
-        DEFAULT_RSS_SUMMARY_MAX_CHARS, DailyReminderTime, OpenAiApiMode, ProviderMode,
-    },
     error::LlmError,
-    provider::{
-        ChatOutcome, LlmProvider, LlmStream, LlmStreamEvent, ToolCallingProtocol, ToolChatRequest,
-        status::{UpstreamStatus, observe_provider},
-        types::{ChatRequest, ModelRoute, TokenUsage},
-    },
+    provider::{LlmStreamEvent, ToolCallingProtocol},
     runtime::{
-        knowledge::KnowledgeIndex,
         pending::PendingOperation,
-        prompt::PromptConfig,
-        query::{QueryExecutor, QueryOutcome, QueryRequest},
         respond::{RespondPlan, RespondRequest, RespondResponse},
-        rss::{RssFetchConfig, RssFetcher, RssStore},
-        session::{SessionMeta, SessionStore},
+        session::SessionMeta,
         todo::{TodoItemDraft, TodoStore, TodoTimePrecision},
-        tools::{RadarExecutor, RadarSnapshot, RadarTarget},
-        train::{TrainExecutor, TrainSchedule, TrainScheduleRequest},
-        weather::{WeatherExecutor, WeatherOutcome, WeatherRequest},
     },
-    storage::{APP_MIGRATIONS, database::SqliteDatabase, knowledge::KnowledgeStore},
     util::metrics::LlmMetrics,
 };
+
+mod support;
+use support::*;
 
 #[test]
 fn private_conversation_derives_private_scope() {
@@ -318,7 +298,7 @@ fn core_plan_routes_todo_context_reference_after_recent_list_to_tool_loop() {
     let provider =
         TestProvider::replying("工具回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_tool_calling(provider, 5, true);
-    let session_store = state.session_store.clone();
+    let session_store = state.stores.session_store.clone();
     let meta = SessionMeta::new(
         private_scope(),
         Some("u1".to_owned()),
@@ -372,7 +352,7 @@ fn core_plan_keeps_pending_confirmation_immediate() {
     let provider =
         TestProvider::replying("unused").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_tool_calling(provider, 5, true);
-    let session_store = state.session_store.clone();
+    let session_store = state.stores.session_store.clone();
     let meta = SessionMeta::new(
         private_scope(),
         Some("u1".to_owned()),
@@ -459,7 +439,7 @@ fn core_plan_keeps_group_plain_chat_streaming_even_when_group_switch_enabled() {
 async fn upstream_check_calls_provider_without_creating_session() {
     let provider = TestProvider::replying("OK");
     let state = test_state(provider.clone(), 5);
-    let session_store = state.session_store.clone();
+    let session_store = state.stores.session_store.clone();
     let service = CoreHandle::new(state);
 
     service.upstream_check().await.unwrap();
@@ -514,7 +494,7 @@ async fn chat_stream_forwards_text_delta_and_completed_from_same_stream() {
         }),
     ]);
     let state = test_state(provider.clone(), 5);
-    let session_store = state.session_store.clone();
+    let session_store = state.stores.session_store.clone();
     let service = CoreHandle::new(state);
     let CoreRespondOutput::Stream(mut stream) =
         service.respond(private_request("hello")).await.unwrap()
@@ -768,7 +748,7 @@ async fn core_private_simple_todo_queries_use_deterministic_path() {
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_tool_calling(provider.clone(), 5, true);
     let owner = TodoStore::owner(Some("u1"), private_scope());
-    let todo_store = state.todo_store.clone();
+    let todo_store = state.stores.todo_store.clone();
     todo_store
         .create(
             &owner,
@@ -877,532 +857,4 @@ async fn core_unsupported_provider_capability_keeps_plain_stream_path() {
     assert_eq!(response.text.as_deref(), Some("未适配 provider 普通回复"));
     assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
     assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
-}
-
-async fn collect_stream_failure(
-    output: Result<CoreRespondOutput, CoreError>,
-) -> CoreRespondFailure {
-    let CoreRespondOutput::Stream(mut stream) = output.unwrap() else {
-        panic!("expected stream output");
-    };
-    collect_failure_without_text_delta(&mut stream).await
-}
-
-async fn collect_failure_without_text_delta(stream: &mut CoreResponseStream) -> CoreRespondFailure {
-    while let Some(event) = stream.recv().await {
-        match event {
-            CoreResponseEvent::Status(_) => {}
-            CoreResponseEvent::Failed(failure) => return failure,
-            CoreResponseEvent::TextDelta(delta) => {
-                panic!("unexpected text delta before failure: {delta}");
-            }
-            CoreResponseEvent::Completed(response) => {
-                panic!("unexpected completed response before failure: {response:?}");
-            }
-        }
-    }
-    panic!("stream ended without failure");
-}
-
-async fn collect_stream_completed(output: Result<CoreRespondOutput, CoreError>) -> CoreResponse {
-    let mut stream = expect_stream(output.unwrap());
-    while let Some(event) = stream.recv().await {
-        if let CoreResponseEvent::Completed(response) = event {
-            return *response;
-        }
-    }
-    panic!("stream ended without completed response");
-}
-
-async fn collect_completed_without_text_delta(stream: &mut CoreResponseStream) -> CoreResponse {
-    while let Some(event) = stream.recv().await {
-        match event {
-            CoreResponseEvent::Status(_) => {}
-            CoreResponseEvent::Completed(response) => return *response,
-            CoreResponseEvent::TextDelta(delta) => {
-                panic!("unexpected text delta before completed response: {delta}");
-            }
-            CoreResponseEvent::Failed(failure) => panic!("unexpected failure: {failure:?}"),
-        }
-    }
-    panic!("stream ended without completed response");
-}
-
-fn expect_stream(output: CoreRespondOutput) -> CoreResponseStream {
-    let CoreRespondOutput::Stream(stream) = output else {
-        panic!("expected stream output");
-    };
-    stream
-}
-
-#[derive(Clone)]
-enum ProviderBehavior {
-    Reply(String),
-    Stream(Vec<Result<LlmStreamEvent, LlmError>>),
-    Error(LlmError),
-    Delayed { reply: String, delay: Duration },
-}
-
-#[derive(Clone)]
-struct TestProvider {
-    behavior: ProviderBehavior,
-    requests: Arc<Mutex<Vec<ChatRequest>>>,
-    calls: Arc<AtomicUsize>,
-    tool_calls: Arc<AtomicUsize>,
-    tool_protocol: Option<ToolCallingProtocol>,
-    stream_enabled: bool,
-}
-
-impl TestProvider {
-    fn replying(reply: &str) -> Self {
-        Self::new(ProviderBehavior::Reply(reply.to_owned()))
-    }
-
-    fn failing(error: LlmError) -> Self {
-        Self::new(ProviderBehavior::Error(error))
-    }
-
-    fn streaming(events: Vec<Result<LlmStreamEvent, LlmError>>) -> Self {
-        Self::new(ProviderBehavior::Stream(events)).with_stream_enabled(true)
-    }
-
-    fn delayed(reply: &str, delay: Duration) -> Self {
-        Self::new(ProviderBehavior::Delayed {
-            reply: reply.to_owned(),
-            delay,
-        })
-    }
-
-    fn new(behavior: ProviderBehavior) -> Self {
-        Self {
-            behavior,
-            requests: Arc::new(Mutex::new(Vec::new())),
-            calls: Arc::new(AtomicUsize::new(0)),
-            tool_calls: Arc::new(AtomicUsize::new(0)),
-            tool_protocol: None,
-            stream_enabled: false,
-        }
-    }
-
-    fn with_stream_enabled(mut self, enabled: bool) -> Self {
-        self.stream_enabled = enabled;
-        self
-    }
-
-    fn with_tool_protocol(mut self, protocol: ToolCallingProtocol) -> Self {
-        self.tool_protocol = Some(protocol);
-        self
-    }
-
-    fn requests(&self) -> Vec<ChatRequest> {
-        self.requests.lock().unwrap().clone()
-    }
-}
-
-#[async_trait::async_trait]
-impl LlmProvider for TestProvider {
-    async fn chat(&self, req: ChatRequest) -> Result<ChatOutcome, LlmError> {
-        self.calls.fetch_add(1, Ordering::SeqCst);
-        self.requests.lock().unwrap().push(req);
-        match &self.behavior {
-            ProviderBehavior::Reply(reply) => Ok(chat_outcome(reply)),
-            ProviderBehavior::Stream(events) => {
-                let reply = events
-                    .iter()
-                    .filter_map(|event| match event {
-                        Ok(LlmStreamEvent::TextDelta(delta)) => Some(delta.as_str()),
-                        _ => None,
-                    })
-                    .collect::<String>();
-                Ok(chat_outcome(&reply))
-            }
-            ProviderBehavior::Error(error) => Err(error.clone()),
-            ProviderBehavior::Delayed { reply, delay } => {
-                tokio::time::sleep(*delay).await;
-                Ok(chat_outcome(reply))
-            }
-        }
-    }
-
-    async fn stream_chat(&self, req: ChatRequest) -> Result<LlmStream, LlmError> {
-        self.calls.fetch_add(1, Ordering::SeqCst);
-        self.requests.lock().unwrap().push(req);
-        match &self.behavior {
-            ProviderBehavior::Reply(reply) => Ok(Box::pin(futures::stream::iter(vec![
-                Ok(LlmStreamEvent::TextDelta(reply.clone())),
-                Ok(LlmStreamEvent::Completed {
-                    usage: None,
-                    finish_reason: None,
-                    fallback_used: false,
-                }),
-            ]))),
-            ProviderBehavior::Stream(events) => {
-                Ok(Box::pin(futures::stream::iter(events.to_vec())))
-            }
-            ProviderBehavior::Error(error) => Err(error.clone()),
-            ProviderBehavior::Delayed { reply, delay } => {
-                let reply = reply.clone();
-                let delay = *delay;
-                Ok(Box::pin(futures::stream::unfold(
-                    (0_u8, reply, delay),
-                    |(state, reply, delay)| async move {
-                        if state == 0 {
-                            tokio::time::sleep(delay).await;
-                            return Some((
-                                Ok(LlmStreamEvent::TextDelta(reply)),
-                                (1, String::new(), delay),
-                            ));
-                        }
-                        if state == 1 {
-                            return Some((
-                                Ok(LlmStreamEvent::Completed {
-                                    usage: None,
-                                    finish_reason: None,
-                                    fallback_used: false,
-                                }),
-                                (2, String::new(), delay),
-                            ));
-                        }
-                        None
-                    },
-                )))
-            }
-        }
-    }
-
-    fn tool_calling_protocol(&self, _model: Option<&str>) -> Option<ToolCallingProtocol> {
-        self.tool_protocol
-    }
-
-    async fn chat_with_tools(&self, req: ToolChatRequest) -> Result<ChatOutcome, LlmError> {
-        self.tool_calls.fetch_add(1, Ordering::SeqCst);
-        self.requests.lock().unwrap().push(req.chat);
-        match &self.behavior {
-            ProviderBehavior::Reply(reply) => Ok(chat_outcome(reply)),
-            ProviderBehavior::Stream(events) => {
-                let reply = events
-                    .iter()
-                    .filter_map(|event| match event {
-                        Ok(LlmStreamEvent::TextDelta(delta)) => Some(delta.as_str()),
-                        _ => None,
-                    })
-                    .collect::<String>();
-                Ok(chat_outcome(&reply))
-            }
-            ProviderBehavior::Error(error) => Err(error.clone()),
-            ProviderBehavior::Delayed { reply, delay } => {
-                tokio::time::sleep(*delay).await;
-                Ok(chat_outcome(reply))
-            }
-        }
-    }
-
-    fn name(&self) -> &str {
-        "test-provider"
-    }
-
-    fn model(&self) -> &str {
-        "test-model"
-    }
-
-    fn stream_enabled(&self) -> bool {
-        self.stream_enabled
-    }
-}
-
-struct EmptyQueryExecutor;
-
-#[async_trait::async_trait]
-impl QueryExecutor for EmptyQueryExecutor {
-    async fn query(&self, _req: QueryRequest) -> Result<QueryOutcome, LlmError> {
-        Err(LlmError::provider("query unused", "query"))
-    }
-
-    fn provider_name(&self) -> &'static str {
-        "empty-query"
-    }
-}
-
-struct EmptyWeatherExecutor;
-
-#[async_trait::async_trait]
-impl WeatherExecutor for EmptyWeatherExecutor {
-    async fn weather(&self, _req: WeatherRequest) -> Result<WeatherOutcome, LlmError> {
-        Err(LlmError::provider("weather unused", "weather"))
-    }
-
-    fn provider_name(&self) -> &'static str {
-        "empty-weather"
-    }
-}
-
-struct EmptyTrainExecutor;
-
-#[async_trait::async_trait]
-impl TrainExecutor for EmptyTrainExecutor {
-    async fn query_train_schedule(
-        &self,
-        _req: TrainScheduleRequest,
-    ) -> Result<TrainSchedule, LlmError> {
-        Err(LlmError::provider("train unused", "train"))
-    }
-
-    fn provider_name(&self) -> &'static str {
-        "empty-train"
-    }
-}
-
-struct EmptyRadarExecutor;
-
-#[async_trait::async_trait]
-impl RadarExecutor for EmptyRadarExecutor {
-    async fn radar(&self, _target: RadarTarget) -> Result<RadarSnapshot, LlmError> {
-        Err(LlmError::provider("radar unused", "radar"))
-    }
-
-    fn provider_name(&self) -> &'static str {
-        "empty-radar"
-    }
-}
-
-fn private_request(text: &str) -> CoreRequest {
-    CoreRequest {
-        text: text.to_owned(),
-        input_parts: Vec::new(),
-        quoted: None,
-        mentions: Vec::new(),
-        tools_visible_snapshot: None,
-        platform: Platform::QqOfficial,
-        account_id: Some("app-1".to_owned()),
-        actor: CoreActor {
-            user_id: Some("u1".to_owned()),
-            union_id: None,
-            display_name: None,
-            group_member_role: None,
-            is_bot: false,
-            identity_source: IdentitySource::Event,
-        },
-        conversation: CoreConversation::Private {
-            peer_id: "u1".to_owned(),
-        },
-    }
-}
-
-fn private_scope() -> &'static str {
-    "platform:qq_official:account:app-1:private:u1"
-}
-
-fn group_request(text: &str) -> CoreRequest {
-    CoreRequest {
-        text: text.to_owned(),
-        input_parts: Vec::new(),
-        quoted: None,
-        mentions: Vec::new(),
-        tools_visible_snapshot: None,
-        platform: Platform::QqOfficial,
-        account_id: Some("app-1".to_owned()),
-        actor: CoreActor {
-            user_id: Some("u1".to_owned()),
-            union_id: None,
-            display_name: None,
-            group_member_role: None,
-            is_bot: false,
-            identity_source: IdentitySource::Event,
-        },
-        conversation: CoreConversation::Group {
-            group_id: "g1".to_owned(),
-        },
-    }
-}
-
-fn wechat_service_request(text: &str) -> CoreRequest {
-    CoreRequest {
-        text: text.to_owned(),
-        input_parts: Vec::new(),
-        quoted: None,
-        mentions: Vec::new(),
-        tools_visible_snapshot: None,
-        platform: Platform::WechatService,
-        account_id: Some("gh-service".to_owned()),
-        actor: CoreActor {
-            user_id: Some("openid-u1".to_owned()),
-            union_id: None,
-            display_name: None,
-            group_member_role: None,
-            is_bot: false,
-            identity_source: IdentitySource::Event,
-        },
-        conversation: CoreConversation::ServiceAccount {
-            account_id: Some("gh_test".to_owned()),
-            peer_id: "openid-u1".to_owned(),
-        },
-    }
-}
-
-fn chat_outcome(reply: &str) -> ChatOutcome {
-    ChatOutcome {
-        reply: reply.to_owned(),
-        metrics: LlmMetrics {
-            provider: "test-provider".to_owned(),
-            model: "test-model".to_owned(),
-            stream: false,
-            ttfe_ms: None,
-            ttft_ms: None,
-            total_latency_ms: 1,
-        },
-        usage: Some(TokenUsage {
-            input_tokens: None,
-            cached_input_tokens: None,
-            output_tokens: None,
-            total_tokens: None,
-        }),
-        fallback_used: false,
-        executed_tools: Vec::new(),
-        tool_results: Vec::new(),
-    }
-}
-
-fn test_state(
-    provider: TestProvider,
-    request_timeout_seconds: u64,
-) -> crate::http::routes::AppState {
-    test_state_with_tool_calling(provider, request_timeout_seconds, false)
-}
-
-fn test_state_with_tool_calling(
-    provider: TestProvider,
-    request_timeout_seconds: u64,
-    tool_calling_enabled: bool,
-) -> crate::http::routes::AppState {
-    test_state_with_group_tool_calling(
-        provider,
-        request_timeout_seconds,
-        tool_calling_enabled,
-        false,
-    )
-}
-
-fn test_state_with_group_tool_calling(
-    provider: TestProvider,
-    request_timeout_seconds: u64,
-    tool_calling_enabled: bool,
-    tool_calling_group_enabled: bool,
-) -> crate::http::routes::AppState {
-    let base_dir = std::env::temp_dir().join(format!(
-        "qq-maid-core-service-test-{}",
-        uuid::Uuid::new_v4()
-    ));
-    let prompt_dir = base_dir.join("prompts");
-    fs::create_dir_all(&prompt_dir).unwrap();
-    for file_name in crate::runtime::prompt::PROMPT_FILES {
-        fs::write(prompt_dir.join(file_name), format!("{file_name} content")).unwrap();
-    }
-    let app_db_file = base_dir.join("app.db");
-    let database = SqliteDatabase::open(&app_db_file, APP_MIGRATIONS).unwrap();
-    let knowledge_dir = base_dir.join("knowledge");
-    let knowledge_index =
-        KnowledgeIndex::new(KnowledgeStore::new(database.clone()), &knowledge_dir);
-    knowledge_index.sync().unwrap();
-    let upstream_status = UpstreamStatus::default();
-
-    crate::http::routes::AppState {
-        config: AppConfig {
-            provider: ProviderMode::OpenAi,
-            model: "test-model".to_owned(),
-            model_route: ModelRoute::parse_config("test-model", "LLM_MODEL").unwrap(),
-            agent_config: crate::config::AgentRuntimeConfig::from_legacy(
-                crate::config::LegacyAgentConfig {
-                    main_model: "test-model".to_owned(),
-                    max_output_tokens: 1200,
-                    openai_search_model: "test-search".to_owned(),
-                    tool_calling_enabled,
-                    group_tool_calling_enabled: tool_calling_group_enabled,
-                    tool_calling_max_rounds: 3,
-                    group_llm_model: None,
-                    private_llm_model: None,
-                    group_openai_search_model: None,
-                    private_openai_search_model: None,
-                },
-            )
-            .unwrap(),
-            title_model: None,
-            todo_model: None,
-            memory_model: None,
-            compact_model: None,
-            translation_model: None,
-            openai_search_model: "test-search".to_owned(),
-            openai_api_key: Some("test".to_owned()),
-            openai_base_url: None,
-            openai_api_mode: OpenAiApiMode::Auto,
-            deepseek_api_key: None,
-            deepseek_base_url: DEFAULT_DEEPSEEK_BASE_URL.to_owned(),
-            deepseek_model: "deepseek-chat".to_owned(),
-            bigmodel_api_key: None,
-            bigmodel_base_url: DEFAULT_BIGMODEL_BASE_URL.to_owned(),
-            bigmodel_model: "glm-5.2".to_owned(),
-            stream: false,
-            request_timeout_seconds,
-            ttft_warn_seconds: 30,
-            media_max_bytes: crate::config::DEFAULT_MEDIA_MAX_BYTES,
-            max_output_tokens: 1200,
-            max_concurrent_responses: 4,
-            tool_calling_enabled,
-            tool_calling_group_enabled,
-            tool_calling_max_rounds: 3,
-            context_budget: qq_maid_llm::context_budget::ContextBudgetConfig {
-                context_window_chars: crate::config::DEFAULT_AGENT_CONTEXT_CHAR_LIMIT as usize,
-                output_reserve_chars: crate::config::DEFAULT_AGENT_CONTEXT_OUTPUT_RESERVE_CHARS
-                    as usize,
-                protected_recent_turns: crate::config::DEFAULT_AGENT_CONTEXT_PROTECTED_RECENT_TURNS
-                    as usize,
-            },
-            tool_result_max_chars: crate::config::DEFAULT_AGENT_TOOL_RESULT_CHAR_LIMIT as usize,
-            status_display_name: crate::config::DEFAULT_STATUS_DISPLAY_NAME.to_owned(),
-            server_host: "127.0.0.1".to_owned(),
-            server_port: 8787,
-            app_db_file: app_db_file.to_string_lossy().into_owned(),
-            sqlite_pool_size: crate::storage::database::DEFAULT_SQLITE_POOL_SIZE,
-            rss_enabled: false,
-            rss_poll_interval_seconds: 300,
-            rss_http_timeout_seconds: 15,
-            rss_max_body_bytes: 2 * 1024 * 1024,
-            rss_max_push_per_feed: 3,
-            rss_summary_max_chars: DEFAULT_RSS_SUMMARY_MAX_CHARS,
-            rss_seen_retention: 500,
-            rss_push_max_failures: 3,
-            rss_push_message_type: "markdown".to_owned(),
-            todo_daily_reminder_enabled: false,
-            todo_daily_reminder_time: DailyReminderTime { hour: 9, minute: 0 },
-            rss_allow_private_urls: true,
-            prompt_dir: prompt_dir.to_string_lossy().into_owned(),
-            prompt_dir_uses_builtin_defaults: false,
-            knowledge_dir: knowledge_dir.to_string_lossy().into_owned(),
-            qweather_api_key: "test".to_owned(),
-            qweather_api_host: "https://api.qweather.com".to_owned(),
-            qweather_geo_host: "https://geoapi.qweather.com".to_owned(),
-            web_console_enabled: false,
-            web_console_allowed_origins: Vec::new(),
-        },
-        provider: observe_provider(Arc::new(provider), upstream_status.clone()),
-        upstream_status,
-        query_executor: Arc::new(EmptyQueryExecutor),
-        weather_executor: Arc::new(EmptyWeatherExecutor),
-        train_executor: Arc::new(EmptyTrainExecutor),
-        radar_executor: Arc::new(EmptyRadarExecutor),
-        memory_store: crate::runtime::memory::MemoryStore::new(database.clone()),
-        session_store: SessionStore::new(database.clone()),
-        todo_store: TodoStore::new(database.clone()),
-        notification_store: crate::storage::notification::NotificationOutboxStore::new(
-            database.clone(),
-        ),
-        rss_store: RssStore::new(database.clone()),
-        rss_fetcher: RssFetcher::new(RssFetchConfig {
-            allow_private_networks: true,
-            ..RssFetchConfig::default()
-        })
-        .unwrap(),
-        knowledge_index,
-        prompt_config: PromptConfig::new(prompt_dir),
-        display_name_store: crate::runtime::display_name::DisplayNameStore::new(database),
-    }
 }

--- a/qq-maid-core/src/service/tests/support.rs
+++ b/qq-maid-core/src/service/tests/support.rs
@@ -1,0 +1,575 @@
+use std::{
+    fs,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use qq_maid_common::identity_context::IdentitySource;
+
+use crate::{
+    app::{CoreExecutors, CoreRuntimeState, CoreStores},
+    config::{
+        AppConfig, DEFAULT_BIGMODEL_BASE_URL, DEFAULT_DEEPSEEK_BASE_URL,
+        DEFAULT_RSS_SUMMARY_MAX_CHARS, DailyReminderTime, OpenAiApiMode, ProviderMode,
+    },
+    error::LlmError,
+    provider::{
+        ChatOutcome, LlmProvider, LlmStream, LlmStreamEvent, ToolCallingProtocol, ToolChatRequest,
+        status::{UpstreamStatus, observe_provider},
+        types::{ChatRequest, ModelRoute, TokenUsage},
+    },
+    runtime::{
+        knowledge::KnowledgeIndex,
+        prompt::PromptConfig,
+        query::{QueryExecutor, QueryOutcome, QueryRequest},
+        rss::{RssFetchConfig, RssFetcher, RssStore},
+        session::SessionStore,
+        tools::{RadarExecutor, RadarSnapshot, RadarTarget},
+        train::{TrainExecutor, TrainSchedule, TrainScheduleRequest},
+        weather::{WeatherExecutor, WeatherOutcome, WeatherRequest},
+    },
+    service::{
+        CoreActor, CoreConversation, CoreError, CoreRequest, CoreRespondFailure, CoreRespondOutput,
+        CoreResponse, CoreResponseEvent, CoreResponseStream, Platform,
+    },
+    storage::{APP_MIGRATIONS, database::SqliteDatabase, knowledge::KnowledgeStore},
+    util::metrics::LlmMetrics,
+};
+
+pub(super) async fn collect_stream_failure(
+    output: Result<CoreRespondOutput, CoreError>,
+) -> CoreRespondFailure {
+    let CoreRespondOutput::Stream(mut stream) = output.unwrap() else {
+        panic!("expected stream output");
+    };
+    collect_failure_without_text_delta(&mut stream).await
+}
+
+pub(super) async fn collect_failure_without_text_delta(
+    stream: &mut CoreResponseStream,
+) -> CoreRespondFailure {
+    while let Some(event) = stream.recv().await {
+        match event {
+            CoreResponseEvent::Status(_) => {}
+            CoreResponseEvent::Failed(failure) => return failure,
+            CoreResponseEvent::TextDelta(delta) => {
+                panic!("unexpected text delta before failure: {delta}");
+            }
+            CoreResponseEvent::Completed(response) => {
+                panic!("unexpected completed response before failure: {response:?}");
+            }
+        }
+    }
+    panic!("stream ended without failure");
+}
+
+pub(super) async fn collect_stream_completed(
+    output: Result<CoreRespondOutput, CoreError>,
+) -> CoreResponse {
+    let mut stream = expect_stream(output.unwrap());
+    while let Some(event) = stream.recv().await {
+        if let CoreResponseEvent::Completed(response) = event {
+            return *response;
+        }
+    }
+    panic!("stream ended without completed response");
+}
+
+pub(super) async fn collect_completed_without_text_delta(
+    stream: &mut CoreResponseStream,
+) -> CoreResponse {
+    while let Some(event) = stream.recv().await {
+        match event {
+            CoreResponseEvent::Status(_) => {}
+            CoreResponseEvent::Completed(response) => return *response,
+            CoreResponseEvent::TextDelta(delta) => {
+                panic!("unexpected text delta before completed response: {delta}");
+            }
+            CoreResponseEvent::Failed(failure) => panic!("unexpected failure: {failure:?}"),
+        }
+    }
+    panic!("stream ended without completed response");
+}
+
+pub(super) fn expect_stream(output: CoreRespondOutput) -> CoreResponseStream {
+    let CoreRespondOutput::Stream(stream) = output else {
+        panic!("expected stream output");
+    };
+    stream
+}
+
+#[derive(Clone)]
+enum ProviderBehavior {
+    Reply(String),
+    Stream(Vec<Result<LlmStreamEvent, LlmError>>),
+    Error(LlmError),
+    Delayed { reply: String, delay: Duration },
+}
+
+#[derive(Clone)]
+pub(super) struct TestProvider {
+    behavior: ProviderBehavior,
+    requests: Arc<Mutex<Vec<ChatRequest>>>,
+    pub(super) calls: Arc<AtomicUsize>,
+    pub(super) tool_calls: Arc<AtomicUsize>,
+    tool_protocol: Option<ToolCallingProtocol>,
+    stream_enabled: bool,
+}
+
+impl TestProvider {
+    pub(super) fn replying(reply: &str) -> Self {
+        Self::new(ProviderBehavior::Reply(reply.to_owned()))
+    }
+
+    pub(super) fn failing(error: LlmError) -> Self {
+        Self::new(ProviderBehavior::Error(error))
+    }
+
+    pub(super) fn streaming(events: Vec<Result<LlmStreamEvent, LlmError>>) -> Self {
+        Self::new(ProviderBehavior::Stream(events)).with_stream_enabled(true)
+    }
+
+    pub(super) fn delayed(reply: &str, delay: Duration) -> Self {
+        Self::new(ProviderBehavior::Delayed {
+            reply: reply.to_owned(),
+            delay,
+        })
+    }
+
+    fn new(behavior: ProviderBehavior) -> Self {
+        Self {
+            behavior,
+            requests: Arc::new(Mutex::new(Vec::new())),
+            calls: Arc::new(AtomicUsize::new(0)),
+            tool_calls: Arc::new(AtomicUsize::new(0)),
+            tool_protocol: None,
+            stream_enabled: false,
+        }
+    }
+
+    pub(super) fn with_stream_enabled(mut self, enabled: bool) -> Self {
+        self.stream_enabled = enabled;
+        self
+    }
+
+    pub(super) fn with_tool_protocol(mut self, protocol: ToolCallingProtocol) -> Self {
+        self.tool_protocol = Some(protocol);
+        self
+    }
+
+    pub(super) fn requests(&self) -> Vec<ChatRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl LlmProvider for TestProvider {
+    async fn chat(&self, req: ChatRequest) -> Result<ChatOutcome, LlmError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.requests.lock().unwrap().push(req);
+        match &self.behavior {
+            ProviderBehavior::Reply(reply) => Ok(chat_outcome(reply)),
+            ProviderBehavior::Stream(events) => {
+                let reply = events
+                    .iter()
+                    .filter_map(|event| match event {
+                        Ok(LlmStreamEvent::TextDelta(delta)) => Some(delta.as_str()),
+                        _ => None,
+                    })
+                    .collect::<String>();
+                Ok(chat_outcome(&reply))
+            }
+            ProviderBehavior::Error(error) => Err(error.clone()),
+            ProviderBehavior::Delayed { reply, delay } => {
+                tokio::time::sleep(*delay).await;
+                Ok(chat_outcome(reply))
+            }
+        }
+    }
+
+    async fn stream_chat(&self, req: ChatRequest) -> Result<LlmStream, LlmError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.requests.lock().unwrap().push(req);
+        match &self.behavior {
+            ProviderBehavior::Reply(reply) => Ok(Box::pin(futures::stream::iter(vec![
+                Ok(LlmStreamEvent::TextDelta(reply.clone())),
+                Ok(LlmStreamEvent::Completed {
+                    usage: None,
+                    finish_reason: None,
+                    fallback_used: false,
+                }),
+            ]))),
+            ProviderBehavior::Stream(events) => {
+                Ok(Box::pin(futures::stream::iter(events.to_vec())))
+            }
+            ProviderBehavior::Error(error) => Err(error.clone()),
+            ProviderBehavior::Delayed { reply, delay } => {
+                let reply = reply.clone();
+                let delay = *delay;
+                Ok(Box::pin(futures::stream::unfold(
+                    (0_u8, reply, delay),
+                    |(state, reply, delay)| async move {
+                        if state == 0 {
+                            tokio::time::sleep(delay).await;
+                            return Some((
+                                Ok(LlmStreamEvent::TextDelta(reply)),
+                                (1, String::new(), delay),
+                            ));
+                        }
+                        if state == 1 {
+                            return Some((
+                                Ok(LlmStreamEvent::Completed {
+                                    usage: None,
+                                    finish_reason: None,
+                                    fallback_used: false,
+                                }),
+                                (2, String::new(), delay),
+                            ));
+                        }
+                        None
+                    },
+                )))
+            }
+        }
+    }
+
+    fn tool_calling_protocol(&self, _model: Option<&str>) -> Option<ToolCallingProtocol> {
+        self.tool_protocol
+    }
+
+    async fn chat_with_tools(&self, req: ToolChatRequest) -> Result<ChatOutcome, LlmError> {
+        self.tool_calls.fetch_add(1, Ordering::SeqCst);
+        self.requests.lock().unwrap().push(req.chat);
+        match &self.behavior {
+            ProviderBehavior::Reply(reply) => Ok(chat_outcome(reply)),
+            ProviderBehavior::Stream(events) => {
+                let reply = events
+                    .iter()
+                    .filter_map(|event| match event {
+                        Ok(LlmStreamEvent::TextDelta(delta)) => Some(delta.as_str()),
+                        _ => None,
+                    })
+                    .collect::<String>();
+                Ok(chat_outcome(&reply))
+            }
+            ProviderBehavior::Error(error) => Err(error.clone()),
+            ProviderBehavior::Delayed { reply, delay } => {
+                tokio::time::sleep(*delay).await;
+                Ok(chat_outcome(reply))
+            }
+        }
+    }
+
+    fn name(&self) -> &str {
+        "test-provider"
+    }
+
+    fn model(&self) -> &str {
+        "test-model"
+    }
+
+    fn stream_enabled(&self) -> bool {
+        self.stream_enabled
+    }
+}
+
+struct EmptyQueryExecutor;
+
+#[async_trait::async_trait]
+impl QueryExecutor for EmptyQueryExecutor {
+    async fn query(&self, _req: QueryRequest) -> Result<QueryOutcome, LlmError> {
+        Err(LlmError::provider("query unused", "query"))
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "empty-query"
+    }
+}
+
+struct EmptyWeatherExecutor;
+
+#[async_trait::async_trait]
+impl WeatherExecutor for EmptyWeatherExecutor {
+    async fn weather(&self, _req: WeatherRequest) -> Result<WeatherOutcome, LlmError> {
+        Err(LlmError::provider("weather unused", "weather"))
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "empty-weather"
+    }
+}
+
+struct EmptyTrainExecutor;
+
+#[async_trait::async_trait]
+impl TrainExecutor for EmptyTrainExecutor {
+    async fn query_train_schedule(
+        &self,
+        _req: TrainScheduleRequest,
+    ) -> Result<TrainSchedule, LlmError> {
+        Err(LlmError::provider("train unused", "train"))
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "empty-train"
+    }
+}
+
+struct EmptyRadarExecutor;
+
+#[async_trait::async_trait]
+impl RadarExecutor for EmptyRadarExecutor {
+    async fn radar(&self, _target: RadarTarget) -> Result<RadarSnapshot, LlmError> {
+        Err(LlmError::provider("radar unused", "radar"))
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "empty-radar"
+    }
+}
+
+pub(super) fn private_request(text: &str) -> CoreRequest {
+    CoreRequest {
+        text: text.to_owned(),
+        input_parts: Vec::new(),
+        quoted: None,
+        mentions: Vec::new(),
+        tools_visible_snapshot: None,
+        platform: Platform::QqOfficial,
+        account_id: Some("app-1".to_owned()),
+        actor: CoreActor {
+            user_id: Some("u1".to_owned()),
+            union_id: None,
+            display_name: None,
+            group_member_role: None,
+            is_bot: false,
+            identity_source: IdentitySource::Event,
+        },
+        conversation: CoreConversation::Private {
+            peer_id: "u1".to_owned(),
+        },
+    }
+}
+
+pub(super) fn private_scope() -> &'static str {
+    "platform:qq_official:account:app-1:private:u1"
+}
+
+pub(super) fn group_request(text: &str) -> CoreRequest {
+    CoreRequest {
+        text: text.to_owned(),
+        input_parts: Vec::new(),
+        quoted: None,
+        mentions: Vec::new(),
+        tools_visible_snapshot: None,
+        platform: Platform::QqOfficial,
+        account_id: Some("app-1".to_owned()),
+        actor: CoreActor {
+            user_id: Some("u1".to_owned()),
+            union_id: None,
+            display_name: None,
+            group_member_role: None,
+            is_bot: false,
+            identity_source: IdentitySource::Event,
+        },
+        conversation: CoreConversation::Group {
+            group_id: "g1".to_owned(),
+        },
+    }
+}
+
+pub(super) fn wechat_service_request(text: &str) -> CoreRequest {
+    CoreRequest {
+        text: text.to_owned(),
+        input_parts: Vec::new(),
+        quoted: None,
+        mentions: Vec::new(),
+        tools_visible_snapshot: None,
+        platform: Platform::WechatService,
+        account_id: Some("gh-service".to_owned()),
+        actor: CoreActor {
+            user_id: Some("openid-u1".to_owned()),
+            union_id: None,
+            display_name: None,
+            group_member_role: None,
+            is_bot: false,
+            identity_source: IdentitySource::Event,
+        },
+        conversation: CoreConversation::ServiceAccount {
+            account_id: Some("gh_test".to_owned()),
+            peer_id: "openid-u1".to_owned(),
+        },
+    }
+}
+
+fn chat_outcome(reply: &str) -> ChatOutcome {
+    ChatOutcome {
+        reply: reply.to_owned(),
+        metrics: LlmMetrics {
+            provider: "test-provider".to_owned(),
+            model: "test-model".to_owned(),
+            stream: false,
+            ttfe_ms: None,
+            ttft_ms: None,
+            total_latency_ms: 1,
+        },
+        usage: Some(TokenUsage {
+            input_tokens: None,
+            cached_input_tokens: None,
+            output_tokens: None,
+            total_tokens: None,
+        }),
+        fallback_used: false,
+        executed_tools: Vec::new(),
+        tool_results: Vec::new(),
+    }
+}
+
+pub(super) fn test_state(provider: TestProvider, request_timeout_seconds: u64) -> CoreRuntimeState {
+    test_state_with_tool_calling(provider, request_timeout_seconds, false)
+}
+
+pub(super) fn test_state_with_tool_calling(
+    provider: TestProvider,
+    request_timeout_seconds: u64,
+    tool_calling_enabled: bool,
+) -> CoreRuntimeState {
+    test_state_with_group_tool_calling(
+        provider,
+        request_timeout_seconds,
+        tool_calling_enabled,
+        false,
+    )
+}
+
+pub(super) fn test_state_with_group_tool_calling(
+    provider: TestProvider,
+    request_timeout_seconds: u64,
+    tool_calling_enabled: bool,
+    tool_calling_group_enabled: bool,
+) -> CoreRuntimeState {
+    let base_dir = std::env::temp_dir().join(format!(
+        "qq-maid-core-service-test-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let prompt_dir = base_dir.join("prompts");
+    fs::create_dir_all(&prompt_dir).unwrap();
+    for file_name in crate::runtime::prompt::PROMPT_FILES {
+        fs::write(prompt_dir.join(file_name), format!("{file_name} content")).unwrap();
+    }
+    let app_db_file = base_dir.join("app.db");
+    let database = SqliteDatabase::open(&app_db_file, APP_MIGRATIONS).unwrap();
+    let knowledge_dir = base_dir.join("knowledge");
+    let knowledge_index =
+        KnowledgeIndex::new(KnowledgeStore::new(database.clone()), &knowledge_dir);
+    knowledge_index.sync().unwrap();
+    let upstream_status = UpstreamStatus::default();
+
+    CoreRuntimeState {
+        config: AppConfig {
+            provider: ProviderMode::OpenAi,
+            model: "test-model".to_owned(),
+            model_route: ModelRoute::parse_config("test-model", "LLM_MODEL").unwrap(),
+            agent_config: crate::config::AgentRuntimeConfig::from_legacy(
+                crate::config::LegacyAgentConfig {
+                    main_model: "test-model".to_owned(),
+                    max_output_tokens: 1200,
+                    openai_search_model: "test-search".to_owned(),
+                    tool_calling_enabled,
+                    group_tool_calling_enabled: tool_calling_group_enabled,
+                    tool_calling_max_rounds: 3,
+                    group_llm_model: None,
+                    private_llm_model: None,
+                    group_openai_search_model: None,
+                    private_openai_search_model: None,
+                },
+            )
+            .unwrap(),
+            title_model: None,
+            todo_model: None,
+            memory_model: None,
+            compact_model: None,
+            translation_model: None,
+            openai_search_model: "test-search".to_owned(),
+            openai_api_key: Some("test".to_owned()),
+            openai_base_url: None,
+            openai_api_mode: OpenAiApiMode::Auto,
+            deepseek_api_key: None,
+            deepseek_base_url: DEFAULT_DEEPSEEK_BASE_URL.to_owned(),
+            deepseek_model: "deepseek-chat".to_owned(),
+            bigmodel_api_key: None,
+            bigmodel_base_url: DEFAULT_BIGMODEL_BASE_URL.to_owned(),
+            bigmodel_model: "glm-5.2".to_owned(),
+            stream: false,
+            request_timeout_seconds,
+            ttft_warn_seconds: 30,
+            media_max_bytes: crate::config::DEFAULT_MEDIA_MAX_BYTES,
+            max_output_tokens: 1200,
+            max_concurrent_responses: 4,
+            tool_calling_enabled,
+            tool_calling_group_enabled,
+            tool_calling_max_rounds: 3,
+            context_budget: qq_maid_llm::context_budget::ContextBudgetConfig {
+                context_window_chars: crate::config::DEFAULT_AGENT_CONTEXT_CHAR_LIMIT as usize,
+                output_reserve_chars: crate::config::DEFAULT_AGENT_CONTEXT_OUTPUT_RESERVE_CHARS
+                    as usize,
+                protected_recent_turns: crate::config::DEFAULT_AGENT_CONTEXT_PROTECTED_RECENT_TURNS
+                    as usize,
+            },
+            tool_result_max_chars: crate::config::DEFAULT_AGENT_TOOL_RESULT_CHAR_LIMIT as usize,
+            status_display_name: crate::config::DEFAULT_STATUS_DISPLAY_NAME.to_owned(),
+            server_host: "127.0.0.1".to_owned(),
+            server_port: 8787,
+            app_db_file: app_db_file.to_string_lossy().into_owned(),
+            sqlite_pool_size: crate::storage::database::DEFAULT_SQLITE_POOL_SIZE,
+            rss_enabled: false,
+            rss_poll_interval_seconds: 300,
+            rss_http_timeout_seconds: 15,
+            rss_max_body_bytes: 2 * 1024 * 1024,
+            rss_max_push_per_feed: 3,
+            rss_summary_max_chars: DEFAULT_RSS_SUMMARY_MAX_CHARS,
+            rss_seen_retention: 500,
+            rss_push_max_failures: 3,
+            rss_push_message_type: "markdown".to_owned(),
+            todo_daily_reminder_enabled: false,
+            todo_daily_reminder_time: DailyReminderTime { hour: 9, minute: 0 },
+            rss_allow_private_urls: true,
+            prompt_dir: prompt_dir.to_string_lossy().into_owned(),
+            prompt_dir_uses_builtin_defaults: false,
+            knowledge_dir: knowledge_dir.to_string_lossy().into_owned(),
+            qweather_api_key: "test".to_owned(),
+            qweather_api_host: "https://api.qweather.com".to_owned(),
+            qweather_geo_host: "https://geoapi.qweather.com".to_owned(),
+            web_console_enabled: false,
+            web_console_allowed_origins: Vec::new(),
+        },
+        provider: observe_provider(Arc::new(provider), upstream_status.clone()),
+        upstream_status,
+        executors: CoreExecutors {
+            query_executor: Arc::new(EmptyQueryExecutor),
+            weather_executor: Arc::new(EmptyWeatherExecutor),
+            train_executor: Arc::new(EmptyTrainExecutor),
+            radar_executor: Arc::new(EmptyRadarExecutor),
+        },
+        stores: CoreStores {
+            memory_store: crate::runtime::memory::MemoryStore::new(database.clone()),
+            session_store: SessionStore::new(database.clone()),
+            todo_store: crate::runtime::todo::TodoStore::new(database.clone()),
+            notification_store: crate::storage::notification::NotificationOutboxStore::new(
+                database.clone(),
+            ),
+            rss_store: RssStore::new(database.clone()),
+            display_name_store: crate::runtime::display_name::DisplayNameStore::new(database),
+        },
+        rss_fetcher: RssFetcher::new(RssFetchConfig {
+            allow_private_networks: true,
+            ..RssFetchConfig::default()
+        })
+        .unwrap(),
+        knowledge_index,
+        prompt_config: PromptConfig::new(prompt_dir),
+    }
+}


### PR DESCRIPTION
Closes #331

## 变更
- 新增 `CoreRuntimeState`、`CoreStores`、`CoreExecutors`，把 Core 业务运行时依赖从 HTTP state 中拆出。
- 新增 `CoreWorkers`，集中装配 RSS scheduler、notification worker、Todo reminder scheduler，spawn 时机仍由 `LlmRuntime` 控制。
- 将 HTTP state 收敛为 `OpsHttpState`，只保留 `/healthz`、console 和 Markdown render 需要的 provider/upstream/console 配置。
- `CoreHandle` 改为持有 `CoreRuntimeState`，不再依赖 Axum HTTP state 构造 `RustRespondService`。
- 将 `service/tests.rs` 改成目录模块：`service/tests/mod.rs` + `service/tests/support.rs`，避免同名文件和文件夹并存。

## 行为说明
- 本次主要是装配边界拆分和代码移动，不拆 Respond 编排，不新增 HTTP respond/query/memory/chat 入口。
- PushSink 缺失时的启动失败语义保持不变。
- RSS、notification worker、Todo daily reminder 的启停条件和 spawn 时机保持稳定。

## 验证
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p qq-maid-core`
- `cargo test -p qq-maid-core http::routes`
- `cargo test -p qq-maid-core service`
- `cargo test -p qq-maid-core runtime::rss`
- `cargo test -p qq-maid-core runtime::notification`
- `cargo test -p qq-maid-core runtime::todo`
- `make test-core`
- `cargo build -p qq-maid-bot`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`