### PR TITLE
[codex] 简化 Todo 写操作回执

### DIFF
--- a/qq-maid-core/src/runtime/respond/agent_outcome.rs
+++ b/qq-maid-core/src/runtime/respond/agent_outcome.rs
@@ -546,19 +546,16 @@ mod tests {
     }
 
     #[test]
-    fn simulated_fact_card_and_todo_receipt_are_ordered_by_block_type() {
+    fn simulated_fact_card_and_light_todo_receipt_are_ordered_by_block_type() {
         let turn = AgentTurnOutcome::from_outcomes(vec![
             outcome(
                 "create_todo",
                 "todo",
                 ToolOutcomeStatus::Succeeded,
                 ToolEffect::Created,
-                vec![
-                    ResponseBlock::MutationReceipt(CommandBody::plain(
-                        "✅ 已新增待办\n乘坐 G34 前往北京南",
-                    )),
-                    ResponseBlock::RelatedList(CommandBody::plain("🚧 当前进行中 · 共 1 项")),
-                ],
+                vec![ResponseBlock::MutationReceipt(CommandBody::plain(
+                    "✅ 已新增待办\n乘坐 G34 前往北京南",
+                ))],
             ),
             outcome(
                 "train_search",

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -898,7 +898,7 @@ async fn tool_loop_created_todo_survives_chat_history_save_and_records_last_acti
         .unwrap();
     let first_text = first.text.unwrap();
     assert!(first_text.contains("✅ 已新增待办"));
-    assert!(first_text.contains("🚧 当前进行中 · 共 1 项"));
+    assert!(!first_text.contains("🚧 当前进行中 · 共 1 项"));
     let first_diagnostics = first.diagnostics.unwrap();
     assert_eq!(first_diagnostics["todo_success_claimed"], true);
     assert_eq!(first_diagnostics["todo_success_verified"], true);
@@ -1160,7 +1160,7 @@ async fn todo_success_then_failure_is_partial_success_and_keeps_database_change(
 }
 
 #[tokio::test]
-async fn multiple_successful_todo_writes_share_one_related_list() {
+async fn multiple_successful_todo_writes_share_one_background_snapshot() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
         .with_tool_calls_json(
@@ -1186,12 +1186,12 @@ async fn multiple_successful_todo_writes_share_one_related_list() {
 
     let text = response.text.unwrap();
     assert_eq!(text.matches("✅ 已新增待办").count(), 2);
-    assert_eq!(text.matches("🚧 当前进行中").count(), 1);
+    assert_eq!(text.matches("🚧 当前进行中").count(), 0);
     assert!(text.contains("第一条新增"));
     assert!(text.contains("第二条新增"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["agent_turn_status"], "succeeded");
-    assert_eq!(diagnostics["tool_outcomes"].as_array().unwrap().len(), 3);
+    assert_eq!(diagnostics["tool_outcomes"].as_array().unwrap().len(), 2);
     let todos = service.todo_store.list_pending(&owner).unwrap();
     assert_eq!(todos.len(), 2);
     let session = service
@@ -1200,7 +1200,7 @@ async fn multiple_successful_todo_writes_share_one_related_list() {
         .unwrap();
     let snapshot = session
         .last_todo_query
-        .expect("missing final related list snapshot");
+        .expect("missing background refreshed snapshot");
     assert_eq!(snapshot.result_ids.len(), 2);
 }
 
@@ -2054,8 +2054,8 @@ async fn todo_edit_receipt_shows_final_detail_card() {
     assert!(text.contains("✏️ 已修改待办"));
     assert!(text.contains("装宽带 · 时间：99-01-01（四）"));
     assert!(text.contains("详情：\n提前确认地址"));
-    // 修改回执和自动刷新的当前列表都应展示详情，避免用户误以为详情没有写入。
-    assert!(text.contains("   提前确认地址"));
+    // 写操作默认不再刷新完整列表；详情只需在修改回执本身展示。
+    assert!(!text.contains("🚧 当前进行中"));
     assert!(!text.contains("旧详情"));
     assert!(!text.contains("created_at"));
     assert_eq!(
@@ -2307,6 +2307,7 @@ async fn todo_cancel_pending_item_executes_without_confirmation() {
         text.contains("第二条待取消"),
         "response should mention cancelled item: {text}"
     );
+    assert!(!text.contains("⛔ 当前已取消"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["agent_turn_status"], "succeeded");
     assert_eq!(diagnostics["tool_outcomes"][0]["status"], "succeeded");
@@ -2519,7 +2520,7 @@ async fn todo_internal_list_before_write_is_not_user_visible_query() {
 
     let text = response.text.unwrap();
     assert!(text.contains("✅ 已完成待办"));
-    assert!(text.contains("🚧 当前进行中 · 共 1 项"));
+    assert!(!text.contains("🚧 当前进行中 · 共 1 项"));
     assert!(!text.contains("先完成\n状态：未完成"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(
@@ -2527,14 +2528,15 @@ async fn todo_internal_list_before_write_is_not_user_visible_query() {
         serde_json::json!(["list_todos", "complete_todos"])
     );
     let outcomes = diagnostics["tool_outcomes"].as_array().unwrap();
-    assert_eq!(outcomes.len(), 2);
+    assert_eq!(outcomes.len(), 1);
     assert_eq!(outcomes[0]["tool"], "complete_todos");
-    assert_eq!(outcomes[1]["tool"], "todo_related_list");
     let session = service
         .session_store
         .get_or_create_active(&private_test_meta())
         .unwrap();
-    let snapshot = session.last_todo_query.expect("missing visible snapshot");
+    let snapshot = session
+        .last_todo_query
+        .expect("missing background refreshed snapshot");
     assert_eq!(snapshot.query_type, "list");
     assert_eq!(snapshot.result_ids.len(), 1);
     assert_eq!(inspector.tool_call_count(), 1);

--- a/qq-maid-core/src/runtime/respond/tests/pending.rs
+++ b/qq-maid-core/src/runtime/respond/tests/pending.rs
@@ -163,7 +163,7 @@ async fn todo_add_pending_confirm_and_cancel_are_supported_for_tool_path() {
     let text = confirmed.text.unwrap();
     assert!(text.contains("✅ 已新增待办"));
     assert!(text.contains("买牛奶"));
-    assert!(text.contains("🚧 当前进行中 · 共 1 项"));
+    assert!(!text.contains("🚧 当前进行中 · 共 1 项"));
     let todos = service.todo_store.list_pending(&owner).unwrap();
     assert_eq!(todos.len(), 1);
     let session = service
@@ -289,7 +289,7 @@ async fn todo_add_confirm_keeps_fresh_last_todo_action_over_stale_db_snapshot() 
     let text = confirmed.text.unwrap();
     assert!(text.contains("✅ 已新增待办"));
     assert!(text.contains("新待办"));
-    assert!(text.contains("🚧 当前进行中"));
+    assert!(!text.contains("🚧 当前进行中"));
 
     // 确认后 last_todo_action 必须指向刚新增的“新待办”；
     // 若 append_pending_response 未合并该字段，latest 里的旧值会反向覆盖。
@@ -337,6 +337,7 @@ async fn todo_delete_confirm_pending_item_refreshes_snapshot_after_delete() {
     let confirmed = service.respond(message("确认")).await.unwrap();
     let text = confirmed.text.unwrap();
     assert!(text.contains("已永久删除 1 条进行中待办"));
+    assert!(!text.contains("🚧 当前进行中"));
 
     let session = service
         .session_store

--- a/qq-maid-core/src/runtime/respond/tests/todo_receipt.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo_receipt.rs
@@ -3,7 +3,7 @@ use qq_maid_llm::provider::ToolCallingProtocol;
 use super::support::*;
 
 #[tokio::test]
-async fn todo_complete_receipt_refreshes_pending_list_and_collapses_one_hidden_item() {
+async fn todo_complete_receipt_is_lightweight_and_refreshes_pending_snapshot() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
         .with_tool_call_json(
@@ -26,13 +26,13 @@ async fn todo_complete_receipt_refreshes_pending_list_and_collapses_one_hidden_i
 
     let text = response.text.unwrap();
     assert!(text.contains("✅ 已完成待办 · 1条"));
-    assert!(text.contains("🚧 当前进行中 · 共 6 项"));
-    assert!(text.contains("还有 1 项进行中待办，可说“查看全部进行中待办”。"));
+    assert!(!text.contains("🚧 当前进行中 · 共 6 项"));
+    assert!(!text.contains("还有 1 项进行中待办"));
     assert_refreshed_pending_snapshot(&service, &owner, 5);
 }
 
 #[tokio::test]
-async fn todo_complete_receipt_collapses_two_hidden_items() {
+async fn todo_complete_receipt_refreshes_pending_snapshot_with_two_hidden_items() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
         .with_tool_call_json(
@@ -54,13 +54,14 @@ async fn todo_complete_receipt_collapses_two_hidden_items() {
         .unwrap();
 
     let text = response.text.unwrap();
-    assert!(text.contains("🚧 当前进行中 · 共 7 项"));
-    assert!(text.contains("还有 2 项进行中待办，可说“查看全部进行中待办”。"));
+    assert!(text.contains("✅ 已完成待办 · 1条"));
+    assert!(!text.contains("🚧 当前进行中 · 共 7 项"));
+    assert!(!text.contains("还有 2 项进行中待办"));
     assert_refreshed_pending_snapshot(&service, &owner, 5);
 }
 
 #[tokio::test]
-async fn todo_complete_receipt_uses_dynamic_pending_collapse_hint() {
+async fn todo_complete_receipt_refreshes_pending_snapshot_with_dynamic_hidden_count() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
         .with_tool_call_json(
@@ -82,7 +83,8 @@ async fn todo_complete_receipt_uses_dynamic_pending_collapse_hint() {
         .unwrap();
 
     let text = response.text.unwrap();
-    assert!(text.contains("🚧 当前进行中 · 共 8 项"));
-    assert!(text.contains("还有 3 项进行中待办，可说“查看全部进行中待办”。"));
+    assert!(text.contains("✅ 已完成待办 · 1条"));
+    assert!(!text.contains("🚧 当前进行中 · 共 8 项"));
+    assert!(!text.contains("还有 3 项进行中待办"));
     assert_refreshed_pending_snapshot(&service, &owner, 5);
 }

--- a/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
+++ b/qq-maid-core/src/runtime/respond/todo_flow/receipt.rs
@@ -1,8 +1,8 @@
 //! Todo Tool 整轮聚合与确定性回执。
 //!
 //! Tool Loop 只负责理解意图并执行白名单 Tool；Todo Tool 的整轮结果在这里统一判断
-//! 用户可见输出、内部辅助查询、相关列表刷新和 `last_todo_query` 快照，避免通用
-//! chat_flow 或 AgentTurnOutcome 理解 Todo 的具体工具语义。
+//! 用户可见输出、内部辅助查询和 `last_todo_query` 快照，避免通用 chat_flow
+//! 或 AgentTurnOutcome 理解 Todo 的具体工具语义。
 
 use std::collections::HashSet;
 
@@ -103,13 +103,7 @@ pub(in crate::runtime::respond) fn aggregate_todo_tool_results(
             outcomes.push((index, outcome));
         }
     }
-    append_todo_related_list_for_turn(
-        todo_store,
-        session,
-        owner,
-        todo_indexes.last().copied(),
-        &mut outcomes,
-    )?;
+    refresh_todo_snapshot_for_turn(todo_store, session, owner, &outcomes)?;
     Ok(TodoTurnAggregation {
         consumed_result_indexes,
         outcomes,
@@ -157,12 +151,11 @@ fn tool_outcome_from_todo_result(
     }))
 }
 
-fn append_todo_related_list_for_turn(
+fn refresh_todo_snapshot_for_turn(
     todo_store: &TodoStore,
     session: &mut SessionRecord,
     owner: &TodoOwner,
-    anchor_index: Option<usize>,
-    outcomes: &mut Vec<(usize, ToolExecutionOutcome)>,
+    outcomes: &[(usize, ToolExecutionOutcome)],
 ) -> Result<(), LlmError> {
     if outcomes.iter().any(|(_, outcome)| {
         outcome.domain == "todo"
@@ -173,7 +166,7 @@ fn append_todo_related_list_for_turn(
     }
 
     let mut specs = Vec::new();
-    for (_, outcome) in outcomes.iter() {
+    for (_, outcome) in outcomes {
         if outcome.domain != "todo" || outcome.status != ToolOutcomeStatus::Succeeded {
             continue;
         }
@@ -189,24 +182,8 @@ fn append_todo_related_list_for_turn(
     if specs.is_empty() {
         return Ok(());
     }
-    let Some(anchor_index) = anchor_index else {
-        return Ok(());
-    };
     let spec = merge_related_list_specs(&specs);
-    let body = related_list_body(todo_store, session, owner, &spec)?;
-    outcomes.push((
-        anchor_index,
-        ToolExecutionOutcome {
-            tool_name: "todo_related_list".to_owned(),
-            domain: "todo".to_owned(),
-            status: ToolOutcomeStatus::Succeeded,
-            effect: ToolEffect::ReadOnly,
-            presentation: OutcomePresentation::Trusted,
-            blocks: vec![ResponseBlock::RelatedList(body)],
-            error_code: None,
-            command: None,
-        },
-    ));
+    remember_related_list_snapshot(todo_store, session, owner, &spec)?;
     Ok(())
 }
 
@@ -276,18 +253,10 @@ fn list_todos_outcome(
     }
 
     let spec = list_spec_from_output(&result.output);
-    let items = list_for_related_spec(todo_store, owner, &spec).map_err(todo_error)?;
-    let total_count = items.len();
-    let shown = visible_related_items(&items, &spec).to_vec();
-    let truncated = total_count > shown.len();
     // `list_todos` 若成为最终用户可见结果，必须同步写入真实可见快照；
     // 仅在 Tool 内部执行但未展示时，原有内部查询上下文仍由 TodoToolScope 保持。
-    session.remember_last_todo_query(
-        &owner.key,
-        spec.query_type,
-        spec.condition.clone(),
-        shown.iter().map(|item| item.id.clone()).collect(),
-    );
+    let (shown, total_count, truncated) =
+        remember_related_list_snapshot(todo_store, session, owner, &spec)?;
 
     let mut lines = Vec::new();
     let mut markdown_lines = Vec::new();
@@ -591,30 +560,26 @@ fn receipt_with_related_list(
     draft: RelatedReceiptDraft,
 ) -> Result<TodoWriteReceipt, LlmError> {
     let RelatedReceiptDraft {
-        mut lines,
-        mut markdown_lines,
+        lines,
+        markdown_lines,
         spec,
         command,
         trailing_hint,
     } = draft;
-    lines.push(String::new());
-    markdown_lines.push(String::new());
-    let related = related_list_body(todo_store, session, owner, &spec)?;
-    lines.push(related.text);
-    markdown_lines.push(
-        related
-            .markdown
-            .unwrap_or_else(|| lines.last().cloned().unwrap_or_default()),
-    );
+    // 写操作默认只返回轻量确认，但仍后台刷新同一范围的可见快照，
+    // 保证下一轮“第一条 / 刚刚那条”等指代继续落到最新列表。
+    remember_related_list_snapshot(todo_store, session, owner, &spec)?;
+    let mut text = lines.join("\n");
+    let mut markdown = markdown_lines.join("\n");
     if let Some(hint) = trailing_hint {
-        lines.push(String::new());
-        lines.push(hint.to_owned());
-        markdown_lines.push(String::new());
-        markdown_lines.push(hint.to_owned());
+        text.push_str("\n\n");
+        text.push_str(hint);
+        markdown.push_str("\n\n");
+        markdown.push_str(hint);
     }
 
     Ok(TodoWriteReceipt {
-        body: CommandBody::dual(lines.join("\n"), markdown_lines.join("\n")),
+        body: CommandBody::dual(text, markdown),
         command,
         error_code: None,
     })
@@ -645,38 +610,25 @@ fn receipt_with_related_list_body(
     )
 }
 
-fn related_list_body(
+fn remember_related_list_snapshot(
     todo_store: &TodoStore,
     session: &mut SessionRecord,
     owner: &TodoOwner,
     spec: &RelatedListSpec,
-) -> Result<CommandBody, LlmError> {
+) -> Result<(Vec<TodoItem>, usize, bool), LlmError> {
     let items = list_for_related_spec(todo_store, owner, spec).map_err(todo_error)?;
     let total_count = items.len();
     let shown = visible_related_items(&items, spec).to_vec();
     let truncated = total_count > shown.len();
-    // 快照只保存本次真正展示的可编号条目；隐藏项不能拥有用户没看到的编号。
+    // 后台刷新仍沿用列表折叠边界：只有下一轮可直接引用的条目进入编号快照，
+    // 隐藏项必须通过显式查看完整列表后才获得编号。
     session.remember_last_todo_query(
         &owner.key,
         spec.query_type,
         spec.condition.clone(),
         shown.iter().map(|item| item.id.clone()).collect(),
     );
-    let mut lines = Vec::new();
-    let mut markdown_lines = Vec::new();
-    append_related_list(&mut lines, &shown, total_count, truncated, spec, false);
-    append_related_list(
-        &mut markdown_lines,
-        &shown,
-        total_count,
-        truncated,
-        spec,
-        true,
-    );
-    Ok(CommandBody::dual(
-        lines.join("\n"),
-        markdown_lines.join("\n"),
-    ))
+    Ok((shown, total_count, truncated))
 }
 
 fn visible_related_items<'a>(items: &'a [TodoItem], spec: &RelatedListSpec) -> &'a [TodoItem] {


### PR DESCRIPTION
## 概要

- Todo 写操作成功后默认只输出轻量确认，不再自动追加完整相关列表。
- 保留写操作后的后台 Todo 快照刷新，后续 "第一条 / 第二条 / 刚刚那条" 仍可基于最新列表解析。
- 显式 list_todos / 查看待办路径继续展示列表并写入可见快照。
- 同步更新 Todo 回执测试和响应编排测试母版。

## 根因

原先 Todo Tool 聚合层会在成功写操作后自动追加 todo_related_list；pending 确认路径也会把相关列表拼到回执正文中。这个逻辑同时承担快照刷新和用户可见列表展示，导致新增、完成、取消、删除等写操作默认刷完整列表。

## 验证

- cargo fmt --all -- --check
- cargo test -p qq-maid-core runtime::respond::tests::todo_receipt --all-features
- cargo test -p qq-maid-core runtime::respond::tests::todo_tool_loop --all-features
- cargo test -p qq-maid-core runtime::respond::tests::pending --all-features
- cargo test -p qq-maid-core runtime::respond::tests::chat --all-features
- cargo test -p qq-maid-core runtime::respond::agent_outcome --all-features
- make test-core
- cargo clippy -p qq-maid-core --all-targets --all-features -- -D warnings
- cargo test -p qq-maid-core --all-features
- git diff --check

Closes #379