### PR TITLE
refactor: 初步收敛交互状态与工具结果投影

### DIFF
--- a/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
@@ -22,20 +22,14 @@ use crate::{
 
 use super::{
     ChatToolPlan, RespondPurpose, RespondRequest, RespondResponse, RustRespondService,
-    agent_outcome::{
-        AgentTurnOutcome, AgentTurnStatus, ResponseBlock, ToolEffect, ToolOutcomeStatus,
-    },
+    agent_outcome::{AgentTurnOutcome, AgentTurnStatus, ToolEffect, ToolOutcomeStatus},
     common::{
         SESSION_HISTORY_MESSAGE_LIMIT, command_response, empty_respond_request, memory_error,
         merge_metadata, session_error,
     },
     llm_service::{ChatService, LlmChatService, response_from_output},
     session_flow::build_session_context,
-    todo_flow::aggregate_todo_tool_results,
-    tool_presenters::{
-        tool_outcome_from_rss_result, tool_outcome_from_train_result,
-        tool_outcome_from_weather_result,
-    },
+    tool_projection::{project_tool_turn, turn_shows_todo_visible_list},
 };
 
 pub(super) use super::conversation_session::recent_session_messages;
@@ -109,7 +103,7 @@ impl RustRespondService {
         let policy = self.resolve_agent_policy(&req)?;
         // 群聊 Tool Loop 中 Todo 可见列表快照属于发起人个人交互状态：
         // #301 已让 Pending / TodoToolScope 落到 interaction session，但聚合层
-        // `build_agent_turn_outcome` 和出站快照读取仍走 conversation session，
+        // Tool outcome projection 和出站快照读取仍走 conversation session，
         // 会让群里 A 列待办后 B 的"第一条"沿用 A 的列表。这里先依据请求计算
         // interaction meta，随后在 Tool Loop 分支按该 meta 加载独立 interaction
         // session 承载写/读。`req.metadata` 会在 `chat_req` 中被 move，提前计算。
@@ -214,12 +208,8 @@ impl RustRespondService {
                 let todo_state_session: &mut SessionRecord =
                     standalone_interaction.as_mut().unwrap_or(&mut session);
 
-                let turn_outcome = build_agent_turn_outcome(
-                    &self.todo_store,
-                    todo_state_session,
-                    &owner,
-                    &output,
-                )?;
+                let turn_outcome =
+                    project_tool_turn(&self.todo_store, todo_state_session, &owner, &output)?;
                 if let Some(interaction) = standalone_interaction.as_mut() {
                     self.session_store
                         .save(interaction)
@@ -370,7 +360,7 @@ impl RustRespondService {
         // 群聊时本轮快照写在发起人的 interaction session，这里必须从同一 session 读取，
         // 避免回读到 conversation session 的旧快照导致跨人串用。
         let snapshot_session = standalone_interaction.as_ref().unwrap_or(&session);
-        if agent_turn_shows_todo_visible_list(agent_turn_outcome.as_ref()) {
+        if turn_shows_todo_visible_list(agent_turn_outcome.as_ref()) {
             response.visible_entity_snapshot =
                 todo_visible_entity_snapshot(snapshot_session, Some(&meta));
         }
@@ -632,40 +622,6 @@ fn todo_success_not_verified_output(
     }
 }
 
-fn build_agent_turn_outcome(
-    todo_store: &crate::runtime::todo::TodoStore,
-    session: &mut SessionRecord,
-    owner: &crate::runtime::todo::TodoOwner,
-    output: &super::llm_service::RespondOutput,
-) -> Result<AgentTurnOutcome, LlmError> {
-    let todo_aggregation =
-        aggregate_todo_tool_results(todo_store, session, owner, &output.tool_results)?;
-    let mut outcomes = Vec::new();
-    let mut todo_outcomes = todo_aggregation.outcomes.into_iter().peekable();
-    for (index, result) in output.tool_results.iter().enumerate() {
-        if todo_aggregation.consumed_result_indexes.contains(&index) {
-            while todo_outcomes
-                .peek()
-                .is_some_and(|(outcome_index, _)| *outcome_index == index)
-            {
-                if let Some((_, outcome)) = todo_outcomes.next() {
-                    outcomes.push(outcome);
-                }
-            }
-        } else if let Some(outcome) = tool_outcome_from_weather_result(result) {
-            outcomes.push(outcome);
-        } else if let Some(outcome) = tool_outcome_from_train_result(result) {
-            outcomes.push(outcome);
-        } else if let Some(outcome) = tool_outcome_from_rss_result(result) {
-            outcomes.push(outcome);
-        } else {
-            outcomes.push(super::agent_outcome::ToolExecutionOutcome::generic(result));
-        }
-    }
-    outcomes.extend(todo_outcomes.map(|(_, outcome)| outcome));
-    Ok(AgentTurnOutcome::from_outcomes(outcomes))
-}
-
 fn apply_agent_turn_outcome(
     output: &mut super::llm_service::RespondOutput,
     outcome: &AgentTurnOutcome,
@@ -782,19 +738,6 @@ fn generic_agent_error_code(
         };
     }
     (use_tool_loop && !todo_success_validation.passed()).then_some("todo_success_not_verified")
-}
-
-fn agent_turn_shows_todo_visible_list(outcome: Option<&AgentTurnOutcome>) -> bool {
-    outcome.is_some_and(|outcome| {
-        outcome.outcomes.iter().any(|item| {
-            item.domain == "todo"
-                && item.status == ToolOutcomeStatus::Succeeded
-                && item
-                    .blocks
-                    .iter()
-                    .any(|block| matches!(block, ResponseBlock::RelatedList(_)))
-        })
-    })
 }
 
 #[cfg(test)]

--- a/qq-maid-core/src/runtime/respond/interaction_state.rs
+++ b/qq-maid-core/src/runtime/respond/interaction_state.rs
@@ -93,29 +93,84 @@ pub(super) fn should_try_todo_flow(user_text: &str) -> bool {
         || todo_flow::is_full_todo_result_request(user_text)
 }
 
-pub(super) fn has_recent_todo_context(
-    req: &RespondRequest,
-    active_session: Option<&SessionRecord>,
-) -> bool {
-    if visible_snapshot_has_todo_items(req.visible_entity_snapshot.as_ref()) {
-        return true;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum InteractionDomain {
+    /// 当前首个接入通用交互快照的 domain；后续 domain 继续在本层扩展。
+    Todo,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct InteractionDomainState {
+    pub domain: InteractionDomain,
+    pub has_visible_snapshot: bool,
+    pub has_recent_operation: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct InteractionStateSnapshot {
+    /// Phase E 的第一步只把最近可见列表/最近操作状态包装成通用快照；
+    /// 底层 `last_todo_query` / `last_todo_action` 仍保持现有存储语义。
+    domains: Vec<InteractionDomainState>,
+}
+
+impl InteractionStateSnapshot {
+    pub(super) fn has_recent_context(&self, domain: InteractionDomain) -> bool {
+        self.domains.iter().any(|state| {
+            state.domain == domain && (state.has_visible_snapshot || state.has_recent_operation)
+        })
     }
 
+    #[cfg(test)]
+    pub(super) fn with_recent_todo_context_for_test() -> Self {
+        Self {
+            domains: vec![InteractionDomainState {
+                domain: InteractionDomain::Todo,
+                has_visible_snapshot: true,
+                has_recent_operation: false,
+            }],
+        }
+    }
+}
+
+pub(super) fn interaction_snapshot(
+    req: &RespondRequest,
+    active_session: Option<&SessionRecord>,
+) -> InteractionStateSnapshot {
+    let mut domains = Vec::new();
+    let todo_state = todo_interaction_state(req, active_session);
+    if todo_state.has_visible_snapshot || todo_state.has_recent_operation {
+        domains.push(todo_state);
+    }
+    InteractionStateSnapshot { domains }
+}
+
+fn todo_interaction_state(
+    req: &RespondRequest,
+    active_session: Option<&SessionRecord>,
+) -> InteractionDomainState {
+    let request_visible_snapshot =
+        visible_snapshot_has_todo_items(req.visible_entity_snapshot.as_ref());
     let Some(session) = active_session else {
-        return false;
+        return InteractionDomainState {
+            domain: InteractionDomain::Todo,
+            has_visible_snapshot: request_visible_snapshot,
+            has_recent_operation: false,
+        };
     };
     let owner = TodoStore::owner(req.user_id.as_deref(), &req.scope_key);
 
     let mut snapshot = session.clone();
-    let has_visible_snapshot = valid_last_visible_todo_query(&mut snapshot, &owner.key)
+    let session_visible_snapshot = valid_last_visible_todo_query(&mut snapshot, &owner.key)
         .is_some_and(|query| !query.result_ids.is_empty());
-    if has_visible_snapshot {
-        return true;
-    }
-
-    session.last_todo_action.as_ref().is_some_and(|action| {
+    let has_recent_operation = session.last_todo_action.as_ref().is_some_and(|action| {
         action.owner_key == owner.key && query_is_fresh(&action.created_at, LAST_QUERY_TTL_SECONDS)
-    })
+    });
+
+    InteractionDomainState {
+        domain: InteractionDomain::Todo,
+        has_visible_snapshot: request_visible_snapshot || session_visible_snapshot,
+        has_recent_operation,
+    }
 }
 
 pub(super) fn route_context_session<'a>(
@@ -125,10 +180,14 @@ pub(super) fn route_context_session<'a>(
 ) -> Option<&'a SessionRecord> {
     // 新 session 状态以 interaction scope 为准；旧 conversation 可见快照只作为路由提示
     // 兼容读取，不迁移、不回写，实际 Todo/Memory 状态仍落在 interaction session。
-    if has_recent_todo_context(req, active_interaction_session) {
+    if interaction_snapshot(req, active_interaction_session)
+        .has_recent_context(InteractionDomain::Todo)
+    {
         return active_interaction_session;
     }
-    if has_recent_todo_context(req, active_conversation_session) {
+    if interaction_snapshot(req, active_conversation_session)
+        .has_recent_context(InteractionDomain::Todo)
+    {
         return active_conversation_session;
     }
     active_interaction_session.or(active_conversation_session)

--- a/qq-maid-core/src/runtime/respond/mod.rs
+++ b/qq-maid-core/src/runtime/respond/mod.rs
@@ -57,6 +57,7 @@ mod tests;
 mod title;
 mod todo_flow;
 mod tool_presenters;
+mod tool_projection;
 mod tool_route;
 mod tool_runtime;
 mod train_flow;

--- a/qq-maid-core/src/runtime/respond/router.rs
+++ b/qq-maid-core/src/runtime/respond/router.rs
@@ -14,7 +14,7 @@ use super::{
     RespondPlan, RespondRequest, RustRespondService,
     common::session_error,
     interaction_state::{
-        classify_inbound_with_active, has_recent_todo_context, pending_blocks_immediate,
+        classify_inbound_with_active, interaction_snapshot, pending_blocks_immediate,
         respond_interaction_meta, respond_meta, route_context_session,
     },
     search_flow,
@@ -216,7 +216,7 @@ impl<'a> RespondRouter<'a> {
                     .tool_calling_protocol(Some(&policy.main_model))
                     .is_some(),
                 enabled_tools_available: !policy.enabled_tools.is_empty(),
-                has_recent_todo_context: has_recent_todo_context(req, active_session),
+                interaction_state: interaction_snapshot(req, active_session),
             },
         )
     }

--- a/qq-maid-core/src/runtime/respond/tool_projection.rs
+++ b/qq-maid-core/src/runtime/respond/tool_projection.rs
@@ -1,0 +1,80 @@
+//! Tool Outcome Projection Adapter 调度层。
+//!
+//! 本模块只负责把一轮 Tool Loop 的原始执行结果分派给各 domain adapter，
+//! 生成通用 `AgentTurnOutcome`。具体业务字段解析、回执渲染和 session 快照写入
+//! 仍留在各 domain adapter 内，避免聊天主流程继续理解 Todo/RSS/Weather/Train 细节。
+
+use crate::{
+    error::LlmError,
+    runtime::{
+        session::SessionRecord,
+        todo::{TodoOwner, TodoStore},
+    },
+};
+
+use super::{
+    agent_outcome::{AgentTurnOutcome, ResponseBlock, ToolExecutionOutcome, ToolOutcomeStatus},
+    llm_service::RespondOutput,
+    todo_flow::aggregate_todo_tool_results,
+    tool_presenters::{
+        tool_outcome_from_rss_result, tool_outcome_from_train_result,
+        tool_outcome_from_weather_result,
+    },
+};
+
+pub(super) fn project_tool_turn(
+    todo_store: &TodoStore,
+    session: &mut SessionRecord,
+    owner: &TodoOwner,
+    output: &RespondOutput,
+) -> Result<AgentTurnOutcome, LlmError> {
+    let todo_aggregation =
+        aggregate_todo_tool_results(todo_store, session, owner, &output.tool_results)?;
+    let mut outcomes = Vec::new();
+    let mut todo_outcomes = todo_aggregation.outcomes.into_iter().peekable();
+
+    for (index, result) in output.tool_results.iter().enumerate() {
+        if todo_aggregation.consumed_result_indexes.contains(&index) {
+            drain_todo_outcomes_for_result(index, &mut todo_outcomes, &mut outcomes);
+        } else if let Some(outcome) = tool_outcome_from_weather_result(result) {
+            outcomes.push(outcome);
+        } else if let Some(outcome) = tool_outcome_from_train_result(result) {
+            outcomes.push(outcome);
+        } else if let Some(outcome) = tool_outcome_from_rss_result(result) {
+            outcomes.push(outcome);
+        } else {
+            outcomes.push(ToolExecutionOutcome::generic(result));
+        }
+    }
+    outcomes.extend(todo_outcomes.map(|(_, outcome)| outcome));
+
+    Ok(AgentTurnOutcome::from_outcomes(outcomes))
+}
+
+pub(super) fn turn_shows_todo_visible_list(outcome: Option<&AgentTurnOutcome>) -> bool {
+    outcome.is_some_and(|outcome| {
+        outcome.outcomes.iter().any(|item| {
+            item.domain == "todo"
+                && item.status == ToolOutcomeStatus::Succeeded
+                && item
+                    .blocks
+                    .iter()
+                    .any(|block| matches!(block, ResponseBlock::RelatedList(_)))
+        })
+    })
+}
+
+fn drain_todo_outcomes_for_result(
+    result_index: usize,
+    todo_outcomes: &mut std::iter::Peekable<impl Iterator<Item = (usize, ToolExecutionOutcome)>>,
+    outcomes: &mut Vec<ToolExecutionOutcome>,
+) {
+    while todo_outcomes
+        .peek()
+        .is_some_and(|(outcome_index, _)| *outcome_index == result_index)
+    {
+        if let Some((_, outcome)) = todo_outcomes.next() {
+            outcomes.push(outcome);
+        }
+    }
+}

--- a/qq-maid-core/src/runtime/respond/tool_route.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route.rs
@@ -9,6 +9,7 @@ use crate::util::time_context;
 
 use super::{
     RespondRequest,
+    interaction_state::{InteractionDomain, InteractionStateSnapshot},
     status_hint::{StatusAction, StatusHint, StatusSubject},
 };
 
@@ -45,15 +46,15 @@ pub(super) struct ToolRouteDecision {
     pub status_hint: Option<StatusHint>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(super) struct ToolRouteContext {
     pub scene_enabled: bool,
     pub tool_calling_enabled: bool,
     pub group_tool_calling_enabled: bool,
     pub provider_supports_tool_calling: bool,
     pub enabled_tools_available: bool,
-    /// 是否存在仍在有效期内的 Todo 可见列表快照或最近单项操作。
-    pub has_recent_todo_context: bool,
+    /// 当前请求可见的通用交互状态快照，由路由层按 domain 消费。
+    pub interaction_state: InteractionStateSnapshot,
 }
 
 const TODO_OBJECT_MARKERS: &[&str] = &["待办", "代办", "任务", "提醒", "事项"];
@@ -131,8 +132,11 @@ pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> To
         );
     }
 
-    let assessment = classify_semantic_route(trimmed, ctx.has_recent_todo_context);
-    let status_hint = classify_status_hint(trimmed, ctx.has_recent_todo_context);
+    let has_recent_todo_context = ctx
+        .interaction_state
+        .has_recent_context(InteractionDomain::Todo);
+    let assessment = classify_semantic_route(trimmed, has_recent_todo_context);
+    let status_hint = classify_status_hint(trimmed, has_recent_todo_context);
     match assessment.semantic_route {
         SemanticRoute::PlainChat => decision(
             ToolLoopRoute::PlainChat,
@@ -750,13 +754,13 @@ mod tests {
             group_tool_calling_enabled: false,
             provider_supports_tool_calling: true,
             enabled_tools_available: true,
-            has_recent_todo_context: false,
+            interaction_state: InteractionStateSnapshot::default(),
         }
     }
 
     fn context_with_recent_todo() -> ToolRouteContext {
         ToolRouteContext {
-            has_recent_todo_context: true,
+            interaction_state: InteractionStateSnapshot::with_recent_todo_context_for_test(),
             ..context()
         }
     }
@@ -1079,7 +1083,7 @@ mod tests {
                     group_tool_calling_enabled: false,
                     provider_supports_tool_calling: true,
                     enabled_tools_available: true,
-                    has_recent_todo_context: false,
+                    interaction_state: InteractionStateSnapshot::default(),
                 },
             )
             .route,


### PR DESCRIPTION
## 背景

本 PR 是 #328 / #333 后续 Phase E/F 的低风险铺垫，不属于 #339 范围。#339 已在 master 合并，本 PR 基于最新 master 单独提交，避免把 VisibleEntitySnapshot / quoted ref binding / Gateway ref_index 边界收敛内容继续混入后续重构。

## 主要改动

- `qq-maid-core/src/runtime/respond.rs` -> `qq-maid-core/src/runtime/respond/mod.rs`
- `qq-maid-core/src/runtime/respond/chat_flow.rs` -> `qq-maid-core/src/runtime/respond/chat_flow/mod.rs`
- 新增 `qq-maid-core/src/runtime/respond/tool_projection.rs`，把 Tool Loop 中 `ToolExecutionResult -> AgentTurnOutcome` 的投影调度从 `chat_flow` 收口出来。
- 在 `interaction_state.rs` 新增 `InteractionStateSnapshot` / `InteractionDomainState`，先把最近可见列表 / 最近操作状态包装成通用交互状态快照。
- `tool_route.rs` 改为消费 `InteractionStateSnapshot`，不再直接接收裸的 `has_recent_todo_context` 字段。

## 文件移动说明

本 PR 中 `respond.rs -> respond/mod.rs` 与 `chat_flow.rs -> respond/chat_flow/mod.rs` 是有意的模块目录化整理，不是单纯文件搬家；目的是为后续继续拆分 Respond / ChatFlow / Tool Projection / Interaction State 提供稳定模块边界。除 `tool_projection.rs` 和 `interaction_state.rs` 相关边界收敛外，文件移动部分应保持原行为不变。

## 完成边界

本 PR 不宣称完整完成 Interaction 通用化。
本 PR 不宣称完整完成 Tool Outcome Projection Adapter。
Todo 仍是当前首个 domain。
`last_todo_query` / `last_todo_action` / `interaction_state` 的进一步通用化仍需后续继续推进。
Tool outcome projection 的跨 domain adapter 化仍需后续继续推进。

## 非目标

- 不关闭 #328 / #333。
- 不改用户可见行为。
- 不引入 ref_index 持久化。
- 不改数据库 schema。
- 不扩大 Tool Loop 进入条件。
- 不重写 Respond 编排层。

## 验收标准

- `qq-maid-core` 编译通过。
- 现有 respond/chat/todo/tool_route 相关测试通过。
- 普通聊天行为不变。
- Slash 命令行为不变。
- Todo 查询、续指、引用编号选择行为不变。
- Tool Loop 进入条件不变。
- 群聊 actor-aware interaction session 隔离不变。
- `chat_flow` 不再直接承担 Tool outcome projection 调度细节。
- `tool_route` 不再直接接收裸的 `has_recent_todo_context` 字段，而是消费 `InteractionStateSnapshot`。

## 测试

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo check -p qq-maid-core --all-features`
- `cargo test -p qq-maid-core runtime::respond::tests::chat:: --all-features`
- `cargo test -p qq-maid-core runtime::respond::tool_route::tests:: --all-features`
- `cargo test -p qq-maid-core --all-features`
- `cargo clippy -p qq-maid-core --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
