### PR TITLE
feat: 增加开机自启动配置

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,12 @@ install:
 	cp -f scripts/validate-runtime.sh runtime/validate-runtime.sh
 	cp -f scripts/qq-maid-healthcheck.sh runtime/qq-maid-healthcheck.sh
 	cp -f scripts/botmon.sh runtime/botmon.sh
+	cp -f scripts/qq-maid-systemd.sh runtime/qq-maid-systemd.sh
+	cp -f scripts/windows-startup-example.bat runtime/windows-startup-example.bat
 	mkdir -p runtime/static
-	find runtime -maxdepth 1 -type f -name 'qq-maid-*' ! -name 'qq-maid-bot' ! -name 'qq-maid-healthcheck.sh' -delete
+	find runtime -maxdepth 1 -type f -name 'qq-maid-*' ! -name 'qq-maid-bot' ! -name 'qq-maid-healthcheck.sh' ! -name 'qq-maid-systemd.sh' -delete
 	find runtime -maxdepth 1 -type f -name '*ctl.sh' ! -name 'botctl.sh' -delete
-	chmod +x runtime/$(BOT_BIN) runtime/botctl.sh runtime/diagnose-network.sh runtime/validate-runtime.sh runtime/qq-maid-healthcheck.sh runtime/botmon.sh
+	chmod +x runtime/$(BOT_BIN) runtime/botctl.sh runtime/diagnose-network.sh runtime/validate-runtime.sh runtime/qq-maid-healthcheck.sh runtime/botmon.sh runtime/qq-maid-systemd.sh
 	@printf '安装完成：runtime/ 目录已包含 release 二进制和控制脚本\n'
 
 deploy: deploy-remote

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ vim config/.env
 
 最少需要填写：`QQ_BOT_APP_ID`、`QQ_BOT_APP_SECRET`，以及默认模型路线实际引用到的 Provider API Key。默认 `config/agent.toml` 声明私聊 / 群聊场景策略，但不绑定具体 Provider 或模型路线；普通聊天会继续继承 `.env` 里的 `LLM_MODEL`、`PRIVATE_LLM_MODEL`、`GROUP_LLM_MODEL`。使用第三方或自建兼容接口时，再在 `.env` 配置对应的 Base URL。需要处理 QQ 图片时，保持 `QQ_MAID_ENABLE_IMAGE=true`，并确认模型路线使用支持图片输入的 provider / model。
 
-完整配置项说明见 [runtime/README.md](./runtime/README.md)。
+完整配置项和开机自启动说明见 [runtime/README.md](./runtime/README.md)。Linux 推荐使用发布包内的 `qq-maid-systemd.sh` 生成 systemd service；Windows 可参考 `windows-startup-example.bat` 做“用户登录后启动”。
 
 ### 路径二：源码构建（需要 Rust 工具链）
 
@@ -279,7 +279,7 @@ cd runtime
 ..\target\release\qq-maid-bot.exe
 ```
 
-Windows 下程序以前台方式运行，关闭终端即停止。如需长期后台运行，可使用 Windows 任务计划程序或第三方服务管理工具；项目目前暂未提供官方 Windows 服务脚本。
+Windows 下程序以前台方式运行，关闭终端即停止。发布包内的 `windows-startup-example.bat` 可用于放入启动目录或创建启动快捷方式，实现用户登录后启动；这不是严格意义上的系统服务。如需无人登录也运行，可使用 Windows 任务计划程序或第三方服务管理工具。
 
 ### 遇到问题？
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -313,6 +313,7 @@ cd runtime
 确认 `WorkingDirectory`、`BOT_BINARY`、`BOT_ENV_FILE` 和运行用户后，再安装系统服务：
 
 ```bash
+./botctl.sh stop
 sudo ./qq-maid-systemd.sh install --runtime-dir "$(pwd)" --user qqmaid
 sudo systemctl enable --now qq-maid-bot.service
 sudo systemctl status qq-maid-bot.service
@@ -340,6 +341,7 @@ sudo ./qq-maid-systemd.sh uninstall --runtime-dir "$(pwd)"
 个人机器也可以使用 user service：
 
 ```bash
+./botctl.sh stop
 ./qq-maid-systemd.sh install --scope user --runtime-dir "$(pwd)"
 systemctl --user enable --now qq-maid-bot.service
 systemctl --user status qq-maid-bot.service

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -11,6 +11,8 @@ runtime/
 ├── .env                             # 兼容环境变量文件，不提交
 ├── qq-maid-bot                      # 部署后的统一 Rust release 二进制，不提交
 ├── botctl.sh                        # 部署后的聚合控制脚本，不提交
+├── qq-maid-systemd.sh               # systemd service 生成 / 安装脚本，不提交
+├── windows-startup-example.bat      # Windows 登录后启动示例，不提交
 ├── validate-runtime.sh              # 部署后的运行诊断脚本，不提交
 ├── README.md                        # 本文件
 ├── static/
@@ -288,9 +290,91 @@ cd runtime
 ./botctl.sh start
 ```
 
