### PR TITLE
[codex] 补充 Tool Loop 进度事件

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -81,6 +81,7 @@ make run
 - [qq-maid-gateway-rs/README.md](../qq-maid-gateway-rs/README.md)：QQ 官方 gateway、事件范围、消息发送、日志、`/ping` 和进程内主动推送。
 - [runtime/README.md](../runtime/README.md)：运行目录、部署产物、真实配置、路径解析、运行数据、控制脚本和诊断。
 - [runtime/config/.env.example](../runtime/config/.env.example)：环境变量模板和字段说明。
+- [response-event-runtime.md](./design/response-event-runtime.md)：统一响应事件流的现状基线、事件模型和分阶段迁移边界。
 
 ## 常用命令
 

--- a/docs/design/response-event-runtime.md
+++ b/docs/design/response-event-runtime.md
@@ -124,7 +124,7 @@ qq-maid-core -> qq-maid-llm
 
 WebSearch 当前已经走 `CoreResponseStream`，但 `/查` 的“正在联网查询中”与真实搜索 delta 都表现为 `TextDelta`。后续收敛时建议：
 
-- 查询启动提示改成 `Status(WebSearchStarted)` 或复用通用 `ToolCallStarted`。
+- 查询启动提示改成 `Status(CommandStarted)` 或 `Status(ToolCallStarted)`：显式 `/查` 入口按命令启动处理，自然语言搜索或未来 Tool Loop 内搜索按工具调用启动处理；暂不新增 WebSearch 专用状态。
 - 搜索结果 delta 若已是最终回答正文，可以继续走 `TextDelta`。
 - 如果后续 WebSearch 纳入通用 Tool Loop，`WebSearchTool::query_stream` 的增量应通过同一 progress/final-answer 边界输出。
 - `/查` 作为兼容入口保留，不强制变成 LLM Tool Call。
@@ -149,6 +149,12 @@ Gateway 的统一职责是消费事件并按平台能力渲染：
 | Buffered render | 群聊、微信服务号、关闭 C2C stream 时 | 消费事件到 `Completed`，按最终 `CoreResponse` 发送。 |
 | Hybrid render | 私聊工具调用、未来可控群聊进度 | 最多发送少量 `Status`，最终正文以 `Completed` 或 final delta 收口。 |
 
+streaming 失败回退边界：
+
+- streaming 初始化失败、或首个用户可见 `TextDelta` / 平台 stream frame 成功发送前失败时，Gateway 可以降级为 buffered render，继续消费事件并等待 `Completed` 后发送最终正文。
+- 一旦已有用户可见 `TextDelta` 或平台 stream frame 成功发出，本轮回复的用户可见输出就归该 stream 所有；后续中间帧、最终帧或 provider 错误不得再重放完整最终正文，避免重复发送或和已展示内容不一致。
+- 该规则与 Tool Loop final answer streaming 的“delta 后不 fallback”原则一致：用户已经看到增量后，只能继续收尾、记录失败或发送安全失败状态，不能重新生成并补发另一份全文。
+
 消息长度、UTF-8/中文/emoji/Markdown 安全分片、Markdown 降级和图片能力仍属于 Gateway。Core 不应引入平台发送上限常量。
 
 ref_index 规则：
@@ -156,6 +162,17 @@ ref_index 规则：
 - 普通 complete / buffered render 以实际发送出去的最终正文记录。
 - progress/status 不作为主要可引用正文。
 - C2C active stream 当前未确认 QQ final 回包字段能被 quote 回传，因此暂不写 bot outbound ref_index；该限制应保持到真机确认。
+
+## RespondPlan 迁移边界
+
+短期内保留现有 `Immediate` / `StreamingChat` / `CompleteToolLoop` / `WebSearch` 路由结构作为兼容层，不在本设计阶段要求重写 router。迁移重点是让这些路径的执行结果逐步统一包装为 `CoreResponseEvent` stream：
+
+- `Immediate` 继续承载 pending、短 slash command 和确定性业务分支，可先由外层 adapter 包装成 `Completed`。
+- `StreamingChat` 继续作为普通聊天流式路径，保持现有 provider streaming 行为。
+- `CompleteToolLoop` 先补工具进度事件，再在最终回答阶段逐步接入 streaming。
+- `WebSearch` 继续作为显式搜索兼容路径，先统一事件语义，再评估是否和通用 Tool Loop 复用更多实现。
+
+只有在 Chat、Tool Loop、WebSearch、slash command、群聊开关和平台降级测试稳定后，才考虑收敛 `RespondPlan` 命名、删除旧 helper 或清理重复路径。后续实现 PR 不应把本文档理解为立即大规模重构 router 的要求。
 
 ## 分阶段迁移建议
 

