### PR TITLE
feat: 将 /查 收敛为搜索 Tool 入口

### DIFF
--- a/qq-maid-core/README.md
+++ b/qq-maid-core/README.md
@@ -13,7 +13,7 @@ QQ 平台事件解析、白名单、`/ping` 本地诊断和消息回发不在本
 - RSS 后台轮询、Todo 单次提醒和 Todo 每日提醒由本模块调度，推送内容先写入 Notification Outbox，再由统一 Worker 通过进程内 `PushSink` 交给 gateway 发送。
 - OpenAI / DeepSeek、模型候选链 fallback、Web Search 传输、Tool Loop 协议和上游健康观测由 `qq-maid-llm` 提供，Core 只保留业务调用边界、Tool 注册与兼容 re-export。
 
-当前 Tool Calling 仍只在私聊普通聊天中默认启用，已注册天气、列车时刻、RSS 最近条目和 Todo 业务 Tool；群聊 Tool Calling 由 `TOOL_CALLING_GROUP_ENABLED` 或 `agent.toml` 显式开启，默认关闭，开启后默认也只暴露天气、列车时刻和 RSS 最近条目工具。群聊如需开放 Todo 查询或写入，必须在场景 `enabled_tools` 白名单中显式加入对应工具名。slash 命令、pending 确认、文件处理和宿主机代码执行不进入 Tool Loop。最终目标是参考 Codex 的受控工具调用体验，但新增工具必须先经过白名单、权限、超时和输出大小限制。
+当前 Tool Calling 仍只在私聊普通聊天中默认启用，已注册天气、列车时刻、RSS 最近条目、联网搜索和 Todo 业务 Tool；群聊 Tool Calling 由 `TOOL_CALLING_GROUP_ENABLED` 或 `agent.toml` 显式开启，默认关闭，开启后默认也只暴露天气、列车时刻、RSS 最近条目和联网搜索工具。群聊如需开放 Todo 查询或写入，必须在场景 `enabled_tools` 白名单中显式加入对应工具名。slash 命令、pending 确认、文件处理和宿主机代码执行不进入 Tool Loop；`/查` 只作为显式触发 `web_search` Tool 的兼容入口。最终目标是参考 Codex 的受控工具调用体验，但新增工具必须先经过白名单、权限、超时和输出大小限制。
 
 旧 HTTP `/query`、HTTP `/memory`、`/v1/chat` 等入口不再公开，也不要重新引入 Python LLM、Python 查询、Python 记忆或 Python fallback 入口。
 
@@ -36,7 +36,7 @@ qq-maid-core/src/
 │   ├── session.rs       # 会话领域逻辑
 │   ├── memory.rs        # 长期记忆领域逻辑
 │   ├── todo.rs          # Todo 领域逻辑
-│   ├── tools/           # Core 业务 Tool 适配层，注册天气、列车时刻、RSS 和 Todo Tool
+│   ├── tools/           # Core 业务 Tool 适配层，注册天气、列车、RSS、搜索和 Todo Tool
 │   ├── train/           # 列车时刻查询执行器
 │   └── weather/         # 天气执行器
 ├── storage/             # SQLite、migration、session/memory/todo/rss/knowledge 持久化
@@ -92,7 +92,7 @@ Notification Outbox 是业务生产者与平台投递之间的唯一主动推送
 - 天气：`/天气杭州`、`/天气 杭州`、`/杭州天气`、`/weather 杭州`。
 - 翻译：`/翻译 文本`、`/翻译日语 文本`、`/翻译成英语 文本`。
 
-私聊普通聊天还可以让模型按需调用天气、列车时刻、RSS 最近条目和 Todo Tool，例如“杭州明天要带伞吗”“查一下 G1 明天的时刻”“查看上次 Codex 发布的 RSS”“看看我还有哪些事情没做”。群聊默认只保留确定性命令和普通聊天；确需在受控群里试用时，可开启群聊 Tool Calling，但默认模型只会看到天气、列车时刻和 RSS 最近条目工具。若要开放 `list_todos`、`get_todo` 或 Todo 写工具，必须在 `agent.toml` 的群聊 `enabled_tools` 中显式加入，并先确认群聊 Todo owner 语义符合预期。这条路径复用现有业务执行器、RSS 本地状态、TodoStore 和 session 快照，但不替代 `/天气`、`/火车`、`/rss`、`/todo` 等显式命令；显式命令始终优先并保持原排版和 session 行为。
+私聊普通聊天还可以让模型按需调用天气、列车时刻、RSS 最近条目、联网搜索和 Todo Tool，例如“杭州明天要带伞吗”“查一下 G1 明天的时刻”“查看上次 Codex 发布的 RSS”“搜索 Rust 最新进展”“看看我还有哪些事情没做”。群聊默认只保留确定性命令和普通聊天；确需在受控群里试用时，可开启群聊 Tool Calling，但默认模型只会看到天气、列车时刻、RSS 最近条目和联网搜索工具。若要开放 `list_todos`、`get_todo` 或 Todo 写工具，必须在 `agent.toml` 的群聊 `enabled_tools` 中显式加入，并先确认群聊 Todo owner 语义符合预期。这条路径复用现有业务执行器、RSS 本地状态、TodoStore、查询执行器和 session 快照，但不替代 `/天气`、`/火车`、`/rss`、`/todo`、`/查` 等显式命令；显式命令始终优先并保持原排版和 session 行为。
 
 待确认操作会优先于普通命令处理；若修改 pending、确认分类或 todo / memory 的状态转换，优先复用 `runtime/pending/` 和 `runtime/respond/pending.rs` 中的既有逻辑。
 
@@ -114,7 +114,7 @@ runtime/.env
 - `LLM_MODEL`、`PRIVATE_LLM_MODEL`、`GROUP_LLM_MODEL`、`TITLE_MODEL`、`MEMORY_MODEL`、`COMPACT_MODEL`、`TRANSLATION_MODEL`：主模型、场景模型和内部任务模型；`TRANSLATION_MODEL` 供 `/翻译` 和 RSS 推送前翻译共用，留空时沿用主模型。`LLM_MODEL` 仍作为主路线兼容默认，`PRIVATE_LLM_MODEL` / `GROUP_LLM_MODEL` 优先覆盖对应场景；`agent.toml` 显式声明同名 `[model_routes.*]` 时再覆盖环境继承路线。`TODO_MODEL` 已不再用于 slash 待办解析，Todo 写操作统一走 Tool Calling。
 - `OPENAI_API_KEY`、`OPENAI_BASE_URL`、`OPENAI_BASE_URLS`、`OPENAI_API_MODE`、`DEEPSEEK_API_KEY`、`DEEPSEEK_BASE_URL`、`DEEPSEEK_MODEL`、`BIGMODEL_API_KEY`、`BIGMODEL_BASE_URL`、`BIGMODEL_MODEL`、`MIMO_API_KEY`：provider 配置；Core 解析后传给 `qq-maid-llm`。`OPENAI_BASE_URLS` 为逗号分隔时取第一个非空地址，优先于 `OPENAI_BASE_URL`。`OPENAI_API_MODE=auto` 优先 Responses API 并在可恢复错误时降级 Chat Completions；`chat_only` 仅用于普通聊天兼容只实现 Chat Completions 的网关，不会请求 `/v1/responses`。MiMo 等自定义 provider 的 base URL 和认证头在 `agent.toml [providers.*]` 声明，真实 key 仍由 `api_key_env` 指向的环境变量提供。
 - `LLM_SERVER_HOST`、`LLM_SERVER_PORT`、`LLM_REQUEST_TIMEOUT_SECONDS`：外部健康 / 控制台 HTTP 服务和请求超时行为。
