### PR TITLE
test: 精简 Todo 测试重复构造

### DIFF
--- a/qq-maid-core/src/runtime/tools/todo/tests.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 
 use serde_json::{Value, json};
 
-use qq_maid_llm::tool::{Tool, ToolContext};
+use qq_maid_llm::{
+    error::LlmError,
+    tool::{Tool, ToolContext, ToolOutput},
+};
 
 use crate::runtime::pending::PendingOperation;
 use crate::runtime::session::{SessionMeta, SessionStore};
@@ -168,6 +171,51 @@ fn json_type_contains(value: &Value, expected: &str) -> bool {
         Some(Value::Array(values)) => values.iter().any(|value| value.as_str() == Some(expected)),
         _ => false,
     }
+}
+
+fn schema_property<'a>(schema: &'a Value, field: &str) -> &'a Value {
+    schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .and_then(|properties| properties.get(field))
+        .unwrap_or_else(|| panic!("missing schema property {field}"))
+}
+
+fn assert_nullable_type(schema: &Value, field: &str, value_type: &str, label: &str) {
+    let property = schema_property(schema, field);
+    assert!(
+        json_type_contains(property, value_type) && json_type_contains(property, "null"),
+        "{label} {field} must accept {value_type}|null"
+    );
+}
+
+fn assert_schema_max_items(schema: &Value, field: &str, expected: usize, label: &str) {
+    assert_eq!(
+        schema_property(schema, field)["maxItems"],
+        json!(expected),
+        "{label} {field} maxItems must use the shared limit"
+    );
+}
+
+fn assert_pending_todo_count(todo_store: &TodoStore, owner: &TodoOwner, expected: usize) {
+    assert_eq!(todo_store.list_pending(owner).unwrap().len(), expected);
+}
+
+fn create_batch_tool(
+    todo_store: TodoStore,
+    session_store: SessionStore,
+    notification_store: crate::storage::notification::NotificationOutboxStore,
+) -> CreateTodoTool {
+    CreateTodoTool::new(todo_store, session_store, notification_store)
+}
+
+async fn execute_batch_create(
+    create_tool: &CreateTodoTool,
+    count: usize,
+) -> Result<ToolOutput, LlmError> {
+    create_tool
+        .execute(test_context(), batch_create_arguments(count))
+        .await
 }
 
 fn tool_order_items() -> Vec<TodoItem> {
@@ -354,48 +402,17 @@ fn todo_selector_schemas_allow_null_for_unused_strict_fields() {
     ];
 
     for (tool_name, schema) in schemas {
-        let properties = schema["properties"].as_object().unwrap();
-        assert!(
-            json_type_contains(&properties["numbers"], "array")
-                && json_type_contains(&properties["numbers"], "null"),
-            "{tool_name} numbers must accept array|null"
-        );
-        assert_eq!(
-            properties["numbers"]["maxItems"],
-            json!(TODO_TOOL_MAX_NUMBERS),
-            "{tool_name} numbers maxItems must use the shared selector limit"
-        );
-        assert!(
-            json_type_contains(&properties["selection_text"], "string")
-                && json_type_contains(&properties["selection_text"], "null"),
-            "{tool_name} selection_text must accept string|null"
-        );
-        assert!(
-            json_type_contains(&properties["reference"], "string")
-                && json_type_contains(&properties["reference"], "null"),
-            "{tool_name} reference must accept string|null"
-        );
+        assert_nullable_type(&schema, "numbers", "array", tool_name);
+        assert_schema_max_items(&schema, "numbers", TODO_TOOL_MAX_NUMBERS, tool_name);
+        assert_nullable_type(&schema, "selection_text", "string", tool_name);
+        assert_nullable_type(&schema, "reference", "string", tool_name);
     }
 
     let edit_schema = EditTodoTool::new(todo_store, session_store, notification_store.clone())
         .metadata()
         .parameters;
-    assert!(json_type_contains(
-        &edit_schema["properties"]["number"],
-        "integer"
-    ));
-    assert!(json_type_contains(
-        &edit_schema["properties"]["number"],
-        "null"
-    ));
-    assert!(json_type_contains(
-        &edit_schema["properties"]["reference"],
-        "string"
-    ));
-    assert!(json_type_contains(
-        &edit_schema["properties"]["reference"],
-        "null"
-    ));
+    assert_nullable_type(&edit_schema, "number", "integer", "edit_todo");
+    assert_nullable_type(&edit_schema, "reference", "string", "edit_todo");
 }
 
 #[test]
