### PR TITLE
[codex] 修复文本整理误触发联网查询

### DIFF
--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -519,10 +519,24 @@ async fn private_search_intent_routes_to_web_search_plan() {
 
     // 普通聊天命中搜索意图且明确对机器人发起（私聊天然为真）时，
     // 不再进入 Tool Loop，而是走显式 WebSearch 流式路径。
-    let plan = service
-        .plan_core_respond(&private_message("联网查询下今日 ai 新闻"))
-        .unwrap();
-    assert_eq!(plan, RespondPlan::WebSearch);
+    for input in ["联网查询下今日 ai 新闻", "查一下今天 AI 新闻"] {
+        let plan = service.plan_core_respond(&private_message(input)).unwrap();
+        assert_eq!(plan, RespondPlan::WebSearch, "{input}");
+    }
+}
+
+#[tokio::test]
+async fn private_pasted_text_processing_does_not_route_to_web_search_plan() {
+    let service = test_service_with_provider_and_tool_calling(MockProvider::new(), true);
+    let input = "\
+Codex 分析结果：
+- 自然语言查询被 route 到 WebSearch
+- 工具返回：查询内容太长了，请压缩到 200 字以内再试。
+- has_search_intent 命中了 search 关键词
+人话说这个";
+
+    let plan = service.plan_core_respond(&private_message(input)).unwrap();
+    assert_eq!(plan, RespondPlan::StreamingChat);
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tool_route.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route.rs
@@ -606,7 +606,12 @@ fn has_rss_intent(text: &str, lower: &str) -> bool {
 }
 
 pub(super) fn has_search_intent(text: &str, lower: &str) -> bool {
+    if has_local_text_processing_intent(text, lower) {
+        return false;
+    }
+
     lower.contains("search")
+        || has_explicit_search_phrase(text)
         || contains_any(
             text,
             &[
@@ -616,12 +621,124 @@ pub(super) fn has_search_intent(text: &str, lower: &str) -> bool {
                 "网络查询",
                 "搜索",
                 "搜一下",
+                "网上有没有",
+                "查 GitHub",
+                "查 github",
                 "查资料",
                 "查新闻",
+                "最新的",
                 "最新消息",
                 "最新进展",
             ],
         )
+}
+
+fn has_explicit_search_phrase(text: &str) -> bool {
+    contains_any(text, &["查一下", "查下", "查查", "查询一下"])
+        && contains_any(
+            text,
+            &[
+                "新闻",
+                "资料",
+                "网上",
+                "网络",
+                "互联网",
+                "GitHub",
+                "github",
+                "最新",
+                "进展",
+                "有没有",
+            ],
+        )
+}
+
+fn has_local_text_processing_intent(text: &str, _lower: &str) -> bool {
+    let Some(instruction) = local_text_processing_instruction(text) else {
+        return false;
+    };
+    let instruction_lower = instruction.to_ascii_lowercase();
+    if has_explicit_online_search_marker(instruction, &instruction_lower) {
+        return false;
+    }
+
+    // 长粘贴内容里的“查询 / Search / Tool”等词只描述待处理文本，
+    // 路由以末尾短指令为准，避免文本整理请求误入 WebSearch。
+    contains_any(
+        instruction,
+        &[
+            "人话说这个",
+            "说人话",
+            "人话说",
+            "总结这段",
+            "总结一下",
+            "总结下",
+            "整理一下",
+            "整理下",
+            "改写一下",
+            "改写下",
+            "润色一下",
+            "润色下",
+            "压缩成",
+            "压缩到",
+            "解释一下",
+            "解释下",
+            "翻译一下",
+            "翻译下",
+            "这段是什么意思",
+            "是什么意思",
+            "说简单点",
+            "简单点",
+            "整理成 issue",
+            "整理成任务书",
+            "整理成 Codex prompt",
+            "整理成 prompt",
+            "上面这段",
+            "这段话",
+            "这段文本",
+            "这段内容",
+            "哪里不通顺",
+            "不通顺",
+            "语病",
+            "病句",
+        ],
+    )
+}
+
+fn local_text_processing_instruction(text: &str) -> Option<&str> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.chars().count() <= 80 {
+        return Some(trimmed);
+    }
+
+    trimmed
+        .lines()
+        .rev()
+        .map(str::trim)
+        .find(|line| !line.is_empty() && line.chars().count() <= 80)
+}
+
+fn has_explicit_online_search_marker(text: &str, _lower: &str) -> bool {
+    contains_any(
+        text,
+        &[
+            "联网",
+            "上网查",
+            "网上查",
+            "网上有没有",
+            "网络查询",
+            "搜索",
+            "搜一下",
+            "查 GitHub",
+            "查 github",
+            "查资料",
+            "查新闻",
+            "最新消息",
+            "最新进展",
+        ],
+    )
 }
 
 fn has_plain_chat_intent(text: &str, lower: &str) -> bool {
@@ -887,6 +1004,50 @@ mod tests {
             assert_eq!(decision.route, ToolLoopRoute::PlainChat, "{input}");
             assert_eq!(decision.semantic_route, SemanticRoute::PlainChat, "{input}");
             assert_eq!(decision.status_hint, None, "{input}");
+        }
+    }
+
+    #[test]
+    fn local_text_processing_requests_do_not_count_as_search_intent() {
+        let codex_output = "\
+Codex 分析结果：
+- route 命中了 WebSearch
+- 查询工具返回：查询内容太长
+- tool_route 里出现 search 关键词
+人话说这个";
+        let log_output = "\
+2026-07-08 ERROR query failed
+WebSearch tool timeout
+查询内容太长，请压缩到 200 字以内再试。
+总结这段";
+        let issue_output = "\
+执行报告：
+1. 查询 router
+2. WebSearch 工具进入错误分支
+3. 输出太长
+帮我整理成 issue";
+
+        for input in [codex_output, log_output, issue_output] {
+            let lower = input.to_ascii_lowercase();
+            assert!(!has_search_intent(input, &lower), "{input}");
+            let decision = route_tool_loop(&request(input), context());
+            assert_ne!(decision.domain, ToolDomain::Search, "{input}");
+            assert_ne!(decision.semantic_route, SemanticRoute::ToolLoop, "{input}");
+        }
+    }
+
+    #[test]
+    fn explicit_search_requests_keep_search_intent() {
+        for input in [
+            "查一下今天 AI 新闻",
+            "联网查询一下 Rust async sink 是什么",
+            "搜索一下这个报错",
+            "帮我看看网上有没有 rust async sink 相关资料",
+            "查 GitHub 上有没有相关 issue",
+            "最新的 Rust 版本是什么",
+        ] {
+            let lower = input.to_ascii_lowercase();
+            assert!(has_search_intent(input, &lower), "{input}");
         }
     }
 

--- a/qq-maid-core/src/service/tests/mod.rs
+++ b/qq-maid-core/src/service/tests/mod.rs
@@ -536,6 +536,26 @@ fn core_plan_routes_group_search_intent_to_web_search_when_bot_mentioned() {
 }
 
 #[test]
+fn core_plan_keeps_group_pasted_text_processing_as_chat_when_bot_mentioned() {
+    let provider =
+        TestProvider::replying("群聊回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let state = test_state_with_group_tool_calling(provider, 5, false, false);
+    let service = CoreHandle::new(state).respond_service();
+    let input = "\
+Codex 执行报告：
+- 检查 WebSearch 路由
+- 查询工具返回：查询内容太长
+- tool_route 命中 search 关键词
+帮我整理成 issue";
+    let req: RespondRequest = group_request_with_self_mention(input).into();
+
+    assert_eq!(
+        service.plan_core_respond(&req).unwrap(),
+        RespondPlan::StreamingChat
+    );
+}
+
+#[test]
 fn core_plan_does_not_route_group_search_intent_to_web_search_without_bot_mention() {
     // 群聊未 @机器人时，仅出现“联网查询 / 搜索”等词不应自动触发 WebSearch；
     // 保留原有路由（这里 Tool Loop 关闭，回落 StreamingChat）。


### PR DESCRIPTION
## 变更内容

- 为自然语言搜索意图增加本地文本处理保护逻辑。
- 对长粘贴内容优先识别末尾短指令，例如“人话说这个”“总结这段”“帮我整理成 issue”。
- 保留明确联网搜索表达和 `/查` 显式命令的 WebSearch 路由。
- 补充私聊、群聊 @ 机器人和搜索兼容场景测试。

## 修复原因

原路由对整段用户消息做关键词匹配。用户粘贴 Codex 输出、日志或执行报告时，正文里的“查询 / WebSearch / search / 工具”等词会被当作搜索意图，导致文本整理请求误进入 WebSearch，并可能返回“查询内容太长”。

现在自然语言搜索会先判断末尾短指令是否是总结、整理、改写、解释、翻译等本地文本处理意图；如果是，则回到普通聊天/流式聊天，不再把 pasted 文本内部关键词作为搜索依据。

## 兼容性

- `/查 今天 AI 新闻` 保持原有 WebSearch 行为。
- `查一下今天 AI 新闻`、`联网查询一下 Rust async sink 是什么` 等明确搜索请求仍进入 WebSearch。
- 文本整理类请求不再进入 WebSearch 的 query 超限分支。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p qq-maid-core search --all-features`
- `cargo check --workspace --all-features`
- `cargo test --workspace --all-features`
- `git diff --check`
