### PR TITLE
refactor: 通用化可见实体快照

### DIFF
--- a/qq-maid-core/src/runtime/mod.rs
+++ b/qq-maid-core/src/runtime/mod.rs
@@ -21,4 +21,5 @@ pub mod todo_reminder;
 pub mod tools;
 pub mod train;
 pub mod translation;
+pub mod visible_entity;
 pub mod weather;

--- a/qq-maid-core/src/runtime/respond/chat_flow.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow.rs
@@ -3,7 +3,7 @@
 //! 承担 `RustRespondService` 中"兜底聊天"路径的实现：
 //! 组装 LLM 请求、发起调用、保存对话记录、自动生成会话标题等。
 
-use std::{future::Future, pin::Pin, sync::Arc};
+use std::{future::Future, pin::Pin};
 
 use serde_json::{Value, json};
 
@@ -11,8 +11,12 @@ use crate::{
     config::agent::AgentConfigSource,
     error::LlmError,
     runtime::{
-        session::{LAST_QUERY_TTL_SECONDS, SessionMeta, SessionRecord, query_is_fresh},
+        session::{SessionMeta, SessionRecord},
         tools::SelectionScope,
+        visible_entity::{
+            VisibleEntityRequestContext, todo_selection_scope_from_visible_snapshot,
+            todo_visible_entity_snapshot,
+        },
     },
 };
 