@@ -493,9 +510,11 @@ fn create_todo_schema_uses_shared_batch_limit() {
     let schema = CreateTodoTool::new(todo_store, session_store, notification_store.clone())
         .metadata()
         .parameters;
-    assert_eq!(
-        schema["properties"]["items"]["maxItems"],
-        json!(TODO_TOOL_MAX_BATCH_CREATE_ITEMS)
+    assert_schema_max_items(
+        &schema,
+        "items",
+        TODO_TOOL_MAX_BATCH_CREATE_ITEMS,
+        "create_todo",
     );
 }
 
@@ -1159,17 +1178,9 @@ async fn create_tool_replay_with_same_call_id_does_not_duplicate_created_todo() 
 #[tokio::test]
 async fn create_tool_accepts_batch_at_contract_limit() {
     let (todo_store, session_store, notification_store, owner) = test_stores();
-    let create_tool = CreateTodoTool::new(
-        todo_store.clone(),
-        session_store,
-        notification_store.clone(),
-    );
+    let create_tool = create_batch_tool(todo_store.clone(), session_store, notification_store);
 
-    let output = create_tool
-        .execute(
-            test_context(),
-            batch_create_arguments(TODO_TOOL_MAX_BATCH_CREATE_ITEMS),
-        )
+    let output = execute_batch_create(&create_tool, TODO_TOOL_MAX_BATCH_CREATE_ITEMS)
         .await
         .unwrap()
         .value;
@@ -1179,45 +1190,27 @@ async fn create_tool_accepts_batch_at_contract_limit() {
         output["created_items"].as_array().unwrap().len(),
         TODO_TOOL_MAX_BATCH_CREATE_ITEMS
     );
-    assert_eq!(
-        todo_store.list_pending(&owner).unwrap().len(),
-        TODO_TOOL_MAX_BATCH_CREATE_ITEMS
-    );
+    assert_pending_todo_count(&todo_store, &owner, TODO_TOOL_MAX_BATCH_CREATE_ITEMS);
 }
 
 #[tokio::test]
 async fn create_tool_rejects_empty_batch_without_writes() {
     let (todo_store, session_store, notification_store, owner) = test_stores();
-    let create_tool = CreateTodoTool::new(
-        todo_store.clone(),
-        session_store,
-        notification_store.clone(),
-    );
+    let create_tool = create_batch_tool(todo_store.clone(), session_store, notification_store);
 
-    let err = create_tool
-        .execute(test_context(), batch_create_arguments(0))
-        .await
-        .unwrap_err();
+    let err = execute_batch_create(&create_tool, 0).await.unwrap_err();
 
     assert_eq!(err.code, "bad_tool_arguments");
     assert!(err.message.contains("at least one"));
-    assert!(todo_store.list_pending(&owner).unwrap().is_empty());
+    assert_pending_todo_count(&todo_store, &owner, 0);
 }
 
 #[tokio::test]
 async fn create_tool_rejects_batch_over_contract_limit_without_partial_writes() {
     let (todo_store, session_store, notification_store, owner) = test_stores();
-    let create_tool = CreateTodoTool::new(
-        todo_store.clone(),
-        session_store,
-        notification_store.clone(),
-    );
+    let create_tool = create_batch_tool(todo_store.clone(), session_store, notification_store);
 
-    let err = create_tool
-        .execute(
-            test_context(),
-            batch_create_arguments(TODO_TOOL_MAX_BATCH_CREATE_ITEMS + 1),
-        )
+    let err = execute_batch_create(&create_tool, TODO_TOOL_MAX_BATCH_CREATE_ITEMS + 1)
         .await
         .unwrap_err();
 
@@ -1227,7 +1220,7 @@ async fn create_tool_rejects_batch_over_contract_limit_without_partial_writes() 
         err.message
             .contains(&TODO_TOOL_MAX_BATCH_CREATE_ITEMS.to_string())
     );
-    assert!(todo_store.list_pending(&owner).unwrap().is_empty());
+    assert_pending_todo_count(&todo_store, &owner, 0);
 }
 
 #[tokio::test]
