### PR TITLE
[codex] 增强 RSS 最近更新与批量管理

### DIFF
--- a/qq-maid-core/src/config/agent.rs
+++ b/qq-maid-core/src/config/agent.rs
@@ -20,6 +20,7 @@ const DEFAULT_PRIVATE_ENABLED_TOOLS: &[&str] = &[
     "get_weather",
     "get_train_schedule",
     "get_rss_recent_items",
+    "manage_rss_subscriptions",
     "web_search",
     "list_todos",
     "get_todo",
@@ -35,6 +36,7 @@ const DEFAULT_GROUP_ENABLED_TOOLS: &[&str] = &[
     "get_weather",
     "get_train_schedule",
     "get_rss_recent_items",
+    "manage_rss_subscriptions",
     "web_search",
 ];
 
@@ -739,6 +741,7 @@ mod tests {
                 "get_weather",
                 "get_train_schedule",
                 "get_rss_recent_items",
+                "manage_rss_subscriptions",
                 "web_search"
             ]
         );
@@ -998,6 +1001,7 @@ profile = "fast"
                 "get_weather",
                 "get_train_schedule",
                 "get_rss_recent_items",
+                "manage_rss_subscriptions",
                 "web_search"
             ]
         );

--- a/qq-maid-core/src/runtime/group_role.rs
+++ b/qq-maid-core/src/runtime/group_role.rs
@@ -18,5 +18,7 @@ pub fn group_management_allowed(
 }
 
 fn is_group_request(group_id: Option<&str>, scope_key: &str) -> bool {
-    group_id.is_some_and(|value| !value.trim().is_empty()) || scope_key.starts_with("group:")
+    group_id.is_some_and(|value| !value.trim().is_empty())
+        || scope_key.starts_with("group:")
+        || scope_key.contains(":group:")
 }

--- a/qq-maid-core/src/runtime/respond/llm_service/mod.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service/mod.rs
@@ -255,6 +255,7 @@ fn tool_context_from_request(req: &RespondRequest) -> ToolContext {
             .unwrap_or_else(|| Uuid::new_v4().to_string()),
         user_id: req.user_id.clone(),
         scope_id: req.scope_key.clone(),
+        group_member_role: req.group_member_role.clone(),
         tool_call_id: None,
     }
 }

--- a/qq-maid-core/src/runtime/respond/mod.rs
+++ b/qq-maid-core/src/runtime/respond/mod.rs
@@ -229,8 +229,14 @@ impl RustRespondService {
     ) -> Self {
         let translation_service =
             TranslationService::new(provider.clone(), options.translation_model);
-        let tool_runtime =
-            tool_runtime::ToolRuntime::new(&executors, &stores, options.tool_result_max_chars);
+        let tool_runtime = tool_runtime::ToolRuntime::new(
+            &executors,
+            &stores,
+            rss_fetcher.clone(),
+            options.rss_summary_max_chars,
+            options.rss_seen_retention,
+            options.tool_result_max_chars,
+        );
         Self {
             provider,
             query_executor: executors.query_executor,

--- a/qq-maid-core/src/runtime/respond/rss_flow.rs
+++ b/qq-maid-core/src/runtime/respond/rss_flow.rs
@@ -64,84 +64,55 @@ impl RustRespondService {
                     "rss_list",
                 )
             }
+            "rss_recent" => {
+                let limit = match parse_recent_limit(&command.argument) {
+                    Ok(limit) => limit,
+                    Err(reply) => {
+                        return Ok(Some(self.append_pending_response(
+                            session,
+                            user_text,
+                            reply,
+                            "rss_recent",
+                        )?));
+                    }
+                };
+                let subscriptions = self
+                    .rss_store
+                    .list_by_scope(&target.scope_key)
+                    .map_err(rss_error)?;
+                let items = self
+                    .rss_store
+                    .recent_items_by_scope(&target.scope_key, None, limit)
+                    .map_err(rss_error)?;
+                (
+                    structured_command_body(format_rss_recent_reply(&subscriptions, &items)),
+                    "rss_recent",
+                )
+            }
             "rss_add" => {
-                let Some((url, name)) = parse_add_argument(&command.argument) else {
+                let Some(entries) = parse_add_arguments(&command.argument) else {
                     return Ok(Some(self.append_pending_response(
                         session,
                         user_text,
-                        "用法：/rss add RSS地址 [名称]",
+                        "用法：/rss add RSS地址 [名称]；也支持多行：标题换行 RSS地址。",
                         "rss_add",
                     )?));
                 };
-                match self
-                    .rss_fetcher
-                    .fetch(&url, self.rss_summary_max_chars)
-                    .await
-                {
-                    Ok(feed) => {
-                        let title = name.unwrap_or(feed.title);
-                        let created = self
-                            .rss_store
-                            .create_subscription(
-                                &target,
-                                &url,
-                                &title,
-                                &feed.items,
-                                self.rss_seen_retention,
-                            )
-                            .map_err(rss_error)?;
-                        (
-                            structured_command_body(format!(
-                                "已添加 RSS 订阅：{}\n地址：{}\n已将当前 {} 条历史条目标记为已见，首次添加不会推送历史文章。",
-                                created.title,
-                                created.url,
-                                feed.items.len()
-                            )),
-                            "rss_add",
-                        )
-                    }
-                    Err(err) => (
-                        structured_command_body(format!(
-                            "RSS 地址无法访问或无法解析：{}",
-                            feed_error_reply(&err)
-                        )),
-                        "rss_add",
-                    ),
-                }
+                let outcome = self.add_rss_subscriptions(&target, entries).await?;
+                (structured_command_body(outcome), "rss_add")
             }
             "rss_delete" => {
-                let argument = command.argument.trim();
-                if argument.is_empty() {
+                let targets = parse_delete_arguments(&command.argument);
+                if targets.is_empty() {
                     ("用法：/rss delete 编号或订阅ID".into(), "rss_delete")
                 } else {
                     let subscriptions = self
                         .rss_store
                         .list_by_scope(&target.scope_key)
                         .map_err(rss_error)?;
-                    let Some(subscription) = resolve_subscription_target(&subscriptions, argument)
-                    else {
-                        return Ok(Some(self.append_pending_response(
-                            session,
-                            user_text,
-                            "没有找到当前目标下对应的 RSS 订阅。",
-                            "rss_delete",
-                        )?));
-                    };
-                    let deleted = self
-                        .rss_store
-                        .delete_for_scope(&target.scope_key, &subscription.id)
-                        .map_err(rss_error)?;
-                    if deleted {
-                        (
-                            structured_command_body(format!(
-                                "已删除 RSS 订阅：{}",
-                                subscription.title
-                            )),
-                            "rss_delete",
-                        )
-                    } else {
-                        ("没有找到当前目标下对应的 RSS 订阅。".into(), "rss_delete")
-                    }
+                    let reply =
+                        self.delete_rss_subscriptions(&target.scope_key, &subscriptions, &targets)?;
+                    (structured_command_body(reply), "rss_delete")
                 }
             }
             "rss_test" => {
@@ -172,6 +143,7 @@ impl RustRespondService {
                     }
                 }
             }
+            "rss_help" => (structured_command_body(rss_usage()), "rss"),
             _ => (structured_command_body(rss_usage()), "rss"),
         };
 
@@ -182,6 +154,138 @@ impl RustRespondService {
             command_name,
         )?))
     }
