### PR TITLE
release: v0.15.0 清理 — 移除 qbot 一键安装脚本

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 本文档基于 [keep a changelog](https://keepachangelog.com/zh-CN/1.0.0/) 格式，记录每个已发布版本的变更。
 
+## [v0.15.0] - 2026-07-10
+
+### Release Focus
+
+* **Tool / Todo 架构边界收敛版本**：本版本在 v0.14.x 事件流和群聊稳定性版本线上继续收口 Tool Loop、Todo、Reminder、RSS/Search/Weather/Train 等业务工具边界。重点是把 Todo / Reminder 路由、pending、可见实体快照、成功验真和查询新鲜度判断下沉到 `runtime/tools/todo/`，并把 Tool Loop 整轮后处理收敛到 `runtime/tools/agent_turn.rs`，让 Respond 层回到跨域调度、会话维护和响应拼装职责。
+
+### Added
+
+* **重复提醒与周期管理**（PR #389 #391 #394）：支持分钟级提醒、周期性纯提醒和重复提醒周期管理；Todo / Reminder 的周期解析、下一次提醒计算和通知 outbox 维护继续收敛到 Todo 工具域。
+
+* **Gemini Provider 与搜索入口**（PR #397）：新增 Gemini Provider 和 Gemini Google Search 路线支持，`agent.toml` 示例补充 `gemini:` 前缀；OpenAI Web Search 与 Gemini Search 继续通过搜索路线配置选择。
+
+* **自定义 Tool 二开指南**（PR #396）：新增 [docs/development/custom-tools.md](./docs/development/custom-tools.md)，说明服务端白名单 Tool 注册、场景白名单、自然语言路由、确定性展示、成功验真、可见实体和查询新鲜度等接入边界。
+
+### Changed
+
+* **Todo 工具域迁移与边界收敛**（PR #393 #398 #399）：Todo 运行实现、Todo / Reminder 路由、pending 状态机、确认/澄清恢复、可见实体快照、成功守卫、查询新鲜度和周期提醒规则集中到 `qq-maid-core/src/runtime/tools/todo/`；`runtime/respond/` 不再承载零散 Todo 业务规则。
+
+* **普通消息 Tool Loop 路由边界收敛**（PR #399）：普通聊天弱意图判断与 Tool Loop 前置路由重新整理。纯聊天、解释、创作、文本整理和 Codex prompt 整理类请求默认保持普通聊天；明确 Todo / Reminder、天气、火车、RSS、Web Search 等工具意图才进入对应工具路径。
+
+* **Tool Loop 后处理收敛到 tools/agent_turn**（PR #399）：整轮工具结果投影、确定性展示、失败/部分成功诊断、Todo 成功验真和可见实体快照写入统一由 tools 层处理；Respond / chat_flow 只负责发起 Tool Loop、保存会话和拼装最终响应。
+
+* **非 Todo 工具路由保持独立**（PR #399）：天气、火车、RSS 和 Web Search 路由从 Todo 判断中拆开，避免非 Todo 工具命中后回退到普通聊天或 Todo 规则。
+
+* **Todo 查询新鲜度与可见实体快照整理**（PR #399）：列表后的“完成第一条”“刚才那条”等续指继续依赖用户实际看到的快照；群聊中不同 actor 的 Todo 交互状态保持隔离，避免串用他人列表。
+
+* **Todo 每日摘要开关恢复**（PR #395）：恢复 Todo 每日摘要开关配置和调度入口，让主动提醒能力保持可控。
+
+### Fixed
+
+* **Todo 成功守卫加强**（PR #398 #399）：工具失败、需要澄清或需要确认时，最终回复不得声称已经完成；Todo 写操作继续以真实工具执行结果和持久化结果为准。
+
+* **RSS 标题污染修复**（PR #385）：修复 RSS 标题污染问题，降低订阅内容展示噪声。
+
+* **群聊冷却提示修复**（PR #387）：群聊冷却命中且消息明确指向机器人时返回轻量提示，避免用户以为消息被无声丢弃。
+
+### Compatibility
+
+* 用户可见行为原则上保持兼容：已有 Todo 增删改查、提醒、重复提醒、天气、火车、RSS、Web Search、普通聊天和文本整理入口继续使用原有表达方式；本版本主要收紧误路由和成功验真边界。
+* 版本号入口仍为根包 `qq-maid-bot` 的 `Cargo.toml`。各内部 crate 版本没有在本次发布中作为统一发布号同步提升。
+
+### Follow-up
+
+* Codex-like Agent Runtime 仍是后续规划，已由 issue #400 跟踪；本版本没有实现 #400，也不把它作为 v0.15.0 已发布能力。
+
 ## [v0.14.2] - 2026-07-09
 
 ### Release Focus
@@ -995,6 +1040,8 @@ bash scripts/deploy-local.sh
 - 移除已废弃的 Python 接入层和旧 Provider
 - rig-core 升级至 0.38.2
 
+[v0.15.0]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.14.2...v0.15.0
+[v0.14.2]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.14.1...v0.14.2
 [v0.14.1]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.14.0...v0.14.1
 [v0.14.0]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.13.2...v0.14.0
 [v0.13.2]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.13.1...v0.13.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,7 +1435,7 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "qq-maid-bot"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "qq-maid-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-bot"
-version = "0.14.2"
+version = "0.15.0"
 edition = "2024"
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -20,16 +20,21 @@
 
 > Rust 单进程 · 多平台入口抽象 · Provider 无关 Agent Loop · 响应事件流 · 多模态输入 · 受控长期记忆 · 主动推送 · 模型自动降级
 
-当前源码版本线：**v0.14.2：事件流、Tool Loop 流式与运维体验收敛版本**。这一版在 v0.14.x 群聊体验优化与 SQLite 连接池版本线上继续推进统一响应事件流、Tool Loop 进度事件和最终回答流式转发，同时修复 Web Search 长查询、文本整理误触发联网查询等问题，并补充开机自启动配置。历史版本记录见 [CHANGELOG.md](./CHANGELOG.md)，实际发布包以 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 页面为准。
+当前源码版本线：**v0.15.0：Tool / Todo 架构边界收敛版本**。这一版在 v0.14.x 事件流、群聊稳定性和 Tool Loop 流式体验基础上，重点收敛普通消息 Tool Loop 路由、Todo / Reminder 工具域、Tool Loop 后处理、Todo 成功验真、可见实体快照和查询新鲜度边界。历史版本记录见 [CHANGELOG.md](./CHANGELOG.md)，实际发布包以 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 页面为准。
 
 ## 当前版本亮点
 
 | 重点 | 说明 |
 | --- | --- |
-| 响应事件流 | 新增统一响应事件流设计基线，普通聊天、Tool Loop 进度、最终回答流式推进和后续多入口发送能力开始收敛到同一套事件语义。 |
-| Tool Loop 流式体验 | Tool Loop 新增可观测进度事件，并接入最终回答流式推进，长工具链请求不再只能等完整结果一次性返回。 |
-| 联网查询更稳 | 修复文本整理误触发联网查询和 Web Search 长查询预处理问题，减少普通文本任务误入搜索链路，也让复杂搜索请求更可靠。 |
-| 运维启动配置 | 补充发布包和运行目录相关的开机自启动配置，继续完善 Linux systemd 与 Windows 启动模板链路。 |
+| Tool / Todo 边界 | Todo / Reminder 路由、pending、确认/澄清、成功验真、可见实体快照和查询新鲜度集中到 `runtime/tools/todo/`，Respond 层只保留跨域调度与响应拼装。 |
+| 普通聊天更稳 | 纯聊天、解释、创作、文本整理和 Codex prompt 整理类请求默认保持普通聊天；明确工具意图才进入 Tool Loop。 |
+| Tool Loop 后处理 | 工具结果投影、确定性展示、失败/部分成功诊断和 Todo 成功守卫收敛到 `runtime/tools/agent_turn.rs`。 |
+| 非 Todo 工具路由 | 天气、火车、RSS、Web Search 路由保持独立，不因 Todo 规则调整而回退或串路由。 |
+| Todo 续指更稳 | “完成第一条”“刚才那条”等操作继续绑定用户实际看到的可见实体快照；群聊中不同 actor 不串用 Todo 快照。 |
+| 重复提醒 | 支持分钟级提醒、周期性纯提醒和重复提醒周期管理，Todo 每日摘要开关恢复。 |
+| Gemini 支持 | 新增 Gemini Provider 与 Gemini Search 路线支持，可在 `agent.toml` 中使用 `gemini:` 前缀。 |
+| 自定义 Tool 文档 | 新增二开指南，说明 Tool 注册、白名单、路由、确定性展示、成功验真和可见实体接入边界。 |
+| 响应事件流 | 统一响应事件流设计基线、Tool Loop 进度事件和最终回答流式推进继续作为底层能力保留。 |
 | RSS 管理增强 | 增强最近更新查看和批量管理能力，订阅排查、整理和日常维护更直接。 |
 | Todo 回执更轻 | 简化 Todo 写操作后的用户可见回执，减少重复状态噪音，同时保留真实执行结果。 |
 | 群聊上下文更稳 | 收紧群聊 pending、引用快照、Tool Loop Todo 聚合状态和入站身份上下文隔离，降低 A/B 用户串上下文、引用旧消息误 fallback、后续操作选错 Todo 的风险。 |
@@ -63,7 +68,7 @@
 
 ### 🧰 不只是“模型说它做了”
 
-私聊普通对话可以进入 Provider 无关的 Agent Loop。模型按需调用白名单工具，Core 根据真实工具结果生成可信回复，而不是仅凭模型文案判断操作是否成功。
+私聊中的明确工具意图可以进入 Provider 无关的 Agent Loop。模型按需调用白名单工具，Core 根据真实工具结果生成可信回复，而不是仅凭模型文案判断操作是否成功；纯聊天、解释、创作和文本整理仍按普通聊天处理。
 
 当前天气和 Todo 已接入确定性展示；Todo 的新增、修改、完成、恢复、取消和删除都有明确执行结果。遇到目标不清楚时，会进入澄清或确认流程，后续消息可以在受限范围内恢复任务。
 
@@ -518,7 +523,7 @@ QQ 官方机器人功能仍受平台权限、审核和接口规则限制。Linux
 
 ## 版本升级
 
-当前源码版本线为 **v0.14.2：事件流、Tool Loop 流式与运维体验收敛版本**；已发布稳定包请以 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 页面为准。版本升级前请先阅读 [CHANGELOG.md](./CHANGELOG.md)，并对比新版 `runtime/config/.env.example` 和 `runtime/config/agent.toml`。
+当前源码版本线为 **v0.15.0：Tool / Todo 架构边界收敛版本**；已发布稳定包请以 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 页面为准。版本升级前请先阅读 [CHANGELOG.md](./CHANGELOG.md)，并对比新版 `runtime/config/.env.example` 和 `runtime/config/agent.toml`。
 
 从 v0.11.x 升级到当前版本线时，重点检查：默认 runtime 是否包含 `config/agent.toml`，旧 `.env` 中的 `LLM_MODEL` / `PRIVATE_LLM_MODEL` / `GROUP_LLM_MODEL` 是否仍符合预期，Todo 提醒是否只在明确需要时开启。需要处理 QQ 图片时，再检查 `QQ_MAID_MEDIA_DIR`、`QQ_MAID_MEDIA_MAX_BYTES` 和所选模型是否支持图片输入。较早版本从 v0.3.x 升级到 v0.4.0 涉及单进程架构迁移，仍需参考 [v0.4.0 迁移说明](./CHANGELOG.md#v040)。
 

--- a/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 use super::{
-    ChatToolPlan, RespondPurpose, RespondRequest, RespondResponse, RustRespondService,
+    RespondPurpose, RespondRequest, RespondResponse, RustRespondService,
     agent_outcome::AgentTurnOutcome,
     common::{
         SESSION_HISTORY_MESSAGE_LIMIT, command_response, empty_respond_request, memory_error,
@@ -26,6 +26,7 @@ use super::{
     },
     llm_service::{ChatService, LlmChatService, response_from_output},
     session_flow::build_session_context,
+    tool_route::ToolRouteDecision,
 };
 
 pub(super) use super::conversation_session::recent_session_messages;
@@ -47,7 +48,7 @@ pub(super) struct PreparedChat {
     pub user_text: String,
     pub meta: SessionMeta,
     pub session: SessionRecord,
-    pub chat_plan: ChatToolPlan,
+    pub respond_route: ToolRouteDecision,
 }
 
 #[derive(Default)]
@@ -74,7 +75,7 @@ impl RustRespondService {
             user_text,
             meta,
             mut session,
-            chat_plan: chat_tool_plan,
+            respond_route,
         } = chat;
         let ChatFlowSinks {
             progress_sink,
@@ -112,7 +113,7 @@ impl RustRespondService {
         let used_memory = !memory_context.trim().is_empty();
         let is_group_chat = is_group_meta(&meta);
         let system_prompts = self.prompt_config.load_system_prompts()?;
-        let system_prompts = if matches!(chat_tool_plan, ChatToolPlan::ForceCompleteToolLoop) {
+        let system_prompts = if respond_route.uses_tool_agent() {
             let mut prompts = system_prompts;
             prompts.push(TOOL_LOOP_AMBIGUITY_PROMPT.to_owned());
             if is_group_chat {
@@ -177,7 +178,7 @@ impl RustRespondService {
         }
         let service =
             LlmChatService::with_context_budget(self.provider.clone(), self.context_budget);
-        let use_tool_loop = matches!(chat_tool_plan, ChatToolPlan::ForceCompleteToolLoop);
+        let use_tool_loop = respond_route.uses_tool_agent();
         let (output, agent_turn_outcome, tool_turn_diagnostics) = if use_tool_loop {
             let tools = self.tool_runtime.registry_for_chat(&policy, &req)?;
             let output = service
@@ -251,6 +252,10 @@ impl RustRespondService {
             "used_knowledge": used_knowledge,
             "knowledge_hit_count": knowledge_context.hit_count,
             "used_search": false,
+            "respond_route": respond_route.route.as_str(),
+            "route_reason": respond_route.reason,
+            "route_domains": respond_route.domains(),
+            "route_semantic": respond_route.semantic_route.as_str(),
             "tool_calling_enabled": use_tool_loop,
             "tool_loop_mode": if use_tool_loop { json!("configured_whitelist") } else { Value::Null },
             "tool_loop_enabled_tools": if use_tool_loop { json!(&policy.enabled_tools) } else { Value::Null },
@@ -287,9 +292,10 @@ impl RustRespondService {
     }
 
     /// 普通聊天真流式路径：复用非流式聊天的上下文构造和后处理，只替换 LLM 调用方式。
-    pub async fn handle_chat_stream<F>(
+    pub(super) async fn handle_chat_stream<F>(
         &self,
         req: RespondRequest,
+        respond_route: ToolRouteDecision,
         on_delta: F,
     ) -> Result<RespondResponse, LlmError>
     where
@@ -309,7 +315,7 @@ impl RustRespondService {
                         user_text,
                         meta,
                         session,
-                        chat_plan: ChatToolPlan::Plain,
+                        respond_route,
                     },
                     ChatFlowSinks::default(),
                 )
@@ -411,6 +417,10 @@ impl RustRespondService {
             "used_knowledge": used_knowledge,
             "knowledge_hit_count": knowledge_context.hit_count,
             "used_search": false,
+            "respond_route": respond_route.route.as_str(),
+            "route_reason": respond_route.reason,
+            "route_domains": respond_route.domains(),
+            "route_semantic": respond_route.semantic_route.as_str(),
             "agent_policy": policy.diagnostic_summary(),
         }));
         Ok(response)

--- a/qq-maid-core/src/runtime/respond/command_dispatcher.rs
+++ b/qq-maid-core/src/runtime/respond/command_dispatcher.rs
@@ -6,7 +6,7 @@
 use crate::error::LlmError;
 
 use super::{
-    ChatToolPlan, RespondPlan, RespondRequest, RespondResponse, RustRespondService,
+    PlannedRespond, RespondPlan, RespondRequest, RespondResponse, RustRespondService,
     chat_flow::PreparedChat,
     common::session_error,
     interaction_state::{
@@ -35,8 +35,9 @@ impl<'a> CommandDispatcher<'a> {
     pub(super) async fn dispatch(
         &self,
         mut req: RespondRequest,
-        plan: RespondPlan,
+        planned: PlannedRespond,
     ) -> Result<DispatchOutcome, LlmError> {
+        let plan = planned.plan();
         let user_text = req.effective_user_text();
         let meta = respond_meta(&req);
         let interaction_meta = respond_interaction_meta(&req);
@@ -95,7 +96,9 @@ impl<'a> CommandDispatcher<'a> {
                 .get_or_create_active(&meta)
                 .map_err(session_error)?,
         };
-        let force_tool_loop = matches!(plan, RespondPlan::CompleteToolLoop);
+        let force_tool_loop = planned
+            .respond_route()
+            .is_some_and(|decision| decision.uses_tool_agent());
 
         // 检查是否为翻译指令（如 "/翻译 文本"、"/翻译日语 文本"）
         if let Some(command) = translation_flow::parse_translation_command(&user_text) {
@@ -227,19 +230,19 @@ impl<'a> CommandDispatcher<'a> {
         // 兜底：进入普通 LLM 聊天流程。手动展示名只在真正进入 LLM 上下文前查询，
         // 避免确定性 slash 命令额外争用当前 SQLite 单连接锁（连接池重构见 #328）。
         apply_manual_display_names(&self.service.display_name_store, &meta, &mut req);
-        let chat_plan = match plan {
-            RespondPlan::CompleteToolLoop => ChatToolPlan::ForceCompleteToolLoop,
-            RespondPlan::Immediate
-            | RespondPlan::CommandEvent
-            | RespondPlan::StreamingChat
-            | RespondPlan::WebSearch => ChatToolPlan::Plain,
-        };
+        let respond_route = planned.respond_route().ok_or_else(|| {
+            LlmError::new(
+                "respond_route_missing",
+                "chat execution requires the router decision",
+                "router",
+            )
+        })?;
         Ok(DispatchOutcome::Chat(Box::new(PreparedChat {
             req,
             user_text,
             meta,
             session,
-            chat_plan,
+            respond_route,
         })))
     }
 }

--- a/qq-maid-core/src/runtime/respond/mod.rs
+++ b/qq-maid-core/src/runtime/respond/mod.rs
@@ -158,10 +158,80 @@ pub(crate) enum RespondPlan {
     WebSearch,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ChatToolPlan {
-    Plain,
-    ForceCompleteToolLoop,
+/// Router 对单个请求生成的不可变执行决策。
+///
+/// `RespondPlan` 只负责 Core/Gateway 输出策略；普通聊天是否进入 Tool Agent
+/// 必须始终读取同一份 `respond_route`，执行阶段不得重新读取 session 或 policy 计算。
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PlannedRespond {
+    plan: RespondPlan,
+    respond_route: Option<tool_route::ToolRouteDecision>,
+}
+
+impl PlannedRespond {
+    const fn web_search() -> Self {
+        Self {
+            plan: RespondPlan::WebSearch,
+            respond_route: None,
+        }
+    }
+
+    pub(crate) const fn command_event() -> Self {
+        Self {
+            plan: RespondPlan::CommandEvent,
+            respond_route: Some(tool_route::ToolRouteDecision::plain_deterministic(
+                "command_event_fallback",
+            )),
+        }
+    }
+
+    fn chat(respond_route: tool_route::ToolRouteDecision) -> Self {
+        let plan = if respond_route.uses_tool_agent() {
+            RespondPlan::CompleteToolLoop
+        } else {
+            RespondPlan::StreamingChat
+        };
+        Self {
+            plan,
+            respond_route: Some(respond_route),
+        }
+    }
+
+    const fn immediate_chat(reason: &'static str) -> Self {
+        Self {
+            plan: RespondPlan::Immediate,
+            respond_route: Some(tool_route::ToolRouteDecision::plain_deterministic(reason)),
+        }
+    }
+
+    pub(crate) const fn plan(self) -> RespondPlan {
+        self.plan
+    }
+
+    const fn respond_route(self) -> Option<tool_route::ToolRouteDecision> {
+        self.respond_route
+    }
+
+    pub(crate) fn status_hint(self) -> StatusHint {
+        if !matches!(self.plan, RespondPlan::CompleteToolLoop) {
+            return StatusHint::model();
+        }
+        self.respond_route
+            .and_then(|decision| decision.status_hint)
+            .unwrap_or_else(StatusHint::default_tool)
+    }
+}
+
+impl PartialEq<RespondPlan> for PlannedRespond {
+    fn eq(&self, other: &RespondPlan) -> bool {
+        self.plan == *other
+    }
+}
+
+impl PartialEq<PlannedRespond> for RespondPlan {
+    fn eq(&self, other: &PlannedRespond) -> bool {
+        *self == other.plan
+    }
 }
 
 /// Rust 原生实现的响应服务。
@@ -288,27 +358,27 @@ impl RustRespondService {
     /// 8. 检查是否为**长期记忆操作**。
     /// 9. 兜底：进入**普通聊天**处理流程。
     pub async fn respond(&self, req: RespondRequest) -> Result<RespondResponse, LlmError> {
-        let plan = self.plan_core_respond(&req)?;
-        self.respond_with_plan(req, plan).await
+        let planned = self.plan_core_respond(&req)?;
+        self.respond_with_plan(req, planned).await
     }
 
     pub(crate) async fn respond_with_plan(
         &self,
         req: RespondRequest,
-        plan: RespondPlan,
+        planned: PlannedRespond,
     ) -> Result<RespondResponse, LlmError> {
-        self.respond_with_plan_and_progress(req, plan, None, None)
+        self.respond_with_plan_and_progress(req, planned, None, None)
             .await
     }
 
     pub(crate) async fn respond_with_plan_and_progress(
         &self,
         req: RespondRequest,
-        plan: RespondPlan,
+        planned: PlannedRespond,
         progress_sink: Option<ToolLoopProgressSink>,
         final_delta_sink: Option<qq_maid_llm::agent_loop::AgentTextDeltaSink>,
     ) -> Result<RespondResponse, LlmError> {
-        match CommandDispatcher::new(self).dispatch(req, plan).await? {
+        match CommandDispatcher::new(self).dispatch(req, planned).await? {
             DispatchOutcome::Respond(response) => Ok(*response),
             DispatchOutcome::Chat(chat) => {
                 self.handle_chat(
@@ -328,7 +398,28 @@ impl RustRespondService {
     /// 本阶段只接通 `/查` 和普通聊天；短命令仍走完整响应路径，避免改变用户可见语义。
     pub async fn respond_stream<F>(
         &self,
+        req: RespondRequest,
+        on_delta: F,
+    ) -> Result<RespondResponse, LlmError>
+    where
+        F: FnMut(String) -> Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send>> + Send,
+    {
+        let planned = self.plan_core_respond(&req)?;
+        if matches!(planned.plan(), RespondPlan::CompleteToolLoop) {
+            // 直接调用方也必须遵守 Router 已确定的 Tool Agent 执行路径，不能把
+            // 同一 decision 交给普通 stream_respond() 后生成错误 diagnostics。
+            return self.respond_with_plan(req, planned).await;
+        }
+        if matches!(planned.plan(), RespondPlan::WebSearch) {
+            return self.respond_web_search_stream(req, on_delta).await;
+        }
+        self.respond_stream_with_plan(req, planned, on_delta).await
+    }
+
+    pub(crate) async fn respond_stream_with_plan<F>(
+        &self,
         mut req: RespondRequest,
+        planned: PlannedRespond,
         on_delta: F,
     ) -> Result<RespondResponse, LlmError>
     where
@@ -388,7 +479,14 @@ impl RustRespondService {
 
         // 真流式只覆盖普通聊天；搜索命令等确定性入口不提前查手动展示名。
         apply_manual_display_names(&self.display_name_store, &meta, &mut req);
-        self.handle_chat_stream(req, on_delta).await
+        let respond_route = planned.respond_route().ok_or_else(|| {
+            LlmError::new(
+                "respond_route_missing",
+                "chat execution requires the router decision",
+                "router",
+            )
+        })?;
+        self.handle_chat_stream(req, respond_route, on_delta).await
     }
 
     /// `RespondPlan::WebSearch` 的流式编放入口。

--- a/qq-maid-core/src/runtime/respond/router.rs
+++ b/qq-maid-core/src/runtime/respond/router.rs
@@ -11,15 +11,14 @@ use crate::{
 };
 
 use super::{
-    RespondPlan, RespondRequest, RustRespondService,
+    PlannedRespond, RespondPlan, RespondRequest, RustRespondService,
     common::session_error,
     interaction_state::{
         classify_inbound_with_active, interaction_snapshot, pending_blocks_immediate,
         respond_interaction_meta, respond_meta, route_context_session,
     },
     search_flow, session_flow,
-    status_hint::StatusHint,
-    tool_route::{self, ToolLoopRoute, ToolRouteContext},
+    tool_route::{self, RespondRoute, ToolRouteContext},
 };
 
 pub(super) struct RespondRouter<'a> {
@@ -31,43 +30,11 @@ impl<'a> RespondRouter<'a> {
         Self { service }
     }
 
-    pub(super) fn status_hint_for_plan(
-        &self,
-        req: &RespondRequest,
-        plan: RespondPlan,
-    ) -> Result<StatusHint, LlmError> {
-        if !matches!(plan, RespondPlan::CompleteToolLoop) {
-            return Ok(StatusHint::model());
-        }
-        let policy = self.resolve_agent_policy(req)?;
-        let meta = respond_meta(req);
-        let interaction_meta = respond_interaction_meta(req);
-        let active_interaction_session = self
-            .service
-            .session_store
-            .get_active(&interaction_meta)
-            .map_err(session_error)?;
-        let active_conversation_session = self
-            .service
-            .session_store
-            .get_active(&meta)
-            .map_err(session_error)?;
-        let route_session = route_context_session(
-            req,
-            active_interaction_session.as_ref(),
-            active_conversation_session.as_ref(),
-        );
-        Ok(self
-            .route_tool_loop_with_active(req, &policy, route_session)
-            .status_hint
-            .unwrap_or_else(StatusHint::default_tool))
-    }
-
-    pub(super) fn plan(&self, req: &RespondRequest) -> Result<RespondPlan, LlmError> {
+    pub(super) fn plan(&self, req: &RespondRequest) -> Result<PlannedRespond, LlmError> {
         let user_text = req.effective_user_text();
         let trimmed = user_text.trim();
         if trimmed.is_empty() && req.effective_input_parts().is_empty() {
-            return Ok(RespondPlan::Immediate);
+            return Ok(PlannedRespond::immediate_chat("deterministic_or_empty"));
         }
 
         let meta = respond_meta(req);
@@ -93,19 +60,21 @@ impl<'a> RespondRouter<'a> {
             active_conversation_session.as_ref(),
             meta.user_id.as_deref(),
         ) {
-            return Ok(RespondPlan::Immediate);
+            return Ok(PlannedRespond::immediate_chat("pending_handler_fallback"));
         }
 
         if search_flow::parse_web_search_command(&user_text).is_some() {
             // 显式 `/查` 入口统一走 WebSearch，复用 `/查` 的流式查询能力，
             // 避免被通用 slash 命令截走而走非流式完整等待路径。
-            return Ok(RespondPlan::WebSearch);
+            return Ok(PlannedRespond::web_search());
         }
         if is_event_wrapped_command(trimmed) {
-            return Ok(RespondPlan::CommandEvent);
+            return Ok(PlannedRespond::command_event());
         }
         if trimmed.starts_with('/') || trimmed.starts_with('／') {
-            return Ok(RespondPlan::Immediate);
+            return Ok(PlannedRespond::immediate_chat(
+                "deterministic_slash_fallback",
+            ));
         }
 
         // 在进入 Tool Loop 路由前，先拦截“明确对机器人发起的搜索意图”。
@@ -115,7 +84,7 @@ impl<'a> RespondRouter<'a> {
         if tool_route::has_search_intent(trimmed, &trimmed.to_ascii_lowercase())
             && directed_to_bot(req)
         {
-            return Ok(RespondPlan::WebSearch);
+            return Ok(PlannedRespond::web_search());
         }
 
         // 先保护已有确定性命令和自然语言 Todo 查询，避免简单列表查询绕过
@@ -127,13 +96,15 @@ impl<'a> RespondRouter<'a> {
             meta.user_id.as_deref(),
         );
         if matches!(classification.kind, CoreInboundKind::Immediate) {
-            return Ok(RespondPlan::Immediate);
+            return Ok(PlannedRespond::immediate_chat(
+                "deterministic_handler_fallback",
+            ));
         }
 
         let policy = self.resolve_agent_policy(req)?;
         let tool_decision = self.route_tool_loop_with_active(req, &policy, route_session);
         let plan = if !req.has_non_text_input_parts()
-            && matches!(tool_decision.route, ToolLoopRoute::CompleteToolLoop)
+            && matches!(tool_decision.route, RespondRoute::ToolAgent)
         {
             RespondPlan::CompleteToolLoop
         } else {
@@ -153,11 +124,7 @@ impl<'a> RespondRouter<'a> {
             enabled_tools_count = policy.enabled_tools.len(),
             "selected core respond route"
         );
-        if matches!(plan, RespondPlan::CompleteToolLoop) {
-            Ok(RespondPlan::CompleteToolLoop)
-        } else {
-            Ok(RespondPlan::StreamingChat)
-        }
+        Ok(PlannedRespond::chat(tool_decision))
     }
 
     pub(super) fn classify_inbound(
@@ -238,15 +205,10 @@ impl<'a> RespondRouter<'a> {
 }
 
 impl RustRespondService {
-    pub(crate) fn status_hint_for_plan(
+    pub(crate) fn plan_core_respond(
         &self,
         req: &RespondRequest,
-        plan: RespondPlan,
-    ) -> Result<StatusHint, LlmError> {
-        RespondRouter::new(self).status_hint_for_plan(req, plan)
-    }
-
-    pub(crate) fn plan_core_respond(&self, req: &RespondRequest) -> Result<RespondPlan, LlmError> {
+    ) -> Result<PlannedRespond, LlmError> {
         RespondRouter::new(self).plan(req)
     }
 

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -3,10 +3,14 @@ use std::{fs, sync::Arc};
 use qq_maid_llm::provider::{ToolCallingProtocol, ToolExecutionResult, types::ChatRole};
 use serde_json::Value;
 
-use crate::runtime::respond::RespondPlan;
+use crate::runtime::respond::{PlannedRespond, RespondPlan};
 
 use super::{
-    super::{RespondRequest, common::empty_respond_request},
+    super::{
+        RespondRequest,
+        command_dispatcher::{CommandDispatcher, DispatchOutcome},
+        common::empty_respond_request,
+    },
     support::*,
 };
 use crate::runtime::session::SessionMeta;
@@ -85,10 +89,12 @@ async fn private_weather_chat_with_openai_responses_capability_enters_tool_loop(
             && message.content.contains("存在歧义")
             && message.content.contains("不要调用写工具")
     }));
-    assert_eq!(
-        response.diagnostics.unwrap()["tool_calling_enabled"],
-        serde_json::json!(true)
-    );
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["respond_route"], "tool_agent");
+    assert_eq!(diagnostics["route_reason"], "semantic_tool_intent");
+    assert_eq!(diagnostics["route_domains"], serde_json::json!(["weather"]));
+    assert_eq!(diagnostics["route_semantic"], "tool_loop");
+    assert_eq!(diagnostics["tool_calling_enabled"], true);
 }
 
 #[tokio::test]
@@ -111,6 +117,10 @@ async fn private_general_chat_with_tool_capability_uses_plain_chat() {
     assert_eq!(inspector.tool_call_count(), 0);
     assert_eq!(inspector.requests().len(), 1);
     let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["respond_route"], "plain_chat");
+    assert_eq!(diagnostics["route_reason"], "semantic_plain_chat");
+    assert_eq!(diagnostics["route_domains"], serde_json::json!([]));
+    assert_eq!(diagnostics["route_semantic"], "plain_chat");
     assert_eq!(
         diagnostics["tool_calling_enabled"],
         serde_json::json!(false)
@@ -121,6 +131,50 @@ async fn private_general_chat_with_tool_capability_uses_plain_chat() {
     );
     assert_eq!(diagnostics["todo_success_claimed"], false);
     assert_eq!(diagnostics["todo_success_verified"], true);
+}
+
+#[tokio::test]
+async fn router_decision_is_passed_unchanged_to_prepared_chat() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector, true);
+    let req = private_message("杭州今天要带伞吗");
+    let planned = service.plan_core_respond(&req).unwrap();
+    let expected_route = planned.respond_route().unwrap();
+
+    let outcome = CommandDispatcher::new(&service)
+        .dispatch(req, planned)
+        .await
+        .unwrap();
+    let DispatchOutcome::Chat(chat) = outcome else {
+        panic!("expected prepared chat");
+    };
+
+    assert_eq!(chat.respond_route, expected_route);
+    assert!(chat.respond_route.uses_tool_agent());
+}
+
+#[tokio::test]
+async fn streaming_chat_uses_planned_plain_route_without_reclassification() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let planned = service
+        .plan_core_respond(&private_message("聊聊 Rust 的所有权"))
+        .unwrap();
+
+    // 执行时故意换成会被 Router 判为天气 Tool Agent 的文本；流式入口必须继续使用
+    // 已生成的 PlainChat decision，不能读取新状态或按文本重新分类。
+    let response = service
+        .respond_stream_with_plan(private_message("杭州今天要带伞吗"), planned, |_| {
+            Box::pin(async { Ok(()) })
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(inspector.tool_call_count(), 0);
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["respond_route"], "plain_chat");
+    assert_eq!(diagnostics["route_reason"], "semantic_plain_chat");
+    assert_eq!(diagnostics["route_semantic"], "plain_chat");
 }
 
 #[tokio::test]
@@ -846,10 +900,11 @@ async fn private_todo_create_phrase_is_handled_by_agent_tool_loop() {
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
 
-    let response = service
-        .respond(private_message("新增待办，明天接老公"))
-        .await
-        .unwrap();
+    let req = private_message("新增待办，明天接老公");
+    let planned = service.plan_core_respond(&req).unwrap();
+    assert_eq!(planned, RespondPlan::CompleteToolLoop);
+    assert!(planned.respond_route().unwrap().uses_tool_agent());
+    let response = service.respond_with_plan(req, planned).await.unwrap();
 
     assert_eq!(response.command.as_deref(), Some("todo_create"));
     let text = response.text.unwrap();
@@ -3049,10 +3104,11 @@ async fn group_chat_does_not_enter_tool_loop() {
     );
     assert_eq!(inspector.tool_call_count(), 0);
     assert_eq!(inspector.requests().len(), 1);
-    assert_eq!(
-        response.diagnostics.unwrap()["tool_calling_enabled"],
-        serde_json::json!(false)
-    );
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["respond_route"], "plain_chat");
+    assert_eq!(diagnostics["route_reason"], "group_tool_loop_disabled");
+    assert_eq!(diagnostics["route_domains"], serde_json::json!([]));
+    assert_eq!(diagnostics["tool_calling_enabled"], false);
 }
 
 #[tokio::test]
@@ -3063,6 +3119,56 @@ async fn slash_command_does_not_enter_tool_loop() {
     service.respond(message("/天气 杭州")).await.unwrap();
 
     assert_eq!(inspector.tool_call_count(), 0);
+}
+
+#[tokio::test]
+async fn unknown_slash_command_falls_back_to_plain_chat_with_router_decision() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let req = private_message("/unknown-route-command");
+    let planned = service.plan_core_respond(&req).unwrap();
+    assert_eq!(planned, RespondPlan::Immediate);
+    assert_eq!(
+        planned.respond_route().unwrap().reason,
+        "deterministic_slash_fallback"
+    );
+    let response = service.respond_with_plan(req, planned).await.unwrap();
+
+    assert_eq!(inspector.tool_call_count(), 0);
+    assert_eq!(inspector.requests().len(), 1);
+    assert!(
+        response
+            .text
+            .as_deref()
+            .is_some_and(|text| text.contains("回复：/unknown-route-command"))
+    );
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["respond_route"], "plain_chat");
+    assert_eq!(diagnostics["route_reason"], "deterministic_slash_fallback");
+    assert_eq!(diagnostics["route_semantic"], "deterministic");
+}
+
+#[tokio::test]
+async fn unconsumed_immediate_plan_uses_preplanned_plain_chat_fallback() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let planned = PlannedRespond::immediate_chat("deterministic_handler_fallback");
+
+    let response = service
+        .respond_with_plan(private_message("没有确定性处理器消费这条消息"), planned)
+        .await
+        .unwrap();
+
+    assert_eq!(inspector.tool_call_count(), 0);
+    assert_eq!(inspector.requests().len(), 1);
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["respond_route"], "plain_chat");
+    assert_eq!(
+        diagnostics["route_reason"],
+        "deterministic_handler_fallback"
+    );
+    assert_eq!(diagnostics["route_semantic"], "deterministic");
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tool_route.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route.rs
@@ -16,9 +16,18 @@ use super::{
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum ToolLoopRoute {
+pub(super) enum RespondRoute {
     PlainChat,
-    CompleteToolLoop,
+    ToolAgent,
+}
+
+impl RespondRoute {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::PlainChat => "plain_chat",
+            Self::ToolAgent => "tool_agent",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27,6 +36,17 @@ pub(super) enum SemanticRoute {
     ToolLoop,
     Deterministic,
     Ambiguous,
+}
+
+impl SemanticRoute {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::PlainChat => "plain_chat",
+            Self::ToolLoop => "tool_loop",
+            Self::Deterministic => "deterministic",
+            Self::Ambiguous => "ambiguous",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -40,13 +60,53 @@ pub(super) enum ToolDomain {
     Unknown,
 }
 
-#[derive(Debug, Clone, Copy)]
+impl ToolDomain {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Todo => "todo",
+            Self::Weather => "weather",
+            Self::Train => "train",
+            Self::Rss => "rss",
+            Self::Search => "search",
+            Self::Memory => "memory",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct ToolRouteDecision {
-    pub route: ToolLoopRoute,
+    pub route: RespondRoute,
     pub semantic_route: SemanticRoute,
     pub domain: ToolDomain,
     pub reason: &'static str,
     pub status_hint: Option<StatusHint>,
+}
+
+impl ToolRouteDecision {
+    /// 为确定性分派准备普通聊天兜底。Router 必须在执行前确定 reason，
+    /// dispatcher 不得在 handler 未消费时临时补造路由信息。
+    pub(super) const fn plain_deterministic(reason: &'static str) -> Self {
+        Self {
+            route: RespondRoute::PlainChat,
+            semantic_route: SemanticRoute::Deterministic,
+            domain: ToolDomain::Unknown,
+            reason,
+            status_hint: None,
+        }
+    }
+
+    pub(super) const fn uses_tool_agent(self) -> bool {
+        matches!(self.route, RespondRoute::ToolAgent)
+    }
+
+    pub(super) fn domains(self) -> Vec<&'static str> {
+        if matches!(self.domain, ToolDomain::Unknown) {
+            Vec::new()
+        } else {
+            vec![self.domain.as_str()]
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -68,13 +128,36 @@ pub(super) struct SemanticAssessment {
 }
 
 pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> ToolRouteDecision {
-    if !ctx.scene_enabled
-        || !ctx.tool_calling_enabled
+    let is_group = req
+        .group_id
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty());
+    if !ctx.scene_enabled {
+        return decision(
+            RespondRoute::PlainChat,
+            SemanticRoute::PlainChat,
+            ToolDomain::Unknown,
+            "tool_loop_unavailable",
+            None,
+        );
+    }
+    // 群聊开关是独立的安全边界，diagnostics 应保留该原因，不能被通用
+    // tool_calling_enabled guard 折叠为无法定位配置项的 unavailable。
+    if is_group && !ctx.group_tool_calling_enabled {
+        return decision(
+            RespondRoute::PlainChat,
+            SemanticRoute::PlainChat,
+            ToolDomain::Unknown,
+            "group_tool_loop_disabled",
+            None,
+        );
+    }
+    if !ctx.tool_calling_enabled
         || !ctx.provider_supports_tool_calling
         || !ctx.enabled_tools_available
     {
         return decision(
-            ToolLoopRoute::PlainChat,
+            RespondRoute::PlainChat,
             SemanticRoute::PlainChat,
             ToolDomain::Unknown,
             "tool_loop_unavailable",
@@ -83,7 +166,7 @@ pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> To
     }
     if req.has_non_text_input_parts() {
         return decision(
-            ToolLoopRoute::PlainChat,
+            RespondRoute::PlainChat,
             SemanticRoute::PlainChat,
             ToolDomain::Unknown,
             "multimodal_plain_chat",
@@ -94,27 +177,13 @@ pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> To
     let trimmed = text.trim();
     if trimmed.is_empty() || trimmed.starts_with('/') || trimmed.starts_with('／') {
         return decision(
-            ToolLoopRoute::PlainChat,
+            RespondRoute::PlainChat,
             SemanticRoute::Deterministic,
             ToolDomain::Unknown,
             "deterministic_or_empty",
             None,
         );
     }
-    let is_group = req
-        .group_id
-        .as_deref()
-        .is_some_and(|value| !value.trim().is_empty());
-    if is_group && !ctx.group_tool_calling_enabled {
-        return decision(
-            ToolLoopRoute::PlainChat,
-            SemanticRoute::PlainChat,
-            ToolDomain::Unknown,
-            "group_tool_loop_disabled",
-            None,
-        );
-    }
-
     let has_recent_todo_context = ctx
         .interaction_state
         .has_recent_context(InteractionDomain::Todo);
@@ -122,35 +191,35 @@ pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> To
     let status_hint = classify_status_hint(trimmed, has_recent_todo_context);
     match assessment.semantic_route {
         SemanticRoute::PlainChat => decision(
-            ToolLoopRoute::PlainChat,
+            RespondRoute::PlainChat,
             SemanticRoute::PlainChat,
             assessment.domain,
             assessment.reason,
             None,
         ),
         SemanticRoute::ToolLoop => decision(
-            ToolLoopRoute::CompleteToolLoop,
+            RespondRoute::ToolAgent,
             SemanticRoute::ToolLoop,
             assessment.domain,
             assessment.reason,
             status_hint,
         ),
         SemanticRoute::Deterministic => decision(
-            ToolLoopRoute::PlainChat,
+            RespondRoute::PlainChat,
             SemanticRoute::Deterministic,
             assessment.domain,
             "deterministic_or_empty",
             None,
         ),
         SemanticRoute::Ambiguous if is_group => decision(
-            ToolLoopRoute::PlainChat,
+            RespondRoute::PlainChat,
             SemanticRoute::Ambiguous,
             assessment.domain,
             "semantic_ambiguous_group_plain",
             None,
         ),
         SemanticRoute::Ambiguous => decision(
-            ToolLoopRoute::PlainChat,
+            RespondRoute::PlainChat,
             SemanticRoute::Ambiguous,
             assessment.domain,
             assessment.reason,
@@ -164,7 +233,7 @@ pub(super) fn has_search_intent(text: &str, lower: &str) -> bool {
 }
 
 fn decision(
-    route: ToolLoopRoute,
+    route: RespondRoute,
     semantic_route: SemanticRoute,
     domain: ToolDomain,
     reason: &'static str,
@@ -334,7 +403,7 @@ mod tests {
             "聊聊天气",
         ] {
             let decision = route_tool_loop(&request(input), context());
-            assert_eq!(decision.route, ToolLoopRoute::PlainChat, "{input}");
+            assert_eq!(decision.route, RespondRoute::PlainChat, "{input}");
             assert_eq!(decision.semantic_route, SemanticRoute::PlainChat, "{input}");
             assert_eq!(decision.status_hint, None, "{input}");
         }
@@ -392,7 +461,7 @@ WebSearch tool timeout
             "查看上次 codex 发布的 rss",
         ] {
             let decision = route_tool_loop(&request(input), context());
-            assert_eq!(decision.route, ToolLoopRoute::CompleteToolLoop, "{input}");
+            assert_eq!(decision.route, RespondRoute::ToolAgent, "{input}");
             assert_eq!(decision.semantic_route, SemanticRoute::ToolLoop, "{input}");
             assert!(decision.status_hint.is_some(), "{input}");
         }
@@ -429,7 +498,7 @@ WebSearch tool timeout
 
         for (input, expected_hint) in cases {
             let decision = route_tool_loop(&request(input), context());
-            assert_eq!(decision.route, ToolLoopRoute::CompleteToolLoop, "{input}");
+            assert_eq!(decision.route, RespondRoute::ToolAgent, "{input}");
             assert_eq!(decision.status_hint, Some(expected_hint), "{input}");
         }
     }
@@ -444,24 +513,20 @@ WebSearch tool timeout
             "这些完成了",
         ] {
             let decision = route_tool_loop(&request(input), context());
-            assert_eq!(decision.route, ToolLoopRoute::CompleteToolLoop, "{input}");
+            assert_eq!(decision.route, RespondRoute::ToolAgent, "{input}");
             assert_eq!(decision.domain, ToolDomain::Todo, "{input}");
         }
 
         for input in ["这个改一下", "都删除了吧"] {
             let without_context = route_tool_loop(&request(input), context());
-            assert_eq!(without_context.route, ToolLoopRoute::PlainChat, "{input}");
+            assert_eq!(without_context.route, RespondRoute::PlainChat, "{input}");
             assert_eq!(
                 without_context.reason, "todo_reference_context_missing",
                 "{input}"
             );
 
             let with_context = route_tool_loop(&request(input), context_with_recent_todo());
-            assert_eq!(
-                with_context.route,
-                ToolLoopRoute::CompleteToolLoop,
-                "{input}"
-            );
+            assert_eq!(with_context.route, RespondRoute::ToolAgent, "{input}");
             assert_eq!(with_context.domain, ToolDomain::Todo, "{input}");
         }
     }
@@ -470,18 +535,14 @@ WebSearch tool timeout
     fn bare_number_todo_operations_require_recent_context() {
         for input in ["7删除", "删除7", "把7合并到6", "6和7合并"] {
             let without_context = route_tool_loop(&request(input), context());
-            assert_eq!(without_context.route, ToolLoopRoute::PlainChat, "{input}");
+            assert_eq!(without_context.route, RespondRoute::PlainChat, "{input}");
             assert_eq!(
                 without_context.reason, "todo_number_context_missing",
                 "{input}"
             );
 
             let with_context = route_tool_loop(&request(input), context_with_recent_todo());
-            assert_eq!(
-                with_context.route,
-                ToolLoopRoute::CompleteToolLoop,
-                "{input}"
-            );
+            assert_eq!(with_context.route, RespondRoute::ToolAgent, "{input}");
             assert_eq!(with_context.domain, ToolDomain::Todo, "{input}");
         }
     }
@@ -490,7 +551,7 @@ WebSearch tool timeout
     fn ambiguous_private_defaults_to_plain_chat() {
         for input in ["安排一下", "帮我处理一下", "刚刚没看到，再来一条"] {
             let decision = route_tool_loop(&request(input), context());
-            assert_eq!(decision.route, ToolLoopRoute::PlainChat, "{input}");
+            assert_eq!(decision.route, RespondRoute::PlainChat, "{input}");
             assert_eq!(decision.semantic_route, SemanticRoute::Ambiguous, "{input}");
             assert_eq!(decision.status_hint, None, "{input}");
         }
@@ -502,7 +563,7 @@ WebSearch tool timeout
         group.group_id = Some("g1".to_owned());
         assert_eq!(
             route_tool_loop(&group, context()).route,
-            ToolLoopRoute::PlainChat
+            RespondRoute::PlainChat
         );
         assert_eq!(
             route_tool_loop(
@@ -513,7 +574,7 @@ WebSearch tool timeout
                 },
             )
             .route,
-            ToolLoopRoute::PlainChat
+            RespondRoute::PlainChat
         );
     }
 
@@ -530,7 +591,7 @@ WebSearch tool timeout
                 },
             )
             .route,
-            ToolLoopRoute::CompleteToolLoop
+            RespondRoute::ToolAgent
         );
     }
 
@@ -552,7 +613,7 @@ WebSearch tool timeout
         ] {
             assert_eq!(
                 route_tool_loop(&request("杭州明天要带伞吗"), ctx).route,
-                ToolLoopRoute::PlainChat
+                RespondRoute::PlainChat
             );
         }
     }

--- a/qq-maid-core/src/service/handle.rs
+++ b/qq-maid-core/src/service/handle.rs
@@ -70,7 +70,8 @@ impl CoreService for CoreHandle {
         let recorder = MetricsRecorder::start();
         let scope_key = req.scope_key.clone();
         let state = self.state.as_ref();
-        let respond_plan = service.plan_core_respond(&req).map_err(CoreError::from)?;
+        let planned = service.plan_core_respond(&req).map_err(CoreError::from)?;
+        let respond_plan = planned.plan();
         if matches!(
             respond_plan,
             RespondPlan::CommandEvent
@@ -82,9 +83,7 @@ impl CoreService for CoreHandle {
             // 让 Gateway 消费 Completed 后再渲染 XML，QQ 官方流式行为保持不变。
             let provider_stream_enabled = state.provider.stream_enabled() && !force_complete_sync;
             let output_policy = output_policy_for_stream(respond_plan, provider_stream_enabled);
-            let status_hint = service
-                .status_hint_for_plan(&req, respond_plan)
-                .map_err(CoreError::from)?;
+            let status_hint = planned.status_hint();
             let status_display_name = service.status_display_name().to_owned();
             let status_audience = if req
                 .group_id
@@ -101,7 +100,7 @@ impl CoreService for CoreHandle {
                     Ok::<_, LlmError>(start_core_response_stream(
                         service,
                         req,
-                        respond_plan,
+                        planned,
                         output_policy,
                         provider_stream_enabled,
                         Duration::from_secs(state.config.request_timeout_seconds),
@@ -134,7 +133,7 @@ impl CoreService for CoreHandle {
         }
         let result = timeout(
             Duration::from_secs(state.config.request_timeout_seconds),
-            service.respond_with_plan(req, respond_plan),
+            service.respond_with_plan(req, planned),
         )
         .await;
 

--- a/qq-maid-core/src/service/streaming.rs
+++ b/qq-maid-core/src/service/streaming.rs
@@ -16,8 +16,8 @@ use qq_maid_llm::agent_loop::{
 use crate::{
     error::LlmError,
     runtime::respond::{
-        RespondPlan, RespondRequest, RespondResponse, RustRespondService, StatusAudience,
-        StatusHint, StatusPhase, status_hint_text,
+        PlannedRespond, RespondPlan, RespondRequest, RespondResponse, RustRespondService,
+        StatusAudience, StatusHint, StatusPhase, status_hint_text,
     },
 };
 
@@ -38,7 +38,7 @@ pub(crate) struct ProgressStatusConfig {
 pub(crate) fn start_core_response_stream(
     service: RustRespondService,
     req: RespondRequest,
-    plan: RespondPlan,
+    planned: PlannedRespond,
     output_policy: CoreOutputPolicy,
     provider_stream_enabled: bool,
     request_timeout: Duration,
@@ -48,6 +48,7 @@ pub(crate) fn start_core_response_stream(
     let cancelled = Arc::new(AtomicBool::new(false));
     let producer_cancelled = cancelled.clone();
     let scope_key = req.scope_key.clone();
+    let plan = planned.plan();
     tokio::spawn(async move {
         if producer_cancelled.load(Ordering::SeqCst) {
             let _ = tx
@@ -58,7 +59,7 @@ pub(crate) fn start_core_response_stream(
         let respond_future = run_streaming_respond(
             &service,
             req,
-            plan,
+            planned,
             tx.clone(),
             producer_cancelled.clone(),
             provider_stream_enabled,
@@ -108,16 +109,18 @@ pub(crate) fn start_core_response_stream(
 async fn run_streaming_respond(
     service: &RustRespondService,
     req: RespondRequest,
-    plan: RespondPlan,
+    planned: PlannedRespond,
     tx: mpsc::Sender<CoreResponseEvent>,
     cancelled: Arc<AtomicBool>,
     provider_stream_enabled: bool,
     progress_status: ProgressStatusConfig,
 ) -> Result<RespondResponse, LlmError> {
+    let plan = planned.plan();
     if matches!(plan, RespondPlan::CompleteToolLoop) {
         return run_complete_tool_loop_respond(
             service,
             req,
+            planned,
             tx,
             cancelled,
             progress_status,
@@ -126,7 +129,7 @@ async fn run_streaming_respond(
         .await;
     }
     if matches!(plan, RespondPlan::CommandEvent) {
-        return run_command_event_respond(service, req, plan, tx, cancelled).await;
+        return run_command_event_respond(service, req, planned, tx, cancelled).await;
     }
     if matches!(plan, RespondPlan::WebSearch) && provider_stream_enabled {
         // WebSearch 不套用 CompleteToolLoop 整体超时：联网查询复用 `/查` 的流式
@@ -136,7 +139,7 @@ async fn run_streaming_respond(
         return run_web_search_respond(service, req, tx, cancelled).await;
     }
     if !provider_stream_enabled {
-        let response = service.respond_with_plan(req, plan).await?;
+        let response = service.respond_with_plan(req, planned).await?;
         debug!(
             respond_plan = respond_plan_name(plan),
             provider_stream_enabled,
@@ -151,7 +154,7 @@ async fn run_streaming_respond(
         return Ok(response);
     }
     service
-        .respond_stream(req, |delta| {
+        .respond_stream_with_plan(req, planned, |delta| {
             let tx = tx.clone();
             let cancelled = cancelled.clone();
             Box::pin(async move { send_core_delta(&tx, &cancelled, delta).await })
@@ -162,7 +165,7 @@ async fn run_streaming_respond(
 async fn run_command_event_respond(
     service: &RustRespondService,
     req: RespondRequest,
-    plan: RespondPlan,
+    planned: PlannedRespond,
     tx: mpsc::Sender<CoreResponseEvent>,
     cancelled: Arc<AtomicBool>,
 ) -> Result<RespondResponse, LlmError> {
@@ -173,7 +176,8 @@ async fn run_command_event_respond(
         "正在处理命令…".to_owned(),
     )
     .await?;
-    let response = service.respond_with_plan(req, plan).await?;
+    let plan = planned.plan();
+    let response = service.respond_with_plan(req, planned).await?;
     if !response.ok {
         return Ok(response);
     }
@@ -221,6 +225,7 @@ async fn run_web_search_respond(
 async fn run_complete_tool_loop_respond(
     service: &RustRespondService,
     req: RespondRequest,
+    planned: PlannedRespond,
     tx: mpsc::Sender<CoreResponseEvent>,
     cancelled: Arc<AtomicBool>,
     progress_status: ProgressStatusConfig,
@@ -252,12 +257,8 @@ async fn run_complete_tool_loop_respond(
     } else {
         None
     };
-    let respond_future = service.respond_with_plan_and_progress(
-        req,
-        RespondPlan::CompleteToolLoop,
-        Some(progress_sink),
-        final_delta_sink,
-    );
+    let respond_future =
+        service.respond_with_plan_and_progress(req, planned, Some(progress_sink), final_delta_sink);
     tokio::pin!(respond_future);
     let mut running_status_sent = false;
 

--- a/qq-maid-core/src/service/tests/mod.rs
+++ b/qq-maid-core/src/service/tests/mod.rs
@@ -10,7 +10,10 @@ use qq_maid_llm::provider::{LlmStreamEvent, ToolCallingProtocol};
 use crate::{
     error::LlmError,
     runtime::{
-        respond::{RespondPlan, RespondRequest, RespondResponse, StatusAudience, StatusHint},
+        respond::{
+            PlannedRespond, RespondPlan, RespondRequest, RespondResponse, StatusAudience,
+            StatusHint,
+        },
         session::SessionMeta,
         tools::todo::{TodoItemDraft, TodoPendingOperation, TodoStore, TodoTimePrecision},
     },
@@ -828,7 +831,7 @@ async fn core_command_event_failure_does_not_send_finished_or_completed() {
     let mut stream = start_core_response_stream(
         service,
         req,
-        RespondPlan::CommandEvent,
+        PlannedRespond::command_event(),
         CoreOutputPolicy::CompleteThenSend,
         false,
         Duration::from_secs(5),


### PR DESCRIPTION
## 变更内容

本次 PR 从 master 分支移除此前通过 #402 引入的 `qbot.sh` 一键安装脚本及相关文档。

### 主要改动

- **删除 `qbot.sh`**（-2069 行）：移除整个一键安装/配置/管理脚本
- **更新 `README.md`**：移除"路径一：一键脚本"部署说明，将剩余部署路径重新编号为路径一和路径二

### 变更原因

`qbot.sh` 在 v0.15.0 发布后以 #402 合入 master，但经评估后决定回退，恢复到以 Release 包和源码构建为主要部署方式。