@@ -1235,43 +1228,17 @@ async fn create_tool_batch_limit_does_not_cap_existing_todo_total() {
     let (todo_store, session_store, notification_store, owner) = test_stores();
     for index in 0..(TODO_TOOL_MAX_BATCH_CREATE_ITEMS + 3) {
         todo_store
-            .create(
-                &owner,
-                TodoItemDraft {
-                    title: format!("已有事项 {index}"),
-                    detail: None,
-                    raw_text: None,
-                    due_date: None,
-                    due_at: None,
-                    reminder_at: None,
-                    time_precision: TodoTimePrecision::None,
-                    recurrence_kind: crate::runtime::todo::TodoRecurrenceKind::None,
-                    recurrence_interval_days: 0,
-                    recurrence_interval: 0,
-                    recurrence_unit: crate::runtime::todo::TodoRecurrenceUnit::Day,
-                },
-            )
+            .create(&owner, tool_test_draft(&format!("已有事项 {index}")))
             .unwrap();
     }
     assert!(todo_store.list_pending(&owner).unwrap().len() > TODO_TOOL_MAX_BATCH_CREATE_ITEMS);
 
-    let create_tool = CreateTodoTool::new(
-        todo_store.clone(),
-        session_store,
-        notification_store.clone(),
-    );
-    let output = create_tool
-        .execute(test_context(), batch_create_arguments(2))
-        .await
-        .unwrap()
-        .value;
+    let create_tool = create_batch_tool(todo_store.clone(), session_store, notification_store);
+    let output = execute_batch_create(&create_tool, 2).await.unwrap().value;
 
     assert_eq!(output["ok"], true);
     assert_eq!(output["created_items"].as_array().unwrap().len(), 2);
-    assert_eq!(
-        todo_store.list_pending(&owner).unwrap().len(),
-        TODO_TOOL_MAX_BATCH_CREATE_ITEMS + 5
-    );
+    assert_pending_todo_count(&todo_store, &owner, TODO_TOOL_MAX_BATCH_CREATE_ITEMS + 5);
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/storage/todo/tests.rs
+++ b/qq-maid-core/src/storage/todo/tests.rs
@@ -31,6 +31,120 @@ fn draft_with_title(title: &str) -> TodoItemDraft {
     }
 }
 
