### PR TITLE
fix: 调整联网查询响应路由

### DIFF
--- a/qq-maid-core/src/runtime/respond/command_dispatcher.rs
+++ b/qq-maid-core/src/runtime/respond/command_dispatcher.rs
@@ -161,7 +161,16 @@ impl<'a> CommandDispatcher<'a> {
             )));
         }
 
-        // 检查是否为联网搜索指令（如 "/查 关键词"）
+        // 检查是否为联网搜索指令（如 "/查 关键词"）。当 router 已判定为
+        // WebSearch 时，自然语言搜索意图也必须复用同一聚合查询路径。
+        if matches!(plan, RespondPlan::WebSearch) {
+            let command = search_flow::web_search_command_for_plan(&user_text);
+            return Ok(DispatchOutcome::Respond(Box::new(
+                self.service
+                    .handle_web_search_command(command, &req, &mut session)
+                    .await?,
+            )));
+        }
         if let Some(command) = search_flow::parse_web_search_command(&user_text) {
             return Ok(DispatchOutcome::Respond(Box::new(
                 self.service

--- a/qq-maid-core/src/runtime/respond/command_dispatcher.rs
+++ b/qq-maid-core/src/runtime/respond/command_dispatcher.rs
@@ -227,7 +227,9 @@ impl<'a> CommandDispatcher<'a> {
         apply_manual_display_names(&self.service.display_name_store, &meta, &mut req);
         let chat_plan = match plan {
             RespondPlan::CompleteToolLoop => ChatToolPlan::ForceCompleteToolLoop,
-            RespondPlan::Immediate | RespondPlan::StreamingChat => ChatToolPlan::Plain,
+            RespondPlan::Immediate | RespondPlan::StreamingChat | RespondPlan::WebSearch => {
+                ChatToolPlan::Plain
+            }
         };
         Ok(DispatchOutcome::Chat(Box::new(PreparedChat {
             req,

--- a/qq-maid-core/src/runtime/respond/mod.rs
+++ b/qq-maid-core/src/runtime/respond/mod.rs
@@ -429,15 +429,7 @@ impl RustRespondService {
                 .map_err(session_error)?,
         };
 
-        let command = search_flow::parse_web_search_command(&user_text).unwrap_or_else(|| {
-            // 自然语言搜索意图：用原话作为 query 复用 `/查` 的流式查询能力。
-            // raw_command 仅用于 session 历史展示，不改变查询语义。
-            crate::runtime::command::ParsedCommand {
-                action: "web_search".to_owned(),
-                argument: user_text.trim().to_owned(),
-                raw_command: "查".to_owned(),
-            }
-        });
+        let command = search_flow::web_search_command_for_plan(&user_text);
         self.handle_web_search_command_stream(command, &req, &mut session, on_delta)
             .await
     }

--- a/qq-maid-core/src/runtime/respond/mod.rs
+++ b/qq-maid-core/src/runtime/respond/mod.rs
@@ -144,6 +144,12 @@ pub(crate) enum RespondPlan {
     Immediate,
     StreamingChat,
     CompleteToolLoop,
+    /// 显式联网查询路径：`/查` 或明确对机器人发起的搜索意图。
+    ///
+    /// 该路径独立于 Tool Loop 路由：群聊只要 @ 机器人并命中搜索意图即触发，
+    /// 不依赖 Tool Loop 开关；查询复用 `/查` 的 `WebSearchTool::query_stream`
+    /// 流式能力，避免长时间非流式阻塞导致超时。
+    WebSearch,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -360,5 +366,79 @@ impl RustRespondService {
         // 真流式只覆盖普通聊天；搜索命令等确定性入口不提前查手动展示名。
         apply_manual_display_names(&self.display_name_store, &meta, &mut req);
         self.handle_chat_stream(req, on_delta).await
+    }
+
+    /// `RespondPlan::WebSearch` 的流式编放入口。
+    ///
+    /// 当 plan 已被 router 判定为 WebSearch 时调用：显式 `/查` 走原有
+    /// `handle_web_search_command_stream`；自然语言搜索意图（如“联网查询下今日 ai 新闻”
+    /// ）不再退化成普通聊天，而是合成查询并复用 `WebSearchTool::query_stream`，
+    /// 避免长时间非流式阻塞导致业务超时。会话加载与 pending 优先级沿用 `respond_stream`，
+    /// 不重复各自重建状态机。
+    pub(crate) async fn respond_web_search_stream<F>(
+        &self,
+        req: RespondRequest,
+        on_delta: F,
+    ) -> Result<RespondResponse, LlmError>
+    where
+        F: FnMut(String) -> Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send>> + Send,
+    {
+        let user_text = req.effective_user_text();
+        let meta = respond_meta(&req);
+        let interaction_meta = respond_interaction_meta(&req);
+        let mut active_interaction_session = self
+            .session_store
+            .get_active(&interaction_meta)
+            .map_err(session_error)?;
+        let mut active_session = self
+            .session_store
+            .get_active(&meta)
+            .map_err(session_error)?;
+
+        let bypass_pending_for_session_command = command_bypasses_pending(&user_text);
+        if !bypass_pending_for_session_command {
+            if let Some(session) = active_interaction_session
+                .as_mut()
+                .filter(|session| session.pending_operation.is_some())
+                && let Some(response) = self
+                    .handle_pending_operation(&req, &user_text, &meta, session)
+                    .await?
+            {
+                return Ok(response);
+            }
+            if let Some(session) = active_session
+                .as_mut()
+                .filter(|session| session_pending_visible_to_user(session, meta.user_id.as_deref()))
+                && let Some(response) = self
+                    .handle_pending_operation(&req, &user_text, &meta, session)
+                    .await?
+            {
+                return Ok(response);
+            }
+        }
+
+        if let Some(command) = session_flow::parse_session_command(&user_text) {
+            return self.handle_session_command(command, &meta).await;
+        }
+
+        let mut session = match active_session {
+            Some(session) => session,
+            None => self
+                .session_store
+                .get_or_create_active(&meta)
+                .map_err(session_error)?,
+        };
+
+        let command = search_flow::parse_web_search_command(&user_text).unwrap_or_else(|| {
+            // 自然语言搜索意图：用原话作为 query 复用 `/查` 的流式查询能力。
+            // raw_command 仅用于 session 历史展示，不改变查询语义。
+            crate::runtime::command::ParsedCommand {
+                action: "web_search".to_owned(),
+                argument: user_text.trim().to_owned(),
+                raw_command: "查".to_owned(),
+            }
+        });
+        self.handle_web_search_command_stream(command, &req, &mut session, on_delta)
+            .await
     }
 }

--- a/qq-maid-core/src/runtime/respond/router.rs
+++ b/qq-maid-core/src/runtime/respond/router.rs
@@ -97,10 +97,22 @@ impl<'a> RespondRouter<'a> {
         }
 
         if search_flow::parse_web_search_command(&user_text).is_some() {
-            return Ok(RespondPlan::StreamingChat);
+            // 显式 `/查` 入口统一走 WebSearch，复用 `/查` 的流式查询能力，
+            // 避免被通用 slash 命令截走而走非流式完整等待路径。
+            return Ok(RespondPlan::WebSearch);
         }
         if trimmed.starts_with('/') || trimmed.starts_with('／') {
             return Ok(RespondPlan::Immediate);
+        }
+
+        // 在进入 Tool Loop 路由前，先拦截“明确对机器人发起的搜索意图”。
+        // 群聊未 @ 机器人时 Gateway 已在入站阶段过滤，Core 侧不再二次判定；
+        // 但为安全起见，群聊仍要求存在 directed_to_bot 信号才自动联网查询，
+        // 避免出现“查/搜索”等词就触发。私聊天然视为明确发起。
+        if tool_route::has_search_intent(trimmed, &trimmed.to_ascii_lowercase())
+            && directed_to_bot(req)
+        {
+            return Ok(RespondPlan::WebSearch);
         }
 
         // 先保护已有确定性命令和自然语言 Todo 查询，避免简单列表查询绕过
@@ -248,4 +260,24 @@ impl RustRespondService {
     ) -> Result<CoreInboundClassification, LlmError> {
         RespondRouter::new(self).classify_inbound(req)
     }
+}
+
+/// 判断消息是否明确对机器人发起，用于普通聊天搜索意图是否进入 WebSearch。
+///
+/// 复用 Gateway 已归一化的 `message_context.mentions[].is_self` 信号，不重复解析
+/// 群聊 @ 文本。群聊只有存在 @ 当前机器人的 mention 才算明确发起；私聊天然为真。
+/// Gateway 入站过滤已保证群聊无 @ 机器人消息不会进入 Core respond，本判断主要作为
+/// Core 内部安全边界，避免直接构造 `RespondRequest` 的调用方误触发联网查询。
+fn directed_to_bot(req: &RespondRequest) -> bool {
+    let is_group = req
+        .group_id
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty());
+    if !is_group {
+        return true;
+    }
+    req.message_context
+        .as_ref()
+        .map(|context| context.mentions.iter().any(|mention| mention.is_self))
+        .unwrap_or(false)
 }

--- a/qq-maid-core/src/runtime/respond/search_flow.rs
+++ b/qq-maid-core/src/runtime/respond/search_flow.rs
@@ -121,6 +121,7 @@ impl RustRespondService {
         }
 
         let command_text = format!("/{} {}", command.raw_command, command.argument);
+        let raw_question = web_search_raw_question(&command_text, req);
         if stream && let Some(on_delta) = on_delta.as_mut() {
             on_delta(WEB_SEARCH_RUNNING_DELTA.to_owned()).await?;
         }
@@ -128,13 +129,13 @@ impl RustRespondService {
         let output_result = if stream {
             self.execute_web_search_tool_stream(
                 query,
-                &command_text,
+                &raw_question,
                 Some(policy.search_model.clone()),
                 on_delta.as_mut(),
             )
             .await
         } else {
-            self.execute_web_search_tool(query, &command_text, Some(policy.search_model.clone()))
+            self.execute_web_search_tool(query, &raw_question, Some(policy.search_model.clone()))
                 .await
         };
         let output = match output_result {
@@ -246,6 +247,57 @@ pub(super) fn parse_web_search_command(text: &str) -> Option<ParsedCommand> {
         return matches!(command.action.as_str(), "web_search").then_some(command);
     }
     parse_compact_web_search_command(text)
+}
+
+/// 在 router 已判定 `RespondPlan::WebSearch` 后，将输入统一转换为 web_search 命令。
+/// 显式 `/查` 保留原命令；自然语言搜索意图用原话作为 query 复用同一查询流程。
+pub(super) fn web_search_command_for_plan(text: &str) -> ParsedCommand {
+    parse_web_search_command(text).unwrap_or_else(|| ParsedCommand {
+        action: "web_search".to_owned(),
+        argument: text.trim().to_owned(),
+        raw_command: "查".to_owned(),
+    })
+}
+
+fn web_search_raw_question(command_text: &str, req: &RespondRequest) -> String {
+    let Some(quoted_context) = quoted_search_context(req) else {
+        return command_text.to_owned();
+    };
+    format!("{command_text}\n\n引用消息上下文：\n{quoted_context}")
+}
+
+fn quoted_search_context(req: &RespondRequest) -> Option<String> {
+    let quoted = req.quoted.as_ref()?;
+    if !quoted.lookup_found {
+        return None;
+    }
+
+    let mut lines = Vec::new();
+    if let Some(text) = quoted
+        .text_summary
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        lines.push(format!("引用文本：{text}"));
+    }
+    for part in &quoted.input_parts {
+        if let Some(text) = part
+            .text_content()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            lines.push(format!("引用文本：{text}"));
+        }
+    }
+    for media in &quoted.media_summaries {
+        let summary = media.summary.trim();
+        if !summary.is_empty() {
+            lines.push(format!("引用媒体：{summary}"));
+        }
+    }
+
+    (!lines.is_empty()).then(|| truncate_chars(&lines.join("\n"), 800))
 }
 
 fn parse_compact_web_search_command(text: &str) -> Option<ParsedCommand> {

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -1,8 +1,9 @@
-use std::fs;
+use std::{fs, sync::Arc};
 
 use serde_json::Value;
 
 use crate::provider::{ToolCallingProtocol, ToolExecutionResult, types::ChatRole};
+use crate::runtime::respond::RespondPlan;
 
 use super::{
     super::{RespondRequest, common::empty_respond_request},
@@ -511,33 +512,63 @@ async fn group_tool_loop_exposes_query_only_tools_when_enabled() {
 }
 
 #[tokio::test]
-async fn private_tool_loop_can_web_search_with_trusted_rendering() {
-    let inspector = MockProvider::new()
-        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
-        .with_tool_call_json(
-            "web_search",
-            r#"{"query":"Rust 最新进展","raw_question":"搜索 Rust 最新进展","max_results":null,"context_size":null}"#,
-            "模型原始搜索总结不应覆盖可信工具结果。",
-        );
-    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+async fn private_search_intent_routes_to_web_search_plan() {
+    let service = test_service_with_provider_and_tool_calling(MockProvider::new(), true);
+
+    // 普通聊天命中搜索意图且明确对机器人发起（私聊天然为真）时，
+    // 不再进入 Tool Loop，而是走显式 WebSearch 流式路径。
+    let plan = service
+        .plan_core_respond(&private_message("联网查询下今日 ai 新闻"))
+        .unwrap();
+    assert_eq!(plan, RespondPlan::WebSearch);
+}
+
+#[tokio::test]
+async fn private_search_intent_web_search_stream_reuses_query_stream() {
+    let deltas = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let collected = deltas.clone();
+    let service = test_service_with_provider_and_tool_calling(MockProvider::new(), true);
 
     let response = service
-        .respond(private_message("搜索 Rust 最新进展"))
+        .respond_web_search_stream(
+            private_message("联网查询下今日 ai 新闻"),
+            move |delta| {
+                let collected = collected.clone();
+                Box::pin(async move {
+                    collected.lock().unwrap().push(delta);
+                    Ok(())
+                })
+            },
+        )
         .await
         .unwrap();
 
-    assert_eq!(inspector.tool_call_count(), 1);
-    let text = response.text.as_deref().unwrap();
-    assert!(text.contains("联网查询"));
-    assert!(text.contains("web answer: Rust 最新进展"));
-    assert!(text.contains("模型原始搜索总结不应覆盖可信工具结果"));
-    assert_eq!(response.command.as_deref(), Some("web_search"));
-    let diagnostics = response.diagnostics.unwrap();
-    assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
-        serde_json::json!(["web_search"])
+    // 复用 `/查` 的流式查询：先发 “正在联网查询中…” 进度，再发结果。
+    let received = deltas.lock().unwrap().clone();
+    assert!(
+        received
+            .first()
+            .is_some_and(|delta| delta.contains("正在联网查询中"))
     );
-    assert_eq!(diagnostics["agent_turn_status"], "succeeded");
+    assert!(
+        received
+            .iter()
+            .any(|delta| delta.contains("联网查询下今日 ai 新闻"))
+    );
+    let text = response.text.as_deref().unwrap();
+    assert!(text.starts_with("【联网查询】"));
+    assert!(text.contains("联网查询下今日 ai 新闻"));
+    assert_eq!(response.command.as_deref(), Some("web_search"));
+}
+
+#[tokio::test]
+async fn private_explicit_search_command_routes_to_web_search_plan() {
+    let service = test_service_with_provider_and_tool_calling(MockProvider::new(), true);
+
+    let plan = service
+        .plan_core_respond(&private_message("/查 今日 ai 新闻"))
+        .unwrap();
+    assert_eq!(plan, RespondPlan::WebSearch);
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tool_route.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route.rs
@@ -605,7 +605,7 @@ fn has_rss_intent(text: &str, lower: &str) -> bool {
     lower.contains("rss") || contains_any(text, &["订阅更新", "最近订阅", "订阅记录"])
 }
 
-fn has_search_intent(text: &str, lower: &str) -> bool {
+pub(super) fn has_search_intent(text: &str, lower: &str) -> bool {
     lower.contains("search")
         || contains_any(
             text,

--- a/qq-maid-core/src/service/handle.rs
+++ b/qq-maid-core/src/service/handle.rs
@@ -73,7 +73,7 @@ impl CoreService for CoreHandle {
         let respond_plan = service.plan_core_respond(&req).map_err(CoreError::from)?;
         if matches!(
             respond_plan,
-            RespondPlan::StreamingChat | RespondPlan::CompleteToolLoop
+            RespondPlan::StreamingChat | RespondPlan::CompleteToolLoop | RespondPlan::WebSearch
         ) {
             // 微信服务号同步 XML 回包无法承载直出流式；这里仅对微信禁用 direct stream，
             // 让 Gateway 消费 Completed 后再渲染 XML，QQ 官方流式行为保持不变。

--- a/qq-maid-core/src/service/streaming.rs
+++ b/qq-maid-core/src/service/streaming.rs
@@ -113,6 +113,13 @@ async fn run_streaming_respond(
     if matches!(plan, RespondPlan::CompleteToolLoop) {
         return run_complete_tool_loop_respond(service, req, tx, cancelled, progress_status).await;
     }
+    if matches!(plan, RespondPlan::WebSearch) && provider_stream_enabled {
+        // WebSearch 不套用 CompleteToolLoop 整体超时：联网查询复用 `/查` 的流式
+        // `WebSearchTool::query_stream`，只要持续有有效片段就不被长等待窗口误杀。
+        // provider 不支持流式时改由下面聚合路径走 `respond_with_plan`，
+        // 由 dispatcher 命中 `/查` 聚合后一次性发送。
+        return run_web_search_respond(service, req, tx, cancelled).await;
+    }
     if !provider_stream_enabled {
         let response = service.respond_with_plan(req, plan).await?;
         debug!(
@@ -135,6 +142,30 @@ async fn run_streaming_respond(
             Box::pin(async move { send_core_delta(&tx, &cancelled, delta).await })
         })
         .await
+}
+
+async fn run_web_search_respond(
+    service: &RustRespondService,
+    req: RespondRequest,
+    tx: mpsc::Sender<CoreResponseEvent>,
+    cancelled: Arc<AtomicBool>,
+) -> Result<RespondResponse, LlmError> {
+    let response = service
+        .respond_web_search_stream(req, |delta| {
+            let tx = tx.clone();
+            let cancelled = cancelled.clone();
+            Box::pin(async move { send_core_delta(&tx, &cancelled, delta).await })
+        })
+        .await?;
+    debug!(
+        respond_plan = respond_plan_name(RespondPlan::WebSearch),
+        synthetic_final_delta = false,
+        final_chars = response_visible_content(&response)
+            .map(|content| content.chars().count())
+            .unwrap_or_default(),
+        "core web search stream completed"
+    );
+    Ok(response)
 }
 
 async fn run_complete_tool_loop_respond(
@@ -245,6 +276,7 @@ fn respond_plan_name(plan: RespondPlan) -> &'static str {
         RespondPlan::Immediate => "immediate",
         RespondPlan::StreamingChat => "streaming_chat",
         RespondPlan::CompleteToolLoop => "complete_tool_loop",
+        RespondPlan::WebSearch => "web_search",
     }
 }
 
@@ -256,6 +288,10 @@ pub(crate) fn output_policy_for_stream(
         RespondPlan::StreamingChat if provider_stream_enabled => CoreOutputPolicy::DirectStream,
         RespondPlan::StreamingChat => CoreOutputPolicy::CompleteThenSend,
         RespondPlan::CompleteToolLoop => CoreOutputPolicy::ProgressThenComplete,
+        // WebSearch 复用 `/查` 的流式查询能力：provider 支持流式时直出，
+        // 否则聚合后一次性发送，避免长时间非流式阻塞导致业务超时。
+        RespondPlan::WebSearch if provider_stream_enabled => CoreOutputPolicy::DirectStream,
+        RespondPlan::WebSearch => CoreOutputPolicy::CompleteThenSend,
         RespondPlan::Immediate => CoreOutputPolicy::CompleteThenSend,
     }
 }

--- a/qq-maid-core/src/service/streaming.rs
+++ b/qq-maid-core/src/service/streaming.rs
@@ -117,7 +117,7 @@ async fn run_streaming_respond(
         // WebSearch 不套用 CompleteToolLoop 整体超时：联网查询复用 `/查` 的流式
         // `WebSearchTool::query_stream`，只要持续有有效片段就不被长等待窗口误杀。
         // provider 不支持流式时改由下面聚合路径走 `respond_with_plan`，
-        // 由 dispatcher 命中 `/查` 聚合后一次性发送。
+        // dispatcher 会按 WebSearch plan 聚合查询后一次性发送。
         return run_web_search_respond(service, req, tx, cancelled).await;
     }
     if !provider_stream_enabled {

--- a/qq-maid-core/src/service/tests/mod.rs
+++ b/qq-maid-core/src/service/tests/mod.rs
@@ -1,7 +1,10 @@
 use super::*;
-use std::{sync::atomic::Ordering, time::Duration};
+use std::{
+    sync::{Arc, atomic::Ordering},
+    time::Duration,
+};
 
-use qq_maid_common::identity_context::IdentitySource;
+use qq_maid_common::{identity_context::IdentitySource, input_part::QuotedMessageContext};
 
 use crate::{
     error::LlmError,
@@ -694,6 +697,108 @@ async fn wechat_service_chat_completes_without_direct_stream() {
         provider.requests()[0].metadata.get("purpose").unwrap(),
         "chat"
     );
+}
+
+#[tokio::test]
+async fn core_web_search_private_intent_uses_query_when_provider_stream_disabled() {
+    let provider = TestProvider::replying("普通聊天不应调用");
+    let query_executor = MockQueryExecutor::default();
+    let state =
+        test_state_with_query_executor(provider.clone(), 5, Arc::new(query_executor.clone()));
+    let service = CoreHandle::new(state);
+
+    let mut stream = expect_stream(
+        service
+            .respond(private_request("联网查询下今日 ai 新闻"))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(stream.output_policy(), CoreOutputPolicy::CompleteThenSend);
+
+    let response = collect_completed_without_text_delta(&mut stream).await;
+
+    assert_eq!(response.command.as_deref(), Some("web_search"));
+    assert!(
+        response
+            .markdown_content()
+            .is_some_and(|text| text.starts_with("【联网查询】"))
+    );
+    assert!(
+        response
+            .text_content()
+            .is_some_and(|text| text.contains("web answer: 联网查询下今日 ai 新闻"))
+    );
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    let requests = query_executor.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].query, "联网查询下今日 ai 新闻");
+    assert_eq!(
+        requests[0].raw_question.as_deref(),
+        Some("/查 联网查询下今日 ai 新闻")
+    );
+}
+
+#[tokio::test]
+async fn core_web_search_wechat_sync_path_uses_query() {
+    let provider = TestProvider::replying("普通聊天不应调用").with_stream_enabled(true);
+    let query_executor = MockQueryExecutor::default();
+    let state =
+        test_state_with_query_executor(provider.clone(), 5, Arc::new(query_executor.clone()));
+    let service = CoreHandle::new(state);
+
+    let mut stream = expect_stream(
+        service
+            .respond(wechat_service_request("联网查询下今日 ai 新闻"))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(stream.output_policy(), CoreOutputPolicy::CompleteThenSend);
+
+    let response = collect_completed_without_text_delta(&mut stream).await;
+
+    assert_eq!(response.command.as_deref(), Some("web_search"));
+    assert!(
+        response
+            .markdown_content()
+            .is_some_and(|text| text.starts_with("【联网查询】"))
+    );
+    assert!(
+        response
+            .text_content()
+            .is_some_and(|text| text.contains("web answer: 联网查询下今日 ai 新闻"))
+    );
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    let requests = query_executor.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].query, "联网查询下今日 ai 新闻");
+}
+
+#[tokio::test]
+async fn core_web_search_query_raw_question_includes_quoted_context() {
+    let provider = TestProvider::replying("普通聊天不应调用");
+    let query_executor = MockQueryExecutor::default();
+    let state =
+        test_state_with_query_executor(provider.clone(), 5, Arc::new(query_executor.clone()));
+    let service = CoreHandle::new(state);
+    let mut request = private_request("联网查询下这件事的最新进展");
+    request.quoted = Some(QuotedMessageContext {
+        lookup_found: true,
+        text_summary: Some("Rust 1.90 发布候选版已经开放测试".to_owned()),
+        ..QuotedMessageContext::default()
+    });
+
+    let mut stream = expect_stream(service.respond(request).await.unwrap());
+    let response = collect_completed_without_text_delta(&mut stream).await;
+
+    assert_eq!(response.command.as_deref(), Some("web_search"));
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    let requests = query_executor.requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].query, "联网查询下这件事的最新进展");
+    let raw_question = requests[0].raw_question.as_deref().unwrap();
+    assert!(raw_question.contains("/查 联网查询下这件事的最新进展"));
+    assert!(raw_question.contains("引用消息上下文"));
+    assert!(raw_question.contains("引用文本：Rust 1.90 发布候选版已经开放测试"));
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/service/tests/mod.rs
+++ b/qq-maid-core/src/service/tests/mod.rs
@@ -518,6 +518,35 @@ fn core_plan_routes_group_chat_to_tool_loop_when_group_switch_enabled() {
 }
 
 #[test]
+fn core_plan_routes_group_search_intent_to_web_search_when_bot_mentioned() {
+    // 群聊 @机器人 + 搜索意图走显式 WebSearch，即使群聊 Tool Loop 关闭也不依赖该开关。
+    let provider =
+        TestProvider::replying("群聊回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let state = test_state_with_group_tool_calling(provider, 5, false, false);
+    let service = CoreHandle::new(state).respond_service();
+    let req: RespondRequest = group_request_with_self_mention("联网查询下今日 ai 新闻").into();
+
+    assert_eq!(
+        service.plan_core_respond(&req).unwrap(),
+        RespondPlan::WebSearch
+    );
+}
+
+#[test]
+fn core_plan_does_not_route_group_search_intent_to_web_search_without_bot_mention() {
+    // 群聊未 @机器人时，仅出现“联网查询 / 搜索”等词不应自动触发 WebSearch；
+    // 保留原有路由（这里 Tool Loop 关闭，回落 StreamingChat）。
+    let provider =
+        TestProvider::replying("群聊回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let state = test_state_with_group_tool_calling(provider, 5, false, false);
+    let service = CoreHandle::new(state).respond_service();
+    let req: RespondRequest = group_request("联网查询下今日 ai 新闻").into();
+
+    let plan = service.plan_core_respond(&req).unwrap();
+    assert_ne!(plan, RespondPlan::WebSearch);
+}
+
+#[test]
 fn core_plan_keeps_group_plain_chat_streaming_even_when_group_switch_enabled() {
     let provider =
         TestProvider::replying("群聊回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);

--- a/qq-maid-core/src/service/tests/support.rs
+++ b/qq-maid-core/src/service/tests/support.rs
@@ -291,6 +291,34 @@ impl QueryExecutor for EmptyQueryExecutor {
     }
 }
 
+#[derive(Clone, Default)]
+pub(super) struct MockQueryExecutor {
+    requests: Arc<Mutex<Vec<QueryRequest>>>,
+}
+
+impl MockQueryExecutor {
+    pub(super) fn requests(&self) -> Vec<QueryRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl QueryExecutor for MockQueryExecutor {
+    async fn query(&self, req: QueryRequest) -> Result<QueryOutcome, LlmError> {
+        self.requests.lock().unwrap().push(req.clone());
+        Ok(QueryOutcome {
+            answer: format!("web answer: {}", req.query),
+            sources: Vec::new(),
+            provider: "mock-query".to_owned(),
+            elapsed_ms: 1,
+        })
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "mock-query"
+    }
+}
+
 struct EmptyWeatherExecutor;
 
 #[async_trait::async_trait]
@@ -465,6 +493,36 @@ pub(super) fn test_state_with_group_tool_calling(
     tool_calling_enabled: bool,
     tool_calling_group_enabled: bool,
 ) -> CoreRuntimeState {
+    test_state_with_group_tool_calling_and_query_executor(
+        provider,
+        request_timeout_seconds,
+        tool_calling_enabled,
+        tool_calling_group_enabled,
+        Arc::new(EmptyQueryExecutor),
+    )
+}
+
+pub(super) fn test_state_with_query_executor(
+    provider: TestProvider,
+    request_timeout_seconds: u64,
+    query_executor: Arc<dyn QueryExecutor>,
+) -> CoreRuntimeState {
+    test_state_with_group_tool_calling_and_query_executor(
+        provider,
+        request_timeout_seconds,
+        false,
+        false,
+        query_executor,
+    )
+}
+
+fn test_state_with_group_tool_calling_and_query_executor(
+    provider: TestProvider,
+    request_timeout_seconds: u64,
+    tool_calling_enabled: bool,
+    tool_calling_group_enabled: bool,
+    query_executor: Arc<dyn QueryExecutor>,
+) -> CoreRuntimeState {
     let base_dir = std::env::temp_dir().join(format!(
         "qq-maid-core-service-test-{}",
         uuid::Uuid::new_v4()
@@ -563,7 +621,7 @@ pub(super) fn test_state_with_group_tool_calling(
         provider: observe_provider(Arc::new(provider), upstream_status.clone()),
         upstream_status,
         executors: CoreExecutors {
-            query_executor: Arc::new(EmptyQueryExecutor),
+            query_executor,
             weather_executor: Arc::new(EmptyWeatherExecutor),
             train_executor: Arc::new(EmptyTrainExecutor),
             radar_executor: Arc::new(EmptyRadarExecutor),

--- a/qq-maid-core/src/service/tests/support.rs
+++ b/qq-maid-core/src/service/tests/support.rs
@@ -7,7 +7,9 @@ use std::{
     time::Duration,
 };
 
-use qq_maid_common::identity_context::IdentitySource;
+use qq_maid_common::identity_context::{
+    IdentitySource, MentionConfidence, MentionIdentity, MessageActorContext,
+};
 
 use crate::{
     app::{CoreExecutors, CoreRuntimeState, CoreStores},
@@ -379,6 +381,18 @@ pub(super) fn group_request(text: &str) -> CoreRequest {
             group_id: "g1".to_owned(),
         },
     }
+}
+
+/// 构造命中 `@当前机器人` mention 的群聊请求，用于验证群聊显式 WebSearch 路径。
+pub(super) fn group_request_with_self_mention(text: &str) -> CoreRequest {
+    let mut request = group_request(text);
+    request.mentions = vec![MentionIdentity {
+        raw_text: Some("@当前机器人".to_owned()),
+        target: MessageActorContext::default(),
+        is_self: true,
+        confidence: MentionConfidence::Event,
+    }];
+    request
 }
 
 pub(super) fn wechat_service_request(text: &str) -> CoreRequest {


### PR DESCRIPTION
## 概要
- 新增 RespondPlan::WebSearch，将 /查 与显式联网查询意图从普通聊天 / Tool Loop 中独立出来
- WebSearch 流式入口复用现有 /查 搜索流，provider 不支持流式时保留聚合回退
- 补充私聊、群聊 @机器人、群聊未 @ 与 /查 路由测试

## 验证
- cargo fmt --all -- --check
- cargo check -p qq-maid-core
- cargo test -p qq-maid-core --lib respond::tests
- cargo test -p qq-maid-core --lib

说明：远端当前默认基线为 master，未发现 origin/main。