### PR TITLE
fix: 修复 RSS 标题污染

### DIFF
--- a/qq-maid-common/src/markdown_strip.rs
+++ b/qq-maid-common/src/markdown_strip.rs
@@ -244,7 +244,13 @@ fn parse_markdown_link(chars: &[char], start: usize) -> Option<(String, String, 
     }
     let url_end = find_closing_paren(chars, url_start)?;
     let label = chars[start + 1..label_end].iter().collect::<String>();
-    let url = chars[url_start + 1..url_end].iter().collect::<String>();
+    let mut url = chars[url_start + 1..url_end].iter().collect::<String>();
+    if let Some(stripped) = url
+        .strip_prefix('<')
+        .and_then(|value| value.strip_suffix('>'))
+    {
+        url = stripped.to_owned();
+    }
     let next = url_end + 1;
     Some((label, url, next))
 }

--- a/qq-maid-core/src/runtime/respond/command_render.rs
+++ b/qq-maid-core/src/runtime/respond/command_render.rs
@@ -66,7 +66,7 @@ impl CommandRender {
 }
 
 /// 转义会出现在 Markdown 行内语境里的动态文本，避免用户输入破坏结构。
-pub(super) fn escape_markdown_inline(text: &str) -> String {
+pub(crate) fn escape_markdown_inline(text: &str) -> String {
     let mut escaped = String::new();
     for ch in text.trim().replace(['\r', '\n'], " ").chars() {
         if matches!(
@@ -95,7 +95,7 @@ pub(super) fn escape_markdown_inline(text: &str) -> String {
 }
 
 /// 多行段落默认逐行按行内文本转义，避免标题、列表和引用被用户输入意外触发。
-pub(super) fn escape_markdown_text(text: &str) -> String {
+pub(crate) fn escape_markdown_text(text: &str) -> String {
     text.lines()
         .map(escape_markdown_inline)
         .collect::<Vec<_>>()

--- a/qq-maid-core/src/runtime/respond/llm_service/tests.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service/tests.rs
@@ -362,6 +362,15 @@ fn strip_markdown_keeps_links_with_underscores_and_parentheses() {
 }
 
 #[test]
+fn strip_markdown_keeps_angle_bracket_link_targets() {
+    let reply = "[release](<https://github.com/kuliantnt/qq-maid-bot/releases/tag/v0.14.2>)";
+    assert_eq!(
+        strip_markdown_for_chat(reply),
+        "release（https://github.com/kuliantnt/qq-maid-bot/releases/tag/v0.14.2）"
+    );
+}
+
+#[test]
 fn strip_markdown_uses_image_alt_text_without_bang_marker() {
     let reply = "![流程图](https://example.test/a_(b).png)";
     assert_eq!(

--- a/qq-maid-core/src/runtime/respond/mod.rs
+++ b/qq-maid-core/src/runtime/respond/mod.rs
@@ -36,7 +36,7 @@ pub use types::{ChatResponse, RespondPurpose, RespondRequest, RespondResponse};
 mod agent_outcome;
 mod chat_flow;
 mod command_dispatcher;
-mod command_render;
+pub(crate) mod command_render;
 mod common;
 mod conversation_session;
 mod help;

--- a/qq-maid-core/src/runtime/respond/rss_flow.rs
+++ b/qq-maid-core/src/runtime/respond/rss_flow.rs
@@ -5,6 +5,8 @@
 
 use qq_maid_common::time_context::format_rss_time_for_display;
 
+use super::command_render::escape_markdown_inline;
+
 use crate::{
     error::LlmError,
     runtime::{
@@ -17,10 +19,12 @@ use crate::{
 use super::{
     RespondRequest, RespondResponse, RustRespondService,
     common::{
-        GROUP_ADMIN_REQUIRED_REPLY, group_management_allowed, rss_error, structured_command_body,
-        truncate_chars,
+        CommandBody, GROUP_ADMIN_REQUIRED_REPLY, group_management_allowed, rss_error,
+        structured_command_body, truncate_chars,
     },
 };
+
+const RSS_RECENT_TITLE_MAX_CHARS: usize = 120;
 
 impl RustRespondService {
     pub(super) async fn handle_rss_flow(
@@ -86,7 +90,7 @@ impl RustRespondService {
                     .recent_items_by_scope(&target.scope_key, None, limit)
                     .map_err(rss_error)?;
                 (
-                    structured_command_body(format_rss_recent_reply(&subscriptions, &items)),
+                    format_rss_recent_reply(&subscriptions, &items),
                     "rss_recent",
                 )
             }
@@ -519,9 +523,9 @@ fn rss_recent_limit_usage() -> String {
 fn format_rss_recent_reply(
     subscriptions: &[RssSubscription],
     items: &[crate::runtime::rss::RssRecentItem],
-) -> String {
+) -> CommandBody {
     if subscriptions.is_empty() {
-        return "当前会话还没有 RSS 订阅，可使用 /rss add 地址 添加。".to_owned();
+        return CommandBody::plain("当前会话还没有 RSS 订阅，可使用 /rss add 地址 添加。");
     }
     if items.is_empty() {
         let failed_count = failed_subscription_count(subscriptions);
@@ -529,38 +533,62 @@ fn format_rss_recent_reply(
             "当前会话已有 RSS 订阅，但还没有抓到更新。可以等待后台检查，或使用 /rss test 地址 检查订阅源。"
                 .to_owned();
         append_recent_failure_hint(&mut reply, failed_count);
-        return reply;
+        return CommandBody::plain(reply);
     }
 
-    let mut rows = vec!["最近 RSS 更新：".to_owned(), String::new()];
+    let mut text_rows = vec!["最近 RSS 更新：".to_owned(), String::new()];
+    let mut markdown_rows = vec!["# 最近 RSS 更新".to_owned(), String::new()];
     for (index, item) in items.iter().enumerate() {
-        rows.push(format!(
+        let subscription_title = truncate_chars(&item.subscription_title, 40);
+        let item_title = rss_recent_display_title(&item.title);
+        text_rows.push(format!(
             "{}. [{}] {}",
             index + 1,
-            truncate_chars(&item.subscription_title, 40),
-            truncate_chars(&item.title, 120)
+            subscription_title,
+            item_title
         ));
-        rows.push(format!(
-            "   {}",
-            item.link
-                .as_deref()
-                .filter(|link| !link.trim().is_empty())
-                .unwrap_or("链接：当前条目未提供")
-        ));
-        rows.push(format!(
-            "   {}：{}",
+        if let Some(link) = item.link.as_deref().filter(|link| !link.trim().is_empty()) {
+            text_rows.push(format!("   {link}"));
+            markdown_rows.push(format!(
+                "{}. [{}] [{}](<{}>)",
+                index + 1,
+                escape_markdown_inline(&subscription_title),
+                escape_markdown_inline(&item_title),
+                link.trim()
+            ));
+        } else {
+            text_rows.push("   链接：当前条目未提供".to_owned());
+            markdown_rows.push(format!(
+                "{}. **{}** {}",
+                index + 1,
+                escape_markdown_inline(&subscription_title),
+                escape_markdown_inline(&item_title)
+            ));
+        }
+        let time_line = format!(
+            "{}：{}",
             rss_recent_time_label(item),
             format_rss_time_for_display(rss_recent_time_value(item))
-        ));
-        rows.push(String::new());
+        );
+        text_rows.push(format!("   {time_line}"));
+        markdown_rows.push(format!("   {time_line}"));
+        text_rows.push(String::new());
+        markdown_rows.push(String::new());
     }
     let failed_count = failed_subscription_count(subscriptions);
     if failed_count > 0 {
-        rows.push(format!(
-            "提示：{failed_count} 个订阅源最近检查失败，可能有更新延迟。"
-        ));
+        let hint = format!("提示：{failed_count} 个订阅源最近检查失败，可能有更新延迟。");
+        text_rows.push(hint.clone());
+        markdown_rows.push(hint);
     }
-    truncate_chars(&rows.join("\n"), RSS_RECENT_MAX_CHARS)
+    CommandBody::dual(
+        truncate_chars(&text_rows.join("\n"), RSS_RECENT_MAX_CHARS),
+        truncate_chars(&markdown_rows.join("\n"), RSS_RECENT_MAX_CHARS),
+    )
+}
+
+fn rss_recent_display_title(raw: &str) -> String {
+    truncate_chars(&raw.replace(['\r', '\n'], " "), RSS_RECENT_TITLE_MAX_CHARS)
 }
 
 fn failed_subscription_count(subscriptions: &[RssSubscription]) -> usize {

--- a/qq-maid-core/src/runtime/respond/tests/rss.rs
+++ b/qq-maid-core/src/runtime/respond/tests/rss.rs
@@ -242,6 +242,119 @@ async fn rss_recent_returns_items_instead_of_subscription_list() {
 }
 
 #[tokio::test]
+async fn rss_recent_sanitizes_markdown_link_title() {
+    let (service, _) = test_service_with_base();
+    let target = RssTarget {
+        target_type: RssTargetType::Group,
+        target_id: "g1".to_owned(),
+        scope_key: "group:g1".to_owned(),
+    };
+    let sub = service
+        .rss_store
+        .create_subscription(
+            &target,
+            "https://example.test/feed.xml",
+            "Release notes",
+            &[],
+            50,
+        )
+        .unwrap();
+    service
+        .rss_store
+        .enqueue_items(
+            &sub.id,
+            &[RssFeedItem {
+                item_key: "release-1".to_owned(),
+                revision_hash: "rev:release-1".to_owned(),
+                title: "v0.14.2\n[cpa_final_answer](x)".to_owned(),
+                link: Some(
+                    "https://github.com/kuliantnt/qq-maid-bot/releases/tag/v0.14.2".to_owned(),
+                ),
+                published_at: Some("2026-07-08T05:00:00+00:00".to_owned()),
+                updated_at: None,
+                summary: Some("What's Changed\ncpa_final_answer 只作为正文".to_owned()),
+                source_order: 0,
+            }],
+            50,
+        )
+        .unwrap();
+
+    let response = service.respond(message("/rss recent")).await.unwrap();
+    let text = response.text.unwrap();
+    let markdown = response.markdown.unwrap();
+
+    assert!(text.contains("[Release notes] v0.14.2 [cpa_final_answer](x)"));
+    assert!(!text.contains("v0.14.2\n[cpa_final_answer](x)"));
+    assert!(markdown.contains(
+        r"[v0.14.2 \[cpa\_final\_answer\]\(x\)](<https://github.com/kuliantnt/qq-maid-bot/releases/tag/v0.14.2>)"
+    ));
+    assert!(!markdown.contains("[v0.14.2\n"));
+}
+
+#[tokio::test]
+async fn rss_recent_release_regression_keeps_title_isolated_from_protocol_like_summary() {
+    let (service, _) = test_service_with_base();
+    let target = RssTarget {
+        target_type: RssTargetType::Group,
+        target_id: "g1".to_owned(),
+        scope_key: "group:g1".to_owned(),
+    };
+    let sub = service
+        .rss_store
+        .create_subscription(
+            &target,
+            "https://example.test/releases.xml",
+            "Release notes from qq-maid-bot",
+            &[],
+            50,
+        )
+        .unwrap();
+    service
+        .rss_store
+        .enqueue_items(
+            &sub.id,
+            &[RssFeedItem {
+                item_key: "release-v0.14.2".to_owned(),
+                revision_hash: "rev:release-v0.14.2".to_owned(),
+                title: "v0.14.2".to_owned(),
+                link: Some(
+                    "https://github.com/kuliantnt/qq-maid-bot/releases/tag/v0.14.2"
+                        .to_owned(),
+                ),
+                published_at: Some("2026-07-08T05:00:00+00:00".to_owned()),
+                updated_at: None,
+                summary: Some(
+                    "What's Changed\n\ncpa_final_answer\ntool_call\nCPA final answer\n最终回答要求\n如果正确的下一步输出是普通的助手文本最终回答".to_owned(),
+                ),
+                source_order: 0,
+            }],
+            50,
+        )
+        .unwrap();
+
+    let response = service.respond(message("/rss recent")).await.unwrap();
+    let text = response.text.unwrap();
+    let markdown = response.markdown.unwrap();
+
+    assert!(text.contains("[Release notes from qq-maid-bot] v0.14.2"));
+    assert!(!text.contains("[Release notes from qq-maid-bot] cpa_final_answer"));
+    assert!(!text.contains("[Release notes from qq-maid-bot] tool_call"));
+    assert!(
+        markdown
+            .contains("[v0.14.2](<https://github.com/kuliantnt/qq-maid-bot/releases/tag/v0.14.2>)")
+    );
+    assert!(!markdown.contains(
+        "[cpa\\_final\\_answer](<https://github.com/kuliantnt/qq-maid-bot/releases/tag/v0.14.2>)"
+    ));
+    assert!(!markdown.contains(
+        "[tool\\_call](<https://github.com/kuliantnt/qq-maid-bot/releases/tag/v0.14.2>)"
+    ));
+    assert!(!markdown.contains(
+        "[最终回答要求](<https://github.com/kuliantnt/qq-maid-bot/releases/tag/v0.14.2>)"
+    ));
+}
+
+#[tokio::test]
 async fn rss_recent_chinese_alias_and_scope_are_isolated() {
     let (service, _) = test_service_with_base();
     let group_sub = service

--- a/qq-maid-core/src/runtime/rss/feed.rs
+++ b/qq-maid-core/src/runtime/rss/feed.rs
@@ -19,6 +19,7 @@ use crate::storage::rss::RssFeedItem;
 
 const DEFAULT_USER_AGENT: &str = "qq-maid-rss/0.1 (+https://github.com/kuliantnt/qqbot)";
 const RSS_HTML_TEXT_WIDTH: usize = 4000;
+const RSS_TITLE_MAX_CHARS: usize = 240;
 
 #[derive(Debug, Clone)]
 pub struct RssFetchConfig {
@@ -158,7 +159,7 @@ pub fn parse_feed_bytes(
     let title = feed
         .title
         .as_ref()
-        .and_then(|text| clean_feed_text(&text.content))
+        .and_then(|text| sanitize_rss_title(&text.content, RSS_TITLE_MAX_CHARS))
         .unwrap_or_else(|| "未命名订阅".to_owned());
     let items = feed
         .entries
@@ -167,6 +168,21 @@ pub fn parse_feed_bytes(
         .map(|(index, entry)| normalize_entry(&feed, entry, index as i64, summary_limit))
         .collect::<Vec<_>>();
     Ok(ParsedFeed { title, items })
+}
+
+/// 规范化 RSS 标题文本。
+///
+/// 标题必须保持单行、短文本语义：
+/// - 去除控制字符并折叠空白，避免外部标题里的换行破坏 Markdown 结构；
+/// - 限制最大长度，避免异常源站或模型输出把正文整段塞进标题；
+/// - 返回 `None` 表示空值或占位值，调用方再决定回退文案。
+pub fn sanitize_rss_title(raw: &str, limit: usize) -> Option<String> {
+    let text = truncate_chars(&clean_text(raw), limit.max(1));
+    if text.is_empty() || is_placeholder_null(&text) {
+        None
+    } else {
+        Some(text)
+    }
 }
 
 pub fn clean_summary_text(raw: &str, limit: usize) -> Option<String> {
@@ -205,7 +221,7 @@ fn normalize_entry(
     let title = entry
         .title
         .as_ref()
-        .and_then(|text| clean_feed_text(&text.content))
+        .and_then(|text| sanitize_rss_title(&text.content, RSS_TITLE_MAX_CHARS))
         .unwrap_or_else(|| "无标题".to_owned());
     let link = entry.links.first().map(|link| normalize_link(&link.href));
     let original_published_at = entry.published.map(|time| time.to_rfc3339());
@@ -259,7 +275,7 @@ fn stable_item_key(
     let feed_title = feed
         .title
         .as_ref()
-        .and_then(|text| clean_feed_text(&text.content))
+        .and_then(|text| sanitize_rss_title(&text.content, RSS_TITLE_MAX_CHARS))
         .unwrap_or_default();
     let fallback_source = format!(
         "{}|{}|{}",
@@ -368,15 +384,6 @@ fn clean_multiline_text(raw: &str) -> String {
     lines.join("\n")
 }
 
-fn clean_feed_text(raw: &str) -> Option<String> {
-    let text = clean_text(raw);
-    if text.is_empty() || is_placeholder_null(&text) {
-        None
-    } else {
-        Some(text)
-    }
-}
-
 fn clean_revision_text(raw: &str) -> Option<String> {
     let without_scripts = strip_script_style(raw);
     let rendered = html2text::from_read(without_scripts.as_bytes(), RSS_HTML_TEXT_WIDTH)
@@ -457,7 +464,10 @@ fn revision_hash(
     // revision 只包含 feed 自身内容，不能混入抓取时间，否则同内容重复轮询会误判更新。
     let input = [
         ("updated", updated_at.unwrap_or("").trim().to_owned()),
-        ("title", clean_feed_text(title).unwrap_or_default()),
+        (
+            "title",
+            sanitize_rss_title(title, RSS_TITLE_MAX_CHARS).unwrap_or_default(),
+        ),
         (
             "summary",
             summary.and_then(clean_revision_text).unwrap_or_default(),
@@ -655,6 +665,44 @@ mod tests {
         assert_eq!(feed.title, "未命名订阅");
         assert_eq!(feed.items[0].title, "无标题");
         assert_eq!(feed.items[0].summary, None);
+    }
+
+    #[test]
+    fn rss_title_only_comes_from_title_field() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Release notes from qq-maid-bot</title>
+  <entry>
+    <id>tag:example.test,2026:release</id>
+    <title>v0.14.2</title>
+    <link href="https://github.com/kuliantnt/qq-maid-bot/releases/tag/v0.14.2"/>
+    <updated>2026-07-08T08:00:00Z</updated>
+    <summary type="html">&lt;p&gt;What's Changed&lt;/p&gt;&lt;p&gt;CPA 传输协议最终回答要求：不应进入标题。&lt;/p&gt;</summary>
+    <content type="html">&lt;article&gt;&lt;p&gt;cpa_final_answer&lt;/p&gt;&lt;p&gt;tool_call&lt;/p&gt;&lt;/article&gt;</content>
+  </entry>
+</feed>"#;
+
+        let feed = parse_feed_bytes(xml.as_bytes(), None, 500).unwrap();
+
+        assert_eq!(feed.items[0].title, "v0.14.2");
+        assert!(
+            feed.items[0]
+                .summary
+                .as_deref()
+                .unwrap()
+                .contains("What's Changed")
+        );
+        assert!(!feed.items[0].title.contains("CPA 传输协议最终回答要求"));
+        assert!(!feed.items[0].title.contains("cpa_final_answer"));
+        assert!(!feed.items[0].title.contains("tool_call"));
+    }
+
+    #[test]
+    fn rss_title_sanitizes_newlines_and_markdown_chars() {
+        let title = sanitize_rss_title(" v0.14.2\n[测试](link) ", 240).unwrap();
+
+        assert_eq!(title, "v0.14.2 [测试](link)");
+        assert!(!title.contains('\n'));
     }
 
     #[test]

--- a/qq-maid-core/src/runtime/rss/scheduler.rs
+++ b/qq-maid-core/src/runtime/rss/scheduler.rs
@@ -11,10 +11,14 @@ use tokio::time::{Instant, MissedTickBehavior, interval_at};
 use tracing::{debug, info, warn};
 
 use crate::{
-    runtime::push::{PushTarget, PushTargetType},
-    runtime::translation::{
-        TRANSLATION_SOURCE_MAX_LENGTH, TranslationPurpose, TranslationRequest, TranslationService,
-        looks_like_chinese_text,
+    runtime::{
+        push::{PushTarget, PushTargetType},
+        respond::command_render::{escape_markdown_inline, escape_markdown_text},
+        rss::feed::sanitize_rss_title,
+        translation::{
+            TRANSLATION_SOURCE_MAX_LENGTH, TranslationPurpose, TranslationRequest,
+            TranslationService, looks_like_chinese_text,
+        },
     },
     storage::notification::{NotificationOutboxStore, NotificationUpsert},
     storage::rss::{RssPendingItem, RssStore, RssSubscription},
@@ -374,10 +378,11 @@ fn rss_dedupe_key(subscription: &RssSubscription, item: &RssPendingItem) -> Stri
 }
 
 pub fn format_push_message(subscription_title: &str, item: &RssPendingItem) -> String {
+    let title = push_title_text(item.title.as_str());
     let mut rows = vec![
         format!("【RSS 更新】{}", subscription_title.trim()),
         String::new(),
-        item.title.trim().to_owned(),
+        title,
     ];
     if let Some(summary) = item
         .summary
@@ -400,8 +405,12 @@ pub fn format_push_message(subscription_title: &str, item: &RssPendingItem) -> S
 }
 
 pub fn format_push_markdown(subscription_title: &str, item: &RssPendingItem) -> String {
+    let title = push_title_markdown(item.title.as_str());
     let mut rows = vec![
-        format!("## RSS 更新：{}", subscription_title.trim()),
+        format!(
+            "## RSS 更新：{}",
+            escape_markdown_inline(subscription_title.trim())
+        ),
         String::new(),
     ];
     if let Some(link) = item
@@ -409,9 +418,9 @@ pub fn format_push_markdown(subscription_title: &str, item: &RssPendingItem) -> 
         .as_deref()
         .filter(|value| !value.trim().is_empty())
     {
-        rows.push(format!("### [{}]({})", item.title.trim(), link.trim()));
+        rows.push(format!("### [{}](<{}>)", title, link.trim()));
     } else {
-        rows.push(format!("### {}", item.title.trim()));
+        rows.push(format!("### {title}"));
     }
     if let Some(summary) = item
         .summary
@@ -419,7 +428,7 @@ pub fn format_push_markdown(subscription_title: &str, item: &RssPendingItem) -> 
         .filter(|value| !value.trim().is_empty())
     {
         rows.push(String::new());
-        rows.push(summary.trim().to_owned());
+        rows.push(escape_markdown_text(summary.trim()));
     }
     if let Some((label, value)) = item_display_time(item) {
         rows.push(String::new());
@@ -434,6 +443,14 @@ pub fn format_push_markdown(subscription_title: &str, item: &RssPendingItem) -> 
         rows.push(format!("链接：{link}"));
     }
     rows.join("\n")
+}
+
+fn push_title_text(raw: &str) -> String {
+    sanitize_rss_title(raw, 120).unwrap_or_else(|| "无标题".to_owned())
+}
+
+fn push_title_markdown(raw: &str) -> String {
+    escape_markdown_inline(&push_title_text(raw))
 }
 
 fn item_display_time(item: &RssPendingItem) -> Option<(&'static str, &str)> {
@@ -678,6 +695,91 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rss_push_end_to_end_keeps_release_title_when_summary_contains_protocol_text() {
+        let provider = MockTranslationProvider::new(vec![Ok(
+            "v0.14.2。最终回答要求：如果正确的下一步输出是普通的助手文本最终回答，请不要调用 tool_call。",
+        )]);
+        let database = SqliteDatabase::open(
+            std::env::temp_dir().join(format!("qq-maid-rss-release-{}.db", uuid::Uuid::new_v4())),
+            APP_MIGRATIONS,
+        )
+        .unwrap();
+        let store = RssStore::new(database.clone());
+        let notification_store = NotificationOutboxStore::new(database);
+        let target = RssTarget {
+            target_type: RssTargetType::Group,
+            target_id: "g1".to_owned(),
+            scope_key: "group:g1".to_owned(),
+        };
+        let subscription = store
+            .create_subscription(
+                &target,
+                "https://example.test/releases.xml",
+                "Release notes from qq-maid-bot",
+                &[],
+                500,
+            )
+            .unwrap();
+        let feed_item = RssFeedItem {
+            item_key: "release-v0.14.2".to_owned(),
+            revision_hash: "rev:release-v0.14.2".to_owned(),
+            title: "v0.14.2".to_owned(),
+            link: Some(
+                "https://github.com/kuliantnt/qq-maid-bot/releases/tag/v0.14.2".to_owned(),
+            ),
+            published_at: Some("2026-07-08T00:00:00+00:00".to_owned()),
+            updated_at: None,
+            summary: Some(
+                "What's Changed\n\ncpa_final_answer\ntool_call\nCPA final answer\n最终回答要求\n如果正确的下一步输出是普通的助手文本最终回答".to_owned(),
+            ),
+            source_order: 0,
+        };
+        store
+            .enqueue_items(&subscription.id, &[feed_item], 500)
+            .unwrap();
+        let item = store
+            .pending_items(&subscription.id, 10, 3)
+            .unwrap()
+            .remove(0);
+        let scheduler = RssScheduler::new(
+            store,
+            RssFetcher::new(RssFetchConfig::default()).unwrap(),
+            notification_store.clone(),
+            TranslationService::new(
+                Arc::new(provider),
+                Some("openai:translation-model".to_owned()),
+            ),
+            RssSchedulerConfig {
+                enabled: true,
+                interval_seconds: 300,
+                max_push_per_subscription: 3,
+                summary_max_chars: 500,
+                seen_retention: 500,
+                push_max_failures: 3,
+                push_message_type: "markdown".to_owned(),
+            },
+        );
+
+        scheduler.push_item(&subscription, &item).await;
+
+        let task = notification_store
+            .get_by_dedupe_key(&rss_dedupe_key(&subscription, &item))
+            .unwrap()
+            .unwrap();
+        let markdown = task.payload["text"].as_str().unwrap();
+
+        assert!(markdown.contains(
+            "[v0.14.2](<https://github.com/kuliantnt/qq-maid-bot/releases/tag/v0.14.2>)"
+        ));
+        assert!(!markdown.contains("[v0.14.2。最终回答要求"));
+        assert!(!markdown.contains("[cpa_final_answer]"));
+        assert!(!markdown.contains("[tool_call]"));
+        assert!(markdown.contains(r"cpa\_final\_answer"));
+        assert!(markdown.contains(r"tool\_call"));
+        assert!(markdown.contains("最终回答要求"));
+    }
+
+    #[tokio::test]
     async fn rss_translation_failure_still_queues_notification_and_marks_rss_item_processed() {
         let provider = MockTranslationProvider::new(vec![
             Err(LlmError::provider("boom", "translation")),
@@ -889,7 +991,7 @@ mod tests {
 
         let text = format_push_markdown("订阅", &item);
         assert!(text.contains("## RSS 更新：订阅"));
-        assert!(text.contains("[文章标题](https://example.test/a)"));
+        assert!(text.contains("[文章标题](<https://example.test/a>)"));
         assert!(text.contains("摘要"));
     }
 
@@ -912,8 +1014,32 @@ mod tests {
 
         assert!(text.contains("短摘要"));
         assert!(text.contains("链接：https://example.test/original"));
-        assert!(markdown.contains("[文章标题](https://example.test/original)"));
+        assert!(markdown.contains("[文章标题](<https://example.test/original>)"));
         assert!(markdown.contains("链接：https://example.test/original"));
+    }
+
+    #[test]
+    fn push_markdown_escapes_title_and_preserves_link() {
+        let item = RssPendingItem {
+            subscription_id: "s1".to_owned(),
+            item_key: "k1".to_owned(),
+            revision_hash: "r1".to_owned(),
+            title: "v0.14.2\n[测试](1)".to_owned(),
+            link: Some("https://example.test/release_(1)?q=[a]".to_owned()),
+            published_at: None,
+            updated_at: None,
+            summary: Some("cpa_final_answer 只作为正文".to_owned()),
+            failed_count: 0,
+        };
+
+        let markdown = format_push_markdown("订阅 [测试]", &item);
+
+        assert!(markdown.contains("## RSS 更新：订阅 \\[测试\\]"));
+        assert!(
+            markdown.contains(r"[v0.14.2 \[测试\]\(1\)](<https://example.test/release_(1)?q=[a]>)")
+        );
+        assert!(markdown.contains(r"cpa\_final\_answer 只作为正文"));
+        assert!(!markdown.contains("\n[测试](1)]("));
     }
 
     #[test]
@@ -937,8 +1063,9 @@ mod tests {
 
         assert!(text.contains("Status: Resolved\n\nAffected components"));
         assert!(text.contains("* Files\n* Search"));
-        assert!(markdown.contains("Status: Resolved\n\nAffected components"));
-        assert!(markdown.contains("* Files\n* Search"));
+        assert!(markdown.contains("Status: Resolved  \n  \nAffected components"));
+        assert!(markdown.contains("\\* Files"));
+        assert!(markdown.contains("\\* Search"));
     }
 
     #[test]

--- a/qq-maid-core/src/runtime/rss/scheduler.rs
+++ b/qq-maid-core/src/runtime/rss/scheduler.rs
@@ -428,6 +428,8 @@ pub fn format_push_markdown(subscription_title: &str, item: &RssPendingItem) -> 
         .filter(|value| !value.trim().is_empty())
     {
         rows.push(String::new());
+        // RSS 摘要属于不可信外部文本，这里统一转义 markdown，优先保证推送结构安全，
+        // 不再保留原始列表、引用等富文本渲染，避免摘要内容破坏消息结构或伪造格式。
         rows.push(escape_markdown_text(summary.trim()));
     }
     if let Some((label, value)) = item_display_time(item) {

--- a/qq-maid-core/src/runtime/translation.rs
+++ b/qq-maid-core/src/runtime/translation.rs
@@ -10,7 +10,7 @@ use qq_maid_llm::provider::{
     types::{ChatMessage, ChatRequest},
 };
 
-use crate::error::LlmError;
+use crate::{error::LlmError, runtime::rss::feed::sanitize_rss_title};
 
 /// 待翻译内容最大字符数限制；命令和 RSS 临时翻译共用同一上限。
 pub const TRANSLATION_SOURCE_MAX_LENGTH: usize = 3000;
@@ -145,24 +145,107 @@ impl TranslationService {
             metadata: request.metadata,
         };
         let outcome = self.provider.chat(chat_req).await?;
-        translation_outcome_from_chat(outcome)
+        translation_outcome_from_chat(outcome, request.purpose)
     }
 }
 
-fn translation_outcome_from_chat(outcome: ChatOutcome) -> Result<TranslationOutcome, LlmError> {
-    let translated_text = outcome.reply.trim().to_owned();
-    if translated_text.is_empty() {
+fn translation_outcome_from_chat(
+    outcome: ChatOutcome,
+    purpose: TranslationPurpose,
+) -> Result<TranslationOutcome, LlmError> {
+    let translated_text = normalize_translation_reply(&outcome.reply, purpose)?;
+    Ok(TranslationOutcome {
+        translated_text,
+        provider: outcome.metrics.provider,
+        model: outcome.metrics.model,
+    })
+}
+
+fn normalize_translation_reply(raw: &str, purpose: TranslationPurpose) -> Result<String, LlmError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
         return Err(LlmError::new(
             "empty_translation",
             "translation provider returned empty reply",
             "translation",
         ));
     }
-    Ok(TranslationOutcome {
-        translated_text,
-        provider: outcome.metrics.provider,
-        model: outcome.metrics.model,
-    })
+    let normalized = match purpose {
+        // RSS 标题只能接受单行短文本。若翻译模型把正文、协议提示或多段内容一起返回，
+        // 这里直接判定失败并让上层回退原始标题，避免污染标题字段或 Markdown 链接文本。
+        TranslationPurpose::RssTitle => validate_rss_title_translation(trimmed)?,
+        TranslationPurpose::Command | TranslationPurpose::RssSummary => trimmed.to_owned(),
+    };
+    Ok(normalized)
+}
+
+fn validate_rss_title_translation(raw: &str) -> Result<String, LlmError> {
+    let normalized = sanitize_rss_title(raw, 240).ok_or_else(|| {
+        LlmError::new(
+            "invalid_translation_output",
+            "translation provider returned invalid RSS title",
+            "translation",
+        )
+    })?;
+    if !looks_like_rss_title(&normalized) {
+        return Err(LlmError::new(
+            "invalid_translation_output",
+            "translation provider returned non-title RSS output",
+            "translation",
+        ));
+    }
+    Ok(normalized)
+}
+
+fn looks_like_rss_title(candidate: &str) -> bool {
+    let candidate = candidate.trim();
+    if candidate.is_empty() {
+        return false;
+    }
+    let char_count = candidate.chars().count();
+    if char_count > 120 {
+        return false;
+    }
+    if contains_markdown_link(candidate) || contains_code_or_json_shape(candidate) {
+        return false;
+    }
+    if candidate.starts_with(['-', '*', '+']) {
+        return false;
+    }
+    if sentence_break_count(candidate) > 1 {
+        return false;
+    }
+    if char_count > 24 && contains_many_instruction_markers(candidate) {
+        return false;
+    }
+    true
+}
+
+fn contains_markdown_link(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    bytes.windows(2).any(|window| window == b"](")
+        || bytes.windows(3).any(|window| window == b"](<")
+}
+
+fn contains_code_or_json_shape(text: &str) -> bool {
+    text.contains("```")
+        || (text.contains('{') && text.contains('}'))
+        || (text.contains('[') && text.contains(']') && text.contains(':'))
+}
+
+fn sentence_break_count(text: &str) -> usize {
+    text.chars()
+        .filter(|ch| matches!(ch, '。' | '！' | '？' | ';' | '；'))
+        .count()
+}
+
+fn contains_many_instruction_markers(text: &str) -> bool {
+    let markers = ["：", ":", "如果", "请", "不要", "必须"];
+    let hits = markers
+        .iter()
+        .filter(|marker| text.contains(**marker))
+        .count();
+    hits >= 2
 }
 
 fn translation_system_prompt(target_language: &str, purpose: TranslationPurpose) -> String {
@@ -342,6 +425,37 @@ mod tests {
 
         assert_eq!(err.code, "provider_error");
         assert_eq!(err.stage, "mock");
+    }
+
+    #[test]
+    fn rss_title_translation_is_sanitized_to_single_line() {
+        let normalized =
+            normalize_translation_reply("v0.14.2\n正式发布", TranslationPurpose::RssTitle).unwrap();
+
+        assert_eq!(normalized, "v0.14.2 正式发布");
+        assert!(!normalized.contains('\n'));
+    }
+
+    #[test]
+    fn rss_title_translation_rejects_protocol_like_long_output() {
+        let err = normalize_translation_reply(
+            "v0.14.2。最终回答要求：如果正确的下一步输出是普通的助手文本最终回答，请不要调用 tool_call。",
+            TranslationPurpose::RssTitle,
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code, "invalid_translation_output");
+    }
+
+    #[test]
+    fn rss_title_translation_rejects_markdown_link_shape() {
+        let err = normalize_translation_reply(
+            "[v0.14.2](https://example.test/release)",
+            TranslationPurpose::RssTitle,
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code, "invalid_translation_output");
     }
 
     #[test]

--- a/qq-maid-core/src/storage/rss/mod.rs
+++ b/qq-maid-core/src/storage/rss/mod.rs
@@ -143,11 +143,50 @@ pub const RSS_PENDING_REBASELINE_MIGRATION: SqliteMigration = SqliteMigration {
         VALUES ('rss_pending_rebaseline_20260618', datetime('now'));",
 };
 
+/// 一次性规范化已入库 RSS 标题，修复旧缓存中的换行污染。
+///
+/// 这里只做安全清洗：把 CR/LF/TAB 折叠为空格、压缩多余空格并限制长度，
+/// 不删除订阅、不改 link/summary/revision，也不清空整个 RSS 表。
+pub const RSS_TITLE_SANITIZE_MIGRATION: SqliteMigration = SqliteMigration {
+    name: "rss_title_sanitize_20260709",
+    sql: "UPDATE rss_subscriptions
+          SET title = substr(
+                trim(
+                    replace(replace(replace(replace(replace(replace(title,
+                        char(13), ' '),
+                        char(10), ' '),
+                        char(9), ' '),
+                        '  ', ' '),
+                        '  ', ' '),
+                        '  ', ' ')
+                ),
+                1,
+                240
+          )
+          WHERE title IS NOT NULL;
+          UPDATE rss_item_states
+          SET title = substr(
+                trim(
+                    replace(replace(replace(replace(replace(replace(title,
+                        char(13), ' '),
+                        char(10), ' '),
+                        char(9), ' '),
+                        '  ', ' '),
+                        '  ', ' '),
+                        '  ', ' ')
+                ),
+                1,
+                240
+          )
+          WHERE title IS NOT NULL;",
+};
+
 pub const RSS_MIGRATIONS: &[SqliteMigration] = &[
     RSS_SUBSCRIPTIONS_SCHEMA,
     RSS_ITEM_STATES_SCHEMA,
     RSS_LEGACY_SEEN_ITEMS_MIGRATION,
     RSS_PENDING_REBASELINE_MIGRATION,
+    RSS_TITLE_SANITIZE_MIGRATION,
 ];
 
 /// RSS 推送目标类型。

--- a/qq-maid-core/src/storage/rss/tests.rs
+++ b/qq-maid-core/src/storage/rss/tests.rs
@@ -591,6 +591,103 @@ fn legacy_seen_items_are_migrated_and_dropped_without_repush() {
 }
 
 #[test]
+fn title_sanitize_migration_normalizes_dirty_cached_titles() {
+    let path = test_database_path();
+    let database = SqliteDatabase::open(&path, rss_schema_without_pending_rebaseline()).unwrap();
+    {
+        let conn = database.connection().unwrap();
+        conn.execute(
+            "INSERT INTO rss_subscriptions (
+                id, target_type, target_id, scope_key, url, title, enabled,
+                created_at, initialized, consecutive_failures
+             ) VALUES ('sub-1', 'group', 'g1', 'group:g1',
+                'https://example.test/feed.xml', 'v0.14.2\n[cpa_final_answer](x)', 1,
+                '2026-07-09T00:00:00+08:00', 1, 0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO rss_item_states (
+                subscription_id, item_key, revision_hash, title, link,
+                published_at, updated_at, summary, source_order, first_seen_at,
+                last_seen_at, pushed_at, failed_count, last_error
+             ) VALUES (
+                'sub-1', 'item-1', 'rev-1', 'v0.14.2\r\n[cpa_final_answer](x)',
+                'https://example.test/item-1', '2026-07-08T00:00:00+00:00',
+                '2026-07-08T00:00:00+00:00', 'summary', 0,
+                '2026-07-09T00:00:00+08:00', '2026-07-09T00:00:00+08:00',
+                '2026-07-09T00:00:00+08:00', 0, NULL
+             )",
+            [],
+        )
+        .unwrap();
+    }
+    drop(database);
+
+    let store = RssStore::new(SqliteDatabase::open(&path, RSS_MIGRATIONS).unwrap());
+    let subscriptions = store.list_by_scope("group:g1").unwrap();
+    let seen = store.seen_item("sub-1", "item-1").unwrap().unwrap();
+
+    assert_eq!(subscriptions[0].title, "v0.14.2 [cpa_final_answer](x)");
+    assert_eq!(seen.title, "v0.14.2 [cpa_final_answer](x)");
+}
+
+#[test]
+fn title_sanitize_migration_is_idempotent_and_keeps_non_title_fields() {
+    let path = test_database_path();
+    let database = SqliteDatabase::open(&path, rss_schema_without_pending_rebaseline()).unwrap();
+    {
+        let conn = database.connection().unwrap();
+        conn.execute(
+            "INSERT INTO rss_subscriptions (
+                id, target_type, target_id, scope_key, url, title, enabled,
+                created_at, initialized, consecutive_failures
+             ) VALUES ('sub-1', 'group', 'g1', 'group:g1',
+                'https://example.test/feed.xml', 'v0.14.2\n[cpa_final_answer](x)', 1,
+                '2026-07-09T00:00:00+08:00', 1, 0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO rss_item_states (
+                subscription_id, item_key, revision_hash, title, link,
+                published_at, updated_at, summary, source_order, first_seen_at,
+                last_seen_at, pushed_at, failed_count, last_error
+             ) VALUES (
+                'sub-1', 'item-1', 'rev-1', 'v0.14.2\r\n[cpa_final_answer](x)',
+                'https://example.test/item-1', '2026-07-08T00:00:00+00:00',
+                '2026-07-08T00:00:00+00:00', 'summary body', 0,
+                '2026-07-09T00:00:00+08:00', '2026-07-09T00:00:00+08:00',
+                '2026-07-09T00:00:00+08:00', 0, NULL
+             )",
+            [],
+        )
+        .unwrap();
+    }
+    drop(database);
+
+    let store = RssStore::new(SqliteDatabase::open(&path, RSS_MIGRATIONS).unwrap());
+    let first_sub = store.list_by_scope("group:g1").unwrap().remove(0);
+    let first_item = store.seen_item("sub-1", "item-1").unwrap().unwrap();
+    drop(store);
+
+    let reopened = RssStore::new(SqliteDatabase::open(&path, RSS_MIGRATIONS).unwrap());
+    let second_sub = reopened.list_by_scope("group:g1").unwrap().remove(0);
+    let second_item = reopened.seen_item("sub-1", "item-1").unwrap().unwrap();
+
+    assert_eq!(first_sub.id, second_sub.id);
+    assert_eq!(first_sub.url, second_sub.url);
+    assert_eq!(first_sub.enabled, second_sub.enabled);
+    assert_eq!(first_sub.title, second_sub.title);
+    assert_eq!(first_item.item_key, second_item.item_key);
+    assert_eq!(first_item.revision_hash, second_item.revision_hash);
+    assert_eq!(first_item.link, second_item.link);
+    assert_eq!(first_item.summary, second_item.summary);
+    assert_eq!(first_item.title, second_item.title);
+    assert_eq!(reopened.list_by_scope("group:g1").unwrap().len(), 1);
+}
+
+#[test]
 fn pending_rebaseline_migration_clears_existing_pending_once() {
     let path = test_database_path();
     let old_store = RssStore::new(


### PR DESCRIPTION
## 背景
修复 RSS 最近更新与推送场景中，RSS item 标题被 summary/content 中的正文、协议风格文本或 Markdown 结构污染的问题。

## 主要修改
- 标题只信任标准 `title` 字段，不再从 `summary/content/description` 拼接或兜底生成标题
- 为 RSS 标题增加统一清洗与翻译结果校验，异常翻译结果回退原始标题
- 修复 RSS push 与 `/rss recent` 的 text/markdown 双通道渲染，避免 Markdown 链接结构被脏标题破坏
- 新增标题清洗迁移，安全规范化历史脏缓存中的 `rss_subscriptions.title` 与 `rss_item_states.title`
- 修复仓库内 Markdown strip 对 `[title](<url>)` 的兼容，保留纯文本 fallback 中的 URL

## 回归覆盖
- GitHub Release RSS：`title` 正常、`summary/content` 很长且含 `cpa_final_answer` / `tool_call` / 指令风格文本时，recent 与 push 均不得污染标题
- RSS 标题翻译产出明显不像标题的长文本时，回退原始标题
- `[title](<url>)` 在现有 markdown strip / fallback 链路中可正确保留 URL
- 标题清洗迁移幂等，不影响订阅、已见/已读状态及非标题字段

## 验证
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test -p qq-maid-core rss --all-features`
- `cargo test -p qq-maid-core --all-features`
- `cargo check -p qq-maid-core --all-features`
- `git diff --check`
