### PR TITLE
fix: 修复发布包缺少 botmon

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -290,7 +290,7 @@ cd runtime
 
 ## Release 包
 
-Release 包采用白名单生成，只包含统一 `qq-maid-bot` release 二进制、`botctl.sh`、`diagnose-network.sh`、`validate-runtime.sh`、`static/index.html`、本文件、`config/.env.example`、`config/agent.toml`、公开 `.example` 配置模板、`VERSION` 和空的 `data/storage/` 目录。真实 `.env`、私有 prompt、私有知识资料、SQLite 数据库、日志、pid 和 `.bak` 备份不会被写入归档。
+Release 包采用白名单生成，只包含统一 `qq-maid-bot` release 二进制、`botctl.sh`、`botmon.sh`、`diagnose-network.sh`、`validate-runtime.sh`、`static/index.html`、本文件、`config/.env.example`、`config/agent.toml`、公开 `.example` 配置模板、`VERSION` 和空的 `data/storage/` 目录。真实 `.env`、私有 prompt、私有知识资料、SQLite 数据库、日志、pid 和 `.bak` 备份不会被写入归档。
 
 GitHub Release 自动生成 `linux-x86_64`、`linux-aarch64`、`macos-x86_64`、`macos-aarch64` 和 `windows-x86_64` 包；Linux / macOS 使用 `.tar.gz`，Windows 使用 `.zip`。
 

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -79,6 +79,7 @@ check_archive_contents() {
         "${PACKAGE_NAME}/config/agent.toml" \
         "${PACKAGE_NAME}/static/index.html" \
         "${PACKAGE_NAME}/botctl.sh" \
+        "${PACKAGE_NAME}/botmon.sh" \
         "${PACKAGE_NAME}/diagnose-network.sh" \
         "${PACKAGE_NAME}/validate-runtime.sh" \
         "${PACKAGE_NAME}/qq-maid-healthcheck.sh"
@@ -99,6 +100,7 @@ main() {
 
     copy_executable "${BUILD_DIR}/qq-maid-bot${EXE_SUFFIX}" "${STAGING_DIR}/qq-maid-bot${EXE_SUFFIX}"
     copy_executable scripts/botctl.sh "${STAGING_DIR}/botctl.sh"
+    copy_executable scripts/botmon.sh "${STAGING_DIR}/botmon.sh"
     copy_executable scripts/diagnose-network.sh "${STAGING_DIR}/diagnose-network.sh"
     copy_executable scripts/validate-runtime.sh "${STAGING_DIR}/validate-runtime.sh"
     copy_executable scripts/qq-maid-healthcheck.sh "${STAGING_DIR}/qq-maid-healthcheck.sh"
@@ -138,7 +140,7 @@ main() {
             if printf '%s\n' "${zip_listing}" | grep -E '(^|[ /])\.env$|(^|[ /])app\.db$|(^|[ /])[^/]*\.db$|(^|[ /])logs/|(^|[ /])run/.*\.pid$' >/dev/null; then
                 die "archive contains forbidden runtime files"
             fi
-            for required in ".env.example" "static/index.html" "botctl.sh" "diagnose-network.sh" "validate-runtime.sh" "qq-maid-healthcheck.sh"; do
+            for required in ".env.example" "static/index.html" "botctl.sh" "botmon.sh" "diagnose-network.sh" "validate-runtime.sh" "qq-maid-healthcheck.sh"; do
                 if ! printf '%s\n' "${zip_listing}" | grep -F "${PACKAGE_NAME}/${required}" >/dev/null; then
                     die "archive missing ${required}"
                 fi
@@ -157,6 +159,7 @@ main() {
 
     test -x "${STAGING_DIR}/qq-maid-bot${EXE_SUFFIX}"
     test -x "${STAGING_DIR}/botctl.sh"
+    test -x "${STAGING_DIR}/botmon.sh"
     test -x "${STAGING_DIR}/diagnose-network.sh"
     test -x "${STAGING_DIR}/validate-runtime.sh"
     test -x "${STAGING_DIR}/qq-maid-healthcheck.sh"


### PR DESCRIPTION
## 背景

Release workflow 在 `Build runtime package` 阶段失败，日志报错：

```text
error: missing botmon.sh
```

原因是 `validate-release-runtime.sh` 已要求发布目录包含 `botmon.sh`，但 `package-release.sh` 没有把 `scripts/botmon.sh` 复制进 staging。

## 修改

- 发布打包时复制 `scripts/botmon.sh` 到 runtime 包根目录。
- tar.gz / zip 包内容校验补充 `botmon.sh`。
- runtime 发布包说明同步补充 `botmon.sh`。

## 验证

```bash
bash -n scripts/package-release.sh scripts/validate-release-runtime.sh scripts/botmon.sh
DIST_DIR=$(mktemp -d) TARGET_TRIPLE=linux-aarch64 ARCHIVE_FORMAT=tar.gz bash scripts/package-release.sh v0.14.0
git diff --check
```

本地打包输出包含 `runtime payload validation ok`，归档列表包含 `botmon.sh`。