-- `TOOL_CALLING_ENABLED`、`TOOL_CALLING_GROUP_ENABLED`、`TOOL_CALLING_MAX_ROUNDS`：旧兼容开关。存在 `agent.toml` 时，请优先使用 `[scenes.*].tool_calling_enabled`、`enabled_tools` 和 profile 的 `max_tool_rounds`；群聊默认仍不会进入 Tool Loop，显式开启后默认也只开放天气、列车时刻和 RSS 最近条目工具。该能力依赖 provider Tool Calling 能力，`OPENAI_API_MODE=chat_only` 时 OpenAI Responses 原生 Tool Loop 不会执行。
+- `TOOL_CALLING_ENABLED`、`TOOL_CALLING_GROUP_ENABLED`、`TOOL_CALLING_MAX_ROUNDS`：旧兼容开关。存在 `agent.toml` 时，请优先使用 `[scenes.*].tool_calling_enabled`、`enabled_tools` 和 profile 的 `max_tool_rounds`；群聊默认仍不会进入 Tool Loop，显式开启后默认也只开放天气、列车时刻、RSS 最近条目和联网搜索工具。该能力依赖 provider Tool Calling 能力，`OPENAI_API_MODE=chat_only` 时 OpenAI Responses 原生 Tool Loop 不会执行。
 - `WEB_CONSOLE_ENABLED`、`WEB_CONSOLE_ALLOWED_ORIGINS`：本地控制台和跨域 allowlist；默认关闭且不允许任意来源。
 - `APP_DB_FILE`：统一 SQLite 文件，承载业务数据和知识检索索引。
 - `QQ_MAID_DB_POOL_MAX_SIZE`：本地 SQLite 连接池大小，默认 8，合法范围 1～32；独立于 `MAX_CONCURRENT_RESPONSES`。

