### PR TITLE
[codex] 修复 Web Search 长查询预处理

### DIFF
--- a/qq-maid-core/src/runtime/respond/search_flow.rs
+++ b/qq-maid-core/src/runtime/respond/search_flow.rs
@@ -3,9 +3,12 @@
 //! `/查` `/查询` `/search` 只负责用户入口兼容、参数校验、session 记录和展示；
 //! 实际联网查询统一通过 `runtime/tools/search.rs` 中的 `web_search` Tool 执行。
 
-use std::{future::Future, pin::Pin};
+use std::{collections::HashMap, future::Future, pin::Pin};
 
-use qq_maid_llm::web_search::WebSearchOutcome;
+use qq_maid_llm::{
+    provider::types::{ChatMessage, ChatRequest, ReasoningEffort},
+    web_search::WebSearchOutcome,
+};
 use serde_json::json;
 
 use crate::{
@@ -31,10 +34,11 @@ use super::{
 // /查 指令的空参数用法提示
 const WEB_SEARCH_USAGE_REPLY: &str = "用法：/查 关键词（也可用 /查询 关键词 或 /search 关键词）
 例如：/查 Cloudflare D1 binding DB is not configured";
-// 查询超长时的提示
-const WEB_SEARCH_TOO_LONG_REPLY: &str = "查询内容太长了，请压缩到 200 字以内再试。";
 // Level 2 进度事件的兼容文本：用户可见，但不写入 session 或模型上下文。
 const WEB_SEARCH_RUNNING_DELTA: &str = "正在联网查询中…\n\n";
+const WEB_SEARCH_REWRITE_PURPOSE: &str = "search_query_rewrite";
+const WEB_SEARCH_REWRITE_MAX_OUTPUT_TOKENS: u64 = 96;
+const WEB_SEARCH_REWRITE_CONTEXT_MAX_CHARS: usize = 1200;
 // 搜索结果为空时的回复
 const WEB_SEARCH_EMPTY_RESULT_REPLY: &str = "【联网查询】
 
@@ -108,31 +112,31 @@ impl RustRespondService {
                 Some(command.action),
             ));
         }
-        if query.chars().count() > WEB_SEARCH_QUERY_MAX_LENGTH {
-            return Ok(command_response(
-                WEB_SEARCH_TOO_LONG_REPLY,
-                Some(session.session_id.clone()),
-                Some(command.action),
-            ));
-        }
 
         let command_text = format!("/{} {}", command.raw_command, command.argument);
         let raw_question = web_search_raw_question(&command_text, req);
+        let policy = self.resolve_agent_policy(req)?;
+        let search_query = self
+            .prepare_web_search_query(query, req, &raw_question, &policy.main_model)
+            .await;
         if stream && let Some(on_delta) = on_delta.as_mut() {
             on_delta(WEB_SEARCH_RUNNING_DELTA.to_owned()).await?;
         }
-        let policy = self.resolve_agent_policy(req)?;
         let output_result = if stream {
             self.execute_web_search_tool_stream(
-                query,
+                &search_query,
                 &raw_question,
                 Some(policy.search_model.clone()),
                 on_delta.take(),
             )
             .await
         } else {
-            self.execute_web_search_tool(query, &raw_question, Some(policy.search_model.clone()))
-                .await
+            self.execute_web_search_tool(
+                &search_query,
+                &raw_question,
+                Some(policy.search_model.clone()),
+            )
+            .await
         };
         let output = match output_result {
             Ok(output) => output,
@@ -225,6 +229,62 @@ impl RustRespondService {
             elapsed_ms: outcome.elapsed_ms,
         })
     }