+
+    async fn add_rss_subscriptions(
+        &self,
+        target: &RssTarget,
+        entries: Vec<RssAddEntry>,
+    ) -> Result<String, LlmError> {
+        let single = entries.len() == 1;
+        let mut created = Vec::new();
+        let mut failed = Vec::new();
+        for entry in entries {
+            match self
+                .rss_fetcher
+                .fetch(&entry.url, self.rss_summary_max_chars)
+                .await
+            {
+                Ok(feed) => {
+                    let feed_items_len = feed.items.len();
+                    let title = entry.name.unwrap_or(feed.title);
+                    match self.rss_store.create_subscription(
+                        target,
+                        &entry.url,
+                        &title,
+                        &feed.items,
+                        self.rss_seen_retention,
+                    ) {
+                        Ok(subscription) => created.push((subscription, feed_items_len)),
+                        Err(err) => failed.push((entry.url, err.message().to_owned())),
+                    }
+                }
+                Err(err) => failed.push((entry.url, feed_error_reply(&err))),
+            }
+        }
+
+        if single {
+            if let Some((subscription, item_count)) = created.first() {
+                return Ok(format!(
+                    "已添加 RSS 订阅：{}\n地址：{}\n已将当前 {} 条历史条目标记为已见，首次添加不会推送历史文章。",
+                    subscription.title, subscription.url, item_count
+                ));
+            }
+            let message = failed
+                .first()
+                .map(|(_, message)| message.as_str())
+                .unwrap_or("未知错误");
+            return Ok(format!("RSS 地址无法访问或无法解析：{message}"));
+        }
+
+        let mut rows = vec!["RSS 批量添加结果：".to_owned()];
+        if !created.is_empty() {
+            rows.push(format!("已添加 {} 个订阅：", created.len()));
+            for (index, (subscription, item_count)) in created.iter().enumerate() {
+                rows.push(format!(
+                    "{}. {} {}（历史条目 {} 条已标记为已见）",
+                    index + 1,
+                    truncate_chars(&subscription.title, 60),
+                    subscription.url,
+                    item_count
+                ));
+            }
+        }
+        if !failed.is_empty() {
+            rows.push(format!("失败 {} 个：", failed.len()));
+            for (index, (url, message)) in failed.iter().enumerate() {
+                rows.push(format!(
+                    "{}. {}：{}",
+                    index + 1,
+                    truncate_chars(url, 100),
+                    message
+                ));
+            }
+        }
+        Ok(rows.join("\n"))
+    }
+
+    fn delete_rss_subscriptions(
+        &self,
+        scope_key: &str,
+        subscriptions: &[RssSubscription],
+        targets: &[String],
+    ) -> Result<String, LlmError> {
+        let mut resolved = Vec::<&RssSubscription>::new();
+        let mut missing = Vec::<String>::new();
+        for target in targets {
+            if let Some(subscription) = resolve_subscription_target(subscriptions, target) {
+                if !resolved.iter().any(|item| item.id == subscription.id) {
+                    resolved.push(subscription);
+                }
+            } else {
+                missing.push(target.clone());
+            }
+        }
+        if resolved.is_empty() {
+            return Ok("没有找到当前目标下对应的 RSS 订阅。".to_owned());
+        }
+
+        let single = targets.len() == 1 && missing.is_empty();
+        let mut deleted = Vec::new();
+        for subscription in resolved {
+            if self
+                .rss_store
+                .delete_for_scope(scope_key, &subscription.id)
+                .map_err(rss_error)?
+            {
+                deleted.push(subscription.title.clone());
+            }
+        }
+        if single {
+            if let Some(title) = deleted.first() {
+                return Ok(format!("已删除 RSS 订阅：{title}"));
+            }
+            return Ok("没有找到当前目标下对应的 RSS 订阅。".to_owned());
+        }
+
+        let mut rows = vec![format!("已删除 {} 个 RSS 订阅：", deleted.len())];
+        for (index, title) in deleted.iter().enumerate() {
+            rows.push(format!("{}. {}", index + 1, truncate_chars(title, 60)));
+        }
+        if !missing.is_empty() {
+            rows.push(format!(
+                "未找到 {} 个目标：{}",
+                missing.len(),
+                missing.join("、")
+            ));
+        }
+        Ok(rows.join("\n"))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RssAddEntry {
+    url: String,
+    name: Option<String>,
 }
 
 pub(super) fn parse_rss_command(text: &str) -> Option<ParsedCommand> {
@@ -202,14 +306,15 @@ pub(super) fn parse_rss_command(text: &str) -> Option<ParsedCommand> {
     let rest = parts.next().unwrap_or("").trim();
     let action = match first.to_ascii_lowercase().as_str() {
         "list" | "ls" | "列表" | "查看" => "rss_list",
+        "recent" | "updates" | "update" | "最近" | "更新" => "rss_recent",
         "add" | "new" | "create" | "添加" | "新增" | "订阅" => "rss_add",
         "delete" | "del" | "rm" | "remove" | "删除" | "取消订阅" => "rss_delete",
         "test" | "测试" => "rss_test",
-        _ => "rss_list",
+        _ => "rss_help",
     };
     Some(ParsedCommand {
         action: action.to_owned(),
-        argument: if action == "rss_list" && !matches!(first, "list" | "ls" | "列表" | "查看") {
+        argument: if action == "rss_help" {
             argument.to_owned()
         } else {
             rest.to_owned()
@@ -252,14 +357,91 @@ fn rss_target_from_meta(meta: &SessionMeta) -> Option<RssTarget> {
     })
 }
 
-fn parse_add_argument(argument: &str) -> Option<(String, Option<String>)> {
-    let mut parts = argument.splitn(2, char::is_whitespace);
-    let url = parts.next()?.trim();
-    if url.is_empty() {
+fn parse_add_arguments(argument: &str) -> Option<Vec<RssAddEntry>> {
+    let argument = argument.trim();
+    if argument.is_empty() {
         return None;
     }
-    let name = parts.next().and_then(clean_display_optional);
-    Some((url.to_owned(), name))
+    let mut old_style_parts = argument.splitn(2, char::is_whitespace);
+    let first = old_style_parts.next()?.trim();
+    if is_rss_url(first) {
+        return Some(vec![RssAddEntry {
+            url: first.to_owned(),
+            name: old_style_parts.next().and_then(clean_display_optional),
+        }]);
+    }
+
+    let mut entries = Vec::new();
+    let mut pending_name: Option<String> = None;
+    for line in argument.lines() {
+        let line = strip_list_marker(line.trim());
+        if line.is_empty() {
+            continue;
+        }
+        if let Some((name_prefix, url, name_suffix)) = extract_url_from_line(line) {
+            let name = clean_display_optional(name_prefix)
+                .or_else(|| pending_name.take())
+                .or_else(|| clean_display_optional(name_suffix));
+            entries.push(RssAddEntry {
+                url: url.to_owned(),
+                name,
+            });
+            continue;
+        }
+        pending_name = clean_display_optional(line);
+    }
+    if entries.is_empty() {
+        None
+    } else {
+        Some(entries)
+    }
+}
+
+fn parse_delete_arguments(argument: &str) -> Vec<String> {
+    argument
+        .lines()
+        .flat_map(|line| line.split(|ch: char| ch.is_whitespace() || matches!(ch, ',' | '，')))
+        .map(strip_list_marker)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+fn strip_list_marker(value: &str) -> &str {
+    let value = value.trim();
+    let digit_count = value.chars().take_while(|ch| ch.is_ascii_digit()).count();
+    if digit_count == 0 {
+        return value;
+    }
+    let Some(rest) = value.get(digit_count..) else {
+        return value;
+    };
+    let rest = rest.trim_start();
+    let mut chars = rest.chars();
+    match chars.next() {
+        Some('.' | '。' | '、' | ')' | '）' | ':' | '：') => chars.as_str().trim_start(),
+        _ => value,
+    }
+}
+
+fn extract_url_from_line(line: &str) -> Option<(&str, &str, &str)> {
+    let start = line.find("https://").or_else(|| line.find("http://"))?;
+    let before = line[..start].trim();
+    let after_start = &line[start..];
+    let url_len = after_start
+        .find(char::is_whitespace)
+        .unwrap_or(after_start.len());
+    let url = &after_start[..url_len];
+    let after = after_start[url_len..].trim();
+    if is_rss_url(url) {
+        Some((before, url, after))
+    } else {
+        None
+    }
+}
+
+fn is_rss_url(value: &str) -> bool {
+    value.starts_with("http://") || value.starts_with("https://")
 }
 
 fn resolve_subscription_target<'a>(
@@ -307,6 +489,140 @@ fn format_rss_list_reply(subscriptions: &[RssSubscription]) -> String {
     rows.join("\n")
 }
 
+const RSS_RECENT_DEFAULT_LIMIT: usize = 5;
+const RSS_RECENT_MAX_LIMIT: usize = 20;
+const RSS_RECENT_MAX_CHARS: usize = 3600;
+
+fn parse_recent_limit(argument: &str) -> Result<usize, String> {
+    let argument = argument.trim();
+    if argument.is_empty() {
+        return Ok(RSS_RECENT_DEFAULT_LIMIT);
+    }
+    let mut parts = argument.split_whitespace();
+    let Some(raw_limit) = parts.next() else {
+        return Ok(RSS_RECENT_DEFAULT_LIMIT);
+    };
+    if parts.next().is_some() {
+        return Err(rss_recent_limit_usage());
+    }
+    match raw_limit.parse::<usize>() {
+        Ok(limit) if (1..=RSS_RECENT_MAX_LIMIT).contains(&limit) => Ok(limit),
+        _ => Err(rss_recent_limit_usage()),
+    }
+}
+
+fn rss_recent_limit_usage() -> String {
+    format!("用法：/rss recent [数量]；数量需为 1～{RSS_RECENT_MAX_LIMIT}。")
+}
+
+fn format_rss_recent_reply(
+    subscriptions: &[RssSubscription],
+    items: &[crate::runtime::rss::RssRecentItem],
+) -> String {
+    if subscriptions.is_empty() {
+        return "当前会话还没有 RSS 订阅，可使用 /rss add 地址 添加。".to_owned();
+    }
+    if items.is_empty() {
+        let failed_count = failed_subscription_count(subscriptions);
+        let mut reply =
+            "当前会话已有 RSS 订阅，但还没有抓到更新。可以等待后台检查，或使用 /rss test 地址 检查订阅源。"
+                .to_owned();
+        append_recent_failure_hint(&mut reply, failed_count);
+        return reply;
+    }
+
+    let mut rows = vec!["最近 RSS 更新：".to_owned(), String::new()];
+    for (index, item) in items.iter().enumerate() {
+        rows.push(format!(
+            "{}. [{}] {}",
+            index + 1,
+            truncate_chars(&item.subscription_title, 40),
+            truncate_chars(&item.title, 120)
+        ));
+        rows.push(format!(
+            "   {}",
+            item.link
+                .as_deref()
+                .filter(|link| !link.trim().is_empty())
+                .unwrap_or("链接：当前条目未提供")
+        ));
+        rows.push(format!(
+            "   {}：{}",
+            rss_recent_time_label(item),
+            format_rss_time_for_display(rss_recent_time_value(item))
+        ));
+        rows.push(String::new());
+    }
+    let failed_count = failed_subscription_count(subscriptions);
+    if failed_count > 0 {
+        rows.push(format!(
+            "提示：{failed_count} 个订阅源最近检查失败，可能有更新延迟。"
+        ));
+    }
+    truncate_chars(&rows.join("\n"), RSS_RECENT_MAX_CHARS)
+}
+
+fn failed_subscription_count(subscriptions: &[RssSubscription]) -> usize {
+    subscriptions
+        .iter()
+        .filter(|subscription| {
+            subscription
+                .last_error
+                .as_deref()
+                .is_some_and(|error| !error.trim().is_empty())
+        })
+        .count()
+}
+
+fn append_recent_failure_hint(reply: &mut String, failed_count: usize) {
+    if failed_count > 0 {
+        reply.push_str(&format!(
+            "\n提示：{failed_count} 个订阅源最近检查失败，可能有更新延迟。"
+        ));
+    }
+}
+
+fn rss_recent_time_label(item: &crate::runtime::rss::RssRecentItem) -> &'static str {
+    if item
+        .published_at
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        "发布时间"
+    } else if item
+        .updated_at
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        "更新时间"
+    } else if item
+        .pushed_at
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        "推送时间"
+    } else {
+        "抓取时间"
+    }
+}
+
+fn rss_recent_time_value(item: &crate::runtime::rss::RssRecentItem) -> &str {
+    item.published_at
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            item.updated_at
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .or_else(|| {
+            item.pushed_at
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .unwrap_or(&item.last_seen_at)
+}
+
 fn format_rss_check_time(value: Option<&str>) -> String {
     // RSS 检查时间在 SQLite 中保留 RFC3339；这里只做用户可读展示，不改变持久化语义。
     value
@@ -316,7 +632,7 @@ fn format_rss_check_time(value: Option<&str>) -> String {
 }
 
 fn rss_usage() -> String {
-    "用法：/rss；/rss add RSS地址 [名称]；/rss delete 编号；/rss test RSS地址".to_owned()
+    "用法：/rss；/rss list；/rss recent [数量]；/rss add RSS地址 [名称]；/rss delete 编号；/rss test RSS地址".to_owned()
 }
 
 fn feed_error_reply(err: &RssFeedError) -> String {
@@ -408,6 +724,26 @@ mod tests {
             resolve_subscription_target(&subscriptions, "1").map(|item| item.id.as_str()),
             Some("sub-1")
         );
+    }
+
+    #[test]
+    fn rss_command_parses_recent_aliases_without_falling_back_to_list() {
+        for input in ["/rss recent", "/rss 最近", "/rss updates", "/rss 更新"] {
+            let command = parse_rss_command(input).unwrap();
+            assert_eq!(command.action, "rss_recent", "input: {input}");
+            assert_eq!(command.argument, "");
+        }
+
+        let limited = parse_rss_command("/rss recent 10").unwrap();
+        assert_eq!(limited.action, "rss_recent");
+        assert_eq!(limited.argument, "10");
+    }
+
+    #[test]
+    fn rss_unknown_subcommand_returns_usage_instead_of_list() {
+        let command = parse_rss_command("/rss nope").unwrap();
+        assert_eq!(command.action, "rss_help");
+        assert_ne!(command.action, "rss_list");
     }
 
     #[test]

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -414,7 +414,7 @@ async fn private_tool_loop_can_query_recent_rss_items_with_trusted_rendering() {
 }
 
 #[tokio::test]
-async fn group_tool_loop_exposes_query_only_tools_when_enabled() {
+async fn group_tool_loop_exposes_rss_management_but_not_todo_when_enabled() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_group_tool_calling(inspector.clone(), true, true);
     let owner = TodoStore::owner(Some("u1"), "group:g1");
@@ -468,6 +468,7 @@ async fn group_tool_loop_exposes_query_only_tools_when_enabled() {
             "get_rss_recent_items",
             "get_train_schedule",
             "get_weather",
+            "manage_rss_subscriptions",
             "web_search",
         ]
     );
@@ -506,6 +507,7 @@ async fn group_tool_loop_exposes_query_only_tools_when_enabled() {
             "get_weather",
             "get_train_schedule",
             "get_rss_recent_items",
+            "manage_rss_subscriptions",
             "web_search"
         ])
     );

--- a/qq-maid-core/src/runtime/respond/tests/pending.rs
+++ b/qq-maid-core/src/runtime/respond/tests/pending.rs
@@ -612,6 +612,7 @@ async fn stable_group_visible_todo_snapshots_are_isolated_by_actor() {
                 task_id: "stable-group-u2-complete".to_owned(),
                 user_id: Some("u2".to_owned()),
                 scope_id: stable_group_scope().to_owned(),
+                group_member_role: None,
                 tool_call_id: Some("call-u2-complete".to_owned()),
             },
             json!({"numbers": [1], "reference": null}),

--- a/qq-maid-core/src/runtime/respond/tests/rss.rs
+++ b/qq-maid-core/src/runtime/respond/tests/rss.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use super::{super::RespondRequest, support::*};
+use crate::runtime::rss::{RssFeedItem, RssTarget, RssTargetType};
 
 const FEED: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0">
@@ -47,6 +48,19 @@ fn private_message(text: &str, user_id: &str) -> RespondRequest {
         platform: "qq_official".to_owned(),
         event_type: "FakeEvent".to_owned(),
         ..RespondRequest::default()
+    }
+}
+
+fn rss_item(key: &str, title: &str, published_at: &str) -> RssFeedItem {
+    RssFeedItem {
+        item_key: key.to_owned(),
+        revision_hash: format!("rev:{key}"),
+        title: title.to_owned(),
+        link: Some(format!("https://example.test/{key}")),
+        published_at: Some(published_at.to_owned()),
+        updated_at: None,
+        summary: Some(format!("{title} 摘要")),
+        source_order: 0,
     }
 }
 
@@ -186,6 +200,188 @@ async fn rss_list_and_delete_use_current_scope_only() {
 }
 
 #[tokio::test]
+async fn rss_recent_returns_items_instead_of_subscription_list() {
+    let (service, _) = test_service_with_base();
+    let target = RssTarget {
+        target_type: RssTargetType::Group,
+        target_id: "g1".to_owned(),
+        scope_key: "group:g1".to_owned(),
+    };
+    let sub = service
+        .rss_store
+        .create_subscription(
+            &target,
+            "https://example.test/feed.xml",
+            "Recent Commits",
+            &[],
+            50,
+        )
+        .unwrap();
+    service
+        .rss_store
+        .enqueue_items(
+            &sub.id,
+            &[rss_item(
+                "commit-1",
+                "修复 RSS recent",
+                "2026-07-08T05:00:00+00:00",
+            )],
+            50,
+        )
+        .unwrap();
+
+    let response = service.respond(message("/rss recent")).await.unwrap();
+    let text = response.text.unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("rss_recent"));
+    assert!(text.contains("最近 RSS 更新"));
+    assert!(text.contains("[Recent Commits] 修复 RSS recent"));
+    assert!(text.contains("https://example.test/commit-1"));
+    assert!(text.contains("发布时间：2026-07-08"));
+    assert!(!text.contains("RSS 订阅："));
+}
+
+#[tokio::test]
+async fn rss_recent_chinese_alias_and_scope_are_isolated() {
+    let (service, _) = test_service_with_base();
+    let group_sub = service
+        .rss_store
+        .create_subscription(
+            &RssTarget {
+                target_type: RssTargetType::Group,
+                target_id: "g1".to_owned(),
+                scope_key: "group:g1".to_owned(),
+            },
+            "https://example.test/group.xml",
+            "群订阅",
+            &[],
+            50,
+        )
+        .unwrap();
+    let other_sub = service
+        .rss_store
+        .create_subscription(
+            &RssTarget {
+                target_type: RssTargetType::Group,
+                target_id: "g2".to_owned(),
+                scope_key: "group:g2".to_owned(),
+            },
+            "https://example.test/other.xml",
+            "其他群订阅",
+            &[],
+            50,
+        )
+        .unwrap();
+    service
+        .rss_store
+        .enqueue_items(
+            &group_sub.id,
+            &[rss_item("group", "当前群更新", "2026-07-08T05:00:00+00:00")],
+            50,
+        )
+        .unwrap();
+    service
+        .rss_store
+        .enqueue_items(
+            &other_sub.id,
+            &[rss_item("other", "其他群更新", "2026-07-08T06:00:00+00:00")],
+            50,
+        )
+        .unwrap();
+
+    let response = service.respond(message("/rss 最近 10")).await.unwrap();
+    let text = response.text.unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("rss_recent"));
+    assert!(text.contains("当前群更新"));
+    assert!(!text.contains("其他群更新"));
+}
+
+#[tokio::test]
+async fn rss_recent_distinguishes_no_subscription_and_no_items() {
+    let (service, _) = test_service_with_base();
+
+    let empty = service.respond(message("/rss recent")).await.unwrap();
+    assert!(
+        empty
+            .text
+            .as_deref()
+            .unwrap()
+            .contains("当前会话还没有 RSS 订阅")
+    );
+
+    service
+        .rss_store
+        .create_subscription(
+            &RssTarget {
+                target_type: RssTargetType::Group,
+                target_id: "g1".to_owned(),
+                scope_key: "group:g1".to_owned(),
+            },
+            "https://example.test/feed.xml",
+            "空订阅",
+            &[],
+            50,
+        )
+        .unwrap();
+    let no_items = service.respond(message("/rss recent")).await.unwrap();
+    assert!(
+        no_items
+            .text
+            .as_deref()
+            .unwrap()
+            .contains("已有 RSS 订阅，但还没有抓到更新")
+    );
+}
+
+#[tokio::test]
+async fn rss_recent_mentions_failed_feeds_without_blocking_items() {
+    let (service, _) = test_service_with_base();
+    let target = RssTarget {
+        target_type: RssTargetType::Group,
+        target_id: "g1".to_owned(),
+        scope_key: "group:g1".to_owned(),
+    };
+    let ok_sub = service
+        .rss_store
+        .create_subscription(&target, "https://example.test/ok.xml", "正常订阅", &[], 50)
+        .unwrap();
+    let failed_sub = service
+        .rss_store
+        .create_subscription(
+            &target,
+            "https://example.test/timeout.xml",
+            "失败订阅",
+            &[],
+            50,
+        )
+        .unwrap();
+    service
+        .rss_store
+        .record_check_failure(&failed_sub.id, "timeout")
+        .unwrap();
+    service
+        .rss_store
+        .enqueue_items(
+            &ok_sub.id,
+            &[rss_item(
+                "ok",
+                "仍然展示的更新",
+                "2026-07-08T05:00:00+00:00",
+            )],
+            50,
+        )
+        .unwrap();
+
+    let response = service.respond(message("/rss recent")).await.unwrap();
+    let text = response.text.unwrap();
+
+    assert!(text.contains("仍然展示的更新"));
+    assert!(text.contains("1 个订阅源最近检查失败"));
+    assert!(!text.contains("失败订阅 [启用]"));
+}
+
+#[tokio::test]
 async fn rss_add_ignores_placeholder_null_custom_name() {
     let (service, _) = test_service_with_base();
     let url = spawn_feed_server(FEED);
@@ -204,4 +400,36 @@ async fn rss_add_ignores_placeholder_null_custom_name() {
     assert!(markdown.contains("已添加 RSS 订阅：Fixture Feed"));
     let subscriptions = service.rss_store.list_by_scope("group:g1").unwrap();
     assert_eq!(subscriptions[0].title, "Fixture Feed");
+}
+
+#[tokio::test]
+async fn rss_add_accepts_numbered_multiline_title_url_pairs() {
+    let (service, _) = test_service_with_base();
+    let releases_url = spawn_feed_server(FEED);
+    let commits_url = spawn_feed_server(FEED);
+
+    let response = service
+        .respond(message(&format!(
+            "/RSS add\n1. Release notes from qq-maid-bot\n{releases_url}\n2. Recent Commits to qq-maid-bot:master\n{commits_url}"
+        )))
+        .await
+        .unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("rss_add"));
+    let text = response.text.unwrap();
+    assert!(text.contains("RSS 批量添加结果"));
+    assert!(text.contains("Release notes from qq-maid-bot"));
+    assert!(text.contains("Recent Commits to qq-maid-bot:master"));
+    let subscriptions = service.rss_store.list_by_scope("group:g1").unwrap();
+    assert_eq!(subscriptions.len(), 2);
+    assert!(
+        subscriptions
+            .iter()
+            .any(|subscription| subscription.title == "Release notes from qq-maid-bot")
+    );
+    assert!(
+        subscriptions
+            .iter()
+            .any(|subscription| subscription.title == "Recent Commits to qq-maid-bot:master")
+    );
 }

--- a/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
@@ -747,6 +747,7 @@ fn clarification_tool_context(session: &SessionRecord, owner: &TodoOwner) -> Too
         task_id: format!("todo-clarify:{}", Uuid::new_v4()),
         user_id: owner.user_id.clone(),
         scope_id: owner.scope_key.clone(),
+        group_member_role: None,
         tool_call_id: Some(format!("clarify-{}", session.session_id)),
     }
 }

