### PR TITLE
refactor: 清理媒体兼容层

### DIFF
--- a/qq-maid-core/src/runtime/respond/common.rs
+++ b/qq-maid-core/src/runtime/respond/common.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 
+use qq_maid_common::markdown_strip::strip_markdown_for_chat;
 pub(super) use qq_maid_common::text::truncate_chars_with_ellipsis_trimmed as truncate_chars;
 use serde_json::{Value, json};
 
@@ -44,10 +45,7 @@ impl CommandBody {
 /// gateway。
 pub(super) fn structured_command_body(markdown: impl Into<String>) -> CommandBody {
     let markdown = markdown.into();
-    CommandBody::dual(
-        super::markdown_strip::strip_markdown_for_chat(&markdown),
-        markdown,
-    )
+    CommandBody::dual(strip_markdown_for_chat(&markdown), markdown)
 }
 
 pub(super) const GROUP_ADMIN_REQUIRED_REPLY: &str = "这个群管理操作只允许群主或管理员执行。";

--- a/qq-maid-core/src/runtime/respond/help.rs
+++ b/qq-maid-core/src/runtime/respond/help.rs
@@ -3,9 +3,8 @@
 //! 模块命令只在这里维护一份：完整帮助复用精简命令列表，模块帮助再补充行为说明，
 //! 避免 `/help all` 与 `/help <模块>` 随功能演进后互相矛盾。
 
-use super::{
-    command_render::CommandRender, common::CommandBody, markdown_strip::strip_markdown_for_chat,
-};
+use super::{command_render::CommandRender, common::CommandBody};
+use qq_maid_common::markdown_strip::strip_markdown_for_chat;
 
 struct HelpModule {
     key: &'static str,

--- a/qq-maid-core/src/runtime/respond/llm_service/mod.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service/mod.rs
@@ -4,9 +4,6 @@
 //! 调用 `LlmProvider` 获取 LLM 回复，并对原始输出做后处理
 //!（去除 Markdown、截断等）。
 //!
-//! Markdown 剥离的纯文本处理逻辑已提取到 `markdown_strip.rs`，
-//! 这里通过 `use` 引入以保持 `strip_markdown_for_chat` 在本模块可用。
-
 use std::env;
 
 use async_trait::async_trait;
@@ -30,6 +27,7 @@ use crate::{
 use qq_maid_common::{
     identity_context::MessageContext,
     input_part::{MediaStatus, MessageInputPart, QuotedMessageContext, TextSource},
+    markdown_strip::strip_markdown_for_chat,
 };
 use qq_maid_llm::{
     context_budget::{
@@ -40,8 +38,7 @@ use qq_maid_llm::{
 };
 
 use super::{
-    RespondPurpose, RespondRequest, RespondResponse, common::truncate_chars,
-    markdown_strip::strip_markdown_for_chat, types::ChatResponse,
+    RespondPurpose, RespondRequest, RespondResponse, common::truncate_chars, types::ChatResponse,
 };
 
 /// 记忆草稿的最大字符数

--- a/qq-maid-core/src/runtime/respond/llm_service/tests.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service/tests.rs
@@ -1,9 +1,7 @@
 use super::*;
-// `strip_markdown_for_chat` 已提取到 `markdown_strip` 模块，这里显式引入，
-// 因为 `use super::*` 不会带入父模块的私有 `use` 导入。
-use super::strip_markdown_for_chat;
 use crate::{provider::types::TokenUsage, util::metrics::LlmMetrics};
 use chrono::TimeZone;
+use qq_maid_common::markdown_strip::strip_markdown_for_chat;
 use qq_maid_common::{
     identity_context::{
         ConversationContext, IdentitySource, MentionConfidence, MentionIdentity,

--- a/qq-maid-core/src/runtime/respond/markdown_strip.rs
+++ b/qq-maid-core/src/runtime/respond/markdown_strip.rs
@@ -1,7 +1,0 @@
-//! Markdown 剥离工具的兼容入口。
-//!
-//! 实现已迁移到 `qq-maid-common::markdown_strip`，这里保留原模块路径，
-//! 避免 `runtime/respond` 内部各 flow（聊天、记忆、天气、帮助等）以及测试
-//! 大面积改 import。新增使用点应直接引用 `qq_maid_common::markdown_strip`。
-
-pub use qq_maid_common::markdown_strip::strip_markdown_for_chat;

--- a/qq-maid-core/src/runtime/respond/mod.rs
+++ b/qq-maid-core/src/runtime/respond/mod.rs
@@ -40,9 +40,6 @@ mod conversation_session;
 mod help;
 mod interaction_state;
 mod llm_service;
-/// Markdown 剥离工具，实现在 `qq-maid-common::markdown_strip`；
-/// 这里仅保留兼容入口，避免内部 flow 与测试大面积改 import。
-mod markdown_strip;
 mod memory_flow;
 mod pending;
 mod radar_flow;

--- a/qq-maid-core/src/runtime/respond/weather_flow.rs
+++ b/qq-maid-core/src/runtime/respond/weather_flow.rs
@@ -22,8 +22,8 @@ use crate::{
 use super::{
     RespondResponse, RustRespondService,
     common::{CommandBody, clean_string, command_response, session_error, truncate_chars},
-    markdown_strip::strip_markdown_for_chat,
 };
+use qq_maid_common::markdown_strip::strip_markdown_for_chat;
 
 // 城市名最大长度限制
 const WEATHER_CITY_MAX_LENGTH: usize = 60;

--- a/qq-maid-gateway-rs/src/render.rs
+++ b/qq-maid-gateway-rs/src/render.rs
@@ -77,47 +77,12 @@ impl OutboundMessage {
     }
 }
 
-pub fn render_respond_response(
-    response: &RespondResponse,
-    enable_markdown: bool,
-    enable_image: bool,
-) -> Option<OutboundMessage> {
-    let profile = RenderProfile {
-        supports_text: true,
-        supports_markdown: enable_markdown,
-        supports_image: enable_image,
-        supports_attachment: false,
-        unsupported_fallback: crate::gateway::outbound::UnsupportedCapabilityFallback::UseText,
-    };
-    render_respond_response_for_profile(response, &profile)
-}
-
 pub(crate) fn render_respond_response_for_profile(
     response: &RespondResponse,
     profile: &RenderProfile,
 ) -> Option<OutboundMessage> {
-    if let Some(output) = response.output.as_ref()
-        && !output.parts.is_empty()
-    {
-        return render_assistant_output_for_profile(output, profile);
-    }
-
-    let text = response.text_content()?;
-    if text.trim().is_empty() {
-        return None;
-    }
-    if profile.supports_markdown
-        && let Some(markdown) = response.markdown_content()
-        && !markdown.trim().is_empty()
-    {
-        return Some(OutboundMessage::Markdown {
-            markdown: MarkdownPayload::new(markdown.to_owned()),
-            fallback_text: text.to_owned(),
-        });
-    }
-    profile.supports_text.then(|| OutboundMessage::Text {
-        text: text.to_owned(),
-    })
+    let output = response.output.as_ref()?;
+    render_assistant_output_for_profile(output, profile)
 }
 
 fn render_assistant_output_for_profile(
@@ -130,12 +95,7 @@ fn render_assistant_output_for_profile(
         UNSUPPORTED_FILE_FALLBACK_TEXT,
     )?;
 
-    if profile.supports_markdown
-        && output
-            .parts
-            .iter()
-            .any(|part| matches!(part, OutputPart::Markdown { .. }))
-    {
+    if profile.supports_markdown && output_has_markdown_channel(output) {
         // 按 parts 拼接 Markdown（媒体 fallback 同样使用平台默认文案）；非空才出 Markdown。
         let markdown = output.render_markdown(
             UNSUPPORTED_IMAGE_FALLBACK_TEXT,
@@ -154,13 +114,33 @@ fn render_assistant_output_for_profile(
     })
 }
 
+fn output_has_markdown_channel(output: &AssistantOutput) -> bool {
+    output
+        .markdown
+        .as_deref()
+        .is_some_and(|markdown| !markdown.trim().is_empty())
+        || output.parts.iter().any(
+            |part| matches!(part, OutputPart::Markdown { markdown } if !markdown.trim().is_empty()),
+        )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use qq_maid_core::service::OutputMedia;
 
+    fn render_profile(enable_markdown: bool, enable_image: bool) -> RenderProfile {
+        RenderProfile {
+            supports_text: true,
+            supports_markdown: enable_markdown,
+            supports_image: enable_image,
+            supports_attachment: false,
+            unsupported_fallback: crate::gateway::outbound::UnsupportedCapabilityFallback::UseText,
+        }
+    }
+
     fn response_with_body(text: Option<&str>, markdown: Option<&str>) -> RespondResponse {
-        // `from_compat_fields` 旧兼容桥接已删除，这里直接用结构化构造函数。
+        // 测试直接构造 Core->Gateway 的结构化 output，不再绕旧 text/markdown 字段。
         let output = match (text, markdown) {
             (Some(text), Some(markdown)) => Some(qq_maid_core::service::AssistantOutput::markdown(
                 text, markdown,
@@ -243,7 +223,10 @@ mod tests {
 
         for case in &cases {
             let response = response_with_body(case.text, case.markdown);
-            let actual = render_respond_response(&response, case.enable_markdown, true);
+            let actual = render_respond_response_for_profile(
+                &response,
+                &render_profile(case.enable_markdown, true),
+            );
             assert_eq!(
                 actual,
                 Some(case.expected.clone()),
@@ -270,7 +253,10 @@ mod tests {
     fn empty_respond_output_renders_to_none() {
         // output 缺失时渲染层返回 None，不再依赖旧 text/markdown 兼容字段。
         assert_eq!(
-            render_respond_response(&response_with_empty_output(), true, true),
+            render_respond_response_for_profile(
+                &response_with_empty_output(),
+                &render_profile(true, true),
+            ),
             None
         );
     }
@@ -315,7 +301,7 @@ mod tests {
         };
 
         assert_eq!(
-            render_respond_response(&response, true, true),
+            render_respond_response_for_profile(&response, &render_profile(true, true)),
             Some(OutboundMessage::Markdown {
                 markdown: MarkdownPayload::new("hello *plain*\n\n## title\n- item"),
                 fallback_text: "plain fallback".to_owned(),
@@ -378,7 +364,7 @@ mod tests {
         };
 
         assert_eq!(
-            render_respond_response(&response, false, true),
+            render_respond_response_for_profile(&response, &render_profile(false, true)),
             Some(OutboundMessage::Text {
                 text: "图片：天气雷达".to_owned(),
             })
@@ -403,7 +389,7 @@ mod tests {
         };
 
         assert_eq!(
-            render_respond_response(&response, true, true),
+            render_respond_response_for_profile(&response, &render_profile(true, true)),
             Some(OutboundMessage::Text {
                 text: UNSUPPORTED_FILE_FALLBACK_TEXT.to_owned(),
             })
@@ -426,7 +412,7 @@ mod tests {
         };
 
         assert_eq!(
-            render_respond_response(&response, true, true),
+            render_respond_response_for_profile(&response, &render_profile(true, true)),
             Some(OutboundMessage::Markdown {
                 markdown: MarkdownPayload::new("**output markdown**"),
                 fallback_text: "output fallback".to_owned(),


### PR DESCRIPTION
## 摘要

- 删除 Gateway 渲染层旧的 `render_respond_response(enable_markdown, enable_image)` 布尔兼容入口，统一走 `RenderProfile` + `AssistantOutput` 主路径。
- 删除 `qq-maid-core/src/runtime/respond/markdown_strip.rs` 旧 re-export，调用点直接引用 `qq_maid_common::markdown_strip::strip_markdown_for_chat`。
- 保持图片/文件出站仍降级为 fallback 文本，不引入真正图片发送能力。

## 范围边界

- 不做真正图片发送能力。
- 不把 `AssistantOutput` 改名为 `MessageOutput*`。
- 不改变 Core 内部 `RespondResponse` 的 text/markdown 双通道中间结构。

## 验证

```bash
cargo fmt --all -- --check
cargo check --workspace
cargo test -p qq-maid-common output_part --all-features
cargo test -p qq-maid-gateway-rs render::tests --all-features
cargo test -p qq-maid-core runtime::respond::llm_service::tests --all-features
cargo test -p qq-maid-gateway-rs --lib --all-features
cargo test -p qq-maid-core --lib --all-features
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --all-features
git diff --check
```

全部通过。

关联 #352。