### PR TITLE
refactor: 删除 Core→Gateway 出站旧兼容接口并下沉出站内容模型到 common

### DIFF
--- a/qq-maid-common/src/lib.rs
+++ b/qq-maid-common/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod identity_context;
 pub mod input_part;
 pub mod markdown_strip;
+pub mod output_part;
 pub mod redaction;
 pub mod text;
 pub mod time_context;

--- a/qq-maid-common/src/output_part.rs
+++ b/qq-maid-common/src/output_part.rs
@@ -1,0 +1,85 @@
+//! 平台无关的出站内容模型。
+//!
+//! 与入站 [`crate::input_part::MessageInputPart`] 对称，这里只描述助手回复的
+//! 顺序化内容块和纯展示元信息，不承载平台发送能力判断、fallback 策略或业务
+//! 语义，便于 gateway、core 和 LLM 层复用。
+//!
+//! `text_fallback` 是所有平台都可降级发送的纯文本；`markdown` 保留结构化排版
+//! 通道；`parts` 为图片、文件、卡片等顺序化出站内容载体。
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssistantOutput {
+    pub text_fallback: String,
+    pub markdown: Option<String>,
+    pub parts: Vec<OutputPart>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OutputPart {
+    Text { text: String },
+    Markdown { markdown: String },
+    Image { media: OutputMedia },
+    File { media: OutputMedia },
+}
+
+/// 出站媒体占位信息。
+///
+/// 作为结构化输出契约存在，平台能力判断和发送由 Gateway render 层负责，
+/// 本结构不要求 Gateway 立即接入发送。
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct OutputMedia {
+    pub mime_type: Option<String>,
+    pub filename: Option<String>,
+    pub size_bytes: Option<u64>,
+    pub url: Option<String>,
+    pub media_id: Option<String>,
+    pub file_id: Option<String>,
+    pub platform: Option<String>,
+    pub fallback_text: Option<String>,
+}
+
+impl AssistantOutput {
+    pub fn text(text: impl Into<String>) -> Self {
+        let text = text.into();
+        Self {
+            text_fallback: text.clone(),
+            markdown: None,
+            parts: non_empty_output_parts([OutputPart::Text { text }]),
+        }
+    }
+
+    pub fn markdown(text_fallback: impl Into<String>, markdown: impl Into<String>) -> Self {
+        let text_fallback = text_fallback.into();
+        let markdown = markdown.into();
+        let mut parts = Vec::new();
+        if !markdown.trim().is_empty() {
+            parts.push(OutputPart::Markdown {
+                markdown: markdown.clone(),
+            });
+        }
+        if parts.is_empty() && !text_fallback.trim().is_empty() {
+            parts.push(OutputPart::Text {
+                text: text_fallback.clone(),
+            });
+        }
+        Self {
+            text_fallback,
+            markdown: Some(markdown),
+            parts,
+        }
+    }
+}
+
+impl OutputPart {
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::Text { text } => text.trim().is_empty(),
+            Self::Markdown { markdown } => markdown.trim().is_empty(),
+            Self::Image { .. } | Self::File { .. } => false,
+        }
+    }
+}
+
+fn non_empty_output_parts(parts: impl IntoIterator<Item = OutputPart>) -> Vec<OutputPart> {
+    parts.into_iter().filter(|part| !part.is_empty()).collect()
+}

--- a/qq-maid-common/src/output_part.rs
+++ b/qq-maid-common/src/output_part.rs
@@ -6,6 +6,13 @@
 //!
 //! `text_fallback` 是所有平台都可降级发送的纯文本；`markdown` 保留结构化排版
 //! 通道；`parts` 为图片、文件、卡片等顺序化出站内容载体。
+//!
+//! 本模块同时提供 parts 到纯文本 / Markdown 的纯渲染 helper，避免 gateway、
+//! core、未来 LLM / tool / push 路径各自重复实现 strip / 拼接逻辑。**平台相关
+//! 的默认文案（如"当前平台暂不支持发送图片"）由调用方作为参数传入**，common
+//! 不绑定任何具体平台文案。
+
+use crate::markdown_strip::strip_markdown_for_chat;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AssistantOutput {
@@ -68,6 +75,82 @@ impl AssistantOutput {
             parts,
         }
     }
+
+    /// 用户可见纯文本 fallback（直读 `text_fallback` 字段，零分配）。
+    ///
+    /// 适合 ref_index 回填、日志等只需读取已组装 fallback 字段的场景。若需要按
+    /// `parts` 重新拼接（含媒体 fallback 文案），使用 [`Self::render_text_fallback`]。
+    pub fn text_content(&self) -> &str {
+        &self.text_fallback
+    }
+
+    /// 用户可见 Markdown 正文（直读 `markdown` 字段，零分配）。
+    ///
+    /// 与 [`Self::text_content`] 对应；纯文本回复时返回 `None`。若需要按 `parts`
+    /// 重新拼接（含媒体 fallback 文案），使用 [`Self::render_markdown`]。
+    pub fn markdown_content(&self) -> Option<&str> {
+        self.markdown.as_deref()
+    }
+
+    /// 按 `parts` 重新拼接用户可见纯文本 fallback。
+    ///
+    /// 优先使用已组装的 `text_fallback`；为空时按 `parts` 顺序拼接各段纯文本
+    /// （Markdown 段会被剥离为纯文本，媒体段在缺少 `fallback_text` 时使用调用方
+    /// 传入的默认文案）。全空时返回 `None`，便于上层判断"无可见正文"。
+    pub fn render_text_fallback(
+        &self,
+        image_fallback: &str,
+        file_fallback: &str,
+    ) -> Option<String> {
+        if !self.text_fallback.trim().is_empty() {
+            return Some(self.text_fallback.clone());
+        }
+        let text = self
+            .parts
+            .iter()
+            .filter_map(|part| part.as_text_segment(image_fallback, file_fallback))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        (!text.trim().is_empty()).then_some(text)
+    }
+
+    /// 按 `parts` 重新拼接用户可见 Markdown 正文。
+    ///
+    /// 优先按 `parts` 中各段拼接（Markdown 段保留原排版，媒体段使用调用方传入的
+    /// 默认文案）；结果为空时回退到 `markdown` 字段，再回退到 `text_fallback`，
+    /// 保证非空 output 总能产出可见正文。
+    pub fn render_markdown(&self, image_fallback: &str, file_fallback: &str) -> String {
+        let markdown = self
+            .parts
+            .iter()
+            .filter_map(|part| part.as_markdown_segment(image_fallback, file_fallback))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        if markdown.trim().is_empty() {
+            self.markdown
+                .clone()
+                .unwrap_or_else(|| self.text_fallback.clone())
+        } else {
+            markdown
+        }
+    }
+
+    /// 按是否偏好 Markdown 取最终单条用户可见正文。
+    ///
+    /// 偏好 Markdown 时返回非空 `markdown` 字段；否则返回非空 `text_fallback`
+    /// 字段。适用于 ref_index 回填、日志、流式收尾等只需一条正文摘要的场景；
+    /// 本方法只读字段不重新拼装 parts，零分配优先。
+    pub fn preferred_text(&self, prefer_markdown: bool) -> Option<String> {
+        if prefer_markdown {
+            self.markdown
+                .as_deref()
+                .map(str::trim)
+                .filter(|text| !text.is_empty())
+                .map(str::to_owned)
+        } else {
+            (!self.text_fallback.trim().is_empty()).then(|| self.text_fallback.clone())
+        }
+    }
 }
 
 impl OutputPart {
@@ -78,8 +161,214 @@ impl OutputPart {
             Self::Image { .. } | Self::File { .. } => false,
         }
     }
