### PR TITLE
release: 准备 v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 本文档基于 [keep a changelog](https://keepachangelog.com/zh-CN/1.0.0/) 格式，记录每个已发布版本的变更。
 
+## [v0.14.0] - 2026-07-07
+
+### Release Focus
+
+* **群聊优化与 SQLite 连接池版本线**：本版本重点收敛群聊中的 pending、引用快照、Tool Loop Todo 聚合状态、入站身份上下文、群成员详情和展示名链路，降低 A/B 用户串上下文、引用旧消息错误 fallback、后续 Todo 操作选错对象的风险；同时引入 SQLite 连接池，改善长期运行时的数据库访问边界。Core runtime、Respond 编排、Visible Entity Snapshot、Interaction State / Tool Projection 的收敛作为本轮稳定性支撑继续推进。
+
+### Added
+
+* **SQLite 连接池**（PR #334）：引入统一 SQLite pool，并新增独立连接池配置。Session、Todo、Memory、RSS 等模块继续使用同一业务数据库，但运行期连接获取、并发访问和后台任务调度边界更清晰。
+
+* **群成员详情查询与身份补全**（PR #323 #324）：新增群成员详情查询接口，并在入站身份上下文链路中补全成员资料；成员详情接口不可用时走明确降级路径，不把平台资料缺失误判为业务身份变化。手动展示名改为通过 `set` 管理（PR #329），减少身份显示与业务 owner 混用。
+
+* **botmon 监控采样脚本**（PR #311 #313）：新增 `botmon.sh` 并集成到部署流程，Uptime 展示改为年月天小时分秒的可读格式。
+
+### Changed
+
+* **Core runtime 装配边界收敛**（PR #336）：收敛 runtime state、stores、executors、workers 的装配职责，减少业务模块直接理解启动细节或跨层持有状态的情况。
+
+* **Respond 编排职责拆分**（PR #337）：拆分 Respond router、command dispatcher、tool runtime、interaction state 和 conversation session 等职责，让普通聊天、slash 命令、Tool Loop、pending 确认与会话状态的边界更明确。
+
+* **Memory 直接操作与原子替换**（PR #338）：记忆新增、编辑、删除等操作改为更直接的服务端执行路径，编辑场景使用原子替换，避免模型文案替代真实持久化结果。
+
+* **Visible Entity Snapshot 通用化**（PR #339）：将 Todo 可见列表快照向通用 Visible Entity Snapshot 收敛，继续支持“第一条 / 第二条 / 刚才那个”等基于用户可见编号的后续操作，同时为后续更多实体类型复用打底。
+
+* **Tool Projection / Interaction State 边界初步收敛**（PR #341）：将工具投影和交互状态快照进一步收敛，减少 Todo 专属快照逻辑向通用交互层泄漏。剩余抽象优化已拆到 #342。
+
+* **入站身份上下文链路增强**（PR #318 #321 #324）：打通并增强入站身份上下文，收敛身份字段，把平台身份、业务 owner/scope 与显示资料的职责继续拆开，降低群聊、多入口和引用场景中串上下文的风险。
+
+* **业务 owner 与 scope 设计文档收敛**（PR #314 #316）：补充 owner 策略、群共享入口和 scope key 历史迁移评估，为后续多平台、多账号和群共享语义提供依据。
+
+### Fixed
+
+* **群聊 pending 交互隔离**（PR #308）：修复群聊 pending 交互状态可能跨用户复用的问题，并补齐 A/B 用户隔离回归测试。
+
+* **群聊引用快照绑定收紧**（PR #309 #310）：收敛引用快照中的 Todo 编号链路，补齐 owner/scope 不匹配时不得 fallback 的回归测试，降低引用旧消息或他人消息时误操作 Todo 的风险。
+
+* **群聊 Tool Loop Todo 聚合状态隔离**（PR #312）：修复群聊 Tool Loop Todo 聚合状态隔离问题，避免不同群成员的工具上下文互相影响。
+
+* **QQ 群关键词触发与 scope/identity 边界说明**（PR #304 #305）：明确 QQ 群关键词触发边界，并澄清 scope 与 identity 的职责分离，减少群聊入口行为误解。
+
+### Removed
+
+* **无效 project-status-sync workflow**（PR #322）：移除从未生效的项目状态同步 workflow，降低维护噪音。
+
+### Known Limitations
+
+* **Todo 快照内部抽象仍会继续优化**：`last_todo_query` / `last_todo_action` 仍是 Todo 专属字段，`tool_projection.rs` 仍保留 Todo 可见列表判断。当前判断是不影响用户可见正确性的架构债，后续由 #342 跟踪，不阻塞本次发布。
+
+### Internal
+
+* 根包 `qq-maid-bot`：`0.13.2` → `0.14.0`
+
 ## [v0.13.2] - 2026-07-06
 
 ### Fixed
@@ -877,6 +929,7 @@ bash scripts/deploy-local.sh
 - 移除已废弃的 Python 接入层和旧 Provider
 - rig-core 升级至 0.38.2
 
+[v0.14.0]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.13.2...v0.14.0
 [v0.13.2]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.13.1...v0.13.2
 [v0.13.1]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.13.0...v0.13.1
 [v0.13.0]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.12.1...v0.13.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,7 +1435,7 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "qq-maid-bot"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "qq-maid-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-bot"
-version = "0.13.2"
+version = "0.14.0"
 edition = "2024"
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -20,17 +20,21 @@
 
 > Rust 单进程 · 多平台入口抽象 · Provider 无关 Agent Loop · 多模态输入 · 受控长期记忆 · 主动推送 · 模型自动降级
 
-当前源码版本线：**v0.13.x：多入口、多模态与主动任务版本线**。这一版从“只会在 QQ 文本里聊天”的机器人，继续推进到能处理 QQ 图片和引用上下文、可选接入微信服务号、能主动投递 RSS / Todo 提醒，并补齐雷达查询、周期待办和多 Provider 路由的 Agent 助手。历史版本记录见 [CHANGELOG.md](./CHANGELOG.md)，实际发布包以 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 页面为准。
+当前源码版本线：**v0.14.x：群聊体验优化与 SQLite 连接池版本线**。这一版重点修复群聊引用、pending、Tool Loop Todo 聚合状态和身份上下文隔离问题，让群聊里“引用消息继续问”“完成第一条”“确认刚才那个操作”等场景更稳；同时引入 SQLite 连接池，降低长期运行中数据库访问互相阻塞的风险。Core runtime、Respond 编排和 Visible Entity Snapshot 的架构收敛作为本轮稳定性支撑继续推进。历史版本记录见 [CHANGELOG.md](./CHANGELOG.md)，实际发布包以 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 页面为准。
 
 ## 当前版本亮点
 
 | 重点 | 说明 |
 | --- | --- |
+| 群聊上下文更稳 | 收紧群聊 pending、引用快照、Tool Loop Todo 聚合状态和入站身份上下文隔离，降低 A/B 用户串上下文、引用旧消息误 fallback、后续操作选错 Todo 的风险。 |
+| 群成员身份更清楚 | 新增群成员详情查询与降级路径，入站身份上下文字段继续收敛，手动展示名改为通过 `set` 管理，减少平台身份、业务 owner 和显示名混用。 |
+| SQLite 连接池 | 统一数据库访问改为连接池模式，并提供独立 pool 配置，降低长期运行中 session、Todo、Memory、RSS 等模块抢连接或阻塞的风险。 |
+| 架构边界继续收敛 | Core runtime 的 state / stores / executors / workers 装配边界更清楚，Respond router、command dispatcher、tool runtime、interaction state 和 conversation session 继续拆分。 |
 | QQ 图片理解 | 私聊 / 群聊里的图片附件会按配置下载到本地媒体缓存，再作为多模态输入交给支持图片的模型；可以直接发截图、报错图、聊天记录图让机器人结合文字回答。 |
-| 引用上下文追问 | 回复或引用上一条消息、图片、流式回复时，会把被引用内容整理进本轮上下文，适合继续追问“这张图什么意思”“刚才那条帮我改一下”。 |
+| 引用上下文追问 | 回复或引用上一条消息、图片、流式回复时，会把被引用内容整理进本轮上下文；Gateway 的 `ref_index` 明确只承担消息引用绑定，业务快照仍由 Core 处理。 |
 | 微信服务号入口 | 可选启用微信服务号明文文本回调，支持同步文本回复和慢请求客服补发，适合把同一套 Agent 能力接到轻量微信入口。 |
 | 主动提醒与订阅 | RSS 更新和 Todo 单次提醒写入 Notification Outbox 后由后台 Worker 投递；机器人不只是被动回答，也能在订阅更新、待办到期时主动找你。 |
-| Todo 更像任务系统 | 支持今天 / 明天等日期查询、最近可见编号续操作、单次提醒和重复待办周期推进；“完成第一条”“刚才那条改到下周一”这类后续操作更稳定。 |
+| Todo 更像任务系统 | 支持今天 / 明天等日期查询、最近可见编号续操作、单次提醒和重复待办周期推进；Visible Entity Snapshot 通用化后，“完成第一条”“刚才那条改到下周一”这类后续操作继续绑定用户实际看到的列表。 |
 | AI 雷达查询 | 新增 `/rader`、`/radar`、`/雷达`，可查看 Codex Radar 和 Claude Code Radar 公开摘要，以及对应反馈入口。 |
 | 模型路线自动降级 | `LLM_PROVIDER=auto` 配合候选链可按 `openai:`、`deepseek:`、`bigmodel:`、`mimo:` 等前缀路由；未配置 Key 或调用失败时按路线尝试后备模型。 |
 | 多入口边界收敛 | QQ、微信和后续 OneBot 先进入统一入站模型，Core 只处理业务语义；平台 ID、引用、发送能力和真实投递目标留在 Gateway 边界。 |
@@ -506,7 +510,7 @@ QQ 官方机器人功能仍受平台权限、审核和接口规则限制。Linux
 
 ## 版本升级
 
-当前源码版本线为 **v0.13.x：多入口、多模态与主动任务版本线**；已发布稳定包请以 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 页面为准。版本升级前请先阅读 [CHANGELOG.md](./CHANGELOG.md)，并对比新版 `runtime/config/.env.example` 和 `runtime/config/agent.toml`。
+当前源码版本线为 **v0.14.x：群聊体验优化与 SQLite 连接池版本线**；已发布稳定包请以 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 页面为准。版本升级前请先阅读 [CHANGELOG.md](./CHANGELOG.md)，并对比新版 `runtime/config/.env.example` 和 `runtime/config/agent.toml`。
 
 从 v0.11.x 升级到当前版本线时，重点检查：默认 runtime 是否包含 `config/agent.toml`，旧 `.env` 中的 `LLM_MODEL` / `PRIVATE_LLM_MODEL` / `GROUP_LLM_MODEL` 是否仍符合预期，Todo 提醒是否只在明确需要时开启。需要处理 QQ 图片时，再检查 `QQ_MAID_MEDIA_DIR`、`QQ_MAID_MEDIA_MAX_BYTES` 和所选模型是否支持图片输入。较早版本从 v0.3.x 升级到 v0.4.0 涉及单进程架构迁移，仍需参考 [v0.4.0 迁移说明](./CHANGELOG.md#v040)。
 
@@ -530,6 +534,8 @@ QQ 官方机器人功能仍受平台权限、审核和接口规则限制。Linux
 - [x] 有 Agent 场景策略配置和模型路线 fallback
 - [x] 能处理 QQ 图片并进入多模态模型链路
 - [x] 能在引用上一条消息或图片时保留上下文
+- [x] 能隔离群聊 pending、引用快照和 Todo 后续操作上下文
+- [x] 有 SQLite 连接池支撑长期运行时的数据库访问
 - [x] 能在私聊中自主调用天气、火车、RSS 和 Todo Tool
 - [x] 能对 Todo 写操作生成可验证的确定性回执
 - [x] 能按今天 / 明天 / 指定日期查询 Todo


### PR DESCRIPTION
## 概要

准备 v0.14.0 正式版发布材料：

- 根包版本更新到 0.14.0
- CHANGELOG 新增 v0.14.0 更新总结
- README 更新为 v0.14.x：群聊体验优化与 SQLite 连接池版本线

## 发布重点

- 群聊 pending、引用快照、Tool Loop Todo 聚合状态和身份上下文隔离
- 群成员详情查询、降级路径与手动展示名管理
- SQLite 连接池
- Core runtime / Respond / Visible Entity Snapshot / Interaction State / Tool Projection 稳定性收敛
- Memory 直接操作与原子替换
- botmon 监控采样脚本

## 验证

- cargo fmt --all -- --check
- git diff --check
- cargo test --workspace --all-features
- cargo clippy --workspace --all-targets --all-features -- -D warnings