+## 开机自启动
+
+自启动只包装现有运行目录，不改变机器人核心逻辑，也不影响 `./botctl.sh start/stop/restart/status/logs` 等手动管理方式。交给 systemd 托管后，应使用 `systemctl` 管理服务，避免同时再用 `./botctl.sh start` 启动第二个进程。配置前先确认 `config/.env` 已填写，且手动启动可用：
+
+```bash
+cd runtime
+./botctl.sh start
+./botctl.sh health
+./botctl.sh stop
+```
+
+### Linux systemd
+
+Linux 服务器推荐使用 systemd。脚本会根据当前运行目录生成 service，默认只打印内容，不写系统目录：
+
+```bash
+cd runtime
+./qq-maid-systemd.sh render --runtime-dir "$(pwd)" --user qqmaid
+```
+
+确认 `WorkingDirectory`、`BOT_BINARY`、`BOT_ENV_FILE` 和运行用户后，再安装系统服务：
+
+```bash
+sudo ./qq-maid-systemd.sh install --runtime-dir "$(pwd)" --user qqmaid
+sudo systemctl enable --now qq-maid-bot.service
+sudo systemctl status qq-maid-bot.service
+```
+
+常用操作：
+
+```bash
+sudo systemctl start qq-maid-bot.service
+sudo systemctl stop qq-maid-bot.service
+sudo systemctl restart qq-maid-bot.service
+sudo systemctl status qq-maid-bot.service
+journalctl -u qq-maid-bot.service -f
+```
+
+禁用或卸载：
+
+```bash
+sudo systemctl disable --now qq-maid-bot.service
+sudo ./qq-maid-systemd.sh uninstall --runtime-dir "$(pwd)"
+```
+
+如果没有专用 Linux 用户，也可以省略 `--user`，由 systemd 使用当前配置运行；生产环境更推荐创建低权限用户，并确保该用户可读取运行目录和 `config/.env`，可写 `data/`、`logs/` 等运行产物目录。脚本不会自动创建用户、不会静默 `sudo`，也不会自动启用或启动服务。
+
+个人机器也可以使用 user service：
+
+```bash
+./qq-maid-systemd.sh install --scope user --runtime-dir "$(pwd)"
+systemctl --user enable --now qq-maid-bot.service
+systemctl --user status qq-maid-bot.service
+journalctl --user -u qq-maid-bot.service -f
+```
+
+user service 只在用户 systemd 会话存在时运行；如需用户退出后仍继续运行，需由部署者自行配置 `loginctl enable-linger <用户名>`。
+
+### Windows 登录后启动
+
+Windows 示例脚本是 `windows-startup-example.bat`。它适合“用户登录后启动”，不是严格意义上的系统服务；用户未登录、注销或终端关闭时，行为取决于 Windows 会话和脚本所在环境。
+
+推荐做法是把发布包放在固定目录，例如 `C:\qq-maid-bot\`，确认 `config\.env` 已配置后，给 `windows-startup-example.bat` 创建快捷方式，并把快捷方式放入启动文件夹：
+
+```text
+Win + R -> shell:startup
+```
+
+如果直接把 `.bat` 复制到启动文件夹，需要编辑脚本里的 `QQ_MAID_RUNTIME_DIR` 为真实发布包目录。
+
+### 非 systemd Linux / Termux / NAS / 路由器
+
+这些环境差异很大，本项目一期不做自动探测和全量适配。可按设备能力选择：
+
+- `crontab @reboot`：调用 `runtime/botctl.sh start`。
+- `rc.local`：系统启动末尾调用 `botctl.sh start`。
+- OpenRC / runit / s6 / Supervisor：把 `runtime/botctl.sh run` 作为前台命令托管。
+- Termux：结合 Termux:Boot，在启动脚本中进入运行目录后执行 `./botctl.sh start`。
+- NAS / 路由器：优先使用厂商自带的启动任务、容器管理或服务管理界面。
+
+这些 fallback 不承诺覆盖所有发行版和设备固件。排障时先确认手动 `./botctl.sh start`、`./botctl.sh health` 可用，再检查对应平台的启动日志。
+
 ## Release 包
 
-Release 包采用白名单生成，只包含统一 `qq-maid-bot` release 二进制、`botctl.sh`、`botmon.sh`、`diagnose-network.sh`、`validate-runtime.sh`、`static/index.html`、本文件、`config/.env.example`、`config/agent.toml`、公开 `.example` 配置模板、`VERSION` 和空的 `data/storage/` 目录。真实 `.env`、私有 prompt、私有知识资料、SQLite 数据库、日志、pid 和 `.bak` 备份不会被写入归档。
+Release 包采用白名单生成，只包含统一 `qq-maid-bot` release 二进制、`botctl.sh`、`botmon.sh`、`qq-maid-systemd.sh`、`windows-startup-example.bat`、`diagnose-network.sh`、`validate-runtime.sh`、`qq-maid-healthcheck.sh`、`static/index.html`、本文件、`config/.env.example`、`config/agent.toml`、公开 `.example` 配置模板、`VERSION` 和空的 `data/storage/` 目录。真实 `.env`、私有 prompt、私有知识资料、SQLite 数据库、日志、pid 和 `.bak` 备份不会被写入归档。
 
 GitHub Release 自动生成 `linux-x86_64`、`linux-aarch64`、`macos-x86_64`、`macos-aarch64` 和 `windows-x86_64` 包；Linux / macOS 使用 `.tar.gz`，Windows 使用 `.zip`。
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -333,8 +333,10 @@ journalctl -u qq-maid-bot.service -f
 
 ```bash
 sudo systemctl disable --now qq-maid-bot.service
