### PR TITLE
[codex] 补全 QQ 正在输入通知载荷

### DIFF
--- a/qq-maid-gateway-rs/src/api/mod.rs
+++ b/qq-maid-gateway-rs/src/api/mod.rs
@@ -94,8 +94,15 @@ struct C2cTextPayload<'a> {
 }
 
 #[derive(Debug, Serialize)]
+struct C2cInputNotify {
+    input_type: u8,
+    input_second: u32,
+}
+
+#[derive(Debug, Serialize)]
 struct C2cTypingPayload<'a> {
     msg_type: u8,
+    input_notify: C2cInputNotify,
     #[serde(skip_serializing_if = "Option::is_none")]
     msg_id: Option<&'a str>,
     msg_seq: u32,
@@ -718,6 +725,10 @@ pub fn build_c2c_text_payload(text: &str, msg_id: Option<&str>, msg_seq: u32) ->
 fn build_c2c_typing_payload(msg_id: Option<&str>, msg_seq: u32) -> Value {
     serde_json::to_value(C2cTypingPayload {
         msg_type: 6,
+        input_notify: C2cInputNotify {
+            input_type: 1,
+            input_second: 60,
+        },
         msg_id,
         msg_seq,
     })

--- a/qq-maid-gateway-rs/src/api/tests.rs
+++ b/qq-maid-gateway-rs/src/api/tests.rs
@@ -61,6 +61,8 @@ fn c2c_typing_payload_uses_native_typing_message_type() {
     let payload = build_c2c_typing_payload(Some("msg-1"), 8);
 
     assert_eq!(payload["msg_type"], 6);
+    assert_eq!(payload["input_notify"]["input_type"], 1);
+    assert_eq!(payload["input_notify"]["input_second"], 60);
     assert_eq!(payload["msg_id"], "msg-1");
     assert_eq!(payload["msg_seq"], 8);
     assert!(payload.get("content").is_none());


### PR DESCRIPTION
## 修改内容

- 为 QQ C2C `msg_type=6` 正在输入通知补充 `input_notify` 对象
- 固定发送 `input_type=1` 和 `input_second=60`
- 扩展 payload 单元测试，覆盖新增协议字段

## 根因

现有实现只发送了 `msg_type`、`msg_id` 和 `msg_seq`，遗漏 QQ 正在输入协议所需的 `input_notify` 字段，因此接口返回 `50059 input type err`。

## 影响

私聊 Agent 请求超过配置延迟后，Gateway 发出的正在输入通知将使用完整载荷。此次不增加 50 秒自动续期，现有发送时机和停止生命周期保持不变。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p qq-maid-gateway-rs`（356 项通过）
- `cargo check -p qq-maid-gateway-rs`
- `git diff --check`

真实 QQ 客户端展示效果仍需部署后验证。
