### PR TITLE
[codex] 支持周期性纯提醒创建

### DIFF
--- a/qq-maid-core/src/runtime/tools/todo/create.rs
+++ b/qq-maid-core/src/runtime/tools/todo/create.rs
@@ -231,7 +231,9 @@ fn validate_batch_create_item_count(count: usize) -> Result<(), LlmError> {
 
 fn create_draft_from_value(value: &Value) -> Result<TodoItemDraft, LlmError> {
     let content = required_non_empty_text(value, "content")?;
-    let title = optional_text(value, "title")?.unwrap_or_else(|| content.clone());
+    let title = optional_text(value, "title")?
+        .or_else(|| reminder_title_from_content(&content))
+        .unwrap_or_else(|| content.clone());
     let detail = optional_text(value, "detail")?;
     let due_date = optional_text(value, "due_date")?;
     let due_at = optional_text(value, "due_at")?;
@@ -269,4 +271,35 @@ fn create_draft_from_value(value: &Value) -> Result<TodoItemDraft, LlmError> {
     // Tool 创建仍复用本地时间推断；模型未传结构化时间时，保持普通待办创建的保守体验。
     enrich_draft_time_from_text(&mut draft, &content, &request_time_context());
     Ok(draft)
+}
+
+fn reminder_title_from_content(content: &str) -> Option<String> {
+    let content = content.trim();
+    for marker in ["提醒我", "通知我", "提示我", "叫我", "喊我"] {
+        let Some(index) = content.find(marker) else {
+            continue;
+        };
+        let after_marker = &content[index + marker.len()..];
+        let title = trim_reminder_title_prefix(after_marker);
+        if !title.is_empty() {
+            return Some(title.to_owned());
+        }
+    }
+    None
+}
+
+fn trim_reminder_title_prefix(value: &str) -> &str {
+    let mut value = value.trim();
+    for prefix in ["一下", "下"] {
+        if let Some(stripped) = value.strip_prefix(prefix) {
+            value = stripped.trim_start();
+            break;
+        }
+    }
+    value = value.trim_start_matches(['，', ',', '。', '：', ':', '；', ';']);
+    value = value.trim_start();
+    if let Some(stripped) = value.strip_prefix('要') {
+        value = stripped.trim_start();
+    }
+    value
 }

--- a/qq-maid-core/src/runtime/tools/todo/tests.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests.rs
@@ -2845,6 +2845,185 @@ async fn create_tool_accepts_minute_recurrence() {
 }
 
 #[tokio::test]
+async fn create_tool_infers_first_reminder_for_periodic_reminder() {
+    let (todo_store, session_store, notification_store, owner) = test_stores();
+    let create_tool = CreateTodoTool::new(
+        todo_store.clone(),
+        session_store,
+        notification_store.clone(),
+    );
+    let before = chrono::Utc::now().with_timezone(&qq_maid_common::time_context::shanghai_offset());
+
+    let output = create_tool
+        .execute(
+            test_context(),
+            json!({
+                "items": null,
+                "content": "每五分钟提醒我一下，要起来走走",
+                "title": null,
+                "detail": null,
+                "due_date": null,
+                "due_at": null,
+                "reminder_at": null,
+                "time_precision": null,
+                "recurrence_kind": null,
+                "recurrence_interval": null,
+                "recurrence_unit": null,
+                "recurrence_interval_days": null
+            }),
+        )
+        .await
+        .unwrap()
+        .value;
+    let after = chrono::Utc::now().with_timezone(&qq_maid_common::time_context::shanghai_offset());
+    let todo = todo_store.list_pending(&owner).unwrap()[0].clone();
+    let reminder = qq_maid_common::time_context::parse_local_datetime_for_comparison(
+        todo.reminder_at.as_deref().unwrap(),
+    )
+    .unwrap();
+    let tasks = notification_store.list_all_for_test().unwrap();
+
+    assert_eq!(output["ok"], true);
+    assert_eq!(todo.title, "起来走走");
+    assert_eq!(todo.due_at, None);
+    assert_eq!(
+        todo.recurrence_kind,
+        crate::runtime::todo::TodoRecurrenceKind::EveryNMinutes
+    );
+    assert_eq!(todo.recurrence_interval, 5);
+    assert_eq!(
+        todo.recurrence_unit,
+        crate::runtime::todo::TodoRecurrenceUnit::Minute
+    );
+    assert!(reminder >= before + chrono::Duration::minutes(5) - chrono::Duration::seconds(1));
+    assert!(reminder <= after + chrono::Duration::minutes(5) + chrono::Duration::seconds(1));
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].source_id, todo.id);
+    assert_eq!(
+        tasks[0].status,
+        crate::storage::notification::NotificationStatus::Pending
+    );
+}
+
+#[tokio::test]
+async fn create_tool_infers_first_reminder_for_chinese_hour_interval() {
+    let (todo_store, session_store, notification_store, owner) = test_stores();
+    let create_tool = CreateTodoTool::new(todo_store.clone(), session_store, notification_store);
+    let before = chrono::Utc::now().with_timezone(&qq_maid_common::time_context::shanghai_offset());
+
+    create_tool
+        .execute(
+            test_context(),
+            json!({
+                "items": null,
+                "content": "每两小时提醒我喝水",
+                "title": "喝水",
+                "detail": null,
+                "due_date": null,
+                "due_at": null,
+                "reminder_at": null,
+                "time_precision": null,
+                "recurrence_kind": null,
+                "recurrence_interval": null,
+                "recurrence_unit": null,
+                "recurrence_interval_days": null
+            }),
+        )
+        .await
+        .unwrap();
+    let after = chrono::Utc::now().with_timezone(&qq_maid_common::time_context::shanghai_offset());
+    let todo = todo_store.list_pending(&owner).unwrap()[0].clone();
+    let reminder = qq_maid_common::time_context::parse_local_datetime_for_comparison(
+        todo.reminder_at.as_deref().unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        todo.recurrence_kind,
+        crate::runtime::todo::TodoRecurrenceKind::EveryNHours
+    );
+    assert_eq!(todo.recurrence_interval, 2);
+    assert_eq!(
+        todo.recurrence_unit,
+        crate::runtime::todo::TodoRecurrenceUnit::Hour
+    );
+    assert!(reminder >= before + chrono::Duration::hours(2) - chrono::Duration::seconds(1));
+    assert!(reminder <= after + chrono::Duration::hours(2) + chrono::Duration::seconds(1));
+}
+
+#[tokio::test]
+async fn create_tool_infers_first_reminder_for_arabic_minute_interval() {
+    let (todo_store, session_store, notification_store, owner) = test_stores();
+    let create_tool = CreateTodoTool::new(todo_store.clone(), session_store, notification_store);
+
+    create_tool
+        .execute(
+            test_context(),
+            json!({
+                "items": null,
+                "content": "每 5 分钟提醒我起来走走",
+                "title": "起来走走",
+                "detail": null,
+                "due_date": null,
+                "due_at": null,
+                "reminder_at": null,
+                "time_precision": null,
+                "recurrence_kind": null,
+                "recurrence_interval": null,
+                "recurrence_unit": null,
+                "recurrence_interval_days": null
+            }),
+        )
+        .await
+        .unwrap();
+    let todo = todo_store.list_pending(&owner).unwrap()[0].clone();
+
+    assert_eq!(
+        todo.recurrence_kind,
+        crate::runtime::todo::TodoRecurrenceKind::EveryNMinutes
+    );
+    assert_eq!(todo.recurrence_interval, 5);
+    assert_eq!(
+        todo.recurrence_unit,
+        crate::runtime::todo::TodoRecurrenceUnit::Minute
+    );
+    assert!(todo.reminder_at.is_some());
+}
+
+#[tokio::test]
+async fn create_tool_recurring_error_message_hides_internal_nulls() {
+    let (todo_store, session_store, notification_store, owner) = test_stores();
+    let create_tool = CreateTodoTool::new(todo_store.clone(), session_store, notification_store);
+
+    let err = create_tool
+        .execute(
+            test_context(),
+            json!({
+                "items": null,
+                "content": "每天写日报",
+                "title": "写日报",
+                "detail": null,
+                "due_date": null,
+                "due_at": null,
+                "reminder_at": null,
+                "time_precision": null,
+                "recurrence_kind": null,
+                "recurrence_interval": null,
+                "recurrence_unit": null,
+                "recurrence_interval_days": null
+            }),
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code.as_str(), "bad_request");
+    assert!(!err.message.contains("null"), "{}", err.message);
+    assert!(!err.message.contains("None"), "{}", err.message);
+    assert!(!err.message.contains("Option"), "{}", err.message);
+    assert!(todo_store.list_pending(&owner).unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn create_tool_rejects_invalid_minute_recurrence_arguments() {
     for (recurrence_interval, recurrence_unit, expected) in [
         (json!(0), json!("minute"), "positive integer"),

--- a/qq-maid-core/src/storage/todo/recurrence.rs
+++ b/qq-maid-core/src/storage/todo/recurrence.rs
@@ -16,7 +16,7 @@ use regex::Regex;
 
 use super::{
     TodoEditRecurrencePatch, TodoError, TodoItem, TodoItemDraft, TodoRecurrenceKind,
-    TodoRecurrenceUnit,
+    TodoRecurrenceUnit, TodoTimePrecision,
 };
 use qq_maid_common::time_context::{
     cycles_to_advance_date_after_calendar, cycles_to_advance_datetime_after_calendar,
@@ -79,14 +79,21 @@ pub(super) fn normalize_todo_recurrence_input(
     };
     apply_normalized_recurrence_to_draft(draft, &normalized);
 
-    if recurrence_rule(draft).is_some()
+    if let Some(rule) = recurrence_rule(draft)
         && draft.due_date.is_none()
         && draft.due_at.is_none()
         && draft.reminder_at.is_none()
     {
-        return Err(TodoError::bad_request(
-            "重复任务需要至少一个日期或提醒时间，请补充提醒时间或到期时间。",
-        ));
+        if is_recurring_reminder_intent(draft) {
+            // 周期性纯提醒没有 due_at 锚点时，第一次提醒从创建时间后一个周期开始。
+            // 后续推进仍复用 reminder_at + recurrence 的既有 outbox / sent hook 链路。
+            draft.reminder_at = Some(next_reminder_from_now(rule)?);
+            draft.time_precision = TodoTimePrecision::DateTime;
+        } else {
+            return Err(TodoError::bad_request(
+                "重复任务需要至少一个日期、到期时间或提醒时间；如果只是周期提醒，请说清楚提醒内容和重复间隔。",
+            ));
+        }
     }
     Ok(normalized)
 }
@@ -419,6 +426,29 @@ fn max_interval_error_message(unit: &TodoRecurrenceUnit) -> &'static str {
         | TodoRecurrenceUnit::Month
         | TodoRecurrenceUnit::Year => "重复间隔过大，最多支持 5 年内的重复周期。",
     }
+}
+
+fn is_recurring_reminder_intent(draft: &TodoItemDraft) -> bool {
+    let mut source = String::new();
+    if let Some(raw_text) = draft.raw_text.as_deref() {
+        source.push_str(raw_text);
+    }
+    source.push_str(&draft.title);
+    if let Some(detail) = draft.detail.as_deref() {
+        source.push_str(detail);
+    }
+    let compact = source.split_whitespace().collect::<String>();
+    ["提醒", "通知我", "提示我", "叫我", "喊我", "闹钟"]
+        .iter()
+        .any(|keyword| compact.contains(keyword))
+}
+
+fn next_reminder_from_now(rule: TodoRecurrenceRule) -> Result<String, TodoError> {
+    let now = Utc::now()
+        .with_timezone(&shanghai_offset())
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string();
+    advance_datetime_value(&now, rule, 1).map_err(TodoError::bad_request)
 }
 
 fn calendar_unit(unit: &TodoRecurrenceUnit) -> CalendarRecurrenceUnit {


### PR DESCRIPTION
## 变更

修复“每五分钟提醒我一下，要起来走走”这类周期性纯提醒创建失败的问题。

- 对带重复规则且具有提醒语义的纯提醒，自动从创建时间推导第一次 reminder_at。
- 保持普通重复 Todo 仍需要日期、到期时间或提醒时间，避免误把普通重复任务变成提醒。
- 为提醒句式补充标题兜底，模型未给 title 时可提取“起来走走”等核心内容。
- 改善缺少时间锚点时的错误文案，避免暴露 null/None/Option。

## 根因

Todo recurrence 归一化层把所有无 due/reminder 锚点的重复规则都当作普通重复 Todo 拒绝，未区分周期性纯提醒。已有 outbox 和 sent hook 实际已经能处理 reminder_at + recurrence 的后续调度，只缺第一次 reminder_at 的推导。

## 验证

- cargo fmt --all -- --check
- cargo test -p qq-maid-core runtime::tools::todo::tests::create_tool_infers_first_reminder --all-features
- cargo test -p qq-maid-core runtime::tools::todo::tests::create_tool_recurring_error_message_hides_internal_nulls --all-features
- cargo test -p qq-maid-core runtime::todo::reminder_task --all-features
- cargo test -p qq-maid-core storage::todo::recurrence --all-features
- cargo test -p qq-maid-core runtime::tools::todo::tests --all-features
- make test-core
- cargo clippy -p qq-maid-core --all-targets --all-features -- -D warnings
- cargo build -p qq-maid-core --all-features
- git diff --check