--- a/qq-maid-core/src/runtime/respond/tool_presenters.rs
+++ b/qq-maid-core/src/runtime/respond/tool_presenters.rs
@@ -24,6 +24,7 @@ use super::{
 };
 
 const RSS_TOOL_NAME: &str = "get_rss_recent_items";
+const RSS_MANAGE_TOOL_NAME: &str = "manage_rss_subscriptions";
 const TRAIN_TOOL_NAME: &str = "get_train_schedule";
 const WEATHER_TOOL_NAME: &str = "get_weather";
 const WEB_SEARCH_TOOL_NAME: &str = "web_search";
@@ -33,6 +34,9 @@ const WEATHER_FACT_MAX_CHARS: usize = 900;
 pub(super) fn tool_outcome_from_rss_result(
     result: &ToolExecutionResult,
 ) -> Option<ToolExecutionOutcome> {
+    if result.name == RSS_MANAGE_TOOL_NAME {
+        return Some(rss_manage_outcome(result));
+    }
     if result.name != RSS_TOOL_NAME {
         return None;
     }
@@ -60,6 +64,33 @@ pub(super) fn tool_outcome_from_rss_result(
         error_code,
         command: Some("rss".to_owned()),
     })
+}
+
+fn rss_manage_outcome(result: &ToolExecutionResult) -> ToolExecutionOutcome {
+    let status = ToolOutcomeStatus::from_tool_result(result);
+    let error_code = structured_error_code(&result.output);
+    let block = match status {
+        ToolOutcomeStatus::Succeeded => {
+            ResponseBlock::MutationReceipt(rss_manage_body(&result.output))
+        }
+        ToolOutcomeStatus::Skipped => ResponseBlock::Warning(rss_skip_body(&result.output)),
+        ToolOutcomeStatus::RequiresClarification => {
+            ResponseBlock::Clarification(CommandBody::plain("请说明要新增或删除哪些 RSS 订阅。"))
+        }
+        ToolOutcomeStatus::PendingConfirmation | ToolOutcomeStatus::Failed => {
+            ResponseBlock::Error(rss_manage_error_body(&result.output))
+        }
+    };
+    ToolExecutionOutcome {
+        tool_name: result.name.clone(),
+        domain: "rss".to_owned(),
+        status,
+        effect: rss_manage_effect(&result.output),
+        presentation: OutcomePresentation::Trusted,
+        blocks: vec![block],
+        error_code,
+        command: Some("rss".to_owned()),
+    }
 }
 
 pub(super) fn tool_outcome_from_train_result(
@@ -240,12 +271,137 @@ fn rss_item_time_line(entry: &Value) -> Option<String> {
     (!parts.is_empty()).then(|| parts.join("；"))
 }
 
+fn rss_manage_body(output: &Value) -> CommandBody {
+    let operation = string_field(output, "operation").unwrap_or_else(|| "manage".to_owned());
+    let title = match operation.as_str() {
+        "add" => "RSS 新增结果",
+        "delete" => "RSS 删除结果",
+        _ => "RSS 管理结果",
+    };
+    let mut lines = vec![title.to_owned(), String::new()];
+    let mut markdown = vec![format!("# {title}"), String::new()];
+
+    match operation.as_str() {
+        "add" => {
+            append_rss_manage_items(
+                &mut lines,
+                &mut markdown,
+                output.get("created").and_then(Value::as_array),
+                "已添加",
+            );
+            append_rss_manage_failures(
+                &mut lines,
+                &mut markdown,
+                output.get("failed").and_then(Value::as_array),
+                "失败",
+            );
+        }
+        "delete" => {
+            append_rss_manage_items(
+                &mut lines,
+                &mut markdown,
+                output.get("deleted").and_then(Value::as_array),
+                "已删除",
+            );
+            if let Some(missing) = output.get("missing").and_then(Value::as_array)
+                && !missing.is_empty()
+            {
+                lines.push(format!("未找到 {} 个目标：", missing.len()));
+                markdown.push(format!("## 未找到 {} 个目标", missing.len()));
+                for (index, item) in missing.iter().enumerate() {
+                    if let Some(value) = item.as_str() {
+                        lines.push(format!("{}. {}", index + 1, value));
+                        markdown.push(format!("{}. `{}`", index + 1, value));
+                    }
+                }
+            }
+        }
+        _ => {
+            if let Some(message) = string_field(output, "message") {
+                lines.push(message.clone());
+                markdown.push(message);
+            }
+        }
+    }
+    CommandBody::dual(lines.join("\n"), markdown.join("\n"))
+}
+
+fn rss_manage_error_body(output: &Value) -> CommandBody {
+    if rss_manage_has_business_details(output) {
+        return rss_manage_body(output);
+    }
+    rss_error_body(output)
+}
+
+fn rss_manage_has_business_details(output: &Value) -> bool {
+    string_field(output, "operation")
+        .map(|operation| matches!(operation.as_str(), "add" | "delete"))
+        .unwrap_or(false)
+        || output
+            .get("failed")
+            .and_then(Value::as_array)
+            .map(|items| !items.is_empty())
+            .unwrap_or(false)
+        || output
+            .get("missing")
+            .and_then(Value::as_array)
+            .map(|items| !items.is_empty())
+            .unwrap_or(false)
+}
+
+fn append_rss_manage_items(
+    lines: &mut Vec<String>,
+    markdown: &mut Vec<String>,
+    items: Option<&Vec<Value>>,
+    label: &str,
+) {
+    let Some(items) = items.filter(|items| !items.is_empty()) else {
+        return;
+    };
+    lines.push(format!("{label} {} 个订阅：", items.len()));
+    markdown.push(format!("## {label} {} 个订阅", items.len()));
+    for (index, item) in items.iter().enumerate() {
+        let title = string_field(item, "title").unwrap_or_else(|| "未命名订阅".to_owned());
+        let url = string_field(item, "url").unwrap_or_default();
+        lines.push(format!("{}. {} {}", index + 1, title, url));
+        markdown.push(format!("{}. **{}** {}", index + 1, title, url));
+    }
+}
+
+fn append_rss_manage_failures(
+    lines: &mut Vec<String>,
+    markdown: &mut Vec<String>,
+    items: Option<&Vec<Value>>,
+    label: &str,
+) {
+    let Some(items) = items.filter(|items| !items.is_empty()) else {
+        return;
+    };
+    lines.push(format!("{label} {} 个：", items.len()));
+    markdown.push(format!("## {label} {} 个", items.len()));
+    for (index, item) in items.iter().enumerate() {
+        let url = string_field(item, "url").unwrap_or_else(|| "未知地址".to_owned());
+        let error = string_field(item, "error").unwrap_or_else(|| "未知错误".to_owned());
+        lines.push(format!("{}. {}：{}", index + 1, url, error));
+        markdown.push(format!("{}. `{}`：{}", index + 1, url, error));
+    }
+}
+
+fn rss_manage_effect(output: &Value) -> ToolEffect {
+    match string_field(output, "operation").as_deref() {
+        Some("add") => ToolEffect::Created,
+        Some("delete") => ToolEffect::Deleted,
+        _ => ToolEffect::Updated,
+    }
+}
+
 fn rss_error_body(output: &Value) -> CommandBody {
     let code = structured_error_code(output);
     let text = match code.as_deref() {
         Some("bad_tool_arguments") => {
-            "【RSS】\n\nRSS 查询参数不完整，请说明订阅名、关键词，或把条数限制在 1 到 10。"
+            "【RSS】\n\nRSS 参数不完整，请说明订阅名、关键词，或把条数限制在 1 到 20。"
         }
+        Some("permission_denied") => "【RSS】\n\n群聊 RSS 管理只允许群主或管理员执行。",
         _ => "【RSS】\n\nRSS 本地记录暂时无法读取，请稍后再试。",
     };
     CommandBody::plain(text)
@@ -592,4 +748,63 @@ fn structured_error_code(output: &Value) -> Option<String> {
                 .and_then(Value::as_str)
         })
         .map(str::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::provider::ToolExecutionResult;
+
+    use super::*;
+
+    fn rss_manage_result(output: Value) -> ToolExecutionResult {
+        ToolExecutionResult {
+            name: RSS_MANAGE_TOOL_NAME.to_owned(),
+            output,
+            succeeded: true,
+        }
+    }
+
+    #[test]
+    fn rss_manage_failed_add_renders_business_failures() {
+        let outcome = rss_manage_outcome(&rss_manage_result(json!({
+            "ok": false,
+            "operation": "add",
+            "created": [],
+            "failed": [
+                {"url": "https://example.test/feed.xml", "error": "rss subscription already exists"}
+            ],
+            "message": "RSS 批量新增完成：成功 0 个，失败 1 个。"
+        })));
+
+        assert_eq!(outcome.status, ToolOutcomeStatus::Failed);
+        let ResponseBlock::Error(body) = &outcome.blocks[0] else {
+            panic!("expected RSS manage error block");
+        };
+        assert!(body.text.contains("RSS 新增结果"));
+        assert!(body.text.contains("https://example.test/feed.xml"));
+        assert!(body.text.contains("rss subscription already exists"));
+        assert!(!body.text.contains("RSS 本地记录暂时无法读取"));
+    }
+
+    #[test]
+    fn rss_manage_failed_delete_renders_missing_targets() {
+        let outcome = rss_manage_outcome(&rss_manage_result(json!({
+            "ok": false,
+            "operation": "delete",
+            "deleted": [],
+            "missing": ["1", "missing-id"],
+            "message": "RSS 批量删除完成：成功 0 个，未找到 2 个。"
+        })));
+
+        assert_eq!(outcome.status, ToolOutcomeStatus::Failed);
+        let ResponseBlock::Error(body) = &outcome.blocks[0] else {
+            panic!("expected RSS manage error block");
+        };
+        assert!(body.text.contains("RSS 删除结果"));
+        assert!(body.text.contains("未找到 2 个目标"));
+        assert!(body.text.contains("missing-id"));
+        assert!(!body.text.contains("RSS 本地记录暂时无法读取"));
+    }
 }

--- a/qq-maid-core/src/runtime/respond/tool_runtime.rs
+++ b/qq-maid-core/src/runtime/respond/tool_runtime.rs
@@ -8,10 +8,11 @@ use std::sync::Arc;
 use crate::{
     config::ResolvedAgentPolicy,
     error::LlmError,
+    runtime::rss::RssFetcher,
     runtime::tools::{
         CancelTodoTool, CompleteTodoTool, CreateTodoTool, DeleteTodoTool, EditTodoTool,
-        GetTodoTool, ListTodoTool, MergeTodoTool, RestoreTodoTool, RssRecentItemsTool,
-        SelectionScope, TrainScheduleTool, WeatherTool, WebSearchTool,
+        GetTodoTool, ListTodoTool, MergeTodoTool, RestoreTodoTool, RssManageSubscriptionsTool,
+        RssRecentItemsTool, SelectionScope, TrainScheduleTool, WeatherTool, WebSearchTool,
     },
     runtime::{session::SessionStore, todo::TodoStore},
     storage::notification::NotificationOutboxStore,
@@ -32,6 +33,9 @@ impl ToolRuntime {
     pub(super) fn new(
         executors: &RespondExecutors,
         stores: &RespondStores,
+        rss_fetcher: RssFetcher,
+        rss_summary_max_chars: usize,
+        rss_seen_retention: usize,
         tool_result_max_chars: usize,
     ) -> Self {
         let mut registry =
@@ -42,6 +46,12 @@ impl ToolRuntime {
                 as qq_maid_llm::tool::DynTool,
             Arc::new(TrainScheduleTool::new(executors.train_executor.clone())),
             Arc::new(RssRecentItemsTool::new(stores.rss_store.clone())),
+            Arc::new(RssManageSubscriptionsTool::new(
+                stores.rss_store.clone(),
+                rss_fetcher,
+                rss_summary_max_chars,
+                rss_seen_retention,
+            )),
             Arc::new(WebSearchTool::new(executors.query_executor.clone())),
             Arc::new(ListTodoTool::new(
                 stores.todo_store.clone(),

--- a/qq-maid-core/src/runtime/tools/mod.rs
+++ b/qq-maid-core/src/runtime/tools/mod.rs
@@ -15,7 +15,7 @@ pub use radar::{
     RadarExecutor, RadarIssueTarget, RadarSnapshot, RadarSourceFailure, RadarSourceKind,
     RadarTarget, build_radar_executor, radar_feedback_url, radar_site_url,
 };
-pub use rss::RssRecentItemsTool;
+pub use rss::{RssManageSubscriptionsTool, RssRecentItemsTool};
 pub(crate) use search::{WEB_SEARCH_QUERY_MAX_LENGTH, WEB_SEARCH_TOOL_NAME};
 pub use search::{WebSearchTool, WebSearchToolRequest};
 pub(crate) use todo::SelectionScope;

--- a/qq-maid-core/src/runtime/tools/rss.rs
+++ b/qq-maid-core/src/runtime/tools/rss.rs
@@ -1,6 +1,6 @@
-//! RSS 最近条目 Tool。
+//! RSS Tool。
 //!
-//! 该 Tool 只读取当前会话 scope 下已入库的 RSS 状态，不新增订阅、不触发远端刷新。
+//! 最近条目查询只读取当前会话 scope 下已入库的 RSS 状态，不触发远端刷新。
 //! “上次某订阅发布了什么”这类问题应基于本地轮询留下的可信状态回答。
 
 use async_trait::async_trait;
@@ -10,13 +10,26 @@ use qq_maid_llm::tool::{Tool, ToolContext, ToolMetadata, ToolOutput};
 
 use crate::{
     error::LlmError,
-    storage::rss::{RssRecentItem, RssStore},
+    runtime::{
+        group_role::group_management_allowed,
+        rss::{RssFetcher, feed::RssFeedError},
+    },
+    storage::rss::{RssRecentItem, RssStore, RssSubscription, RssTarget, RssTargetType},
 };
 
 const RSS_TOOL_NAME: &str = "get_rss_recent_items";
+const RSS_MANAGE_TOOL_NAME: &str = "manage_rss_subscriptions";
 const RSS_TOOL_QUERY_MAX_CHARS: usize = 80;
 const RSS_TOOL_DEFAULT_LIMIT: usize = 3;
-const RSS_TOOL_MAX_LIMIT: usize = 10;
+const RSS_TOOL_MAX_LIMIT: usize = 20;
+const RSS_TOOL_MAX_BATCH_ITEMS: usize = 10;
+const RSS_TOOL_NAME_MAX_CHARS: usize = 120;
+const RSS_TOOL_URL_MAX_CHARS: usize = 500;
+const RSS_MANAGE_OUTPUT_TITLE_MAX_CHARS: usize = 80;
+const RSS_MANAGE_OUTPUT_URL_MAX_CHARS: usize = 180;
+const RSS_MANAGE_OUTPUT_ERROR_MAX_CHARS: usize = 180;
+const RSS_MANAGE_OUTPUT_TARGET_MAX_CHARS: usize = 120;
+const RSS_MANAGE_OUTPUT_SCOPE_MAX_CHARS: usize = 120;
 
 /// 模型可调用的 RSS 最近条目查询 Tool。
 #[derive(Clone)]
@@ -35,7 +48,7 @@ impl Tool for RssRecentItemsTool {
     fn metadata(&self) -> ToolMetadata {
         ToolMetadata {
             name: RSS_TOOL_NAME.to_owned(),
-            description: "查询当前会话已订阅 RSS / Atom 的最近条目。用于回答某个订阅或关键词上次发布了什么、最近 RSS 更新有哪些；只读取本地已轮询入库状态，不新增订阅、不刷新远端。".to_owned(),
+            description: "查询当前会话已订阅 RSS / Atom 的最近条目。用于回答某个订阅或关键词上次发布了什么、最近 RSS 更新有哪些，也用于先读取本地条目的标题、摘要、链接和时间后总结最近更新；只读取本地已轮询入库状态，不新增订阅、不刷新远端。".to_owned(),
             parameters: json!({
                 "type": "object",
                 "properties": {
@@ -45,7 +58,7 @@ impl Tool for RssRecentItemsTool {
                     },
                     "limit": {
                         "type": ["integer", "null"],
-                        "description": "返回条数，1 到 10；询问“上次/最新一条”时传 1，不确定时传 null",
+                        "description": "返回条数，1 到 20；询问“上次/最新一条”时传 1，需要总结最近更新时可传 10 到 20，不确定时传 null",
                         "minimum": 1,
                         "maximum": RSS_TOOL_MAX_LIMIT
                     }
@@ -78,7 +91,215 @@ impl Tool for RssRecentItemsTool {
             "query": query,
             "limit": limit,
             "items": items.iter().map(recent_item_json).collect::<Vec<_>>(),
+            "summary_guidance": "如用户要求总结 RSS 最近更新，请只基于 items 中的 title/summary/link/published_at/updated_at 归纳，不要编造未返回的更新。",
         })))
+    }
+}
+
+/// 模型可调用的 RSS 订阅管理 Tool。
+#[derive(Clone)]
+pub struct RssManageSubscriptionsTool {
+    store: RssStore,
+    fetcher: RssFetcher,
+    summary_max_chars: usize,
+    seen_retention: usize,
+}
+
+impl RssManageSubscriptionsTool {
+    pub fn new(
+        store: RssStore,
+        fetcher: RssFetcher,
+        summary_max_chars: usize,
+        seen_retention: usize,
+    ) -> Self {
+        Self {
+            store,
+            fetcher,
+            summary_max_chars,
+            seen_retention,
+        }
+    }
+
+    async fn execute_add(
+        &self,
+        context: &ToolContext,
+        arguments: &Value,
+    ) -> Result<ToolOutput, LlmError> {
+        let entries = parse_tool_add_entries(arguments)?;
+        let target = target_from_context(context);
+        let mut created = Vec::new();
+        let mut failed = Vec::new();
+        let mut details_truncated = false;
+        for entry in entries {
+            match self.fetcher.fetch(&entry.url, self.summary_max_chars).await {
+                Ok(feed) => {
+                    let item_count = feed.items.len();
+                    let title = entry.title.unwrap_or(feed.title);
+                    match self.store.create_subscription(
+                        &target,
+                        &entry.url,
+                        &title,
+                        &feed.items,
+                        self.seen_retention,
+                    ) {
+                        Ok(subscription) => created.push(compact_manage_subscription_json(
+                            &subscription,
+                            Some(item_count),
+                            &mut details_truncated,
+                        )),
+                        Err(err) => failed.push(compact_manage_failure_json(
+                            &entry.url,
+                            err.message(),
+                            &mut details_truncated,
+                        )),
+                    }
+                }
+                Err(err) => failed.push(compact_manage_failure_json(
+                    &entry.url,
+                    &feed_error_reply(&err),
+                    &mut details_truncated,
+                )),
+            }
+        }
+        Ok(ToolOutput::json(json!({
+            "ok": !created.is_empty(),
+            "operation": "add",
+            "scope_id": compact_manage_string(&context.scope_id, RSS_MANAGE_OUTPUT_SCOPE_MAX_CHARS, &mut details_truncated),
+            "created": created,
+            "failed": failed,
+            "details_truncated": details_truncated,
+            "message": format_manage_message("add", created.len(), failed.len()),
+        })))
+    }
+
+    async fn execute_delete(
+        &self,
+        context: &ToolContext,
+        arguments: &Value,
+    ) -> Result<ToolOutput, LlmError> {
+        let targets = parse_tool_delete_targets(arguments)?;
+        let subscriptions = self
+            .store
+            .list_by_scope(&context.scope_id)
+            .map_err(rss_store_error)?;
+        let mut resolved = Vec::<&RssSubscription>::new();
+        let mut missing = Vec::<String>::new();
+        let mut details_truncated = false;
+        for target in &targets {
+            if let Some(subscription) = resolve_subscription_target(&subscriptions, target) {
+                if !resolved.iter().any(|item| item.id == subscription.id) {
+                    resolved.push(subscription);
+                }
+            } else {
+                missing.push(compact_manage_string(
+                    target,
+                    RSS_MANAGE_OUTPUT_TARGET_MAX_CHARS,
+                    &mut details_truncated,
+                ));
+            }
+        }
+
+        let mut deleted = Vec::new();
+        for subscription in resolved {
+            if self
+                .store
+                .delete_for_scope(&context.scope_id, &subscription.id)
+                .map_err(rss_store_error)?
+            {
+                deleted.push(compact_manage_subscription_json(
+                    subscription,
+                    None,
+                    &mut details_truncated,
+                ));
+            }
+        }
+        Ok(ToolOutput::json(json!({
+            "ok": !deleted.is_empty(),
+            "operation": "delete",
+            "scope_id": compact_manage_string(&context.scope_id, RSS_MANAGE_OUTPUT_SCOPE_MAX_CHARS, &mut details_truncated),
+            "deleted": deleted,
+            "missing": missing,
+            "details_truncated": details_truncated,
+            "message": format_manage_message("delete", deleted.len(), missing.len()),
+        })))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RssToolAddEntry {
+    url: String,
+    title: Option<String>,
+}
+
+#[async_trait]
+impl Tool for RssManageSubscriptionsTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            name: RSS_MANAGE_TOOL_NAME.to_owned(),
+            description: "管理当前会话 scope 下的 RSS / Atom 订阅，支持批量新增和批量删除。新增会真实访问并解析 URL，成功后写入订阅表并把当前历史条目标记为已见；删除只会删除当前 scope 内匹配的订阅。群聊中只有群主或管理员允许执行。用户只是询问最近更新或要求总结时，不要调用本工具，应调用 get_rss_recent_items。".to_owned(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "operation": {
+                        "type": "string",
+                        "enum": ["add", "delete"],
+                        "description": "要执行的管理动作。"
+                    },
+                    "feeds": {
+                        "type": ["array", "null"],
+                        "description": "新增订阅列表；operation=add 时使用。每项 url 必填，title 可为 null。",
+                        "minItems": 1,
+                        "maxItems": RSS_TOOL_MAX_BATCH_ITEMS,
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "url": {"type": "string"},
+                                "title": {"type": ["string", "null"]}
+                            },
+                            "required": ["url", "title"],
+                            "additionalProperties": false
+                        }
+                    },
+                    "targets": {
+                        "type": ["array", "null"],
+                        "description": "删除目标列表；operation=delete 时使用。可传 /rss list 中显示的编号、订阅 ID 或 ID 前缀。",
+                        "minItems": 1,
+                        "maxItems": RSS_TOOL_MAX_BATCH_ITEMS,
+                        "items": {"type": "string"}
+                    },
+                    "raw_text": {
+                        "type": ["string", "null"],
+                        "description": "兼容用户粘贴的多行 RSS 列表，例如“1. 标题\\nhttps://example.com/feed.xml”。feeds/targets 已结构化时传 null。"
+                    }
+                },
+                "required": ["operation", "feeds", "targets", "raw_text"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    async fn execute(
+        &self,
+        context: ToolContext,
+        arguments: Value,
+    ) -> Result<ToolOutput, LlmError> {
+        if !group_management_allowed(
+            None,
+            &context.scope_id,
+            context.group_member_role.as_deref(),
+        ) {
+            return Ok(ToolOutput::json(json!({
+                "ok": false,
+                "error": {"code": "permission_denied", "message": "群聊 RSS 管理只允许群主或管理员执行。"},
+            })));
+        }
+
+        let operation = required_string(arguments.get("operation"), "operation")?;
+        match operation.as_str() {
+            "add" => self.execute_add(&context, &arguments).await,
+            "delete" => self.execute_delete(&context, &arguments).await,
+            _ => reject_bad_arguments("operation must be add or delete"),
+        }
     }
 }
 
@@ -112,15 +333,288 @@ fn parse_limit(value: Option<&Value>) -> Result<usize, LlmError> {
     match value {
         Value::Number(n) if !n.is_f64() => match n.as_i64() {
             Some(i) if (1..=RSS_TOOL_MAX_LIMIT as i64).contains(&i) => Ok(i as usize),
-            _ => reject_bad_arguments("limit must be an integer between 1 and 10"),
+            _ => reject_bad_arguments("limit must be an integer between 1 and 20"),
         },
         _ => reject_bad_arguments("limit must be an integer or null"),
     }
 }
 
+fn parse_tool_add_entries(arguments: &Value) -> Result<Vec<RssToolAddEntry>, LlmError> {
+    let mut entries = Vec::new();
+    if let Some(feeds) = arguments.get("feeds").and_then(Value::as_array) {
+        if feeds.len() > RSS_TOOL_MAX_BATCH_ITEMS {
+            return reject_bad_arguments("feeds is too long");
+        }
+        for feed in feeds {
+            let url = required_string(feed.get("url"), "url")?;
+            validate_url(&url)?;
+            let title = optional_string(feed.get("title"), "title", RSS_TOOL_NAME_MAX_CHARS)?;
+            entries.push(RssToolAddEntry { url, title });
+        }
+    }
+    if entries.is_empty()
+        && let Some(raw_text) = optional_string(arguments.get("raw_text"), "raw_text", 4000)?
+    {
+        entries = parse_raw_add_entries(&raw_text);
+    }
+    if entries.is_empty() {
+        return reject_bad_arguments("feeds or raw_text must contain at least one RSS URL");
+    }
+    if entries.len() > RSS_TOOL_MAX_BATCH_ITEMS {
+        return reject_bad_arguments("too many RSS feeds");
+    }
+    Ok(entries)
+}
+
+fn parse_tool_delete_targets(arguments: &Value) -> Result<Vec<String>, LlmError> {
+    let mut targets = Vec::new();
+    if let Some(values) = arguments.get("targets").and_then(Value::as_array) {
+        if values.len() > RSS_TOOL_MAX_BATCH_ITEMS {
+            return reject_bad_arguments("targets is too long");
+        }
+        for value in values {
+            targets.push(required_string(Some(value), "target")?);
+        }
+    }
+    if targets.is_empty()
+        && let Some(raw_text) = optional_string(arguments.get("raw_text"), "raw_text", 4000)?
+    {
+        targets = raw_text
+            .lines()
+            .flat_map(|line| line.split(|ch: char| ch.is_whitespace() || matches!(ch, ',' | '，')))
+            .map(strip_list_marker)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+            .collect();
+    }
+    if targets.is_empty() {
+        return reject_bad_arguments("targets or raw_text must contain at least one delete target");
+    }
+    if targets.len() > RSS_TOOL_MAX_BATCH_ITEMS {
+        return reject_bad_arguments("too many delete targets");
+    }
+    Ok(targets)
+}
+
+fn parse_raw_add_entries(raw_text: &str) -> Vec<RssToolAddEntry> {
+    let mut entries = Vec::new();
+    let mut pending_title: Option<String> = None;
+    for line in raw_text.lines() {
+        let line = strip_list_marker(line.trim());
+        if line.is_empty() {
+            continue;
+        }
+        if let Some((title_prefix, url, title_suffix)) = extract_url_from_line(line) {
+            let title = clean_optional(title_prefix, RSS_TOOL_NAME_MAX_CHARS)
+                .or_else(|| pending_title.take())
+                .or_else(|| clean_optional(title_suffix, RSS_TOOL_NAME_MAX_CHARS));
+            entries.push(RssToolAddEntry {
+                url: url.to_owned(),
+                title,
+            });
+            continue;
+        }
+        pending_title = clean_optional(line, RSS_TOOL_NAME_MAX_CHARS);
+    }
+    entries
+}
+
+fn required_string(value: Option<&Value>, field: &str) -> Result<String, LlmError> {
+    optional_string(value, field, RSS_TOOL_URL_MAX_CHARS)?
+        .ok_or_else(|| LlmError::new("bad_tool_arguments", format!("{field} is required"), "tool"))
+}
+
+fn optional_string(
+    value: Option<&Value>,
+    field: &str,
+    max_chars: usize,
+) -> Result<Option<String>, LlmError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let Some(text) = value.as_str() else {
+        return reject_bad_arguments(&format!("{field} must be a string or null"));
+    };
+    Ok(clean_optional(text, max_chars))
+}
+
+fn clean_optional(value: &str, max_chars: usize) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    Some(value.chars().take(max_chars).collect())
+}
+
+fn validate_url(url: &str) -> Result<(), LlmError> {
+    if url.chars().count() > RSS_TOOL_URL_MAX_CHARS {
+        return reject_bad_arguments("url is too long");
+    }
+    if !(url.starts_with("http://") || url.starts_with("https://")) {
+        return reject_bad_arguments("url must be http or https");
+    }
+    Ok(())
+}
+
+fn target_from_context(context: &ToolContext) -> RssTarget {
+    let is_group = context.scope_id.starts_with("group:") || context.scope_id.contains(":group:");
+    let target_id = if is_group {
+        id_from_scope(&context.scope_id, "group").unwrap_or_else(|| context.scope_id.clone())
+    } else {
+        id_from_scope(&context.scope_id, "private").unwrap_or_else(|| {
+            context
+                .user_id
+                .clone()
+                .unwrap_or_else(|| context.scope_id.clone())
+        })
+    };
+    RssTarget {
+        target_type: if is_group {
+            RssTargetType::Group
+        } else {
+            RssTargetType::Private
+        },
+        // ToolContext 不额外携带 group_id；这里仅从服务端 scope 中恢复订阅目标 id，
+        // scope_key 仍是隔离边界，删除和查询不会跨会话泄漏。
+        target_id,
+        scope_key: context.scope_id.clone(),
+    }
+}
+
+fn id_from_scope(scope_id: &str, marker: &str) -> Option<String> {
+    let prefix = format!("{marker}:");
+    if let Some(id) = scope_id.strip_prefix(&prefix) {
+        return clean_optional(id, RSS_TOOL_URL_MAX_CHARS);
+    }
+    let marker = format!(":{marker}:");
+    scope_id
+        .rsplit_once(&marker)
+        .and_then(|(_, id)| clean_optional(id, RSS_TOOL_URL_MAX_CHARS))
+}
+
+fn resolve_subscription_target<'a>(
+    subscriptions: &'a [RssSubscription],
+    target: &str,
+) -> Option<&'a RssSubscription> {
+    let target = target.split_whitespace().next().unwrap_or("").trim();
+    if target.chars().all(|ch| ch.is_ascii_digit()) {
+        let index = target.parse::<usize>().ok()?;
+        return subscriptions
+            .get(index.saturating_sub(1))
+            .filter(|_| index > 0);
+    }
+    subscriptions
+        .iter()
+        .find(|subscription| subscription.id == target || subscription.id.starts_with(target))
+}
+
+fn strip_list_marker(value: &str) -> &str {
+    let value = value.trim();
+    let digit_count = value.chars().take_while(|ch| ch.is_ascii_digit()).count();
+    if digit_count == 0 {
+        return value;
+    }
+    let Some(rest) = value.get(digit_count..) else {
+        return value;
+    };
+    let rest = rest.trim_start();
+    let mut chars = rest.chars();
+    match chars.next() {
+        Some('.' | '。' | '、' | ')' | '）' | ':' | '：') => chars.as_str().trim_start(),
+        _ => value,
+    }
+}
+
+fn extract_url_from_line(line: &str) -> Option<(&str, &str, &str)> {
+    let start = line.find("https://").or_else(|| line.find("http://"))?;
+    let before = line[..start].trim();
+    let after_start = &line[start..];
+    let url_len = after_start
+        .find(char::is_whitespace)
+        .unwrap_or(after_start.len());
+    let url = &after_start[..url_len];
+    let after = after_start[url_len..].trim();
+    Some((before, url, after))
+}
+
+fn rss_store_error(err: crate::storage::rss::RssStoreError) -> LlmError {
+    LlmError::new(
+        err.code().to_owned(),
+        format!("rss store failed: {}", err.message()),
+        "rss",
+    )
+}
+
+fn feed_error_reply(err: &RssFeedError) -> String {
+    match err {
+        RssFeedError::Status(status) => format!("HTTP {status}"),
+        RssFeedError::UnsafeHost => "地址指向本机、内网或 metadata，已拦截".to_owned(),
+        _ => err.to_string(),
+    }
+}
+
+fn compact_manage_subscription_json(
+    subscription: &RssSubscription,
+    baseline_item_count: Option<usize>,
+    details_truncated: &mut bool,
+) -> Value {
+    let mut item = json!({
+        "id": subscription.id,
+        "title": compact_manage_string(
+            &subscription.title,
+            RSS_MANAGE_OUTPUT_TITLE_MAX_CHARS,
+            details_truncated,
+        ),
+        "url": compact_manage_string(
+            &subscription.url,
+            RSS_MANAGE_OUTPUT_URL_MAX_CHARS,
+            details_truncated,
+        ),
+    });
+    if let Some(count) = baseline_item_count {
+        item["baseline_item_count"] = json!(count);
+    }
+    item
+}
+
+fn compact_manage_failure_json(url: &str, error: &str, details_truncated: &mut bool) -> Value {
+    json!({
+        "url": compact_manage_string(url, RSS_MANAGE_OUTPUT_URL_MAX_CHARS, details_truncated),
+        "error": compact_manage_string(
+            error,
+            RSS_MANAGE_OUTPUT_ERROR_MAX_CHARS,
+            details_truncated,
+        ),
+    })
+}
+
+fn compact_manage_string(value: &str, max_chars: usize, details_truncated: &mut bool) -> String {
+    let value = value.trim();
+    if value.chars().count() <= max_chars {
+        return value.to_owned();
+    }
+    *details_truncated = true;
+    value
+        .chars()
+        .take(max_chars.saturating_sub(3))
+        .collect::<String>()
+        + "..."
+}
+
+fn format_manage_message(operation: &str, success: usize, failed: usize) -> String {
+    match operation {
+        "add" => format!("RSS 批量新增完成：成功 {success} 个，失败 {failed} 个。"),
+        "delete" => format!("RSS 批量删除完成：成功 {success} 个，未找到 {failed} 个。"),
+        _ => "RSS 管理操作完成。".to_owned(),
+    }
+}
+
 fn reject_bad_arguments<T>(message: &str) -> Result<T, LlmError> {
     tracing::warn!(
-        tool = RSS_TOOL_NAME,
+        tool = "rss",
         error_code = "bad_tool_arguments",
         "invalid RSS tool argument rejected",
     );
@@ -150,11 +644,18 @@ fn recent_item_json(item: &RssRecentItem) -> Value {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+        thread,
+    };
+
     use crate::{
+        runtime::rss::RssFetchConfig,
         storage::{
             APP_MIGRATIONS,
             database::SqliteDatabase,
-            rss::{RssFeedItem, RssTarget, RssTargetType},
+            rss::{RssFeedItem, RssSubscription, RssTarget, RssTargetType},
         },
         util::time_context::now_iso_cn,
     };
@@ -166,12 +667,46 @@ mod tests {
             task_id: "msg-1".to_owned(),
             user_id: Some("u1".to_owned()),
             scope_id: "private:u1".to_owned(),
+            group_member_role: None,
             tool_call_id: Some("call-1".to_owned()),
         }
     }
 
     fn test_store() -> RssStore {
         RssStore::new(SqliteDatabase::open_temp("rss-tool-tests", APP_MIGRATIONS).unwrap())
+    }
+
+    fn test_fetcher() -> RssFetcher {
+        RssFetcher::new(RssFetchConfig {
+            timeout_seconds: 5,
+            max_body_bytes: 1024 * 1024,
+            user_agent: "rss-tool-test".to_owned(),
+            allow_private_networks: true,
+        })
+        .unwrap()
+    }
+
+    fn spawn_feed_server(title: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let mut buffer = [0_u8; 1024];
+            let _ = stream.read(&mut buffer);
+            let body = format!(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel><title>{title}</title><item><title>Item</title><link>https://example.test/item</link><guid>{title}</guid></item></channel></rss>"#
+            );
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/rss+xml\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+        });
+        format!("http://{addr}/feed.xml")
     }
 
     fn feed_item(key: &str, title: &str) -> RssFeedItem {
@@ -277,5 +812,130 @@ mod tests {
                 .starts_with("private:")
         );
         assert!(!now_iso_cn().is_empty());
+    }
+
+    #[tokio::test]
+    async fn rss_manage_tool_adds_numbered_raw_text_in_current_scope() {
+        let store = test_store();
+        let first = spawn_feed_server("Feed One");
+        let second = spawn_feed_server("Feed Two");
+        let tool = RssManageSubscriptionsTool::new(store.clone(), test_fetcher(), 500, 50);
+
+        let output = tool
+            .execute(
+                test_context(),
+                json!({
+                    "operation": "add",
+                    "feeds": null,
+                    "targets": null,
+                    "raw_text": format!("1. Release notes\n{first}\n2. Recent Commits\n{second}")
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(output.value["ok"], true);
+        assert_eq!(output.value["created"].as_array().unwrap().len(), 2);
+        let subscriptions = store.list_by_scope("private:u1").unwrap();
+        assert_eq!(subscriptions.len(), 2);
+        assert!(
+            subscriptions
+                .iter()
+                .any(|subscription| subscription.title == "Release notes")
+        );
+        assert!(
+            subscriptions
+                .iter()
+                .any(|subscription| subscription.title == "Recent Commits")
+        );
+    }
+
+    #[tokio::test]
+    async fn rss_manage_tool_rejects_group_member_without_admin_role() {
+        let tool = RssManageSubscriptionsTool::new(test_store(), test_fetcher(), 500, 50);
+        let mut context = test_context();
+        context.scope_id = "platform:qq_official:account:app-1:group:g1".to_owned();
+        context.group_member_role = Some("member".to_owned());
+
+        let output = tool
+            .execute(
+                context,
+                json!({
+                    "operation": "delete",
+                    "feeds": null,
+                    "targets": ["1"],
+                    "raw_text": null
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(output.value["ok"], false);
+        assert_eq!(output.value["error"]["code"], "permission_denied");
+    }
+
+    #[test]
+    fn rss_manage_compact_output_stays_under_default_tool_limit_for_full_batch() {
+        let long_title = "很长的订阅标题".repeat(20);
+        let long_url = format!("https://example.test/{}", "a".repeat(470));
+        let long_error = "解析失败：返回内容不是 RSS 或 Atom 文档。".repeat(20);
+        let now = now_iso_cn();
+        let created = (0..RSS_TOOL_MAX_BATCH_ITEMS)
+            .map(|index| {
+                let subscription = RssSubscription {
+                    id: format!("00000000-0000-0000-0000-{index:012}"),
+                    target_type: RssTargetType::Private,
+                    target_id: "u1".to_owned(),
+                    scope_key: "private:u1".to_owned(),
+                    url: long_url.clone(),
+                    title: long_title.clone(),
+                    enabled: true,
+                    created_at: now.clone(),
+                    last_checked_at: None,
+                    last_success_at: None,
+                    last_error: None,
+                    consecutive_failures: 0,
+                    initialized: true,
+                };
+                let mut details_truncated = false;
+                compact_manage_subscription_json(&subscription, Some(1), &mut details_truncated)
+            })
+            .collect::<Vec<_>>();
+        let mut details_truncated = false;
+        let failed = (0..RSS_TOOL_MAX_BATCH_ITEMS)
+            .map(|_| compact_manage_failure_json(&long_url, &long_error, &mut details_truncated))
+            .collect::<Vec<_>>();
+        let outputs = [
+            json!({
+                "ok": true,
+                "operation": "add",
+                "scope_id": "private:u1",
+                "created": created,
+                "failed": [],
+                "details_truncated": true,
+                "message": format_manage_message("add", RSS_TOOL_MAX_BATCH_ITEMS, 0),
+            }),
+            json!({
+                "ok": false,
+                "operation": "add",
+                "scope_id": "private:u1",
+                "created": [],
+                "failed": failed,
+                "details_truncated": details_truncated,
+                "message": format_manage_message("add", 0, RSS_TOOL_MAX_BATCH_ITEMS),
+            }),
+        ];
+
+        for output in outputs {
+            let serialized = serde_json::to_string(&output).unwrap();
+            assert!(
+                serialized.chars().count() <= qq_maid_llm::tool::DEFAULT_TOOL_OUTPUT_MAX_CHARS,
+                "RSS 管理输出不应触发通用 Tool 截断，实际 {} 字符",
+                serialized.chars().count()
+            );
+            assert_eq!(output["details_truncated"], true);
+            assert_eq!(output["operation"], "add");
+            assert!(output.get("ok").and_then(Value::as_bool).is_some());
+        }
     }
 }

--- a/qq-maid-core/src/runtime/tools/rss.rs
+++ b/qq-maid-core/src/runtime/tools/rss.rs
@@ -347,7 +347,6 @@ fn parse_tool_add_entries(arguments: &Value) -> Result<Vec<RssToolAddEntry>, Llm
         }
         for feed in feeds {
             let url = required_string(feed.get("url"), "url")?;
-            validate_url(&url)?;
             let title = optional_string(feed.get("title"), "title", RSS_TOOL_NAME_MAX_CHARS)?;
             entries.push(RssToolAddEntry { url, title });
         }
@@ -363,7 +362,15 @@ fn parse_tool_add_entries(arguments: &Value) -> Result<Vec<RssToolAddEntry>, Llm
     if entries.len() > RSS_TOOL_MAX_BATCH_ITEMS {
         return reject_bad_arguments("too many RSS feeds");
     }
+    validate_add_entries(&entries)?;
     Ok(entries)
+}
+
+fn validate_add_entries(entries: &[RssToolAddEntry]) -> Result<(), LlmError> {
+    for entry in entries {
+        validate_url(&entry.url)?;
+    }
+    Ok(())
 }
 
 fn parse_tool_delete_targets(arguments: &Value) -> Result<Vec<String>, LlmError> {
@@ -848,6 +855,30 @@ mod tests {
                 .iter()
                 .any(|subscription| subscription.title == "Recent Commits")
         );
+    }
+
+    #[tokio::test]
+    async fn rss_manage_tool_rejects_too_long_raw_text_url() {
+        let tool = RssManageSubscriptionsTool::new(test_store(), test_fetcher(), 500, 50);
+        let url = format!(
+            "https://example.test/{}",
+            "a".repeat(RSS_TOOL_URL_MAX_CHARS)
+        );
+
+        let err = tool
+            .execute(
+                test_context(),
+                json!({
+                    "operation": "add",
+                    "feeds": null,
+                    "targets": null,
+                    "raw_text": url
+                }),
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, "bad_tool_arguments");
     }
 
     #[tokio::test]

--- a/qq-maid-core/src/runtime/tools/search.rs
+++ b/qq-maid-core/src/runtime/tools/search.rs
@@ -277,6 +277,7 @@ mod tests {
             task_id: "task-1".to_owned(),
             user_id: Some("u1".to_owned()),
             scope_id: "private:u1".to_owned(),
+            group_member_role: None,
             tool_call_id: None,
         }
     }

--- a/qq-maid-core/src/runtime/tools/todo/tests.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests.rs
@@ -30,6 +30,7 @@ fn test_context() -> ToolContext {
         task_id: "msg-1".to_owned(),
         user_id: Some("u1".to_owned()),
         scope_id: "private:u1".to_owned(),
+        group_member_role: None,
         tool_call_id: Some("call-1".to_owned()),
     }
 }

--- a/qq-maid-core/src/runtime/tools/train.rs
+++ b/qq-maid-core/src/runtime/tools/train.rs
@@ -191,6 +191,7 @@ mod tests {
             task_id: "msg-1".to_owned(),
             user_id: Some("u1".to_owned()),
             scope_id: "private:u1".to_owned(),
+            group_member_role: None,
             tool_call_id: Some("call-1".to_owned()),
         }
     }

--- a/qq-maid-core/src/runtime/tools/weather.rs
+++ b/qq-maid-core/src/runtime/tools/weather.rs
@@ -231,6 +231,7 @@ mod tests {
             task_id: "task-1".to_owned(),
             user_id: Some("u1".to_owned()),
             scope_id: "private:u1".to_owned(),
+            group_member_role: None,
             tool_call_id: None,
         }
     }

--- a/qq-maid-core/src/storage/rss/mod.rs
+++ b/qq-maid-core/src/storage/rss/mod.rs
@@ -479,7 +479,7 @@ impl RssStore {
         query: Option<&str>,
         limit: usize,
     ) -> Result<Vec<RssRecentItem>, RssStoreError> {
-        let limit = limit.clamp(1, 10);
+        let limit = limit.clamp(1, 20);
         let query = query.and_then(clean_optional);
         let pattern = query.as_ref().map(|value| format!("%{value}%"));
         let conn = self.connection()?;

--- a/qq-maid-gateway-rs/src/respond.rs
+++ b/qq-maid-gateway-rs/src/respond.rs
@@ -788,7 +788,7 @@ mod tests {
 
     #[test]
     fn group_command_content_strips_platform_prefixes() {
-        let keywords = vec!["召唤词".to_owned()];
+        let keywords = vec!["召唤词".to_owned(), "小女仆".to_owned()];
 
         for input in [
             "@脸脸家的小女仆 /help",
@@ -798,6 +798,8 @@ mod tests {
             "[CQ:at,qq=123] ／help",
             "召唤词 /rss add https://hnrss.org/newcomments",
             "召唤词：/rss",
+            "召唤词/rss recent",
+            "小女仆/rss recent",
             "召唤词：／rss",
             "召唤词： /rss \n",
             "召唤词： ／rss \n",

--- a/qq-maid-llm/src/agent_loop/tests.rs
+++ b/qq-maid-llm/src/agent_loop/tests.rs
@@ -18,6 +18,7 @@ fn test_context() -> ToolContext {
         task_id: "task-1".to_owned(),
         user_id: Some("u1".to_owned()),
         scope_id: "private:u1".to_owned(),
+        group_member_role: None,
         tool_call_id: None,
     }
 }

--- a/qq-maid-llm/src/provider/openai/tool_loop.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop.rs
@@ -332,6 +332,7 @@ mod tests {
             task_id: "task-1".to_owned(),
             user_id: Some("u1".to_owned()),
             scope_id: "private:u1".to_owned(),
+            group_member_role: None,
             tool_call_id: None,
         }
     }

--- a/qq-maid-llm/src/provider/test_support.rs
+++ b/qq-maid-llm/src/provider/test_support.rs
@@ -56,6 +56,7 @@ pub(crate) fn test_tool_context() -> ToolContext {
         task_id: "task-1".to_owned(),
         user_id: Some("u1".to_owned()),
         scope_id: "private:u1".to_owned(),
+        group_member_role: None,
         tool_call_id: None,
     }
 }

--- a/qq-maid-llm/src/provider/tests.rs
+++ b/qq-maid-llm/src/provider/tests.rs
@@ -155,6 +155,7 @@ fn tool_request() -> ToolChatRequest {
             task_id: "task-1".to_owned(),
             user_id: Some("u1".to_owned()),
             scope_id: "private:u1".to_owned(),
+            group_member_role: None,
             tool_call_id: None,
         },
         max_rounds: 3,

--- a/qq-maid-llm/src/tool.rs
+++ b/qq-maid-llm/src/tool.rs
@@ -41,6 +41,8 @@ pub struct ToolContext {
     pub user_id: Option<String>,
     /// 当前请求的会话/业务作用域 ID。
     pub scope_id: String,
+    /// 当前群成员角色；非群聊或平台未提供时为空。
+    pub group_member_role: Option<String>,
     /// 当前工具调用的稳定标识；由上游 Tool Loop 生成，用于幂等去重与审计关联。
     pub tool_call_id: Option<String>,
 }
@@ -406,6 +408,7 @@ mod tests {
             task_id: "task-1".to_owned(),
             user_id: Some("u1".to_owned()),
             scope_id: "private:u1".to_owned(),
+            group_member_role: None,
             tool_call_id: None,
         }
     }

--- a/runtime/config/agent.toml
+++ b/runtime/config/agent.toml
@@ -6,7 +6,8 @@
 # - 如果 scenes.*.tool_calling_enabled 省略，会继承旧开关：
 #   私聊继承 TOOL_CALLING_ENABLED，群聊继承 TOOL_CALLING_GROUP_ENABLED。
 # - 如果 scenes.*.enabled_tools 省略，私聊默认开放全部业务 Tool；
-#   群聊默认只开放 get_weather / get_train_schedule / get_rss_recent_items / web_search。
+#   群聊默认只开放 get_weather / get_train_schedule / get_rss_recent_items /
+#   manage_rss_subscriptions / web_search。
 # - 如果默认 config/agent.toml 缺失，会回退到旧环境变量内置策略。
 #
 # 不要在这里写 API Key、Access Token、私有 Base URL、真实 prompt、用户资料、群资料、
@@ -90,6 +91,7 @@ tool_calling_enabled = true
 #   "get_weather",
 #   "get_train_schedule",
 #   "get_rss_recent_items",
+#   "manage_rss_subscriptions",
 #   "web_search",
 #   "list_todos",
 #   "get_todo",
@@ -112,4 +114,4 @@ profile = "fast"
 main_route = "group_main"
 search_route = "group_search"
 tool_calling_enabled = false
-# enabled_tools = ["get_weather", "get_train_schedule", "get_rss_recent_items", "web_search"]
+enabled_tools = ["get_weather", "get_train_schedule", "get_rss_recent_items", "manage_rss_subscriptions", "web_search"]


### PR DESCRIPTION
## 变更内容

- 新增 `/rss recent [数量]`，用于查看当前会话最近 RSS 更新，并区分“无订阅”“有订阅但无更新”和“部分订阅检查失败”。
- 增强 `/rss add` / `/rss delete`，支持多行、编号、批量新增与批量删除，并保留单项操作的兼容回复。
- 注册 `manage_rss_subscriptions` Tool，让私聊和已开启 Tool Loop 的群聊可通过白名单管理 RSS；群聊管理仍要求群主或管理员。
- 为 ToolContext 透传群成员角色，修复稳定 group scope 下的群管理权限判断。
- 增加 RSS 管理工具的确定性展示，失败时展示 `failed` / `missing` 明细；压缩管理工具输出，避免大批量结果被通用 Tool 输出截断包装破坏结构。
- 同步默认 Agent 工具白名单与 `runtime/config/agent.toml`，保留群聊 RSS 管理能力，不开放 Todo 写工具。

## 修复原因

RSS 最近更新之前容易退回订阅列表语义，批量订阅管理也只能走 slash 单项流程。新增 Tool 后还存在两个问题：业务失败会被展示成“RSS 本地记录暂时无法读取”，以及批量长字段结果可能超过 Tool 输出上限而丢失 `ok`、`operation` 和明细。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p qq-maid-core rss_manage --all-features`
- `cargo check -p qq-maid-core --all-features`
- `cargo test -p qq-maid-core default_agent_toml_preserves_private_and_group_scene_routes --all-features`
- `cargo test -p qq-maid-core group_tool_loop_exposes_rss_management_but_not_todo_when_enabled --all-features`
- `cargo test --workspace --all-features`
- `git diff --check`
