### PR TITLE
refactor: 统一普通消息路由结果

### DIFF
--- a/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 use super::{
-    ChatToolPlan, RespondPurpose, RespondRequest, RespondResponse, RustRespondService,
+    RespondPurpose, RespondRequest, RespondResponse, RustRespondService,
     agent_outcome::AgentTurnOutcome,
     common::{
         SESSION_HISTORY_MESSAGE_LIMIT, command_response, empty_respond_request, memory_error,
@@ -26,6 +26,7 @@ use super::{
     },
     llm_service::{ChatService, LlmChatService, response_from_output},
     session_flow::build_session_context,
+    tool_route::ToolRouteDecision,
 };
 
 pub(super) use super::conversation_session::recent_session_messages;
@@ -47,7 +48,7 @@ pub(super) struct PreparedChat {
     pub user_text: String,
     pub meta: SessionMeta,
     pub session: SessionRecord,
-    pub chat_plan: ChatToolPlan,
+    pub respond_route: ToolRouteDecision,
 }
 
 #[derive(Default)]
@@ -74,7 +75,7 @@ impl RustRespondService {
             user_text,
             meta,
             mut session,
-            chat_plan: chat_tool_plan,
+            respond_route,
         } = chat;
         let ChatFlowSinks {
             progress_sink,
@@ -112,7 +113,7 @@ impl RustRespondService {
         let used_memory = !memory_context.trim().is_empty();
         let is_group_chat = is_group_meta(&meta);
         let system_prompts = self.prompt_config.load_system_prompts()?;
-        let system_prompts = if matches!(chat_tool_plan, ChatToolPlan::ForceCompleteToolLoop) {
+        let system_prompts = if respond_route.uses_tool_agent() {
             let mut prompts = system_prompts;
             prompts.push(TOOL_LOOP_AMBIGUITY_PROMPT.to_owned());
             if is_group_chat {
@@ -177,7 +178,7 @@ impl RustRespondService {
         }
         let service =
             LlmChatService::with_context_budget(self.provider.clone(), self.context_budget);
-        let use_tool_loop = matches!(chat_tool_plan, ChatToolPlan::ForceCompleteToolLoop);
+        let use_tool_loop = respond_route.uses_tool_agent();
         let (output, agent_turn_outcome, tool_turn_diagnostics) = if use_tool_loop {
             let tools = self.tool_runtime.registry_for_chat(&policy, &req)?;
             let output = service
@@ -251,6 +252,10 @@ impl RustRespondService {
             "used_knowledge": used_knowledge,
             "knowledge_hit_count": knowledge_context.hit_count,
             "used_search": false,
+            "respond_route": respond_route.route.as_str(),
+            "route_reason": respond_route.reason,
+            "route_domains": respond_route.domains(),
+            "route_semantic": respond_route.semantic_route.as_str(),
             "tool_calling_enabled": use_tool_loop,
             "tool_loop_mode": if use_tool_loop { json!("configured_whitelist") } else { Value::Null },
             "tool_loop_enabled_tools": if use_tool_loop { json!(&policy.enabled_tools) } else { Value::Null },
@@ -295,6 +300,7 @@ impl RustRespondService {
     where
         F: FnMut(String) -> Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send>> + Send,
     {
+        let respond_route = self.respond_route(&req)?;
         let user_text = req.effective_user_text();
         let meta = super::respond_meta(&req);
         let mut session = self
@@ -309,7 +315,7 @@ impl RustRespondService {
                         user_text,
                         meta,
                         session,
-                        chat_plan: ChatToolPlan::Plain,
+                        respond_route,
                     },
                     ChatFlowSinks::default(),
                 )
@@ -411,6 +417,10 @@ impl RustRespondService {
             "used_knowledge": used_knowledge,
             "knowledge_hit_count": knowledge_context.hit_count,
             "used_search": false,
+            "respond_route": respond_route.route.as_str(),
+            "route_reason": respond_route.reason,
+            "route_domains": respond_route.domains(),
+            "route_semantic": respond_route.semantic_route.as_str(),
             "agent_policy": policy.diagnostic_summary(),
         }));
         Ok(response)

--- a/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
@@ -292,15 +292,15 @@ impl RustRespondService {
     }
 
     /// 普通聊天真流式路径：复用非流式聊天的上下文构造和后处理，只替换 LLM 调用方式。
-    pub async fn handle_chat_stream<F>(
+    pub(super) async fn handle_chat_stream<F>(
         &self,
         req: RespondRequest,
+        respond_route: ToolRouteDecision,
         on_delta: F,
     ) -> Result<RespondResponse, LlmError>
     where
         F: FnMut(String) -> Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send>> + Send,
     {
-        let respond_route = self.respond_route(&req)?;
         let user_text = req.effective_user_text();
         let meta = super::respond_meta(&req);
         let mut session = self

--- a/qq-maid-core/src/runtime/respond/command_dispatcher.rs
+++ b/qq-maid-core/src/runtime/respond/command_dispatcher.rs
@@ -6,7 +6,7 @@
 use crate::error::LlmError;
 
 use super::{
-    ChatToolPlan, RespondPlan, RespondRequest, RespondResponse, RustRespondService,
+    RespondPlan, RespondRequest, RespondResponse, RustRespondService,
     chat_flow::PreparedChat,
     common::session_error,
     interaction_state::{
@@ -227,19 +227,18 @@ impl<'a> CommandDispatcher<'a> {
         // 兜底：进入普通 LLM 聊天流程。手动展示名只在真正进入 LLM 上下文前查询，
         // 避免确定性 slash 命令额外争用当前 SQLite 单连接锁（连接池重构见 #328）。
         apply_manual_display_names(&self.service.display_name_store, &meta, &mut req);
-        let chat_plan = match plan {
-            RespondPlan::CompleteToolLoop => ChatToolPlan::ForceCompleteToolLoop,
-            RespondPlan::Immediate
-            | RespondPlan::CommandEvent
-            | RespondPlan::StreamingChat
-            | RespondPlan::WebSearch => ChatToolPlan::Plain,
-        };
+        let respond_route = self.service.respond_route(&req)?;
+        debug_assert_eq!(
+            matches!(plan, RespondPlan::CompleteToolLoop),
+            respond_route.uses_tool_agent(),
+            "router plan and prepared chat route must stay aligned"
+        );
         Ok(DispatchOutcome::Chat(Box::new(PreparedChat {
             req,
             user_text,
             meta,
             session,
-            chat_plan,
+            respond_route,
         })))
     }
 }

--- a/qq-maid-core/src/runtime/respond/command_dispatcher.rs
+++ b/qq-maid-core/src/runtime/respond/command_dispatcher.rs
@@ -6,7 +6,7 @@
 use crate::error::LlmError;
 
 use super::{
-    RespondPlan, RespondRequest, RespondResponse, RustRespondService,
+    PlannedRespond, RespondPlan, RespondRequest, RespondResponse, RustRespondService,
     chat_flow::PreparedChat,
     common::session_error,
     interaction_state::{
@@ -35,8 +35,9 @@ impl<'a> CommandDispatcher<'a> {
     pub(super) async fn dispatch(
         &self,
         mut req: RespondRequest,
-        plan: RespondPlan,
+        planned: PlannedRespond,
     ) -> Result<DispatchOutcome, LlmError> {
+        let plan = planned.plan();
         let user_text = req.effective_user_text();
         let meta = respond_meta(&req);
         let interaction_meta = respond_interaction_meta(&req);
@@ -95,7 +96,9 @@ impl<'a> CommandDispatcher<'a> {
                 .get_or_create_active(&meta)
                 .map_err(session_error)?,
         };
-        let force_tool_loop = matches!(plan, RespondPlan::CompleteToolLoop);
+        let force_tool_loop = planned
+            .respond_route()
+            .is_some_and(|decision| decision.uses_tool_agent());
 
         // 检查是否为翻译指令（如 "/翻译 文本"、"/翻译日语 文本"）
         if let Some(command) = translation_flow::parse_translation_command(&user_text) {
@@ -227,12 +230,13 @@ impl<'a> CommandDispatcher<'a> {
         // 兜底：进入普通 LLM 聊天流程。手动展示名只在真正进入 LLM 上下文前查询，
         // 避免确定性 slash 命令额外争用当前 SQLite 单连接锁（连接池重构见 #328）。
         apply_manual_display_names(&self.service.display_name_store, &meta, &mut req);
-        let respond_route = self.service.respond_route(&req)?;
-        debug_assert_eq!(
-            matches!(plan, RespondPlan::CompleteToolLoop),
-            respond_route.uses_tool_agent(),
-            "router plan and prepared chat route must stay aligned"
-        );
+        let respond_route = planned.respond_route().ok_or_else(|| {
+            LlmError::new(
+                "respond_route_missing",
+                "chat execution requires the router decision",
+                "router",
+            )
+        })?;
         Ok(DispatchOutcome::Chat(Box::new(PreparedChat {
             req,
             user_text,

--- a/qq-maid-core/src/runtime/respond/mod.rs
+++ b/qq-maid-core/src/runtime/respond/mod.rs
@@ -158,6 +158,77 @@ pub(crate) enum RespondPlan {
     WebSearch,
 }
 
+/// Router 对单个请求生成的不可变执行决策。
+///
+/// `RespondPlan` 只负责 Core/Gateway 输出策略；普通聊天是否进入 Tool Agent
+/// 必须始终读取同一份 `respond_route`，执行阶段不得重新读取 session 或 policy 计算。
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PlannedRespond {
+    plan: RespondPlan,
+    respond_route: Option<tool_route::ToolRouteDecision>,
+}
+
+impl PlannedRespond {
+    const fn without_chat_route(plan: RespondPlan) -> Self {
+        Self {
+            plan,
+            respond_route: None,
+        }
+    }
+
+    pub(crate) const fn command_event() -> Self {
+        Self::without_chat_route(RespondPlan::CommandEvent)
+    }
+
+    fn chat(respond_route: tool_route::ToolRouteDecision) -> Self {
+        let plan = if respond_route.uses_tool_agent() {
+            RespondPlan::CompleteToolLoop
+        } else {
+            RespondPlan::StreamingChat
+        };
+        Self {
+            plan,
+            respond_route: Some(respond_route),
+        }
+    }
+
+    const fn immediate_chat(respond_route: tool_route::ToolRouteDecision) -> Self {
+        Self {
+            plan: RespondPlan::Immediate,
+            respond_route: Some(respond_route),
+        }
+    }
+
+    pub(crate) const fn plan(self) -> RespondPlan {
+        self.plan
+    }
+
+    const fn respond_route(self) -> Option<tool_route::ToolRouteDecision> {
+        self.respond_route
+    }
+
+    pub(crate) fn status_hint(self) -> StatusHint {
+        if !matches!(self.plan, RespondPlan::CompleteToolLoop) {
+            return StatusHint::model();
+        }
+        self.respond_route
+            .and_then(|decision| decision.status_hint)
+            .unwrap_or_else(StatusHint::default_tool)
+    }
+}
+
+impl PartialEq<RespondPlan> for PlannedRespond {
+    fn eq(&self, other: &RespondPlan) -> bool {
+        self.plan == *other
+    }
+}
+
+impl PartialEq<PlannedRespond> for RespondPlan {
+    fn eq(&self, other: &PlannedRespond) -> bool {
+        *self == other.plan
+    }
+}
+
 /// Rust 原生实现的响应服务。
 ///
 /// 聚合所有外部依赖（LLM Provider、会话存储、记忆存储、待办存储等），
@@ -282,27 +353,27 @@ impl RustRespondService {
     /// 8. 检查是否为**长期记忆操作**。
     /// 9. 兜底：进入**普通聊天**处理流程。
     pub async fn respond(&self, req: RespondRequest) -> Result<RespondResponse, LlmError> {
-        let plan = self.plan_core_respond(&req)?;
-        self.respond_with_plan(req, plan).await
+        let planned = self.plan_core_respond(&req)?;
+        self.respond_with_plan(req, planned).await
     }
 
     pub(crate) async fn respond_with_plan(
         &self,
         req: RespondRequest,
-        plan: RespondPlan,
+        planned: PlannedRespond,
     ) -> Result<RespondResponse, LlmError> {
-        self.respond_with_plan_and_progress(req, plan, None, None)
+        self.respond_with_plan_and_progress(req, planned, None, None)
             .await
     }
 
     pub(crate) async fn respond_with_plan_and_progress(
         &self,
         req: RespondRequest,
-        plan: RespondPlan,
+        planned: PlannedRespond,
         progress_sink: Option<ToolLoopProgressSink>,
         final_delta_sink: Option<qq_maid_llm::agent_loop::AgentTextDeltaSink>,
     ) -> Result<RespondResponse, LlmError> {
-        match CommandDispatcher::new(self).dispatch(req, plan).await? {
+        match CommandDispatcher::new(self).dispatch(req, planned).await? {
             DispatchOutcome::Respond(response) => Ok(*response),
             DispatchOutcome::Chat(chat) => {
                 self.handle_chat(
@@ -322,7 +393,28 @@ impl RustRespondService {
     /// 本阶段只接通 `/查` 和普通聊天；短命令仍走完整响应路径，避免改变用户可见语义。
     pub async fn respond_stream<F>(
         &self,
+        req: RespondRequest,
+        on_delta: F,
+    ) -> Result<RespondResponse, LlmError>
+    where
+        F: FnMut(String) -> Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send>> + Send,
+    {
+        let planned = self.plan_core_respond(&req)?;
+        if matches!(planned.plan(), RespondPlan::CompleteToolLoop) {
+            // 直接调用方也必须遵守 Router 已确定的 Tool Agent 执行路径，不能把
+            // 同一 decision 交给普通 stream_respond() 后生成错误 diagnostics。
+            return self.respond_with_plan(req, planned).await;
+        }
+        if matches!(planned.plan(), RespondPlan::WebSearch) {
+            return self.respond_web_search_stream(req, on_delta).await;
+        }
+        self.respond_stream_with_plan(req, planned, on_delta).await
+    }
+
+    pub(crate) async fn respond_stream_with_plan<F>(
+        &self,
         mut req: RespondRequest,
+        planned: PlannedRespond,
         on_delta: F,
     ) -> Result<RespondResponse, LlmError>
     where
@@ -382,7 +474,14 @@ impl RustRespondService {
 
         // 真流式只覆盖普通聊天；搜索命令等确定性入口不提前查手动展示名。
         apply_manual_display_names(&self.display_name_store, &meta, &mut req);
-        self.handle_chat_stream(req, on_delta).await
+        let respond_route = planned.respond_route().ok_or_else(|| {
+            LlmError::new(
+                "respond_route_missing",
+                "chat execution requires the router decision",
+                "router",
+            )
+        })?;
+        self.handle_chat_stream(req, respond_route, on_delta).await
     }
 
     /// `RespondPlan::WebSearch` 的流式编放入口。

--- a/qq-maid-core/src/runtime/respond/mod.rs
+++ b/qq-maid-core/src/runtime/respond/mod.rs
@@ -169,15 +169,20 @@ pub(crate) struct PlannedRespond {
 }
 
 impl PlannedRespond {
-    const fn without_chat_route(plan: RespondPlan) -> Self {
+    const fn web_search() -> Self {
         Self {
-            plan,
+            plan: RespondPlan::WebSearch,
             respond_route: None,
         }
     }
 
     pub(crate) const fn command_event() -> Self {
-        Self::without_chat_route(RespondPlan::CommandEvent)
+        Self {
+            plan: RespondPlan::CommandEvent,
+            respond_route: Some(tool_route::ToolRouteDecision::plain_deterministic(
+                "command_event_fallback",
+            )),
+        }
     }
 
     fn chat(respond_route: tool_route::ToolRouteDecision) -> Self {
@@ -192,10 +197,10 @@ impl PlannedRespond {
         }
     }
 
-    const fn immediate_chat(respond_route: tool_route::ToolRouteDecision) -> Self {
+    const fn immediate_chat(reason: &'static str) -> Self {
         Self {
             plan: RespondPlan::Immediate,
-            respond_route: Some(respond_route),
+            respond_route: Some(tool_route::ToolRouteDecision::plain_deterministic(reason)),
         }
     }
 

--- a/qq-maid-core/src/runtime/respond/mod.rs
+++ b/qq-maid-core/src/runtime/respond/mod.rs
@@ -158,12 +158,6 @@ pub(crate) enum RespondPlan {
     WebSearch,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ChatToolPlan {
-    Plain,
-    ForceCompleteToolLoop,
-}
-
 /// Rust 原生实现的响应服务。
 ///
 /// 聚合所有外部依赖（LLM Provider、会话存储、记忆存储、待办存储等），

--- a/qq-maid-core/src/runtime/respond/router.rs
+++ b/qq-maid-core/src/runtime/respond/router.rs
@@ -18,9 +18,7 @@ use super::{
         respond_interaction_meta, respond_meta, route_context_session,
     },
     search_flow, session_flow,
-    tool_route::{
-        self, RespondRoute, SemanticRoute, ToolDomain, ToolRouteContext, ToolRouteDecision,
-    },
+    tool_route::{self, RespondRoute, ToolRouteContext},
 };
 
 pub(super) struct RespondRouter<'a> {
@@ -36,13 +34,7 @@ impl<'a> RespondRouter<'a> {
         let user_text = req.effective_user_text();
         let trimmed = user_text.trim();
         if trimmed.is_empty() && req.effective_input_parts().is_empty() {
-            return Ok(PlannedRespond::immediate_chat(ToolRouteDecision {
-                route: RespondRoute::PlainChat,
-                semantic_route: SemanticRoute::Deterministic,
-                domain: ToolDomain::Unknown,
-                reason: "deterministic_or_empty",
-                status_hint: None,
-            }));
+            return Ok(PlannedRespond::immediate_chat("deterministic_or_empty"));
         }
 
         let meta = respond_meta(req);
@@ -68,19 +60,21 @@ impl<'a> RespondRouter<'a> {
             active_conversation_session.as_ref(),
             meta.user_id.as_deref(),
         ) {
-            return Ok(PlannedRespond::without_chat_route(RespondPlan::Immediate));
+            return Ok(PlannedRespond::immediate_chat("pending_handler_fallback"));
         }
 
         if search_flow::parse_web_search_command(&user_text).is_some() {
             // 显式 `/查` 入口统一走 WebSearch，复用 `/查` 的流式查询能力，
             // 避免被通用 slash 命令截走而走非流式完整等待路径。
-            return Ok(PlannedRespond::without_chat_route(RespondPlan::WebSearch));
+            return Ok(PlannedRespond::web_search());
         }
         if is_event_wrapped_command(trimmed) {
             return Ok(PlannedRespond::command_event());
         }
         if trimmed.starts_with('/') || trimmed.starts_with('／') {
-            return Ok(PlannedRespond::without_chat_route(RespondPlan::Immediate));
+            return Ok(PlannedRespond::immediate_chat(
+                "deterministic_slash_fallback",
+            ));
         }
 
         // 在进入 Tool Loop 路由前，先拦截“明确对机器人发起的搜索意图”。
@@ -90,7 +84,7 @@ impl<'a> RespondRouter<'a> {
         if tool_route::has_search_intent(trimmed, &trimmed.to_ascii_lowercase())
             && directed_to_bot(req)
         {
-            return Ok(PlannedRespond::without_chat_route(RespondPlan::WebSearch));
+            return Ok(PlannedRespond::web_search());
         }
 
         // 先保护已有确定性命令和自然语言 Todo 查询，避免简单列表查询绕过
@@ -102,7 +96,9 @@ impl<'a> RespondRouter<'a> {
             meta.user_id.as_deref(),
         );
         if matches!(classification.kind, CoreInboundKind::Immediate) {
-            return Ok(PlannedRespond::without_chat_route(RespondPlan::Immediate));
+            return Ok(PlannedRespond::immediate_chat(
+                "deterministic_handler_fallback",
+            ));
         }
 
         let policy = self.resolve_agent_policy(req)?;

--- a/qq-maid-core/src/runtime/respond/router.rs
+++ b/qq-maid-core/src/runtime/respond/router.rs
@@ -19,7 +19,7 @@ use super::{
     },
     search_flow, session_flow,
     status_hint::StatusHint,
-    tool_route::{self, ToolLoopRoute, ToolRouteContext},
+    tool_route::{self, RespondRoute, ToolRouteContext},
 };
 
 pub(super) struct RespondRouter<'a> {
@@ -133,7 +133,7 @@ impl<'a> RespondRouter<'a> {
         let policy = self.resolve_agent_policy(req)?;
         let tool_decision = self.route_tool_loop_with_active(req, &policy, route_session);
         let plan = if !req.has_non_text_input_parts()
-            && matches!(tool_decision.route, ToolLoopRoute::CompleteToolLoop)
+            && matches!(tool_decision.route, RespondRoute::ToolAgent)
         {
             RespondPlan::CompleteToolLoop
         } else {
@@ -213,6 +213,31 @@ impl<'a> RespondRouter<'a> {
         self.service.agent_config.resolve(scene)
     }
 
+    pub(super) fn respond_route(
+        &self,
+        req: &RespondRequest,
+    ) -> Result<tool_route::ToolRouteDecision, LlmError> {
+        let policy = self.resolve_agent_policy(req)?;
+        let meta = respond_meta(req);
+        let interaction_meta = respond_interaction_meta(req);
+        let active_interaction_session = self
+            .service
+            .session_store
+            .get_active(&interaction_meta)
+            .map_err(session_error)?;
+        let active_conversation_session = self
+            .service
+            .session_store
+            .get_active(&meta)
+            .map_err(session_error)?;
+        let route_session = route_context_session(
+            req,
+            active_interaction_session.as_ref(),
+            active_conversation_session.as_ref(),
+        );
+        Ok(self.route_tool_loop_with_active(req, &policy, route_session))
+    }
+
     fn route_tool_loop_with_active(
         &self,
         req: &RespondRequest,
@@ -255,6 +280,13 @@ impl RustRespondService {
         req: &RespondRequest,
     ) -> Result<ResolvedAgentPolicy, LlmError> {
         RespondRouter::new(self).resolve_agent_policy(req)
+    }
+
+    pub(super) fn respond_route(
+        &self,
+        req: &RespondRequest,
+    ) -> Result<tool_route::ToolRouteDecision, LlmError> {
+        RespondRouter::new(self).respond_route(req)
     }
 
     pub fn classify_inbound(

--- a/qq-maid-core/src/runtime/respond/router.rs
+++ b/qq-maid-core/src/runtime/respond/router.rs
@@ -11,15 +11,16 @@ use crate::{
 };
 
 use super::{
-    RespondPlan, RespondRequest, RustRespondService,
+    PlannedRespond, RespondPlan, RespondRequest, RustRespondService,
     common::session_error,
     interaction_state::{
         classify_inbound_with_active, interaction_snapshot, pending_blocks_immediate,
         respond_interaction_meta, respond_meta, route_context_session,
     },
     search_flow, session_flow,
-    status_hint::StatusHint,
-    tool_route::{self, RespondRoute, ToolRouteContext},
+    tool_route::{
+        self, RespondRoute, SemanticRoute, ToolDomain, ToolRouteContext, ToolRouteDecision,
+    },
 };
 
 pub(super) struct RespondRouter<'a> {
@@ -31,43 +32,17 @@ impl<'a> RespondRouter<'a> {
         Self { service }
     }
 
-    pub(super) fn status_hint_for_plan(
-        &self,
-        req: &RespondRequest,
-        plan: RespondPlan,
-    ) -> Result<StatusHint, LlmError> {
-        if !matches!(plan, RespondPlan::CompleteToolLoop) {
-            return Ok(StatusHint::model());
-        }
-        let policy = self.resolve_agent_policy(req)?;
-        let meta = respond_meta(req);
-        let interaction_meta = respond_interaction_meta(req);
-        let active_interaction_session = self
-            .service
-            .session_store
-            .get_active(&interaction_meta)
-            .map_err(session_error)?;
-        let active_conversation_session = self
-            .service
-            .session_store
-            .get_active(&meta)
-            .map_err(session_error)?;
-        let route_session = route_context_session(
-            req,
-            active_interaction_session.as_ref(),
-            active_conversation_session.as_ref(),
-        );
-        Ok(self
-            .route_tool_loop_with_active(req, &policy, route_session)
-            .status_hint
-            .unwrap_or_else(StatusHint::default_tool))
-    }
-
-    pub(super) fn plan(&self, req: &RespondRequest) -> Result<RespondPlan, LlmError> {
+    pub(super) fn plan(&self, req: &RespondRequest) -> Result<PlannedRespond, LlmError> {
         let user_text = req.effective_user_text();
         let trimmed = user_text.trim();
         if trimmed.is_empty() && req.effective_input_parts().is_empty() {
-            return Ok(RespondPlan::Immediate);
+            return Ok(PlannedRespond::immediate_chat(ToolRouteDecision {
+                route: RespondRoute::PlainChat,
+                semantic_route: SemanticRoute::Deterministic,
+                domain: ToolDomain::Unknown,
+                reason: "deterministic_or_empty",
+                status_hint: None,
+            }));
         }
 
         let meta = respond_meta(req);
@@ -93,19 +68,19 @@ impl<'a> RespondRouter<'a> {
             active_conversation_session.as_ref(),
             meta.user_id.as_deref(),
         ) {
-            return Ok(RespondPlan::Immediate);
+            return Ok(PlannedRespond::without_chat_route(RespondPlan::Immediate));
         }
 
         if search_flow::parse_web_search_command(&user_text).is_some() {
             // 显式 `/查` 入口统一走 WebSearch，复用 `/查` 的流式查询能力，
             // 避免被通用 slash 命令截走而走非流式完整等待路径。
-            return Ok(RespondPlan::WebSearch);
+            return Ok(PlannedRespond::without_chat_route(RespondPlan::WebSearch));
         }
         if is_event_wrapped_command(trimmed) {
-            return Ok(RespondPlan::CommandEvent);
+            return Ok(PlannedRespond::command_event());
         }
         if trimmed.starts_with('/') || trimmed.starts_with('／') {
-            return Ok(RespondPlan::Immediate);
+            return Ok(PlannedRespond::without_chat_route(RespondPlan::Immediate));
         }
 
         // 在进入 Tool Loop 路由前，先拦截“明确对机器人发起的搜索意图”。
@@ -115,7 +90,7 @@ impl<'a> RespondRouter<'a> {
         if tool_route::has_search_intent(trimmed, &trimmed.to_ascii_lowercase())
             && directed_to_bot(req)
         {
-            return Ok(RespondPlan::WebSearch);
+            return Ok(PlannedRespond::without_chat_route(RespondPlan::WebSearch));
         }
 
         // 先保护已有确定性命令和自然语言 Todo 查询，避免简单列表查询绕过
@@ -127,7 +102,7 @@ impl<'a> RespondRouter<'a> {
             meta.user_id.as_deref(),
         );
         if matches!(classification.kind, CoreInboundKind::Immediate) {
-            return Ok(RespondPlan::Immediate);
+            return Ok(PlannedRespond::without_chat_route(RespondPlan::Immediate));
         }
 
         let policy = self.resolve_agent_policy(req)?;
@@ -153,11 +128,7 @@ impl<'a> RespondRouter<'a> {
             enabled_tools_count = policy.enabled_tools.len(),
             "selected core respond route"
         );
-        if matches!(plan, RespondPlan::CompleteToolLoop) {
-            Ok(RespondPlan::CompleteToolLoop)
-        } else {
-            Ok(RespondPlan::StreamingChat)
-        }
+        Ok(PlannedRespond::chat(tool_decision))
     }
 
     pub(super) fn classify_inbound(
@@ -213,31 +184,6 @@ impl<'a> RespondRouter<'a> {
         self.service.agent_config.resolve(scene)
     }
 
-    pub(super) fn respond_route(
-        &self,
-        req: &RespondRequest,
-    ) -> Result<tool_route::ToolRouteDecision, LlmError> {
-        let policy = self.resolve_agent_policy(req)?;
-        let meta = respond_meta(req);
-        let interaction_meta = respond_interaction_meta(req);
-        let active_interaction_session = self
-            .service
-            .session_store
-            .get_active(&interaction_meta)
-            .map_err(session_error)?;
-        let active_conversation_session = self
-            .service
-            .session_store
-            .get_active(&meta)
-            .map_err(session_error)?;
-        let route_session = route_context_session(
-            req,
-            active_interaction_session.as_ref(),
-            active_conversation_session.as_ref(),
-        );
-        Ok(self.route_tool_loop_with_active(req, &policy, route_session))
-    }
-
     fn route_tool_loop_with_active(
         &self,
         req: &RespondRequest,
@@ -263,15 +209,10 @@ impl<'a> RespondRouter<'a> {
 }
 
 impl RustRespondService {
-    pub(crate) fn status_hint_for_plan(
+    pub(crate) fn plan_core_respond(
         &self,
         req: &RespondRequest,
-        plan: RespondPlan,
-    ) -> Result<StatusHint, LlmError> {
-        RespondRouter::new(self).status_hint_for_plan(req, plan)
-    }
-
-    pub(crate) fn plan_core_respond(&self, req: &RespondRequest) -> Result<RespondPlan, LlmError> {
+    ) -> Result<PlannedRespond, LlmError> {
         RespondRouter::new(self).plan(req)
     }
 
@@ -280,13 +221,6 @@ impl RustRespondService {
         req: &RespondRequest,
     ) -> Result<ResolvedAgentPolicy, LlmError> {
         RespondRouter::new(self).resolve_agent_policy(req)
-    }
-
-    pub(super) fn respond_route(
-        &self,
-        req: &RespondRequest,
-    ) -> Result<tool_route::ToolRouteDecision, LlmError> {
-        RespondRouter::new(self).respond_route(req)
     }
 
     pub fn classify_inbound(

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -85,10 +85,12 @@ async fn private_weather_chat_with_openai_responses_capability_enters_tool_loop(
             && message.content.contains("存在歧义")
             && message.content.contains("不要调用写工具")
     }));
-    assert_eq!(
-        response.diagnostics.unwrap()["tool_calling_enabled"],
-        serde_json::json!(true)
-    );
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["respond_route"], "tool_agent");
+    assert_eq!(diagnostics["route_reason"], "semantic_tool_intent");
+    assert_eq!(diagnostics["route_domains"], serde_json::json!(["weather"]));
+    assert_eq!(diagnostics["route_semantic"], "tool_loop");
+    assert_eq!(diagnostics["tool_calling_enabled"], true);
 }
 
 #[tokio::test]
@@ -111,6 +113,10 @@ async fn private_general_chat_with_tool_capability_uses_plain_chat() {
     assert_eq!(inspector.tool_call_count(), 0);
     assert_eq!(inspector.requests().len(), 1);
     let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["respond_route"], "plain_chat");
+    assert_eq!(diagnostics["route_reason"], "semantic_plain_chat");
+    assert_eq!(diagnostics["route_domains"], serde_json::json!([]));
+    assert_eq!(diagnostics["route_semantic"], "plain_chat");
     assert_eq!(
         diagnostics["tool_calling_enabled"],
         serde_json::json!(false)
@@ -3049,10 +3055,11 @@ async fn group_chat_does_not_enter_tool_loop() {
     );
     assert_eq!(inspector.tool_call_count(), 0);
     assert_eq!(inspector.requests().len(), 1);
-    assert_eq!(
-        response.diagnostics.unwrap()["tool_calling_enabled"],
-        serde_json::json!(false)
-    );
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["respond_route"], "plain_chat");
+    assert_eq!(diagnostics["route_reason"], "group_tool_loop_disabled");
+    assert_eq!(diagnostics["route_domains"], serde_json::json!([]));
+    assert_eq!(diagnostics["tool_calling_enabled"], false);
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -3,7 +3,7 @@ use std::{fs, sync::Arc};
 use qq_maid_llm::provider::{ToolCallingProtocol, ToolExecutionResult, types::ChatRole};
 use serde_json::Value;
 
-use crate::runtime::respond::RespondPlan;
+use crate::runtime::respond::{PlannedRespond, RespondPlan};
 
 use super::{
     super::{
@@ -3119,6 +3119,56 @@ async fn slash_command_does_not_enter_tool_loop() {
     service.respond(message("/天气 杭州")).await.unwrap();
 
     assert_eq!(inspector.tool_call_count(), 0);
+}
+
+#[tokio::test]
+async fn unknown_slash_command_falls_back_to_plain_chat_with_router_decision() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let req = private_message("/unknown-route-command");
+    let planned = service.plan_core_respond(&req).unwrap();
+    assert_eq!(planned, RespondPlan::Immediate);
+    assert_eq!(
+        planned.respond_route().unwrap().reason,
+        "deterministic_slash_fallback"
+    );
+    let response = service.respond_with_plan(req, planned).await.unwrap();
+
+    assert_eq!(inspector.tool_call_count(), 0);
+    assert_eq!(inspector.requests().len(), 1);
+    assert!(
+        response
+            .text
+            .as_deref()
+            .is_some_and(|text| text.contains("回复：/unknown-route-command"))
+    );
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["respond_route"], "plain_chat");
+    assert_eq!(diagnostics["route_reason"], "deterministic_slash_fallback");
+    assert_eq!(diagnostics["route_semantic"], "deterministic");
+}
+
+#[tokio::test]
+async fn unconsumed_immediate_plan_uses_preplanned_plain_chat_fallback() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let planned = PlannedRespond::immediate_chat("deterministic_handler_fallback");
+
+    let response = service
+        .respond_with_plan(private_message("没有确定性处理器消费这条消息"), planned)
+        .await
+        .unwrap();
+
+    assert_eq!(inspector.tool_call_count(), 0);
+    assert_eq!(inspector.requests().len(), 1);
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["respond_route"], "plain_chat");
+    assert_eq!(
+        diagnostics["route_reason"],
+        "deterministic_handler_fallback"
+    );
+    assert_eq!(diagnostics["route_semantic"], "deterministic");
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -6,7 +6,11 @@ use serde_json::Value;
 use crate::runtime::respond::RespondPlan;
 
 use super::{
-    super::{RespondRequest, common::empty_respond_request},
+    super::{
+        RespondRequest,
+        command_dispatcher::{CommandDispatcher, DispatchOutcome},
+        common::empty_respond_request,
+    },
     support::*,
 };
 use crate::runtime::session::SessionMeta;
@@ -127,6 +131,50 @@ async fn private_general_chat_with_tool_capability_uses_plain_chat() {
     );
     assert_eq!(diagnostics["todo_success_claimed"], false);
     assert_eq!(diagnostics["todo_success_verified"], true);
+}
+
+#[tokio::test]
+async fn router_decision_is_passed_unchanged_to_prepared_chat() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector, true);
+    let req = private_message("杭州今天要带伞吗");
+    let planned = service.plan_core_respond(&req).unwrap();
+    let expected_route = planned.respond_route().unwrap();
+
+    let outcome = CommandDispatcher::new(&service)
+        .dispatch(req, planned)
+        .await
+        .unwrap();
+    let DispatchOutcome::Chat(chat) = outcome else {
+        panic!("expected prepared chat");
+    };
+
+    assert_eq!(chat.respond_route, expected_route);
+    assert!(chat.respond_route.uses_tool_agent());
+}
+
+#[tokio::test]
+async fn streaming_chat_uses_planned_plain_route_without_reclassification() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let planned = service
+        .plan_core_respond(&private_message("聊聊 Rust 的所有权"))
+        .unwrap();
+
+    // 执行时故意换成会被 Router 判为天气 Tool Agent 的文本；流式入口必须继续使用
+    // 已生成的 PlainChat decision，不能读取新状态或按文本重新分类。
+    let response = service
+        .respond_stream_with_plan(private_message("杭州今天要带伞吗"), planned, |_| {
+            Box::pin(async { Ok(()) })
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(inspector.tool_call_count(), 0);
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["respond_route"], "plain_chat");
+    assert_eq!(diagnostics["route_reason"], "semantic_plain_chat");
+    assert_eq!(diagnostics["route_semantic"], "plain_chat");
 }
 
 #[tokio::test]
@@ -852,10 +900,11 @@ async fn private_todo_create_phrase_is_handled_by_agent_tool_loop() {
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
 
-    let response = service
-        .respond(private_message("新增待办，明天接老公"))
-        .await
-        .unwrap();
+    let req = private_message("新增待办，明天接老公");
+    let planned = service.plan_core_respond(&req).unwrap();
+    assert_eq!(planned, RespondPlan::CompleteToolLoop);
+    assert!(planned.respond_route().unwrap().uses_tool_agent());
+    let response = service.respond_with_plan(req, planned).await.unwrap();
 
     assert_eq!(response.command.as_deref(), Some("todo_create"));
     let text = response.text.unwrap();

--- a/qq-maid-core/src/runtime/respond/tool_route.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route.rs
@@ -74,7 +74,7 @@ impl ToolDomain {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct ToolRouteDecision {
     pub route: RespondRoute,
     pub semantic_route: SemanticRoute,

--- a/qq-maid-core/src/runtime/respond/tool_route.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route.rs
@@ -84,6 +84,18 @@ pub(super) struct ToolRouteDecision {
 }
 
 impl ToolRouteDecision {
+    /// 为确定性分派准备普通聊天兜底。Router 必须在执行前确定 reason，
+    /// dispatcher 不得在 handler 未消费时临时补造路由信息。
+    pub(super) const fn plain_deterministic(reason: &'static str) -> Self {
+        Self {
+            route: RespondRoute::PlainChat,
+            semantic_route: SemanticRoute::Deterministic,
+            domain: ToolDomain::Unknown,
+            reason,
+            status_hint: None,
+        }
+    }
+
     pub(super) const fn uses_tool_agent(self) -> bool {
         matches!(self.route, RespondRoute::ToolAgent)
     }

--- a/qq-maid-core/src/runtime/respond/tool_route.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route.rs
@@ -16,9 +16,18 @@ use super::{
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum ToolLoopRoute {
+pub(super) enum RespondRoute {
     PlainChat,
-    CompleteToolLoop,
+    ToolAgent,
+}
+
+impl RespondRoute {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::PlainChat => "plain_chat",
+            Self::ToolAgent => "tool_agent",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27,6 +36,17 @@ pub(super) enum SemanticRoute {
     ToolLoop,
     Deterministic,
     Ambiguous,
+}
+
+impl SemanticRoute {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::PlainChat => "plain_chat",
+            Self::ToolLoop => "tool_loop",
+            Self::Deterministic => "deterministic",
+            Self::Ambiguous => "ambiguous",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -40,13 +60,41 @@ pub(super) enum ToolDomain {
     Unknown,
 }
 
+impl ToolDomain {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Todo => "todo",
+            Self::Weather => "weather",
+            Self::Train => "train",
+            Self::Rss => "rss",
+            Self::Search => "search",
+            Self::Memory => "memory",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(super) struct ToolRouteDecision {
-    pub route: ToolLoopRoute,
+    pub route: RespondRoute,
     pub semantic_route: SemanticRoute,
     pub domain: ToolDomain,
     pub reason: &'static str,
     pub status_hint: Option<StatusHint>,
+}
+
+impl ToolRouteDecision {
+    pub(super) const fn uses_tool_agent(self) -> bool {
+        matches!(self.route, RespondRoute::ToolAgent)
+    }
+
+    pub(super) fn domains(self) -> Vec<&'static str> {
+        if matches!(self.domain, ToolDomain::Unknown) {
+            Vec::new()
+        } else {
+            vec![self.domain.as_str()]
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -68,13 +116,36 @@ pub(super) struct SemanticAssessment {
 }
 
 pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> ToolRouteDecision {
-    if !ctx.scene_enabled
-        || !ctx.tool_calling_enabled
+    let is_group = req
+        .group_id
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty());
+    if !ctx.scene_enabled {
+        return decision(
+            RespondRoute::PlainChat,
+            SemanticRoute::PlainChat,
+            ToolDomain::Unknown,
+            "tool_loop_unavailable",
+            None,
+        );
+    }
+    // 群聊开关是独立的安全边界，diagnostics 应保留该原因，不能被通用
+    // tool_calling_enabled guard 折叠为无法定位配置项的 unavailable。
+    if is_group && !ctx.group_tool_calling_enabled {
+        return decision(
+            RespondRoute::PlainChat,
+            SemanticRoute::PlainChat,
+            ToolDomain::Unknown,
+            "group_tool_loop_disabled",
+            None,
+        );
+    }
+    if !ctx.tool_calling_enabled
         || !ctx.provider_supports_tool_calling
         || !ctx.enabled_tools_available
     {
         return decision(
-            ToolLoopRoute::PlainChat,
+            RespondRoute::PlainChat,
             SemanticRoute::PlainChat,
             ToolDomain::Unknown,
             "tool_loop_unavailable",
@@ -83,7 +154,7 @@ pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> To
     }
     if req.has_non_text_input_parts() {
         return decision(
-            ToolLoopRoute::PlainChat,
+            RespondRoute::PlainChat,
             SemanticRoute::PlainChat,
             ToolDomain::Unknown,
             "multimodal_plain_chat",
@@ -94,27 +165,13 @@ pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> To
     let trimmed = text.trim();
     if trimmed.is_empty() || trimmed.starts_with('/') || trimmed.starts_with('／') {
         return decision(
-            ToolLoopRoute::PlainChat,
+            RespondRoute::PlainChat,
             SemanticRoute::Deterministic,
             ToolDomain::Unknown,
             "deterministic_or_empty",
             None,
         );
     }
-    let is_group = req
-        .group_id
-        .as_deref()
-        .is_some_and(|value| !value.trim().is_empty());
-    if is_group && !ctx.group_tool_calling_enabled {
-        return decision(
-            ToolLoopRoute::PlainChat,
-            SemanticRoute::PlainChat,
-            ToolDomain::Unknown,
-            "group_tool_loop_disabled",
-            None,
-        );
-    }
-
     let has_recent_todo_context = ctx
         .interaction_state
         .has_recent_context(InteractionDomain::Todo);
@@ -122,35 +179,35 @@ pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> To
     let status_hint = classify_status_hint(trimmed, has_recent_todo_context);
     match assessment.semantic_route {
         SemanticRoute::PlainChat => decision(
-            ToolLoopRoute::PlainChat,
+            RespondRoute::PlainChat,
             SemanticRoute::PlainChat,
             assessment.domain,
             assessment.reason,
             None,
         ),
         SemanticRoute::ToolLoop => decision(
-            ToolLoopRoute::CompleteToolLoop,
+            RespondRoute::ToolAgent,
             SemanticRoute::ToolLoop,
             assessment.domain,
             assessment.reason,
             status_hint,
         ),
         SemanticRoute::Deterministic => decision(
-            ToolLoopRoute::PlainChat,
+            RespondRoute::PlainChat,
             SemanticRoute::Deterministic,
             assessment.domain,
             "deterministic_or_empty",
             None,
         ),
         SemanticRoute::Ambiguous if is_group => decision(
-            ToolLoopRoute::PlainChat,
+            RespondRoute::PlainChat,
             SemanticRoute::Ambiguous,
             assessment.domain,
             "semantic_ambiguous_group_plain",
             None,
         ),
         SemanticRoute::Ambiguous => decision(
-            ToolLoopRoute::PlainChat,
+            RespondRoute::PlainChat,
             SemanticRoute::Ambiguous,
             assessment.domain,
             assessment.reason,
@@ -164,7 +221,7 @@ pub(super) fn has_search_intent(text: &str, lower: &str) -> bool {
 }
 
 fn decision(
-    route: ToolLoopRoute,
+    route: RespondRoute,
     semantic_route: SemanticRoute,
     domain: ToolDomain,
     reason: &'static str,
@@ -334,7 +391,7 @@ mod tests {
             "聊聊天气",
         ] {
             let decision = route_tool_loop(&request(input), context());
-            assert_eq!(decision.route, ToolLoopRoute::PlainChat, "{input}");
+            assert_eq!(decision.route, RespondRoute::PlainChat, "{input}");
             assert_eq!(decision.semantic_route, SemanticRoute::PlainChat, "{input}");
             assert_eq!(decision.status_hint, None, "{input}");
         }
@@ -392,7 +449,7 @@ WebSearch tool timeout
             "查看上次 codex 发布的 rss",
         ] {
             let decision = route_tool_loop(&request(input), context());
-            assert_eq!(decision.route, ToolLoopRoute::CompleteToolLoop, "{input}");
+            assert_eq!(decision.route, RespondRoute::ToolAgent, "{input}");
             assert_eq!(decision.semantic_route, SemanticRoute::ToolLoop, "{input}");
             assert!(decision.status_hint.is_some(), "{input}");
         }
@@ -429,7 +486,7 @@ WebSearch tool timeout
 
         for (input, expected_hint) in cases {
             let decision = route_tool_loop(&request(input), context());
-            assert_eq!(decision.route, ToolLoopRoute::CompleteToolLoop, "{input}");
+            assert_eq!(decision.route, RespondRoute::ToolAgent, "{input}");
             assert_eq!(decision.status_hint, Some(expected_hint), "{input}");
         }
     }
@@ -444,24 +501,20 @@ WebSearch tool timeout
             "这些完成了",
         ] {
             let decision = route_tool_loop(&request(input), context());
-            assert_eq!(decision.route, ToolLoopRoute::CompleteToolLoop, "{input}");
+            assert_eq!(decision.route, RespondRoute::ToolAgent, "{input}");
             assert_eq!(decision.domain, ToolDomain::Todo, "{input}");
         }
 
         for input in ["这个改一下", "都删除了吧"] {
             let without_context = route_tool_loop(&request(input), context());
-            assert_eq!(without_context.route, ToolLoopRoute::PlainChat, "{input}");
+            assert_eq!(without_context.route, RespondRoute::PlainChat, "{input}");
             assert_eq!(
                 without_context.reason, "todo_reference_context_missing",
                 "{input}"
             );
 
             let with_context = route_tool_loop(&request(input), context_with_recent_todo());
-            assert_eq!(
-                with_context.route,
-                ToolLoopRoute::CompleteToolLoop,
-                "{input}"
-            );
+            assert_eq!(with_context.route, RespondRoute::ToolAgent, "{input}");
             assert_eq!(with_context.domain, ToolDomain::Todo, "{input}");
         }
     }
@@ -470,18 +523,14 @@ WebSearch tool timeout
     fn bare_number_todo_operations_require_recent_context() {
         for input in ["7删除", "删除7", "把7合并到6", "6和7合并"] {
             let without_context = route_tool_loop(&request(input), context());
-            assert_eq!(without_context.route, ToolLoopRoute::PlainChat, "{input}");
+            assert_eq!(without_context.route, RespondRoute::PlainChat, "{input}");
             assert_eq!(
                 without_context.reason, "todo_number_context_missing",
                 "{input}"
             );
 
             let with_context = route_tool_loop(&request(input), context_with_recent_todo());
-            assert_eq!(
-                with_context.route,
-                ToolLoopRoute::CompleteToolLoop,
-                "{input}"
-            );
+            assert_eq!(with_context.route, RespondRoute::ToolAgent, "{input}");
             assert_eq!(with_context.domain, ToolDomain::Todo, "{input}");
         }
     }
@@ -490,7 +539,7 @@ WebSearch tool timeout
     fn ambiguous_private_defaults_to_plain_chat() {
         for input in ["安排一下", "帮我处理一下", "刚刚没看到，再来一条"] {
             let decision = route_tool_loop(&request(input), context());
-            assert_eq!(decision.route, ToolLoopRoute::PlainChat, "{input}");
+            assert_eq!(decision.route, RespondRoute::PlainChat, "{input}");
             assert_eq!(decision.semantic_route, SemanticRoute::Ambiguous, "{input}");
             assert_eq!(decision.status_hint, None, "{input}");
         }
@@ -502,7 +551,7 @@ WebSearch tool timeout
         group.group_id = Some("g1".to_owned());
         assert_eq!(
             route_tool_loop(&group, context()).route,
-            ToolLoopRoute::PlainChat
+            RespondRoute::PlainChat
         );
         assert_eq!(
             route_tool_loop(
@@ -513,7 +562,7 @@ WebSearch tool timeout
                 },
             )
             .route,
-            ToolLoopRoute::PlainChat
+            RespondRoute::PlainChat
         );
     }
 
@@ -530,7 +579,7 @@ WebSearch tool timeout
                 },
             )
             .route,
-            ToolLoopRoute::CompleteToolLoop
+            RespondRoute::ToolAgent
         );
     }
 
@@ -552,7 +601,7 @@ WebSearch tool timeout
         ] {
             assert_eq!(
                 route_tool_loop(&request("杭州明天要带伞吗"), ctx).route,
-                ToolLoopRoute::PlainChat
+                RespondRoute::PlainChat
             );
         }
     }

--- a/qq-maid-core/src/service/handle.rs
+++ b/qq-maid-core/src/service/handle.rs
@@ -70,7 +70,8 @@ impl CoreService for CoreHandle {
         let recorder = MetricsRecorder::start();
         let scope_key = req.scope_key.clone();
         let state = self.state.as_ref();
-        let respond_plan = service.plan_core_respond(&req).map_err(CoreError::from)?;
+        let planned = service.plan_core_respond(&req).map_err(CoreError::from)?;
+        let respond_plan = planned.plan();
         if matches!(
             respond_plan,
             RespondPlan::CommandEvent
@@ -82,9 +83,7 @@ impl CoreService for CoreHandle {
             // 让 Gateway 消费 Completed 后再渲染 XML，QQ 官方流式行为保持不变。
             let provider_stream_enabled = state.provider.stream_enabled() && !force_complete_sync;
             let output_policy = output_policy_for_stream(respond_plan, provider_stream_enabled);
-            let status_hint = service
-                .status_hint_for_plan(&req, respond_plan)
-                .map_err(CoreError::from)?;
+            let status_hint = planned.status_hint();
             let status_display_name = service.status_display_name().to_owned();
             let status_audience = if req
                 .group_id
@@ -101,7 +100,7 @@ impl CoreService for CoreHandle {
                     Ok::<_, LlmError>(start_core_response_stream(
                         service,
                         req,
-                        respond_plan,
+                        planned,
                         output_policy,
                         provider_stream_enabled,
                         Duration::from_secs(state.config.request_timeout_seconds),
@@ -134,7 +133,7 @@ impl CoreService for CoreHandle {
         }
         let result = timeout(
             Duration::from_secs(state.config.request_timeout_seconds),
-            service.respond_with_plan(req, respond_plan),
+            service.respond_with_plan(req, planned),
         )
         .await;
 

--- a/qq-maid-core/src/service/streaming.rs
+++ b/qq-maid-core/src/service/streaming.rs
@@ -16,8 +16,8 @@ use qq_maid_llm::agent_loop::{
 use crate::{
     error::LlmError,
     runtime::respond::{
-        RespondPlan, RespondRequest, RespondResponse, RustRespondService, StatusAudience,
-        StatusHint, StatusPhase, status_hint_text,
+        PlannedRespond, RespondPlan, RespondRequest, RespondResponse, RustRespondService,
+        StatusAudience, StatusHint, StatusPhase, status_hint_text,
     },
 };
 
@@ -38,7 +38,7 @@ pub(crate) struct ProgressStatusConfig {
 pub(crate) fn start_core_response_stream(
     service: RustRespondService,
     req: RespondRequest,
-    plan: RespondPlan,
+    planned: PlannedRespond,
     output_policy: CoreOutputPolicy,
     provider_stream_enabled: bool,
     request_timeout: Duration,
@@ -48,6 +48,7 @@ pub(crate) fn start_core_response_stream(
     let cancelled = Arc::new(AtomicBool::new(false));
     let producer_cancelled = cancelled.clone();
     let scope_key = req.scope_key.clone();
+    let plan = planned.plan();
     tokio::spawn(async move {
         if producer_cancelled.load(Ordering::SeqCst) {
             let _ = tx
@@ -58,7 +59,7 @@ pub(crate) fn start_core_response_stream(
         let respond_future = run_streaming_respond(
             &service,
             req,
-            plan,
+            planned,
             tx.clone(),
             producer_cancelled.clone(),
             provider_stream_enabled,
@@ -108,16 +109,18 @@ pub(crate) fn start_core_response_stream(
 async fn run_streaming_respond(
     service: &RustRespondService,
     req: RespondRequest,
-    plan: RespondPlan,
+    planned: PlannedRespond,
     tx: mpsc::Sender<CoreResponseEvent>,
     cancelled: Arc<AtomicBool>,
     provider_stream_enabled: bool,
     progress_status: ProgressStatusConfig,
 ) -> Result<RespondResponse, LlmError> {
+    let plan = planned.plan();
     if matches!(plan, RespondPlan::CompleteToolLoop) {
         return run_complete_tool_loop_respond(
             service,
             req,
+            planned,
             tx,
             cancelled,
             progress_status,
@@ -126,7 +129,7 @@ async fn run_streaming_respond(
         .await;
     }
     if matches!(plan, RespondPlan::CommandEvent) {
-        return run_command_event_respond(service, req, plan, tx, cancelled).await;
+        return run_command_event_respond(service, req, planned, tx, cancelled).await;
     }
     if matches!(plan, RespondPlan::WebSearch) && provider_stream_enabled {
         // WebSearch 不套用 CompleteToolLoop 整体超时：联网查询复用 `/查` 的流式
@@ -136,7 +139,7 @@ async fn run_streaming_respond(
         return run_web_search_respond(service, req, tx, cancelled).await;
     }
     if !provider_stream_enabled {
-        let response = service.respond_with_plan(req, plan).await?;
+        let response = service.respond_with_plan(req, planned).await?;
         debug!(
             respond_plan = respond_plan_name(plan),
             provider_stream_enabled,
@@ -151,7 +154,7 @@ async fn run_streaming_respond(
         return Ok(response);
     }
     service
-        .respond_stream(req, |delta| {
+        .respond_stream_with_plan(req, planned, |delta| {
             let tx = tx.clone();
             let cancelled = cancelled.clone();
             Box::pin(async move { send_core_delta(&tx, &cancelled, delta).await })
@@ -162,7 +165,7 @@ async fn run_streaming_respond(
 async fn run_command_event_respond(
     service: &RustRespondService,
     req: RespondRequest,
-    plan: RespondPlan,
+    planned: PlannedRespond,
     tx: mpsc::Sender<CoreResponseEvent>,
     cancelled: Arc<AtomicBool>,
 ) -> Result<RespondResponse, LlmError> {
@@ -173,7 +176,8 @@ async fn run_command_event_respond(
         "正在处理命令…".to_owned(),
     )
     .await?;
-    let response = service.respond_with_plan(req, plan).await?;
+    let plan = planned.plan();
+    let response = service.respond_with_plan(req, planned).await?;
     if !response.ok {
         return Ok(response);
     }
@@ -221,6 +225,7 @@ async fn run_web_search_respond(
 async fn run_complete_tool_loop_respond(
     service: &RustRespondService,
     req: RespondRequest,
+    planned: PlannedRespond,
     tx: mpsc::Sender<CoreResponseEvent>,
     cancelled: Arc<AtomicBool>,
     progress_status: ProgressStatusConfig,
@@ -252,12 +257,8 @@ async fn run_complete_tool_loop_respond(
     } else {
         None
     };
-    let respond_future = service.respond_with_plan_and_progress(
-        req,
-        RespondPlan::CompleteToolLoop,
-        Some(progress_sink),
-        final_delta_sink,
-    );
+    let respond_future =
+        service.respond_with_plan_and_progress(req, planned, Some(progress_sink), final_delta_sink);
     tokio::pin!(respond_future);
     let mut running_status_sent = false;
 

--- a/qq-maid-core/src/service/tests/mod.rs
+++ b/qq-maid-core/src/service/tests/mod.rs
@@ -10,7 +10,10 @@ use qq_maid_llm::provider::{LlmStreamEvent, ToolCallingProtocol};
 use crate::{
     error::LlmError,
     runtime::{
-        respond::{RespondPlan, RespondRequest, RespondResponse, StatusAudience, StatusHint},
+        respond::{
+            PlannedRespond, RespondPlan, RespondRequest, RespondResponse, StatusAudience,
+            StatusHint,
+        },
         session::SessionMeta,
         tools::todo::{TodoItemDraft, TodoPendingOperation, TodoStore, TodoTimePrecision},
     },
@@ -828,7 +831,7 @@ async fn core_command_event_failure_does_not_send_finished_or_completed() {
     let mut stream = start_core_response_stream(
         service,
         req,
-        RespondPlan::CommandEvent,
+        PlannedRespond::command_event(),
         CoreOutputPolicy::CompleteThenSend,
         false,
         Duration::from_secs(5),


### PR DESCRIPTION
## 变更内容

- 将普通消息路由结果统一为 `RespondRoute::PlainChat` / `RespondRoute::ToolAgent`
- 引入不可变 `PlannedRespond`，同时携带顶层 `RespondPlan` 和 Router 单次生成的 `ToolRouteDecision`
- 让 Core streaming、dispatcher、旧 Todo / Memory flow 跳过判断、chat flow、status hint 与 diagnostics 消费同一份 decision
- 删除执行阶段重新读取 session / policy 的 `respond_route()`、重复计算式 `status_hint_for_plan()` 和仅在 Debug 生效的 `debug_assert_eq!`
- 普通流式聊天直接接收已规划的 PlainChat decision；Tool Agent 不会进入普通 `stream_respond()`
- 为 pending、slash、确定性 handler 和 CommandEvent 计划预置 `PlainChat` fallback decision，handler 未消费时仍可进入原有聊天兜底
- 仅 `PlannedRespond::web_search()` 不携带聊天 fallback route，避免合法 Immediate 路径触发 `respond_route_missing`
- 保留群聊 Tool Agent 开关、工具白名单、domain 后处理和现有 Tool Loop 协议

## 范围

这是 #400 的第一阶段，只收敛统一路由结果、不可变数据流与可观测 diagnostics。暂不引入结构化 Router Model，也不重写现有 Agent Loop。

## 测试

新增或调整测试覆盖：

- Router decision 原样传入 `PreparedChat`
- Todo `CompleteToolLoop` 的旧 flow 跳过与 Tool Agent 执行来自同一 `PlannedRespond`
- 普通流式聊天不按执行时文本重新分类，diagnostics 固定报告已规划的 `plain_chat`
- 未知 slash 命令使用 Router 预置的 `deterministic_slash_fallback` 进入普通聊天
- 未被确定性 handler 消费的 Immediate 计划使用 `deterministic_handler_fallback` 正常兜底
- command event 测试使用受限的 `PlannedRespond::command_event()` 夹具

## 验证

- `cargo fmt --all -- --check`
- `cargo check -p qq-maid-core --all-features`
- `cargo test -p qq-maid-core --all-features`（783 passed）
- `cargo clippy -p qq-maid-core --all-targets --all-features -- -D warnings`
- `git diff --check`

Part of #400