-sudo ./qq-maid-systemd.sh uninstall --runtime-dir "$(pwd)"
+sudo ./qq-maid-systemd.sh uninstall --service-name qq-maid-bot --scope system
 ```
+
+卸载只依赖服务名和安装范围定位 service 文件，不要求运行目录、二进制或 `config/.env` 仍然存在。
 
 如果没有专用 Linux 用户，也可以省略 `--user`，由 systemd 使用当前配置运行；生产环境更推荐创建低权限用户，并确保该用户可读取运行目录和 `config/.env`，可写 `data/`、`logs/` 等运行产物目录。脚本不会自动创建用户、不会静默 `sudo`，也不会自动启用或启动服务。
 

--- a/scripts/botctl.sh
+++ b/scripts/botctl.sh
@@ -22,6 +22,7 @@ Usage: botctl.sh <command>
 
 Commands:
   start     Start qq-maid-bot in the background
+  run       Run qq-maid-bot in the foreground
   stop      Stop qq-maid-bot
   restart   Restart qq-maid-bot
   status    Show process status
@@ -131,6 +132,21 @@ start() {
     echo "qq-maid-bot started, pid=$(read_pid), log=${LOG_FILE}"
 }
 
+run_foreground() {
+    [[ -f "${BINARY}" ]] || die "executable not found: ${BINARY}"
+    if [[ ! -x "${BINARY}" ]]; then
+        chmod +x "${BINARY}"
+    fi
+
+    mkdir -p "$(dirname -- "${PID_FILE}")" "$(dirname -- "${LOG_FILE}")"
+    load_env
+    export RUST_LOG="${RUST_LOG:-info,qq_maid_gateway_rs=debug,qq_maid_core=info,tower_http=info}"
+
+    # systemd 等外部进程管理器需要前台进程；后台启动仍走 start。
+    cd "${RUNTIME_DIR}"
+    exec "${BINARY}"
+}
+
 stop() {
     local pid
     if ! pid="$(read_pid)"; then
@@ -198,6 +214,9 @@ command="${1:-}"
 case "${command}" in
     start)
         start
+        ;;
+    run)
+        run_foreground
         ;;
     stop)
         stop

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 #
 # 远程服务器信息从 scripts/deploy.conf 读取 (与 sync_knowledge.sh 共用)。
 # 首次使用请从 deploy.conf.example 复制并填入实际值。
-# 部署组件: qq-maid-bot、控制脚本、健康检查脚本与诊断工具
+# 部署组件: qq-maid-bot、控制脚本、健康检查、systemd/Windows 启动模板与诊断工具
 # ============================================================
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -43,6 +43,8 @@ prepare_validate_runtime() {
     install -m 0755 scripts/validate-runtime.sh "${LOCAL_VALIDATE_DIR}/validate-runtime.sh"
     install -m 0755 scripts/qq-maid-healthcheck.sh "${LOCAL_VALIDATE_DIR}/qq-maid-healthcheck.sh"
     install -m 0755 scripts/botmon.sh "${LOCAL_VALIDATE_DIR}/botmon.sh"
+    install -m 0755 scripts/qq-maid-systemd.sh "${LOCAL_VALIDATE_DIR}/qq-maid-systemd.sh"
+    install -m 0644 scripts/windows-startup-example.bat "${LOCAL_VALIDATE_DIR}/windows-startup-example.bat"
     install -m 0644 runtime/config/.env.example "${LOCAL_VALIDATE_DIR}/.env.example"
     install -m 0644 runtime/config/agent.toml "${LOCAL_VALIDATE_DIR}/config/agent.toml"
     install -m 0644 runtime/README.md "${LOCAL_VALIDATE_DIR}/README.md"
@@ -73,6 +75,8 @@ scp scripts/diagnose-network.sh "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.diagnose-
 scp scripts/validate-runtime.sh "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.validate-runtime.sh.new"
 scp scripts/qq-maid-healthcheck.sh "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.qq-maid-healthcheck.sh.new"
 scp scripts/botmon.sh "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.botmon.sh.new"
+scp scripts/qq-maid-systemd.sh "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.qq-maid-systemd.sh.new"
+scp scripts/windows-startup-example.bat "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/windows-startup-example.bat.new"
 scp runtime/config/.env.example "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.env.example"
 ssh "${REMOTE_HOST}" "mkdir -p '${REMOTE_RUNTIME_DIR}/config'"
 scp runtime/config/agent.toml "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/config/agent.toml.new"
@@ -81,8 +85,8 @@ scp -r runtime/static "${REMOTE_HOST}:${REMOTE_RUNTIME_DIR}/.static.new"
 
 echo "==> Installing artifacts..."
 # 设置可执行权限后，将临时文件原子地替换为目标文件；清理旧 qq-maid-* 时需保留
-# 当前二进制和健康检查脚本，避免远端巡检入口在部署后被误删。
-ssh "${REMOTE_HOST}" "cd '${REMOTE_RUNTIME_DIR}' && rm -rf static.old && chmod 0755 .qq-maid-bot.new .botctl.sh.new .diagnose-network.sh.new .validate-runtime.sh.new .qq-maid-healthcheck.sh.new .botmon.sh.new && mv -f .qq-maid-bot.new qq-maid-bot && mv -f .botctl.sh.new botctl.sh && mv -f .diagnose-network.sh.new diagnose-network.sh && mv -f .validate-runtime.sh.new validate-runtime.sh && mv -f .qq-maid-healthcheck.sh.new qq-maid-healthcheck.sh && mv -f .botmon.sh.new botmon.sh && find . -maxdepth 1 -type f -name 'qq-maid-*' ! -name 'qq-maid-bot' ! -name 'qq-maid-healthcheck.sh' -delete && find . -maxdepth 1 -type f -name '*ctl.sh' ! -name 'botctl.sh' -delete && { test ! -d static || mv static static.old; } && mv .static.new static && rm -rf static.old"
+# 当前二进制、健康检查脚本和 systemd 管理脚本，避免远端巡检/自启动入口在部署后被误删。
+ssh "${REMOTE_HOST}" "cd '${REMOTE_RUNTIME_DIR}' && rm -rf static.old && chmod 0755 .qq-maid-bot.new .botctl.sh.new .diagnose-network.sh.new .validate-runtime.sh.new .qq-maid-healthcheck.sh.new .botmon.sh.new .qq-maid-systemd.sh.new && mv -f .qq-maid-bot.new qq-maid-bot && mv -f .botctl.sh.new botctl.sh && mv -f .diagnose-network.sh.new diagnose-network.sh && mv -f .validate-runtime.sh.new validate-runtime.sh && mv -f .qq-maid-healthcheck.sh.new qq-maid-healthcheck.sh && mv -f .botmon.sh.new botmon.sh && mv -f .qq-maid-systemd.sh.new qq-maid-systemd.sh && mv -f windows-startup-example.bat.new windows-startup-example.bat && find . -maxdepth 1 -type f -name 'qq-maid-*' ! -name 'qq-maid-bot' ! -name 'qq-maid-healthcheck.sh' ! -name 'qq-maid-systemd.sh' -delete && find . -maxdepth 1 -type f -name '*ctl.sh' ! -name 'botctl.sh' -delete && { test ! -d static || mv static static.old; } && mv .static.new static && rm -rf static.old"
 # agent.toml 是运行期活动策略文件。远端已存在时只留下新版本供人工比对，
 # 避免部署覆盖本机模型路线、profile 或 Tool Calling 开关。
 ssh "${REMOTE_HOST}" "cd '${REMOTE_RUNTIME_DIR}' && { test -f config/agent.toml || mv config/agent.toml.new config/agent.toml; }"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -82,7 +82,9 @@ check_archive_contents() {
         "${PACKAGE_NAME}/botmon.sh" \
         "${PACKAGE_NAME}/diagnose-network.sh" \
         "${PACKAGE_NAME}/validate-runtime.sh" \
-        "${PACKAGE_NAME}/qq-maid-healthcheck.sh"
+        "${PACKAGE_NAME}/qq-maid-healthcheck.sh" \
+        "${PACKAGE_NAME}/qq-maid-systemd.sh" \
+        "${PACKAGE_NAME}/windows-startup-example.bat"
     do
         if ! printf '%s\n' "${listing}" | grep -Fx "${required}" >/dev/null; then
             die "archive missing ${required#${PACKAGE_NAME}/}"
@@ -104,7 +106,9 @@ main() {
     copy_executable scripts/diagnose-network.sh "${STAGING_DIR}/diagnose-network.sh"
     copy_executable scripts/validate-runtime.sh "${STAGING_DIR}/validate-runtime.sh"
     copy_executable scripts/qq-maid-healthcheck.sh "${STAGING_DIR}/qq-maid-healthcheck.sh"
+    copy_executable scripts/qq-maid-systemd.sh "${STAGING_DIR}/qq-maid-systemd.sh"
     copy_file runtime/README.md "${STAGING_DIR}/README.md"
+    copy_file scripts/windows-startup-example.bat "${STAGING_DIR}/windows-startup-example.bat"
     copy_file runtime/config/.env.example "${STAGING_DIR}/.env.example"
     copy_file runtime/static/index.html "${STAGING_DIR}/static/index.html"
 
@@ -140,7 +144,7 @@ main() {
             if printf '%s\n' "${zip_listing}" | grep -E '(^|[ /])\.env$|(^|[ /])app\.db$|(^|[ /])[^/]*\.db$|(^|[ /])logs/|(^|[ /])run/.*\.pid$' >/dev/null; then
                 die "archive contains forbidden runtime files"
             fi
-            for required in ".env.example" "static/index.html" "botctl.sh" "botmon.sh" "diagnose-network.sh" "validate-runtime.sh" "qq-maid-healthcheck.sh"; do
+            for required in ".env.example" "static/index.html" "botctl.sh" "botmon.sh" "diagnose-network.sh" "validate-runtime.sh" "qq-maid-healthcheck.sh" "qq-maid-systemd.sh" "windows-startup-example.bat"; do
                 if ! printf '%s\n' "${zip_listing}" | grep -F "${PACKAGE_NAME}/${required}" >/dev/null; then
                     die "archive missing ${required}"
                 fi
@@ -163,6 +167,8 @@ main() {
     test -x "${STAGING_DIR}/diagnose-network.sh"
     test -x "${STAGING_DIR}/validate-runtime.sh"
     test -x "${STAGING_DIR}/qq-maid-healthcheck.sh"
+    test -x "${STAGING_DIR}/qq-maid-systemd.sh"
+    test -f "${STAGING_DIR}/windows-startup-example.bat"
     test -f "${STAGING_DIR}/static/index.html"
 
     printf 'created %s\n' "${ARCHIVE_PATH}"

--- a/scripts/qq-maid-systemd.sh
+++ b/scripts/qq-maid-systemd.sh
@@ -5,8 +5,10 @@ SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ -d "${SCRIPT_DIR}/config" ]]; then
     DEFAULT_RUNTIME_DIR="${SCRIPT_DIR}"
-else
+elif [[ -d "${SCRIPT_DIR}/../runtime" ]]; then
     DEFAULT_RUNTIME_DIR="$(CDPATH= cd -- "${SCRIPT_DIR}/../runtime" && pwd)"
+else
+    DEFAULT_RUNTIME_DIR="${SCRIPT_DIR}/../runtime"
 fi
 
 COMMAND="${1:-render}"
@@ -136,22 +138,46 @@ resolve_defaults() {
     ENV_FILE="$(abs_path "${ENV_FILE}")"
 }
 
-validate_inputs() {
+validate_common_inputs() {
     [[ "${SCOPE}" == "system" || "${SCOPE}" == "user" ]] || die "--scope must be system or user"
+    validate_system_user
+    validate_service_name
+}
+
+validate_render_install_inputs() {
+    validate_common_inputs
     validate_systemd_path "runtime dir" "${RUNTIME_DIR}"
     validate_systemd_path "binary path" "${BINARY}"
     validate_systemd_path "env file path" "${ENV_FILE}"
-    validate_system_user
-    validate_service_name
     [[ -d "${RUNTIME_DIR}" ]] || die "runtime dir not found: ${RUNTIME_DIR}"
     [[ -f "${RUNTIME_DIR}/botctl.sh" ]] || die "botctl.sh not found in runtime dir: ${RUNTIME_DIR}"
     [[ -f "${BINARY}" ]] || die "binary not found: ${BINARY}"
     [[ -f "${ENV_FILE}" ]] || die "env file not found: ${ENV_FILE}"
 }
 
+validate_uninstall_inputs() {
+    validate_common_inputs
+    if [[ "${SCOPE}" == "user" ]]; then
+        user_service_config_home >/dev/null
+    fi
+}
+
+user_service_config_home() {
+    if [[ -n "${XDG_CONFIG_HOME:-}" ]]; then
+        printf '%s\n' "${XDG_CONFIG_HOME}"
+        return 0
+    fi
+    if [[ -n "${HOME:-}" ]]; then
+        printf '%s/.config\n' "${HOME}"
+        return 0
+    fi
+    die "HOME is not set; set HOME or XDG_CONFIG_HOME to locate user systemd service directory"
+}
+
 service_path() {
     if [[ "${SCOPE}" == "user" ]]; then
-        local config_home="${XDG_CONFIG_HOME:-${HOME}/.config}"
+        local config_home
+        config_home="$(user_service_config_home)"
         printf '%s/systemd/user/%s.service\n' "${config_home}" "${SERVICE_NAME}"
     else
         printf '/etc/systemd/system/%s.service\n' "${SERVICE_NAME}"
@@ -298,18 +324,20 @@ case "${COMMAND}" in
         ;;
 esac
 
-resolve_defaults
-validate_inputs
-
 case "${COMMAND}" in
     render)
+        resolve_defaults
+        validate_render_install_inputs
         echo "target: $(service_path)"
         render_service
         ;;
     install)
+        resolve_defaults
+        validate_render_install_inputs
         install_service
         ;;
     uninstall)
+        validate_uninstall_inputs
         uninstall_service
         ;;
     *)

--- a/scripts/qq-maid-systemd.sh
+++ b/scripts/qq-maid-systemd.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -d "${SCRIPT_DIR}/config" ]]; then
+    DEFAULT_RUNTIME_DIR="${SCRIPT_DIR}"
+else
+    DEFAULT_RUNTIME_DIR="$(CDPATH= cd -- "${SCRIPT_DIR}/../runtime" && pwd)"
+fi
+
+COMMAND="${1:-render}"
+if [[ $# -gt 0 ]]; then
+    shift
+fi
+
+SERVICE_NAME="qq-maid-bot"
+SCOPE="system"
+RUNTIME_DIR="${QQ_MAID_RUNTIME_DIR:-${DEFAULT_RUNTIME_DIR}}"
+BINARY=""
+ENV_FILE=""
+RUN_AS_USER="${QQ_MAID_SYSTEMD_USER:-}"
+
+usage() {
+    cat <<'EOF'
+Usage: qq-maid-systemd.sh <command> [options]
+
+Commands:
+  render     Print the generated systemd service without writing files
+  install    Write the service file and run daemon-reload
+  uninstall  Remove the service file and run daemon-reload
+
+Options:
+  --runtime-dir PATH    Runtime directory, default: detected runtime/
+  --binary PATH         qq-maid-bot executable, default: <runtime-dir>/qq-maid-bot
+  --env-file PATH       Env file, default: config/.env then .env under runtime
+  --service-name NAME   Service name without ".service", default: qq-maid-bot
+  --scope system|user   Install as system or user service, default: system
+  --user NAME           Linux user for system service; omit for current systemd user
+  -h, --help            Show this help
+
+Examples:
+  bash scripts/qq-maid-systemd.sh render --runtime-dir /opt/qqbot/runtime --user qqmaid
+  sudo bash scripts/qq-maid-systemd.sh install --runtime-dir /opt/qqbot/runtime --user qqmaid
+  bash scripts/qq-maid-systemd.sh install --scope user --runtime-dir "$HOME/qq-maid-bot/runtime"
+EOF
+}
+
+die() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+abs_path() {
+    local path="$1"
+    if [[ "${path}" == /* ]]; then
+        printf '%s\n' "${path}"
+    else
+        printf '%s/%s\n' "$(pwd)" "${path}"
+    fi
+}
+
+quote_env_value() {
+    local value="$1"
+    value="${value//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    printf '"%s"' "${value}"
+}
+
+validate_service_name() {
+    [[ "${SERVICE_NAME}" =~ ^[A-Za-z0-9_.@-]+$ ]] || die "invalid service name: ${SERVICE_NAME}"
+    SERVICE_NAME="${SERVICE_NAME%.service}"
+}
+
+resolve_defaults() {
+    RUNTIME_DIR="$(abs_path "${RUNTIME_DIR}")"
+    BINARY="${BINARY:-${RUNTIME_DIR}/qq-maid-bot}"
+
+    if [[ -z "${ENV_FILE}" ]]; then
+        if [[ -f "${RUNTIME_DIR}/config/.env" ]]; then
+            ENV_FILE="${RUNTIME_DIR}/config/.env"
+        else
+            ENV_FILE="${RUNTIME_DIR}/.env"
+        fi
+    fi
+
+    BINARY="$(abs_path "${BINARY}")"
+    ENV_FILE="$(abs_path "${ENV_FILE}")"
+}
+
+validate_inputs() {
+    [[ "${SCOPE}" == "system" || "${SCOPE}" == "user" ]] || die "--scope must be system or user"
+    [[ -d "${RUNTIME_DIR}" ]] || die "runtime dir not found: ${RUNTIME_DIR}"
+    [[ -f "${RUNTIME_DIR}/botctl.sh" ]] || die "botctl.sh not found in runtime dir: ${RUNTIME_DIR}"
+    [[ -f "${BINARY}" ]] || die "binary not found: ${BINARY}"
+    [[ -f "${ENV_FILE}" ]] || die "env file not found: ${ENV_FILE}"
+    validate_service_name
+}
+
+service_path() {
+    if [[ "${SCOPE}" == "user" ]]; then
+        local config_home="${XDG_CONFIG_HOME:-${HOME}/.config}"
+        printf '%s/systemd/user/%s.service\n' "${config_home}" "${SERVICE_NAME}"
+    else
+        printf '/etc/systemd/system/%s.service\n' "${SERVICE_NAME}"
+    fi
+}
+
+systemctl_cmd() {
+    if [[ "${SCOPE}" == "user" ]]; then
+        printf 'systemctl --user'
+    else
+        printf 'systemctl'
+    fi
+}
+
+render_service() {
+    local install_target user_line
+    if [[ "${SCOPE}" == "user" ]]; then
+        install_target="default.target"
+        user_line=""
+    else
+        install_target="multi-user.target"
+        if [[ -n "${RUN_AS_USER}" ]]; then
+            user_line="User=${RUN_AS_USER}"
+        else
+            user_line=""
+        fi
+    fi
+
+    cat <<EOF
+[Unit]
+Description=QQ Maid Bot
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+EOF
+    if [[ -n "${user_line}" ]]; then
+        printf '%s\n' "${user_line}"
+    fi
+    cat <<EOF
+WorkingDirectory=${RUNTIME_DIR}
+Environment=$(quote_env_value "QQ_MAID_RUNTIME_DIR=${RUNTIME_DIR}")
+Environment=$(quote_env_value "BOT_BINARY=${BINARY}")
+Environment=$(quote_env_value "BOT_ENV_FILE=${ENV_FILE}")
+ExecStart=${RUNTIME_DIR}/botctl.sh run
+Restart=on-failure
+RestartSec=5s
+KillSignal=SIGTERM
+TimeoutStopSec=30s
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+
+[Install]
+WantedBy=${install_target}
+EOF
+}
+
+install_service() {
+    command -v systemctl >/dev/null 2>&1 || die "systemctl not found; use the non-systemd fallback in runtime/README.md"
+
+    local target
+    target="$(service_path)"
+
+    if [[ "${SCOPE}" == "system" && "${EUID}" -ne 0 ]]; then
+        die "system service install requires root; rerun with sudo or use --scope user"
+    fi
+
+    echo "target: ${target}"
+    echo "service content:"
+    render_service
+
+    mkdir -p "$(dirname -- "${target}")"
+    render_service > "${target}"
+    chmod 0644 "${target}"
+    $(systemctl_cmd) daemon-reload
+
+    echo "installed ${target}"
+    echo "next: $(systemctl_cmd) enable --now ${SERVICE_NAME}.service"
+}
+
+uninstall_service() {
+    command -v systemctl >/dev/null 2>&1 || die "systemctl not found"
+
+    local target
+    target="$(service_path)"
+
+    if [[ "${SCOPE}" == "system" && "${EUID}" -ne 0 ]]; then
+        die "system service uninstall requires root; rerun with sudo or use --scope user"
+    fi
+
+    if [[ -f "${target}" ]]; then
+        $(systemctl_cmd) disable --now "${SERVICE_NAME}.service" 2>/dev/null || true
+        rm -f "${target}"
+        $(systemctl_cmd) daemon-reload
+        echo "removed ${target}"
+    else
+        echo "service file not found: ${target}"
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --runtime-dir)
+            RUNTIME_DIR="${2:-}"
+            shift 2
+            ;;
+        --binary)
+            BINARY="${2:-}"
+            shift 2
+            ;;
+        --env-file)
+            ENV_FILE="${2:-}"
+            shift 2
+            ;;
+        --service-name)
+            SERVICE_NAME="${2:-}"
+            shift 2
+            ;;
+        --scope)
+            SCOPE="${2:-}"
+            shift 2
+            ;;
+        --user)
+            RUN_AS_USER="${2:-}"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown option: $1"
+            ;;
+    esac
+done
+
+case "${COMMAND}" in
+    -h|--help|help)
+        usage
+        exit 0
+        ;;
+esac
+
+resolve_defaults
+validate_inputs
+
+case "${COMMAND}" in
+    render)
+        echo "target: $(service_path)"
+        render_service
+        ;;
+    install)
+        install_service
+        ;;
+    uninstall)
+        uninstall_service
+        ;;
+    *)
+        usage >&2
+        exit 2
+        ;;
+esac

--- a/scripts/qq-maid-systemd.sh
+++ b/scripts/qq-maid-systemd.sh
@@ -51,6 +51,15 @@ die() {
     exit 1
 }
 
+require_value() {
+    local option="$1"
+    local value="${2-}"
+    if [[ $# -lt 2 || -z "${value}" || "${value}" == --* ]]; then
+        die "${option} requires a value"
+    fi
+    printf '%s\n' "${value}"
+}
+
 abs_path() {
     local path="$1"
     if [[ "${path}" == /* ]]; then
@@ -68,8 +77,47 @@ quote_env_value() {
 }
 
 validate_service_name() {
-    [[ "${SERVICE_NAME}" =~ ^[A-Za-z0-9_.@-]+$ ]] || die "invalid service name: ${SERVICE_NAME}"
     SERVICE_NAME="${SERVICE_NAME%.service}"
+    [[ -n "${SERVICE_NAME}" ]] || die "--service-name must not be empty"
+    [[ "${SERVICE_NAME}" =~ ^[A-Za-z0-9_.@-]+$ ]] || die "invalid service name: ${SERVICE_NAME}; allowed: letters, digits, dot, underscore, @ and dash"
+}
+
+validate_systemd_path() {
+    local name="$1"
+    local value="$2"
+    [[ -n "${value}" ]] || die "${name} must not be empty"
+    if [[ "${value}" =~ [[:cntrl:]] ]]; then
+        die "${name} contains control characters, which are not safe in systemd unit fields"
+    fi
+    if [[ "${value}" =~ [[:space:]] ]]; then
+        die "${name} contains whitespace; use a path without spaces for systemd unit generation"
+    fi
+    if [[ "${value}" == *%* ]]; then
+        die "${name} contains %, which systemd treats as a specifier; use a path without %"
+    fi
+}
+
+validate_system_user() {
+    if [[ "${SCOPE}" == "user" ]]; then
+        if [[ -n "${RUN_AS_USER}" ]]; then
+            die "--user and QQ_MAID_SYSTEMD_USER are only valid with --scope system"
+        fi
+        return 0
+    fi
+
+    [[ -z "${RUN_AS_USER}" ]] && return 0
+    if [[ "${RUN_AS_USER}" =~ [[:cntrl:]] || "${RUN_AS_USER}" =~ [[:space:]] ]]; then
+        die "--user contains whitespace or control characters"
+    fi
+    if [[ "${RUN_AS_USER}" == */* ]]; then
+        die "--user must be a Linux user name, not a path"
+    fi
+    if [[ "${RUN_AS_USER}" == *:* ]]; then
+        die "--user must not contain ':'"
+    fi
+    if [[ ! "${RUN_AS_USER}" =~ ^[A-Za-z_][A-Za-z0-9_.@-]*[$]?$ && ! "${RUN_AS_USER}" =~ ^[0-9]+$ ]]; then
+        die "--user has invalid format; use a Linux user name or numeric UID"
+    fi
 }
 
 resolve_defaults() {
@@ -90,11 +138,15 @@ resolve_defaults() {
 
 validate_inputs() {
     [[ "${SCOPE}" == "system" || "${SCOPE}" == "user" ]] || die "--scope must be system or user"
+    validate_systemd_path "runtime dir" "${RUNTIME_DIR}"
+    validate_systemd_path "binary path" "${BINARY}"
+    validate_systemd_path "env file path" "${ENV_FILE}"
+    validate_system_user
+    validate_service_name
     [[ -d "${RUNTIME_DIR}" ]] || die "runtime dir not found: ${RUNTIME_DIR}"
     [[ -f "${RUNTIME_DIR}/botctl.sh" ]] || die "botctl.sh not found in runtime dir: ${RUNTIME_DIR}"
     [[ -f "${BINARY}" ]] || die "binary not found: ${BINARY}"
     [[ -f "${ENV_FILE}" ]] || die "env file not found: ${ENV_FILE}"
-    validate_service_name
 }
 
 service_path() {
@@ -179,6 +231,7 @@ install_service() {
     $(systemctl_cmd) daemon-reload
 
     echo "installed ${target}"
+    echo "before enabling: run './botctl.sh stop' in ${RUNTIME_DIR} if a background botctl process is already running"
     echo "next: $(systemctl_cmd) enable --now ${SERVICE_NAME}.service"
 }
 
@@ -205,27 +258,27 @@ uninstall_service() {
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --runtime-dir)
-            RUNTIME_DIR="${2:-}"
+            RUNTIME_DIR="$(require_value "$1" "${2-}")"
             shift 2
             ;;
         --binary)
-            BINARY="${2:-}"
+            BINARY="$(require_value "$1" "${2-}")"
             shift 2
             ;;
         --env-file)
-            ENV_FILE="${2:-}"
+            ENV_FILE="$(require_value "$1" "${2-}")"
             shift 2
             ;;
         --service-name)
-            SERVICE_NAME="${2:-}"
+            SERVICE_NAME="$(require_value "$1" "${2-}")"
             shift 2
             ;;
         --scope)
-            SCOPE="${2:-}"
+            SCOPE="$(require_value "$1" "${2-}")"
             shift 2
             ;;
         --user)
-            RUN_AS_USER="${2:-}"
+            RUN_AS_USER="$(require_value "$1" "${2-}")"
             shift 2
             ;;
         -h|--help)

--- a/scripts/validate-release-runtime.sh
+++ b/scripts/validate-release-runtime.sh
@@ -35,6 +35,8 @@ require_executable validate-runtime.sh
 require_executable diagnose-network.sh
 require_executable qq-maid-healthcheck.sh
 require_executable botmon.sh
+require_executable qq-maid-systemd.sh
+require_file windows-startup-example.bat
 require_file .env.example
 require_file config/agent.toml
 require_file README.md

--- a/scripts/windows-startup-example.bat
+++ b/scripts/windows-startup-example.bat
@@ -1,0 +1,25 @@
+@echo off
+setlocal
+
+rem 如果把本文件放在发布包根目录，默认使用脚本所在目录作为运行目录。
+rem 如果把本文件复制到 Windows 启动文件夹，请把下一行改成真实发布包目录。
+set "QQ_MAID_RUNTIME_DIR=%~dp0"
+
+set "BOT_BINARY=%QQ_MAID_RUNTIME_DIR%qq-maid-bot.exe"
+set "BOT_ENV_FILE=%QQ_MAID_RUNTIME_DIR%config\.env"
+
+if not exist "%BOT_BINARY%" (
+  echo qq-maid-bot.exe not found: "%BOT_BINARY%"
+  pause
+  exit /b 1
+)
+
+if not exist "%BOT_ENV_FILE%" (
+  echo env file not found: "%BOT_ENV_FILE%"
+  echo Copy config\.env.example to config\.env and edit it first.
+  pause
+  exit /b 1
+)
+
+cd /d "%QQ_MAID_RUNTIME_DIR%"
+"%BOT_BINARY%"


### PR DESCRIPTION
## Summary

- add a systemd helper that renders, installs, and uninstalls qq-maid-bot service files without silent privilege escalation
- add `botctl.sh run` for foreground process managers and include startup helper files in install/release packaging
- document systemd, Windows login startup, and non-systemd fallback paths

Closes #370

## Checks

- `bash -n scripts/botctl.sh`
- `bash -n scripts/qq-maid-systemd.sh`
- `bash -n scripts/package-release.sh`
- `bash -n scripts/validate-release-runtime.sh`
- `bash scripts/qq-maid-systemd.sh render --runtime-dir scripts --binary /bin/true --env-file runtime/config/.env.example --user qqmaid`
- `bash scripts/qq-maid-systemd.sh render --scope user --runtime-dir scripts --binary /bin/true --env-file runtime/config/.env.example`
- `bash scripts/qq-maid-systemd.sh --help`
- `git diff --check`