--- a/docs/design/response-event-runtime.md
+++ b/docs/design/response-event-runtime.md
@@ -1,0 +1,215 @@
+# 统一响应事件流设计基线
+
+本文对应 Issue #366 的 Phase 1：梳理现有响应路径，定义后续收敛到统一流式 Agent Runtime 的最小事件模型和迁移边界。本文只记录设计基线，不改变当前运行行为。
+
+## 目标边界
+
+统一响应事件流的目标不是让所有平台都真实 token streaming，而是让 Core 对 Chat、Tool Loop、WebSearch 和 slash command 尽量输出同一种响应事件，再由 Gateway 根据平台能力渲染。
+
+必须保留的边界：
+
+- Gateway 负责平台字段、消息长度、分片、Markdown 降级、流式 state/index 和 ref_index 回填。
+- Core 负责业务路由、session、pending、Todo、Memory、RSS、WebSearch 命令和具体业务 Tool。
+- LLM 负责 Provider 协议、SSE、fallback、Tool Loop 协议和工具调用执行框架。
+- Tool Calling 只执行服务端显式注册的白名单工具，工具结果必须以真实执行结果为准。
+- 模型中间草稿、tool arguments、原始 JSON 和内部错误栈不得作为用户可见事件外发。
+
+## 当前响应路径
+
+| 路径 | 当前入口 | 当前输出形态 | 现状判断 |
+| --- | --- | --- | --- |
+| 普通聊天 | `RespondPlan::StreamingChat` -> `respond_stream` -> `handle_chat_stream` | provider 支持时产生 `TextDelta`，最终 `Completed` | 已接入 `CoreResponseStream`，是当前最接近目标的路径。 |
+| Tool Loop | `RespondPlan::CompleteToolLoop` -> `handle_chat` -> `respond_with_tools` | `Status(ToolLoopStarted/Running/Finalizing)` + `Completed` | Core 已有可见进度壳，但工具轮本身仍是完整等待，最终回答也不是流式生成。 |
+| WebSearch | `RespondPlan::WebSearch` -> `respond_web_search_stream` | provider 支持时复用 `/查` 的 `query_stream` delta，最终 `Completed` | 已接入 `CoreResponseStream`，但事件语义仍被压成普通文本 delta。 |
+| slash command | `CommandDispatcher` 内确定性分发 | `RespondResponse` complete | 仍是完整响应路径，尚未纳入统一事件模型。 |
+| pending 确认 | `handle_pending_operation` | `RespondResponse` complete | 应保持确定性，不默认进入 Agent Loop。 |
+| 群聊 stream | Gateway `consume_respond_stream` | 消费到 `Completed` 后普通群消息发送 | 已是 buffered render；当前不发送群进度，避免刷屏。 |
+
+核心代码基线：
+
+- Core 事件契约：`qq-maid-core/src/service/types.rs::CoreResponseEvent`
+- Core stream 包装：`qq-maid-core/src/service/streaming.rs::start_core_response_stream`
+- Respond 路由：`qq-maid-core/src/runtime/respond/router.rs::RespondRouter::plan`
+- 命令分发：`qq-maid-core/src/runtime/respond/command_dispatcher.rs`
+- Tool Loop 调用：`qq-maid-core/src/runtime/respond/chat_flow/mod.rs::handle_chat`
+- LLM 工具执行：`qq-maid-llm/src/provider/tool_loop.rs::ToolLoopExecutor`
+- C2C 流式渲染：`qq-maid-gateway-rs/src/gateway/stream/delivery.rs`
+- 群聊聚合渲染：`qq-maid-gateway-rs/src/gateway/group.rs::consume_respond_stream`
+
+## 当前事件契约
+
+当前 Core 已有最小事件：
+
+```text
+CoreResponseEvent::Status(CoreResponseStatus)
+CoreResponseEvent::TextDelta(String)
+CoreResponseEvent::Completed(CoreResponse)
+CoreResponseEvent::Failed(CoreRespondFailure)
+```
+
+当前状态类型只有：
+
+```text
+ToolLoopStarted
+ToolLoopRunning
+ToolLoopFinalizing
+```
+
+这已经覆盖了“有一个统一 stream 外壳”的基础，但还不足以表达工具轮、单个工具、命令开始/结束、最终回答开始等语义。后续应优先扩展既有事件契约，而不是新增一套平行 stream 抽象。
+
+## 最小目标事件模型
+
+建议把外部稳定契约继续收敛在 `CoreResponseEvent`，第一阶段只扩展可见事件，不暴露模型内部消息。
+
+```text
+ResponseStarted
+Status(kind, text)
+TextDelta(text)
+Completed(CoreResponse)
+Failed(CoreRespondFailure)
+```
+
+其中 `StatusKind` 可分阶段扩展：
+
+```text
+ToolLoopStarted
+ToolRoundStarted
+ToolCallStarted
+ToolCallFinished
+ToolCallFailed
+ToolLoopFinalizing
+CommandStarted
+CommandFinished
+FinalAnswerStarted
+```
+
+实现时可以先不引入 `ResponseStarted`，因为当前 stream 创建本身已隐含开始；若后续 Gateway 需要统一初始化渲染状态，再补充该事件。`FinalAnswerStarted` 可以先作为 `StatusKind`，等最终回答流式路径稳定后再决定是否独立成事件。
+
+用户可见规则：
+
+- `TextDelta` 只承载最终回答正文或 WebSearch 真实结果增量。
+- 工具轮产生 tool call 时，只发系统生成的 status/progress，不发模型同轮自然语言草稿。
+- 工具参数、工具原始结果、JSON、stack、secret 不进入任何用户可见事件。
+- `Completed` 仍是最终权威响应，session、diagnostics、visible snapshot 和 ref_index 相关信息以它为准。
+- `Failed` 必须携带用户可理解的安全失败文案，不能要求 Gateway 解析内部错误。
+
+## Tool Loop 事件落点
+
+后续 Tool Loop 支持事件输出时，不应让 `qq-maid-llm` 反向依赖 `qq-maid-core`。可选实现方向：
+
+1. 在 `qq-maid-llm` 定义 provider 级 `ToolLoopProgressEvent` 或回调 sink。
+2. `ToolLoopExecutor::prepare_call` / `execute_prepared_call` 在准备、开始、完成、失败时触发内部进度事件。
+3. Core 在调用 `respond_with_tools` 时传入回调，把 provider 级事件映射成 `CoreResponseEvent::Status`。
+4. Core 负责把工具名映射成安全、短、用户可见的提示文案；LLM 层只传结构化事实，不拼业务文案。
+
+这样可以保持依赖方向：
+
+```text
+qq-maid-core -> qq-maid-llm
+```
+
+同时避免 `qq-maid-llm` 理解 QQ、session、Todo 可见编号或 Gateway 渲染策略。
+
+## 最终回答流式化
+
+当前 `respond_with_tools` 返回完整 `ChatOutcome`，工具完成后的最终回答也随 Tool Loop 一次性返回。Phase 3 的关键不是 Gateway，而是 LLM Tool Loop 需要区分：
+
+- 工具调用轮：只产出受控 status，不外显模型草稿。
+- 最终回答轮：禁止继续调用工具后，优先使用 provider streaming 产生最终 `TextDelta`。
+- provider 不支持 streaming 时，保留聚合输出并只发 `Completed`。
+
+需要注意：如果 final answer streaming 已经开始，后续 provider 错误不能回退到另一个 provider 重新生成不同全文，避免用户已看到的内容和最终答案不一致。这个规则应沿用现有 stream fallback 的“delta 后不 fallback”原则。
+
+## WebSearch 收敛方式
+
+WebSearch 当前已经走 `CoreResponseStream`，但 `/查` 的“正在联网查询中”与真实搜索 delta 都表现为 `TextDelta`。后续收敛时建议：
+
+- 查询启动提示改成 `Status(WebSearchStarted)` 或复用通用 `ToolCallStarted`。
+- 搜索结果 delta 若已是最终回答正文，可以继续走 `TextDelta`。
+- 如果后续 WebSearch 纳入通用 Tool Loop，`WebSearchTool::query_stream` 的增量应通过同一 progress/final-answer 边界输出。
+- `/查` 作为兼容入口保留，不强制变成 LLM Tool Call。
+
+## slash command 接入方式
+
+slash command 仍应保持确定性执行，不默认变成 LLM Tool Call。建议迁移顺序：
+
+1. 短命令先由 Core 包装成事件流：`CommandStarted` -> `Completed`。
+2. 长耗时命令再补 `Status` 进度，如 RSS 拉取、WebSearch、外部查询。
+3. 命令业务函数仍返回 `RespondResponse`，先由外层 adapter 转成事件，等稳定后再决定是否让命令内部直接产出事件。
+
+这样可以减少一次性改造所有命令的风险。
+
+## Gateway 渲染策略
+
+Gateway 的统一职责是消费事件并按平台能力渲染：
+
+| 策略 | 当前或目标平台 | 行为 |
+| --- | --- | --- |
+| Streaming render | QQ C2C 支持 Markdown stream 时 | `TextDelta` 增量发送，`Completed` 发结束帧；首帧成功后不再补发普通全文。 |
+| Buffered render | 群聊、微信服务号、关闭 C2C stream 时 | 消费事件到 `Completed`，按最终 `CoreResponse` 发送。 |
+| Hybrid render | 私聊工具调用、未来可控群聊进度 | 最多发送少量 `Status`，最终正文以 `Completed` 或 final delta 收口。 |
+
+消息长度、UTF-8/中文/emoji/Markdown 安全分片、Markdown 降级和图片能力仍属于 Gateway。Core 不应引入平台发送上限常量。
+
+ref_index 规则：
+
+- 普通 complete / buffered render 以实际发送出去的最终正文记录。
+- progress/status 不作为主要可引用正文。
+- C2C active stream 当前未确认 QQ final 回包字段能被 quote 回传，因此暂不写 bot outbound ref_index；该限制应保持到真机确认。
+
+## 分阶段迁移建议
+
+### Phase 2：Tool Loop 进度事件
+
+- 在 `qq-maid-llm` Tool Loop 执行器旁增加内部 progress 事件或回调。
+- Core 将工具开始、完成、失败映射为安全 `Status`。
+- 私聊可显示较细进度；群聊默认仍不发送或只发送一条受控状态。
+- 不改变工具业务逻辑、权限、白名单、超时和输出大小限制。
+
+### Phase 3：工具完成后的最终回答流式
+
+- 在 Tool Loop 最终回答阶段接入 provider streaming。
+- `TextDelta` 只从最终回答轮产生。
+- provider 不支持 streaming 时保持 `ProgressThenComplete`。
+- 测试覆盖“工具轮不外显模型草稿”和“最终回答可流式”。
+
+### Phase 4：WebSearch 并入统一事件语义
+
+- 把启动提示从文本 delta 收敛为 status。
+- 保留 `/查` 兼容入口。
+- 评估 WebSearch Tool Loop 与 `/查` 是否能复用同一 final-answer stream。
+
+### Phase 5：slash command 事件包装
+
+- 先在外层包装短命令，不改各命令业务函数。
+- 长耗时命令按需增加进度事件。
+- pending 确认继续保持确定性路径。
+
+### Phase 6：Gateway 统一事件渲染
+
+- 把 C2C stream、C2C stream disabled 和 group consume 的公共事件消费规则抽出。
+- 继续由平台 capability 决定 streaming/buffered/hybrid。
+- 分片和 ref_index 仍以 Gateway 最终实际发送结果为准。
+
+### Phase 7：清理旧路径
+
+- 新路径稳定后再收敛 `CompleteToolLoop` 命名和 WebSearch 单独 stream helper。
+- 删除重复 helper 前必须有 Chat、Tool Loop、WebSearch、slash、群聊开关测试覆盖。
+
+## 需要测试覆盖的关键行为
+
+- 私聊普通聊天仍能输出 `TextDelta` 并正常 `Completed`。
+- 私聊 Tool Loop 至少输出一个受控 status，工具参数和模型草稿不外显。
+- 工具完成后的最终回答在 provider 支持时能继续流式输出。
+- provider 不支持 streaming 时仍能聚合发送完整最终回复。
+- 群聊未唤醒不触发工具；群聊 Tool Loop 关闭时明确工具请求不回落无 tools 普通聊天让模型猜外部状态。
+- slash command 行为保持兼容，事件包装不改变命令结果。
+- 超长最终正文仍由 Gateway 安全分片。
+- ref_index 记录最终实际发送正文，不记录处理中状态。
+
+## 当前未解决问题
+
+- 当前未发现可直接复用的通用 command event adapter，需要实现前再评估 `CommandDispatcher` 的最小改造点。
+- 当前 C2C active stream 的 ref_index 回填仍需 QQ 真机确认最终帧或回调字段。
+- Tool Loop final answer streaming 需要 provider 协议层设计，不能只在 Core 外层补 synthetic delta。
+- 群聊 progress 策略需要结合真实刷屏风险设置节流，默认应继续保守。

