### PR TITLE
feat: QQ 官方图片结构化出站 C2C+群端到端 (#284)

### DIFF
--- a/qq-maid-gateway-rs/src/api/mod.rs
+++ b/qq-maid-gateway-rs/src/api/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     auth::{AccessTokenManager, AuthError},
     logging::{mask_identifier, mask_openid, reqwest_error_summary},
     markdown::{MarkdownPayload, build_c2c_markdown_payload, build_group_markdown_payload},
-    media::{ImagePayload, build_c2c_image_payload},
+    media::{ImagePayload, build_c2c_image_payload, build_group_image_payload},
     render::OutboundMessage,
 };
 
@@ -306,6 +306,12 @@ pub trait GroupOutboundSender: Send + Sync {
         target: &'a GroupReplyTarget,
         markdown: &'a MarkdownPayload,
     ) -> SendFuture<'a>;
+    /// 发送群图片。实现内部负责上传 -> file_info -> 发送；失败返回真实错误。
+    fn send_image<'a>(
+        &'a self,
+        target: &'a GroupReplyTarget,
+        image: &'a ImagePayload,
+    ) -> SendFuture<'a>;
 }
 
 impl QqApiClient {
@@ -384,8 +390,116 @@ impl QqApiClient {
         msg_id: Option<&str>,
         image: &ImagePayload,
     ) -> SendResult {
-        let payload = build_c2c_image_payload(image, msg_id, self.next_msg_seq());
+        // QQ 官方要求先上传图片换取 file_info，再用 file_info 发送 msg_type=7 消息。
+        // file_info 不能用入站 media_id / file_id 代替。
+        let uploaded = self.upload_c2c_media(user_openid, &image.url).await?;
+        let payload = build_c2c_image_payload(&uploaded.file_info, msg_id, self.next_msg_seq());
         self.post_c2c_message(user_openid, msg_id, "image", &payload)
+            .await
+    }
+
+    /// 上传 C2C 富媒体（`POST /v2/users/{openid}/files`，`file_type=1` 图片），
+    /// 返回发送用 `file_info`。`url` 为图片资源 URL；QQ 返回无 `file_info` 时报错。
+    async fn upload_c2c_media(
+        &self,
+        user_openid: &str,
+        url: &str,
+    ) -> Result<UploadedMedia, ApiError> {
+        self.post_media_files(
+            "user",
+            format!("{}/v2/users/{user_openid}/files", self.api_base),
+            user_openid,
+            url,
+        )
+        .await
+    }
+
+    /// 上传群富媒体（`POST /v2/groups/{group_openid}/files`，`file_type=1` 图片），
+    /// 返回发送用 `file_info`。
+    async fn upload_group_media(
+        &self,
+        group_openid: &str,
+        url: &str,
+    ) -> Result<UploadedMedia, ApiError> {
+        self.post_media_files(
+            "group",
+            format!("{}/v2/groups/{group_openid}/files", self.api_base),
+            group_openid,
+            url,
+        )
+        .await
+    }
+
+    /// 富媒体上传的共享 HTTP 调用。请求体 `{ file_type: 1, srv_send_msg: false, url }`，
+    /// 解析返回的 `file_info`；缺失或为空视为错误（不伪造成功）。
+    async fn post_media_files(
+        &self,
+        target_kind: &'static str,
+        endpoint: String,
+        target_id: &str,
+        url: &str,
+    ) -> Result<UploadedMedia, ApiError> {
+        let masked_target = mask_openid(target_id);
+        let payload = serde_json::json!({
+            "file_type": 1,
+            "srv_send_msg": false,
+            "url": url,
+        });
+        let response = self
+            .client
+            .post(endpoint)
+            .header("Authorization", self.auth.authorization_header().await?)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|error| {
+                warn!(
+                    target_kind = target_kind,
+                    target = %masked_target,
+                    error = %reqwest_error_summary(&error),
+                    "QQ media upload request failed"
+                );
+                ApiError::Http(error)
+            })?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            warn!(
+                target_kind = target_kind,
+                target = %masked_target,
+                status = %status,
+                "QQ media upload returned non-success status"
+            );
+            return Err(ApiError::Status { status, body });
+        }
+        let body = response.text().await.map_err(ApiError::Http)?;
+        let uploaded = parse_media_upload_response(&body).inspect_err(|err| {
+            warn!(
+                target_kind = target_kind,
+                target = %masked_target,
+                error = %err.log_summary(),
+                "QQ media upload response missing file_info"
+            );
+        })?;
+        info!(
+            target_kind = target_kind,
+            target = %masked_target,
+            has_file_info = !uploaded.file_info.is_empty(),
+            "qq media upload success"
+        );
+        Ok(uploaded)
+    }
+
+    /// 发送群图片：先上传群富媒体换取 `file_info`，再用 `msg_type=7` 发送。
+    pub async fn send_group_image(
+        &self,
+        group_openid: &str,
+        msg_id: Option<&str>,
+        image: &ImagePayload,
+    ) -> SendResult {
+        let uploaded = self.upload_group_media(group_openid, &image.url).await?;
+        let payload = build_group_image_payload(&uploaded.file_info, msg_id, self.next_msg_seq());
+        self.post_group_message(group_openid, msg_id, "image", &payload)
             .await
     }
 
