### PR TITLE
fix: 群聊冷却命中指向机器人时发轻量提示 (#386 次要问题)

### DIFF
--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -11,6 +11,12 @@ use std::{
 use tracing::{debug, info, warn};
 
 const EMPTY_GROUP_REPLY_FALLBACK_TEXT: &str = "唔，小女仆刚刚没整理出可用回复。可以再说一次。";
+/// 群聊冷却命中但明确指向机器人时的轻量提示文案。
+///
+/// 不走 LLM，仅让用户知道“机器人听见了但要稍等”，避免静默吞掉造成“没听见”的体感
+/// （#386）。文案保持小女仆口吻且不携带任何业务臆测。
+const GROUP_COOLDOWN_HINT_TEXT: &str =
+    "哦哦，刚刚在处理上一条消息，稍后再说一声小女仆就能继续了呢。";
 
 use super::{
     bot_identity::SharedBotIdentity,
@@ -18,8 +24,8 @@ use super::{
     dedupe::MessageDedupe,
     event::{GroupEventType, GroupMessage},
     group_filter::{
-        GroupCooldowns, mentions_current_bot, should_ignore_group_message,
-        should_process_group_message,
+        GroupCooldowns, group_message_addresses_bot, mentions_current_bot,
+        should_ignore_group_message, should_process_group_message,
     },
     logging::{group_message_log_summary, mask_openid},
     media_fetch::{MediaFetchContext, fetch_qq_official_image_attachments},
@@ -87,6 +93,33 @@ fn group_respond_error_texts(
     (qq_text, log_text)
 }
 
+/// 群聊冷却命中但明确指向机器人时发送轻量提示。
+///
+/// 这里只发一条普通文本，挂在被冷却消息的 `message_id` 上回复；不走 LLM、不调 Core，
+/// 发送失败只记录运行状态日志，不阻断或重试，避免冷却路径本身被放大成新的负担。
+async fn send_cooldown_hint(
+    api: &QqApiClient,
+    runtime: &GatewayRuntimeStatus,
+    message: &GroupMessage,
+) {
+    let result = send_group_text_with_status(
+        api,
+        runtime,
+        &message.group_openid,
+        Some(&message.message_id),
+        GROUP_COOLDOWN_HINT_TEXT,
+    )
+    .await;
+    if let Err(error) = result {
+        warn!(
+            message_id = %message.message_id,
+            group = %mask_openid(&message.group_openid),
+            error = %error.log_summary(),
+            "group cooldown hint send failed"
+        );
+    }
+}
+
 // 群消息链路同样需要显式串起 QQ 回复、LLM 调用、去重、冷却和运行状态；
 // 这里沿用私聊分支的做法保留展开参数，避免把跨层依赖藏进临时聚合对象。
 #[allow(clippy::too_many_arguments)]
@@ -142,18 +175,32 @@ pub(super) async fn handle_group_message(
         );
         return Ok(());
     }
+    // 群级/用户级冷却只对普通群消息生效，避免刷屏。冷却仍保持限流，但用户通过结构化
+    // @ 机器人或引用机器人刚刚发出的回复进行追问时，属于明确的对话意图，静默吞掉会让
+    // 用户以为“机器人没听到”（#386）。这里在冷却命中且明确指向机器人时，发送一条轻
+    // 量提示（不走 LLM），让用户知道稍后再说；普通非指向消息继续静默忽略。
     if message.event_type == GroupEventType::GroupMessage
         && !group_cooldowns
             .lock()
             .unwrap()
             .check_and_mark(&message, Instant::now())
     {
-        info!(
-            message_id = %message.message_id,
-            group = %masked_group,
-            member = %message.member_openid.as_deref().map(mask_openid).unwrap_or_default(),
-            "group message ignored by cooldown"
-        );
+        if group_message_addresses_bot(&message, group_outbound_cache) {
+            info!(
+                message_id = %message.message_id,
+                group = %masked_group,
+                member = %message.member_openid.as_deref().map(mask_openid).unwrap_or_default(),
+                "group message throttled by cooldown; sending lightweight hint"
+            );
+            send_cooldown_hint(api, runtime, &message).await;
+        } else {
+            info!(
+                message_id = %message.message_id,
+                group = %masked_group,
+                member = %message.member_openid.as_deref().map(mask_openid).unwrap_or_default(),
+                "group message ignored by cooldown"
+            );
+        }
         return Ok(());
     }
 
@@ -960,6 +1007,74 @@ mod tests {
         .unwrap();
 
         assert_eq!(hits_third.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn explicit_mention_during_cooldown_skips_llm_and_sends_hint() {
+        // #386：用户明确 @ 机器人但在群冷却窗口内时，不能吞掉也不走 LLM，
+        // 只发一条轻量提示。这里用 fake API endpoint 验证：第一条 @ 消息会调 Core
+        // 并因发送失败报错；第二条 @ 消息在冷却窗口内，不调 Core、返回 Ok。
+        let mut config = test_config();
+        config.group_message_mode = GroupMessageMode::Mention;
+        let outbound_cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        let cooldowns = Arc::new(Mutex::new(GroupCooldowns::default()));
+        let dedupe = crate::gateway::dedupe::MessageDedupe::new(Duration::from_secs(60));
+        let respond_calls = Arc::new(AtomicUsize::new(0));
+        let respond = respond_client_with_counter(respond_calls.clone());
+        let api = api_client();
+        let runtime = GatewayRuntimeStatus::new();
+        let identity = bot_identity();
+        let ref_index = crate::gateway::ref_index::ref_index();
+
+        let mut first = group_message("总结一下", GroupEventType::GroupMessage);
+        first.message_id = "group-mention-1".to_owned();
+        first.mentions = vec![crate::gateway::event::GroupMention {
+            is_you: true,
+            member_role: None,
+            target_id: None,
+        }];
+
+        handle_group_message(
+            first,
+            &config,
+            &respond,
+            &api,
+            &dedupe,
+            &outbound_cache,
+            &cooldowns,
+            &identity,
+            &runtime,
+            &ref_index,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(respond_calls.load(Ordering::SeqCst), 1);
+
+        let mut second = group_message("再总结一下", GroupEventType::GroupMessage);
+        second.message_id = "group-mention-2".to_owned();
+        second.mentions = vec![crate::gateway::event::GroupMention {
+            is_you: true,
+            member_role: None,
+            target_id: None,
+        }];
+
+        handle_group_message(
+            second,
+            &config,
+            &respond,
+            &api,
+            &dedupe,
+            &outbound_cache,
+            &cooldowns,
+            &identity,
+            &runtime,
+            &ref_index,
+        )
+        .await
+        .unwrap();
+
+        // 冷却命中 + 明确指向机器人 = 不调 LLM，只发轻量提示。
+        assert_eq!(respond_calls.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/qq-maid-gateway-rs/src/gateway/group_filter.rs
+++ b/qq-maid-gateway-rs/src/gateway/group_filter.rs
@@ -185,6 +185,20 @@ fn is_reply_to_bot(
     })
 }
 
+/// 群普通消息是否明确指向当前机器人。
+///
+/// 普通群消息（`GROUP_MESSAGE_CREATE`）默认受群级/用户级冷却限制以避免刷屏；但用户通过
+/// 结构化 @ 机器人或引用机器人刚刚发出的回复进行追问时，属于明确的对话意图，不应被
+/// 冷却静默吞掉（#386）。这里只判定“是否明确指向机器人”，冷却本身的去重/限流仍由
+/// `GroupCooldowns` 负责；调用方在冷却命中且命中此判定时，应发送轻量提示文案
+/// （不走 LLM）而非静默忽略，也不应绕过冷却直接走 LLM，以免高频 @ 短期堆 token 成本。
+pub(crate) fn group_message_addresses_bot(
+    message: &GroupMessage,
+    bot_outbound_cache: &Arc<Mutex<BotOutboundCache>>,
+) -> bool {
+    mentions_current_bot(message) || is_reply_to_bot(message, bot_outbound_cache)
+}
+
 /// 构造群内用户冷却键：`group_openid:member_openid`。
 pub(crate) fn group_user_key(message: &GroupMessage) -> String {
     let member = message.member_openid.as_deref().unwrap_or("unknown");
@@ -730,5 +744,49 @@ mod tests {
         assert!(
             cooldowns.check_and_mark(&message, now + GROUP_USER_COOLDOWN + Duration::from_secs(1))
         );
+    }
+
+    #[test]
+    fn explicit_mention_or_reply_to_bot_addresses_bot() {
+        let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+
+        // 普通群消息既不 @ 机器人也不引用机器人，不属于明确指向机器人。
+        let ordinary = group_message("随便聊聊", GroupEventType::GroupMessage);
+        assert!(!group_message_addresses_bot(&ordinary, &cache));
+
+        // 结构化 @ 机器人的普通群消息明确指向机器人。
+        let mut mentioned = group_message("总结一下", GroupEventType::GroupMessage);
+        mentioned.mentions = vec![official_bot_mention()];
+        assert!(group_message_addresses_bot(&mentioned, &cache));
+
+        // GROUP_AT_MESSAGE_CREATE 事件本身就是 @ 机器人，明确指向机器人。
+        let at_event = group_message("总结一下", GroupEventType::GroupAtMessage);
+        assert!(group_message_addresses_bot(&at_event, &cache));
+
+        // 引用机器人刚发出的回复（命中 outbound ref_index id）明确指向机器人。
+        let mut quoted = group_message("总结一下", GroupEventType::GroupMessage);
+        quoted.reply = Some(MessageReply {
+            message_id: "qq_reply_id".to_owned(),
+            ref_msg_idx: Some("REFIDX_bot_reply".to_owned()),
+            content: None,
+            input_parts: Vec::new(),
+            media_summaries: Vec::new(),
+        });
+        {
+            let mut guard = cache.lock().unwrap();
+            guard.insert_ref_index_id(Some("REFIDX_bot_reply".to_owned()));
+        }
+        assert!(group_message_addresses_bot(&quoted, &cache));
+
+        // 引用普通用户消息（未命中 outbound 缓存）不属于明确指向机器人。
+        let mut quoted_user = group_message("这句话什么意思", GroupEventType::GroupMessage);
+        quoted_user.reply = Some(MessageReply {
+            message_id: "user_msg_id".to_owned(),
+            ref_msg_idx: None,
+            content: None,
+            input_parts: Vec::new(),
+            media_summaries: Vec::new(),
+        });
+        assert!(!group_message_addresses_bot(&quoted_user, &cache));
     }
 }


### PR DESCRIPTION
## 背景

#386 次要问题：用户明确 @ 机器人或引用机器人刚发出的回复进行追问时，如果落在群聊冷却窗口内，会被 cooldown 静默忽略，用户体感变成"机器人没听见"，只能重发。

issue 主问题（机器人 outbound Markdown 消息未进入 ref_index 导致引用 miss）涉及 `ref_index` 的 key 语义边界，**不在本 PR 范围**，将作为独立设计调查另行处理（详见 [issue #386](https://github.com/kuliantnt/qq-maid-bot/issues/386) 中的拆分约定）。

## 改动

保持冷却限流不动，仅在冷却命中且明确指向机器人时，发送一条轻量提示（不走 LLM），让用户知道稍后再说。

- **`group_filter.rs`**：新增 `group_message_addresses_bot(message, bot_outbound_cache)`，判定群普通消息是否明确指向当前机器人（复用既有 `mentions_current_bot` / `is_reply_to_bot`，不新增任何判定维度）。
- **`group.rs`**：冷却命中分流——明确指向机器人时发提示文案并走真实发送 + runtime 记录；普通非指向消息维持原静默忽略行为。新增 `send_cooldown_hint`：用既有 `send_group_text_with_status` 挂在本条 `message_id` 上回复，失败只 `warn` 不阻断/重试。

### 文案
`GROUP_COOLDOWN_HINT_TEXT`：`哦哦，刚刚在处理上一条消息，稍后再说一声小女仆就能继续了呢。`（小女仆口吻，不携带业务臆测）

## 边界

- **不修改 `ref_index` 的 key 语义**：维持 commit `f5b7cae` 收口的"QQ 引用恢复只能用官方下发的 `ref_msg_idx`/`REFIDX`，`reply.message_id` 不伪造成 lookup key"。
- **不恢复 `message_id` fallback**，不把 bot outbound Markdown 强行塞进 `ref_index`。
- 不绕过 cooldown 直接走 LLM，避免高频 @ 短期堆 token 成本。

## 验证

- `cargo check -p qq-maid-gateway-rs` 通过
- `cargo test -p qq-maid-gateway-rs --lib`：356 passed / 0 failed（含 2 个新增测试）
  - `explicit_mention_or_reply_to_bot_addresses_bot`（`group_filter.rs` 单测，覆盖 5 个分支）
  - `explicit_mention_during_cooldown_skips_llm_and_sends_hint`（`group.rs` 集成测试，验证冷却内第 2 条 @ 机器人消息 `respond_calls` 不增长，仅发提示）
- `cargo clippy -p qq-maid-gateway-rs --all-targets --all-features -- -D warnings` 无告警
- `cargo fmt -p qq-maid-gateway-rs -- --check` 通过

## 未验证 / 残余风险

- 未做真实 QQ 群聊手工验证；hint 文案与平台发送行为需后续在真实环境确认（fake API endpoint 测试只验证不调 Core 且不 panic）。
- 未跑完整 `make test` / release 构建；本次改动局限于 gateway crate，已按 AGENTS.md 用等价范围覆盖。