### PR TITLE
refactor: 收敛 Core→Gateway 出站正文读取到统一访问器

### DIFF
--- a/qq-maid-core/src/service/tests/mod.rs
+++ b/qq-maid-core/src/service/tests/mod.rs
@@ -247,6 +247,80 @@ fn core_response_with_output_keeps_legacy_fields_compatible() {
 }
 
 #[test]
+fn text_content_and_markdown_content_prefer_structured_output() {
+    // 结构化 output 存在时，访问器优先返回 output 的内容，而不是旧 text/markdown 字段。
+    let response = CoreResponse {
+        output: Some(AssistantOutput::markdown(
+            "structured fallback",
+            "# structured",
+        )),
+        text: Some("legacy text".to_owned()),
+        markdown: Some("legacy markdown".to_owned()),
+        handled: Some(true),
+        session_id: None,
+        command: None,
+        diagnostics: None,
+        visible_entity_snapshot: None,
+    };
+
+    assert_eq!(response.text_content(), Some("structured fallback"));
+    assert_eq!(response.markdown_content(), Some("# structured"));
+}
+
+#[test]
+fn text_content_falls_back_to_legacy_fields_when_output_absent() {
+    // 旧兼容路径：output 缺失时回退到 text/markdown 兼容字段。
+    let response = CoreResponse {
+        output: None,
+        text: Some("legacy text".to_owned()),
+        markdown: Some("legacy markdown".to_owned()),
+        handled: Some(true),
+        session_id: None,
+        command: None,
+        diagnostics: None,
+        visible_entity_snapshot: None,
+    };
+
+    assert_eq!(response.text_content(), Some("legacy text"));
+    assert_eq!(response.markdown_content(), Some("legacy markdown"));
+}
+
+#[test]
+fn markdown_content_falls_back_to_legacy_when_output_markdown_none() {
+    // output 仅含纯文本 part（markdown=None）时，markdown_content 回退到旧 markdown 字段。
+    let response = CoreResponse {
+        output: Some(AssistantOutput::text("plain")),
+        text: Some("plain".to_owned()),
+        markdown: Some("# legacy".to_owned()),
+        handled: Some(true),
+        session_id: None,
+        command: None,
+        diagnostics: None,
+        visible_entity_snapshot: None,
+    };
+
+    assert_eq!(response.text_content(), Some("plain"));
+    assert_eq!(response.markdown_content(), Some("# legacy"));
+}
+
+#[test]
+fn text_content_returns_none_when_no_content_anywhere() {
+    let response = CoreResponse {
+        output: None,
+        text: None,
+        markdown: None,
+        handled: Some(false),
+        session_id: None,
+        command: None,
+        diagnostics: None,
+        visible_entity_snapshot: None,
+    };
+
+    assert_eq!(response.text_content(), None);
+    assert_eq!(response.markdown_content(), None);
+}
+
+#[test]
 fn core_plan_routes_general_private_chat_to_streaming_when_tools_available() {
     let provider =
         TestProvider::replying("普通回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);

--- a/qq-maid-core/src/service/types.rs
+++ b/qq-maid-core/src/service/types.rs
@@ -128,8 +128,19 @@ pub enum CoreConversation {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CoreResponse {
+    /// 结构化出站内容，Core → Gateway 完整回复的正式契约。
+    ///
+    /// Gateway 出站渲染、ref_index 文本回填、流式收尾等读取用户可见正文时，
+    /// 应优先通过 [`CoreResponse::text_content`] / [`CoreResponse::markdown_content`]
+    /// 访问，而不是直接读下方的兼容字段。
     pub output: Option<AssistantOutput>,
+    /// 兼容字段：与 `output.text_fallback` 保持同步。
+    ///
+    /// 仅为过渡期保留，覆盖 Core 内部 `RespondResponse` 仍按 text/markdown 双通道
+    /// 组装正文、以及部分测试断言的旧路径。待 Core 内部 flow 全量迁移到
+    /// `AssistantOutput` 且无测试直接断言后可删除。
     pub text: Option<String>,
+    /// 兼容字段：与 `output.markdown` 保持同步，删除条件同 `text`。
     pub markdown: Option<String>,
     pub handled: Option<bool>,
     pub session_id: Option<String>,
@@ -295,6 +306,29 @@ impl CoreResponse {
         self.output = Some(output);
         self
     }
+
+    /// 用户可见文本 fallback，优先取结构化 `AssistantOutput::text_fallback`。
+    ///
+    /// Gateway 出站 / ref_index 回填 / 流式收尾 / 日志等需要读取最终正文的路径应统一
+    /// 走本访问器，不再直接读 `text` 兼容字段，避免 Core 内部迁移到 `AssistantOutput`
+    /// 后出现两套数据源。`text` 字段仅在 `output` 缺失（旧兼容路径）时兜底。
+    pub fn text_content(&self) -> Option<&str> {
+        self.output
+            .as_ref()
+            .map(|output| output.text_fallback.as_str())
+            .or(self.text.as_deref())
+    }
+
+    /// 用户可见 Markdown 正文，优先取结构化 `AssistantOutput::markdown`。
+    ///
+    /// 与 [`Self::text_content`] 对应；`markdown` 兼容字段仅在 `output` 缺失或其
+    /// `markdown` 为 `None` 时兜底。
+    pub fn markdown_content(&self) -> Option<&str> {
+        self.output
+            .as_ref()
+            .and_then(|output| output.markdown.as_deref())
+            .or(self.markdown.as_deref())
+    }
 }
 
 impl AssistantOutput {
@@ -335,10 +369,6 @@ impl AssistantOutput {
             Some(markdown) => Self::markdown(text, markdown),
             None => Self::text(text),
         })
-    }
-
-    pub fn into_compat_fields(self) -> (String, Option<String>) {
-        (self.text_fallback, self.markdown)
     }
 }
 

--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -86,9 +86,8 @@ async fn send_c2c_respond_response(
         send_c2c_respond_response_with_sender(&sender, message, response, config, &capability)
             .await?;
     let text = response
-        .markdown
-        .as_deref()
-        .or(response.text.as_deref())
+        .markdown_content()
+        .or(response.text_content())
         .unwrap_or("");
     record_c2c_bot_outbound_refs(
         ref_index,
@@ -515,9 +514,8 @@ where
                 })?;
                 if let Some(ref_index) = ref_index {
                     let text = response
-                        .markdown
-                        .as_deref()
-                        .or(response.text.as_deref())
+                        .markdown_content()
+                        .or(response.text_content())
                         .unwrap_or("");
                     record_c2c_bot_outbound_refs(
                         ref_index,

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -359,9 +359,8 @@ fn record_group_bot_outbound_send(
     }
     let inbound = platform::qq_official::inbound_from_group(message);
     let text = response
-        .markdown
-        .as_deref()
-        .or(response.text.as_deref())
+        .markdown_content()
+        .or(response.text_content())
         .unwrap_or("");
     ref_index.lock().unwrap().insert_bot_outbound(
         platform::Platform::QqOfficial,

--- a/qq-maid-gateway-rs/src/gateway/stream/send.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/send.rs
@@ -9,7 +9,7 @@ use crate::{
 pub(crate) const STREAM_FINAL_MARKER: &str = "\u{200B}";
 
 pub(crate) fn completed_response_content(response: &RespondResponse) -> Option<&str> {
-    response.markdown.as_deref().or(response.text.as_deref())
+    response.markdown_content().or(response.text_content())
 }
 
 pub(crate) fn stream_final_packet_content(pending_delta: &str) -> &str {

--- a/qq-maid-gateway-rs/src/render.rs
+++ b/qq-maid-gateway-rs/src/render.rs
@@ -103,30 +103,22 @@ pub(crate) fn render_respond_response_for_profile(
         return render_assistant_output_for_profile(output, profile);
     }
 
-    let text = response
-        .text
-        .as_ref()
-        .or_else(|| response.output.as_ref().map(|output| &output.text_fallback))?;
+    let text = response.text_content()?;
     if text.trim().is_empty() {
         return None;
     }
     if profile.supports_markdown
-        && let Some(markdown) = response.markdown.as_ref().or_else(|| {
-            response
-                .output
-                .as_ref()
-                .and_then(|output| output.markdown.as_ref())
-        })
+        && let Some(markdown) = response.markdown_content()
         && !markdown.trim().is_empty()
     {
         return Some(OutboundMessage::Markdown {
-            markdown: MarkdownPayload::new(markdown.clone()),
-            fallback_text: text.clone(),
+            markdown: MarkdownPayload::new(markdown.to_owned()),
+            fallback_text: text.to_owned(),
         });
     }
-    profile
-        .supports_text
-        .then(|| OutboundMessage::Text { text: text.clone() })
+    profile.supports_text.then(|| OutboundMessage::Text {
+        text: text.to_owned(),
+    })
 }
 
 fn render_assistant_output_for_profile(

--- a/qq-maid-gateway-rs/src/respond.rs
+++ b/qq-maid-gateway-rs/src/respond.rs
@@ -272,8 +272,7 @@ fn log_core_output_success(
                 handled_present = response.handled.is_some(),
                 command = response.command.as_deref().unwrap_or(""),
                 reply_len = response
-                    .text
-                    .as_deref()
+                    .text_content()
                     .map(|text| text.chars().count())
                     .unwrap_or(0),
                 transport = "complete",


### PR DESCRIPTION
## 背景

part of #352

本 PR 是 #352（收敛 Core ↔ Gateway 输入输出接口，清理旧出站兼容路径）的**阶段性子任务**，只完成其中 **Core→Gateway 出站正文读取收敛**的一小步。#352 的完整范围更大，仍保持 open 继续跟踪。

随着 `AssistantOutput / OutputPart` 结构化出站契约落地（#350 / #351），仓库中仍保留旧 `CoreResponse.text / markdown` 兼容字段，且 Gateway 多处出站读取点（ref_index 回填、流式收尾、日志、render fallback）直接读旧字段，绕过结构化 `output`，形成 Core↔Gateway 之间两套正文数据源。

本 PR 收敛输出边界，不改动业务语义。

## 本 PR 范围（相对 #352）

✅ 本 PR 只做：
- Core→Gateway 出站正文读取统一走 `text_content()` / `markdown_content()` 访问器。
- render fallback、ref_index 回填、流式 completed、日志等读取点收敛。

❌ 本 PR **不包含**（#352 仍需后续处理）：
- 媒体输入链路收敛（入站 media / input_part / 媒体取回）。
- 媒体输出全链路清理（image / file 出站 adapter、多消息出站）。
- QQ / OneBot / WeChat adapter 全链路统一。
- `RespondClient` / push / notification 通道进一步收敛。
- OpenAI 多模态输入转换链路。
- 旧接口（`CoreResponse.text / markdown`、内部 `RespondResponse` 双通道等）的**最终删除**——本 PR 仅以访问器作为薄适配层，字段保留。

## 改动

### Core 侧
- `qq-maid-core/src/service/types.rs`
  - 新增 `CoreResponse::text_content()` / `markdown_content()` 统一访问器：优先读 `output.text_fallback / output.markdown`，仅在 `output` 缺失时回退到旧 `text / markdown` 兼容字段。
  - 给 `output / text / markdown` 字段补充文档与后续删除条件。
  - 删除无调用方、无测试的死代码 `AssistantOutput::into_compat_fields`。

### Gateway 侧
所有非 render 的正文读取点改走访问器，不再直接读旧字段：
- `render.rs` 兼容 fallback 分支
- `gateway/c2c.rs` 两处 ref_index 文本回填（普通回复 + 禁用流式 Completed）
- `gateway/group.rs` ref_index 文本回填
- `gateway/stream/send.rs` `completed_response_content`
- `respond.rs` 成功日志 `reply_len`

### 测试
- 新增 4 条访问器单测：结构化优先、output 缺失回退、`output.markdown=None` 回退、全空返回 `None`。

## 不动的部分

- **输入侧**：`CoreRequest` 已是唯一入口（`message_context()` / `scope_key()` 均由权威字段派生），无需改动。
- **流式契约**：`CoreResponseStream / CoreResponseEvent` 保留，`Completed` 事件复用 `CoreResponse`，自动与统一出站模型兼容，未新建第二套流式富媒体协议。
- **render 层**：仍是平台出站 / 能力判断 / fallback 的唯一入口，未被绕过。
- **`CoreResponse.command`**：诊断字段（命令名），非内容出站，保留。
- **`PushIntent` / 通知通道**：独立推送通道，非响应契约，保留。
- 未新增 Voice / Video / File / Card / Button 等新富媒体能力。

## 暂不删除的旧接口

`CoreResponse.text / markdown` 不能立即删：Core 内部 `RespondResponse` 仍按 text/markdown 双通道组装正文，`From<RespondResponse> for CoreResponse` 用 `from_compat_fields` 合成 `output`，且大量测试直接断言这两个字段。本 PR 以访问器作为薄适配层收敛，后续待 Core 内部 flow 全量迁移到直接产出 `AssistantOutput` 后再删除字段。

## 验证

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo test --workspace` ✅（common 27 / core 717 / gateway 341 / llm 184，全绿）

行为未变：普通文本、Markdown fallback、image fallback、stream、command、tool loop 完成输出、不支持平台降级路径均由既有回归测试覆盖。