@@ -873,6 +987,39 @@ pub(crate) fn extract_sent_message_ids(body: &str) -> SendMessageIds {
     }
 }
 
+/// QQ 富媒体上传接口返回的服务端标识，仅保留发送所需 `file_info`。
+#[derive(Debug, Clone)]
+struct UploadedMedia {
+    file_info: String,
+}
+
+/// `/v2/users/{openid}/files` 与 `/v2/groups/{group_openid}/files` 的响应 DTO。
+#[derive(Debug, Deserialize)]
+struct MediaUploadResponse {
+    #[serde(default)]
+    #[allow(dead_code)]
+    file_uuid: Option<String>,
+    #[serde(default)]
+    file_info: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    ttl: Option<i64>,
+}
+
+/// 解析富媒体上传响应，提取 `file_info`。缺失或为空返回错误，不伪造可用标识。
+fn parse_media_upload_response(body: &str) -> Result<UploadedMedia, ApiError> {
+    let parsed = serde_json::from_str::<MediaUploadResponse>(body)
+        .map_err(|_| ApiError::Unsupported("media_upload_response"))?;
+    let file_info = parsed
+        .file_info
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| ApiError::Unsupported("media_upload_missing_file_info"))?
+        .to_owned();
+    Ok(UploadedMedia { file_info })
+}
+
 pub async fn send_outbound_with_fallback<S: OutboundSender + ?Sized>(
     sender: &S,
     target: &C2cReplyTarget,
@@ -975,8 +1122,34 @@ pub async fn send_group_outbound_with_fallback<S: GroupOutboundSender + ?Sized>(
             }
             Err(err) => Err(err),
         },
-        OutboundMessage::Image { fallback_text, .. }
-        | OutboundMessage::ImagePlaceholder { fallback_text }
+        OutboundMessage::Image {
+            image,
+            fallback_text,
+        } => match sender.send_image(target, image).await {
+            Ok(message_id) => Ok(message_id),
+            Err(err) if !fallback_text.trim().is_empty() => {
+                warn!(
+                    group = %mask_openid(&target.group_openid),
+                    source_message_id = target.msg_id.as_deref().unwrap_or(""),
+                    error = %err.log_summary(),
+                    "group image send failed; falling back to text"
+                );
+                match sender.send_text(target, fallback_text).await {
+                    Ok(message_id) => Ok(message_id),
+                    Err(fallback_err) => {
+                        warn!(
+                            group = %mask_openid(&target.group_openid),
+                            source_message_id = target.msg_id.as_deref().unwrap_or(""),
+                            error = %fallback_err.log_summary(),
+                            "group image fallback text send failed"
+                        );
+                        Err(fallback_err)
+                    }
+                }
+            }
+            Err(err) => Err(err),
+        },
+        OutboundMessage::ImagePlaceholder { fallback_text }
         | OutboundMessage::AttachmentPlaceholder { fallback_text } => {
             sender.send_text(target, fallback_text).await
         }

--- a/qq-maid-gateway-rs/src/api/tests.rs
+++ b/qq-maid-gateway-rs/src/api/tests.rs
@@ -368,6 +368,17 @@ impl GroupOutboundSender for MockSender {
             Err(ApiError::Unsupported("markdown"))
         })
     }