+struct DeleteByStatusFixture {
+    owner: TodoOwner,
+    other_owner: TodoOwner,
+    pending_id: String,
+    matching_id: String,
+    protected_other_status_id: String,
+    other_owner_matching_id: String,
+    protected_other_status: TodoStatus,
+}
+
+fn create_todo_for_test(store: &TodoStore, owner: &TodoOwner, title: &str) -> TodoItem {
+    store.create(owner, draft_with_title(title)).unwrap()
+}
+
+fn seed_delete_by_status_fixture(
+    store: &TodoStore,
+    delete_status: TodoStatus,
+) -> DeleteByStatusFixture {
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    let other_owner = TodoStore::owner(Some("u2"), "group:g1");
+
+    let pending = create_todo_for_test(store, &owner, "未完成");
+    let completed = create_todo_for_test(store, &owner, "已完成");
+    let cancelled = create_todo_for_test(store, &owner, "已取消");
+    let other_owner_item = create_todo_for_test(store, &other_owner, "其他用户同状态");
+
+    store.complete(&owner, &completed.id).unwrap();
+    store.cancel(&owner, &cancelled.id).unwrap();
+    match &delete_status {
+        TodoStatus::Completed => store.complete(&other_owner, &other_owner_item.id).unwrap(),
+        TodoStatus::Cancelled => store.cancel(&other_owner, &other_owner_item.id).unwrap(),
+        TodoStatus::Pending => {
+            unreachable!("terminal delete fixture only covers archived statuses")
+        }
+    };
+
+    let (matching_id, protected_other_status_id, protected_other_status) = match delete_status {
+        TodoStatus::Completed => (completed.id, cancelled.id, TodoStatus::Cancelled),
+        TodoStatus::Cancelled => (cancelled.id, completed.id, TodoStatus::Completed),
+        TodoStatus::Pending => {
+            unreachable!("terminal delete fixture only covers archived statuses")
+        }
+    };
+
+    DeleteByStatusFixture {
+        owner,
+        other_owner,
+        pending_id: pending.id,
+        matching_id,
+        protected_other_status_id,
+        other_owner_matching_id: other_owner_item.id,
+        protected_other_status,
+    }
+}
+
+fn delete_by_status_for_test(
+    store: &TodoStore,
+    owner: &TodoOwner,
+    status: TodoStatus,
+    ids: &[String],
+) -> TodoBulkDeleteOutcome {
+    match status {
+        TodoStatus::Completed => store.delete_completed_by_ids(owner, ids),
+        TodoStatus::Cancelled => store.delete_cancelled_by_ids(owner, ids),
+        TodoStatus::Pending => store.delete_pending_by_ids(owner, ids),
+    }
+    .unwrap()
+}
+
+fn assert_delete_by_status_keeps_filters(
+    store: &TodoStore,
+    fixture: &DeleteByStatusFixture,
+    delete_status: TodoStatus,
+) {
+    let outcome = delete_by_status_for_test(
+        store,
+        &fixture.owner,
+        delete_status.clone(),
+        &[
+            fixture.pending_id.clone(),
+            fixture.matching_id.clone(),
+            fixture.protected_other_status_id.clone(),
+            fixture.other_owner_matching_id.clone(),
+            "999".to_owned(),
+        ],
+    );
+
+    assert_eq!(outcome.deleted_count, 1);
+    assert_eq!(outcome.skipped_ids.len(), 4);
+
+    let own_items = store.list_all(&fixture.owner).unwrap();
+    assert!(own_items.iter().all(|item| item.id != fixture.matching_id));
+    assert_eq!(
+        own_items
+            .iter()
+            .find(|item| item.id == fixture.pending_id)
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
+    assert_eq!(
+        own_items
+            .iter()
+            .find(|item| item.id == fixture.protected_other_status_id)
+            .unwrap()
+            .status,
+        fixture.protected_other_status
+    );
+    assert_eq!(
+        store.list_all(&fixture.other_owner).unwrap()[0].status,
+        delete_status
+    );
+}
+
 #[test]
 fn infers_common_chinese_dates() {
     let ctx = fixed_context();
@@ -1210,241 +1324,15 @@ fn completed_at_filter_uses_shanghai_date_and_bulk_cancel_preserves_completed_at
 #[test]
 fn delete_cancelled_by_ids_filters_owner_scope_and_status_in_transaction() {
     let store = test_store();
-    let owner = TodoStore::owner(Some("u1"), "group:g1");
-    let other_owner = TodoStore::owner(Some("u2"), "group:g1");
+    let fixture = seed_delete_by_status_fixture(&store, TodoStatus::Cancelled);
 
-    let pending = store
-        .create(
-            &owner,
-            TodoItemDraft {
-                title: "未完成".to_owned(),
-                detail: None,
-                raw_text: None,
-                due_date: None,
-                due_at: None,
-                reminder_at: None,
-                time_precision: TodoTimePrecision::None,
-                recurrence_kind: crate::runtime::todo::TodoRecurrenceKind::None,
-                recurrence_interval_days: 0,
-                recurrence_interval: 0,
-                recurrence_unit: crate::runtime::todo::TodoRecurrenceUnit::Day,
-            },
-        )
-        .unwrap();
-    let completed = store
-        .create(
-            &owner,
-            TodoItemDraft {
-                title: "已完成".to_owned(),
-                detail: None,
-                raw_text: None,
-                due_date: None,
-                due_at: None,
-                reminder_at: None,
-                time_precision: TodoTimePrecision::None,
-                recurrence_kind: crate::runtime::todo::TodoRecurrenceKind::None,
-                recurrence_interval_days: 0,
-                recurrence_interval: 0,
-                recurrence_unit: crate::runtime::todo::TodoRecurrenceUnit::Day,
-            },
-        )
-        .unwrap();
-    let cancelled = store
-        .create(
-            &owner,
-            TodoItemDraft {
-                title: "已取消".to_owned(),
-                detail: None,
-                raw_text: None,
-                due_date: None,
-                due_at: None,
-                reminder_at: None,
-                time_precision: TodoTimePrecision::None,
-                recurrence_kind: crate::runtime::todo::TodoRecurrenceKind::None,
-                recurrence_interval_days: 0,
-                recurrence_interval: 0,
-                recurrence_unit: crate::runtime::todo::TodoRecurrenceUnit::Day,
-            },
-        )
-        .unwrap();
-    let other_cancelled = store
-        .create(
-            &other_owner,
-            TodoItemDraft {
-                title: "其他用户已取消".to_owned(),
-                detail: None,
-                raw_text: None,
-                due_date: None,
-                due_at: None,
-                reminder_at: None,
-                time_precision: TodoTimePrecision::None,
-                recurrence_kind: crate::runtime::todo::TodoRecurrenceKind::None,
-                recurrence_interval_days: 0,
-                recurrence_interval: 0,
-                recurrence_unit: crate::runtime::todo::TodoRecurrenceUnit::Day,
-            },
-        )
-        .unwrap();
-    store.complete(&owner, &completed.id).unwrap();
-    store.cancel(&owner, &cancelled.id).unwrap();
-    store.cancel(&other_owner, &other_cancelled.id).unwrap();
-
-    let outcome = store
-        .delete_cancelled_by_ids(
-            &owner,
-            &[
-                pending.id.clone(),
-                completed.id.clone(),
-                cancelled.id.clone(),
-                other_cancelled.id.clone(),
-                "999".to_owned(),
-            ],
-        )
-        .unwrap();
-
-    assert_eq!(outcome.deleted_count, 1);
-    assert_eq!(outcome.skipped_ids.len(), 4);
-    let own_items = store.list_all(&owner).unwrap();
-    assert!(own_items.iter().all(|item| item.id != cancelled.id));
-    assert_eq!(
-        own_items
-            .iter()
-            .find(|item| item.id == pending.id)
-            .unwrap()
-            .status,
-        TodoStatus::Pending
-    );
-    assert_eq!(
-        own_items
-            .iter()
-            .find(|item| item.id == completed.id)
-            .unwrap()
-            .status,
-        TodoStatus::Completed
-    );
-    assert_eq!(
-        store.list_all(&other_owner).unwrap()[0].status,
-        TodoStatus::Cancelled
-    );
+    assert_delete_by_status_keeps_filters(&store, &fixture, TodoStatus::Cancelled);
 }
 
 #[test]
 fn delete_completed_by_ids_filters_owner_scope_and_status_in_transaction() {
     let store = test_store();
-    let owner = TodoStore::owner(Some("u1"), "group:g1");
-    let other_owner = TodoStore::owner(Some("u2"), "group:g1");
+    let fixture = seed_delete_by_status_fixture(&store, TodoStatus::Completed);
 
-    let pending = store
-        .create(
-            &owner,
-            TodoItemDraft {
-                title: "未完成".to_owned(),
-                detail: None,
-                raw_text: None,
-                due_date: None,
-                due_at: None,
-                reminder_at: None,
-                time_precision: TodoTimePrecision::None,
-                recurrence_kind: crate::runtime::todo::TodoRecurrenceKind::None,
-                recurrence_interval_days: 0,
-                recurrence_interval: 0,
-                recurrence_unit: crate::runtime::todo::TodoRecurrenceUnit::Day,
-            },
-        )
-        .unwrap();
-    let completed = store
-        .create(
-            &owner,
-            TodoItemDraft {
-                title: "已完成".to_owned(),
-                detail: None,
-                raw_text: None,
-                due_date: None,
-                due_at: None,
-                reminder_at: None,
-                time_precision: TodoTimePrecision::None,
-                recurrence_kind: crate::runtime::todo::TodoRecurrenceKind::None,
-                recurrence_interval_days: 0,
-                recurrence_interval: 0,
-                recurrence_unit: crate::runtime::todo::TodoRecurrenceUnit::Day,
-            },
-        )
-        .unwrap();
-    let cancelled = store
-        .create(
-            &owner,
-            TodoItemDraft {
-                title: "已取消".to_owned(),
-                detail: None,
-                raw_text: None,
-                due_date: None,
-                due_at: None,
-                reminder_at: None,
-                time_precision: TodoTimePrecision::None,
-                recurrence_kind: crate::runtime::todo::TodoRecurrenceKind::None,
-                recurrence_interval_days: 0,
-                recurrence_interval: 0,
-                recurrence_unit: crate::runtime::todo::TodoRecurrenceUnit::Day,
-            },
-        )
-        .unwrap();
-    let other_completed = store
-        .create(
-            &other_owner,
-            TodoItemDraft {
-                title: "其他用户已完成".to_owned(),
-                detail: None,
-                raw_text: None,
-                due_date: None,
-                due_at: None,
-                reminder_at: None,
-                time_precision: TodoTimePrecision::None,
-                recurrence_kind: crate::runtime::todo::TodoRecurrenceKind::None,
-                recurrence_interval_days: 0,
-                recurrence_interval: 0,
-                recurrence_unit: crate::runtime::todo::TodoRecurrenceUnit::Day,
-            },
-        )
-        .unwrap();
-    store.complete(&owner, &completed.id).unwrap();
-    store.cancel(&owner, &cancelled.id).unwrap();
-    store.complete(&other_owner, &other_completed.id).unwrap();
-
-    let outcome = store
-        .delete_completed_by_ids(
-            &owner,
-            &[
-                pending.id.clone(),
-                completed.id.clone(),
-                cancelled.id.clone(),
-                other_completed.id.clone(),
-                "999".to_owned(),
-            ],
-        )
-        .unwrap();
-
-    assert_eq!(outcome.deleted_count, 1);
-    assert_eq!(outcome.skipped_ids.len(), 4);
-    let own_items = store.list_all(&owner).unwrap();
-    assert!(own_items.iter().all(|item| item.id != completed.id));
-    assert_eq!(
-        own_items
-            .iter()
-            .find(|item| item.id == pending.id)
-            .unwrap()
-            .status,
-        TodoStatus::Pending
-    );
-    assert_eq!(
-        own_items
-            .iter()
-            .find(|item| item.id == cancelled.id)
-            .unwrap()
-            .status,
-        TodoStatus::Cancelled
-    );
-    assert_eq!(
-        store.list_all(&other_owner).unwrap()[0].status,
-        TodoStatus::Completed
-    );
+    assert_delete_by_status_keeps_filters(&store, &fixture, TodoStatus::Completed);
 }


### PR DESCRIPTION
## 背景

Closes #187。

本 PR 执行 Todo 测试第一轮低风险瘦身，只抽取重复 fixture、Tool 调用和公共断言，不删除关键跨层测试，不修改生产行为。

## 修改内容

- Storage 删除过滤测试：
  - 抽取 `DeleteByStatusFixture`、`seed_delete_by_status_fixture`、`assert_delete_by_status_keeps_filters` 等 helper。
  - 保留 `delete_cancelled_by_ids_filters_owner_scope_and_status_in_transaction` 和 `delete_completed_by_ids_filters_owner_scope_and_status_in_transaction` 两个独立测试入口。
  - 继续覆盖 owner、scope、status 过滤，以及目标项删除、非目标状态保留、其他 owner 同状态项保留和 skipped 计数。
- Todo Tool Schema 契约测试：
  - 抽取 `schema_property`、`assert_nullable_type`、`assert_schema_max_items`。
  - 选择器 nullable 与批量创建 `maxItems` 仍保持独立测试。
- 批量创建边界测试：
  - 抽取 `create_batch_tool`、`execute_batch_create`、`assert_pending_todo_count`。
  - 保留空批次、达到上限、超过上限无部分写入、已有总量不受单次上限影响四个独立语义。

## 未删除内容

- 未删除 Tool、Respond、Pending、Storage 的关键跨层测试。
- 未删除或弱化 selection_text parser / Tool 集成测试。
- 未修改生产代码。

## 代码规模

- `qq-maid-core/src/runtime/tools/todo/tests.rs`
- `qq-maid-core/src/storage/todo/tests.rs`
- 合计：`191 insertions(+), 336 deletions(-)`

## 验证

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`
- 定向 Storage 测试：
  - `cargo test -p qq-maid-core storage::todo::tests::delete_cancelled_by_ids_filters_owner_scope_and_status_in_transaction`
  - `cargo test -p qq-maid-core storage::todo::tests::delete_completed_by_ids_filters_owner_scope_and_status_in_transaction`
- 定向 Schema 测试：
  - `cargo test -p qq-maid-core runtime::tools::todo::tests::todo_selector_schemas_allow_null_for_unused_strict_fields`
  - `cargo test -p qq-maid-core runtime::tools::todo::tests::create_todo_schema_uses_shared_batch_limit`
- `cargo test -p qq-maid-core create_tool_`
- `make test-core`
- `cargo clippy -p qq-maid-core --all-targets --all-features -- -D warnings`
- `cargo test -p qq-maid-core --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo build --workspace --release --all-features`