--- a/docs/design/response-event-runtime.md
+++ b/docs/design/response-event-runtime.md
@@ -47,15 +47,18 @@ CoreResponseEvent::Completed(CoreResponse)
 CoreResponseEvent::Failed(CoreRespondFailure)
 ```
 
-当前状态类型只有：
+当前状态类型已有：
 
 ```text
 ToolLoopStarted
 ToolLoopRunning
+ToolCallStarted
+ToolCallFinished
+ToolCallFailed
 ToolLoopFinalizing
 ```
 
-这已经覆盖了“有一个统一 stream 外壳”的基础，但还不足以表达工具轮、单个工具、命令开始/结束、最终回答开始等语义。后续应优先扩展既有事件契约，而不是新增一套平行 stream 抽象。
+这已经覆盖了“有一个统一 stream 外壳”和“单个工具开始/完成/失败”的基础，但还不足以表达命令开始/结束、最终回答开始等语义。后续应优先扩展既有事件契约，而不是新增一套平行 stream 抽象。
 
 ## 最小目标事件模型
 
@@ -178,8 +181,8 @@ ref_index 规则：
 
 ### Phase 2：Tool Loop 进度事件
 
-- 在 `qq-maid-llm` Tool Loop 执行器旁增加内部 progress 事件或回调。
-- Core 将工具开始、完成、失败映射为安全 `Status`。
+- 已在 `qq-maid-llm` Tool Loop 执行器旁增加内部 progress 回调。
+- Core 已将工具开始、完成、失败映射为安全 `Status`。
 - 私聊可显示较细进度；群聊默认仍不发送或只发送一条受控状态。
 - 不改变工具业务逻辑、权限、白名单、超时和输出大小限制。
 

--- a/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
@@ -5,6 +5,7 @@
 
 use std::{future::Future, pin::Pin};
 
+use qq_maid_llm::agent_loop::ToolLoopProgressSink;
 use serde_json::{Value, json};
 
 use crate::{
@@ -63,6 +64,7 @@ impl RustRespondService {
         meta: SessionMeta,
         mut session: SessionRecord,
         chat_tool_plan: ChatToolPlan,
+        progress_sink: Option<ToolLoopProgressSink>,
     ) -> Result<RespondResponse, LlmError> {
         if user_text.trim().is_empty() && req.effective_input_parts().is_empty() {
             let reply = "唔，我在。可以直接说要我看哪一块。";
@@ -174,7 +176,7 @@ impl RustRespondService {
                     .tool_runtime
                     .registry_for_chat(&policy, quoted_todo_selection_scope.clone())?;
                 let mut output = service
-                    .respond_with_tools(chat_req, tools, policy.max_tool_rounds)
+                    .respond_with_tools(chat_req, tools, policy.max_tool_rounds, progress_sink)
                     .await?;
 
                 let mut latest_session = self
@@ -389,7 +391,7 @@ impl RustRespondService {
             .map_err(session_error)?;
         if user_text.trim().is_empty() && req.effective_input_parts().is_empty() {
             return self
-                .handle_chat(req, user_text, meta, session, ChatToolPlan::Plain)
+                .handle_chat(req, user_text, meta, session, ChatToolPlan::Plain, None)
                 .await;
         }
         if is_prompt_extraction_request(&user_text) {

--- a/qq-maid-core/src/runtime/respond/llm_service/mod.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service/mod.rs
@@ -30,6 +30,7 @@ use qq_maid_common::{
     markdown_strip::strip_markdown_for_chat,
 };
 use qq_maid_llm::{
+    agent_loop::ToolLoopProgressSink,
     context_budget::{
         BudgetItem, BudgetItemKind, ContextBudgetConfig, apply_context_budget,
         estimated_json_chars, log_budget_report,
@@ -190,6 +191,7 @@ impl LlmChatService {
         req: RespondRequest,
         tools: ToolRegistry,
         max_rounds: usize,
+        progress_sink: Option<ToolLoopProgressSink>,
     ) -> Result<RespondOutput, LlmError> {
         let messages = self.build_messages_for_request(&req)?;
         trace_chat_messages(&req, &messages);
@@ -201,6 +203,7 @@ impl LlmChatService {
                     tools,
                     tool_context: tool_context_from_request(&req),
                     max_rounds,
+                    progress_sink,
                 })
                 .await?
         } else {

--- a/qq-maid-core/src/runtime/respond/mod.rs
+++ b/qq-maid-core/src/runtime/respond/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     },
     storage::notification::NotificationOutboxStore,
 };
-use qq_maid_llm::context_budget::ContextBudgetConfig;
+use qq_maid_llm::{agent_loop::ToolLoopProgressSink, context_budget::ContextBudgetConfig};
 
 mod types;
 pub use types::{ChatResponse, RespondPurpose, RespondRequest, RespondResponse};
@@ -291,6 +291,15 @@ impl RustRespondService {
         req: RespondRequest,
         plan: RespondPlan,
     ) -> Result<RespondResponse, LlmError> {
+        self.respond_with_plan_and_progress(req, plan, None).await
+    }
+
+    pub(crate) async fn respond_with_plan_and_progress(
+        &self,
+        req: RespondRequest,
+        plan: RespondPlan,
+        progress_sink: Option<ToolLoopProgressSink>,
+    ) -> Result<RespondResponse, LlmError> {
         match CommandDispatcher::new(self).dispatch(req, plan).await? {
             DispatchOutcome::Respond(response) => Ok(*response),
             DispatchOutcome::Chat(chat) => {
@@ -300,6 +309,7 @@ impl RustRespondService {
                     chat.meta,
                     chat.session,
                     chat.chat_plan,
+                    progress_sink,
                 )
                 .await
             }

--- a/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/pending.rs
@@ -424,6 +424,7 @@ impl RustRespondService {
                 tools: registry,
                 tool_context: context,
                 max_rounds: policy.max_tool_rounds.max(1),
+                progress_sink: None,
             })
             .await
         {

--- a/qq-maid-core/src/service/streaming.rs
+++ b/qq-maid-core/src/service/streaming.rs
@@ -9,6 +9,8 @@ use std::{
 use tokio::{sync::mpsc, time::timeout};
 use tracing::{debug, warn};
 
+use qq_maid_llm::agent_loop::{ToolLoopProgressEvent, ToolLoopProgressSink};
+
 use crate::{
     error::LlmError,
     runtime::respond::{
@@ -188,7 +190,13 @@ async fn run_complete_tool_loop_respond(
     )
     .await?;
 
-    let respond_future = service.respond_with_plan(req, RespondPlan::CompleteToolLoop);
+    let progress_sink =
+        tool_loop_progress_sink(tx.clone(), cancelled.clone(), progress_status.clone());
+    let respond_future = service.respond_with_plan_and_progress(
+        req,
+        RespondPlan::CompleteToolLoop,
+        Some(progress_sink),
+    );
     tokio::pin!(respond_future);
     let mut running_status_sent = false;
 
@@ -265,6 +273,46 @@ async fn send_core_status(
     tx.send(CoreResponseEvent::Status(CoreResponseStatus { kind, text }))
         .await
         .map_err(|_| LlmError::new("cancelled", "stream receiver dropped", "stream"))
+}
+
+fn tool_loop_progress_sink(
+    tx: mpsc::Sender<CoreResponseEvent>,
+    cancelled: Arc<AtomicBool>,
+    progress_status: ProgressStatusConfig,
+) -> ToolLoopProgressSink {
+    std::sync::Arc::new(move |event| {
+        let tx = tx.clone();
+        let cancelled = cancelled.clone();
+        let progress_status = progress_status.clone();
+        Box::pin(async move {
+            let (kind, phase) = match event {
+                ToolLoopProgressEvent::ToolCallStarted { .. } => (
+                    CoreResponseStatusKind::ToolCallStarted,
+                    StatusPhase::Started,
+                ),
+                ToolLoopProgressEvent::ToolCallFinished { .. } => (
+                    CoreResponseStatusKind::ToolCallFinished,
+                    StatusPhase::Finalizing,
+                ),
+                ToolLoopProgressEvent::ToolCallFailed { .. } => (
+                    CoreResponseStatusKind::ToolCallFailed,
+                    StatusPhase::Finalizing,
+                ),
+            };
+            send_core_status(
+                &tx,
+                &cancelled,
+                kind,
+                status_hint_text(
+                    progress_status.audience,
+                    progress_status.hint,
+                    phase,
+                    &progress_status.display_name,
+                ),
+            )
+            .await
+        })
+    })
 }
 
 fn response_visible_content(response: &RespondResponse) -> Option<&str> {

--- a/qq-maid-core/src/service/tests/mod.rs
+++ b/qq-maid-core/src/service/tests/mod.rs
@@ -845,6 +845,18 @@ async fn core_private_weather_chat_with_tool_capability_completes_without_synthe
     assert_eq!(status.kind, CoreResponseStatusKind::ToolLoopStarted);
     assert_eq!(status.text, "小女仆正在查天气…");
 
+    let Some(CoreResponseEvent::Status(status)) = stream.recv().await else {
+        panic!("expected tool call started status");
+    };
+    assert_eq!(status.kind, CoreResponseStatusKind::ToolCallStarted);
+    assert_eq!(status.text, "小女仆正在查天气…");
+
+    let Some(CoreResponseEvent::Status(status)) = stream.recv().await else {
+        panic!("expected tool call finished status");
+    };
+    assert_eq!(status.kind, CoreResponseStatusKind::ToolCallFinished);
+    assert_eq!(status.text, "小女仆正在确认结果…");
+
     let response = collect_completed_without_text_delta(&mut stream).await;
 
     assert_eq!(response.text_content(), Some("工具完整回复"));

--- a/qq-maid-core/src/service/tests/support.rs
+++ b/qq-maid-core/src/service/tests/support.rs
@@ -10,6 +10,7 @@ use std::{
 use qq_maid_common::identity_context::{
     IdentitySource, MentionConfidence, MentionIdentity, MessageActorContext,
 };
+use qq_maid_llm::agent_loop::ToolLoopProgressEvent;
 
 use crate::{
     app::{CoreExecutors, CoreRuntimeState, CoreStores},
@@ -244,7 +245,18 @@ impl LlmProvider for TestProvider {
 
     async fn chat_with_tools(&self, req: ToolChatRequest) -> Result<ChatOutcome, LlmError> {
         self.tool_calls.fetch_add(1, Ordering::SeqCst);
+        let progress_sink = req.progress_sink.clone();
         self.requests.lock().unwrap().push(req.chat);
+        if let Some(sink) = progress_sink {
+            sink(ToolLoopProgressEvent::ToolCallStarted {
+                tool_name: "mock_tool".to_owned(),
+            })
+            .await?;
+            sink(ToolLoopProgressEvent::ToolCallFinished {
+                tool_name: "mock_tool".to_owned(),
+            })
+            .await?;
+        }
         match &self.behavior {
             ProviderBehavior::Reply(reply) => Ok(chat_outcome(reply)),
             ProviderBehavior::Stream(events) => {

--- a/qq-maid-core/src/service/types.rs
+++ b/qq-maid-core/src/service/types.rs
@@ -207,6 +207,9 @@ pub struct CoreResponseStatus {
 pub enum CoreResponseStatusKind {
     ToolLoopStarted,
     ToolLoopRunning,
+    ToolCallStarted,
+    ToolCallFinished,
+    ToolCallFailed,
     ToolLoopFinalizing,
 }
 
@@ -215,6 +218,9 @@ impl CoreResponseStatusKind {
         match self {
             Self::ToolLoopStarted => "tool_loop_started",
             Self::ToolLoopRunning => "tool_loop_running",
+            Self::ToolCallStarted => "tool_call_started",
+            Self::ToolCallFinished => "tool_call_finished",
+            Self::ToolCallFailed => "tool_call_failed",
             Self::ToolLoopFinalizing => "tool_loop_finalizing",
         }
     }

--- a/qq-maid-llm/src/agent_loop/mod.rs
+++ b/qq-maid-llm/src/agent_loop/mod.rs
@@ -42,7 +42,10 @@ pub mod types;
 
 pub use runner::run_agent_loop;
 pub use session::AgentStepSession;
-pub use types::{AgentSessionRequest, AgentStep, AgentToolCall, AgentToolResult};
+pub use types::{
+    AgentSessionRequest, AgentStep, AgentToolCall, AgentToolResult, ToolLoopProgressEvent,
+    ToolLoopProgressFuture, ToolLoopProgressSink,
+};
 
 #[cfg(test)]
 mod tests;

--- a/qq-maid-llm/src/agent_loop/runner.rs
+++ b/qq-maid-llm/src/agent_loop/runner.rs
@@ -12,6 +12,7 @@
 use tracing::{debug, warn};
 
 use crate::{
+    agent_loop::ToolLoopProgressSink,
     error::LlmError,
     metrics::MetricsRecorder,
     provider::types::TokenUsage,
@@ -35,6 +36,7 @@ pub async fn run_agent_loop(
     tools: ToolRegistry,
     tool_context: ToolContext,
     max_rounds: usize,
+    progress_sink: Option<ToolLoopProgressSink>,
 ) -> Result<ChatOutcome, LlmError> {
     if tools.is_empty() {
         return Err(LlmError::new(
@@ -54,7 +56,7 @@ pub async fn run_agent_loop(
     let provider = session.provider().to_owned();
     let model = session.model().to_owned();
     let recorder = MetricsRecorder::start();
-    let mut executor = ToolLoopExecutor::new(&tools, &tool_context);
+    let mut executor = ToolLoopExecutor::new(&tools, &tool_context, progress_sink);
     let mut usage: Option<TokenUsage> = None;
     // 上一轮工具执行结果；首轮为空，由 Loop 在执行后回填给下一轮 advance。
     let mut results: Vec<AgentToolResult> = Vec::new();
@@ -108,7 +110,7 @@ pub async fn run_agent_loop(
                         "tool_loop",
                     ));
                 }
-                results = execute_tool_batch(&calls, round, &mut executor).await;
+                results = execute_tool_batch(&calls, round, &mut executor).await?;
             }
         }
     }
@@ -129,7 +131,7 @@ async fn execute_tool_batch(
     calls: &[AgentToolCall],
     round: usize,
     executor: &mut ToolLoopExecutor<'_>,
-) -> Vec<AgentToolResult> {
+) -> Result<Vec<AgentToolResult>, LlmError> {
     executor.reset_dependency_chain();
     let prepared_calls = calls
         .iter()
@@ -148,13 +150,13 @@ async fn execute_tool_batch(
         .collect::<Vec<_>>();
     let mut results = Vec::with_capacity(calls.len());
     for (call, prepared) in calls.iter().zip(prepared_calls) {
-        let output = executor.execute_prepared_call(prepared).await;
+        let output = executor.execute_prepared_call(prepared).await?;
         results.push(AgentToolResult {
             call_id: call.call_id.clone(),
             output: output.output,
         });
     }
-    results
+    Ok(results)
 }
 
 /// 合并多轮 token 用量；任一缺失时保留另一侧。

--- a/qq-maid-llm/src/agent_loop/tests.rs
+++ b/qq-maid-llm/src/agent_loop/tests.rs
@@ -204,7 +204,7 @@ async fn no_tool_answer_completes_immediately() {
         "m",
         vec![final_reply("你好呀")],
     ));
-    let outcome = run_agent_loop(session, registry, test_context(), 3)
+    let outcome = run_agent_loop(session, registry, test_context(), 3, None)
         .await
         .unwrap();
     assert_eq!(outcome.reply, "你好呀");
@@ -229,7 +229,7 @@ async fn single_tool_then_final_answer() {
             final_reply("done"),
         ],
     ));
-    let outcome = run_agent_loop(session, registry, test_context(), 3)
+    let outcome = run_agent_loop(session, registry, test_context(), 3, None)
         .await
         .unwrap();
     assert_eq!(outcome.reply, "done");
@@ -237,6 +237,100 @@ async fn single_tool_then_final_answer() {
     assert_eq!(outcome.executed_tools, vec!["echo".to_owned()]);
     assert_eq!(outcome.tool_results.len(), 1);
     assert!(outcome.tool_results[0].succeeded);
+}
+
+#[tokio::test]
+async fn progress_sink_reports_tool_start_and_finish() {
+    let events = Arc::new(StdMutex::new(Vec::new()));
+    let progress_sink = {
+        let events = events.clone();
+        Arc::new(move |event: ToolLoopProgressEvent| {
+            let events = events.clone();
+            Box::pin(async move {
+                events.lock().unwrap().push(event);
+                Ok(())
+            }) as ToolLoopProgressFuture
+        })
+    };
+    let registry = registry_with(vec![Arc::new(CountingTool {
+        name: "echo",
+        calls: Arc::new(StdMutex::new(0)),
+        fail: false,
+        soft_fail: false,
+        dependency: ToolCallDependency::None,
+    }) as _]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![tool_call("echo", "c1", r#"{"value":"a"}"#)]),
+            final_reply("done"),
+        ],
+    ));
+
+    let outcome = run_agent_loop(session, registry, test_context(), 3, Some(progress_sink))
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.reply, "done");
+    assert_eq!(
+        *events.lock().unwrap(),
+        vec![
+            ToolLoopProgressEvent::ToolCallStarted {
+                tool_name: "echo".to_owned()
+            },
+            ToolLoopProgressEvent::ToolCallFinished {
+                tool_name: "echo".to_owned()
+            }
+        ]
+    );
+}
+
+#[tokio::test]
+async fn progress_sink_reports_tool_failure() {
+    let events = Arc::new(StdMutex::new(Vec::new()));
+    let progress_sink = {
+        let events = events.clone();
+        Arc::new(move |event: ToolLoopProgressEvent| {
+            let events = events.clone();
+            Box::pin(async move {
+                events.lock().unwrap().push(event);
+                Ok(())
+            }) as ToolLoopProgressFuture
+        })
+    };
+    let registry = registry_with(vec![Arc::new(CountingTool {
+        name: "echo",
+        calls: Arc::new(StdMutex::new(0)),
+        fail: false,
+        soft_fail: true,
+        dependency: ToolCallDependency::None,
+    }) as _]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![tool_call("echo", "c1", r#"{"value":"a"}"#)]),
+            final_reply("done"),
+        ],
+    ));
+
+    let outcome = run_agent_loop(session, registry, test_context(), 3, Some(progress_sink))
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.reply, "done");
+    assert_eq!(
+        *events.lock().unwrap(),
+        vec![
+            ToolLoopProgressEvent::ToolCallStarted {
+                tool_name: "echo".to_owned()
+            },
+            ToolLoopProgressEvent::ToolCallFailed {
+                tool_name: "echo".to_owned()
+            }
+        ]
+    );
 }
 
 #[tokio::test]
@@ -263,7 +357,7 @@ async fn same_round_multiple_tools_prepare_before_execute() {
             final_reply("ok"),
         ],
     ));
-    let outcome = run_agent_loop(session, registry, test_context(), 3)
+    let outcome = run_agent_loop(session, registry, test_context(), 3, None)
         .await
         .unwrap();
     assert_eq!(outcome.reply, "ok");
@@ -297,7 +391,7 @@ async fn multi_round_continues_after_tool_result() {
             final_reply("merged"),
         ],
     ));
-    let outcome = run_agent_loop(session, registry, test_context(), 3)
+    let outcome = run_agent_loop(session, registry, test_context(), 3, None)
         .await
         .unwrap();
     assert_eq!(outcome.reply, "merged");
@@ -325,7 +419,7 @@ async fn execution_exception_still_records_result_and_continues() {
             final_reply("recovered"),
         ],
     ));
-    let outcome = run_agent_loop(session, registry, test_context(), 3)
+    let outcome = run_agent_loop(session, registry, test_context(), 3, None)
         .await
         .unwrap();
     assert_eq!(outcome.reply, "recovered");
@@ -351,7 +445,7 @@ async fn soft_business_failure_marks_unsucceeded() {
             final_reply("noted"),
         ],
     ));
-    let outcome = run_agent_loop(session, registry, test_context(), 3)
+    let outcome = run_agent_loop(session, registry, test_context(), 3, None)
         .await
         .unwrap();
     assert_eq!(outcome.reply, "noted");
@@ -390,7 +484,7 @@ async fn dependency_skip_after_failure() {
             final_reply("done"),
         ],
     ));
-    let outcome = run_agent_loop(session, registry, test_context(), 3)
+    let outcome = run_agent_loop(session, registry, test_context(), 3, None)
         .await
         .unwrap();
     assert_eq!(outcome.reply, "done");
@@ -425,7 +519,7 @@ async fn max_rounds_returns_tool_loop_limit_without_executing_last_batch() {
             tool_calls(vec![tool_call("echo", "c2", r#"{"value":"b"}"#)]),
         ],
     ));
-    let err = run_agent_loop(session, registry, test_context(), 1)
+    let err = run_agent_loop(session, registry, test_context(), 1, None)
         .await
         .unwrap_err();
     assert_eq!(err.code, "tool_loop_limit");
@@ -456,7 +550,7 @@ async fn last_round_uses_allow_tool_calls_false() {
         ],
     );
     let observed_inner = session.observed.clone();
-    let outcome = run_agent_loop(Box::new(session), registry, test_context(), 1)
+    let outcome = run_agent_loop(Box::new(session), registry, test_context(), 1, None)
         .await
         .unwrap();
     assert_eq!(outcome.reply, "ok");
@@ -469,7 +563,7 @@ async fn last_round_uses_allow_tool_calls_false() {
 #[tokio::test]
 async fn empty_tools_rejected_before_any_request() {
     let session = Box::new(ScriptedSession::new("mock", "m", vec![final_reply("x")]));
-    let err = run_agent_loop(session, ToolRegistry::new(), test_context(), 3)
+    let err = run_agent_loop(session, ToolRegistry::new(), test_context(), 3, None)
         .await
         .unwrap_err();
     assert_eq!(err.code, "bad_request");
@@ -489,7 +583,7 @@ async fn zero_max_rounds_rejected() {
         }) as _)
         .unwrap();
     let session = Box::new(ScriptedSession::new("mock", "m", vec![final_reply("x")]));
-    let err = run_agent_loop(session, registry, test_context(), 0)
+    let err = run_agent_loop(session, registry, test_context(), 0, None)
         .await
         .unwrap_err();
     assert_eq!(err.code, "bad_request");
@@ -532,7 +626,7 @@ async fn usage_merges_across_rounds() {
             dependency: ToolCallDependency::None,
         }) as _)
         .unwrap();
-    let outcome = run_agent_loop(session, registry, test_context(), 3)
+    let outcome = run_agent_loop(session, registry, test_context(), 3, None)
         .await
         .unwrap();
     let usage = outcome.usage.unwrap();

--- a/qq-maid-llm/src/agent_loop/tests.rs
+++ b/qq-maid-llm/src/agent_loop/tests.rs
@@ -334,6 +334,49 @@ async fn progress_sink_reports_tool_failure() {
 }
 
 #[tokio::test]
+async fn progress_sink_error_interrupts_before_tool_execution() {
+    let calls = Arc::new(StdMutex::new(0));
+    let progress_sink = Arc::new(move |event: ToolLoopProgressEvent| {
+        Box::pin(async move {
+            assert_eq!(
+                event,
+                ToolLoopProgressEvent::ToolCallStarted {
+                    tool_name: "echo".to_owned()
+                }
+            );
+            Err(LlmError::new(
+                "cancelled",
+                "stream receiver dropped",
+                "stream",
+            ))
+        }) as ToolLoopProgressFuture
+    });
+    let registry = registry_with(vec![Arc::new(CountingTool {
+        name: "echo",
+        calls: calls.clone(),
+        fail: false,
+        soft_fail: false,
+        dependency: ToolCallDependency::None,
+    }) as _]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![tool_call("echo", "c1", r#"{"value":"a"}"#)]),
+            final_reply("done"),
+        ],
+    ));
+
+    let err = run_agent_loop(session, registry, test_context(), 3, Some(progress_sink))
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code, "cancelled");
+    assert_eq!(err.stage, "stream");
+    assert_eq!(*calls.lock().unwrap(), 0);
+}
+
+#[tokio::test]
 async fn same_round_multiple_tools_prepare_before_execute() {
     let sequence = Arc::new(StdMutex::new(Vec::new()));
     let registry = registry_with(vec![

--- a/qq-maid-llm/src/agent_loop/types.rs
+++ b/qq-maid-llm/src/agent_loop/types.rs
@@ -70,6 +70,10 @@ pub enum ToolLoopProgressEvent {
 pub type ToolLoopProgressFuture =
     Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send + 'static>>;
 
+/// Tool Loop 进度事件接收器，同时承担取消通道语义。
+///
+/// 返回 `Err` 表示上层 stream 已取消、receiver 已关闭或无法继续安全投递进度；
+/// Agent Loop 必须中断后续工具执行。普通日志/观测失败不应通过该 sink 返回。
 pub type ToolLoopProgressSink =
     Arc<dyn Fn(ToolLoopProgressEvent) -> ToolLoopProgressFuture + Send + Sync + 'static>;
 

--- a/qq-maid-llm/src/agent_loop/types.rs
+++ b/qq-maid-llm/src/agent_loop/types.rs
@@ -4,6 +4,9 @@
 //! `LlmProvider::begin_agent_session` 的公开签名组成部分，因此必须 `pub`。
 //! 不含任何协议形态（Responses `input` / Chat Completions `messages`）。
 
+use std::{future::Future, pin::Pin, sync::Arc};
+
+use crate::error::LlmError;
 use crate::provider::types::{ChatRequest, TokenUsage};
 use crate::tool::ToolRegistry;
 
@@ -52,6 +55,23 @@ pub struct AgentToolResult {
     /// 回传给模型的工具输出正文（已序列化为字符串）。
     pub output: String,
 }
+
+/// Tool Loop 内部产生的受控进度事件。
+///
+/// 事件只携带服务端白名单工具名和执行结果状态，不包含工具参数、原始输出或
+/// provider 协议 payload；上层 Core 可据此映射成用户可见的安全状态提示。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolLoopProgressEvent {
+    ToolCallStarted { tool_name: String },
+    ToolCallFinished { tool_name: String },
+    ToolCallFailed { tool_name: String },
+}
+
+pub type ToolLoopProgressFuture =
+    Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send + 'static>>;
+
+pub type ToolLoopProgressSink =
+    Arc<dyn Fn(ToolLoopProgressEvent) -> ToolLoopProgressFuture + Send + Sync + 'static>;
 
 /// 创建 [`AgentStepSession`] 的请求。
 #[derive(Clone, Copy)]

--- a/qq-maid-llm/src/provider/bigmodel.rs
+++ b/qq-maid-llm/src/provider/bigmodel.rs
@@ -396,6 +396,7 @@ mod tests {
                 tools,
                 tool_context: test_tool_context(),
                 max_rounds: 2,
+                progress_sink: None,
             })
             .await
             .unwrap();

--- a/qq-maid-llm/src/provider/deepseek.rs
+++ b/qq-maid-llm/src/provider/deepseek.rs
@@ -424,6 +424,7 @@ mod tests {
                 tools,
                 tool_context: test_tool_context(),
                 max_rounds: 2,
+                progress_sink: None,
             })
             .await
             .unwrap();

--- a/qq-maid-llm/src/provider/mod.rs
+++ b/qq-maid-llm/src/provider/mod.rs
@@ -30,7 +30,7 @@ use async_trait::async_trait;
 use futures::{Stream, StreamExt, stream};
 
 use crate::{
-    agent_loop::{AgentSessionRequest, AgentStepSession, run_agent_loop},
+    agent_loop::{AgentSessionRequest, AgentStepSession, ToolLoopProgressSink, run_agent_loop},
     config::{LlmConfig, ProviderMode},
     error::LlmError,
     metrics::{LlmMetrics, MetricsRecorder},
@@ -97,6 +97,8 @@ pub struct ToolChatRequest {
     pub tool_context: ToolContext,
     /// 最多允许执行工具调用轮数。
     pub max_rounds: usize,
+    /// Tool Loop 执行进度回调；未传入时保持完全静默的旧行为。
+    pub progress_sink: Option<ToolLoopProgressSink>,
 }
 
 /// Provider 已适配的 Tool Calling 协议类型。
@@ -168,6 +170,7 @@ pub trait LlmProvider: Send + Sync {
             tools,
             tool_context,
             max_rounds,
+            progress_sink,
         } = req;
         match self
             .begin_agent_session(AgentSessionRequest {
@@ -176,7 +179,9 @@ pub trait LlmProvider: Send + Sync {
             })
             .await?
         {
-            Some(session) => run_agent_loop(session, tools, tool_context, max_rounds).await,
+            Some(session) => {
+                run_agent_loop(session, tools, tool_context, max_rounds, progress_sink).await
+            }
             None => self.chat(chat).await,
         }
     }

--- a/qq-maid-llm/src/provider/mod.rs
+++ b/qq-maid-llm/src/provider/mod.rs
@@ -98,6 +98,8 @@ pub struct ToolChatRequest {
     /// 最多允许执行工具调用轮数。
     pub max_rounds: usize,
     /// Tool Loop 执行进度回调；未传入时保持完全静默的旧行为。
+    ///
+    /// 回调 `Err` 被视为取消/接收端关闭，会中断 Tool Loop；它不是普通日志 hook。
     pub progress_sink: Option<ToolLoopProgressSink>,
 }
 

--- a/qq-maid-llm/src/provider/openai/chat_tool_loop.rs
+++ b/qq-maid-llm/src/provider/openai/chat_tool_loop.rs
@@ -455,9 +455,9 @@ mod tests {
             context_budget,
         )
         .unwrap();
-        Box::pin(
-            async move { run_agent_loop(Box::new(session), tools, tool_context, max_rounds).await },
-        )
+        Box::pin(async move {
+            run_agent_loop(Box::new(session), tools, tool_context, max_rounds, None).await
+        })
     }
 
     #[tokio::test]

--- a/qq-maid-llm/src/provider/openai/tool_loop.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop.rs
@@ -845,6 +845,7 @@ mod tests {
             registry,
             test_context(),
             3,
+            None,
         )
         .await
         .unwrap();
@@ -894,6 +895,7 @@ mod tests {
             registry,
             test_context(),
             3,
+            None,
         )
         .await
         .unwrap_err();
@@ -933,6 +935,7 @@ mod tests {
             registry,
             test_context(),
             3,
+            None,
         )
         .await
         .unwrap_err();
@@ -974,6 +977,7 @@ mod tests {
             registry,
             test_context(),
             3,
+            None,
         )
         .await
         .unwrap_err();
@@ -1021,6 +1025,7 @@ mod tests {
             registry,
             test_context(),
             3,
+            None,
         )
         .await
         .unwrap();
@@ -1086,6 +1091,7 @@ mod tests {
             registry,
             test_context(),
             3,
+            None,
         )
         .await
         .unwrap();
@@ -1132,6 +1138,7 @@ mod tests {
             registry,
             test_context(),
             3,
+            None,
         )
         .await
         .unwrap();
@@ -1193,6 +1200,7 @@ mod tests {
             registry,
             test_context(),
             3,
+            None,
         )
         .await
         .unwrap();

--- a/qq-maid-llm/src/provider/routing.rs
+++ b/qq-maid-llm/src/provider/routing.rs
@@ -242,6 +242,7 @@ impl LlmProvider for ModelRouteProvider {
                         tools: req.tools.clone(),
                         tool_context: req.tool_context.clone(),
                         max_rounds: req.max_rounds,
+                        progress_sink: req.progress_sink.clone(),
                     })
                     .await
             } else {

--- a/qq-maid-llm/src/provider/tests.rs
+++ b/qq-maid-llm/src/provider/tests.rs
@@ -159,6 +159,7 @@ fn tool_request() -> ToolChatRequest {
             tool_call_id: None,
         },
         max_rounds: 3,
+        progress_sink: None,
     }
 }
 

--- a/qq-maid-llm/src/provider/tool_loop.rs
+++ b/qq-maid-llm/src/provider/tool_loop.rs
@@ -7,6 +7,7 @@
 use serde_json::{Value, json};
 
 use crate::{
+    agent_loop::{ToolLoopProgressEvent, ToolLoopProgressSink},
     error::LlmError,
     provider::ToolExecutionResult,
     tool::{PreparedToolCall, ToolCallDependency, ToolContext, ToolRegistry},
@@ -18,6 +19,7 @@ pub(crate) struct ToolLoopExecutor<'a> {
     previous_call_succeeded: bool,
     executed_tools: Vec<String>,
     tool_results: Vec<ToolExecutionResult>,
+    progress_sink: Option<ToolLoopProgressSink>,
 }
 
 pub(crate) struct ToolLoopCall<'a> {
@@ -35,13 +37,18 @@ pub(crate) struct PreparedToolLoopCall {
 }
 
 impl<'a> ToolLoopExecutor<'a> {
-    pub(crate) fn new(tools: &'a ToolRegistry, base_context: &'a ToolContext) -> Self {
+    pub(crate) fn new(
+        tools: &'a ToolRegistry,
+        base_context: &'a ToolContext,
+        progress_sink: Option<ToolLoopProgressSink>,
+    ) -> Self {
         Self {
             tools,
             base_context,
             previous_call_succeeded: true,
             executed_tools: Vec::new(),
             tool_results: Vec::new(),
+            progress_sink,
         }
     }
 
@@ -70,11 +77,15 @@ impl<'a> ToolLoopExecutor<'a> {
     pub(crate) async fn execute_prepared_call(
         &mut self,
         call: PreparedToolLoopCall,
-    ) -> ToolLoopCallOutput {
+    ) -> Result<ToolLoopCallOutput, LlmError> {
         let (tool_name, output, succeeded) = match call.prepared {
             Ok(prepared) => {
                 let tool_name = prepared.name.clone();
                 self.executed_tools.push(tool_name.clone());
+                self.emit_progress(ToolLoopProgressEvent::ToolCallStarted {
+                    tool_name: tool_name.clone(),
+                })
+                .await?;
                 if prepared.dependency == ToolCallDependency::PreviousCallSuccess
                     && !self.previous_call_succeeded
                 {
@@ -93,14 +104,30 @@ impl<'a> ToolLoopExecutor<'a> {
                     }
                 }
             }
-            Err(err) => ("unknown".to_owned(), tool_error_output(&err), false),
+            Err(err) => {
+                self.emit_progress(ToolLoopProgressEvent::ToolCallFailed {
+                    tool_name: "unknown".to_owned(),
+                })
+                .await?;
+                ("unknown".to_owned(), tool_error_output(&err), false)
+            }
         };
         self.previous_call_succeeded = succeeded;
         if tool_name != "unknown" {
+            let event = if succeeded {
+                ToolLoopProgressEvent::ToolCallFinished {
+                    tool_name: tool_name.clone(),
+                }
+            } else {
+                ToolLoopProgressEvent::ToolCallFailed {
+                    tool_name: tool_name.clone(),
+                }
+            };
+            self.emit_progress(event).await?;
             self.tool_results
                 .push(tool_execution_result(&tool_name, &output, succeeded));
         }
-        ToolLoopCallOutput { output }
+        Ok(ToolLoopCallOutput { output })
     }
 
     pub(crate) fn executed_tools(&self) -> Vec<String> {
@@ -109,6 +136,13 @@ impl<'a> ToolLoopExecutor<'a> {
 
     pub(crate) fn tool_results(&self) -> Vec<ToolExecutionResult> {
         self.tool_results.clone()
+    }
+
+    async fn emit_progress(&self, event: ToolLoopProgressEvent) -> Result<(), LlmError> {
+        let Some(sink) = &self.progress_sink else {
+            return Ok(());
+        };
+        sink(event).await
     }
 }
 

--- a/qq-maid-llm/src/provider/tool_loop.rs
+++ b/qq-maid-llm/src/provider/tool_loop.rs
@@ -142,6 +142,8 @@ impl<'a> ToolLoopExecutor<'a> {
         let Some(sink) = &self.progress_sink else {
             return Ok(());
         };
+        // progress sink 是 Core stream 的取消边界：返回 Err 表示上层不再消费事件，
+        // 继续执行工具可能产生无人接收的副作用，因此必须把错误向外传播。
         sink(event).await
     }
 }


### PR DESCRIPTION
## 概要

继续推进 #366 第二阶段：让 Tool Loop 在执行过程中产出受控进度事件。

## 主要改动

- 在 `qq-maid-llm` Agent Loop 中新增 `ToolLoopProgressEvent` 和可选 progress sink。
- 在 Tool Loop 执行器中输出工具开始、完成、失败事件，事件不包含工具参数、原始结果或 provider payload。
- 在 Core stream 边界把 Tool Loop progress 映射为 `CoreResponseEvent::Status`。
- 扩展 `CoreResponseStatusKind`，新增 `ToolCallStarted`、`ToolCallFinished`、`ToolCallFailed`。
- 更新 #366 设计文档，标记 Phase 2 当前落地状态。
- 增加 LLM progress sink 单测和 Core stream 映射测试。

## 验证

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test -p qq-maid-llm`
- `cargo test -p qq-maid-core`
- `git diff --check`

## 未覆盖

- 未跑完整 clippy / release build。
- 未做真实 QQ/Gateway 联调；本次只改 Core/LLM 事件链路，Gateway 渲染仍沿用现有消费逻辑。