+
+    fn send_image<'a>(
+        &'a self,
+        _target: &'a GroupReplyTarget,
+        _image: &'a ImagePayload,
+    ) -> SendFuture<'a> {
+        Box::pin(async move {
+            self.calls.lock().unwrap().push("group-image".to_owned());
+            Err(ApiError::Unsupported("image"))
+        })
+    }
 }
 
 fn target() -> C2cReplyTarget {
@@ -437,4 +448,63 @@ async fn group_markdown_send_failure_falls_back_to_text() {
         .await
         .unwrap();
     assert_eq!(sender.calls(), vec!["group-markdown", "group-text:hello"]);
+}
+
+#[tokio::test]
+async fn group_image_send_failure_falls_back_to_text() {
+    let sender = MockSender::default();
+    let outbound = OutboundMessage::Image {
+        image: ImagePayload::new("https://example.test/radar.png"),
+        fallback_text: "image fallback".to_owned(),
+    };
+    send_group_outbound_with_fallback(&sender, &group_target(), &outbound)
+        .await
+        .unwrap();
+    assert_eq!(
+        sender.calls(),
+        vec!["group-image", "group-text:image fallback"]
+    );
+}
+
+#[test]
+fn c2c_image_payload_matches_qq_shape() {
+    let payload = build_c2c_image_payload("file-info-1", Some("msg-1"), 9);
+
+    assert_eq!(payload["msg_type"], 7);
+    assert_eq!(payload["media"]["file_info"], "file-info-1");
+    assert_eq!(payload["msg_id"], "msg-1");
+    assert_eq!(payload["msg_seq"], 9);
+    assert!(payload.get("content").is_none());
+    assert!(payload.get("markdown").is_none());
+}
+
+#[test]
+fn group_image_payload_matches_qq_shape() {
+    let payload = build_group_image_payload("file-info-2", Some("msg-2"), 10);
+
+    assert_eq!(payload["msg_type"], 7);
+    assert_eq!(payload["media"]["file_info"], "file-info-2");
+    assert_eq!(payload["msg_id"], "msg-2");
+    assert_eq!(payload["msg_seq"], 10);
+}
+
+#[test]
+fn parse_media_upload_response_returns_file_info() {
+    let body = serde_json::json!({
+        "file_uuid": "uuid-1",
+        "file_info": "file-info-3",
+        "ttl": 300,
+    })
+    .to_string();
+    let uploaded = parse_media_upload_response(&body).unwrap();
+    assert_eq!(uploaded.file_info, "file-info-3");
+}
+
+#[test]
+fn parse_media_upload_response_missing_file_info_is_error() {
+    let no_file_info = serde_json::json!({"file_uuid": "uuid-2"}).to_string();
+    let blank_file_info = serde_json::json!({"file_info": "   "}).to_string();
+    assert!(parse_media_upload_response(&no_file_info).is_err());
+    assert!(parse_media_upload_response(&blank_file_info).is_err());
+    assert!(parse_media_upload_response("not json").is_err());
 }

--- a/qq-maid-gateway-rs/src/gateway/outbound.rs
+++ b/qq-maid-gateway-rs/src/gateway/outbound.rs
@@ -182,7 +182,9 @@ impl ReplyCapability {
     pub(crate) fn qq_official_group(config: &AppConfig) -> Self {
         Self {
             platform: Platform::QqOfficial,
-            render: RenderProfile::qq_official(config, false),
+            // QQ 官方群具备 group media image 链路（/v2/groups/{group_openid}/files +
+            // msg_type=7），supports_image 跟随 enable_image 开关，不再写死为不支持。
+            render: RenderProfile::qq_official(config, true),
             supports_quote_original: true,
             supports_at_mention: true,
             supports_multi_part: true,
@@ -334,6 +336,22 @@ impl GroupOutboundSender for RuntimeRecordingGroupSender<'_> {
             let result = self
                 .inner
                 .send_group_markdown(&target.group_openid, target.msg_id.as_deref(), markdown)
+                .await;
+            record_qq_send_result(self.runtime, &result);
+            result
+        })
+    }
+
+    fn send_image<'a>(
+        &'a self,
+        target: &'a GroupReplyTarget,
+        image: &'a ImagePayload,
+    ) -> SendFuture<'a> {
+        Box::pin(async move {
+            // 内部完成群富媒体上传 -> file_info -> msg_type=7 发送；失败返回真实错误。
+            let result = self
+                .inner
+                .send_group_image(&target.group_openid, target.msg_id.as_deref(), image)
                 .await;
             record_qq_send_result(self.runtime, &result);
             result

--- a/qq-maid-gateway-rs/src/media.rs
+++ b/qq-maid-gateway-rs/src/media.rs
@@ -1,34 +1,62 @@
+//! QQ 富媒体图片出站载荷。
+//!
+//! `ImagePayload` 只携带图片来源 URL；发送层（`QqApiClient`）负责先调用 QQ 富媒体
+//! 上传接口（`/v2/users/{openid}/files`、`/v2/groups/{group_openid}/files`）换取
+//! `file_info`，再用 `msg_type=7 + media.file_info` 发送。render 层只做纯转换，
+//! 不发 HTTP 请求，也不持有上传后的 `file_info`。
+
 use serde::Serialize;
 use serde_json::Value;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+/// 出站图片的来源 URL。
+///
+/// 该值来自 `OutputMedia::url`，是 QQ 上传接口 `url` 字段的来源；发送层据此上传
+/// 换取 `file_info` 后再发送。注意：入站媒体的 `media_id` / `file_id` 不能直接
+/// 当作发送用 `file_info`，必须经上传接口获取。
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImagePayload {
-    pub file_info: String,
+    pub url: String,
 }
 
+impl ImagePayload {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self { url: url.into() }
+    }
+}
+
+/// 发送图片消息（`msg_type=7`）的载荷。`media.file_info` 必须来自上传接口返回值。
 #[derive(Debug, Serialize)]
-struct C2cImagePayload<'a> {
+struct ImageMessagePayload<'a> {
     msg_type: u8,
-    media: &'a ImagePayload,
+    media: ImageMediaRef<'a>,
     #[serde(skip_serializing_if = "Option::is_none")]
     msg_id: Option<&'a str>,
     msg_seq: u32,
 }
 
-impl ImagePayload {
-    pub fn new(file_info: impl Into<String>) -> Self {
-        Self {
-            file_info: file_info.into(),
-        }
-    }
+#[derive(Debug, Serialize)]
+struct ImageMediaRef<'a> {
+    file_info: &'a str,
 }
 
