### PR TITLE
[codex] 收敛 Gateway 消费策略命名

### DIFF
--- a/qq-maid-core/src/service/tests/mod.rs
+++ b/qq-maid-core/src/service/tests/mod.rs
@@ -694,15 +694,51 @@ async fn stream_disabled_chat_completes_without_synthetic_delta() {
 }
 
 #[test]
-fn output_policy_maps_tool_loop_streaming_by_provider_capability() {
-    assert_eq!(
-        output_policy_for_stream(RespondPlan::CompleteToolLoop, true),
-        CoreOutputPolicy::ProgressThenStream
-    );
-    assert_eq!(
-        output_policy_for_stream(RespondPlan::CompleteToolLoop, false),
-        CoreOutputPolicy::ProgressThenComplete
-    );
+fn output_policy_names_are_consistent_across_stream_plans() {
+    let cases = [
+        (
+            RespondPlan::StreamingChat,
+            true,
+            CoreOutputPolicy::DirectStream,
+            "direct_stream",
+        ),
+        (
+            RespondPlan::StreamingChat,
+            false,
+            CoreOutputPolicy::CompleteThenSend,
+            "ordinary_complete",
+        ),
+        (
+            RespondPlan::WebSearch,
+            true,
+            CoreOutputPolicy::DirectStream,
+            "direct_stream",
+        ),
+        (
+            RespondPlan::WebSearch,
+            false,
+            CoreOutputPolicy::CompleteThenSend,
+            "ordinary_complete",
+        ),
+        (
+            RespondPlan::CompleteToolLoop,
+            true,
+            CoreOutputPolicy::ProgressThenStream,
+            "progress_then_stream",
+        ),
+        (
+            RespondPlan::CompleteToolLoop,
+            false,
+            CoreOutputPolicy::ProgressThenComplete,
+            "progress_then_complete",
+        ),
+    ];
+
+    for (plan, provider_stream_enabled, expected_policy, expected_name) in cases {
+        let policy = output_policy_for_stream(plan, provider_stream_enabled);
+        assert_eq!(policy, expected_policy);
+        assert_eq!(policy.as_str(), expected_name);
+    }
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/service/types.rs
+++ b/qq-maid-core/src/service/types.rs
@@ -157,7 +157,6 @@ pub enum CoreRespondOutput {
 pub enum CoreOutputPolicy {
     DirectStream,
     CompleteThenSend,
-    CompleteToolLoop,
     ProgressThenComplete,
     ProgressThenStream,
 }
@@ -167,7 +166,6 @@ impl CoreOutputPolicy {
         match self {
             Self::DirectStream => "direct_stream",
             Self::CompleteThenSend => "ordinary_complete",
-            Self::CompleteToolLoop => "complete_tool_loop",
             Self::ProgressThenComplete => "progress_then_complete",
             Self::ProgressThenStream => "progress_then_stream",
         }

--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -490,7 +490,7 @@ where
                     debug!(
                         message_id = %message.message_id,
                         user = %mask_openid(&message.user_openid),
-                        response_delivery_mode = "ordinary_complete",
+                        response_delivery_mode = output_policy.as_str(),
                         final_send_exit = "ordinary_reply",
                         text_delta_count,
                         status_event_count,
@@ -501,7 +501,7 @@ where
                     warn!(
                         message_id = %message.message_id,
                         user = %mask_openid(&message.user_openid),
-                        response_delivery_mode = "ordinary_complete",
+                        response_delivery_mode = output_policy.as_str(),
                         final_send_exit = "ordinary_reply",
                         text_delta_count,
                         status_event_count,
@@ -1117,6 +1117,51 @@ mod tests {
             RespondEvent::Completed(Box::new(respond_response("最终回复"))),
         ])
         .with_policy(CoreOutputPolicy::ProgressThenComplete);
+        let sender = FakeOutboundSender::default();
+        let mut typing = None;
+
+        let outcome = handle_c2c_stream_disabled(
+            events,
+            &sender,
+            &c2c_message(),
+            &test_config(),
+            &mut typing,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, DisabledStreamOutcome::Completed);
+        assert_eq!(
+            sender.calls(),
+            vec![
+                FakeCall::Text {
+                    content: "小女仆正在处理…".to_owned(),
+                    msg_id: Some("msg-1".to_owned()),
+                },
+                FakeCall::Markdown {
+                    content: "最终回复".to_owned(),
+                    msg_id: Some("msg-1".to_owned()),
+                }
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_stream_progress_then_stream_sends_one_visible_hint_then_final_reply() {
+        let events = FakeEventStream::new([
+            RespondEvent::Status(CoreResponseStatus {
+                kind: CoreResponseStatusKind::ToolLoopStarted,
+                text: "小女仆正在处理…".to_owned(),
+            }),
+            RespondEvent::Status(CoreResponseStatus {
+                kind: CoreResponseStatusKind::ToolLoopFinalizing,
+                text: "小女仆正在确认结果…".to_owned(),
+            }),
+            RespondEvent::TextDelta("不应外发".to_owned()),
+            RespondEvent::Completed(Box::new(respond_response("最终回复"))),
+        ])
+        .with_policy(CoreOutputPolicy::ProgressThenStream);
         let sender = FakeOutboundSender::default();
         let mut typing = None;
 

--- a/qq-maid-gateway-rs/src/gateway/stream/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests.rs
@@ -437,6 +437,54 @@ async fn progress_policy_status_sends_one_visible_hint_then_final_reply() {
 }
 
 #[tokio::test]
+async fn progress_then_stream_sends_one_visible_hint_then_streams_final_answer() {
+    let events = FakeEventStream::new([
+        RespondEvent::Status(CoreResponseStatus {
+            kind: CoreResponseStatusKind::ToolLoopStarted,
+            text: "小女仆正在处理…".to_owned(),
+        }),
+        RespondEvent::Status(CoreResponseStatus {
+            kind: CoreResponseStatusKind::ToolLoopFinalizing,
+            text: "小女仆正在确认结果…".to_owned(),
+        }),
+        RespondEvent::TextDelta("最终".to_owned()),
+        RespondEvent::Completed(Box::new(respond_response("最终回复"))),
+    ])
+    .with_policy(CoreOutputPolicy::ProgressThenStream);
+    let sender = FakeStreamSender::new([Ok(Some("stream-1".to_owned())), Ok(None)]);
+
+    stream_respond_c2c_with_sender(events, &sender, &c2c_message(), &test_config())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        sender.calls(),
+        vec![
+            FakeCall::Text {
+                content: "小女仆正在处理…".to_owned(),
+                msg_id: Some("msg-1".to_owned()),
+            },
+            FakeCall::Stream {
+                content: "最终".to_owned(),
+                msg_id: Some("msg-1".to_owned()),
+                stream_id: None,
+                index: 0,
+                stream_state_value: 1,
+                reset: Some(false),
+            },
+            FakeCall::Stream {
+                content: STREAM_FINAL_MARKER.to_owned(),
+                msg_id: Some("msg-1".to_owned()),
+                stream_id: Some("stream-1".to_owned()),
+                index: 1,
+                stream_state_value: 10,
+                reset: Some(false),
+            },
+        ]
+    );
+}
+
+#[tokio::test]
 async fn stream_first_send_without_id_falls_back_to_completed_response() {
     let events = FakeEventStream::new([
         RespondEvent::TextDelta("晚上".to_owned()),


### PR DESCRIPTION
## 概要

- 移除不再作为 Gateway output_policy 暴露的 `CoreOutputPolicy::CompleteToolLoop`
- 补齐 Chat / WebSearch / Tool Loop 在 streaming 与 buffered 能力下的 output_policy 命名测试
- 让 C2C disabled-stream 聚合路径日志使用真实 `output_policy.as_str()`
- 补充 `progress_then_stream` 在流式和 disabled/buffered 路径下的 progress/final 行为测试

## 背景

对应 #366 的 PR B 范围：只做 Gateway 消费策略的小收敛，确认策略命名和 progress/final 行为一致，不重写 Gateway 渲染器。

## 与 #374 的合并顺序

本 PR 当前仍基于 `master`，不包含 #374 的 WebSearch streaming policy 收敛。因此本 PR 中 WebSearch streaming 的测试期望按 `master` 现状保持为 `DirectStream` / `direct_stream`。

如果 #374 的变更先进入本 PR 的 base，需要 rebase 本 PR，并将 `output_policy_names_are_consistent_across_stream_plans` 中 `RespondPlan::WebSearch + provider_stream_enabled=true` 的期望同步调整为 `CoreOutputPolicy::ProgressThenStream` / `progress_then_stream`；WebSearch disabled/non-streaming 仍保持 `CompleteThenSend` / `ordinary_complete`。

## 验证

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p qq-maid-core -p qq-maid-gateway-rs --all-features`
- `cargo test -p qq-maid-core --all-features`
- `cargo test -p qq-maid-gateway-rs --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`