+
+    /// 转为纯文本段（Markdown 段会被剥离为纯文本）；空段返回 `None`。
+    ///
+    /// 媒体段在缺少 `fallback_text` 时使用调用方传入的默认文案，避免 common
+    /// 绑定任何具体平台文案。
+    pub fn as_text_segment(&self, image_fallback: &str, file_fallback: &str) -> Option<String> {
+        let text = match self {
+            Self::Text { text } => text.clone(),
+            Self::Markdown { markdown } => strip_markdown_for_chat(markdown),
+            Self::Image { media } => media.fallback_text_or(image_fallback),
+            Self::File { media } => media.fallback_text_or(file_fallback),
+        };
+        (!text.trim().is_empty()).then_some(text)
+    }
+
+    /// 转为 Markdown 段（保留原排版）；空段返回 `None`。
+    ///
+    /// 媒体段 fallback 与 [`Self::as_text_segment`] 一致。
+    pub fn as_markdown_segment(&self, image_fallback: &str, file_fallback: &str) -> Option<String> {
+        let text = match self {
+            Self::Text { text } => text.clone(),
+            Self::Markdown { markdown } => markdown.clone(),
+            Self::Image { media } => media.fallback_text_or(image_fallback),
+            Self::File { media } => media.fallback_text_or(file_fallback),
+        };
+        (!text.trim().is_empty()).then_some(text)
+    }
+}
+
+impl OutputMedia {
+    /// 媒体出站的用户可见 fallback 文本。
+    ///
+    /// 优先使用 `fallback_text`（去掉首尾空白后非空）；否则返回调用方传入的默认
+    /// 文案。默认文案由调用方提供，common 不内置平台相关文案。
+    pub fn fallback_text_or(&self, default_text: &str) -> String {
+        self.fallback_text
+            .as_deref()
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .unwrap_or(default_text)
+            .to_owned()
+    }
 }
 
 fn non_empty_output_parts(parts: impl IntoIterator<Item = OutputPart>) -> Vec<OutputPart> {
     parts.into_iter().filter(|part| !part.is_empty()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_output_carries_single_text_part() {
+        let output = AssistantOutput::text("hello");
+        assert_eq!(output.text_content(), "hello");
+        assert_eq!(output.markdown_content(), None);
+        assert_eq!(
+            output.parts,
+            vec![OutputPart::Text {
+                text: "hello".to_owned()
+            }]
+        );
+    }
+
+    #[test]
+    fn markdown_output_carries_markdown_part_and_field() {
+        let output = AssistantOutput::markdown("plain", "# title");
+        assert_eq!(output.text_content(), "plain");
+        assert_eq!(output.markdown_content(), Some("# title"));
+        assert_eq!(
+            output.parts,
+            vec![OutputPart::Markdown {
+                markdown: "# title".to_owned()
+            }]
+        );
+    }
+
+    #[test]
+    fn render_text_fallback_prefers_text_fallback_field() {
+        let output = AssistantOutput::markdown("plain", "# title");
+        assert_eq!(
+            output.render_text_fallback("no-img", "no-file"),
+            Some("plain".to_owned())
+        );
+    }
+
+    #[test]
+    fn render_text_fallback_joins_parts_when_field_empty() {
+        let output = AssistantOutput {
+            text_fallback: String::new(),
+            markdown: None,
+            parts: vec![
+                OutputPart::Text {
+                    text: "hello".to_owned(),
+                },
+                OutputPart::Markdown {
+                    markdown: "# title".to_owned(),
+                },
+            ],
+        };
+        // text_fallback 为空时按 parts 拼接；markdown 段会被 strip。
+        assert_eq!(
+            output.render_text_fallback("no-img", "no-file"),
+            Some("hello\n\ntitle".to_owned())
+        );
+    }
+
+    #[test]
+    fn render_text_fallback_uses_media_default_when_missing() {
+        let output = AssistantOutput {
+            text_fallback: String::new(),
+            markdown: None,
+            parts: vec![OutputPart::Image {
+                media: OutputMedia::default(),
+            }],
+        };
+        assert_eq!(
+            output.render_text_fallback("图片不支持", "文件不支持"),
+            Some("图片不支持".to_owned())
+        );
+    }
+
+    #[test]
+    fn render_text_fallback_returns_none_when_all_empty() {
+        let output = AssistantOutput {
+            text_fallback: String::new(),
+            markdown: None,
+            parts: Vec::new(),
+        };
+        assert_eq!(output.render_text_fallback("no-img", "no-file"), None);
+    }
+
+    #[test]
+    fn render_markdown_prefers_parts_markdown_segments() {
+        let output = AssistantOutput {
+            text_fallback: "plain".to_owned(),
+            markdown: Some("# legacy".to_owned()),
+            parts: vec![
+                OutputPart::Text {
+                    text: "hello".to_owned(),
+                },
+                OutputPart::Markdown {
+                    markdown: "## title".to_owned(),
+                },
+            ],
+        };
+        assert_eq!(
+            output.render_markdown("no-img", "no-file"),
+            "hello\n\n## title".to_owned()
+        );
+    }
+
+    #[test]
+    fn render_markdown_falls_back_to_markdown_field_when_parts_empty() {
+        let output = AssistantOutput {
+            text_fallback: "plain".to_owned(),
+            markdown: Some("# legacy".to_owned()),
+            parts: Vec::new(),
+        };
+        assert_eq!(output.render_markdown("no-img", "no-file"), "# legacy");
+    }
+
+    #[test]
+    fn render_markdown_falls_back_to_text_fallback_when_markdown_absent() {
+        let output = AssistantOutput::text("plain");
+        assert_eq!(output.render_markdown("no-img", "no-file"), "plain");
+    }
+
+    #[test]
+    fn media_fallback_text_prefers_explicit_value() {
+        let media = OutputMedia {
+            fallback_text: Some("  图片：天气雷达  ".to_owned()),
+            ..OutputMedia::default()
+        };
+        assert_eq!(media.fallback_text_or("default"), "图片：天气雷达");
+    }
+
+    #[test]
+    fn media_fallback_text_uses_default_when_blank_or_missing() {
+        assert_eq!(OutputMedia::default().fallback_text_or("默认"), "默认");
+        let media = OutputMedia {
+            fallback_text: Some("   ".to_owned()),
+            ..OutputMedia::default()
+        };
+        assert_eq!(media.fallback_text_or("默认"), "默认");
+    }
+
+    #[test]
+    fn preferred_text_returns_markdown_when_preferred_and_present() {
+        let output = AssistantOutput::markdown("plain", "# title");
+        assert_eq!(output.preferred_text(true), Some("# title".to_owned()));
+    }
+
+    #[test]
+    fn preferred_text_returns_text_fallback_when_markdown_absent() {
+        let output = AssistantOutput::text("plain");
+        assert_eq!(output.preferred_text(true), None);
+        assert_eq!(output.preferred_text(false), Some("plain".to_owned()));
+    }
+
+    #[test]
+    fn preferred_text_ignores_blank_markdown_field() {
+        let output = AssistantOutput {
+            text_fallback: "plain".to_owned(),
+            markdown: Some("   ".to_owned()),
+            parts: Vec::new(),
+        };
+        assert_eq!(output.preferred_text(true), None);
+    }
 }

--- a/qq-maid-core/src/service/handle.rs
+++ b/qq-maid-core/src/service/handle.rs
@@ -267,12 +267,15 @@ impl From<CoreRequest> for RespondRequest {
 
 impl From<RespondResponse> for CoreResponse {
     fn from(value: RespondResponse) -> Self {
-        let output =
-            AssistantOutput::from_compat_fields(value.text.as_deref(), value.markdown.as_deref());
+        // `RespondResponse` 仍按 text/markdown 双通道组装正文，属于 Core 内部中间结构；
+        // 这里将其合成为唯一的结构化 `AssistantOutput` 输出，不再向 Gateway 暴露旧字段。
+        let output = match (value.text, value.markdown) {
+            (Some(text), Some(markdown)) => Some(AssistantOutput::markdown(text, markdown)),
+            (Some(text), None) => Some(AssistantOutput::text(text)),
+            _ => None,
+        };
         Self {
             output,
-            text: value.text,
-            markdown: value.markdown,
             handled: value.handled,
             session_id: value.session_id,
             command: value.command,

--- a/qq-maid-core/src/service/tests/mod.rs
+++ b/qq-maid-core/src/service/tests/mod.rs
@@ -191,8 +191,9 @@ fn core_response_keeps_public_fields_from_respond_response() {
         error: None,
     });
 
-    assert_eq!(response.text.as_deref(), Some("text"));
-    assert_eq!(response.markdown.as_deref(), Some("**text**"));
+    // Core→Gateway 正文只通过结构化 output 表达，旧 text/markdown 字段已删除。
+    assert_eq!(response.text_content(), Some("text"));
+    assert_eq!(response.markdown_content(), Some("**text**"));
     let output = response.output.as_ref().expect("assistant output");
     assert_eq!(output.text_fallback, "text");
     assert_eq!(output.markdown.as_deref(), Some("**text**"));
@@ -223,11 +224,9 @@ fn assistant_output_text_builds_plain_fallback_part() {
 }
 
 #[test]
-fn core_response_with_output_keeps_legacy_fields_compatible() {
+fn core_response_with_output_sets_structured_output() {
     let response = CoreResponse {
         output: None,
-        text: None,
-        markdown: None,
         handled: Some(true),
         session_id: None,
         command: None,
@@ -236,8 +235,8 @@ fn core_response_with_output_keeps_legacy_fields_compatible() {
     }
     .with_output(AssistantOutput::markdown("fallback", "# title"));
 
-    assert_eq!(response.text.as_deref(), Some("fallback"));
-    assert_eq!(response.markdown.as_deref(), Some("# title"));
+    assert_eq!(response.text_content(), Some("fallback"));
+    assert_eq!(response.markdown_content(), Some("# title"));
     assert_eq!(
         response.output.as_ref().map(|output| output.parts.clone()),
         Some(vec![OutputPart::Markdown {
@@ -247,15 +246,13 @@ fn core_response_with_output_keeps_legacy_fields_compatible() {
 }
 
 #[test]
-fn text_content_and_markdown_content_prefer_structured_output() {
-    // 结构化 output 存在时，访问器优先返回 output 的内容，而不是旧 text/markdown 字段。
+fn text_content_and_markdown_content_read_structured_output() {
+    // 正文访问器只读取结构化 output，旧 text/markdown 兼容字段已删除。
     let response = CoreResponse {
         output: Some(AssistantOutput::markdown(
             "structured fallback",
             "# structured",
         )),
-        text: Some("legacy text".to_owned()),
-        markdown: Some("legacy markdown".to_owned()),
         handled: Some(true),
         session_id: None,
         command: None,
@@ -268,30 +265,10 @@ fn text_content_and_markdown_content_prefer_structured_output() {
 }
 
 #[test]
-fn text_content_falls_back_to_legacy_fields_when_output_absent() {
-    // 旧兼容路径：output 缺失时回退到 text/markdown 兼容字段。
-    let response = CoreResponse {
-        output: None,
-        text: Some("legacy text".to_owned()),
-        markdown: Some("legacy markdown".to_owned()),
-        handled: Some(true),
-        session_id: None,
-        command: None,
-        diagnostics: None,
-        visible_entity_snapshot: None,
-    };
-
-    assert_eq!(response.text_content(), Some("legacy text"));
-    assert_eq!(response.markdown_content(), Some("legacy markdown"));
-}
-
-#[test]
-fn markdown_content_falls_back_to_legacy_when_output_markdown_none() {
-    // output 仅含纯文本 part（markdown=None）时，markdown_content 回退到旧 markdown 字段。
+fn markdown_content_is_none_when_output_only_has_text() {
+    // output 仅含纯文本 part（markdown=None）时，markdown_content 返回 None。
     let response = CoreResponse {
         output: Some(AssistantOutput::text("plain")),
-        text: Some("plain".to_owned()),
-        markdown: Some("# legacy".to_owned()),
         handled: Some(true),
         session_id: None,
         command: None,
@@ -300,15 +277,13 @@ fn markdown_content_falls_back_to_legacy_when_output_markdown_none() {
     };
 
     assert_eq!(response.text_content(), Some("plain"));
-    assert_eq!(response.markdown_content(), Some("# legacy"));
+    assert_eq!(response.markdown_content(), None);
 }
 
 #[test]
-fn text_content_returns_none_when_no_content_anywhere() {
+fn text_content_returns_none_when_output_absent() {
     let response = CoreResponse {
         output: None,
-        text: None,
-        markdown: None,
         handled: Some(false),
         session_id: None,
         command: None,
@@ -600,7 +575,7 @@ async fn stream_response_is_not_cut_by_request_total_timeout() {
 
     let response = collect_stream_completed(service.respond(private_request("hello")).await).await;
 
-    assert_eq!(response.text.as_deref(), Some("late"));
+    assert_eq!(response.text_content(), Some("late"));
 }
 
 #[tokio::test]
@@ -636,7 +611,7 @@ async fn chat_stream_forwards_text_delta_and_completed_from_same_stream() {
         panic!("expected completed response");
     };
 
-    assert_eq!(response.text.as_deref(), Some("你好"));
+    assert_eq!(response.text_content(), Some("你好"));
     assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
     let sessions = session_store.list_for_scope(private_scope(), None).unwrap();
     assert_eq!(sessions[0].history.last().unwrap().content, "你好");
@@ -658,7 +633,7 @@ async fn stream_disabled_chat_completes_without_synthetic_delta() {
         panic!("expected completed response");
     };
 
-    assert_eq!(response.text.as_deref(), Some("非流完整回复"));
+    assert_eq!(response.text_content(), Some("非流完整回复"));
     assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
     assert_eq!(
         provider.requests()[0].metadata.get("purpose").unwrap(),
@@ -684,7 +659,7 @@ async fn wechat_service_chat_completes_without_direct_stream() {
         panic!("expected completed response");
     };
 
-    assert_eq!(response.text.as_deref(), Some("微信完整回复"));
+    assert_eq!(response.text_content(), Some("微信完整回复"));
     assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
     assert_eq!(
         provider.requests()[0].metadata.get("purpose").unwrap(),
@@ -718,7 +693,7 @@ async fn core_private_weather_chat_with_tool_capability_completes_without_synthe
 
     let response = collect_completed_without_text_delta(&mut stream).await;
 
-    assert_eq!(response.text.as_deref(), Some("工具完整回复"));
+    assert_eq!(response.text_content(), Some("工具完整回复"));
     assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
     assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
 }
@@ -808,7 +783,7 @@ async fn core_tool_loop_completes_only_after_final_answer_is_trusted() {
         }
     };
 
-    assert_eq!(response.text.as_deref(), Some("候选草稿"));
+    assert_eq!(response.text_content(), Some("候选草稿"));
     assert!(status_kinds.contains(&CoreResponseStatusKind::ToolLoopStarted));
     assert!(status_kinds.contains(&CoreResponseStatusKind::ToolLoopFinalizing));
     // Tool Loop 事件流来自完整 Tool Loop 的最终结果，不消费 provider token 流，
@@ -898,8 +873,8 @@ async fn core_private_simple_todo_queries_use_deterministic_path() {
         };
         let response = *response;
         assert_eq!(response.command.as_deref(), Some("todo_list"), "{input}");
-        assert!(response.text.as_deref().unwrap().contains("待查看项目"));
-        responses.push(response.text);
+        assert!(response.text_content().unwrap().contains("待查看项目"));
+        responses.push(response.text_content().map(str::to_owned));
     }
 
     assert_eq!(responses[0], responses[1]);
@@ -916,7 +891,7 @@ async fn core_private_general_chat_with_tool_capability_uses_streaming_chat() {
 
     let response = collect_stream_completed(service.respond(private_request("晚上好")).await).await;
 
-    assert_eq!(response.text.as_deref(), Some("普通完整回复"));
+    assert_eq!(response.text_content(), Some("普通完整回复"));
     assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
     assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
 }
@@ -931,7 +906,7 @@ async fn core_group_chat_keeps_stream_path_even_when_tool_capable() {
     let response =
         collect_stream_completed(service.respond(group_request("群里问天气")).await).await;
 
-    assert_eq!(response.text.as_deref(), Some("群聊普通回复"));
+    assert_eq!(response.text_content(), Some("群聊普通回复"));
     assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
     assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
 }
@@ -962,7 +937,7 @@ async fn core_tool_calling_disabled_keeps_plain_stream_path() {
 
     let response = collect_stream_completed(service.respond(private_request("hello")).await).await;
 
-    assert_eq!(response.text.as_deref(), Some("普通流式回复"));
+    assert_eq!(response.text_content(), Some("普通流式回复"));
     assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
     assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
 }
@@ -975,7 +950,7 @@ async fn core_unsupported_provider_capability_keeps_plain_stream_path() {
 
     let response = collect_stream_completed(service.respond(private_request("hello")).await).await;
 
-    assert_eq!(response.text.as_deref(), Some("未适配 provider 普通回复"));
+    assert_eq!(response.text_content(), Some("未适配 provider 普通回复"));
     assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
     assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
 }

--- a/qq-maid-core/src/service/types.rs
+++ b/qq-maid-core/src/service/types.rs
@@ -8,6 +8,10 @@ use qq_maid_common::{
     identity_context::{ConversationContext, MentionIdentity, MessageActorContext, MessageContext},
     input_part::{MessageInputPart, QuotedMessageContext},
 };
+
+// 平台无关出站内容模型已下沉到 common，这里重新导出以维持
+// `crate::service::{AssistantOutput, OutputPart, OutputMedia}` 的对外路径稳定。
+pub use qq_maid_common::output_part::{AssistantOutput, OutputMedia, OutputPart};
 use tokio::sync::mpsc;
 
 use crate::identity::conversation_scope_key;
@@ -128,59 +132,19 @@ pub enum CoreConversation {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CoreResponse {
-    /// 结构化出站内容，Core → Gateway 完整回复的正式契约。
+    /// 结构化出站内容，Core → Gateway 完整回复的唯一正文契约。
     ///
-    /// Gateway 出站渲染、ref_index 文本回填、流式收尾等读取用户可见正文时，
-    /// 应优先通过 [`CoreResponse::text_content`] / [`CoreResponse::markdown_content`]
-    /// 访问，而不是直接读下方的兼容字段。
+    /// Gateway 出站渲染、ref_index 文本回填、流式收尾、日志等读取用户可见正文
+    /// 时，应统一通过 [`CoreResponse::text_content`] / [`CoreResponse::markdown_content`]
+    /// 访问，不再存在平行的旧 `text` / `markdown` 字段。Core 内部 `RespondResponse`
+    /// 仍可按 text/markdown 双通道组装正文，但只在转换为 `CoreResponse` 时合成为
+    /// 该结构化 output，不外泄到 Core→Gateway 边界。
     pub output: Option<AssistantOutput>,
-    /// 兼容字段：与 `output.text_fallback` 保持同步。
-    ///
-    /// 仅为过渡期保留，覆盖 Core 内部 `RespondResponse` 仍按 text/markdown 双通道
-    /// 组装正文、以及部分测试断言的旧路径。待 Core 内部 flow 全量迁移到
-    /// `AssistantOutput` 且无测试直接断言后可删除。
-    pub text: Option<String>,
-    /// 兼容字段：与 `output.markdown` 保持同步，删除条件同 `text`。
-    pub markdown: Option<String>,
     pub handled: Option<bool>,
     pub session_id: Option<String>,
     pub command: Option<String>,
     pub diagnostics: Option<serde_json::Value>,
     pub visible_entity_snapshot: Option<VisibleEntitySnapshot>,
-}
-
-/// 平台无关的助手出站内容模型。
-///
-/// `text_fallback` 是所有平台都可降级发送的纯文本；`markdown` 保留现有 Markdown
-/// 通道兼容；`parts` 为后续图片、文件、卡片等结构化出站内容预留顺序化载体。
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AssistantOutput {
-    pub text_fallback: String,
-    pub markdown: Option<String>,
-    pub parts: Vec<OutputPart>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum OutputPart {
-    Text { text: String },
-    Markdown { markdown: String },
-    Image { media: OutputMedia },
-    File { media: OutputMedia },
-}
-
-/// 出站媒体占位信息。
-///
-/// 第一阶段只作为 Core 内结构化输出契约，不要求 Gateway 立即接入发送。
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct OutputMedia {
-    pub mime_type: Option<String>,
-    pub filename: Option<String>,
-    pub size_bytes: Option<u64>,
-    pub url: Option<String>,
-    pub media_id: Option<String>,
-    pub file_id: Option<String>,
-    pub platform: Option<String>,
-    pub fallback_text: Option<String>,
 }
 
 #[derive(Debug)]
@@ -301,89 +265,28 @@ impl CoreRespondOutput {
 
 impl CoreResponse {
     pub fn with_output(mut self, output: AssistantOutput) -> Self {
-        self.text = Some(output.text_fallback.clone());
-        self.markdown = output.markdown.clone();
         self.output = Some(output);
         self
     }
 
-    /// 用户可见文本 fallback，优先取结构化 `AssistantOutput::text_fallback`。
+    /// 用户可见文本 fallback，读取结构化 `AssistantOutput::text_fallback`。
     ///
     /// Gateway 出站 / ref_index 回填 / 流式收尾 / 日志等需要读取最终正文的路径应统一
-    /// 走本访问器，不再直接读 `text` 兼容字段，避免 Core 内部迁移到 `AssistantOutput`
-    /// 后出现两套数据源。`text` 字段仅在 `output` 缺失（旧兼容路径）时兜底。
+    /// 走本访问器；旧 `text` 兼容字段已删除，正文只存在于 `output`。
     pub fn text_content(&self) -> Option<&str> {
         self.output
             .as_ref()
             .map(|output| output.text_fallback.as_str())
-            .or(self.text.as_deref())
     }
 
-    /// 用户可见 Markdown 正文，优先取结构化 `AssistantOutput::markdown`。
+    /// 用户可见 Markdown 正文，读取结构化 `AssistantOutput::markdown`。
     ///
-    /// 与 [`Self::text_content`] 对应；`markdown` 兼容字段仅在 `output` 缺失或其
-    /// `markdown` 为 `None` 时兜底。
+    /// 与 [`Self::text_content`] 对应；旧 `markdown` 兼容字段已删除，正文只存在于 `output`。
     pub fn markdown_content(&self) -> Option<&str> {
         self.output
             .as_ref()
             .and_then(|output| output.markdown.as_deref())
-            .or(self.markdown.as_deref())
     }
-}
-
-impl AssistantOutput {
-    pub fn text(text: impl Into<String>) -> Self {
-        let text = text.into();
-        Self {
-            text_fallback: text.clone(),
-            markdown: None,
-            parts: non_empty_output_parts([OutputPart::Text { text }]),
-        }
-    }
-
-    pub fn markdown(text_fallback: impl Into<String>, markdown: impl Into<String>) -> Self {
-        let text_fallback = text_fallback.into();
-        let markdown = markdown.into();
-        let mut parts = Vec::new();
-        if !markdown.trim().is_empty() {
-            parts.push(OutputPart::Markdown {
-                markdown: markdown.clone(),
-            });
-        }
-        if parts.is_empty() && !text_fallback.trim().is_empty() {
-            parts.push(OutputPart::Text {
-                text: text_fallback.clone(),
-            });
-        }
-        Self {
-            text_fallback,
-            markdown: Some(markdown),
-            parts,
-        }
-    }
-
-    pub fn from_compat_fields(text: Option<&str>, markdown: Option<&str>) -> Option<Self> {
-        let text = text?.to_owned();
-        let markdown = markdown.map(str::to_owned);
-        Some(match markdown {
-            Some(markdown) => Self::markdown(text, markdown),
-            None => Self::text(text),
-        })
-    }
-}
-
-impl OutputPart {
-    fn is_empty(&self) -> bool {
-        match self {
-            Self::Text { text } => text.trim().is_empty(),
-            Self::Markdown { markdown } => markdown.trim().is_empty(),
-            Self::Image { .. } | Self::File { .. } => false,
-        }
-    }
-}
-
-fn non_empty_output_parts(parts: impl IntoIterator<Item = OutputPart>) -> Vec<OutputPart> {
-    parts.into_iter().filter(|part| !part.is_empty()).collect()
 }
 
 impl CoreRequest {

--- a/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
@@ -40,8 +40,6 @@ impl CoreService for MockCore {
     async fn respond(&self, _request: CoreRequest) -> Result<CoreRespondOutput, CoreError> {
         Ok(CoreRespondOutput::Complete(Box::new(CoreResponse {
             output: Some(qq_maid_core::service::AssistantOutput::text("ok")),
-            text: Some("ok".to_owned()),
-            markdown: None,
             handled: Some(true),
             session_id: None,
             command: None,

--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -805,8 +805,6 @@ mod tests {
     fn respond_response(text: &str) -> RespondResponse {
         RespondResponse {
             output: Some(qq_maid_core::service::AssistantOutput::markdown(text, text)),
-            text: Some(text.to_owned()),
-            markdown: Some(text.to_owned()),
             handled: Some(true),
             session_id: None,
             command: None,

--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -82,19 +82,15 @@ async fn send_c2c_respond_response(
         runtime,
     };
     let capability = ReplyCapability::qq_official_c2c(config);
-    let sent_ids =
+    let (sent_ids, fallback_text) =
         send_c2c_respond_response_with_sender(&sender, message, response, config, &capability)
             .await?;
-    let text = response
-        .markdown_content()
-        .or(response.text_content())
-        .unwrap_or("");
     record_c2c_bot_outbound_refs(
         ref_index,
         message,
         config,
         sent_ids,
-        text,
+        &fallback_text,
         response.visible_entity_snapshot.clone(),
     );
     Ok(())
@@ -132,7 +128,7 @@ pub(super) async fn send_c2c_respond_response_with_sender<S: OutboundSender + ?S
     response: &RespondResponse,
     config: &AppConfig,
     capability: &ReplyCapability,
-) -> anyhow::Result<Vec<SendMessageIds>> {
+) -> anyhow::Result<(Vec<SendMessageIds>, String)> {
     let masked_user = mask_openid(&message.user_openid);
     let outbound = match render_respond_response_for_profile(response, &capability.render) {
         Some(outbound) => outbound,
@@ -166,8 +162,9 @@ pub(super) async fn send_c2c_respond_response_with_sender<S: OutboundSender + ?S
         config.text_chunk_soft_limit,
     );
     // 普通回复统一走分段编排：长回复拆成多条逐段发送，段间失败返回 PartiallySent。
+    let fallback_text = outbound.fallback_text().to_owned();
     match send_c2c_outbound_chunked(sender, &target, &outbound, &limits, |_, _| {}).await {
-        Ok(sent_ids) => Ok(sent_ids),
+        Ok(sent_ids) => Ok((sent_ids, fallback_text)),
         Err(OutboundSendError::NotSent { source }) => {
             warn!(
                 message_id = target.msg_id.as_deref().unwrap_or(""),
@@ -481,7 +478,7 @@ where
             RespondEvent::Completed(response) => {
                 stop_typing(typing, TypingStopReason::FinalReply);
                 let capability = ReplyCapability::qq_official_c2c(config);
-                let sent_ids = send_c2c_respond_response_with_sender(
+                let (sent_ids, fallback_text) = send_c2c_respond_response_with_sender(
                     sender,
                     message,
                     &response,
@@ -513,16 +510,12 @@ where
                     );
                 })?;
                 if let Some(ref_index) = ref_index {
-                    let text = response
-                        .markdown_content()
-                        .or(response.text_content())
-                        .unwrap_or("");
                     record_c2c_bot_outbound_refs(
                         ref_index,
                         message,
                         config,
                         sent_ids,
-                        text,
+                        &fallback_text,
                         response.visible_entity_snapshot.clone(),
                     );
                 }
@@ -1026,6 +1019,54 @@ mod tests {
         assert_eq!(
             quoted_lookup_found(&ref_index, &config, "markdown-id"),
             None
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_stream_completed_records_rendered_parts_fallback_ref_index() {
+        let config = test_config();
+        let response = RespondResponse {
+            output: Some(qq_maid_core::service::AssistantOutput {
+                text_fallback: String::new(),
+                markdown: None,
+                parts: vec![
+                    qq_maid_core::service::OutputPart::Markdown {
+                        markdown: "# 标题".to_owned(),
+                    },
+                    qq_maid_core::service::OutputPart::Image {
+                        media: qq_maid_core::service::OutputMedia {
+                            fallback_text: Some("图片：天气雷达".to_owned()),
+                            ..qq_maid_core::service::OutputMedia::default()
+                        },
+                    },
+                ],
+            }),
+            handled: Some(true),
+            session_id: None,
+            command: None,
+            diagnostics: None,
+            visible_entity_snapshot: None,
+        };
+        let events = FakeEventStream::new([RespondEvent::Completed(Box::new(response))]);
+        let sender = FakeOutboundSender::default();
+        let mut typing = None;
+        let ref_index = crate::gateway::ref_index::ref_index();
+
+        let outcome = handle_c2c_stream_disabled(
+            events,
+            &sender,
+            &c2c_message(),
+            &config,
+            &mut typing,
+            Some(&ref_index),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, DisabledStreamOutcome::Completed);
+        assert_eq!(
+            quoted_lookup_found(&ref_index, &config, "REFIDX_markdown_id").as_deref(),
+            Some("标题\n\n图片：天气雷达")
         );
     }
 

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -331,6 +331,7 @@ async fn send_group_respond_response(
             response,
             config,
             sent_ids,
+            outbound.fallback_text(),
         );
     })
     .await
@@ -351,6 +352,7 @@ fn record_group_bot_outbound_send(
     response: &RespondResponse,
     config: &AppConfig,
     sent_ids: &SendMessageIds,
+    text: &str,
 ) {
     {
         let mut cache = group_outbound_cache.lock().unwrap();
@@ -358,10 +360,6 @@ fn record_group_bot_outbound_send(
         cache.insert_ref_index_id(sent_ids.ref_index_id.clone());
     }
     let inbound = platform::qq_official::inbound_from_group(message);
-    let text = response
-        .markdown_content()
-        .or(response.text_content())
-        .unwrap_or("");
     ref_index.lock().unwrap().insert_bot_outbound(
         platform::Platform::QqOfficial,
         Some(&config.app_id),
@@ -1020,7 +1018,15 @@ mod tests {
             ref_index_id: Some("REFIDX_1".to_owned()),
         };
 
-        record_group_bot_outbound_send(&cache, &ref_index, &message, &response, &config, &sent_ids);
+        record_group_bot_outbound_send(
+            &cache,
+            &ref_index,
+            &message,
+            &response,
+            &config,
+            &sent_ids,
+            "机器人回复",
+        );
 
         assert!(cache.lock().unwrap().contains("qq_msg_1"));
         assert!(!cache.lock().unwrap().contains("REFIDX_1"));
@@ -1053,6 +1059,63 @@ mod tests {
     }
 
     #[test]
+    fn group_send_records_rendered_fallback_when_output_text_field_is_empty() {
+        let config = test_config();
+        let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        let ref_index = crate::gateway::ref_index::ref_index();
+        let message = group_message("小女仆 看图", GroupEventType::GroupMessage);
+        let response = RespondResponse {
+            output: Some(qq_maid_core::service::AssistantOutput {
+                text_fallback: String::new(),
+                markdown: None,
+                parts: vec![qq_maid_core::service::OutputPart::Image {
+                    media: qq_maid_core::service::OutputMedia {
+                        fallback_text: Some("图片：天气雷达".to_owned()),
+                        ..qq_maid_core::service::OutputMedia::default()
+                    },
+                }],
+            }),
+            handled: Some(true),
+            session_id: None,
+            command: None,
+            diagnostics: None,
+            visible_entity_snapshot: None,
+        };
+
+        record_group_bot_outbound_send(
+            &cache,
+            &ref_index,
+            &message,
+            &response,
+            &config,
+            &SendMessageIds {
+                message_id: Some("qq_msg_1".to_owned()),
+                ref_index_id: Some("REFIDX_rendered".to_owned()),
+            },
+            "图片：天气雷达",
+        );
+
+        let mut quoted = group_message("继续", GroupEventType::GroupMessage);
+        quoted.reply = Some(crate::gateway::event::MessageReply {
+            message_id: "qq_reply_payload_id".to_owned(),
+            ref_msg_idx: Some("REFIDX_rendered".to_owned()),
+            content: None,
+            input_parts: Vec::new(),
+            media_summaries: Vec::new(),
+        });
+        let mut inbound = platform::qq_official::inbound_from_group(&quoted);
+        inbound.account_id = Some(config.app_id.clone());
+        ref_index.lock().unwrap().enrich_inbound(&mut inbound);
+
+        let quoted_context = inbound.quoted.as_ref().unwrap();
+        assert!(quoted_context.lookup_found);
+        assert_eq!(
+            quoted_context.text_summary.as_deref(),
+            Some("图片：天气雷达")
+        );
+    }
+
+    #[test]
     fn group_send_does_not_cross_use_message_id_and_refidx_when_one_is_missing() {
         let config = test_config();
         let response = RespondResponse {
@@ -1077,6 +1140,7 @@ mod tests {
                 message_id: Some("qq_msg_only".to_owned()),
                 ref_index_id: None,
             },
+            "机器人回复",
         );
         assert!(message_only_cache.lock().unwrap().contains("qq_msg_only"));
         assert!(
@@ -1109,6 +1173,7 @@ mod tests {
                 message_id: None,
                 ref_index_id: Some("REFIDX_only".to_owned()),
             },
+            "机器人回复",
         );
         assert!(!refidx_only_cache.lock().unwrap().contains("REFIDX_only"));
         assert!(

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -589,8 +589,6 @@ mod tests {
         RespondClient::new(Arc::new(MockCore {
             response: RespondResponse {
                 output: None,
-                text: None,
-                markdown: None,
                 handled: Some(true),
                 session_id: None,
                 command: None,
@@ -1011,8 +1009,6 @@ mod tests {
                 "机器人回复",
                 "机器人回复",
             )),
-            text: Some("机器人回复".to_owned()),
-            markdown: Some("机器人回复".to_owned()),
             handled: Some(true),
             session_id: None,
             command: None,
@@ -1061,8 +1057,6 @@ mod tests {
         let config = test_config();
         let response = RespondResponse {
             output: Some(qq_maid_core::service::AssistantOutput::text("机器人回复")),
-            text: Some("机器人回复".to_owned()),
-            markdown: None,
             handled: Some(true),
             session_id: None,
             command: None,

--- a/qq-maid-gateway-rs/src/gateway/stream/delivery.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/delivery.rs
@@ -637,7 +637,7 @@ where
                             output_policy.as_str()
                         };
                         let capability = ReplyCapability::qq_official_c2c(config);
-                        let sent_ids = send_c2c_respond_response_with_sender(
+                        let (sent_ids, fallback_text) = send_c2c_respond_response_with_sender(
                             sender,
                             message,
                             &response,
@@ -686,7 +686,7 @@ where
                                 message,
                                 config,
                                 sent_ids,
-                                final_content,
+                                &fallback_text,
                                 response.visible_entity_snapshot.clone(),
                             );
                         }
@@ -773,7 +773,7 @@ where
         C2cStreamingPhase::Pending(_) if !accumulated.is_empty() && !stream_first_attempted => {
             let response = response_from_incomplete_stream_text(&accumulated);
             let capability = ReplyCapability::qq_official_c2c(config);
-            let sent_ids = send_c2c_respond_response_with_sender(
+            let (sent_ids, fallback_text) = send_c2c_respond_response_with_sender(
                 sender,
                 message,
                 &response,
@@ -787,7 +787,7 @@ where
                     message,
                     config,
                     sent_ids,
-                    &accumulated,
+                    &fallback_text,
                     None,
                 );
             }

--- a/qq-maid-gateway-rs/src/gateway/stream/send.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/send.rs
@@ -25,8 +25,6 @@ pub(crate) fn response_from_incomplete_stream_text(content: &str) -> RespondResp
         output: Some(qq_maid_core::service::AssistantOutput::markdown(
             content, content,
         )),
-        text: Some(content.to_owned()),
-        markdown: Some(content.to_owned()),
         handled: Some(true),
         session_id: None,
         command: None,

--- a/qq-maid-gateway-rs/src/gateway/stream/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests.rs
@@ -217,8 +217,6 @@ fn c2c_message() -> C2cMessage {
 fn respond_response(text: &str) -> RespondResponse {
     RespondResponse {
         output: Some(qq_maid_core::service::AssistantOutput::markdown(text, text)),
-        text: Some(text.to_owned()),
-        markdown: Some(text.to_owned()),
         handled: Some(true),
         session_id: None,
         command: None,

--- a/qq-maid-gateway-rs/src/gateway/wechat_service/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/wechat_service/tests.rs
@@ -177,8 +177,6 @@ impl CoreService for MockCore {
                 "hello <wx> & user",
                 "**hello**",
             )),
-            text: Some("hello <wx> & user".to_owned()),
-            markdown: Some("**hello**".to_owned()),
             handled: Some(true),
             session_id: None,
             command: None,

--- a/qq-maid-gateway-rs/src/render.rs
+++ b/qq-maid-gateway-rs/src/render.rs
@@ -357,6 +357,35 @@ mod tests {
     }
 
     #[test]
+    fn structured_image_part_uses_fallback_text_even_when_image_supported() {
+        let response = RespondResponse {
+            output: Some(AssistantOutput {
+                text_fallback: String::new(),
+                markdown: None,
+                parts: vec![OutputPart::Image {
+                    media: OutputMedia {
+                        media_id: Some("image-media-id".to_owned()),
+                        fallback_text: Some("图片：天气雷达".to_owned()),
+                        ..OutputMedia::default()
+                    },
+                }],
+            }),
+            handled: Some(true),
+            session_id: None,
+            command: None,
+            diagnostics: None,
+            visible_entity_snapshot: None,
+        };
+
+        assert_eq!(
+            render_respond_response(&response, false, true),
+            Some(OutboundMessage::Text {
+                text: "图片：天气雷达".to_owned(),
+            })
+        );
+    }
+
+    #[test]
     fn unsupported_structured_part_uses_explicit_fallback_text() {
         let response = RespondResponse {
             output: Some(AssistantOutput {

--- a/qq-maid-gateway-rs/src/render.rs
+++ b/qq-maid-gateway-rs/src/render.rs
@@ -2,8 +2,7 @@ use crate::{
     gateway::outbound::RenderProfile, markdown::MarkdownPayload, media::ImagePayload,
     respond::RespondResponse,
 };
-use qq_maid_common::markdown_strip::strip_markdown_for_chat;
-use qq_maid_core::service::{AssistantOutput, OutputMedia, OutputPart};
+use qq_maid_core::service::{AssistantOutput, OutputPart};
 
 const UNSUPPORTED_IMAGE_FALLBACK_TEXT: &str = "当前平台暂不支持发送这类图片内容。";
 const UNSUPPORTED_FILE_FALLBACK_TEXT: &str = "当前平台暂不支持发送这类文件内容。";
@@ -125,7 +124,11 @@ fn render_assistant_output_for_profile(
     output: &AssistantOutput,
     profile: &RenderProfile,
 ) -> Option<OutboundMessage> {
-    let fallback_text = normalized_output_fallback(output)?;
+    // 用户可见纯文本 fallback（媒体缺文案时使用平台默认文案），全空时整体不渲染。
+    let fallback_text = output.render_text_fallback(
+        UNSUPPORTED_IMAGE_FALLBACK_TEXT,
+        UNSUPPORTED_FILE_FALLBACK_TEXT,
+    )?;
 
     if profile.supports_markdown
         && output
@@ -133,7 +136,11 @@ fn render_assistant_output_for_profile(
             .iter()
             .any(|part| matches!(part, OutputPart::Markdown { .. }))
     {
-        let markdown = render_parts_as_markdown(output);
+        // 按 parts 拼接 Markdown（媒体 fallback 同样使用平台默认文案）；非空才出 Markdown。
+        let markdown = output.render_markdown(
+            UNSUPPORTED_IMAGE_FALLBACK_TEXT,
+            UNSUPPORTED_FILE_FALLBACK_TEXT,
+        );
         if !markdown.trim().is_empty() {
             return Some(OutboundMessage::Markdown {
                 markdown: MarkdownPayload::new(markdown),
@@ -142,80 +149,15 @@ fn render_assistant_output_for_profile(
         }
     }
 
-    profile.supports_text.then(|| OutboundMessage::Text {
-        text: render_parts_as_text(output),
+    profile.supports_text.then_some(OutboundMessage::Text {
+        text: fallback_text,
     })
-}
-
-fn normalized_output_fallback(output: &AssistantOutput) -> Option<String> {
-    let text = output.text_fallback.trim();
-    if !text.is_empty() {
-        return Some(output.text_fallback.clone());
-    }
-
-    let text = output
-        .parts
-        .iter()
-        .filter_map(part_text_fallback)
-        .collect::<Vec<_>>()
-        .join("\n\n");
-    (!text.trim().is_empty()).then_some(text)
-}
-
-fn render_parts_as_text(output: &AssistantOutput) -> String {
-    normalized_output_fallback(output).unwrap_or_default()
-}
-
-fn render_parts_as_markdown(output: &AssistantOutput) -> String {
-    let markdown = output
-        .parts
-        .iter()
-        .filter_map(part_markdown_render)
-        .collect::<Vec<_>>()
-        .join("\n\n");
-    if markdown.trim().is_empty() {
-        output
-            .markdown
-            .clone()
-            .unwrap_or_else(|| output.text_fallback.clone())
-    } else {
-        markdown
-    }
-}
-
-fn part_text_fallback(part: &OutputPart) -> Option<String> {
-    let text = match part {
-        OutputPart::Text { text } => text.clone(),
-        OutputPart::Markdown { markdown } => strip_markdown_for_chat(markdown),
-        OutputPart::Image { media } => media_fallback_text(media, UNSUPPORTED_IMAGE_FALLBACK_TEXT),
-        OutputPart::File { media } => media_fallback_text(media, UNSUPPORTED_FILE_FALLBACK_TEXT),
-    };
-    (!text.trim().is_empty()).then_some(text)
-}
-
-fn part_markdown_render(part: &OutputPart) -> Option<String> {
-    let text = match part {
-        OutputPart::Text { text } => text.clone(),
-        OutputPart::Markdown { markdown } => markdown.clone(),
-        OutputPart::Image { media } => media_fallback_text(media, UNSUPPORTED_IMAGE_FALLBACK_TEXT),
-        OutputPart::File { media } => media_fallback_text(media, UNSUPPORTED_FILE_FALLBACK_TEXT),
-    };
-    (!text.trim().is_empty()).then_some(text)
-}
-
-fn media_fallback_text(media: &OutputMedia, default_text: &'static str) -> String {
-    media
-        .fallback_text
-        .as_deref()
-        .map(str::trim)
-        .filter(|text| !text.is_empty())
-        .unwrap_or(default_text)
-        .to_owned()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use qq_maid_core::service::OutputMedia;
 
     fn response_with_body(text: Option<&str>, markdown: Option<&str>) -> RespondResponse {
         // `from_compat_fields` 旧兼容桥接已删除，这里直接用结构化构造函数。

--- a/qq-maid-gateway-rs/src/render.rs
+++ b/qq-maid-gateway-rs/src/render.rs
@@ -218,17 +218,28 @@ mod tests {
     use super::*;
 
     fn response_with_body(text: Option<&str>, markdown: Option<&str>) -> RespondResponse {
-        let mut response = response_with_legacy_body(text, markdown);
-        response.output =
-            qq_maid_core::service::AssistantOutput::from_compat_fields(text, markdown);
-        response
+        // `from_compat_fields` 旧兼容桥接已删除，这里直接用结构化构造函数。
+        let output = match (text, markdown) {
+            (Some(text), Some(markdown)) => Some(qq_maid_core::service::AssistantOutput::markdown(
+                text, markdown,
+            )),
+            (Some(text), None) => Some(qq_maid_core::service::AssistantOutput::text(text)),
+            _ => None,
+        };
+        RespondResponse {
+            output,
+            handled: Some(true),
+            session_id: None,
+            command: None,
+            diagnostics: None,
+            visible_entity_snapshot: None,
+        }
     }
 
-    fn response_with_legacy_body(text: Option<&str>, markdown: Option<&str>) -> RespondResponse {
+    fn response_with_empty_output() -> RespondResponse {
+        // 渲染层在 output 缺失时返回 None，对应旧空正文路径。
         RespondResponse {
             output: None,
-            text: text.map(str::to_owned),
-            markdown: markdown.map(str::to_owned),
             handled: Some(true),
             session_id: None,
             command: None,
@@ -314,17 +325,10 @@ mod tests {
     }
 
     #[test]
-    fn empty_legacy_respond_text_renders_to_none() {
+    fn empty_respond_output_renders_to_none() {
+        // output 缺失时渲染层返回 None，不再依赖旧 text/markdown 兼容字段。
         assert_eq!(
-            render_respond_response(
-                &response_with_legacy_body(Some(" \n\t"), Some("# hi")),
-                true,
-                true
-            ),
-            None
-        );
-        assert_eq!(
-            render_respond_response(&response_with_legacy_body(None, Some("# hi")), true, true),
+            render_respond_response(&response_with_empty_output(), true, true),
             None
         );
     }
@@ -361,8 +365,6 @@ mod tests {
                     },
                 ],
             }),
-            text: Some("legacy text ignored".to_owned()),
-            markdown: Some("legacy markdown ignored".to_owned()),
             handled: Some(true),
             session_id: None,
             command: None,
@@ -397,8 +399,6 @@ mod tests {
                     },
                 ],
             }),
-            text: None,
-            markdown: None,
             handled: Some(true),
             session_id: None,
             command: None,
@@ -424,8 +424,6 @@ mod tests {
                     media: OutputMedia::default(),
                 }],
             }),
-            text: None,
-            markdown: None,
             handled: Some(true),
             session_id: None,
             command: None,
@@ -442,15 +440,13 @@ mod tests {
     }
 
     #[test]
-    fn output_with_empty_parts_uses_legacy_compat_fields() {
+    fn output_with_empty_parts_falls_back_to_text_fallback_and_markdown() {
         let response = RespondResponse {
             output: Some(AssistantOutput {
                 text_fallback: "output fallback".to_owned(),
                 markdown: Some("**output markdown**".to_owned()),
                 parts: Vec::new(),
             }),
-            text: None,
-            markdown: None,
             handled: Some(true),
             session_id: None,
             command: None,

--- a/qq-maid-gateway-rs/src/respond.rs
+++ b/qq-maid-gateway-rs/src/respond.rs
@@ -914,8 +914,6 @@ mod tests {
     fn unsafe_error_detail_is_not_shown_to_user() {
         let _response = RespondResponse {
             output: None,
-            text: None,
-            markdown: None,
             handled: Some(false),
             session_id: None,
             command: None,


### PR DESCRIPTION
## 背景

推进 #352「媒体链路接口收敛：清理旧接口与过渡兼容层」。PR #354 已把 Gateway 读取用户可见正文的路径统一走 `CoreResponse::text_content() / markdown_content()`，但 `CoreResponse.text / markdown` 旧兼容字段与 `AssistantOutput::from_compat_fields` 旧桥接仍保留，存在双轨维护。本 PR 继续收敛，并把平台无关出站内容模型及其纯渲染 helper 下沉到 `qq-maid-common`，与入站 `MessageInputPart` 的分层对称。

## 改动

### 出站内容模型下沉到 common
- 新增 `qq-maid-common/src/output_part.rs`，承载 `AssistantOutput / OutputPart / OutputMedia` 及纯构造与渲染 helper
- `qq-maid-core/src/service/types.rs` 改为 `pub use qq_maid_common::output_part::{AssistantOutput, OutputPart, OutputMedia};`，维持 `qq_maid_core::service::AssistantOutput` 等对外路径稳定
- `CoreRequest / CoreResponse / CoreResponseStream / CoreResponseEvent / CoreError` 继续留在 core；`RenderProfile / OutboundMessage` 平台逻辑继续留在 gateway

### 删除 Core→Gateway 出站旧兼容接口
- 删除 `CoreResponse.text`、`CoreResponse.markdown` 兼容字段：Core→Gateway 完整回复正文只通过 `output: Option<AssistantOutput>` 表达
- 精简 `CoreResponse::text_content / markdown_content`：只读 `output`，不再兜底旧字段
- `With_output` 只设置 `output`，不再回填旧字段
- `From<RespondResponse> for CoreResponse` 直接由 `RespondResponse` 内部 `text/markdown`（仍是 Core 内部中间结构）合成 `AssistantOutput`，不再向 Gateway 暴露双轨字段
- 删除 `AssistantOutput::from_compat_fields` 旧桥接（无剩余调用方）

### 纯渲染 helper 下沉，清理 gateway 重复实现
- `AssistantOutput::text_content / markdown_content / render_text_fallback / render_markdown / preferred_text`
- `OutputPart::as_text_segment / as_markdown_segment`：Markdown 段降级复用 `qq_maid_common::markdown_strip::strip_markdown_for_chat`，不重新实现
- `OutputMedia::fallback_text_or(default)`：媒体可见文案的纯查询，平台默认文案由调用方传入，common 不内置平台文案
- gateway `render.rs` 删除 `normalized_output_fallback / render_parts_as_text / render_parts_as_markdown / part_text_fallback / part_markdown_render / media_fallback_text` 六个重复 helper，`render_assistant_output_for_profile` 只做平台相关动作（能力判断 + `OutboundMessage` 构造 + 平台默认文案传参），纯拼接全部委托 common

### 本次核对补充
- 核对当前 `master` 与本 PR 后确认：`OutputPart::Image` 当前没有接入到 `OutboundMessage::Image` 实际图片发送，现有行为是结构化媒体 part 渲染为用户可见 fallback 文本；本 PR 不新增图片实际发送能力
- 为 Image part 在支持图片 profile 下仍降级为 fallback 文本补充测试，避免把结构化模型误解为已完成图片发送接入
- C2C / Group 的 ref_index 回填改为记录 Gateway 实际渲染出的 `OutboundMessage::fallback_text()`，避免 `text_fallback` 为空但 `parts` 有 Markdown/Text/媒体 fallback 时记录空文本
- C2C 禁用流式 Completed、C2C stream Pending fallback、Group 分段发送回填均复用渲染后的 fallback 文本

### 测试与 fixture
- core / gateway 全部 `CoreResponse { text, markdown, ... }`、`RespondResponse { text, markdown, ... }` fixture 移除 `text/markdown` 字段
- 改为通过访问器或 `AssistantOutput` 断言正文；删除只验证旧字段同步的双轨测试；为 common 新 helper 补充单元测试
- 补充 Image/File part 当前 fallback 行为与 ref_index 渲染 fallback 回填测试

## 用户可见行为保持

普通文本聊天、Markdown 输出、不支持 Markdown 平台的文本 fallback、命令响应、Tool Loop 最终输出、流式增量与禁用流式 Completed 行为保持不变。

当前图片/文件结构化 part 的用户可见行为是 fallback 文本出站；本 PR 保持该能力边界，不声称已支持图片实际发送。ref_index 出站文本回填改为与实际用户可见 fallback 一致。

## 验证

```
cargo fmt --all -- --check                                   # 通过
cargo test -p qq-maid-gateway-rs                              # 344 通过，0 失败
cargo test --workspace --all-features                         # 通过
cargo clippy --workspace --all-targets --all-features -- -D warnings  # 通过
```

## 兼容层保留说明

- `text_content / markdown_content` 访问器保留，但实现只读 `output`，不再隐藏旧字段
- `RespondResponse`（Core 内部）仍按 `text/markdown` 双通道组装正文，不进入 Core→Gateway 边界，符合任务「内部中间结构可保留」的允许
- 本次保留原名 `AssistantOutput / OutputPart / OutputMedia`，未改名为 `MessageOutput*`，避免本 PR 引入过大重命名风险；如需统一命名可单独开 PR

## 关联 Issue

Refs #352