@@ -113,7 +117,7 @@ impl RustRespondService {
         let owner =
             crate::runtime::todo::TodoStore::owner(meta.user_id.as_deref(), &meta.scope_key);
         let quoted_todo_selection_scope =
-            todo_selection_scope_from_tools_visible_snapshot(&req, &owner);
+            todo_selection_scope_from_visible_entity_snapshot(&req, &owner);
         let chat_req = RespondRequest {
             session_id: session.session_id.clone(),
             purpose: RespondPurpose::Chat,
@@ -367,8 +371,8 @@ impl RustRespondService {
         // 避免回读到 conversation session 的旧快照导致跨人串用。
         let snapshot_session = standalone_interaction.as_ref().unwrap_or(&session);
         if agent_turn_shows_todo_visible_list(agent_turn_outcome.as_ref()) {
-            response.tools_visible_snapshot =
-                super::todo_flow::todo_tools_visible_snapshot(snapshot_session, Some(&meta));
+            response.visible_entity_snapshot =
+                todo_visible_entity_snapshot(snapshot_session, Some(&meta));
         }
         Ok(response)
     }
@@ -533,50 +537,25 @@ impl RustRespondService {
     }
 }
 
-fn todo_selection_scope_from_tools_visible_snapshot(
+fn todo_selection_scope_from_visible_entity_snapshot(
     req: &RespondRequest,
     owner: &crate::runtime::todo::TodoOwner,
 ) -> Option<SelectionScope> {
-    let had_quoted_lookup = req
+    let quoted_bot_lookup = req
         .quoted
         .as_ref()
         .is_some_and(|quoted| quoted.lookup_found && quoted.from_bot == Some(true));
-    let Some(snapshot) = req.tools_visible_snapshot.as_ref() else {
-        return had_quoted_lookup.then_some(SelectionScope::Blocked);
-    };
-    if snapshot.scope_key != req.scope_key
-        || snapshot
-            .owner_key
-            .as_deref()
-            .is_some_and(|key| key != owner.key)
-        || snapshot.platform != req.platform
-        || snapshot.account_id != req.account_id
-        || !query_is_fresh(&snapshot.created_at, LAST_QUERY_TTL_SECONDS)
-    {
-        return Some(SelectionScope::Blocked);
-    }
-    let mut todo_items = snapshot
-        .items
-        .iter()
-        .filter(|item| item.domain == "todo" && item.entity_kind == "todo")
-        .collect::<Vec<_>>();
-    if todo_items.is_empty() {
-        return had_quoted_lookup.then_some(SelectionScope::Blocked);
-    }
-    todo_items.sort_by_key(|item| item.visible_number);
-    if todo_items
-        .iter()
-        .enumerate()
-        .any(|(index, item)| item.visible_number != index + 1 || item.entity_id.trim().is_empty())
-    {
-        return Some(SelectionScope::Blocked);
-    }
-    Some(SelectionScope::Scoped(Arc::from(
-        todo_items
-            .into_iter()
-            .map(|item| item.entity_id.clone())
-            .collect::<Vec<_>>(),
-    )))
+    todo_selection_scope_from_visible_snapshot(
+        req.visible_entity_snapshot.as_ref(),
+        VisibleEntityRequestContext {
+            platform: &req.platform,
+            account_id: req.account_id.as_deref(),
+            scope_key: &req.scope_key,
+            owner_key: Some(owner.key.as_str()),
+            quoted_bot_lookup,
+        },
+        owner,
+    )
 }
 
 fn is_prompt_extraction_request(text: &str) -> bool {
@@ -859,7 +838,7 @@ mod prompt_protection_tests {
 #[cfg(test)]
 mod selection_scope_tests {
     use super::*;
-    use crate::service::{ToolsVisibleItem, ToolsVisibleSnapshot};
+    use crate::service::{VisibleEntityItem, VisibleEntitySnapshot};
     use qq_maid_common::input_part::QuotedMessageContext;
 
     fn quoted_from_bot(summary: &str, ref_id: &str) -> QuotedMessageContext {
@@ -878,8 +857,8 @@ mod selection_scope_tests {
         }
     }
 
-    fn todo_item(entity_id: &str, visible_number: usize) -> ToolsVisibleItem {
-        ToolsVisibleItem {
+    fn todo_item(entity_id: &str, visible_number: usize) -> VisibleEntityItem {
+        VisibleEntityItem {
             domain: "todo".to_owned(),
             entity_kind: "todo".to_owned(),
             entity_id: entity_id.to_owned(),
@@ -893,9 +872,9 @@ mod selection_scope_tests {
         scope_key: &str,
         owner_key: Option<String>,
         account_id: Option<&str>,
-        items: Vec<ToolsVisibleItem>,
-    ) -> ToolsVisibleSnapshot {
-        ToolsVisibleSnapshot {
+        items: Vec<VisibleEntityItem>,
+    ) -> VisibleEntitySnapshot {
+        VisibleEntitySnapshot {
             platform: "qq_official".to_owned(),
             account_id: account_id.map(str::to_owned),
             scope_key: scope_key.to_owned(),
@@ -913,7 +892,7 @@ mod selection_scope_tests {
         req.platform = "qq_official".to_owned();
         req.account_id = Some("app-a".to_owned());
         req.quoted = Some(quoted_from_bot("1. A", "msg-a"));
-        req.tools_visible_snapshot = Some(snapshot(
+        req.visible_entity_snapshot = Some(snapshot(
             "private:u1",
             Some("private:u1::u1".to_owned()),
             Some("app-b"),
@@ -922,7 +901,7 @@ mod selection_scope_tests {
 
         let owner = crate::runtime::todo::TodoStore::owner(Some("u1"), "private:u1");
         assert!(matches!(
-            todo_selection_scope_from_tools_visible_snapshot(&req, &owner),
+            todo_selection_scope_from_visible_entity_snapshot(&req, &owner),
             Some(SelectionScope::Blocked)
         ));
     }
@@ -943,7 +922,7 @@ mod selection_scope_tests {
         req.account_id = Some("app-1".to_owned());
         req.group_id = Some("g1".to_owned());
         req.quoted = Some(quoted_from_bot("1. 买票", "msg-a"));
-        req.tools_visible_snapshot = Some(snapshot(
+        req.visible_entity_snapshot = Some(snapshot(
             group_scope,
             Some(owner_user_a.key.clone()),
             Some("app-1"),
@@ -952,7 +931,7 @@ mod selection_scope_tests {
 
         assert!(
             matches!(
-                todo_selection_scope_from_tools_visible_snapshot(&req, &owner_user_b),
+                todo_selection_scope_from_visible_entity_snapshot(&req, &owner_user_b),
                 Some(SelectionScope::Blocked)
             ),
             "跨人 owner 的引用快照必须 Blocked，避免 B 用 A 的可见编号"
@@ -974,7 +953,7 @@ mod selection_scope_tests {
         req.account_id = Some("app-1".to_owned());
         req.group_id = Some("g2".to_owned());
         req.quoted = Some(quoted_from_bot("1. 买票", "msg-g1"));
-        req.tools_visible_snapshot = Some(snapshot(
+        req.visible_entity_snapshot = Some(snapshot(
             group_a,
             Some(owner_in_b.key.clone()),
             Some("app-1"),
@@ -983,7 +962,7 @@ mod selection_scope_tests {
 
         assert!(
             matches!(
-                todo_selection_scope_from_tools_visible_snapshot(&req, &owner_in_b),
+                todo_selection_scope_from_visible_entity_snapshot(&req, &owner_in_b),
                 Some(SelectionScope::Blocked)
             ),
             "跨群 scope 的引用快照必须 Blocked，避免跨群编号串用"

--- a/qq-maid-core/src/runtime/respond/common.rs
+++ b/qq-maid-core/src/runtime/respond/common.rs
@@ -99,7 +99,7 @@ pub(super) fn empty_respond_request() -> RespondRequest {
         input_parts: Vec::new(),
         quoted: None,
         message_context: None,
-        tools_visible_snapshot: None,
+        visible_entity_snapshot: None,
         scope_key: String::new(),
         user_id: None,
         group_member_role: None,
@@ -166,7 +166,7 @@ pub(super) fn command_response_with_stream(
         },
         usage: None,
         error: None,
-        tools_visible_snapshot: None,
+        visible_entity_snapshot: None,
     }
 }
 

--- a/qq-maid-core/src/runtime/respond/interaction_state.rs
+++ b/qq-maid-core/src/runtime/respond/interaction_state.rs
@@ -12,8 +12,9 @@ use crate::{
             valid_last_visible_todo_query,
         },
         todo::TodoStore,
+        visible_entity::visible_snapshot_has_todo_items,
     },
-    service::{CoreInboundClassification, CoreInboundKind, ToolsVisibleSnapshot},
+    service::{CoreInboundClassification, CoreInboundKind},
 };
 
 use super::{
@@ -96,7 +97,7 @@ pub(super) fn has_recent_todo_context(
     req: &RespondRequest,
     active_session: Option<&SessionRecord>,
 ) -> bool {
-    if tools_visible_snapshot_has_todo_items(req.tools_visible_snapshot.as_ref()) {
+    if visible_snapshot_has_todo_items(req.visible_entity_snapshot.as_ref()) {
         return true;
     }
 
@@ -114,15 +115,6 @@ pub(super) fn has_recent_todo_context(
 
     session.last_todo_action.as_ref().is_some_and(|action| {
         action.owner_key == owner.key && query_is_fresh(&action.created_at, LAST_QUERY_TTL_SECONDS)
-    })
-}
-
-fn tools_visible_snapshot_has_todo_items(snapshot: Option<&ToolsVisibleSnapshot>) -> bool {
-    snapshot.is_some_and(|snapshot| {
-        snapshot
-            .items
-            .iter()
-            .any(|item| item.domain == "todo" && item.entity_kind == "todo")
     })
 }
 

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -1442,7 +1442,7 @@ async fn only_list_todos_success_does_not_claim_todo_write_success() {
         .unwrap();
 
     let visible_snapshot = response
-        .tools_visible_snapshot
+        .visible_entity_snapshot
         .as_ref()
         .expect("visible list response should carry snapshot");
     assert_eq!(visible_snapshot.items.len(), 1);
@@ -1465,7 +1465,7 @@ async fn ordinary_chat_response_does_not_inherit_old_todo_visible_snapshot() {
 
     let list_response = service.respond(private_message("/todo")).await.unwrap();
     assert!(
-        list_response.tools_visible_snapshot.is_some(),
+        list_response.visible_entity_snapshot.is_some(),
         "deterministic todo list should bind its own snapshot"
     );
 
@@ -1475,7 +1475,7 @@ async fn ordinary_chat_response_does_not_inherit_old_todo_visible_snapshot() {
         .unwrap();
 
     assert!(
-        chat_response.tools_visible_snapshot.is_none(),
+        chat_response.visible_entity_snapshot.is_none(),
         "ordinary chat response must not bind stale last_todo_query"
     );
 }

--- a/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/mod.rs
@@ -9,8 +9,8 @@ use crate::{
     runtime::{
         session::{SessionMeta, SessionRecord},
         todo::{TodoItem, TodoOwner, TodoStatus, TodoStore},
+        visible_entity::todo_visible_entity_snapshot,
     },
-    service::{ToolsVisibleItem, ToolsVisibleSnapshot},
     storage::session::valid_last_visible_todo_query,
     util::time_context::{parse_single_date_expression, request_time_context},
 };
@@ -156,7 +156,7 @@ impl RustRespondService {
             .map_err(super::common::session_error)?;
         let mut response =
             super::common::command_response(reply, Some(session.session_id.clone()), Some(command));
-        response.tools_visible_snapshot = todo_tools_visible_snapshot(session, Some(meta));
+        response.visible_entity_snapshot = todo_visible_entity_snapshot(session, Some(meta));
         Ok(response)
     }
 
@@ -622,40 +622,6 @@ impl RustRespondService {
             )),
         }
     }
-}
-
-pub(in crate::runtime::respond) fn todo_tools_visible_snapshot(
-    session: &SessionRecord,
-    meta: Option<&SessionMeta>,
-) -> Option<ToolsVisibleSnapshot> {
-    let query = session.last_todo_query.as_ref()?;
-    if query.result_ids.is_empty() {
-        return None;
-    }
-    Some(ToolsVisibleSnapshot {
-        platform: meta
-            .map(|meta| meta.platform.clone())
-            .unwrap_or_else(|| session.platform.clone()),
-        account_id: meta.and_then(|meta| meta.account_id.clone()),
-        scope_key: meta
-            .map(|meta| meta.scope_key.clone())
-            .unwrap_or_else(|| session.scope_key.clone()),
-        owner_key: Some(query.owner_key.clone()),
-        created_at: query.created_at.clone(),
-        items: query
-            .result_ids
-            .iter()
-            .enumerate()
-            .map(|(index, id)| ToolsVisibleItem {
-                domain: "todo".to_owned(),
-                entity_kind: "todo".to_owned(),
-                entity_id: id.clone(),
-                visible_number: index + 1,
-                label: None,
-                status: Some(query.query_type.clone()),
-            })
-            .collect(),
-    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/qq-maid-core/src/runtime/respond/types.rs
+++ b/qq-maid-core/src/runtime/respond/types.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use crate::{
     error::ErrorInfo,
     provider::types::{ChatMessage, ReasoningEffort, TokenUsage},
-    service::ToolsVisibleSnapshot,
+    service::VisibleEntitySnapshot,
     util::metrics::LlmMetrics,
 };
 use qq_maid_common::{
@@ -75,7 +75,7 @@ pub struct RespondRequest {
     /// 引用消息绑定的工具可见实体快照。仅服务端内部用于 Tool selection scope，
     /// 不进入模型 prompt，也不作为用户可见响应序列化。
     #[serde(default, skip)]
-    pub tools_visible_snapshot: Option<ToolsVisibleSnapshot>,
+    pub visible_entity_snapshot: Option<VisibleEntitySnapshot>,
     /// 作用域键，用于隔离不同群 / 频道的会话
     #[serde(default)]
     pub scope_key: String,
@@ -180,7 +180,7 @@ impl Default for RespondRequest {
             input_parts: Vec::new(),
             quoted: None,
             message_context: None,
-            tools_visible_snapshot: None,
+            visible_entity_snapshot: None,
             scope_key: String::new(),
             user_id: None,
             group_member_role: None,
@@ -257,7 +257,7 @@ pub struct RespondResponse {
     /// 当前回复绑定的工具可见实体快照。该字段只供 Gateway 写入引用索引，
     /// 序列化时跳过，避免内部实体 ID 暴露到 HTTP/诊断面。
     #[serde(default, skip)]
-    pub tools_visible_snapshot: Option<ToolsVisibleSnapshot>,
+    pub visible_entity_snapshot: Option<VisibleEntitySnapshot>,
 }
 
 impl ChatResponse {
@@ -298,7 +298,7 @@ impl RespondResponse {
             metrics: chat.metrics,
             usage: chat.usage,
             error: chat.error,
-            tools_visible_snapshot: None,
+            visible_entity_snapshot: None,
         }
     }
 }

--- a/qq-maid-core/src/runtime/visible_entity.rs
+++ b/qq-maid-core/src/runtime/visible_entity.rs
@@ -1,0 +1,150 @@
+//! 用户可见实体快照与引用绑定解析。
+//!
+//! Core 在这里定义“出站消息展示了哪些可被编号引用的业务实体”。具体业务域只负责
+//! 把自己的查询结果投影为 visible entity；Gateway 只保存并按消息引用回填快照，不解析
+//! `domain` / `entity_kind` 的业务含义。
+
+use std::sync::Arc;
+
+use crate::{
+    runtime::{
+        session::{LAST_QUERY_TTL_SECONDS, SessionMeta, SessionRecord, query_is_fresh},
+        todo::TodoOwner,
+        tools::SelectionScope,
+    },
+    service::{VisibleEntityItem, VisibleEntitySnapshot},
+};
+
+const TODO_DOMAIN: &str = "todo";
+const TODO_ENTITY_KIND: &str = "todo";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum VisibleEntitySelectionScope {
+    Scoped(Arc<[String]>),
+    Blocked,
+}
+
+pub(crate) struct VisibleEntityRequestContext<'a> {
+    pub(crate) platform: &'a str,
+    pub(crate) account_id: Option<&'a str>,
+    pub(crate) scope_key: &'a str,
+    pub(crate) owner_key: Option<&'a str>,
+    pub(crate) quoted_bot_lookup: bool,
+}
+
+/// 从消息引用回填的通用 visible snapshot 中解析某个业务域的可见编号作用域。
+///
+/// 有过机器人消息引用查找但快照缺失或不匹配时返回 `Blocked`，调用方必须禁止回退到
+/// 当前 session 的旧编号快照，避免跨 owner / account / conversation 误操作。
+pub(crate) fn selection_scope_from_visible_snapshot(
+    snapshot: Option<&VisibleEntitySnapshot>,
+    context: VisibleEntityRequestContext<'_>,
+    domain: &str,
+    entity_kind: &str,
+) -> Option<VisibleEntitySelectionScope> {
+    let Some(snapshot) = snapshot else {
+        return context
+            .quoted_bot_lookup
+            .then_some(VisibleEntitySelectionScope::Blocked);
+    };
+    if snapshot.scope_key != context.scope_key
+        || snapshot.platform != context.platform
+        || snapshot.account_id.as_deref() != context.account_id
+        || snapshot
+            .owner_key
+            .as_deref()
+            .is_some_and(|key| Some(key) != context.owner_key)
+        || !query_is_fresh(&snapshot.created_at, LAST_QUERY_TTL_SECONDS)
+    {
+        return Some(VisibleEntitySelectionScope::Blocked);
+    }
+
+    let mut items = snapshot
+        .items
+        .iter()
+        .filter(|item| item.domain == domain && item.entity_kind == entity_kind)
+        .collect::<Vec<_>>();
+    if items.is_empty() {
+        return context
+            .quoted_bot_lookup
+            .then_some(VisibleEntitySelectionScope::Blocked);
+    }
+    items.sort_by_key(|item| item.visible_number);
+    if items
+        .iter()
+        .enumerate()
+        .any(|(index, item)| item.visible_number != index + 1 || item.entity_id.trim().is_empty())
+    {
+        return Some(VisibleEntitySelectionScope::Blocked);
+    }
+    Some(VisibleEntitySelectionScope::Scoped(Arc::from(
+        items
+            .into_iter()
+            .map(|item| item.entity_id.clone())
+            .collect::<Vec<_>>(),
+    )))
+}
+
+pub(crate) fn visible_snapshot_has_domain_items(
+    snapshot: Option<&VisibleEntitySnapshot>,
+    domain: &str,
+    entity_kind: &str,
+) -> bool {
+    snapshot.is_some_and(|snapshot| {
+        snapshot
+            .items
+            .iter()
+            .any(|item| item.domain == domain && item.entity_kind == entity_kind)
+    })
+}
+
+pub(crate) fn todo_visible_entity_snapshot(
+    session: &SessionRecord,
+    meta: Option<&SessionMeta>,
+) -> Option<VisibleEntitySnapshot> {
+    let query = session.last_todo_query.as_ref()?;
+    if query.result_ids.is_empty() {
+        return None;
+    }
+    Some(VisibleEntitySnapshot {
+        platform: meta
+            .map(|meta| meta.platform.clone())
+            .unwrap_or_else(|| session.platform.clone()),
+        account_id: meta.and_then(|meta| meta.account_id.clone()),
+        scope_key: meta
+            .map(|meta| meta.scope_key.clone())
+            .unwrap_or_else(|| session.scope_key.clone()),
+        owner_key: Some(query.owner_key.clone()),
+        created_at: query.created_at.clone(),
+        items: query
+            .result_ids
+            .iter()
+            .enumerate()
+            .map(|(index, id)| VisibleEntityItem {
+                domain: TODO_DOMAIN.to_owned(),
+                entity_kind: TODO_ENTITY_KIND.to_owned(),
+                entity_id: id.clone(),
+                visible_number: index + 1,
+                label: None,
+                status: Some(query.query_type.clone()),
+            })
+            .collect(),
+    })
+}
+
+pub(crate) fn todo_selection_scope_from_visible_snapshot(
+    snapshot: Option<&VisibleEntitySnapshot>,
+    context: VisibleEntityRequestContext<'_>,
+    _owner: &TodoOwner,
+) -> Option<SelectionScope> {
+    selection_scope_from_visible_snapshot(snapshot, context, TODO_DOMAIN, TODO_ENTITY_KIND).map(
+        |scope| match scope {
+            VisibleEntitySelectionScope::Scoped(ids) => SelectionScope::Scoped(ids),
+            VisibleEntitySelectionScope::Blocked => SelectionScope::Blocked,
+        },
+    )
+}
+
+pub(crate) fn visible_snapshot_has_todo_items(snapshot: Option<&VisibleEntitySnapshot>) -> bool {
+    visible_snapshot_has_domain_items(snapshot, TODO_DOMAIN, TODO_ENTITY_KIND)
+}

--- a/qq-maid-core/src/service/handle.rs
+++ b/qq-maid-core/src/service/handle.rs
@@ -247,7 +247,7 @@ impl From<CoreRequest> for RespondRequest {
             input_parts: value.input_parts,
             quoted: value.quoted,
             message_context: Some(message_context),
-            tools_visible_snapshot: value.tools_visible_snapshot,
+            visible_entity_snapshot: value.visible_entity_snapshot,
             scope_key,
             user_id: value.actor.user_id,
             group_member_role: value
@@ -274,7 +274,7 @@ impl From<RespondResponse> for CoreResponse {
             session_id: value.session_id,
             command: value.command,
             diagnostics: value.diagnostics,
-            tools_visible_snapshot: value.tools_visible_snapshot,
+            visible_entity_snapshot: value.visible_entity_snapshot,
         }
     }
 }

--- a/qq-maid-core/src/service/tests/mod.rs
+++ b/qq-maid-core/src/service/tests/mod.rs
@@ -25,7 +25,7 @@ fn private_conversation_derives_private_scope() {
         input_parts: Vec::new(),
         quoted: None,
         mentions: Vec::new(),
-        tools_visible_snapshot: None,
+        visible_entity_snapshot: None,
         platform: Platform::QqOfficial,
         account_id: Some("app-1".to_owned()),
         actor: CoreActor {
@@ -59,7 +59,7 @@ fn group_conversation_derives_group_scope_without_member_split() {
         input_parts: Vec::new(),
         quoted: None,
         mentions: Vec::new(),
-        tools_visible_snapshot: None,
+        visible_entity_snapshot: None,
         platform: Platform::QqOfficial,
         account_id: Some("app-1".to_owned()),
         actor: CoreActor {
@@ -107,7 +107,7 @@ fn message_context_is_derived_from_core_request_authoritative_fields() {
             is_self: false,
             confidence: MentionConfidence::Event,
         }],
-        tools_visible_snapshot: None,
+        visible_entity_snapshot: None,
         platform: Platform::QqOfficial,
         account_id: Some("app-1".to_owned()),
         actor: CoreActor {
@@ -178,7 +178,7 @@ fn core_response_keeps_public_fields_from_respond_response() {
         session_id: Some("session-1".to_owned()),
         command: Some("chat".to_owned()),
         diagnostics: Some(serde_json::json!({"k":"v"})),
-        tools_visible_snapshot: None,
+        visible_entity_snapshot: None,
         metrics: LlmMetrics {
             provider: "test".to_owned(),
             model: "test".to_owned(),

--- a/qq-maid-core/src/service/tests/support.rs
+++ b/qq-maid-core/src/service/tests/support.rs
@@ -337,7 +337,7 @@ pub(super) fn private_request(text: &str) -> CoreRequest {
         input_parts: Vec::new(),
         quoted: None,
         mentions: Vec::new(),
-        tools_visible_snapshot: None,
+        visible_entity_snapshot: None,
         platform: Platform::QqOfficial,
         account_id: Some("app-1".to_owned()),
         actor: CoreActor {
@@ -364,7 +364,7 @@ pub(super) fn group_request(text: &str) -> CoreRequest {
         input_parts: Vec::new(),
         quoted: None,
         mentions: Vec::new(),
-        tools_visible_snapshot: None,
+        visible_entity_snapshot: None,
         platform: Platform::QqOfficial,
         account_id: Some("app-1".to_owned()),
         actor: CoreActor {
@@ -387,7 +387,7 @@ pub(super) fn wechat_service_request(text: &str) -> CoreRequest {
         input_parts: Vec::new(),
         quoted: None,
         mentions: Vec::new(),
-        tools_visible_snapshot: None,
+        visible_entity_snapshot: None,
         platform: Platform::WechatService,
         account_id: Some("gh-service".to_owned()),
         actor: CoreActor {

--- a/qq-maid-core/src/service/types.rs
+++ b/qq-maid-core/src/service/types.rs
@@ -33,7 +33,7 @@ pub struct CoreRequest {
     pub text: String,
     pub input_parts: Vec<MessageInputPart>,
     pub quoted: Option<QuotedMessageContext>,
-    pub tools_visible_snapshot: Option<ToolsVisibleSnapshot>,
+    pub visible_entity_snapshot: Option<VisibleEntitySnapshot>,
     pub platform: Platform,
     pub account_id: Option<String>,
     pub actor: CoreActor,
@@ -47,17 +47,17 @@ pub struct CoreRequest {
 /// Core 内各 Tool 消费自己认识的 `domain`，例如 Todo Tool 使用 `todo` 项把
 /// visible number 映射回服务端内部实体 ID。
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ToolsVisibleSnapshot {
+pub struct VisibleEntitySnapshot {
     pub platform: String,
     pub account_id: Option<String>,
     pub scope_key: String,
     pub owner_key: Option<String>,
-    pub items: Vec<ToolsVisibleItem>,
+    pub items: Vec<VisibleEntityItem>,
     pub created_at: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ToolsVisibleItem {
+pub struct VisibleEntityItem {
     pub domain: String,
     pub entity_kind: String,
     pub entity_id: String,
@@ -134,7 +134,7 @@ pub struct CoreResponse {
     pub session_id: Option<String>,
     pub command: Option<String>,
     pub diagnostics: Option<serde_json::Value>,
-    pub tools_visible_snapshot: Option<ToolsVisibleSnapshot>,
+    pub visible_entity_snapshot: Option<VisibleEntitySnapshot>,
 }
 
 #[derive(Debug)]

--- a/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
@@ -45,7 +45,7 @@ impl CoreService for MockCore {
             session_id: None,
             command: None,
             diagnostics: None,
-            tools_visible_snapshot: None,
+            visible_entity_snapshot: None,
         })))
     }
 
@@ -1163,7 +1163,7 @@ fn request_scope_key_matches_private_message() {
         input_parts: Vec::new(),
         quoted: None,
         mentions: Vec::new(),
-        tools_visible_snapshot: None,
+        visible_entity_snapshot: None,
         platform: Platform::QqOfficial,
         account_id: None,
         actor: CoreActor {

--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -96,7 +96,7 @@ async fn send_c2c_respond_response(
         config,
         sent_ids,
         text,
-        response.tools_visible_snapshot.clone(),
+        response.visible_entity_snapshot.clone(),
     );
     Ok(())
 }
@@ -107,7 +107,7 @@ pub(super) fn record_c2c_bot_outbound_refs(
     config: &AppConfig,
     sent_ids: impl IntoIterator<Item = SendMessageIds>,
     text: &str,
-    tools_visible_snapshot: Option<qq_maid_core::service::ToolsVisibleSnapshot>,
+    visible_entity_snapshot: Option<qq_maid_core::service::VisibleEntitySnapshot>,
 ) {
     let inbound = platform::qq_official::inbound_from_c2c(message);
     let mut index = ref_index.lock().unwrap();
@@ -118,7 +118,7 @@ pub(super) fn record_c2c_bot_outbound_refs(
             &inbound.conversation,
             sent_id.ref_index_lookup_id().map(str::to_owned),
             text,
-            tools_visible_snapshot.clone(),
+            visible_entity_snapshot.clone(),
         );
     }
 }
@@ -525,7 +525,7 @@ where
                         config,
                         sent_ids,
                         text,
-                        response.tools_visible_snapshot.clone(),
+                        response.visible_entity_snapshot.clone(),
                     );
                 }
                 return Ok(DisabledStreamOutcome::Completed);
@@ -812,7 +812,7 @@ mod tests {
             session_id: None,
             command: None,
             diagnostics: None,
-            tools_visible_snapshot: None,
+            visible_entity_snapshot: None,
         }
     }
 

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -369,7 +369,7 @@ fn record_group_bot_outbound_send(
         &inbound.conversation,
         sent_ids.ref_index_lookup_id().map(str::to_owned),
         text,
-        response.tools_visible_snapshot.clone(),
+        response.visible_entity_snapshot.clone(),
     );
 }
 
@@ -595,7 +595,7 @@ mod tests {
                 session_id: None,
                 command: None,
                 diagnostics: None,
-                tools_visible_snapshot: None,
+                visible_entity_snapshot: None,
             },
             respond_calls,
         }))
@@ -1013,7 +1013,7 @@ mod tests {
             session_id: None,
             command: None,
             diagnostics: None,
-            tools_visible_snapshot: None,
+            visible_entity_snapshot: None,
         };
         let sent_ids = SendMessageIds {
             message_id: Some("qq_msg_1".to_owned()),
@@ -1062,7 +1062,7 @@ mod tests {
             session_id: None,
             command: None,
             diagnostics: None,
-            tools_visible_snapshot: None,
+            visible_entity_snapshot: None,
         };
 
         let message_only_cache = Arc::new(Mutex::new(BotOutboundCache::default()));

--- a/qq-maid-gateway-rs/src/gateway/platform/core.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/core.rs
@@ -44,7 +44,7 @@ pub(crate) fn to_core_request(
         text,
         input_parts: effective_input_parts(inbound),
         quoted: inbound.quoted.clone(),
-        tools_visible_snapshot: inbound.tools_visible_snapshot.clone(),
+        visible_entity_snapshot: inbound.visible_entity_snapshot.clone(),
         platform,
         account_id: inbound.account_id.clone(),
         actor: CoreActor {
@@ -189,7 +189,7 @@ mod tests {
             }),
             mentions: Vec::new(),
             mentioned_bot: false,
-            tools_visible_snapshot: None,
+            visible_entity_snapshot: None,
         };
 
         assert_eq!(render_text_for_core(&inbound), "看一下\n[图片]");
@@ -233,7 +233,7 @@ mod tests {
             }),
             mentions: Vec::new(),
             mentioned_bot: false,
-            tools_visible_snapshot: None,
+            visible_entity_snapshot: None,
         };
 
         let rendered = render_text_for_core(&inbound);

--- a/qq-maid-gateway-rs/src/gateway/platform/member_enrich.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/member_enrich.rs
@@ -328,7 +328,7 @@ mod tests {
                 confidence: MentionConfidence::Event,
             }],
             mentioned_bot: false,
-            tools_visible_snapshot: None,
+            visible_entity_snapshot: None,
         }
     }
 

--- a/qq-maid-gateway-rs/src/gateway/platform/model.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/model.rs
@@ -7,7 +7,7 @@ use qq_maid_common::{
     identity_context::{IdentitySource, MentionIdentity},
     input_part::{MessageInputPart, MessageMedia, QuotedMessageContext},
 };
-use qq_maid_core::service::ToolsVisibleSnapshot;
+use qq_maid_core::service::VisibleEntitySnapshot;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Platform {
@@ -44,7 +44,7 @@ pub(crate) struct InboundMessage {
     pub(crate) attachments: Vec<Attachment>,
     pub(crate) quoted: Option<QuotedMessageContext>,
     /// 引用消息关联的工具可见实体快照。Gateway 只透传，不解析具体 domain。
-    pub(crate) tools_visible_snapshot: Option<ToolsVisibleSnapshot>,
+    pub(crate) visible_entity_snapshot: Option<VisibleEntitySnapshot>,
     /// 平台事件提供的结构化 mention 目标。文本 @昵称 不应伪造成稳定身份。
     pub(crate) mentions: Vec<MentionIdentity>,
     pub(crate) mentioned_bot: bool,
@@ -232,7 +232,7 @@ mod tests {
             quoted: None,
             mentions: Vec::new(),
             mentioned_bot: false,
-            tools_visible_snapshot: None,
+            visible_entity_snapshot: None,
         };
 
         assert_eq!(
@@ -290,7 +290,7 @@ mod tests {
             }),
             mentions: Vec::new(),
             mentioned_bot: true,
-            tools_visible_snapshot: None,
+            visible_entity_snapshot: None,
         };
 
         assert_eq!(
@@ -328,7 +328,7 @@ mod tests {
             quoted: None,
             mentions: Vec::new(),
             mentioned_bot: false,
-            tools_visible_snapshot: None,
+            visible_entity_snapshot: None,
         };
         let group = InboundMessage {
             platform: Platform::QqOfficial,
@@ -346,7 +346,7 @@ mod tests {
             quoted: None,
             mentions: Vec::new(),
             mentioned_bot: true,
-            tools_visible_snapshot: None,
+            visible_entity_snapshot: None,
         };
 
         assert_eq!(
@@ -378,7 +378,7 @@ mod tests {
             quoted: None,
             mentions: Vec::new(),
             mentioned_bot: false,
-            tools_visible_snapshot: None,
+            visible_entity_snapshot: None,
         };
 
         assert_eq!(inbound.dedupe_message_key(), None);

--- a/qq-maid-gateway-rs/src/gateway/platform/qq_official.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/qq_official.rs
@@ -43,7 +43,7 @@ pub(crate) fn inbound_from_c2c(message: &C2cMessage) -> InboundMessage {
                 message.current_msg_idx.as_deref(),
             )
         }),
-        tools_visible_snapshot: None,
+        visible_entity_snapshot: None,
         mentions: Vec::new(),
         mentioned_bot: false,
     }
@@ -77,7 +77,7 @@ pub(crate) fn inbound_from_group(message: &GroupMessage) -> InboundMessage {
                 message.current_msg_idx.as_deref(),
             )
         }),
-        tools_visible_snapshot: None,
+        visible_entity_snapshot: None,
         mentions: mentions_from_group_event(message),
         mentioned_bot: message.event_type == GroupEventType::GroupAtMessage
             || message.mentions.iter().any(|mention| mention.is_you),

--- a/qq-maid-gateway-rs/src/gateway/platform/wechat_service.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/wechat_service.rs
@@ -98,7 +98,7 @@ pub(crate) fn inbound_from_text_message(message: &WechatTextMessage) -> InboundM
         },
         attachments: Vec::new(),
         quoted: None,
-        tools_visible_snapshot: None,
+        visible_entity_snapshot: None,
         mentions: Vec::new(),
         mentioned_bot: false,
     }

--- a/qq-maid-gateway-rs/src/gateway/push.rs
+++ b/qq-maid-gateway-rs/src/gateway/push.rs
@@ -472,7 +472,7 @@ mod tests {
                 is_bot: false,
                 source: qq_maid_common::identity_context::IdentitySource::Event,
             },
-            tools_visible_snapshot: None,
+            visible_entity_snapshot: None,
             message_id: "gm-quote".to_owned(),
             current_msg_idx: None,
             timestamp: None,

--- a/qq-maid-gateway-rs/src/gateway/ref_index/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/ref_index/mod.rs
@@ -1,6 +1,8 @@
-//! QQ 引用消息短时索引。
+//! QQ 消息引用绑定索引。
 //!
-//! 这里只保存平台归一化后的消息摘要，解决 QQ `REFIDX_*` 无法回查原文的问题。
+//! 这里只保存平台归一化后的消息摘要、引用发送者和机器人出站消息绑定的可见实体快照，
+//! 解决 QQ `REFIDX_*` 无法回查原文或出站展示实体的问题。Gateway 不解析 Todo、Memory、RSS
+//! 等业务 domain；引用命中后仅把 `VisibleEntitySnapshot` 原样回填给 Core。
 //! 当前实现为进程内缓存，重启后历史引用会失效；业务上下文组装仍由 Core 完成。
 
 pub(crate) mod qq;
@@ -12,7 +14,7 @@ use std::{
 
 use qq_maid_common::identity_context::MessageActorContext;
 use qq_maid_common::input_part::{MediaStatus, MessageInputPart, MessageMedia, QuotedMediaSummary};
-use qq_maid_core::service::{CoreGroupMemberRole, ToolsVisibleSnapshot};
+use qq_maid_core::service::{CoreGroupMemberRole, VisibleEntitySnapshot};
 use tracing::{debug, warn};
 
 use super::{
@@ -43,7 +45,8 @@ pub(crate) struct RefIndexEntry {
     /// 被引用消息发送者身份摘要；insert_inbound 时从 actor 回填，供后续 quote 查询回填 sender。
     pub(crate) sender: Option<MessageActorContext>,
     pub(crate) timestamp: Option<String>,
-    pub(crate) tools_visible_snapshot: Option<ToolsVisibleSnapshot>,
+    /// 机器人出站消息展示的通用可见实体快照；Gateway 只按 ref id 绑定和回填，不解析业务域。
+    pub(crate) visible_entity_snapshot: Option<VisibleEntitySnapshot>,
 }
 
 #[derive(Debug, Default)]
@@ -67,7 +70,7 @@ impl RefIndex {
         conversation: &ConversationTarget,
         ref_index_id: Option<String>,
         text: &str,
-        tools_visible_snapshot: Option<ToolsVisibleSnapshot>,
+        visible_entity_snapshot: Option<VisibleEntitySnapshot>,
     ) {
         let Some(ref_index_id) = clean_optional(ref_index_id) else {
             return;
@@ -88,7 +91,7 @@ impl RefIndex {
                 ..Default::default()
             }),
             timestamp: None,
-            tools_visible_snapshot,
+            visible_entity_snapshot,
         };
         let key = key_for(platform, account_id, conversation, &ref_index_id);
         self.insert_key(key, entry);
@@ -117,7 +120,8 @@ impl RefIndex {
             quoted.from_bot = Some(entry.from_bot);
             quoted.sender = entry.sender.clone();
             quoted.fallback_reason = None;
-            inbound.tools_visible_snapshot = entry.tools_visible_snapshot.clone();
+            // 引用命中机器人出站消息时，把出站消息绑定的可见实体快照原样交回 Core。
+            inbound.visible_entity_snapshot = entry.visible_entity_snapshot.clone();
             log_ref_index_hit("quoted_lookup", &key, entry);
         } else {
             log_ref_index_miss(&self.entries, &key);
@@ -214,7 +218,7 @@ fn entry_from_inbound(inbound: &InboundMessage) -> RefIndexEntry {
         from_bot: inbound.actor.is_bot,
         sender,
         timestamp: inbound.timestamp.clone(),
-        tools_visible_snapshot: None,
+        visible_entity_snapshot: None,
     }
 }
 
@@ -387,16 +391,16 @@ mod tests {
     use super::*;
     use qq_maid_common::identity_context::IdentitySource;
     use qq_maid_common::input_part::{MessageMedia, QuotedMessageContext};
-    use qq_maid_core::service::{ToolsVisibleItem, ToolsVisibleSnapshot};
+    use qq_maid_core::service::{VisibleEntityItem, VisibleEntitySnapshot};
 
-    fn test_snapshot(entity_id: &str) -> ToolsVisibleSnapshot {
-        ToolsVisibleSnapshot {
+    fn test_snapshot(entity_id: &str) -> VisibleEntitySnapshot {
+        VisibleEntitySnapshot {
             platform: "qq_official".to_owned(),
             account_id: Some("app".to_owned()),
             scope_key: "private:u1".to_owned(),
             owner_key: Some("private:u1".to_owned()),
             created_at: "2026-07-06T10:00:00+08:00".to_owned(),
-            items: vec![ToolsVisibleItem {
+            items: vec![VisibleEntityItem {
                 domain: "todo".to_owned(),
                 entity_kind: "todo".to_owned(),
                 entity_id: entity_id.to_owned(),
@@ -431,7 +435,7 @@ mod tests {
             quoted: None,
             mentions: Vec::new(),
             mentioned_bot: false,
-            tools_visible_snapshot: None,
+            visible_entity_snapshot: None,
         }
     }
 
@@ -700,7 +704,7 @@ mod tests {
     }
 
     #[test]
-    fn bot_outbound_tools_visible_snapshot_binds_to_refidx_not_latest_message() {
+    fn bot_outbound_visible_entity_snapshot_binds_to_refidx_not_latest_message() {
         let mut store = RefIndex::default();
         let conversation = ConversationTarget::Private {
             target_id: "user-1".to_owned(),
@@ -731,7 +735,7 @@ mod tests {
 
         assert!(quoted_a.quoted.as_ref().unwrap().lookup_found);
         assert_eq!(
-            quoted_a.tools_visible_snapshot.as_ref().unwrap().items[0].entity_id,
+            quoted_a.visible_entity_snapshot.as_ref().unwrap().items[0].entity_id,
             "todo-a-1"
         );
     }

--- a/qq-maid-gateway-rs/src/gateway/stream/delivery.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/delivery.rs
@@ -687,7 +687,7 @@ where
                                 config,
                                 sent_ids,
                                 final_content,
-                                response.tools_visible_snapshot.clone(),
+                                response.visible_entity_snapshot.clone(),
                             );
                         }
                         return Ok(C2cStreamingPhase::Completed);

--- a/qq-maid-gateway-rs/src/gateway/stream/send.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/send.rs
@@ -28,7 +28,7 @@ pub(crate) fn response_from_incomplete_stream_text(content: &str) -> RespondResp
         session_id: None,
         command: None,
         diagnostics: None,
-        tools_visible_snapshot: None,
+        visible_entity_snapshot: None,
     }
 }
 

--- a/qq-maid-gateway-rs/src/gateway/stream/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests.rs
@@ -222,7 +222,7 @@ fn respond_response(text: &str) -> RespondResponse {
         session_id: None,
         command: None,
         diagnostics: None,
-        tools_visible_snapshot: None,
+        visible_entity_snapshot: None,
     }
 }
 

--- a/qq-maid-gateway-rs/src/gateway/wechat_service/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/wechat_service/tests.rs
@@ -179,7 +179,7 @@ impl CoreService for MockCore {
             session_id: None,
             command: None,
             diagnostics: None,
-            tools_visible_snapshot: None,
+            visible_entity_snapshot: None,
         })))
     }
 

--- a/qq-maid-gateway-rs/src/render.rs
+++ b/qq-maid-gateway-rs/src/render.rs
@@ -122,7 +122,7 @@ mod tests {
             session_id: None,
             command: None,
             diagnostics: None,
-            tools_visible_snapshot: None,
+            visible_entity_snapshot: None,
         }
     }
 

--- a/qq-maid-gateway-rs/src/respond.rs
+++ b/qq-maid-gateway-rs/src/respond.rs
@@ -920,7 +920,7 @@ mod tests {
             session_id: None,
             command: None,
             diagnostics: None,
-            tools_visible_snapshot: None,
+            visible_entity_snapshot: None,
         };
 
         let text = respond_error_to_qq_text(&RespondError::Core(CoreError::new(


### PR DESCRIPTION
## 背景

Refs #333

本 PR 将当前 Todo 专属的出站可见编号快照收敛为通用 Visible Entity 机制，并明确 Gateway `ref_index` 只承担消息引用绑定与快照透传职责，不解析具体业务 domain。

## 完成边界

本 PR 完成的是 #333 中的 visible entity snapshot / quoted ref binding 收敛：

- 出站可见实体快照改为通用 `VisibleEntitySnapshot` / `VisibleEntityItem`。
- Core 统一处理 quoted outbound snapshot 的 scope / owner / platform / account / TTL 校验。
- Gateway `ref_index` 继续只做消息引用绑定和快照透传，不理解 Todo、Memory、RSS 等业务 domain。
- Todo 仍是首个 domain adapter，负责把 `last_todo_query` 投影为 visible entities，并把 visible entity scope 适配为 Todo `SelectionScope`。

本 PR 不宣称完整完成 Interaction 通用化。`last_todo_query` / `last_todo_action` / `interaction_state` 的进一步通用化，以及 Tool outcome projection 的跨 domain 抽象，建议后续拆独立 issue 处理。

## 主要改动

- 新增 `qq-maid-core/src/runtime/visible_entity.rs`，集中定义：
  - visible entity snapshot 的通用 domain/item 检测
  - quoted outbound snapshot 的 scope / owner / platform / account / TTL 校验
  - Todo domain 到 `SelectionScope` 的适配
  - Todo `last_todo_query` 到 `VisibleEntitySnapshot` 的投影
- 将 `ToolsVisibleSnapshot` / `ToolsVisibleItem` 直接改名为 `VisibleEntitySnapshot` / `VisibleEntityItem`。
- 将 Core / Gateway 间字段 `tools_visible_snapshot` 直接改名为 `visible_entity_snapshot`。
- 从 `todo_flow` 移出可见实体快照构造逻辑；Todo 作为第一个 domain adapter 保留。
- 从 `chat_flow` 移出 quoted snapshot 的通用校验逻辑，只保留“何时绑定 Todo 可见列表”的业务判断。
- 更新 Gateway `ref_index` 注释，明确它是消息引用绑定索引，只保存和回填平台归一化摘要、sender 和通用 visible entity snapshot。

## 剩余工作建议

建议后续单独拆 issue：

- `Phase E: 通用化 Interaction Snapshot 与最近操作状态`
  - 将 `last_todo_query` / `last_todo_action` 的会话状态抽象成通用 interaction snapshot / recent action 语义。
  - 保持 Todo 作为 adapter，不把 Todo 语义藏入通用层。
- `Phase F: 通用化 Tool Outcome Projection Adapter`
  - 把当前 Todo outcome projection 的领域解析边界整理为 adapter 接口。
  - 通用层只处理状态、实体与展示绑定，不解析具体业务字段。

## 拆分说明

- `chat_flow.rs` 原来接近 1000 行，并混有 quoted visible snapshot 的通用校验逻辑；本 PR 将该职责拆到 `runtime/visible_entity.rs`。
- `todo_flow/mod.rs` 原来持有 `last_todo_query -> snapshot` 投影逻辑；本 PR 移到 `runtime/visible_entity.rs`，让 Todo flow 只负责 Todo 查询与展示。
- `gateway/ref_index/mod.rs` 当前仍低于 1000 行且职责集中在引用绑定，未拆文件；本 PR 只收敛命名和注释边界。
- 本 PR 未引入 ref_index 持久化，active C2C stream 不写 ref_index 的约束保持不变。

## 验证

- `cargo fmt --all -- --check`
- `cargo check -p qq-maid-core -p qq-maid-gateway-rs`
- `cargo test -p qq-maid-core runtime::respond::tests::chat`
- `cargo test -p qq-maid-core runtime::respond::tests::todo`
- `cargo test -p qq-maid-core runtime::respond::tests::todo_tool_loop`
- `cargo test -p qq-maid-core runtime::tools::todo`
- `cargo test -p qq-maid-gateway-rs gateway::ref_index`
- `cargo test -p qq-maid-gateway-rs gateway::stream`
- `make test-core`
- `make test-gateway`
- `make test`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