--- a/qq-maid-core/src/config/agent.rs
+++ b/qq-maid-core/src/config/agent.rs
@@ -20,6 +20,7 @@ const DEFAULT_PRIVATE_ENABLED_TOOLS: &[&str] = &[
     "get_weather",
     "get_train_schedule",
     "get_rss_recent_items",
+    "web_search",
     "list_todos",
     "get_todo",
     "create_todo",
@@ -30,8 +31,12 @@ const DEFAULT_PRIVATE_ENABLED_TOOLS: &[&str] = &[
     "delete_todos",
     "merge_todos",
 ];
-const DEFAULT_GROUP_ENABLED_TOOLS: &[&str] =
-    &["get_weather", "get_train_schedule", "get_rss_recent_items"];
+const DEFAULT_GROUP_ENABLED_TOOLS: &[&str] = &[
+    "get_weather",
+    "get_train_schedule",
+    "get_rss_recent_items",
+    "web_search",
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChatScene {
@@ -730,7 +735,12 @@ mod tests {
         assert_eq!(group.search_model, "gpt-search-fast");
         assert_eq!(
             group.enabled_tools,
-            vec!["get_weather", "get_train_schedule", "get_rss_recent_items"]
+            vec![
+                "get_weather",
+                "get_train_schedule",
+                "get_rss_recent_items",
+                "web_search"
+            ]
         );
         assert!(!group.enabled_tools.iter().any(|name| name == "list_todos"));
         assert!(!group.group_tool_calling_enabled);
@@ -984,7 +994,12 @@ profile = "fast"
         assert_eq!(group.max_tool_rounds, 2);
         assert_eq!(
             group.enabled_tools,
-            vec!["get_weather", "get_train_schedule", "get_rss_recent_items"]
+            vec![
+                "get_weather",
+                "get_train_schedule",
+                "get_rss_recent_items",
+                "web_search"
+            ]
         );
         assert!(!group.group_tool_calling_enabled);
     }

--- a/qq-maid-core/src/runtime/respond/llm_service/mod.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service/mod.rs
@@ -239,7 +239,7 @@ impl LlmChatService {
     }
 }
 
-fn tool_context_from_request(req: &RespondRequest) -> ToolContext {
+pub(super) fn tool_context_from_request(req: &RespondRequest) -> ToolContext {
     // ToolContext 只从服务端请求上下文生成，禁止模型通过工具参数提供用户或 scope。
     //
     // 已知局限：task_id 当前复用入站 message_id，仅在单条消息作用域内唯一。

--- a/qq-maid-core/src/runtime/respond/llm_service/mod.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service/mod.rs
@@ -239,7 +239,7 @@ impl LlmChatService {
     }
 }
 
-pub(super) fn tool_context_from_request(req: &RespondRequest) -> ToolContext {
+fn tool_context_from_request(req: &RespondRequest) -> ToolContext {
     // ToolContext 只从服务端请求上下文生成，禁止模型通过工具参数提供用户或 scope。
     //
     // 已知局限：task_id 当前复用入站 message_id，仅在单条消息作用域内唯一。

--- a/qq-maid-core/src/runtime/respond/search_flow.rs
+++ b/qq-maid-core/src/runtime/respond/search_flow.rs
@@ -1,18 +1,21 @@
 //! 联网搜索指令的处理流程。
-//! 负责解析 `/查` `/查询` `/search` 等指令，调用查询执行器进行联网搜索，
-//! 并格式化搜索结果回复。同时处理超时、配置缺失、上游异常等错误场景。
+//!
+//! `/查` `/查询` `/search` 只负责用户入口兼容、参数校验、session 记录和展示；
+//! 实际联网查询统一通过 `runtime/tools/search.rs` 中的 `web_search` Tool 执行。
 
 use std::{future::Future, pin::Pin};
 
-use serde_json::json;
+use serde_json::{Value, json};
 use tokio::sync::mpsc;
 
 use crate::{
     error::LlmError,
     runtime::{
         command::{ParsedCommand, parse_slash_command},
-        query::QueryRequest,
         session::SessionRecord,
+        tools::{
+            WEB_SEARCH_QUERY_MAX_LENGTH, WEB_SEARCH_TOOL_NAME, WebSearchTool, WebSearchToolRequest,
+        },
     },
 };
 
@@ -22,15 +25,16 @@ use super::{
         command_response, command_response_with_stream, session_error, structured_command_body,
         truncate_chars,
     },
+    llm_service::tool_context_from_request,
 };
 
-// 联网搜索查询内容最大字符数限制
-const WEB_SEARCH_QUERY_MAX_LENGTH: usize = 200;
 // /查 指令的空参数用法提示
 const WEB_SEARCH_USAGE_REPLY: &str = "用法：/查 关键词（也可用 /查询 关键词 或 /search 关键词）
 例如：/查 Cloudflare D1 binding DB is not configured";
 // 查询超长时的提示
 const WEB_SEARCH_TOO_LONG_REPLY: &str = "查询内容太长了，请压缩到 200 字以内再试。";
+// Level 2 进度事件的兼容文本：用户可见，但不写入 session 或模型上下文。
+const WEB_SEARCH_RUNNING_DELTA: &str = "正在联网查询中…\n\n";
 // 搜索结果为空时的回复
 const WEB_SEARCH_EMPTY_RESULT_REPLY: &str = "【联网查询】
 
@@ -48,13 +52,57 @@ const WEB_SEARCH_UPSTREAM_ERROR_REPLY: &str = "【联网查询】
 
 联网查询服务暂时不可用，可能是上游接口、代理或网络配置异常。请稍后再试。";
 
+type WebSearchDeltaHandler<'a> = Box<
+    dyn FnMut(String) -> Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send>> + Send + 'a,
+>;
+
+#[derive(Debug, Clone)]
+struct WebSearchToolOutput {
+    answer: String,
+    provider: String,
+    elapsed_ms: u64,
+}
+
 impl RustRespondService {
-    /// 处理联网搜索指令的主入口。校验参数、调用查询执行器、格式化结果或错误回复。
+    /// 处理联网搜索指令的主入口。校验参数、显式执行 `web_search` Tool、格式化结果或错误回复。
     pub(super) async fn handle_web_search_command(
         &self,
         command: ParsedCommand,
         req: &RespondRequest,
         session: &mut SessionRecord,
+    ) -> Result<RespondResponse, LlmError> {
+        self.handle_web_search_command_inner(command, req, session, false, None)
+            .await
+    }
+
+    /// `/查` 流式入口：通过 `WebSearchTool::query_stream` 转发真实搜索增量。
+    pub async fn handle_web_search_command_stream<F>(
+        &self,
+        command: ParsedCommand,
+        req: &RespondRequest,
+        session: &mut SessionRecord,
+        on_delta: F,
+    ) -> Result<RespondResponse, LlmError>
+    where
+        F: FnMut(String) -> Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send>> + Send,
+    {
+        self.handle_web_search_command_inner(
+            command,
+            req,
+            session,
+            true,
+            Some(Box::new(on_delta) as WebSearchDeltaHandler<'_>),
+        )
+        .await
+    }
+
+    async fn handle_web_search_command_inner(
+        &self,
+        command: ParsedCommand,
+        req: &RespondRequest,
+        session: &mut SessionRecord,
+        stream: bool,
+        mut on_delta: Option<WebSearchDeltaHandler<'_>>,
     ) -> Result<RespondResponse, LlmError> {
         let query = command.argument.trim();
         if query.is_empty() {
@@ -73,25 +121,35 @@ impl RustRespondService {
         }
 
         let command_text = format!("/{} {}", command.raw_command, command.argument);
+        if stream && let Some(on_delta) = on_delta.as_mut() {
+            on_delta(WEB_SEARCH_RUNNING_DELTA.to_owned()).await?;
+        }
         let policy = self.resolve_agent_policy(req)?;
-        let outcome = match self
-            .query_executor
-            .query(QueryRequest {
-                query: query.to_owned(),
-                raw_question: Some(command_text.clone()),
-                max_results: None,
-                context_size: None,
-                model_override: Some(policy.search_model.clone()),
-            })
+        let output_result = if stream {
+            self.execute_web_search_tool_stream(
+                query,
+                &command_text,
+                Some(policy.search_model.clone()),
+                on_delta.as_mut(),
+            )
             .await
-        {
-            Ok(outcome) => outcome,
+        } else {
+            self.execute_web_search_tool(
+                req,
+                query,
+                &command_text,
+                Some(policy.search_model.clone()),
+            )
+            .await
+        };
+        let output = match output_result {
+            Ok(output) => output,
             Err(err) => {
                 tracing::warn!(
                     error_code = err.code,
                     error_stage = err.stage,
                     query_provider = self.query_executor.provider_name(),
-                    "web search command failed"
+                    "web search command tool failed"
                 );
                 let reply = format_web_search_error_reply(&err);
                 self.session_store
@@ -105,112 +163,16 @@ impl RustRespondService {
                     self.query_executor.provider_name().to_owned(),
                     Some(err.code.clone()),
                     Some(err.stage.clone()),
-                    false,
+                    stream,
                 );
                 return Ok(response);
             }
         };
-        let reply = if outcome.answer.trim().is_empty() {
+
+        let reply = if output.answer.trim().is_empty() {
             WEB_SEARCH_EMPTY_RESULT_REPLY.to_owned()
         } else {
-            format_web_search_command_reply(&outcome.answer)
-        };
-        self.session_store
-            .append_exchange(session, &command_text, &reply)
-            .map_err(session_error)?;
-
-        let response = build_web_search_success_response(
-            session.session_id.clone(),
-            command.action,
-            reply,
-            outcome.provider,
-            outcome.elapsed_ms,
-            false,
-        );
-        Ok(response)
-    }
-
-    /// `/查` 真流式路径：只消费执行器的 `query_stream`，不退回完整 `query()` 伪增量。
-    pub async fn handle_web_search_command_stream<F>(
-        &self,
-        command: ParsedCommand,
-        req: &RespondRequest,
-        session: &mut SessionRecord,
-        mut on_delta: F,
-    ) -> Result<RespondResponse, LlmError>
-    where
-        F: FnMut(String) -> Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send>> + Send,
-    {
-        let query = command.argument.trim();
-        if query.is_empty() {
-            return Ok(command_response(
-                WEB_SEARCH_USAGE_REPLY,
-                Some(session.session_id.clone()),
-                Some(command.action),
-            ));
-        }
-        if query.chars().count() > WEB_SEARCH_QUERY_MAX_LENGTH {
-            return Ok(command_response(
-                WEB_SEARCH_TOO_LONG_REPLY,
-                Some(session.session_id.clone()),
-                Some(command.action),
-            ));
-        }
-
-        let command_text = format!("/{} {}", command.raw_command, command.argument);
-        let policy = self.resolve_agent_policy(req)?;
-        let (delta_tx, mut delta_rx) = mpsc::channel(16);
-        let query_executor = self.query_executor.clone();
-        let query_req = QueryRequest {
-            query: query.to_owned(),
-            raw_question: Some(command_text.clone()),
-            max_results: None,
-            context_size: None,
-            model_override: Some(policy.search_model.clone()),
-        };
-        let query_task =
-            tokio::spawn(async move { query_executor.query_stream(query_req, delta_tx).await });
-        while let Some(delta) = delta_rx.recv().await {
-            if !delta.is_empty()
-                && let Err(err) = on_delta(delta).await
-            {
-                // 接收方取消时必须停止继续 poll provider stream，而不是只停止转发。
-                query_task.abort();
-                return Err(err);
-            }
-        }
-        let outcome = match query_task.await.map_err(|err| {
-            LlmError::provider(format!("web search stream task failed: {err}"), "internal")
-        })? {
-            Ok(outcome) => outcome,
-            Err(err) => {
-                tracing::warn!(
-                    error_code = err.code,
-                    error_stage = err.stage,
-                    query_provider = self.query_executor.provider_name(),
-                    "web search stream command failed"
-                );
-                let reply = format_web_search_error_reply(&err);
-                self.session_store
-                    .append_exchange(session, &command_text, &reply)
-                    .map_err(session_error)?;
-
-                let response = build_web_search_response(
-                    session.session_id.clone(),
-                    command.action.clone(),
-                    reply,
-                    self.query_executor.provider_name().to_owned(),
-                    Some(err.code.clone()),
-                    Some(err.stage.clone()),
-                    true,
-                );
-                return Ok(response);
-            }
-        };
-        let reply = if outcome.answer.trim().is_empty() {
-            WEB_SEARCH_EMPTY_RESULT_REPLY.to_owned()
-        } else {
-            format_web_search_command_reply(&outcome.answer)
+            format_web_search_command_reply(&output.answer)
         };
         self.session_store
             .append_exchange(session, &command_text, &reply)
@@ -220,10 +182,75 @@ impl RustRespondService {
             session.session_id.clone(),
             command.action,
             reply,
-            outcome.provider,
-            outcome.elapsed_ms,
-            true,
+            output.provider,
+            output.elapsed_ms,
+            stream,
         ))
+    }
+
+    async fn execute_web_search_tool(
+        &self,
+        req: &RespondRequest,
+        query: &str,
+        raw_question: &str,
+        model_override: Option<String>,
+    ) -> Result<WebSearchToolOutput, LlmError> {
+        let registry = self
+            .tool_runtime
+            .registry_for_tool_name(WEB_SEARCH_TOOL_NAME)?;
+        let arguments = json!({
+            "query": query,
+            "raw_question": raw_question,
+            "max_results": Value::Null,
+            "context_size": Value::Null,
+            "model_override": model_override,
+        })
+        .to_string();
+        let output = registry
+            .execute_json(
+                &tool_context_from_request(req),
+                WEB_SEARCH_TOOL_NAME,
+                &arguments,
+            )
+            .await?;
+        parse_web_search_tool_output(&output)
+    }
+
+    async fn execute_web_search_tool_stream(
+        &self,
+        query: &str,
+        raw_question: &str,
+        model_override: Option<String>,
+        on_delta: Option<&mut WebSearchDeltaHandler<'_>>,
+    ) -> Result<WebSearchToolOutput, LlmError> {
+        let (delta_tx, mut delta_rx) = mpsc::channel(16);
+        let tool = WebSearchTool::new(self.query_executor.clone());
+        let request = WebSearchToolRequest {
+            query: query.to_owned(),
+            raw_question: Some(raw_question.to_owned()),
+            max_results: None,
+            context_size: None,
+            model_override,
+        };
+        let query_task = tokio::spawn(async move { tool.query_stream(request, delta_tx).await });
+        let mut on_delta = on_delta;
+        while let Some(delta) = delta_rx.recv().await {
+            if !delta.is_empty()
+                && let Some(handler) = on_delta.as_mut()
+                && let Err(err) = handler(delta).await
+            {
+                query_task.abort();
+                return Err(err);
+            }
+        }
+        let outcome = query_task.await.map_err(|err| {
+            LlmError::provider(format!("web search stream task failed: {err}"), "internal")
+        })??;
+        Ok(WebSearchToolOutput {
+            answer: outcome.answer,
+            provider: outcome.provider,
+            elapsed_ms: outcome.elapsed_ms,
+        })
     }
 }
 
@@ -259,7 +286,7 @@ fn parse_compact_web_search_command(text: &str) -> Option<ParsedCommand> {
     None
 }
 
-fn format_web_search_command_reply(answer: &str) -> String {
+pub(super) fn format_web_search_command_reply(answer: &str) -> String {
     let mut text = answer.trim().to_owned();
     if text.is_empty() {
         text = "没查到明确结果。可以换一个关键词再试。".to_owned();
@@ -270,12 +297,38 @@ fn format_web_search_command_reply(answer: &str) -> String {
     truncate_chars(&text, 1500)
 }
 
-fn format_web_search_error_reply(err: &LlmError) -> String {
+pub(super) fn format_web_search_error_reply(err: &LlmError) -> String {
     match err.code.as_str() {
         "config" => WEB_SEARCH_CONFIG_ERROR_REPLY.to_owned(),
         "timeout" => WEB_SEARCH_TIMEOUT_REPLY.to_owned(),
         _ => WEB_SEARCH_UPSTREAM_ERROR_REPLY.to_owned(),
     }
+}
+
+fn parse_web_search_tool_output(output: &str) -> Result<WebSearchToolOutput, LlmError> {
+    let value = serde_json::from_str::<Value>(output).map_err(|err| {
+        LlmError::new(
+            "tool_output_error",
+            format!("failed to parse web_search tool output: {err}"),
+            "tool",
+        )
+    })?;
+    let answer = value
+        .get("answer")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned();
+    let provider = value
+        .get("provider")
+        .and_then(Value::as_str)
+        .unwrap_or("web_search")
+        .to_owned();
+    let elapsed_ms = value.get("elapsed_ms").and_then(Value::as_u64).unwrap_or(0);
+    Ok(WebSearchToolOutput {
+        answer,
+        provider,
+        elapsed_ms,
+    })
 }
 
 fn build_web_search_response(
@@ -299,6 +352,7 @@ fn build_web_search_response(
         "used_memory": false,
         "used_search": true,
         "query_provider": query_provider,
+        "search_tool": WEB_SEARCH_TOOL_NAME,
     });
     if let Some(code) = query_error_code {
         diagnostics["query_error_code"] = json!(code);
@@ -331,6 +385,7 @@ fn build_web_search_success_response(
         "used_search": true,
         "query_provider": query_provider,
         "query_elapsed_ms": query_elapsed_ms,
+        "search_tool": WEB_SEARCH_TOOL_NAME,
     }));
     response
 }

--- a/qq-maid-core/src/runtime/respond/search_flow.rs
+++ b/qq-maid-core/src/runtime/respond/search_flow.rs
@@ -5,13 +5,14 @@
 
 use std::{future::Future, pin::Pin};
 
-use serde_json::{Value, json};
+use serde_json::json;
 use tokio::sync::mpsc;
 
 use crate::{
     error::LlmError,
     runtime::{
         command::{ParsedCommand, parse_slash_command},
+        query::QueryOutcome,
         session::SessionRecord,
         tools::{
             WEB_SEARCH_QUERY_MAX_LENGTH, WEB_SEARCH_TOOL_NAME, WebSearchTool, WebSearchToolRequest,
@@ -25,7 +26,6 @@ use super::{
         command_response, command_response_with_stream, session_error, structured_command_body,
         truncate_chars,
     },
-    llm_service::tool_context_from_request,
 };
 
 // /查 指令的空参数用法提示
@@ -134,13 +134,8 @@ impl RustRespondService {
             )
             .await
         } else {
-            self.execute_web_search_tool(
-                req,
-                query,
-                &command_text,
-                Some(policy.search_model.clone()),
-            )
-            .await
+            self.execute_web_search_tool(query, &command_text, Some(policy.search_model.clone()))
+                .await
         };
         let output = match output_result {
             Ok(output) => output,
@@ -190,30 +185,21 @@ impl RustRespondService {
 
     async fn execute_web_search_tool(
         &self,
-        req: &RespondRequest,
         query: &str,
         raw_question: &str,
         model_override: Option<String>,
     ) -> Result<WebSearchToolOutput, LlmError> {
-        let registry = self
-            .tool_runtime
-            .registry_for_tool_name(WEB_SEARCH_TOOL_NAME)?;
-        let arguments = json!({
-            "query": query,
-            "raw_question": raw_question,
-            "max_results": Value::Null,
-            "context_size": Value::Null,
-            "model_override": model_override,
-        })
-        .to_string();
-        let output = registry
-            .execute_json(
-                &tool_context_from_request(req),
-                WEB_SEARCH_TOOL_NAME,
-                &arguments,
-            )
+        let tool = WebSearchTool::new(self.query_executor.clone());
+        let outcome = tool
+            .query(WebSearchToolRequest {
+                query: query.to_owned(),
+                raw_question: Some(raw_question.to_owned()),
+                max_results: None,
+                context_size: None,
+                model_override,
+            })
             .await?;
-        parse_web_search_tool_output(&output)
+        Ok(web_search_output_from_outcome(outcome))
     }
 
     async fn execute_web_search_tool_stream(
@@ -305,30 +291,12 @@ pub(super) fn format_web_search_error_reply(err: &LlmError) -> String {
     }
 }
 
-fn parse_web_search_tool_output(output: &str) -> Result<WebSearchToolOutput, LlmError> {
-    let value = serde_json::from_str::<Value>(output).map_err(|err| {
-        LlmError::new(
-            "tool_output_error",
-            format!("failed to parse web_search tool output: {err}"),
-            "tool",
-        )
-    })?;
-    let answer = value
-        .get("answer")
-        .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_owned();
-    let provider = value
-        .get("provider")
-        .and_then(Value::as_str)
-        .unwrap_or("web_search")
-        .to_owned();
-    let elapsed_ms = value.get("elapsed_ms").and_then(Value::as_u64).unwrap_or(0);
-    Ok(WebSearchToolOutput {
-        answer,
-        provider,
-        elapsed_ms,
-    })
+fn web_search_output_from_outcome(outcome: QueryOutcome) -> WebSearchToolOutput {
+    WebSearchToolOutput {
+        answer: outcome.answer,
+        provider: outcome.provider,
+        elapsed_ms: outcome.elapsed_ms,
+    }
 }
 
 fn build_web_search_response(

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -463,7 +463,12 @@ async fn group_tool_loop_exposes_query_only_tools_when_enabled() {
     tool_names.sort();
     assert_eq!(
         tool_names,
-        vec!["get_rss_recent_items", "get_train_schedule", "get_weather",]
+        vec![
+            "get_rss_recent_items",
+            "get_train_schedule",
+            "get_weather",
+            "web_search",
+        ]
     );
 
     let list_err = tool_request
@@ -496,8 +501,43 @@ async fn group_tool_loop_exposes_query_only_tools_when_enabled() {
     );
     assert_eq!(
         diagnostics["tool_loop_enabled_tools"],
-        serde_json::json!(["get_weather", "get_train_schedule", "get_rss_recent_items"])
+        serde_json::json!([
+            "get_weather",
+            "get_train_schedule",
+            "get_rss_recent_items",
+            "web_search"
+        ])
     );
+}
+
+#[tokio::test]
+async fn private_tool_loop_can_web_search_with_trusted_rendering() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json(
+            "web_search",
+            r#"{"query":"Rust 最新进展","raw_question":"搜索 Rust 最新进展","max_results":null,"context_size":null}"#,
+            "模型原始搜索总结不应覆盖可信工具结果。",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service
+        .respond(private_message("搜索 Rust 最新进展"))
+        .await
+        .unwrap();
+
+    assert_eq!(inspector.tool_call_count(), 1);
+    let text = response.text.as_deref().unwrap();
+    assert!(text.contains("联网查询"));
+    assert!(text.contains("web answer: Rust 最新进展"));
+    assert!(text.contains("模型原始搜索总结不应覆盖可信工具结果"));
+    assert_eq!(response.command.as_deref(), Some("web_search"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(
+        diagnostics["tool_loop_executed_tools"],
+        serde_json::json!(["web_search"])
+    );
+    assert_eq!(diagnostics["agent_turn_status"], "succeeded");
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tests/search.rs
+++ b/qq-maid-core/src/runtime/respond/tests/search.rs
@@ -7,7 +7,7 @@ use super::support::*;
 use crate::error::LlmError;
 
 #[tokio::test]
-async fn web_search_command_uses_query_executor() {
+async fn web_search_command_executes_web_search_tool() {
     let service = test_service();
 
     let response = service.respond(message("/查 keyword")).await.unwrap();
@@ -31,7 +31,7 @@ async fn web_search_command_uses_query_executor() {
 }
 
 #[tokio::test]
-async fn web_search_stream_uses_query_stream_and_forwards_deltas() {
+async fn web_search_stream_executes_tool_stream_and_forwards_deltas() {
     let query_calls = Arc::new(AtomicUsize::new(0));
     let stream_calls = Arc::new(AtomicUsize::new(0));
     let (service, _base) = test_service_with_provider_base_title_and_query(
@@ -57,10 +57,14 @@ async fn web_search_stream_uses_query_stream_and_forwards_deltas() {
         .await
         .unwrap();
 
-    assert_eq!(deltas.lock().unwrap().as_slice(), ["你", "好"]);
+    assert_eq!(
+        deltas.lock().unwrap().as_slice(),
+        ["正在联网查询中…\n\n", "你", "好"]
+    );
     assert_eq!(response.text.as_deref(), Some("【联网查询】\n\n你好"));
     assert_eq!(query_calls.load(Ordering::SeqCst), 0);
     assert_eq!(stream_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(response.diagnostics.unwrap()["search_tool"], "web_search");
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tests/search.rs
+++ b/qq-maid-core/src/runtime/respond/tests/search.rs
@@ -3,8 +3,35 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
 };
 
+use async_trait::async_trait;
+
 use super::support::*;
-use crate::error::LlmError;
+use crate::{
+    error::LlmError,
+    runtime::query::{QueryExecutor, QueryOutcome, QueryRequest, QuerySource},
+};
+
+struct LongAnswerQueryExecutor;
+
+#[async_trait]
+impl QueryExecutor for LongAnswerQueryExecutor {
+    async fn query(&self, req: QueryRequest) -> Result<QueryOutcome, LlmError> {
+        Ok(QueryOutcome {
+            answer: format!("长结果 {} {}", req.query, "内容".repeat(3000)),
+            sources: vec![QuerySource {
+                title: "长结果来源".to_owned(),
+                url: "https://example.test/long-search".to_owned(),
+                snippet: "用于覆盖 ToolRegistry 输出截断的回归测试".to_owned(),
+            }],
+            provider: "long-answer-query".to_owned(),
+            elapsed_ms: 42,
+        })
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "long-answer-query"
+    }
+}
 
 #[tokio::test]
 async fn web_search_command_executes_web_search_tool() {
@@ -28,6 +55,26 @@ async fn web_search_command_executes_web_search_tool() {
     );
     assert_eq!(response.diagnostics.unwrap()["used_search"], true);
     assert_eq!(response.command.as_deref(), Some("web_search"));
+}
+
+#[tokio::test]
+async fn web_search_command_long_answer_uses_untruncated_tool_result() {
+    let (service, _base) = test_service_with_provider_base_title_and_query(
+        MockProvider::new(),
+        None,
+        Arc::new(LongAnswerQueryExecutor),
+    );
+
+    let response = service.respond(message("/查 long keyword")).await.unwrap();
+
+    let text = response.text.as_deref().unwrap();
+    assert!(text.starts_with("【联网查询】"));
+    assert!(text.contains("长结果 long keyword"));
+    assert!(!text.contains("没查到明确结果"));
+    assert!(text.chars().count() <= 1500);
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["query_provider"], "long-answer-query");
+    assert_eq!(diagnostics["search_tool"], "web_search");
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tool_presenters.rs
+++ b/qq-maid-core/src/runtime/respond/tool_presenters.rs
@@ -17,7 +17,8 @@ use super::{
     agent_outcome::{
         OutcomePresentation, ResponseBlock, ToolEffect, ToolExecutionOutcome, ToolOutcomeStatus,
     },
-    common::{CommandBody, truncate_chars},
+    common::{CommandBody, structured_command_body, truncate_chars},
+    search_flow::{format_web_search_command_reply, format_web_search_error_reply},
     train_flow::{format_train_error_reply, format_train_schedule_reply},
     weather_flow::{format_forecast_day_label, weather_code_label},
 };
@@ -25,6 +26,7 @@ use super::{
 const RSS_TOOL_NAME: &str = "get_rss_recent_items";
 const TRAIN_TOOL_NAME: &str = "get_train_schedule";
 const WEATHER_TOOL_NAME: &str = "get_weather";
+const WEB_SEARCH_TOOL_NAME: &str = "web_search";
 const RSS_FACT_MAX_CHARS: usize = 1200;
 const WEATHER_FACT_MAX_CHARS: usize = 900;
 
@@ -91,6 +93,43 @@ pub(super) fn tool_outcome_from_train_result(
         blocks: vec![block],
         error_code,
         command: Some("train".to_owned()),
+    })
+}
+
+pub(super) fn tool_outcome_from_web_search_result(
+    result: &ToolExecutionResult,
+) -> Option<ToolExecutionOutcome> {
+    if result.name != WEB_SEARCH_TOOL_NAME {
+        return None;
+    }
+
+    let status = ToolOutcomeStatus::from_tool_result(result);
+    let error_code = structured_error_code(&result.output);
+    let block = match status {
+        ToolOutcomeStatus::Succeeded => {
+            let answer = string_field(&result.output, "answer").unwrap_or_default();
+            ResponseBlock::FactCard(structured_command_body(format_web_search_command_reply(
+                &answer,
+            )))
+        }
+        ToolOutcomeStatus::Skipped => ResponseBlock::Warning(web_search_skip_body(&result.output)),
+        ToolOutcomeStatus::RequiresClarification => {
+            ResponseBlock::Clarification(CommandBody::plain("请说明要联网查询什么内容。"))
+        }
+        ToolOutcomeStatus::PendingConfirmation | ToolOutcomeStatus::Failed => {
+            ResponseBlock::Error(web_search_error_body(&result.output))
+        }
+    };
+
+    Some(ToolExecutionOutcome {
+        tool_name: result.name.clone(),
+        domain: "search".to_owned(),
+        status,
+        effect: ToolEffect::ReadOnly,
+        presentation: OutcomePresentation::Trusted,
+        blocks: vec![block],
+        error_code,
+        command: Some("web_search".to_owned()),
     })
 }
 
@@ -293,6 +332,28 @@ fn train_skip_body(output: &Value) -> CommandBody {
         }
         Some(reason) => format!("火车查询已跳过：{reason}。"),
         None => "火车查询已跳过。".to_owned(),
+    };
+    CommandBody::plain(text)
+}
+
+fn web_search_error_body(output: &Value) -> CommandBody {
+    let code = structured_error_code(output).unwrap_or_else(|| "provider_error".to_owned());
+    let stage = output
+        .get("error")
+        .and_then(|error| error.get("stage"))
+        .and_then(Value::as_str)
+        .unwrap_or("web_search");
+    let err = LlmError::new(code, "web search tool failed", stage);
+    structured_command_body(format_web_search_error_reply(&err))
+}
+
+fn web_search_skip_body(output: &Value) -> CommandBody {
+    let text = match string_field(output, "reason").as_deref() {
+        Some("dependency_previous_call_failed") => {
+            "联网查询因前序工具失败已跳过；根因以上方失败信息为准。".to_owned()
+        }
+        Some(reason) => format!("联网查询已跳过：{reason}。"),
+        None => "联网查询已跳过。".to_owned(),
     };
     CommandBody::plain(text)
 }

--- a/qq-maid-core/src/runtime/respond/tool_projection.rs
+++ b/qq-maid-core/src/runtime/respond/tool_projection.rs
@@ -18,7 +18,7 @@ use super::{
     todo_flow::aggregate_todo_tool_results,
     tool_presenters::{
         tool_outcome_from_rss_result, tool_outcome_from_train_result,
-        tool_outcome_from_weather_result,
+        tool_outcome_from_weather_result, tool_outcome_from_web_search_result,
     },
 };
 
@@ -41,6 +41,8 @@ pub(super) fn project_tool_turn(
         } else if let Some(outcome) = tool_outcome_from_train_result(result) {
             outcomes.push(outcome);
         } else if let Some(outcome) = tool_outcome_from_rss_result(result) {
+            outcomes.push(outcome);
+        } else if let Some(outcome) = tool_outcome_from_web_search_result(result) {
             outcomes.push(outcome);
         } else {
             outcomes.push(ToolExecutionOutcome::generic(result));

--- a/qq-maid-core/src/runtime/respond/tool_route.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route.rs
@@ -33,6 +33,7 @@ pub(super) enum ToolDomain {
     Weather,
     Train,
     Rss,
+    Search,
     Memory,
     Unknown,
 }
@@ -287,6 +288,13 @@ fn classify_semantic_route(text: &str, has_recent_todo_context: bool) -> Semanti
             "semantic_tool_intent",
         );
     }
+    if has_search_intent(text, &lower) {
+        return assessment(
+            SemanticRoute::ToolLoop,
+            ToolDomain::Search,
+            "semantic_tool_intent",
+        );
+    }
 
     if mentions_inert_weather_topic(text) {
         return assessment(
@@ -353,6 +361,9 @@ fn classify_status_hint(text: &str, has_recent_todo_context: bool) -> Option<Sta
     }
     if has_rss_intent(text, &lower) {
         return Some(StatusHint::new(StatusSubject::Rss, StatusAction::Query));
+    }
+    if has_search_intent(text, &lower) {
+        return Some(StatusHint::new(StatusSubject::Tool, StatusAction::Query));
     }
     None
 }
@@ -592,6 +603,25 @@ fn has_train_intent(text: &str, _lower: &str) -> bool {
 
 fn has_rss_intent(text: &str, lower: &str) -> bool {
     lower.contains("rss") || contains_any(text, &["订阅更新", "最近订阅", "订阅记录"])
+}
+
+fn has_search_intent(text: &str, lower: &str) -> bool {
+    lower.contains("search")
+        || contains_any(
+            text,
+            &[
+                "联网",
+                "上网查",
+                "网上查",
+                "网络查询",
+                "搜索",
+                "搜一下",
+                "查资料",
+                "查新闻",
+                "最新消息",
+                "最新进展",
+            ],
+        )
 }
 
 fn has_plain_chat_intent(text: &str, lower: &str) -> bool {

--- a/qq-maid-core/src/runtime/respond/tool_runtime.rs
+++ b/qq-maid-core/src/runtime/respond/tool_runtime.rs
@@ -11,7 +11,7 @@ use crate::{
     runtime::tools::{
         CancelTodoTool, CompleteTodoTool, CreateTodoTool, DeleteTodoTool, EditTodoTool,
         GetTodoTool, ListTodoTool, MergeTodoTool, RestoreTodoTool, RssRecentItemsTool,
-        SelectionScope, TrainScheduleTool, WeatherTool,
+        SelectionScope, TrainScheduleTool, WeatherTool, WebSearchTool,
     },
     runtime::{session::SessionStore, todo::TodoStore},
     storage::notification::NotificationOutboxStore,
@@ -42,6 +42,7 @@ impl ToolRuntime {
                 as qq_maid_llm::tool::DynTool,
             Arc::new(TrainScheduleTool::new(executors.train_executor.clone())),
             Arc::new(RssRecentItemsTool::new(stores.rss_store.clone())),
+            Arc::new(WebSearchTool::new(executors.query_executor.clone())),
             Arc::new(ListTodoTool::new(
                 stores.todo_store.clone(),
                 stores.session_store.clone(),

--- a/qq-maid-core/src/runtime/tools/mod.rs
+++ b/qq-maid-core/src/runtime/tools/mod.rs
@@ -5,6 +5,7 @@
 
 mod radar;
 mod rss;
+mod search;
 mod todo;
 mod train;
 mod weather;
@@ -15,6 +16,8 @@ pub use radar::{
     RadarTarget, build_radar_executor, radar_feedback_url, radar_site_url,
 };
 pub use rss::RssRecentItemsTool;
+pub(crate) use search::{WEB_SEARCH_QUERY_MAX_LENGTH, WEB_SEARCH_TOOL_NAME};
+pub use search::{WebSearchTool, WebSearchToolRequest};
 pub(crate) use todo::SelectionScope;
 pub use todo::{
     CancelTodoTool, CompleteTodoTool, CreateTodoTool, DeleteTodoTool, EditTodoTool, GetTodoTool,

--- a/qq-maid-core/src/runtime/tools/search.rs
+++ b/qq-maid-core/src/runtime/tools/search.rs
@@ -1,0 +1,373 @@
+//! 联网搜索 Tool。
+//!
+//! 该 Tool 复用现有 `QueryExecutor`，把 OpenAI Responses web_search 能力纳入
+//! 服务端白名单 ToolRegistry。`/查` 只作为显式触发入口，仍在 respond/search_flow.rs
+//! 负责参数兼容、session 记录和用户可见错误文案。
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tokio::sync::mpsc;
+
+use qq_maid_llm::tool::{Tool, ToolContext, ToolMetadata, ToolOutput};
+
+use crate::{
+    error::LlmError,
+    runtime::query::{DynQueryExecutor, QueryOutcome, QueryRequest, QuerySource},
+};
+
+pub(crate) const WEB_SEARCH_TOOL_NAME: &str = "web_search";
+pub(crate) const WEB_SEARCH_QUERY_MAX_LENGTH: usize = 200;
+const WEB_SEARCH_MAX_RESULTS_LIMIT: u8 = 10;
+
+/// 服务端显式触发联网搜索 Tool 时使用的 typed request。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WebSearchToolRequest {
+    pub query: String,
+    pub raw_question: Option<String>,
+    pub max_results: Option<u8>,
+    pub context_size: Option<String>,
+    pub model_override: Option<String>,
+}
+
+/// 模型可调用的联网搜索 Tool。
+#[derive(Clone)]
+pub struct WebSearchTool {
+    executor: DynQueryExecutor,
+}
+
+impl WebSearchTool {
+    pub fn new(executor: DynQueryExecutor) -> Self {
+        Self { executor }
+    }
+
+    pub async fn query(&self, req: WebSearchToolRequest) -> Result<QueryOutcome, LlmError> {
+        self.executor.query(query_request(req)).await
+    }
+
+    pub async fn query_stream(
+        &self,
+        req: WebSearchToolRequest,
+        delta_tx: mpsc::Sender<String>,
+    ) -> Result<QueryOutcome, LlmError> {
+        self.executor
+            .query_stream(query_request(req), delta_tx)
+            .await
+    }
+}
+
+#[async_trait]
+impl Tool for WebSearchTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            name: WEB_SEARCH_TOOL_NAME.to_owned(),
+            description: "联网查询和搜索公开网页信息。用于回答需要实时信息、新闻、网页资料、最新版本、公开资料核实的问题；不用于查询本地待办、天气、火车时刻或 RSS 本地记录。".to_owned(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "要搜索的关键词或问题，保持具体明确"
+                    },
+                    "raw_question": {
+                        "type": ["string", "null"],
+                        "description": "用户原始问题；不确定时传 null"
+                    },
+                    "max_results": {
+                        "type": ["integer", "null"],
+                        "description": "期望返回的搜索结果数量，1 到 10；不确定时传 null"
+                    },
+                    "context_size": {
+                        "type": ["string", "null"],
+                        "description": "搜索上下文大小，可选 low、medium、high；不确定时传 null",
+                        "enum": ["low", "medium", "high", null]
+                    }
+                },
+                "required": ["query", "raw_question", "max_results", "context_size"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    async fn execute(
+        &self,
+        context: ToolContext,
+        arguments: Value,
+    ) -> Result<ToolOutput, LlmError> {
+        let outcome = self
+            .query(request_from_arguments(&context, &arguments)?)
+            .await?;
+        Ok(ToolOutput::json(web_search_tool_output(&outcome)))
+    }
+}
+
+fn request_from_arguments(
+    context: &ToolContext,
+    arguments: &Value,
+) -> Result<WebSearchToolRequest, LlmError> {
+    // 搜索模型路由只允许 `/查` 等服务端直接执行入口注入；模型 Tool Loop 调用
+    // 会带稳定 tool_call_id，此时忽略任何伪造的 model_override 参数。
+    let model_override = if context.tool_call_id.is_none() {
+        optional_string_field(arguments, "model_override")
+    } else {
+        None
+    };
+    Ok(WebSearchToolRequest {
+        query: parse_query(arguments)?,
+        raw_question: optional_string_field(arguments, "raw_question"),
+        max_results: parse_max_results(arguments.get("max_results"))?,
+        context_size: parse_context_size(arguments.get("context_size"))?,
+        model_override,
+    })
+}
+
+fn query_request(req: WebSearchToolRequest) -> QueryRequest {
+    QueryRequest {
+        query: req.query,
+        raw_question: req.raw_question,
+        max_results: req.max_results,
+        context_size: req.context_size,
+        model_override: req.model_override,
+    }
+}
+
+fn parse_query(arguments: &Value) -> Result<String, LlmError> {
+    let query = arguments
+        .get("query")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            LlmError::new(
+                "bad_tool_arguments",
+                "web_search requires non-empty query",
+                "tool",
+            )
+        })?;
+    if query.chars().count() > WEB_SEARCH_QUERY_MAX_LENGTH {
+        return Err(LlmError::new(
+            "bad_tool_arguments",
+            "query is too long",
+            "tool",
+        ));
+    }
+    Ok(query.to_owned())
+}
+
+fn parse_max_results(value: Option<&Value>) -> Result<Option<u8>, LlmError> {
+    match value {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Number(number)) if !number.is_f64() => match number.as_u64() {
+            Some(value) if (1..=WEB_SEARCH_MAX_RESULTS_LIMIT as u64).contains(&value) => {
+                Ok(Some(value as u8))
+            }
+            _ => reject_invalid_max_results(),
+        },
+        _ => reject_invalid_max_results(),
+    }
+}
+
+fn reject_invalid_max_results() -> Result<Option<u8>, LlmError> {
+    tracing::warn!(
+        tool = WEB_SEARCH_TOOL_NAME,
+        error_code = "bad_tool_arguments",
+        argument = "max_results",
+        "invalid web search max_results argument rejected",
+    );
+    Err(LlmError::new(
+        "bad_tool_arguments",
+        "max_results must be an integer between 1 and 10 or null",
+        "tool",
+    ))
+}
+
+fn parse_context_size(value: Option<&Value>) -> Result<Option<String>, LlmError> {
+    match value {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(text)) => {
+            let text = text.trim();
+            if matches!(text, "low" | "medium" | "high") {
+                Ok(Some(text.to_owned()))
+            } else {
+                reject_invalid_context_size()
+            }
+        }
+        _ => reject_invalid_context_size(),
+    }
+}
+
+fn reject_invalid_context_size() -> Result<Option<String>, LlmError> {
+    tracing::warn!(
+        tool = WEB_SEARCH_TOOL_NAME,
+        error_code = "bad_tool_arguments",
+        argument = "context_size",
+        "invalid web search context_size argument rejected",
+    );
+    Err(LlmError::new(
+        "bad_tool_arguments",
+        "context_size must be low, medium, high, or null",
+        "tool",
+    ))
+}
+
+fn optional_string_field(arguments: &Value, key: &str) -> Option<String> {
+    match arguments.get(key) {
+        Some(Value::String(value)) => {
+            let value = value.trim();
+            (!value.is_empty()).then(|| value.to_owned())
+        }
+        _ => None,
+    }
+}
+
+fn web_search_tool_output(outcome: &QueryOutcome) -> Value {
+    json!({
+        "provider": outcome.provider,
+        "answer": outcome.answer,
+        "sources": outcome.sources.iter().map(web_search_source_json).collect::<Vec<_>>(),
+        "elapsed_ms": outcome.elapsed_ms,
+    })
+}
+
+fn web_search_source_json(source: &QuerySource) -> Value {
+    json!({
+        "title": source.title,
+        "url": source.url,
+        "snippet": source.snippet,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+
+    use crate::runtime::query::QueryExecutor;
+
+    use super::*;
+
+    #[derive(Clone, Default)]
+    struct MockQueryExecutor {
+        requests: Arc<Mutex<Vec<QueryRequest>>>,
+    }
+
+    #[async_trait]
+    impl QueryExecutor for MockQueryExecutor {
+        async fn query(&self, req: QueryRequest) -> Result<QueryOutcome, LlmError> {
+            self.requests.lock().unwrap().push(req.clone());
+            Ok(QueryOutcome {
+                answer: format!("answer: {}", req.query),
+                sources: vec![QuerySource {
+                    title: "source title".to_owned(),
+                    url: "https://example.com".to_owned(),
+                    snippet: "source snippet".to_owned(),
+                }],
+                provider: "mock-query".to_owned(),
+                elapsed_ms: 12,
+            })
+        }
+
+        fn provider_name(&self) -> &'static str {
+            "mock-query"
+        }
+    }
+
+    fn test_context() -> ToolContext {
+        ToolContext {
+            task_id: "task-1".to_owned(),
+            user_id: Some("u1".to_owned()),
+            scope_id: "private:u1".to_owned(),
+            tool_call_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn web_search_tool_reuses_query_executor() {
+        let executor = MockQueryExecutor::default();
+        let requests = executor.requests.clone();
+        let tool = WebSearchTool::new(Arc::new(executor));
+
+        let output = tool
+            .execute(
+                test_context(),
+                json!({
+                    "query": "Rust 新闻",
+                    "raw_question": "/查 Rust 新闻",
+                    "max_results": 3,
+                    "context_size": "medium",
+                    "model_override": "gpt-search",
+                }),
+            )
+            .await
+            .unwrap();
+
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].query, "Rust 新闻");
+        assert_eq!(requests[0].raw_question.as_deref(), Some("/查 Rust 新闻"));
+        assert_eq!(requests[0].max_results, Some(3));
+        assert_eq!(requests[0].context_size.as_deref(), Some("medium"));
+        assert_eq!(requests[0].model_override.as_deref(), Some("gpt-search"));
+        assert_eq!(output.value["answer"], "answer: Rust 新闻");
+        assert_eq!(output.value["sources"][0]["url"], "https://example.com");
+    }
+
+    #[tokio::test]
+    async fn web_search_tool_rejects_empty_query_without_calling_executor() {
+        let executor = MockQueryExecutor::default();
+        let requests = executor.requests.clone();
+        let tool = WebSearchTool::new(Arc::new(executor));
+
+        let err = tool
+            .execute(
+                test_context(),
+                json!({
+                    "query": " ",
+                    "raw_question": null,
+                    "max_results": null,
+                    "context_size": null,
+                    "model_override": null,
+                }),
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, "bad_tool_arguments");
+        assert_eq!(requests.lock().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn web_search_tool_rejects_invalid_options() {
+        let tool = WebSearchTool::new(Arc::new(MockQueryExecutor::default()));
+
+        let err = tool
+            .execute(
+                test_context(),
+                json!({
+                    "query": "Rust",
+                    "raw_question": null,
+                    "max_results": 99,
+                    "context_size": null,
+                    "model_override": null,
+                }),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, "bad_tool_arguments");
+
+        let err = tool
+            .execute(
+                test_context(),
+                json!({
+                    "query": "Rust",
+                    "raw_question": null,
+                    "max_results": null,
+                    "context_size": "huge",
+                    "model_override": null,
+                }),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, "bad_tool_arguments");
+    }
+}

--- a/runtime/config/agent.toml
+++ b/runtime/config/agent.toml
@@ -6,7 +6,7 @@
 # - 如果 scenes.*.tool_calling_enabled 省略，会继承旧开关：
 #   私聊继承 TOOL_CALLING_ENABLED，群聊继承 TOOL_CALLING_GROUP_ENABLED。
 # - 如果 scenes.*.enabled_tools 省略，私聊默认开放全部业务 Tool；
-#   群聊默认只开放 get_weather / get_train_schedule / get_rss_recent_items。
+#   群聊默认只开放 get_weather / get_train_schedule / get_rss_recent_items / web_search。
 # - 如果默认 config/agent.toml 缺失，会回退到旧环境变量内置策略。
 #
 # 不要在这里写 API Key、Access Token、私有 Base URL、真实 prompt、用户资料、群资料、
@@ -90,6 +90,7 @@ tool_calling_enabled = true
 #   "get_weather",
 #   "get_train_schedule",
 #   "get_rss_recent_items",
+#   "web_search",
 #   "list_todos",
 #   "get_todo",
 #   "create_todo",
@@ -111,4 +112,4 @@ profile = "fast"
 main_route = "group_main"
 search_route = "group_search"
 tool_calling_enabled = false
-# enabled_tools = ["get_weather", "get_train_schedule", "get_rss_recent_items"]
+# enabled_tools = ["get_weather", "get_train_schedule", "get_rss_recent_items", "web_search"]


### PR DESCRIPTION
## 背景

关闭/推进 #358。将 `/查` 显式查询入口收敛到 Core 统一 ToolRegistry / Agent Tool Loop 的 `web_search` Tool，避免命令链路继续直接维护查询执行、上下文和结果适配。

## 主要修改

- 新增 `qq-maid-core/src/runtime/tools/search.rs`，提供 `WebSearchTool` / `WebSearchToolRequest`，复用现有 `QueryExecutor`，同时支持非流式 `query` 和显式入口使用的 `query_stream`。
- `/查` 旧链路位于 `qq-maid-core/src/runtime/respond/search_flow.rs`，现在只保留命令解析、参数校验、session 记录和用户展示，实际执行改为显式调用 `web_search` Tool。
- `/查` 流式体验保留：先发用户可见的“正在联网查询中…”进度 delta，再转发真实搜索 delta；只有最终 answer 写入 session / Core 响应，不把进度事件写入模型上下文。
- 将 `web_search` 注册到 `ToolRuntime`，加入私聊和群聊默认工具白名单；普通自然语言搜索意图可进入 Tool Loop，并通过 Tool presenter 生成可信展示。
- 更新 `agent.toml` 模板和 `qq-maid-core/README.md`，同步搜索 Tool 边界。

## 兼容性

- 保留 `/查 <内容>`、`/查询 <内容>`、`/search <内容>` 和中文紧凑写法 `/查今日新闻`。
- `/查` 空参数、超长参数、查询失败、超时等用户可见文案保持兼容。
- 普通聊天只在路由识别到搜索意图且 Tool Calling 可用时进入 Tool Loop；slash 命令仍优先。
- 模型 Tool Loop 调用不能伪造搜索 `model_override`；场景搜索模型只由服务端显式 `/查` 路径注入。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p qq-maid-core`（727 passed）
- `cargo check --workspace`
- `git diff --check`

## 说明

本次没有删除 `runtime/query` 兼容 facade；它仍作为 `qq-maid-llm` Web Search 执行器在 Core 内的类型 re-export，被新 `web_search` Tool 复用。