+
+    async fn prepare_web_search_query(
+        &self,
+        query: &str,
+        req: &RespondRequest,
+        raw_question: &str,
+        rewrite_model: &str,
+    ) -> String {
+        let query = normalize_query_text(query);
+        if !should_rewrite_search_query(&query, req) {
+            return query;
+        }
+
+        match self
+            .rewrite_web_search_query(&query, req, raw_question, rewrite_model)
+            .await
+        {
+            Ok(Some(rewritten)) => rewritten,
+            Ok(None) => fallback_web_search_query(&query, req),
+            Err(err) => {
+                tracing::warn!(
+                    error_code = err.code,
+                    error_stage = err.stage,
+                    "web search query rewrite failed; using local compact fallback"
+                );
+                fallback_web_search_query(&query, req)
+            }
+        }
+    }
+
+    async fn rewrite_web_search_query(
+        &self,
+        query: &str,
+        req: &RespondRequest,
+        raw_question: &str,
+        rewrite_model: &str,
+    ) -> Result<Option<String>, LlmError> {
+        let mut metadata = HashMap::new();
+        metadata.insert("purpose".to_owned(), WEB_SEARCH_REWRITE_PURPOSE.to_owned());
+        let outcome = self
+            .provider
+            .chat(ChatRequest {
+                session_id: req.session_id.clone(),
+                model: Some(rewrite_model.to_owned()),
+                messages: vec![
+                    ChatMessage::system(web_search_rewrite_system_prompt()),
+                    ChatMessage::user(web_search_rewrite_user_prompt(query, raw_question)),
+                ],
+                context_budget: None,
+                max_output_tokens: Some(WEB_SEARCH_REWRITE_MAX_OUTPUT_TOKENS),
+                reasoning_effort: Some(ReasoningEffort::Low),
+                metadata,
+            })
+            .await?;
+        Ok(clean_rewritten_search_query(&outcome.reply))
+    }
 }
 
 /// 从用户文本中解析联网搜索指令（/查、/查询、/search 等）。
@@ -250,6 +310,285 @@ fn web_search_raw_question(command_text: &str, req: &RespondRequest) -> String {
         return command_text.to_owned();
     };
     format!("{command_text}\n\n引用消息上下文：\n{quoted_context}")