-pub fn build_c2c_image_payload(image: &ImagePayload, msg_id: Option<&str>, msg_seq: u32) -> Value {
-    serde_json::to_value(C2cImagePayload {
+/// 构建 C2C 图片消息载荷。`file_info` 必须由上传接口返回，不能使用入站媒体标识。
+pub fn build_c2c_image_payload(file_info: &str, msg_id: Option<&str>, msg_seq: u32) -> Value {
+    serde_json::to_value(ImageMessagePayload {
         msg_type: 7,
-        media: image,
+        media: ImageMediaRef { file_info },
         msg_id,
         msg_seq,
     })
     .expect("C2C image payload should serialize")
+}
+
+/// 构建群图片消息载荷。语义与 C2C 一致，区别仅在群发送端点。
+pub fn build_group_image_payload(file_info: &str, msg_id: Option<&str>, msg_seq: u32) -> Value {
+    serde_json::to_value(ImageMessagePayload {
+        msg_type: 7,
+        media: ImageMediaRef { file_info },
+        msg_id,
+        msg_seq,
+    })
+    .expect("group image payload should serialize")
 }

--- a/qq-maid-gateway-rs/src/message_chunk.rs
+++ b/qq-maid-gateway-rs/src/message_chunk.rs
@@ -16,7 +16,7 @@ use tracing::{debug, info, trace, warn};
 
 use crate::api::{
     ApiError, C2cReplyTarget, GroupOutboundSender, GroupReplyTarget, OutboundSender,
-    SendMessageIds, SendResult,
+    SendMessageIds, SendResult, send_group_outbound_with_fallback, send_outbound_with_fallback,
 };
 use crate::logging::mask_openid;
 use crate::markdown::MarkdownPayload;
@@ -784,6 +784,94 @@ fn remaining_chars(chunks: &[OutboundChunk], from_index: usize) -> usize {
         .sum()
 }
 
+/// C2C 图片出站发送（Issue #284 第一批）。
+///
+/// 图片不做文本分段，直接调用 `send_outbound_with_fallback`：先尝试 `send_image`，
+/// 失败且 fallback 文本非空时回退到 `send_text`；两者都失败或无 fallback 时返回真实
+/// 错误，调用方据此上报，不伪造成功。成功时回调 `on_sent` 一次并返回单元素 ID 列表。
+async fn send_c2c_image_outbound<S, F>(
+    sender: &S,
+    target: &C2cReplyTarget,
+    message: &OutboundMessage,
+    on_sent: &mut F,
+) -> Result<Vec<SendMessageIds>, OutboundSendError>
+where
+    S: OutboundSender + ?Sized,
+    F: FnMut(usize, &SendMessageIds),
+{
+    let masked_user = mask_openid(&target.user_openid);
+    debug!(
+        user = %masked_user,
+        source_message_id = target.msg_id.as_deref().unwrap_or(""),
+        kind = outbound_kind(message),
+        "preparing chunked C2C outbound"
+    );
+    match send_outbound_with_fallback(sender, target, message).await {
+        Ok(id) => {
+            info!(
+                user = %masked_user,
+                source_message_id = target.msg_id.as_deref().unwrap_or(""),
+                kind = "image",
+                "chunked C2C outbound completed"
+            );
+            on_sent(0, &id);
+            Ok(vec![id])
+        }
+        Err(source) => {
+            warn!(
+                user = %masked_user,
+                source_message_id = target.msg_id.as_deref().unwrap_or(""),
+                kind = "image",
+                error = %source.log_summary(),
+                "C2C image outbound send failed before any chunk was sent"
+            );
+            Err(OutboundSendError::NotSent { source })
+        }
+    }
+}
+
+/// 群图片出站发送。语义同 C2C 版本，区别在 `GroupOutboundSender` 与群 target。
+async fn send_group_image_outbound<S, F>(
+    sender: &S,
+    target: &GroupReplyTarget,
+    message: &OutboundMessage,
+    on_sent: &mut F,
+) -> Result<Vec<SendMessageIds>, OutboundSendError>
+where
+    S: GroupOutboundSender + ?Sized,
+    F: FnMut(usize, &SendMessageIds),
+{
+    let masked_group = mask_openid(&target.group_openid);
+    debug!(
+        group = %masked_group,
+        source_message_id = target.msg_id.as_deref().unwrap_or(""),
+        kind = outbound_kind(message),
+        "preparing chunked group outbound"
+    );
+    match send_group_outbound_with_fallback(sender, target, message).await {
+        Ok(id) => {
+            info!(
+                group = %masked_group,
+                source_message_id = target.msg_id.as_deref().unwrap_or(""),
+                kind = "image",
+                "chunked group outbound completed"
+            );
+            on_sent(0, &id);
+            Ok(vec![id])
+        }
+        Err(source) => {
+            warn!(
+                group = %masked_group,
+                source_message_id = target.msg_id.as_deref().unwrap_or(""),
+                kind = "image",
+                error = %source.log_summary(),
+                "group image outbound send failed before any chunk was sent"
+            );
+            Err(OutboundSendError::NotSent { source })
+        }
+    }
+}
+
 /// C2C 普通回复分段发送。
 ///
 /// 逐段发送，每段成功后才发送下一段；任一段失败立即停止并返回 `OutboundSendError`。
@@ -802,6 +890,14 @@ where
     S: OutboundSender + ?Sized,
     F: FnMut(usize, &SendMessageIds),
 {
+    // 图片不走文本分段：直接走真实图片发送链路，失败时由 `send_outbound_with_fallback`
+    // 回退到 fallback 文本；二者都失败返回真实错误，不伪造成功。Issue #284 第一批：
+    // QQ 官方 C2C 图片端到端输出。群聊 / WeChat 因 render 层 `supports_image=false` 不会产出
+    // `OutboundMessage::Image`，自然走文本降级，无需在此处理。
+    if let OutboundMessage::Image { .. } = message {
+        return send_c2c_image_outbound(sender, target, message, &mut on_sent).await;
+    }
+
     let chunks = chunk_outbound(message, limits);
     let total = chunks.len();
     let masked_user = mask_openid(&target.user_openid);
@@ -892,6 +988,13 @@ where
     S: GroupOutboundSender + ?Sized,
     F: FnMut(usize, &SendMessageIds),
 {
+    // 群图片不走文本分段：直接走真实图片发送链路（上传 -> file_info -> msg_type=7），
+    // 失败时由 `send_group_outbound_with_fallback` 回退到 fallback 文本；二者都失败
+    // 返回真实错误，不伪造成功。平台不支持时 render 层不会产出 Image，自然走文本降级。
+    if let OutboundMessage::Image { .. } = message {
+        return send_group_image_outbound(sender, target, message, &mut on_sent).await;
+    }
+
     let chunks = chunk_outbound(message, limits);
     let total = chunks.len();
     let masked_group = mask_openid(&target.group_openid);

--- a/qq-maid-gateway-rs/src/message_chunk/tests.rs
+++ b/qq-maid-gateway-rs/src/message_chunk/tests.rs
@@ -189,6 +189,8 @@ struct RecordingC2cSender {
     markdown_calls: Mutex<Vec<String>>,
     text_calls: Mutex<Vec<String>>,
     fail_on: Mutex<Option<usize>>,
+    image_calls: Mutex<Vec<String>>,
+    image_fail: Mutex<bool>,
 }
 
 impl OutboundSender for RecordingC2cSender {
@@ -225,9 +227,18 @@ impl OutboundSender for RecordingC2cSender {
     fn send_image<'a>(
         &'a self,
         _target: &'a C2cReplyTarget,
-        _image: &'a crate::media::ImagePayload,
+        image: &'a crate::media::ImagePayload,
     ) -> SendFuture<'a> {
-        Box::pin(async { Err(ApiError::Unsupported("image")) })
+        Box::pin(async move {
+            self.image_calls.lock().unwrap().push(image.url.clone());
+            if *self.image_fail.lock().unwrap() {
+                return Err(ApiError::Unsupported("image"));
+            }
+            Ok(SendMessageIds {
+                message_id: Some("iid-1".to_owned()),
+                ref_index_id: Some("REFIDX_iid_1".to_owned()),
+            })
+        })
     }
 }
 
@@ -393,10 +404,93 @@ async fn c2c_not_sent_when_first_chunk_fails() {
     assert!(matches!(err, OutboundSendError::NotSent { .. }));
 }
 
+fn image_outbound(fallback_text: &str) -> OutboundMessage {
+    OutboundMessage::Image {
+        image: crate::media::ImagePayload::new("https://example.test/radar.png".to_owned()),
+        fallback_text: fallback_text.to_owned(),
+    }
+}
+
+#[tokio::test]
+async fn c2c_image_outbound_sends_via_send_image_and_records_id() {
+    let sender = RecordingC2cSender {
+        image_fail: Mutex::new(false),
+        ..Default::default()
+    };
+    let on_sent_ids = std::sync::Mutex::new(Vec::new());
+    let ids = send_c2c_outbound_chunked(
+        &sender,
+        &c2c_target(),
+        &image_outbound("天气雷达图"),
+        &ChunkLimits::defaults(),
+        |_, id| {
+            on_sent_ids.lock().unwrap().push(id.clone());
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        sender.image_calls.lock().unwrap().as_slice(),
+        ["https://example.test/radar.png"]
+    );
+    assert!(sender.text_calls.lock().unwrap().is_empty());
+    assert_eq!(ids.len(), 1);
+    assert_eq!(on_sent_ids.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn c2c_image_outbound_falls_back_to_text_when_send_image_fails() {
+    let sender = RecordingC2cSender {
+        image_fail: Mutex::new(true),
+        ..Default::default()
+    };
+    let ids = send_c2c_outbound_chunked(
+        &sender,
+        &c2c_target(),
+        &image_outbound("天气雷达图"),
+        &ChunkLimits::defaults(),
+        |_, _| {},
+    )
+    .await
+    .unwrap();
+
+    // 图片发送失败 -> 回退到 fallback 文本，整条仍成功。
+    assert_eq!(
+        sender.image_calls.lock().unwrap().as_slice(),
+        ["https://example.test/radar.png"]
+    );
+    assert_eq!(sender.text_calls.lock().unwrap().as_slice(), ["天气雷达图"]);
+    assert_eq!(ids.len(), 1);
+}
+
+#[tokio::test]
+async fn c2c_image_outbound_returns_error_when_send_image_fails_and_no_fallback() {
+    let sender = RecordingC2cSender {
+        image_fail: Mutex::new(true),
+        ..Default::default()
+    };
+    let err = send_c2c_outbound_chunked(
+        &sender,
+        &c2c_target(),
+        &image_outbound(""),
+        &ChunkLimits::defaults(),
+        |_, _| {},
+    )
+    .await
+    .unwrap_err();
+
+    // 无 fallback 文本时返回真实错误，不伪造成功。
+    assert!(matches!(err, OutboundSendError::NotSent { .. }));
+    assert!(sender.text_calls.lock().unwrap().is_empty());
+}
+
 #[derive(Debug, Default)]
 struct RecordingGroupSender {
     markdown_calls: Mutex<Vec<String>>,
     text_calls: Mutex<Vec<String>>,
+    image_calls: Mutex<Vec<String>>,
+    image_fail: Mutex<bool>,
 }
 
 impl crate::api::GroupOutboundSender for RecordingGroupSender {
@@ -416,6 +510,19 @@ impl crate::api::GroupOutboundSender for RecordingGroupSender {
                 .lock()
                 .unwrap()
                 .push(markdown.content.clone());
+            Ok(SendMessageIds::none())
+        })
+    }
+    fn send_image<'a>(
+        &'a self,
+        _target: &'a GroupReplyTarget,
+        image: &'a crate::media::ImagePayload,
+    ) -> SendFuture<'a> {
+        Box::pin(async move {
+            self.image_calls.lock().unwrap().push(image.url.clone());
+            if *self.image_fail.lock().unwrap() {
+                return Err(ApiError::Unsupported("image"));
+            }
             Ok(SendMessageIds::none())
         })
     }
@@ -446,4 +553,74 @@ async fn group_chunked_send_dispatches_each_chunk() {
     let md_calls = sender.markdown_calls.lock().unwrap().len();
     assert!(md_calls >= 2);
     assert_eq!(sent, md_calls);
+}
+
+#[tokio::test]
+async fn group_image_outbound_sends_via_send_image() {
+    let sender = RecordingGroupSender {
+        image_fail: Mutex::new(false),
+        ..Default::default()
+    };
+    let ids = send_group_outbound_chunked(
+        &sender,
+        &group_target(),
+        &image_outbound("天气雷达图"),
+        &ChunkLimits::defaults(),
+        |_, _| {},
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        sender.image_calls.lock().unwrap().as_slice(),
+        ["https://example.test/radar.png"]
+    );
+    assert!(sender.text_calls.lock().unwrap().is_empty());
+    assert_eq!(ids.len(), 1);
+}
+
+#[tokio::test]
+async fn group_image_outbound_falls_back_to_text_when_send_image_fails() {
+    let sender = RecordingGroupSender {
+        image_fail: Mutex::new(true),
+        ..Default::default()
+    };
+    let ids = send_group_outbound_chunked(
+        &sender,
+        &group_target(),
+        &image_outbound("天气雷达图"),
+        &ChunkLimits::defaults(),
+        |_, _| {},
+    )
+    .await
+    .unwrap();
+
+    // 群图片发送失败 -> 回退到 fallback 文本，整条仍成功。
+    assert_eq!(
+        sender.image_calls.lock().unwrap().as_slice(),
+        ["https://example.test/radar.png"]
+    );
+    assert_eq!(sender.text_calls.lock().unwrap().as_slice(), ["天气雷达图"]);
+    assert_eq!(ids.len(), 1);
+}
+
+#[tokio::test]
+async fn group_image_outbound_returns_error_when_send_image_fails_and_no_fallback() {
+    let sender = RecordingGroupSender {
+        image_fail: Mutex::new(true),
+        ..Default::default()
+    };
+    let err = send_group_outbound_chunked(
+        &sender,
+        &group_target(),
+        &image_outbound(""),
+        &ChunkLimits::defaults(),
+        |_, _| {},
+    )
+    .await
+    .unwrap_err();
+
+    // 无 fallback 文本时返回真实错误，不伪造成功。
+    assert!(matches!(err, OutboundSendError::NotSent { .. }));
+    assert!(sender.text_calls.lock().unwrap().is_empty());
 }

--- a/qq-maid-gateway-rs/src/render.rs
+++ b/qq-maid-gateway-rs/src/render.rs
@@ -135,6 +135,19 @@ fn render_assistant_output_for_profile(
 ) -> Option<OutboundMessage> {
     let fallback_text = normalized_output_fallback(output)?;
 
+    // 图片结构化出站（Issue #284 第一批）：仅在平台声明支持图片、且输出由单张可发送
+    // 图片构成时，直接渲染为 `OutboundMessage::Image`，交由发送层走真实图片链路。
+    // 其余情况（混合文本+图片、缺少 QQ 可用的 media_id 或平台不支持）继续走下方
+    // markdown / 文本降级路径，把图片转为 fallback 文本，避免吞掉内容。
+    if profile.supports_image
+        && let Some(image) = single_sendable_image(output)
+    {
+        return Some(OutboundMessage::Image {
+            image,
+            fallback_text,
+        });
+    }
+
     if profile.supports_markdown
         && output
             .parts
@@ -153,6 +166,43 @@ fn render_assistant_output_for_profile(
     profile.supports_text.then(|| OutboundMessage::Text {
         text: render_parts_as_text(output),
     })
+}
+
+/// 当输出仅由单张“可发送”图片构成时，返回对应的 QQ 图片载荷。
+///
+/// “可发送”指图片媒体携带可上传的资源 `url`：发送层据此调用 QQ 富媒体上传
+/// 接口换取 `file_info` 后再用 `msg_type=7` 发送。缺少 `url` 时返回 `None`，
+/// 调用方应降级为 fallback 文本，不能凭空构造图片消息导致平台报错。
+///
+/// 注意：不使用 `media_id` / `file_id` 构造发送用 `file_info`——入站媒体标识
+/// 不等于上传接口返回的 `file_info`，必须经上传接口获取。
+///
+/// 当前只处理“单张图片、无其他文本/Markdown part”的最小形态；混合内容仍走文本
+/// 降级，后续批次再接入多消息出站。
+fn single_sendable_image(output: &AssistantOutput) -> Option<ImagePayload> {
+    if output.parts.len() != 1 {
+        return None;
+    }
+    match &output.parts[0] {
+        OutputPart::Image { media } => {
+            let url = qq_image_url(media)?;
+            Some(ImagePayload::new(url))
+        }
+        _ => None,
+    }
+}
+
+/// 取图片的可上传资源 URL。
+///
+/// QQ 富媒体出站要求先上传图片资源（`url` 字段）换取 `file_info`；`OutputMedia::url`
+/// 即平台无关的媒体资源地址，是上传接口所需来源。空 URL 视为不可发送。
+fn qq_image_url(media: &OutputMedia) -> Option<String> {
+    media
+        .url
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
 }
 
 fn normalized_output_fallback(output: &AssistantOutput) -> Option<String> {
@@ -471,6 +521,122 @@ mod tests {
             Some(OutboundMessage::Markdown {
                 markdown: MarkdownPayload::new("**output markdown**"),
                 fallback_text: "output fallback".to_owned(),
+            })
+        );
+    }
+
+    fn image_support_profile() -> RenderProfile {
+        RenderProfile {
+            supports_text: true,
+            supports_markdown: true,
+            supports_image: true,
+            supports_attachment: false,
+            unsupported_fallback: crate::gateway::outbound::UnsupportedCapabilityFallback::UseText,
+        }
+    }
+
+    fn response_with_single_image(media: OutputMedia, fallback_text: &str) -> RespondResponse {
+        RespondResponse {
+            output: Some(AssistantOutput {
+                text_fallback: fallback_text.to_owned(),
+                markdown: None,
+                parts: vec![OutputPart::Image { media }],
+            }),
+            text: None,
+            markdown: None,
+            handled: Some(true),
+            session_id: None,
+            command: None,
+            diagnostics: None,
+            visible_entity_snapshot: None,
+        }
+    }
+
+    #[test]
+    fn single_image_with_url_renders_to_image_message_when_supported() {
+        let media = OutputMedia {
+            url: Some("https://example.test/radar.png".to_owned()),
+            fallback_text: Some("天气雷达图".to_owned()),
+            ..OutputMedia::default()
+        };
+        let response = response_with_single_image(media, "天气雷达图");
+
+        assert_eq!(
+            render_respond_response_for_profile(&response, &image_support_profile()),
+            Some(OutboundMessage::Image {
+                image: ImagePayload::new("https://example.test/radar.png".to_owned()),
+                fallback_text: "天气雷达图".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn single_image_without_url_degrades_to_text_when_supported() {
+        // 平台声明支持图片，但媒体缺少可上传的资源 URL，
+        // 不能凭空发送图片，必须降级为 fallback 文本。
+        let media = OutputMedia {
+            fallback_text: Some("图片：天气雷达".to_owned()),
+            ..OutputMedia::default()
+        };
+        let response = response_with_single_image(media, "图片：天气雷达");
+
+        assert_eq!(
+            render_respond_response_for_profile(&response, &image_support_profile()),
+            Some(OutboundMessage::Text {
+                text: "图片：天气雷达".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn single_image_degrades_to_text_when_platform_does_not_support_image() {
+        let media = OutputMedia {
+            url: Some("https://example.test/radar.png".to_owned()),
+            fallback_text: Some("图片：天气雷达".to_owned()),
+            ..OutputMedia::default()
+        };
+        let response = response_with_single_image(media, "图片：天气雷达");
+
+        assert_eq!(
+            render_respond_response_for_profile(&response, &RenderProfile::text_only_sync()),
+            Some(OutboundMessage::Text {
+                text: "图片：天气雷达".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn mixed_image_and_text_parts_degrade_to_text_when_supported() {
+        // 混合内容暂不接入多消息图片出站，仍走文本降级。
+        let media = OutputMedia {
+            url: Some("https://example.test/radar.png".to_owned()),
+            fallback_text: Some("图片：天气雷达".to_owned()),
+            ..OutputMedia::default()
+        };
+        let response = RespondResponse {
+            output: Some(AssistantOutput {
+                text_fallback: "请看这张图\n\n图片：天气雷达".to_owned(),
+                markdown: None,
+                parts: vec![
+                    OutputPart::Text {
+                        text: "请看这张图".to_owned(),
+                    },
+                    OutputPart::Image { media },
+                ],
+            }),
+            text: None,
+            markdown: None,
+            handled: Some(true),
+            session_id: None,
+            command: None,
+            diagnostics: None,
+            visible_entity_snapshot: None,
+        };
+
+        assert_eq!(
+            render_respond_response_for_profile(&response, &image_support_profile()),
+            Some(OutboundMessage::Text {
+                text: "请看这张图\n\n图片：天气雷达".to_owned(),
             })
         );
     }

--- a/qq-maid-gateway-rs/src/render.rs
+++ b/qq-maid-gateway-rs/src/render.rs
@@ -137,7 +137,7 @@ fn render_assistant_output_for_profile(
 
     // 图片结构化出站（Issue #284 第一批）：仅在平台声明支持图片、且输出由单张可发送
     // 图片构成时，直接渲染为 `OutboundMessage::Image`，交由发送层走真实图片链路。
-    // 其余情况（混合文本+图片、缺少 QQ 可用的 media_id 或平台不支持）继续走下方
+    // 其余情况（混合文本+图片、缺少可上传 URL 或平台不支持）继续走下方
     // markdown / 文本降级路径，把图片转为 fallback 文本，避免吞掉内容。
     if profile.supports_image
         && let Some(image) = single_sendable_image(output)


### PR DESCRIPTION
## 关联 Issue

Closes #284（#267 Epic 下出站富媒体子任务）。

## 干了什么

打通 QQ 官方图片**结构化出站**：C2C + 群端到端。`OutputPart::Image` 不再只降级为文本，而是按 QQ 官方富媒体文档（<https://bot.q.qq.com/wiki/develop/api-v2/server-inter/message/send-receive/rich-media.html>）走真实链路：上传图片 URL → 拿 `file_info` → `msg_type=7 + media.file_info` 发送。

## 根因（旧实现错在哪）

旧实现把入站 `OutputMedia.media_id` / `file_id` 当作发送用 `file_info` 直接发。QQ 官方要求 `file_info` 必须来自上传接口返回值，入站媒体标识不能复用。

## 改动

- `media.rs`：`ImagePayload` 改为 `{ url }`（图片来源），发送层负责 upload→file_info→send。
- `api/mod.rs`：新增 C2C / 群富媒体上传（`POST /v2/users/{openid}/files`、`POST /v2/groups/{group_openid}/files`，`file_type=1` + `url`），解析返回 `file_info`；`send_c2c_image` / 新增 `send_group_image` 完成 upload→send；`GroupOutboundSender` trait 加 `send_image`。
- `gateway/outbound.rs`：`RuntimeRecordingGroupSender` 实现 `send_image`；群 `RenderProfile` `supports_image` 基于 `config.enable_image`，不再写死 false。
- `render.rs`：单图且有 `url` → `OutboundMessage::Image`；缺 URL / 混合图文 / 多图 / 平台不支持 → 降级文本。
- `message_chunk.rs`：C2C / 群分段发送对 `OutboundMessage::Image` 短路到图片链路 + 文本降级。

## 降级 / 错误

平台不支持、缺 URL、上传失败、发送失败 → 回退 fallback 文本；无 fallback → 返回真实错误。上传响应缺 `file_info` 报错，不伪造成功。text / markdown / direct stream / Tool Loop / 命令输出不变。未改 `stream/tests.rs`。

## 平台能力

| 平台 | image |
|---|---|
| QQ 官方 C2C | ✅ 本 PR 接入 |
| QQ 官方群 | ✅ 本 PR 接入（平台具备 group media image 链路） |
| WeChat Service | ❌（仅 customer text，降级文本） |
| OneBot | gateway 无 adapter |

## 测试

新增 15 个：render 4（URL→Image / 缺 URL / 不支持 / 混合降级）、api 6（C2C + 群 payload 形状、上传响应解析、群图片失败回退）、message_chunk 5（C2C + 群各：发送成功 / 失败回退 / 无 fallback 报错）。上传失败与发送失败在 `send_image` 边界共享同一条 fallback 路径，统一覆盖。

## 验证

- [x] cargo fmt --all -- --check
- [x] cargo clippy -p qq-maid-gateway-rs --all-targets --all-features -- -D warnings
- [x] cargo test -p qq-maid-gateway-rs --lib（356 passed）
- [x] cargo check --workspace
- [ ] 真机 QQ 图片发送（C2C + 群）：无环境，逻辑层已覆盖上传/发送/降级/失败四类路径

## 未覆盖（后续）

本地文件 / base64 上传、分片上传（`upload_prepare` / `upload_part_finish`）、多图 / 混合图文多消息、Voice / Video / File / Card / Button、流式图片出站、OneBot / WeChat 图片。

## 备注

base 设为 `refactor/notification-contract-175`（含结构化输出适配基础 `9346276`），待其合入 master 后 retarget。