### PR TITLE
fix: 注入手动展示名到普通聊天上下文

### DIFF
--- a/qq-maid-core/src/runtime/respond/interaction_state.rs
+++ b/qq-maid-core/src/runtime/respond/interaction_state.rs
@@ -4,6 +4,10 @@
 //! 属于 actor-aware interaction session。本模块集中这些 scope 派生和状态探测，避免路由、
 //! 命令分派和聊天流程各自复制状态判断。
 
+use qq_maid_common::identity_context::{
+    ConversationContext, IdentitySource, MessageActorContext, MessageContext,
+};
+
 use crate::{
     identity::{interaction_scope_key, parse_stable_scope_key},
     runtime::{
@@ -232,14 +236,16 @@ pub(super) fn classify_inbound_with_active(
 /// 用手动展示名增强 `message_context` 与 `quoted.sender` 中的展示名（#326）。
 ///
 /// 优先级：`manual_display_name` > 平台 `display_name` > fallback。
-/// 这里只覆盖展示名和 display_name_source，不改动任何稳定身份字段；拉取失败时静默跳过，
-/// 不阻断主流程。`meta.scope_key` 是 conversation scope，与展示名存储的绑定键一致。
+/// 这里只补齐 LLM 可见身份上下文并覆盖展示名 / display_name_source，不改动权限、
+/// owner 或 request 权威身份字段；拉取失败时静默跳过，不阻断主流程。
+/// `meta.scope_key` 是 conversation scope，与展示名存储的绑定键一致。
 pub(super) fn apply_manual_display_names(
     store: &crate::runtime::display_name::DisplayNameStore,
     meta: &SessionMeta,
     req: &mut RespondRequest,
 ) {
     let scope_key = meta.scope_key.as_str();
+    ensure_message_context_actor_identity(meta, req);
     if let Some(context) = req.message_context.as_mut() {
         if let Some(actor) = context.actor.as_mut() {
             apply_manual_display_name_to_actor(store, scope_key, actor);
@@ -253,6 +259,114 @@ pub(super) fn apply_manual_display_names(
         && let Some(sender) = &mut quoted.sender
     {
         apply_manual_display_name_to_actor(store, scope_key, sender);
+    }
+}
+
+fn ensure_message_context_actor_identity(meta: &SessionMeta, req: &mut RespondRequest) {
+    let fallback_user_id = req
+        .user_id
+        .as_deref()
+        .or(meta.user_id.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let fallback_role = req
+        .group_member_role
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    if req.message_context.is_none() {
+        req.message_context = Some(MessageContext {
+            actor: None,
+            mentions: Vec::new(),
+            conversation: fallback_conversation_context(meta),
+        });
+    }
+
+    let Some(context) = req.message_context.as_mut() else {
+        return;
+    };
+    fill_empty_conversation_context(&mut context.conversation, meta);
+
+    if context.actor.is_none() && (fallback_user_id.is_some() || fallback_role.is_some()) {
+        context.actor = Some(MessageActorContext {
+            user_id: fallback_user_id.map(str::to_owned),
+            group_member_role: fallback_role.map(str::to_owned),
+            source: IdentitySource::LegacyFallback,
+            ..Default::default()
+        });
+        return;
+    }
+
+    let Some(actor) = context.actor.as_mut() else {
+        return;
+    };
+    if actor
+        .user_id
+        .as_deref()
+        .map(str::trim)
+        .is_none_or(str::is_empty)
+        && let Some(user_id) = fallback_user_id
+    {
+        actor.user_id = Some(user_id.to_owned());
+    }
+    if actor
+        .group_member_role
+        .as_deref()
+        .map(str::trim)
+        .is_none_or(str::is_empty)
+        && let Some(role) = fallback_role
+    {
+        actor.group_member_role = Some(role.to_owned());
+    }
+}
+
+fn fallback_conversation_context(meta: &SessionMeta) -> ConversationContext {
+    ConversationContext {
+        kind: if meta.scope.trim().is_empty() {
+            "unknown".to_owned()
+        } else {
+            meta.scope.clone()
+        },
+        id: meta
+            .group_id
+            .clone()
+            .or_else(|| meta.channel_id.clone())
+            .or_else(|| meta.user_id.clone())
+            .or_else(|| Some(meta.scope_key.clone())),
+        platform: Some(meta.platform.clone()),
+        account_id: meta.account_id.clone(),
+    }
+}
+
+fn fill_empty_conversation_context(context: &mut ConversationContext, meta: &SessionMeta) {
+    let fallback = fallback_conversation_context(meta);
+    if context.kind.trim().is_empty() {
+        context.kind = fallback.kind;
+    }
+    if context
+        .id
+        .as_deref()
+        .map(str::trim)
+        .is_none_or(str::is_empty)
+    {
+        context.id = fallback.id;
+    }
+    if context
+        .platform
+        .as_deref()
+        .map(str::trim)
+        .is_none_or(str::is_empty)
+    {
+        context.platform = fallback.platform;
+    }
+    if context
+        .account_id
+        .as_deref()
+        .map(str::trim)
+        .is_none_or(str::is_empty)
+    {
+        context.account_id = fallback.account_id;
     }
 }
 

--- a/qq-maid-core/src/runtime/respond/tests/session.rs
+++ b/qq-maid-core/src/runtime/respond/tests/session.rs
@@ -276,6 +276,68 @@ async fn manual_display_name_overrides_platform_name_in_message_context() {
 }
 
 #[tokio::test]
+async fn manual_display_name_uses_request_user_id_when_message_context_actor_missing() {
+    let inspector = MockProvider::new();
+    let service = test_service_with_provider(inspector.clone());
+
+    service
+        .respond(message_in_scope("/set 昵称 雪雪", "group:g1", "u1", "g1"))
+        .await
+        .unwrap();
+
+    let mut req = message_in_scope("我是谁？", "group:g1", "u1", "g1");
+    // 模拟成员详情接口不可用或旧入口未能给 LLM 上下文补 actor：权威 req.user_id 仍应可用于读取本地展示名。
+    req.message_context = Some(qq_maid_common::identity_context::MessageContext {
+        actor: None,
+        mentions: Vec::new(),
+        conversation: qq_maid_common::identity_context::ConversationContext {
+            kind: "group".to_owned(),
+            id: Some("g1".to_owned()),
+            platform: Some("qq_official".to_owned()),
+            account_id: None,
+        },
+    });
+    service.respond(req).await.unwrap();
+    let joined = last_chat_request_text(&inspector);
+    assert!(joined.contains("昵称=雪雪"));
+    assert!(joined.contains("昵称来源=manual"));
+    assert!(joined.contains("稳定ID=u1"));
+
+    service
+        .respond(message_in_scope("/unset 昵称", "group:g1", "u1", "g1"))
+        .await
+        .unwrap();
+    let mut req = message_in_scope("我是谁？", "group:g1", "u1", "g1");
+    req.message_context = None;
+    service.respond(req).await.unwrap();
+    let joined = last_chat_request_text(&inspector);
+    assert!(!joined.contains("昵称=雪雪"));
+    assert!(!joined.contains("昵称来源=manual"));
+}
+
+#[tokio::test]
+async fn manual_display_name_does_not_grant_group_management_permission() {
+    let service = test_service();
+
+    service
+        .respond(message_in_scope("/set 昵称 群主", "group:g1", "u2", "g1"))
+        .await
+        .unwrap();
+
+    let mut req = message_in_scope(
+        "/rss add http://127.0.0.1:9/feed.xml 测试订阅",
+        "group:g1",
+        "u2",
+        "g1",
+    );
+    req.group_member_role = Some("member".to_owned());
+    let response = service.respond(req).await.unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("group_admin_required"));
+    assert!(response.text.unwrap().contains("群主或管理员"));
+}
+
+#[tokio::test]
 async fn group_manual_display_names_are_isolated_by_current_actor_user_id() {
     let inspector = MockProvider::new();
     let service = test_service_with_provider(inspector.clone());


### PR DESCRIPTION
## 背景

群聊中执行 `/set 昵称 <展示名>` 后，手动展示名已成功写入本地 `manual_display_names`，但普通聊天身份上下文可能只依赖 `message_context.actor.user_id`。当 QQ 群成员详情接口不可用、旧入口或降级路径没有补齐 actor 时，LLM 输入上下文读不到本地展示名。

## 修改

- 在普通聊天进入 LLM 前的 `apply_manual_display_names` 阶段，先用 `RespondRequest.user_id` / `SessionMeta.user_id` 补齐 LLM 可见的 actor 身份上下文。
- 保持读取 key 与 `/set 昵称` 写入一致：conversation `scope_key` + 当前 actor `user_id`。
- 只补齐 LLM 可见 `message_context`，不修改 request 权威身份字段、owner、权限或群管理角色。
- 保留 mention target / quoted sender 的手动展示名增强逻辑。
- 补充回归测试：actor 缺失时仍注入手动展示名、`/unset 昵称` 后不再注入、展示名不提升群管理权限。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p qq-maid-core --all-features`
- `cargo check -p qq-maid-core --all-features`
- `make test-core`
- `make test`
- `git diff --check`

## 说明

QQ 群成员详情接口 400 / 无权限时，仍允许 gateway 走 negative cache；本改动不伪造成员详情成功，只保证本地手动展示名读取不依赖该接口。