+}
+
+fn should_rewrite_search_query(query: &str, req: &RespondRequest) -> bool {
+    if query.chars().count() > WEB_SEARCH_QUERY_MAX_LENGTH {
+        return true;
+    }
+    quoted_search_context(req).is_some() && query_needs_quoted_context(query)
+}
+
+fn query_needs_quoted_context(query: &str) -> bool {
+    let compact = query
+        .chars()
+        .filter(|ch| !ch.is_whitespace() && !matches!(ch, '，' | '。' | '？' | '?' | '！' | '!'))
+        .collect::<String>()
+        .to_lowercase();
+    [
+        "帮我查询",
+        "帮我查",
+        "帮我看看",
+        "帮忙查询",
+        "帮忙查",
+        "查下",
+        "查一下",
+        "查询一下",
+        "搜下",
+        "搜一下",
+        "搜索一下",
+        "整理下上下文",
+        "整理一下上下文",
+        "结合上下文",
+        "根据上下文",
+        "引用内容",
+        "这条",
+        "这个",
+        "上面",
+    ]
+    .iter()
+    .any(|needle| compact.contains(needle))
+}
+
+fn web_search_rewrite_system_prompt() -> String {
+    format!(
+        "你是搜索查询改写器。任务：把用户追问和可能存在的引用上下文整理成一个公开网页搜索 query。\n\
+要求：\n\
+- 只输出 query 本身，不要解释、不要 Markdown、不要加引号。\n\
+- query 必须不超过 {WEB_SEARCH_QUERY_MAX_LENGTH} 个字符。\n\
+- 优先保留专有名词、URL、错误码、版本号、日期/时间范围、产品名和用户限制条件。\n\
+- 用户只说“帮我查一下”“整理上下文查询一下”时，从引用上下文中抽取可搜索实体和条件。\n\
+- 不要把整段聊天原文塞进 query。"
+    )
+}
+
+fn web_search_rewrite_user_prompt(query: &str, raw_question: &str) -> String {
+    format!(
+        "用户追问：\n{}\n\n原始问题与引用上下文：\n{}",
+        query,
+        truncate_chars(raw_question, WEB_SEARCH_REWRITE_CONTEXT_MAX_CHARS)
+    )
+}
+
+fn clean_rewritten_search_query(output: &str) -> Option<String> {
+    if rewrite_output_has_invalid_shape(output) {
+        return None;
+    }
+    let mut text = output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with("```"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    text = normalize_query_text(&text);
+    for prefix in [
+        "query:",
+        "query：",
+        "搜索 query:",
+        "搜索 query：",
+        "搜索词:",
+        "搜索词：",
+        "查询词:",
+        "查询词：",
+        "查询:",
+        "查询：",
+    ] {
+        if text.to_lowercase().starts_with(prefix) {
+            text = text[prefix.len()..].trim().to_owned();
+        }
+    }
+    if rewrite_query_is_invalid(&text) {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+fn fallback_web_search_query(query: &str, req: &RespondRequest) -> String {
+    let cleaned_query = strip_search_instruction_shell(query);
+    let base = if let Some(quoted) =
+        quoted_search_context(req).filter(|_| query_needs_quoted_context(query))
+    {
+        let quoted = compact_quoted_search_context(&quoted);
+        if cleaned_query.is_empty() {
+            quoted
+        } else {
+            format!("{cleaned_query} {quoted}")
+        }
+    } else if cleaned_query.is_empty() {
+        query.to_owned()
+    } else {
+        cleaned_query
+    };
+    compact_search_query(&base, WEB_SEARCH_QUERY_MAX_LENGTH)
+}
+
+fn normalize_query_text(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn rewrite_output_has_invalid_shape(output: &str) -> bool {
+    let non_empty = output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    if non_empty.len() != 1 {
+        return true;
+    }
+    let line = non_empty[0];
+    line.starts_with("```")
+        || line.starts_with('#')
+        || line.starts_with('>')
+        || line.starts_with("- ")
+        || line.starts_with("* ")
+        || line.chars().next().is_some_and(|ch| ch.is_ascii_digit())
+            && line
+                .chars()
+                .nth(1)
+                .is_some_and(|ch| matches!(ch, '.' | '、' | ')'))
+}
+
+fn rewrite_query_is_invalid(text: &str) -> bool {
+    let text = text.trim();
+    if text.is_empty() || text.chars().count() > WEB_SEARCH_QUERY_MAX_LENGTH {
+        return true;
+    }
+    if is_wrapped_in_quotes(text) {
+        return true;
+    }
+    let lower = text.to_lowercase();
+    [
+        "我将",
+        "我会",
+        "我可以",
+        "建议搜索",
+        "建议查询",
+        "可以搜索",
+        "可以查询",
+        "以下是",
+        "好的",
+        "我来",
+        "帮你查",
+        "来帮你",
+        "这是",
+        "搜索query是",
+        "搜索 query 是",
+        "搜索关键词",
+        "查询query是",
+        "查询 query 是",
+        "查询关键词",
+        "联网查询",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+}
+
+fn is_wrapped_in_quotes(text: &str) -> bool {
+    matches!(
+        (text.chars().next(), text.chars().next_back(),),
+        (Some('"'), Some('"'))
+            | (Some('\''), Some('\''))
+            | (Some('“'), Some('”'))
+            | (Some('‘'), Some('’'))
+            | (Some('`'), Some('`'))
+    )
+}
+
+fn strip_search_instruction_shell(query: &str) -> String {
+    let mut text = normalize_query_text(query);
+    for phrase in [
+        "帮我查询一下",
+        "帮我查询",
+        "帮我查一下",
+        "帮我查",
+        "帮忙查询一下",
+        "帮忙查询",
+        "帮忙查一下",
+        "帮忙查",
+        "整理一下上下文查询一下",
+        "整理下上下文查询一下",
+        "整理一下上下文",
+        "整理下上下文",
+        "结合上下文查询一下",
+        "根据上下文查询一下",
+        "联网查询一下",
+        "联网查询",
+        "查一下",
+        "查询一下",
+        "搜一下",
+        "搜索一下",
+        "看看",
+        "看下",
+        "这个",
+        "这条",
+        "上面",
+    ] {
+        text = text.replace(phrase, " ");
+    }
+    normalize_query_text(&text)
+        .trim_matches(|ch| {
+            matches!(
+                ch,
+                ':' | '：' | ',' | '，' | '.' | '。' | '?' | '？' | '!' | '！'
+            )
+        })
+        .trim()
+        .to_owned()
+}
+
+fn compact_quoted_search_context(context: &str) -> String {
+    let mut selected = context
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .filter(|line| {
+            line.contains("http://")
+                || line.contains("https://")
+                || line.chars().any(|ch| ch.is_ascii_digit())
+                || line.chars().any(|ch| ch.is_ascii_uppercase())
+                || line.contains("错误")
+                || line.contains("报错")
+                || line.contains("版本")
+                || line.contains("标题")
+                || line.contains("发布")
+                || line.contains("公告")
+        })
+        .take(6)
+        .collect::<Vec<_>>();
+    if selected.is_empty() {
+        selected = context
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .take(3)
+            .collect();
+    }
+    normalize_query_text(&selected.join(" "))
+}
+
+fn compact_search_query(text: &str, limit: usize) -> String {
+    let text = normalize_query_text(text);
+    let total = text.chars().count();
+    if total <= limit {
+        return text;
+    }
+    if limit <= 1 {
+        return text.chars().take(limit).collect();
+    }
+
+    let head_len = (limit * 2 / 3).max(1);
+    let tail_len = limit.saturating_sub(head_len + 1).max(1);
+    let head = text.chars().take(head_len).collect::<String>();
+    let tail = text
+        .chars()
+        .rev()
+        .take(tail_len)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<String>();
+    format!("{head} {tail}").trim().to_owned()
 }
 
 fn quoted_search_context(req: &RespondRequest) -> Option<String> {

--- a/qq-maid-core/src/runtime/respond/search_flow.rs
+++ b/qq-maid-core/src/runtime/respond/search_flow.rs
@@ -442,11 +442,23 @@ fn rewrite_output_has_invalid_shape(output: &str) -> bool {
         || line.starts_with('>')
         || line.starts_with("- ")
         || line.starts_with("* ")
-        || line.chars().next().is_some_and(|ch| ch.is_ascii_digit())
-            && line
-                .chars()
-                .nth(1)
-                .is_some_and(|ch| matches!(ch, '.' | '、' | ')'))
+        || rewrite_line_starts_with_numbered_list_marker(line)
+}
+
+fn rewrite_line_starts_with_numbered_list_marker(line: &str) -> bool {
+    let mut chars = line.chars();
+    let (Some(first), Some(marker)) = (chars.next(), chars.next()) else {
+        return false;
+    };
+    if !first.is_ascii_digit() {
+        return false;
+    }
+    // `1. Rust` 是编号列表；`1.75 Rust` / `4.22.0 Wrangler` 是合法版本号查询。
+    match marker {
+        '.' | ')' => chars.next().is_some_and(char::is_whitespace),
+        '、' => true,
+        _ => false,
+    }
 }
 
 fn rewrite_query_is_invalid(text: &str) -> bool {
@@ -464,6 +476,7 @@ fn rewrite_query_is_invalid(text: &str) -> bool {
         "我可以",
         "建议搜索",
         "建议查询",
+        "建议联网查询",
         "可以搜索",
         "可以查询",
         "以下是",
@@ -478,7 +491,6 @@ fn rewrite_query_is_invalid(text: &str) -> bool {
         "查询query是",
         "查询 query 是",
         "查询关键词",
-        "联网查询",
     ]
     .iter()
     .any(|needle| lower.contains(needle))

--- a/qq-maid-core/src/runtime/respond/tests/search.rs
+++ b/qq-maid-core/src/runtime/respond/tests/search.rs
@@ -1,17 +1,30 @@
 use std::sync::{
-    Arc,
+    Arc, Mutex,
     atomic::{AtomicUsize, Ordering},
 };
 
 use async_trait::async_trait;
+use qq_maid_common::input_part::QuotedMessageContext;
 use qq_maid_llm::web_search::{
     WebSearchExecutor, WebSearchOutcome, WebSearchRequest, WebSearchSource,
 };
+use tokio::sync::mpsc;
 
 use super::support::*;
 use crate::error::LlmError;
 
 struct LongAnswerWebSearchExecutor;
+
+#[derive(Default)]
+struct RecordingWebSearchExecutor {
+    requests: Arc<Mutex<Vec<WebSearchRequest>>>,
+}
+
+impl RecordingWebSearchExecutor {
+    fn requests(&self) -> Arc<Mutex<Vec<WebSearchRequest>>> {
+        self.requests.clone()
+    }
+}
 
 #[async_trait]
 impl WebSearchExecutor for LongAnswerWebSearchExecutor {
@@ -30,6 +43,47 @@ impl WebSearchExecutor for LongAnswerWebSearchExecutor {
 
     fn provider_name(&self) -> &'static str {
         "long-answer-query"
+    }
+}
+
+#[async_trait]
+impl WebSearchExecutor for RecordingWebSearchExecutor {
+    async fn query(&self, req: WebSearchRequest) -> Result<WebSearchOutcome, LlmError> {
+        self.requests.lock().unwrap().push(req.clone());
+        Ok(recording_search_outcome(&req.query, "recording-query"))
+    }
+
+    async fn query_stream(
+        &self,
+        req: WebSearchRequest,
+        delta_tx: mpsc::Sender<String>,
+    ) -> Result<WebSearchOutcome, LlmError> {
+        self.requests.lock().unwrap().push(req.clone());
+        delta_tx
+            .send(format!("stream answer: {}", req.query))
+            .await
+            .map_err(|err| LlmError::provider(format!("stream delta failed: {err}"), "test"))?;
+        Ok(recording_search_outcome(
+            &req.query,
+            "recording-stream-query",
+        ))
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "recording-query"
+    }
+}
+
+fn recording_search_outcome(query: &str, provider: &str) -> WebSearchOutcome {
+    WebSearchOutcome {
+        answer: format!("web answer: {query}"),
+        sources: vec![WebSearchSource {
+            title: "记录来源".to_owned(),
+            url: "https://example.test/search".to_owned(),
+            snippet: "用于记录最终搜索 query".to_owned(),
+        }],
+        provider: provider.to_owned(),
+        elapsed_ms: 9,
     }
 }
 
@@ -183,9 +237,18 @@ async fn web_search_command_rejects_empty_argument() {
 }
 
 #[tokio::test]
-async fn web_search_command_rejects_overlong_argument() {
-    let service = test_service();
-    let query = "a".repeat(201);
+async fn web_search_command_rewrites_overlong_argument_before_querying() {
+    let provider = MockProvider::with_search_query_rewrite_replies(vec![Ok(
+        "Rust E0502 borrow checker Vec push immutable borrow 1.75",
+    )]);
+    let executor = RecordingWebSearchExecutor::default();
+    let requests = executor.requests();
+    let (service, _base) =
+        test_service_with_provider_base_title_and_query(provider.clone(), None, Arc::new(executor));
+    let query = format!(
+        "{} Rust 编译报错排查，最后的关键限制是版本 1.75 和 E0502",
+        "背景说明".repeat(80)
+    );
 
     let response = service
         .respond(message(&format!("/查 {query}")))
@@ -193,7 +256,224 @@ async fn web_search_command_rejects_overlong_argument() {
         .unwrap();
 
     assert_eq!(response.command.as_deref(), Some("web_search"));
-    assert!(response.text.as_deref().unwrap().contains("查询内容太长了"));
+    let requests = requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].query,
+        "Rust E0502 borrow checker Vec push immutable borrow 1.75"
+    );
+    assert!(
+        requests[0]
+            .raw_question
+            .as_deref()
+            .unwrap()
+            .contains("E0502")
+    );
+    assert_eq!(
+        provider.requests()[0]
+            .metadata
+            .get("purpose")
+            .map(String::as_str),
+        Some("search_query_rewrite")
+    );
+}
+
+#[tokio::test]
+async fn web_search_command_keeps_short_query_without_rewrite() {
+    let provider = MockProvider::new();
+    let executor = RecordingWebSearchExecutor::default();
+    let requests = executor.requests();
+    let (service, _base) =
+        test_service_with_provider_base_title_and_query(provider.clone(), None, Arc::new(executor));
+
+    service.respond(message("/查 Rust 新闻")).await.unwrap();
+
+    assert_eq!(requests.lock().unwrap()[0].query, "Rust 新闻");
+    assert!(
+        provider.requests().is_empty(),
+        "短 query 不应额外调用模型 rewrite"
+    );
+}
+
+#[tokio::test]
+async fn web_search_command_keeps_clear_short_query_with_quote_without_rewrite() {
+    let provider = MockProvider::new();
+    let executor = RecordingWebSearchExecutor::default();
+    let requests = executor.requests();
+    let (service, _base) =
+        test_service_with_provider_base_title_and_query(provider.clone(), None, Arc::new(executor));
+    let mut req = message("/查 Rust 新闻");
+    req.quoted = Some(QuotedMessageContext {
+        lookup_found: true,
+        text_summary: Some("一段引用上下文，不应让明确短 query 多打一轮模型。".to_owned()),
+        ..QuotedMessageContext::default()
+    });
+
+    service.respond(req).await.unwrap();
+
+    assert_eq!(requests.lock().unwrap()[0].query, "Rust 新闻");
+    assert!(
+        provider.requests().is_empty(),
+        "明确短 query 即使带引用也不应额外调用模型 rewrite"
+    );
+}
+
+#[tokio::test]
+async fn web_search_command_rewrites_short_followup_with_quoted_context() {
+    let provider = MockProvider::with_search_query_rewrite_replies(vec![Ok(
+        "Cloudflare D1 binding DB not configured Wrangler 4.22.0",
+    )]);
+    let executor = RecordingWebSearchExecutor::default();
+    let requests = executor.requests();
+    let (service, _base) =
+        test_service_with_provider_base_title_and_query(provider, None, Arc::new(executor));
+    let mut req = message("/查 帮我查询一下");
+    req.quoted = Some(QuotedMessageContext {
+        lookup_found: true,
+        text_summary: Some(format!(
+            "{}\n错误：Cloudflare D1 binding DB is not configured\n版本：Wrangler 4.22.0",
+            "无关上下文".repeat(120)
+        )),
+        ..QuotedMessageContext::default()
+    });
+
+    service.respond(req).await.unwrap();
+
+    let requests = requests.lock().unwrap();
+    assert_eq!(
+        requests[0].query,
+        "Cloudflare D1 binding DB not configured Wrangler 4.22.0"
+    );
+    assert!(
+        requests[0]
+            .raw_question
+            .as_deref()
+            .unwrap()
+            .contains("引用消息上下文")
+    );
+}
+
+#[tokio::test]
+async fn web_search_command_falls_back_when_rewrite_model_fails() {
+    let provider =
+        MockProvider::with_search_query_rewrite_replies(vec![Err(LlmError::timeout("rewrite"))]);
+    let executor = RecordingWebSearchExecutor::default();
+    let requests = executor.requests();
+    let (service, _base) =
+        test_service_with_provider_base_title_and_query(provider, None, Arc::new(executor));
+    let query = format!(
+        "帮我查一下 {} 关键错误码 TAIL-KEY-9876",
+        "很多背景 ".repeat(80)
+    );
+
+    service
+        .respond(message(&format!("/查 {query}")))
+        .await
+        .unwrap();
+
+    let query = requests.lock().unwrap()[0].query.clone();
+    assert!(query.chars().count() <= 200);
+    assert!(query.contains("TAIL-KEY-9876"));
+    assert!(!query.contains("帮我查一下"));
+}
+
+#[tokio::test]
+async fn web_search_command_fallback_extracts_key_terms_from_quoted_context() {
+    let provider =
+        MockProvider::with_search_query_rewrite_replies(vec![Err(LlmError::timeout("rewrite"))]);
+    let executor = RecordingWebSearchExecutor::default();
+    let requests = executor.requests();
+    let (service, _base) =
+        test_service_with_provider_base_title_and_query(provider, None, Arc::new(executor));
+    let mut req = message("/查 整理下上下文查询一下");
+    req.quoted = Some(QuotedMessageContext {
+        lookup_found: true,
+        text_summary: Some(format!(
+            "{}\n标题：OpenAI Responses API web_search 报错\nURL：https://platform.openai.com/docs/guides/tools-web-search\n错误码：invalid_request_error 400\n版本：gpt-5-mini",
+            "普通讨论 ".repeat(100)
+        )),
+        ..QuotedMessageContext::default()
+    });
+
+    service.respond(req).await.unwrap();
+
+    let query = requests.lock().unwrap()[0].query.clone();
+    assert!(query.chars().count() <= 200);
+    assert!(query.contains("OpenAI Responses API web_search"));
+    assert!(query.contains("https://platform.openai.com/docs/guides/tools-web-search"));
+    assert!(query.contains("invalid_request_error 400"));
+    assert!(!query.contains("整理下上下文查询一下"));
+}
+
+#[tokio::test]
+async fn web_search_command_falls_back_when_rewrite_output_is_invalid() {
+    for reply in [
+        String::new(),
+        "x".repeat(201),
+        "我将搜索 Rust E0502".to_owned(),
+        "- Rust E0502".to_owned(),
+    ] {
+        let provider = MockProvider::with_search_query_rewrite_replies(vec![Ok(reply.as_str())]);
+        let executor = RecordingWebSearchExecutor::default();
+        let requests = executor.requests();
+        let (service, _base) =
+            test_service_with_provider_base_title_and_query(provider, None, Arc::new(executor));
+        let query = format!(
+            "帮我查询一下 {} 最后条件 Rust E0502 Vec push",
+            "上下文 ".repeat(90)
+        );
+
+        service
+            .respond(message(&format!("/查 {query}")))
+            .await
+            .unwrap();
+
+        let final_query = requests.lock().unwrap()[0].query.clone();
+        assert!(final_query.chars().count() <= 200, "{reply}");
+        assert!(final_query.contains("Rust E0502 Vec push"), "{reply}");
+        assert!(!final_query.contains("我将搜索"), "{reply}");
+        assert!(!final_query.starts_with("- "), "{reply}");
+    }
+}
+
+#[tokio::test]
+async fn web_search_stream_rewrites_overlong_argument_before_querying() {
+    let provider = MockProvider::with_search_query_rewrite_replies(vec![Ok(
+        "Tokio timeout JoinHandle abort stream regression",
+    )]);
+    let executor = RecordingWebSearchExecutor::default();
+    let requests = executor.requests();
+    let (service, _base) =
+        test_service_with_provider_base_title_and_query(provider, None, Arc::new(executor));
+    let deltas = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let collected = deltas.clone();
+    let query = format!(
+        "联网查询 {} 关键限制 Tokio JoinHandle abort stream regression",
+        "长背景 ".repeat(90)
+    );
+
+    service
+        .respond_stream(message(&format!("/查 {query}")), move |delta| {
+            let collected = collected.clone();
+            Box::pin(async move {
+                collected.lock().unwrap().push(delta);
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        requests.lock().unwrap()[0].query,
+        "Tokio timeout JoinHandle abort stream regression"
+    );
+    assert!(
+        deltas
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|delta| delta.contains("stream answer"))
+    );
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tests/search.rs
+++ b/qq-maid-core/src/runtime/respond/tests/search.rs
@@ -354,6 +354,32 @@ async fn web_search_command_rewrites_short_followup_with_quoted_context() {
 }
 
 #[tokio::test]
+async fn web_search_command_accepts_numeric_version_rewrite_outputs() {
+    for reply in [
+        "1.75 Rust E0502 borrow checker Vec push",
+        "4.22.0 Wrangler D1 binding DB not configured",
+        "qq-maid-bot 联网查询 200 字限制",
+    ] {
+        let provider = MockProvider::with_search_query_rewrite_replies(vec![Ok(reply)]);
+        let executor = RecordingWebSearchExecutor::default();
+        let requests = executor.requests();
+        let (service, _base) =
+            test_service_with_provider_base_title_and_query(provider, None, Arc::new(executor));
+        let query = format!(
+            "帮我查询一下 {} 最后条件 Rust E0502 Vec push Wrangler D1 binding DB",
+            "上下文 ".repeat(90)
+        );
+
+        service
+            .respond(message(&format!("/查 {query}")))
+            .await
+            .unwrap();
+
+        assert_eq!(requests.lock().unwrap()[0].query, reply);
+    }
+}
+
+#[tokio::test]
 async fn web_search_command_falls_back_when_rewrite_model_fails() {
     let provider =
         MockProvider::with_search_query_rewrite_replies(vec![Err(LlmError::timeout("rewrite"))]);
@@ -411,7 +437,9 @@ async fn web_search_command_falls_back_when_rewrite_output_is_invalid() {
         String::new(),
         "x".repeat(201),
         "我将搜索 Rust E0502".to_owned(),
+        "我来帮你联网查询 Rust E0502".to_owned(),
         "- Rust E0502".to_owned(),
+        "1. Rust E0502".to_owned(),
     ] {
         let provider = MockProvider::with_search_query_rewrite_replies(vec![Ok(reply.as_str())]);
         let executor = RecordingWebSearchExecutor::default();
@@ -432,7 +460,9 @@ async fn web_search_command_falls_back_when_rewrite_output_is_invalid() {
         assert!(final_query.chars().count() <= 200, "{reply}");
         assert!(final_query.contains("Rust E0502 Vec push"), "{reply}");
         assert!(!final_query.contains("我将搜索"), "{reply}");
+        assert!(!final_query.contains("我来帮你联网查询"), "{reply}");
         assert!(!final_query.starts_with("- "), "{reply}");
+        assert!(!final_query.starts_with("1. "), "{reply}");
     }
 }
 

--- a/qq-maid-core/src/runtime/respond/tests/support.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support.rs
@@ -59,6 +59,7 @@ pub(super) struct MockProvider {
     tool_protocol: Option<ToolCallingProtocol>,
     tool_actions: Arc<Mutex<Vec<MockToolAction>>>,
     title_replies: Arc<Mutex<Vec<Result<String, LlmError>>>>,
+    search_query_rewrite_replies: Arc<Mutex<Vec<Result<String, LlmError>>>>,
     title_delay: Option<std::time::Duration>,
 }
 
@@ -162,6 +163,7 @@ impl MockProvider {
             tool_protocol: None,
             tool_actions: Arc::new(Mutex::new(Vec::new())),
             title_replies: Arc::new(Mutex::new(Vec::new())),
+            search_query_rewrite_replies: Arc::new(Mutex::new(Vec::new())),
             title_delay: None,
         }
     }
@@ -176,6 +178,7 @@ impl MockProvider {
             tool_protocol: None,
             tool_actions: Arc::new(Mutex::new(Vec::new())),
             title_replies: Arc::new(Mutex::new(Vec::new())),
+            search_query_rewrite_replies: Arc::new(Mutex::new(Vec::new())),
             title_delay: None,
         }
     }
@@ -189,6 +192,18 @@ impl MockProvider {
                     .collect(),
             )),
             title_delay: None,
+            ..Self::new()
+        }
+    }
+
+    pub(super) fn with_search_query_rewrite_replies(replies: Vec<Result<&str, LlmError>>) -> Self {
+        Self {
+            search_query_rewrite_replies: Arc::new(Mutex::new(
+                replies
+                    .into_iter()
+                    .map(|result| result.map(str::to_owned))
+                    .collect(),
+            )),
             ..Self::new()
         }
     }
@@ -416,6 +431,33 @@ impl LlmProvider for MockProvider {
                 tokio::time::sleep(delay).await;
             }
             let reply = self.title_replies.lock().unwrap().remove(0)?;
+            return Ok(ChatOutcome {
+                reply,
+                metrics: LlmMetrics {
+                    provider: "mock".to_owned(),
+                    model: req.model.unwrap_or_else(|| "mock-model".to_owned()),
+                    stream: false,
+                    ttfe_ms: None,
+                    ttft_ms: None,
+                    total_latency_ms: 1,
+                },
+                usage: Some(TokenUsage {
+                    input_tokens: None,
+                    cached_input_tokens: None,
+                    output_tokens: None,
+                    total_tokens: None,
+                }),
+                fallback_used: false,
+                executed_tools: Vec::new(),
+                tool_results: Vec::new(),
+            });
+        }
+        if req.metadata.get("purpose").map(String::as_str) == Some("search_query_rewrite") {
+            let reply = self
+                .search_query_rewrite_replies
+                .lock()
+                .unwrap()
+                .remove(0)?;
             return Ok(ChatOutcome {
                 reply,
                 metrics: LlmMetrics {

--- a/qq-maid-core/src/runtime/tools/search.rs
+++ b/qq-maid-core/src/runtime/tools/search.rs
@@ -367,6 +367,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn web_search_tool_rejects_overlong_query_without_calling_executor() {
+        let executor = MockWebSearchExecutor::default();
+        let requests = executor.requests.clone();
+        let tool = WebSearchTool::new(Arc::new(executor));
+
+        let err = tool
+            .execute(
+                test_context(),
+                json!({
+                    "query": "a".repeat(WEB_SEARCH_QUERY_MAX_LENGTH + 1),
+                    "raw_question": null,
+                    "max_results": null,
+                    "context_size": null,
+                    "model_override": null,
+                }),
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, "bad_tool_arguments");
+        assert_eq!(err.message, "query is too long");
+        assert_eq!(requests.lock().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
     async fn web_search_tool_rejects_invalid_options() {
         let tool = WebSearchTool::new(Arc::new(MockWebSearchExecutor::default()));
 


### PR DESCRIPTION
## 变更内容

修复 Web Search 显式查询路径中过长输入被 200 字限制直接拒绝的问题。

- 在 `/查` 和 `RespondPlan::WebSearch` 进入 `web_search` Tool 前新增搜索 query 预处理。
- 短且明确的 query 直接查询，不额外调用模型。
- 超长 query 或明显依赖引用上下文的追问，先用 `search_query_rewrite` 辅助生成短搜索 query。
- rewrite 输出会硬校验；为空、超长、Markdown、列表、引号包裹、寒暄或解释文本时，走本地规则兜底。
- 本地兜底会去掉“帮我查一下 / 搜一下 / 看看 / 联网查”等指令壳，并尽量保留最新问题、引用中的 URL、标题、错误码和版本号。
- 保留 Tool Loop 侧 `web_search` 参数 200 字保护，避免模型把整段上下文塞进工具。

## 根因

原先 `WEB_SEARCH_QUERY_MAX_LENGTH = 200` 同时影响显式查询入口和模型 Tool 参数校验。`/查` 与自然语言 WebSearch 在进入工具前直接拒绝超过 200 字的用户输入，导致关键条件在查询前丢失。

本次把“显式搜索路由的 query 生成”与“Tool Loop 工具参数安全限制”拆开处理。

## 影响

- 长问题不再直接提示“查询内容太长”。
- “帮我查询一下”并引用长消息时，会从引用上下文生成更适合搜索的 query。
- 短 query 不增加一次 rewrite 模型调用，避免额外延迟。
- 流式与非流式搜索路径共用同一套 query 预处理逻辑。

## 验证

- `cargo fmt --all`
- `cargo test -p qq-maid-core runtime::respond::tests::search`
- `cargo test -p qq-maid-core runtime::tools::search`
- `cargo test -p qq-maid-core`
- `cargo check --workspace`
- `git diff --check`

Closes #373
