### PR TITLE
[codex] 统一普通消息 Agent Chat 入口

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -157,14 +157,14 @@ Rust HTTP 层只公开外部运维 / 管理能力：
 - 自定义业务 Tool 的二开步骤见 [custom-tools.md](./development/custom-tools.md)，包括新增文件、注册、`agent.toml` 白名单和测试要求。
 - 未来目标是支持多入口的通用机器人；不要把具体人设、群聊内容、真实用户信息或业务材料写死进代码。
 
-## Tool Loop 边界
+## Agent Chat 与 Tool 边界
 
-普通聊天进入 Tool Loop 前后的工具域业务判断必须收敛到 `qq-maid-core/src/runtime/tools/`。`runtime/respond/` 只保留通用路由胶水、会话连接、状态提示和响应拼装，不直接理解 Todo、RSS、天气、火车、搜索等业务域的工具结果。
+普通纯文本消息在场景、Provider 能力、群聊开关和工具白名单允许时统一进入 Agent Chat。模型可在同一次原生响应中直接回答、请求澄清或发出 Tool Call；关键词分类只能提供状态提示和 diagnostics，不能决定模型是否看到工具。工具域业务判断必须收敛到 `qq-maid-core/src/runtime/tools/`，`runtime/respond/` 不直接理解 Todo、RSS、天气、火车、搜索等业务域的工具结果。
 
-- `runtime/respond/tool_route.rs`：普通消息是否进入 Tool Loop 的通用调度入口，只保留可用性检查、群聊开关、空消息 / slash / 多模态等跨域规则，以及 `SemanticRoute` / `ToolDomain` / `StatusHint` 等公共返回结构。
-- `runtime/respond/plain_chat_route.rs`：普通闲聊、创作、解释、本地长文本整理等“不应调用工具”的通用弱意图判断。这里不能加入具体工具业务关键词。
-- `runtime/respond/tool_route_domains.rs`：非 Todo 工具域的轻量路由分发层。当前只承载天气、火车、RSS、Web Search、Memory 等低状态路由提示；某个域一旦出现复杂规则，应迁到 `runtime/tools/<domain>/route.rs`。
-- `runtime/tools/todo/route.rs`：Todo / Reminder 自然语言路由门面，只判断是否明显属于 Todo Tool Loop，不解析最终目标、编号、日期或写入语义。
+- `runtime/respond/agent_route.rs`：Agent Chat 能力入口，只用确定性条件决定是否暴露工具，并返回 `AgentRouteDecision`。`SemanticRoute` / `ToolDomain` / `StatusHint` 只用于诊断和用户状态提示。
+- `runtime/respond/plain_chat_route.rs`：普通闲聊、创作、解释、本地长文本整理等弱语义提示。这里不能加入具体工具业务关键词，也不能据此关闭 Agent 能力。
+- `runtime/respond/tool_route_domains.rs`：非 Todo 工具域的轻量语义提示分发层。当前承载天气、火车、RSS、Web Search、Memory 等状态提示；某个域一旦出现复杂规则，应迁到 `runtime/tools/<domain>/route.rs`。
+- `runtime/tools/todo/route.rs`：Todo / Reminder 自然语言语义门面，只为状态提示和 diagnostics 提供候选 domain/action，不解析最终目标、编号、日期或写入语义。
 - `runtime/tools/<domain>/`：具体业务域的关键词、状态字段、成功判断、失败文案、可见实体、pending、owner 和持久化不变量都应放在这里。
 
 Tool Loop 执行完成后的整轮后处理也在 tools 层：

--- a/docs/design/response-event-runtime.md
+++ b/docs/design/response-event-runtime.md
@@ -1,10 +1,10 @@
 # 统一响应事件流设计基线
 
-本文对应 Issue #366 的 Phase 1：梳理现有响应路径，定义后续收敛到统一流式 Agent Runtime 的最小事件模型和迁移边界。本文只记录设计基线，不改变当前运行行为。
+本文源自 Issue #366 的响应事件流基线，并随 Issue #400 的 Agent Chat 演进更新当前实现边界。
 
 ## 目标边界
 
-统一响应事件流的目标不是让所有平台都真实 token streaming，而是让 Core 对 Chat、Tool Loop、WebSearch 和 slash command 尽量输出同一种响应事件，再由 Gateway 根据平台能力渲染。
+统一响应事件流的目标不是让所有平台都真实 token streaming，而是让 Core 对 Chat、Agent Chat、WebSearch 和 slash command 尽量输出同一种响应事件，再由 Gateway 根据平台能力渲染。
 
 必须保留的边界：
 
@@ -18,8 +18,8 @@
 
 | 路径 | 当前入口 | 当前输出形态 | 现状判断 |
 | --- | --- | --- | --- |
-| 普通聊天 | `RespondPlan::StreamingChat` -> `respond_stream` -> `handle_chat_stream` | provider 支持时产生 `TextDelta`，最终 `Completed` | 已接入 `CoreResponseStream`，是当前最接近目标的路径。 |
-| Tool Loop | `RespondPlan::CompleteToolLoop` -> `handle_chat` -> `respond_with_tools` | `Status(ToolLoopStarted/Running/Finalizing)` + `Completed` | Core 已有可见进度壳，但工具轮本身仍是完整等待，最终回答也不是流式生成。 |
+| Agent Chat | `RespondPlan::AgentChat` -> `handle_chat` -> `respond_with_tools` | `Status(AgentStarted/Running/Finalizing)`；provider 支持时产生最终回答 `TextDelta`，最后 `Completed` | 普通纯文本消息在能力允许时统一走此路径；模型首轮可直接回答或发出 Tool Call。 |
+| 普通聊天降级 | `RespondPlan::StreamingChat` -> `respond_stream` -> `handle_chat_stream` | provider 支持时产生 `TextDelta`，最终 `Completed` | 仅用于 Tool Calling 未启用、Provider 不支持、工具为空或多模态等兼容场景。 |
 | WebSearch | `RespondPlan::WebSearch` -> `respond_web_search_stream` | provider 支持时复用 `/查` 的 `query_stream` delta，最终 `Completed` | 已接入 `CoreResponseStream`，但事件语义仍被压成普通文本 delta。 |
 | slash command | `/help` 试点走 `RespondPlan::CommandEvent`；其它命令仍由 `CommandDispatcher` 内确定性分发 | `/help` 输出 `Status(CommandStarted/CommandFinished)` + `Completed`；其它命令仍是 `RespondResponse` complete | 已有 `/help` 事件化试点，命令执行仍保持确定性；其余 slash command 尚未迁移。 |
 | pending 确认 | `handle_pending_operation` | `RespondResponse` complete | 应保持确定性，不默认进入 Agent Loop。 |
@@ -31,7 +31,7 @@
 - Core stream 包装：`qq-maid-core/src/service/streaming.rs::start_core_response_stream`
 - Respond 路由：`qq-maid-core/src/runtime/respond/router.rs::RespondRouter::plan`
 - 命令分发：`qq-maid-core/src/runtime/respond/command_dispatcher.rs`
-- Tool Loop 调用：`qq-maid-core/src/runtime/respond/chat_flow/mod.rs::handle_chat`
+- Agent Chat 调用：`qq-maid-core/src/runtime/respond/chat_flow/mod.rs::handle_chat`
 - LLM 工具执行：`qq-maid-llm/src/provider/tool_loop.rs::ToolLoopExecutor`
 - C2C 流式渲染：`qq-maid-gateway-rs/src/gateway/stream/delivery.rs`
 - 群聊聚合渲染：`qq-maid-gateway-rs/src/gateway/group.rs::consume_respond_stream`
@@ -52,12 +52,12 @@ CoreResponseEvent::Failed(CoreRespondFailure)
 ```text
 CommandStarted
 CommandFinished
-ToolLoopStarted
-ToolLoopRunning
+AgentStarted
+AgentRunning
 ToolCallStarted
 ToolCallFinished
 ToolCallFailed
-ToolLoopFinalizing
+AgentFinalizing
 ```
 
 这已经覆盖了“有一个统一 stream 外壳”和“单个工具开始/完成/失败”的基础，但还不足以表达命令开始/结束、最终回答开始等语义。后续应优先扩展既有事件契约，而不是新增一套平行 stream 抽象。
@@ -77,12 +77,12 @@ Failed(CoreRespondFailure)
 其中 `StatusKind` 可分阶段扩展：
 
 ```text
-ToolLoopStarted
+AgentStarted
 ToolRoundStarted
 ToolCallStarted
 ToolCallFinished
 ToolCallFailed
-ToolLoopFinalizing
+AgentFinalizing
 CommandStarted
 CommandFinished
 FinalAnswerStarted
@@ -98,7 +98,7 @@ FinalAnswerStarted
 - `Completed` 仍是最终权威响应，session、diagnostics、visible snapshot 和 ref_index 相关信息以它为准。
 - `Failed` 必须携带用户可理解的安全失败文案，不能要求 Gateway 解析内部错误。
 
-## Tool Loop 事件落点
+## Agent Chat 事件落点
 
 后续 Tool Loop 支持事件输出时，不应让 `qq-maid-llm` 反向依赖 `qq-maid-core`。可选实现方向：
 
@@ -170,17 +170,17 @@ ref_index 规则：
 - progress/status 不作为主要可引用正文。
 - C2C active stream 当前未确认 QQ final 回包字段能被 quote 回传，因此暂不写 bot outbound ref_index；该限制应保持到真机确认。
 
-## RespondPlan 迁移边界
+## RespondPlan 当前边界
 
-短期内保留现有 `Immediate` / `StreamingChat` / `CompleteToolLoop` / `WebSearch` 路由结构作为兼容层，不在本设计阶段要求重写 router。迁移重点是让这些路径的执行结果逐步统一包装为 `CoreResponseEvent` stream：
+当前保留 `Immediate` / `StreamingChat` / `AgentChat` / `WebSearch` 路由结构：
 
 - `Immediate` 继续承载 pending、短 slash command 和确定性业务分支，可先由外层 adapter 包装成 `Completed`。
 - `CommandEvent` 当前只承载 `/help` / `/帮助` 试点，命令业务仍复用 `CommandDispatcher`，Gateway 继续按通用事件消费。
-- `StreamingChat` 继续作为普通聊天流式路径，保持现有 provider streaming 行为。
-- `CompleteToolLoop` 先补工具进度事件，再在最终回答阶段逐步接入 streaming。
+- `StreamingChat` 作为不具备 Tool Calling 能力时的兼容流式路径。
+- `AgentChat` 是普通纯文本的统一原生 Tool Calling 路径；直接回答和工具完成后的最终回答都复用最终文本 delta sink。
 - `WebSearch` 继续作为显式搜索兼容路径，先统一事件语义，再评估是否和通用 Tool Loop 复用更多实现。
 
-只有在 Chat、Tool Loop、WebSearch、slash command、群聊开关和平台降级测试稳定后，才考虑收敛 `RespondPlan` 命名、删除旧 helper 或清理重复路径。后续实现 PR 不应把本文档理解为立即大规模重构 router 的要求。
+后续仍应保持小步演进，不把 Agent Chat 改造扩散成一次性重写全部 router、命令或 WebSearch 路径。
 
 ## 分阶段迁移建议
 
@@ -218,7 +218,7 @@ ref_index 规则：
 
 ### Phase 7：清理旧路径
 
-- 新路径稳定后再收敛 `CompleteToolLoop` 命名和 WebSearch 单独 stream helper。
+- `CompleteToolLoop` 已收敛为 `AgentChat`；后续继续评估 WebSearch 单独 stream helper。
 - 删除重复 helper 前必须有 Chat、Tool Loop、WebSearch、slash、群聊开关测试覆盖。
 
 ## 需要测试覆盖的关键行为

--- a/docs/development/custom-tools.md
+++ b/docs/development/custom-tools.md
@@ -26,21 +26,21 @@
 实际运行时不是“写了 Tool 模型就能直接调”，而是下面这条链路：
 
 1. `qq-maid-core/src/runtime/respond/tool_runtime.rs` 启动时构造服务端全量 `ToolRegistry`。
-2. 每次普通聊天进入 Tool Loop 前，`ToolRuntime::registry_for_chat()` 根据当前场景策略读取 `policy.enabled_tools`。
+2. 每次普通纯文本 Agent Chat 调用前，`ToolRuntime::registry_for_chat()` 根据当前场景策略读取 `policy.enabled_tools`。
 3. `ToolRegistry::subset()` 只保留本场景允许的工具；未注册或未在白名单里的工具对模型不可见。
 4. Todo 这类需要用户可见编号和引用恢复的工具，会在 `replace_scoped_tools_from_request()` 中替换成带当前请求快照的受限实例。
 5. LLM crate 只负责 Tool Loop 协议和执行注册表里的 Tool，不知道 Todo、RSS 或服务器命令的业务规则。
 
 默认策略也按这个链路生效：私聊 `tool_calling_enabled = true`，默认开放 `DEFAULT_PRIVATE_ENABLED_TOOLS`；群聊 `tool_calling_enabled = false`，即使开启也默认只开放 `DEFAULT_GROUP_ENABLED_TOOLS` 里的查询类工具。
 
-## Tool Loop 路由和后处理接入
+## Agent Chat 语义提示和后处理接入
 
-Tool 注册只解决“模型能不能调用”。普通聊天是否进入 Tool Loop、工具结果如何确定性展示、写入是否真实成功、用户后续能否引用结果，都需要在 tools 层补齐。
+Tool 注册和场景 policy 决定“模型能不能调用”。普通消息通过能力约束后统一进入 Agent Chat，由模型原生响应决定直接回答还是 Tool Call；领域语义提示、工具结果的确定性展示、写入验真和后续引用仍需要在 tools 层补齐。
 
 按能力选择接入面：
 
-- 自然语言路由：在 `qq-maid-core/src/runtime/tools/<domain>/route.rs` 暴露轻量分类门面。`respond/tool_route.rs` 只做通用调度；非 Todo 的简单路由可以先接到 `respond/tool_route_domains.rs`，复杂后再迁到 domain。
-- 普通聊天弱意图保护：通用闲聊、创作、解释、本地长文本整理放在 `respond/plain_chat_route.rs`。不要把具体工具关键词放进这个文件。
+- 自然语言语义提示：在 `qq-maid-core/src/runtime/tools/<domain>/route.rs` 暴露轻量分类门面。`respond/agent_route.rs` 只做能力约束和通用调度；分类结果只能用于 status/diagnostics，不能决定是否向模型暴露 Tool Schema。
+- 普通聊天弱语义：通用闲聊、创作、解释、本地长文本整理放在 `respond/plain_chat_route.rs`。不要把具体工具关键词放进这个文件，也不要把它重新变成前置 Router。
 - 只读结果展示：先在 `qq-maid-core/src/runtime/tools/agent_presenters.rs` 增加 `ToolExecutionResult -> ToolExecutionOutcome` 适配。
 - 多步写入或跨存储副作用：在 `qq-maid-core/src/runtime/tools/<domain>/ops.rs` 提供领域操作门面，Tool 文件只做参数解析、上下文校验和结构化结果返回。
 - 确认和澄清：把领域 payload、状态机和恢复执行放在 `runtime/tools/<domain>/pending.rs` 或 `runtime/tools/<domain>/flow/pending.rs`；`respond/pending.rs` 只保留跨域 envelope / 会话写入 helper。
@@ -52,7 +52,7 @@ Tool 注册只解决“模型能不能调用”。普通聊天是否进入 Tool 
 
 ```text
 qq-maid-core/src/runtime/tools/todo/
-  route.rs              # 自然语言是否进入 Todo Tool Loop
+  route.rs              # Todo 自然语言语义与状态提示候选
   ops.rs                # 多步写入与通知 outbox 等领域操作门面
   pending.rs            # Todo 专属 pending payload
   flow/pending.rs       # 确认/澄清状态机与受限 Tool Loop 恢复

--- a/qq-maid-core/src/http/routes.rs
+++ b/qq-maid-core/src/http/routes.rs
@@ -291,6 +291,7 @@ mod tests {
                 fallback_used: false,
                 executed_tools: Vec::new(),
                 tool_results: Vec::new(),
+                agent: Default::default(),
             })
         }
 

--- a/qq-maid-core/src/runtime/memory.rs
+++ b/qq-maid-core/src/runtime/memory.rs
@@ -4,7 +4,7 @@
 //! 供 runtime 模块内的其他子模块统一使用。
 
 pub(crate) mod route {
-    //! 记忆普通消息 Tool Loop 路由判断。
+    //! 记忆普通消息 Agent Chat 路由判断。
     //!
     //! 长期记忆仍必须走明确记忆意图和用户确认流程；这里仅决定普通消息是否可进入
     //! 受控 Tool Loop，真实草稿/确认/写入规则由 memory_flow 与 Memory Tool 负责。

--- a/qq-maid-core/src/runtime/respond/agent_route.rs
+++ b/qq-maid-core/src/runtime/respond/agent_route.rs
@@ -1,9 +1,9 @@
-//! 普通消息 Tool Loop 前置路由。
+//! 普通消息 Agent 能力前置路由。
 //!
-//! 本模块只保留通用入口、公共类型和跨域调度胶水。具体工具域的自然语言
-//! 路由规则优先由工具域提供；当前 Todo/Reminder 规则已下沉到
-//! `runtime::tools::todo::route`，其他工具域规则由
-//! `respond::tool_route_domains` 调度到对应 domain provider，避免本入口重新膨胀成业务判断集合。
+//! 代码侧只决定当前请求是否允许向模型暴露工具。通过场景、Provider 能力、
+//! 群聊开关和白名单约束后，普通纯文本消息统一进入具备原生 Tool Calling 的
+//! 模型流程；自然语言语义分类只用于状态提示和 diagnostics，不再决定模型能否
+//! 看到工具。
 
 use crate::runtime::tools::todo::route::{self as todo_route, TodoRouteAction, TodoRouteKind};
 
@@ -18,14 +18,14 @@ use super::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum RespondRoute {
     PlainChat,
-    ToolAgent,
+    AgentChat,
 }
 
 impl RespondRoute {
     pub(super) const fn as_str(self) -> &'static str {
         match self {
             Self::PlainChat => "plain_chat",
-            Self::ToolAgent => "tool_agent",
+            Self::AgentChat => "agent_chat",
         }
     }
 }
@@ -33,7 +33,7 @@ impl RespondRoute {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum SemanticRoute {
     PlainChat,
-    ToolLoop,
+    ToolIntent,
     Deterministic,
     Ambiguous,
 }
@@ -42,7 +42,7 @@ impl SemanticRoute {
     pub(super) const fn as_str(self) -> &'static str {
         match self {
             Self::PlainChat => "plain_chat",
-            Self::ToolLoop => "tool_loop",
+            Self::ToolIntent => "tool_intent",
             Self::Deterministic => "deterministic",
             Self::Ambiguous => "ambiguous",
         }
@@ -75,7 +75,7 @@ impl ToolDomain {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) struct ToolRouteDecision {
+pub(super) struct AgentRouteDecision {
     pub route: RespondRoute,
     pub semantic_route: SemanticRoute,
     pub domain: ToolDomain,
@@ -83,7 +83,7 @@ pub(super) struct ToolRouteDecision {
     pub status_hint: Option<StatusHint>,
 }
 
-impl ToolRouteDecision {
+impl AgentRouteDecision {
     /// 为确定性分派准备普通聊天兜底。Router 必须在执行前确定 reason，
     /// dispatcher 不得在 handler 未消费时临时补造路由信息。
     pub(super) const fn plain_deterministic(reason: &'static str) -> Self {
@@ -96,8 +96,8 @@ impl ToolRouteDecision {
         }
     }
 
-    pub(super) const fn uses_tool_agent(self) -> bool {
-        matches!(self.route, RespondRoute::ToolAgent)
+    pub(super) const fn uses_agent_runtime(self) -> bool {
+        matches!(self.route, RespondRoute::AgentChat)
     }
 
     pub(super) fn domains(self) -> Vec<&'static str> {
@@ -110,7 +110,7 @@ impl ToolRouteDecision {
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct ToolRouteContext {
+pub(super) struct AgentRouteContext {
     pub scene_enabled: bool,
     pub tool_calling_enabled: bool,
     pub group_tool_calling_enabled: bool,
@@ -127,7 +127,7 @@ pub(super) struct SemanticAssessment {
     pub reason: &'static str,
 }
 
-pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> ToolRouteDecision {
+pub(super) fn route_agent_chat(req: &RespondRequest, ctx: AgentRouteContext) -> AgentRouteDecision {
     let is_group = req
         .group_id
         .as_deref()
@@ -137,7 +137,7 @@ pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> To
             RespondRoute::PlainChat,
             SemanticRoute::PlainChat,
             ToolDomain::Unknown,
-            "tool_loop_unavailable",
+            "agent_unavailable",
             None,
         );
     }
@@ -148,7 +148,7 @@ pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> To
             RespondRoute::PlainChat,
             SemanticRoute::PlainChat,
             ToolDomain::Unknown,
-            "group_tool_loop_disabled",
+            "group_agent_disabled",
             None,
         );
     }
@@ -160,7 +160,7 @@ pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> To
             RespondRoute::PlainChat,
             SemanticRoute::PlainChat,
             ToolDomain::Unknown,
-            "tool_loop_unavailable",
+            "agent_unavailable",
             None,
         );
     }
@@ -189,43 +189,25 @@ pub(super) fn route_tool_loop(req: &RespondRequest, ctx: ToolRouteContext) -> To
         .has_recent_context(InteractionDomain::Todo);
     let assessment = classify_semantic_route(trimmed, has_recent_todo_context);
     let status_hint = classify_status_hint(trimmed, has_recent_todo_context);
-    match assessment.semantic_route {
-        SemanticRoute::PlainChat => decision(
-            RespondRoute::PlainChat,
-            SemanticRoute::PlainChat,
-            assessment.domain,
-            assessment.reason,
-            None,
-        ),
-        SemanticRoute::ToolLoop => decision(
-            RespondRoute::ToolAgent,
-            SemanticRoute::ToolLoop,
-            assessment.domain,
-            assessment.reason,
-            status_hint,
-        ),
-        SemanticRoute::Deterministic => decision(
+    if matches!(assessment.semantic_route, SemanticRoute::Deterministic) {
+        return decision(
             RespondRoute::PlainChat,
             SemanticRoute::Deterministic,
             assessment.domain,
             "deterministic_or_empty",
             None,
-        ),
-        SemanticRoute::Ambiguous if is_group => decision(
-            RespondRoute::PlainChat,
-            SemanticRoute::Ambiguous,
-            assessment.domain,
-            "semantic_ambiguous_group_plain",
-            None,
-        ),
-        SemanticRoute::Ambiguous => decision(
-            RespondRoute::PlainChat,
-            SemanticRoute::Ambiguous,
-            assessment.domain,
-            assessment.reason,
-            None,
-        ),
+        );
     }
+
+    // 能力边界已经由上方 guard 确定。这里不能再根据关键词或模糊度剥夺模型的
+    // Tool Schema；模型可以在同一次原生响应中直接回答、请求澄清或发出 Tool Call。
+    decision(
+        RespondRoute::AgentChat,
+        assessment.semantic_route,
+        assessment.domain,
+        assessment.reason,
+        status_hint,
+    )
 }
 
 pub(super) fn has_search_intent(text: &str, lower: &str) -> bool {
@@ -238,8 +220,8 @@ fn decision(
     domain: ToolDomain,
     reason: &'static str,
     status_hint: Option<StatusHint>,
-) -> ToolRouteDecision {
-    ToolRouteDecision {
+) -> AgentRouteDecision {
+    AgentRouteDecision {
         route,
         semantic_route,
         domain,
@@ -279,7 +261,7 @@ fn classify_semantic_route(text: &str, has_recent_todo_context: bool) -> Semanti
     );
     if todo_intent.routes_to_tool_loop() {
         return assessment(
-            SemanticRoute::ToolLoop,
+            SemanticRoute::ToolIntent,
             ToolDomain::Todo,
             todo_intent.reason,
         );
@@ -370,8 +352,8 @@ mod tests {
         }
     }
 
-    fn context() -> ToolRouteContext {
-        ToolRouteContext {
+    fn context() -> AgentRouteContext {
+        AgentRouteContext {
             scene_enabled: true,
             tool_calling_enabled: true,
             group_tool_calling_enabled: false,
@@ -381,15 +363,15 @@ mod tests {
         }
     }
 
-    fn context_with_recent_todo() -> ToolRouteContext {
-        ToolRouteContext {
+    fn context_with_recent_todo() -> AgentRouteContext {
+        AgentRouteContext {
             interaction_state: InteractionStateSnapshot::with_recent_todo_context_for_test(),
             ..context()
         }
     }
 
     #[test]
-    fn private_plain_messages_keep_streaming_chat() {
+    fn private_plain_messages_enter_tool_capable_agent() {
         for input in [
             "晚上好",
             "下午好呀",
@@ -402,8 +384,8 @@ mod tests {
             "今天天气真好",
             "聊聊天气",
         ] {
-            let decision = route_tool_loop(&request(input), context());
-            assert_eq!(decision.route, RespondRoute::PlainChat, "{input}");
+            let decision = route_agent_chat(&request(input), context());
+            assert_eq!(decision.route, RespondRoute::AgentChat, "{input}");
             assert_eq!(decision.semantic_route, SemanticRoute::PlainChat, "{input}");
             assert_eq!(decision.status_hint, None, "{input}");
         }
@@ -415,7 +397,7 @@ mod tests {
 Codex 分析结果：
 - route 命中了 WebSearch
 - 查询工具返回：查询内容太长
-- tool_route 里出现 search 关键词
+- agent_route 里出现 search 关键词
 人话说这个";
         let log_output = "\
 2026-07-08 ERROR query failed
@@ -426,9 +408,14 @@ WebSearch tool timeout
         for input in [codex_output, log_output] {
             let lower = input.to_ascii_lowercase();
             assert!(!has_search_intent(input, &lower), "{input}");
-            let decision = route_tool_loop(&request(input), context());
+            let decision = route_agent_chat(&request(input), context());
             assert_ne!(decision.domain, ToolDomain::Search, "{input}");
-            assert_ne!(decision.semantic_route, SemanticRoute::ToolLoop, "{input}");
+            assert_ne!(
+                decision.semantic_route,
+                SemanticRoute::ToolIntent,
+                "{input}"
+            );
+            assert_eq!(decision.route, RespondRoute::AgentChat, "{input}");
         }
     }
 
@@ -464,9 +451,13 @@ WebSearch tool timeout
             "查一下 G1 时刻",
             "查看上次 codex 发布的 rss",
         ] {
-            let decision = route_tool_loop(&request(input), context());
-            assert_eq!(decision.route, RespondRoute::ToolAgent, "{input}");
-            assert_eq!(decision.semantic_route, SemanticRoute::ToolLoop, "{input}");
+            let decision = route_agent_chat(&request(input), context());
+            assert_eq!(decision.route, RespondRoute::AgentChat, "{input}");
+            assert_eq!(
+                decision.semantic_route,
+                SemanticRoute::ToolIntent,
+                "{input}"
+            );
             assert!(decision.status_hint.is_some(), "{input}");
         }
     }
@@ -501,8 +492,8 @@ WebSearch tool timeout
         ];
 
         for (input, expected_hint) in cases {
-            let decision = route_tool_loop(&request(input), context());
-            assert_eq!(decision.route, RespondRoute::ToolAgent, "{input}");
+            let decision = route_agent_chat(&request(input), context());
+            assert_eq!(decision.route, RespondRoute::AgentChat, "{input}");
             assert_eq!(decision.status_hint, Some(expected_hint), "{input}");
         }
     }
@@ -516,21 +507,21 @@ WebSearch tool timeout
             "删掉这个",
             "这些完成了",
         ] {
-            let decision = route_tool_loop(&request(input), context());
-            assert_eq!(decision.route, RespondRoute::ToolAgent, "{input}");
+            let decision = route_agent_chat(&request(input), context());
+            assert_eq!(decision.route, RespondRoute::AgentChat, "{input}");
             assert_eq!(decision.domain, ToolDomain::Todo, "{input}");
         }
 
         for input in ["这个改一下", "都删除了吧"] {
-            let without_context = route_tool_loop(&request(input), context());
-            assert_eq!(without_context.route, RespondRoute::PlainChat, "{input}");
+            let without_context = route_agent_chat(&request(input), context());
+            assert_eq!(without_context.route, RespondRoute::AgentChat, "{input}");
             assert_eq!(
                 without_context.reason, "todo_reference_context_missing",
                 "{input}"
             );
 
-            let with_context = route_tool_loop(&request(input), context_with_recent_todo());
-            assert_eq!(with_context.route, RespondRoute::ToolAgent, "{input}");
+            let with_context = route_agent_chat(&request(input), context_with_recent_todo());
+            assert_eq!(with_context.route, RespondRoute::AgentChat, "{input}");
             assert_eq!(with_context.domain, ToolDomain::Todo, "{input}");
         }
     }
@@ -538,24 +529,24 @@ WebSearch tool timeout
     #[test]
     fn bare_number_todo_operations_require_recent_context() {
         for input in ["7删除", "删除7", "把7合并到6", "6和7合并"] {
-            let without_context = route_tool_loop(&request(input), context());
-            assert_eq!(without_context.route, RespondRoute::PlainChat, "{input}");
+            let without_context = route_agent_chat(&request(input), context());
+            assert_eq!(without_context.route, RespondRoute::AgentChat, "{input}");
             assert_eq!(
                 without_context.reason, "todo_number_context_missing",
                 "{input}"
             );
 
-            let with_context = route_tool_loop(&request(input), context_with_recent_todo());
-            assert_eq!(with_context.route, RespondRoute::ToolAgent, "{input}");
+            let with_context = route_agent_chat(&request(input), context_with_recent_todo());
+            assert_eq!(with_context.route, RespondRoute::AgentChat, "{input}");
             assert_eq!(with_context.domain, ToolDomain::Todo, "{input}");
         }
     }
 
     #[test]
-    fn ambiguous_private_defaults_to_plain_chat() {
+    fn ambiguous_private_enters_agent_and_can_clarify() {
         for input in ["安排一下", "帮我处理一下", "刚刚没看到，再来一条"] {
-            let decision = route_tool_loop(&request(input), context());
-            assert_eq!(decision.route, RespondRoute::PlainChat, "{input}");
+            let decision = route_agent_chat(&request(input), context());
+            assert_eq!(decision.route, RespondRoute::AgentChat, "{input}");
             assert_eq!(decision.semantic_route, SemanticRoute::Ambiguous, "{input}");
             assert_eq!(decision.status_hint, None, "{input}");
         }
@@ -566,13 +557,13 @@ WebSearch tool timeout
         let mut group = request("杭州明天要带伞吗");
         group.group_id = Some("g1".to_owned());
         assert_eq!(
-            route_tool_loop(&group, context()).route,
+            route_agent_chat(&group, context()).route,
             RespondRoute::PlainChat
         );
         assert_eq!(
-            route_tool_loop(
+            route_agent_chat(
                 &request("杭州明天要带伞吗"),
-                ToolRouteContext {
+                AgentRouteContext {
                     tool_calling_enabled: false,
                     ..context()
                 },
@@ -587,36 +578,36 @@ WebSearch tool timeout
         let mut group = request("杭州明天要带伞吗");
         group.group_id = Some("g1".to_owned());
         assert_eq!(
-            route_tool_loop(
+            route_agent_chat(
                 &group,
-                ToolRouteContext {
+                AgentRouteContext {
                     group_tool_calling_enabled: true,
                     ..context()
                 },
             )
             .route,
-            RespondRoute::ToolAgent
+            RespondRoute::AgentChat
         );
     }
 
     #[test]
     fn availability_guards_keep_plain_route() {
         for ctx in [
-            ToolRouteContext {
+            AgentRouteContext {
                 scene_enabled: false,
                 ..context()
             },
-            ToolRouteContext {
+            AgentRouteContext {
                 enabled_tools_available: false,
                 ..context()
             },
-            ToolRouteContext {
+            AgentRouteContext {
                 provider_supports_tool_calling: false,
                 ..context()
             },
         ] {
             assert_eq!(
-                route_tool_loop(&request("杭州明天要带伞吗"), ctx).route,
+                route_agent_chat(&request("杭州明天要带伞吗"), ctx).route,
                 RespondRoute::PlainChat
             );
         }

--- a/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
@@ -179,6 +179,15 @@ impl RustRespondService {
         let service =
             LlmChatService::with_context_budget(self.provider.clone(), self.context_budget);
         let use_agent_runtime = respond_route.uses_agent_runtime();
+        let tool_turn_context = crate::runtime::tools::agent_turn::ToolTurnContext {
+            semantic_domain: (!matches!(
+                respond_route.domain,
+                super::agent_route::ToolDomain::Unknown
+            ))
+            .then_some(respond_route.domain.as_str()),
+            status_subject: respond_route.status_hint.map(|hint| hint.subject.as_str()),
+            status_action: respond_route.status_hint.map(|hint| hint.action.as_str()),
+        };
         let (output, agent_turn_outcome, tool_turn_diagnostics) = if use_agent_runtime {
             let tools = self.tool_runtime.registry_for_chat(&policy, &req)?;
             let output = service
@@ -216,6 +225,7 @@ impl RustRespondService {
                 &meta,
                 &interaction_meta,
                 output,
+                tool_turn_context,
             )?;
             (
                 postprocess.output,
@@ -230,7 +240,13 @@ impl RustRespondService {
 
         let reply = output.reply.clone();
         let executed_tools = output.executed_tools.clone();
-        let tool_calling_used = !output.tool_results.is_empty();
+        let tool_call_emitted = !output.agent.emitted_tools.is_empty();
+        let tool_execution_attempted = output.agent.tool_execution_attempted;
+        let agent_result = output
+            .agent
+            .stop_reason
+            .map(|reason| reason.as_str())
+            .unwrap_or("direct_answer");
         if use_agent_runtime {
             tool_turn_diagnostics.log_tool_loop_results(&executed_tools);
         }
@@ -258,8 +274,11 @@ impl RustRespondService {
             "route_domains": respond_route.domains(),
             "route_semantic": respond_route.semantic_route.as_str(),
             "tool_calling_available": use_agent_runtime,
-            "tool_calling_used": tool_calling_used,
-            "agent_result": if tool_calling_used { "tool_used" } else { "direct_answer" },
+            "tool_call_emitted": tool_call_emitted,
+            "tool_execution_attempted": tool_execution_attempted,
+            "tool_calling_used": tool_call_emitted,
+            "agent_result": agent_result,
+            "stop_reason": agent_result,
             "tool_calling_enabled": use_agent_runtime,
             "agent_mode": if use_agent_runtime { json!("configured_whitelist") } else { Value::Null },
             "agent_enabled_tools": if use_agent_runtime { json!(&policy.enabled_tools) } else { Value::Null },
@@ -426,8 +445,11 @@ impl RustRespondService {
             "route_domains": respond_route.domains(),
             "route_semantic": respond_route.semantic_route.as_str(),
             "tool_calling_available": false,
+            "tool_call_emitted": false,
+            "tool_execution_attempted": false,
             "tool_calling_used": false,
             "agent_result": "direct_answer",
+            "stop_reason": "direct_answer",
             "tool_calling_enabled": false,
             "agent_executed_tools": [],
             "agent_policy": policy.diagnostic_summary(),

--- a/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
@@ -20,13 +20,13 @@ use crate::{
 use super::{
     RespondPurpose, RespondRequest, RespondResponse, RustRespondService,
     agent_outcome::AgentTurnOutcome,
+    agent_route::AgentRouteDecision,
     common::{
         SESSION_HISTORY_MESSAGE_LIMIT, command_response, empty_respond_request, memory_error,
         merge_metadata, session_error,
     },
     llm_service::{ChatService, LlmChatService, response_from_output},
     session_flow::build_session_context,
-    tool_route::ToolRouteDecision,
 };
 
 pub(super) use super::conversation_session::recent_session_messages;
@@ -48,7 +48,7 @@ pub(super) struct PreparedChat {
     pub user_text: String,
     pub meta: SessionMeta,
     pub session: SessionRecord,
-    pub respond_route: ToolRouteDecision,
+    pub respond_route: AgentRouteDecision,
 }
 
 #[derive(Default)]
@@ -113,7 +113,7 @@ impl RustRespondService {
         let used_memory = !memory_context.trim().is_empty();
         let is_group_chat = is_group_meta(&meta);
         let system_prompts = self.prompt_config.load_system_prompts()?;
-        let system_prompts = if respond_route.uses_tool_agent() {
+        let system_prompts = if respond_route.uses_agent_runtime() {
             let mut prompts = system_prompts;
             prompts.push(TOOL_LOOP_AMBIGUITY_PROMPT.to_owned());
             if is_group_chat {
@@ -178,8 +178,8 @@ impl RustRespondService {
         }
         let service =
             LlmChatService::with_context_budget(self.provider.clone(), self.context_budget);
-        let use_tool_loop = respond_route.uses_tool_agent();
-        let (output, agent_turn_outcome, tool_turn_diagnostics) = if use_tool_loop {
+        let use_agent_runtime = respond_route.uses_agent_runtime();
+        let (output, agent_turn_outcome, tool_turn_diagnostics) = if use_agent_runtime {
             let tools = self.tool_runtime.registry_for_chat(&policy, &req)?;
             let output = service
                 .respond_with_tools(
@@ -230,7 +230,8 @@ impl RustRespondService {
 
         let reply = output.reply.clone();
         let executed_tools = output.executed_tools.clone();
-        if use_tool_loop {
+        let tool_calling_used = !output.tool_results.is_empty();
+        if use_agent_runtime {
             tool_turn_diagnostics.log_tool_loop_results(&executed_tools);
         }
         self.session_store
@@ -256,11 +257,14 @@ impl RustRespondService {
             "route_reason": respond_route.reason,
             "route_domains": respond_route.domains(),
             "route_semantic": respond_route.semantic_route.as_str(),
-            "tool_calling_enabled": use_tool_loop,
-            "tool_loop_mode": if use_tool_loop { json!("configured_whitelist") } else { Value::Null },
-            "tool_loop_enabled_tools": if use_tool_loop { json!(&policy.enabled_tools) } else { Value::Null },
+            "tool_calling_available": use_agent_runtime,
+            "tool_calling_used": tool_calling_used,
+            "agent_result": if tool_calling_used { "tool_used" } else { "direct_answer" },
+            "tool_calling_enabled": use_agent_runtime,
+            "agent_mode": if use_agent_runtime { json!("configured_whitelist") } else { Value::Null },
+            "agent_enabled_tools": if use_agent_runtime { json!(&policy.enabled_tools) } else { Value::Null },
             "agent_policy": policy.diagnostic_summary(),
-            "tool_loop_executed_tools": executed_tools,
+            "agent_executed_tools": executed_tools,
             "agent_turn_status": agent_diagnostics["agent_turn_status"].clone(),
             "tool_outcomes": agent_diagnostics["tool_outcomes"].clone(),
             "tool_retry_count": 0,
@@ -271,7 +275,7 @@ impl RustRespondService {
                 json!(error_code)
             } else if let Some(error_code) = tool_turn_error_code(
                 agent_turn_outcome.as_ref(),
-                use_tool_loop,
+                use_agent_runtime,
                 &tool_turn_diagnostics,
             ) {
                 json!(error_code)
@@ -295,7 +299,7 @@ impl RustRespondService {
     pub(super) async fn handle_chat_stream<F>(
         &self,
         req: RespondRequest,
-        respond_route: ToolRouteDecision,
+        respond_route: AgentRouteDecision,
         on_delta: F,
     ) -> Result<RespondResponse, LlmError>
     where
@@ -421,6 +425,11 @@ impl RustRespondService {
             "route_reason": respond_route.reason,
             "route_domains": respond_route.domains(),
             "route_semantic": respond_route.semantic_route.as_str(),
+            "tool_calling_available": false,
+            "tool_calling_used": false,
+            "agent_result": "direct_answer",
+            "tool_calling_enabled": false,
+            "agent_executed_tools": [],
             "agent_policy": policy.diagnostic_summary(),
         }));
         Ok(response)

--- a/qq-maid-core/src/runtime/respond/command_dispatcher.rs
+++ b/qq-maid-core/src/runtime/respond/command_dispatcher.rs
@@ -98,7 +98,7 @@ impl<'a> CommandDispatcher<'a> {
         };
         let force_tool_loop = planned
             .respond_route()
-            .is_some_and(|decision| decision.uses_tool_agent());
+            .is_some_and(|decision| decision.uses_agent_runtime());
 
         // 检查是否为翻译指令（如 "/翻译 文本"、"/翻译日语 文本"）
         if let Some(command) = translation_flow::parse_translation_command(&user_text) {
@@ -184,7 +184,7 @@ impl<'a> CommandDispatcher<'a> {
             return Ok(DispatchOutcome::Respond(Box::new(response)));
         }
 
-        // CompleteToolLoop 下由 Agent 自行决定是否调用 Todo Tool；
+        // AgentChat 下由 Agent 自行决定是否调用 Todo Tool；
         // slash 命令、pending 和确定性 Todo 查询已在前面保持原路径。
         if !force_tool_loop {
             // 检查是否为待办相关操作（新增、查看、完成、编辑、删除等）

--- a/qq-maid-core/src/runtime/respond/llm_service/mod.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service/mod.rs
@@ -19,7 +19,8 @@ use qq_maid_llm::{
         estimated_json_chars, log_budget_report,
     },
     provider::{
-        ChatOutcome, DynLlmProvider, LlmStreamEvent, ToolChatRequest, ToolExecutionResult,
+        AgentRunDiagnostics, ChatOutcome, DynLlmProvider, LlmStreamEvent, ToolChatRequest,
+        ToolExecutionResult,
         types::{ChatMessage, ChatRequest, ChatRole},
     },
     tool::{ToolContext, ToolRegistry},
@@ -77,6 +78,8 @@ pub struct RespondOutput {
     pub executed_tools: Vec<String>,
     /// Tool Loop 中实际工具输出摘要；普通聊天为空。
     pub tool_results: Vec<ToolExecutionResult>,
+    /// Agent Runtime 的结构化执行轨迹。
+    pub agent: AgentRunDiagnostics,
 }
 
 /// `ChatService` 的默认实现。
@@ -173,6 +176,7 @@ impl LlmChatService {
             fallback_used,
             executed_tools: Vec::new(),
             tool_results: Vec::new(),
+            agent: Default::default(),
         };
         log_llm_request_completed(&req, &outcome);
         output_from_raw_reply(&req, raw_reply, outcome)
@@ -321,6 +325,7 @@ fn output_from_raw_reply(
         chat,
         executed_tools: outcome.executed_tools,
         tool_results: outcome.tool_results,
+        agent: outcome.agent,
     })
 }
 

--- a/qq-maid-core/src/runtime/respond/mod.rs
+++ b/qq-maid-core/src/runtime/respond/mod.rs
@@ -33,6 +33,7 @@ mod types;
 pub use types::{ChatResponse, RespondPurpose, RespondRequest, RespondResponse};
 
 pub(crate) mod agent_outcome;
+mod agent_route;
 mod chat_flow;
 mod command_dispatcher;
 pub(crate) mod command_render;
@@ -54,7 +55,6 @@ mod status_hint;
 #[cfg(test)]
 pub(crate) mod tests;
 mod title;
-mod tool_route;
 mod tool_route_domains;
 mod tool_runtime;
 pub(crate) mod train_flow;
@@ -128,7 +128,7 @@ pub struct RespondServiceOptions {
     pub tool_calling_enabled: bool,
     /// 是否允许群聊普通聊天进入 Tool Calling；默认关闭，避免工具调用阻塞群聊。
     pub tool_calling_group_enabled: bool,
-    /// 单次 Tool Loop 最大工具调用轮数。
+    /// 单次 Agent 最大工具调用轮数。
     pub tool_calling_max_rounds: usize,
     /// 聊天上下文预算；只由 Core 装配层读取配置后注入。
     pub context_budget: ContextBudgetConfig,
@@ -149,10 +149,10 @@ pub(crate) enum RespondPlan {
     /// 这里仅让 Core -> Gateway 边界统一输出 Status / Completed / Failed。
     CommandEvent,
     StreamingChat,
-    CompleteToolLoop,
+    AgentChat,
     /// 显式联网查询路径：`/查` 或明确对机器人发起的搜索意图。
     ///
-    /// 该路径独立于 Tool Loop 路由：群聊只要 @ 机器人并命中搜索意图即触发，
+    /// 该路径独立于 Agent Chat 路由：群聊只要 @ 机器人并命中搜索意图即触发，
     /// 不依赖 Tool Loop 开关；查询复用 `/查` 的 `WebSearchTool::query_stream`
     /// 流式能力，避免长时间非流式阻塞导致超时。
     WebSearch,
@@ -165,7 +165,7 @@ pub(crate) enum RespondPlan {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct PlannedRespond {
     plan: RespondPlan,
-    respond_route: Option<tool_route::ToolRouteDecision>,
+    respond_route: Option<agent_route::AgentRouteDecision>,
 }
 
 impl PlannedRespond {
@@ -179,15 +179,15 @@ impl PlannedRespond {
     pub(crate) const fn command_event() -> Self {
         Self {
             plan: RespondPlan::CommandEvent,
-            respond_route: Some(tool_route::ToolRouteDecision::plain_deterministic(
+            respond_route: Some(agent_route::AgentRouteDecision::plain_deterministic(
                 "command_event_fallback",
             )),
         }
     }
 
-    fn chat(respond_route: tool_route::ToolRouteDecision) -> Self {
-        let plan = if respond_route.uses_tool_agent() {
-            RespondPlan::CompleteToolLoop
+    fn chat(respond_route: agent_route::AgentRouteDecision) -> Self {
+        let plan = if respond_route.uses_agent_runtime() {
+            RespondPlan::AgentChat
         } else {
             RespondPlan::StreamingChat
         };
@@ -200,7 +200,7 @@ impl PlannedRespond {
     const fn immediate_chat(reason: &'static str) -> Self {
         Self {
             plan: RespondPlan::Immediate,
-            respond_route: Some(tool_route::ToolRouteDecision::plain_deterministic(reason)),
+            respond_route: Some(agent_route::AgentRouteDecision::plain_deterministic(reason)),
         }
     }
 
@@ -208,17 +208,17 @@ impl PlannedRespond {
         self.plan
     }
 
-    const fn respond_route(self) -> Option<tool_route::ToolRouteDecision> {
+    const fn respond_route(self) -> Option<agent_route::AgentRouteDecision> {
         self.respond_route
     }
 
     pub(crate) fn status_hint(self) -> StatusHint {
-        if !matches!(self.plan, RespondPlan::CompleteToolLoop) {
+        if !matches!(self.plan, RespondPlan::AgentChat) {
             return StatusHint::model();
         }
         self.respond_route
             .and_then(|decision| decision.status_hint)
-            .unwrap_or_else(StatusHint::default_tool)
+            .unwrap_or_else(StatusHint::model)
     }
 }
 
@@ -405,7 +405,7 @@ impl RustRespondService {
         F: FnMut(String) -> Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send>> + Send,
     {
         let planned = self.plan_core_respond(&req)?;
-        if matches!(planned.plan(), RespondPlan::CompleteToolLoop) {
+        if matches!(planned.plan(), RespondPlan::AgentChat) {
             // 直接调用方也必须遵守 Router 已确定的 Tool Agent 执行路径，不能把
             // 同一 decision 交给普通 stream_respond() 后生成错误 diagnostics。
             return self.respond_with_plan(req, planned).await;

--- a/qq-maid-core/src/runtime/respond/router.rs
+++ b/qq-maid-core/src/runtime/respond/router.rs
@@ -1,6 +1,6 @@
 //! Respond 路由决策服务。
 //!
-//! 这里是普通消息进入 Immediate / StreamingChat / CompleteToolLoop 的唯一决策边界。
+//! 这里是普通消息进入 Immediate / StreamingChat / AgentChat 的唯一决策边界。
 //! 它只读取现有 session 状态和 agent policy，不执行命令、不创建会话、不调用 LLM。
 
 use crate::{
@@ -12,13 +12,13 @@ use crate::{
 
 use super::{
     PlannedRespond, RespondPlan, RespondRequest, RustRespondService,
+    agent_route::{self, AgentRouteContext, RespondRoute},
     common::session_error,
     interaction_state::{
         classify_inbound_with_active, interaction_snapshot, pending_blocks_immediate,
         respond_interaction_meta, respond_meta, route_context_session,
     },
     search_flow, session_flow,
-    tool_route::{self, RespondRoute, ToolRouteContext},
 };
 
 pub(super) struct RespondRouter<'a> {
@@ -77,11 +77,11 @@ impl<'a> RespondRouter<'a> {
             ));
         }
 
-        // 在进入 Tool Loop 路由前，先拦截“明确对机器人发起的搜索意图”。
+        // 在进入 Agent Chat 路由前，先拦截“明确对机器人发起的搜索意图”。
         // 群聊未 @ 机器人时 Gateway 已在入站阶段过滤，Core 侧不再二次判定；
         // 但为安全起见，群聊仍要求存在 directed_to_bot 信号才自动联网查询，
         // 避免出现“查/搜索”等词就触发。私聊天然视为明确发起。
-        if tool_route::has_search_intent(trimmed, &trimmed.to_ascii_lowercase())
+        if agent_route::has_search_intent(trimmed, &trimmed.to_ascii_lowercase())
             && directed_to_bot(req)
         {
             return Ok(PlannedRespond::web_search());
@@ -102,20 +102,20 @@ impl<'a> RespondRouter<'a> {
         }
 
         let policy = self.resolve_agent_policy(req)?;
-        let tool_decision = self.route_tool_loop_with_active(req, &policy, route_session);
+        let agent_decision = self.route_agent_chat_with_active(req, &policy, route_session);
         let plan = if !req.has_non_text_input_parts()
-            && matches!(tool_decision.route, RespondRoute::ToolAgent)
+            && matches!(agent_decision.route, RespondRoute::AgentChat)
         {
-            RespondPlan::CompleteToolLoop
+            RespondPlan::AgentChat
         } else {
             RespondPlan::StreamingChat
         };
         tracing::debug!(
             respond_plan = ?plan,
-            tool_loop_route = ?tool_decision.route,
-            semantic_route = ?tool_decision.semantic_route,
-            tool_domain = ?tool_decision.domain,
-            route_reason = tool_decision.reason,
+            tool_loop_route = ?agent_decision.route,
+            semantic_route = ?agent_decision.semantic_route,
+            tool_domain = ?agent_decision.domain,
+            route_reason = agent_decision.reason,
             is_group = req
                 .group_id
                 .as_deref()
@@ -124,7 +124,7 @@ impl<'a> RespondRouter<'a> {
             enabled_tools_count = policy.enabled_tools.len(),
             "selected core respond route"
         );
-        Ok(PlannedRespond::chat(tool_decision))
+        Ok(PlannedRespond::chat(agent_decision))
     }
 
     pub(super) fn classify_inbound(
@@ -180,15 +180,15 @@ impl<'a> RespondRouter<'a> {
         self.service.agent_config.resolve(scene)
     }
 
-    fn route_tool_loop_with_active(
+    fn route_agent_chat_with_active(
         &self,
         req: &RespondRequest,
         policy: &ResolvedAgentPolicy,
         active_session: Option<&SessionRecord>,
-    ) -> tool_route::ToolRouteDecision {
-        tool_route::route_tool_loop(
+    ) -> agent_route::AgentRouteDecision {
+        agent_route::route_agent_chat(
             req,
-            ToolRouteContext {
+            AgentRouteContext {
                 scene_enabled: policy.enabled,
                 tool_calling_enabled: policy.tool_calling_enabled,
                 group_tool_calling_enabled: policy.group_tool_calling_enabled,

--- a/qq-maid-core/src/runtime/respond/status_hint.rs
+++ b/qq-maid-core/src/runtime/respond/status_hint.rs
@@ -20,6 +20,20 @@ pub(crate) enum StatusSubject {
     Record,
 }
 
+impl StatusSubject {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Model => "model",
+            Self::Tool => "tool",
+            Self::Weather => "weather",
+            Self::Todo => "todo",
+            Self::Rss => "rss",
+            Self::Train => "train",
+            Self::Record => "record",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum StatusAction {
     Think,
@@ -28,6 +42,19 @@ pub(crate) enum StatusAction {
     Write,
     Confirm,
     Read,
+}
+
+impl StatusAction {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Think => "think",
+            Self::Process => "process",
+            Self::Query => "query",
+            Self::Write => "write",
+            Self::Confirm => "confirm",
+            Self::Read => "read",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/qq-maid-core/src/runtime/respond/status_hint.rs
+++ b/qq-maid-core/src/runtime/respond/status_hint.rs
@@ -1,6 +1,6 @@
 //! 用户可见处理状态文案映射。
 //!
-//! 这里只消费已经确定的会话类型、工具类别和动作类别，不参与是否进入 Tool Loop
+//! 这里只消费已经确定的会话类型、工具类别和动作类别，不参与是否进入 Agent Chat
 //! 的路由判断，避免状态提示反向影响业务执行边界。
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -46,10 +46,6 @@ pub(crate) struct StatusHint {
 impl StatusHint {
     pub(crate) const fn new(subject: StatusSubject, action: StatusAction) -> Self {
         Self { subject, action }
-    }
-
-    pub(crate) const fn default_tool() -> Self {
-        Self::new(StatusSubject::Tool, StatusAction::Process)
     }
 
     pub(crate) const fn model() -> Self {
@@ -189,7 +185,7 @@ mod tests {
                 "小女仆正在翻记录…",
             ),
             (
-                StatusHint::default_tool(),
+                StatusHint::new(StatusSubject::Tool, StatusAction::Process),
                 StatusPhase::Finalizing,
                 "小女仆正在确认结果…",
             ),
@@ -221,9 +217,13 @@ mod tests {
                 StatusPhase::Started,
                 "正在确认…",
             ),
-            (StatusHint::default_tool(), StatusPhase::Running, "处理中…"),
             (
-                StatusHint::default_tool(),
+                StatusHint::new(StatusSubject::Tool, StatusAction::Process),
+                StatusPhase::Running,
+                "处理中…",
+            ),
+            (
+                StatusHint::new(StatusSubject::Tool, StatusAction::Process),
                 StatusPhase::Finalizing,
                 "正在确认…",
             ),

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -131,6 +131,27 @@ async fn private_general_chat_with_tool_capability_uses_agent_direct_answer() {
 }
 
 #[tokio::test]
+async fn rejected_tool_call_is_not_reported_as_direct_answer() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_rejected_tool_call("unknown_tool", "这个工具不可用。");
+    let service = test_service_with_provider_and_tool_calling(inspector, true);
+
+    let response = service
+        .respond(private_message("尝试一个不存在的工具"))
+        .await
+        .unwrap();
+
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["tool_calling_available"], true);
+    assert_eq!(diagnostics["tool_call_emitted"], true);
+    assert_eq!(diagnostics["tool_execution_attempted"], true);
+    assert_eq!(diagnostics["agent_executed_tools"], serde_json::json!([]));
+    assert_eq!(diagnostics["agent_result"], "rejected");
+    assert_eq!(diagnostics["stop_reason"], "rejected");
+}
+
+#[tokio::test]
 async fn router_decision_is_passed_unchanged_to_prepared_chat() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector, true);
@@ -216,6 +237,42 @@ async fn private_generation_and_explanation_requests_use_agent_direct_answer() {
 
     assert_eq!(inspector.tool_call_count(), 3);
     assert_eq!(inspector.requests().len(), 0);
+}
+
+#[tokio::test]
+async fn non_todo_agent_direct_answers_with_success_markers_are_not_guarded() {
+    let cases = [
+        (
+            "写一句以‘已完成’开头的通知",
+            "已完成：本次维护工作顺利结束。",
+        ),
+        ("把这句话改成：已记录，后续处理", "已记录，后续处理"),
+        (
+            "解释‘已删除项目不可恢复’",
+            "已删除项目不可恢复，表示删除操作无法撤销。",
+        ),
+    ];
+    let mut inspector =
+        MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    for (_, reply) in cases {
+        inspector = inspector.with_tool_loop_reply_without_tool(reply);
+    }
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    for (input, expected) in cases {
+        let response = service.respond(private_message(input)).await.unwrap();
+        assert_eq!(response.text.as_deref(), Some(expected), "{input}");
+        let diagnostics = response.diagnostics.unwrap();
+        assert_eq!(diagnostics["todo_success_claimed"], false, "{input}");
+        assert_eq!(diagnostics["todo_success_verified"], true, "{input}");
+        assert_ne!(
+            diagnostics["error_code"], "todo_success_not_verified",
+            "{input}"
+        );
+        assert_eq!(diagnostics["tool_call_emitted"], false, "{input}");
+    }
+
+    assert_eq!(inspector.tool_call_count(), 3);
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -90,15 +90,15 @@ async fn private_weather_chat_with_openai_responses_capability_enters_tool_loop(
             && message.content.contains("不要调用写工具")
     }));
     let diagnostics = response.diagnostics.unwrap();
-    assert_eq!(diagnostics["respond_route"], "tool_agent");
+    assert_eq!(diagnostics["respond_route"], "agent_chat");
     assert_eq!(diagnostics["route_reason"], "semantic_tool_intent");
     assert_eq!(diagnostics["route_domains"], serde_json::json!(["weather"]));
-    assert_eq!(diagnostics["route_semantic"], "tool_loop");
+    assert_eq!(diagnostics["route_semantic"], "tool_intent");
     assert_eq!(diagnostics["tool_calling_enabled"], true);
 }
 
 #[tokio::test]
-async fn private_general_chat_with_tool_capability_uses_plain_chat() {
+async fn private_general_chat_with_tool_capability_uses_agent_direct_answer() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
 
@@ -114,21 +114,18 @@ async fn private_general_chat_with_tool_capability_uses_plain_chat() {
             .unwrap()
             .contains("回复：聊聊 Rust 的所有权")
     );
-    assert_eq!(inspector.tool_call_count(), 0);
-    assert_eq!(inspector.requests().len(), 1);
+    assert_eq!(inspector.tool_call_count(), 1);
+    assert_eq!(inspector.requests().len(), 0);
     let diagnostics = response.diagnostics.unwrap();
-    assert_eq!(diagnostics["respond_route"], "plain_chat");
+    assert_eq!(diagnostics["respond_route"], "agent_chat");
     assert_eq!(diagnostics["route_reason"], "semantic_plain_chat");
     assert_eq!(diagnostics["route_domains"], serde_json::json!([]));
     assert_eq!(diagnostics["route_semantic"], "plain_chat");
-    assert_eq!(
-        diagnostics["tool_calling_enabled"],
-        serde_json::json!(false)
-    );
-    assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
-        serde_json::json!([])
-    );
+    assert_eq!(diagnostics["tool_calling_enabled"], serde_json::json!(true));
+    assert_eq!(diagnostics["tool_calling_available"], true);
+    assert_eq!(diagnostics["tool_calling_used"], false);
+    assert_eq!(diagnostics["agent_result"], "direct_answer");
+    assert_eq!(diagnostics["agent_executed_tools"], serde_json::json!([]));
     assert_eq!(diagnostics["todo_success_claimed"], false);
     assert_eq!(diagnostics["todo_success_verified"], true);
 }
@@ -150,13 +147,13 @@ async fn router_decision_is_passed_unchanged_to_prepared_chat() {
     };
 
     assert_eq!(chat.respond_route, expected_route);
-    assert!(chat.respond_route.uses_tool_agent());
+    assert!(chat.respond_route.uses_agent_runtime());
 }
 
 #[tokio::test]
 async fn streaming_chat_uses_planned_plain_route_without_reclassification() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
-    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), false);
     let planned = service
         .plan_core_respond(&private_message("聊聊 Rust 的所有权"))
         .unwrap();
@@ -173,12 +170,12 @@ async fn streaming_chat_uses_planned_plain_route_without_reclassification() {
     assert_eq!(inspector.tool_call_count(), 0);
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["respond_route"], "plain_chat");
-    assert_eq!(diagnostics["route_reason"], "semantic_plain_chat");
+    assert_eq!(diagnostics["route_reason"], "agent_unavailable");
     assert_eq!(diagnostics["route_semantic"], "plain_chat");
 }
 
 #[tokio::test]
-async fn private_chinese_greetings_and_emotion_with_time_words_keep_plain_chat() {
+async fn private_chinese_greetings_and_emotion_use_agent_direct_answer() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
 
@@ -195,12 +192,12 @@ async fn private_chinese_greetings_and_emotion_with_time_words_keep_plain_chat()
         );
     }
 
-    assert_eq!(inspector.tool_call_count(), 0);
-    assert_eq!(inspector.requests().len(), 5);
+    assert_eq!(inspector.tool_call_count(), 5);
+    assert_eq!(inspector.requests().len(), 0);
 }
 
 #[tokio::test]
-async fn private_generation_and_explanation_requests_keep_plain_chat() {
+async fn private_generation_and_explanation_requests_use_agent_direct_answer() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
 
@@ -217,8 +214,8 @@ async fn private_generation_and_explanation_requests_keep_plain_chat() {
         );
     }
 
-    assert_eq!(inspector.tool_call_count(), 0);
-    assert_eq!(inspector.requests().len(), 3);
+    assert_eq!(inspector.tool_call_count(), 3);
+    assert_eq!(inspector.requests().len(), 0);
 }
 
 #[tokio::test]
@@ -247,7 +244,7 @@ async fn private_strong_todo_reference_without_context_enters_tool_loop_and_clar
     );
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
+        diagnostics["agent_executed_tools"],
         serde_json::json!(["complete_todos"])
     );
 
@@ -318,9 +315,12 @@ async fn private_tool_loop_can_query_train_schedule_with_trusted_rendering() {
     assert_eq!(response.command.as_deref(), Some("train"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
+        diagnostics["agent_executed_tools"],
         serde_json::json!(["get_train_schedule"])
     );
+    assert_eq!(diagnostics["tool_calling_available"], true);
+    assert_eq!(diagnostics["tool_calling_used"], true);
+    assert_eq!(diagnostics["agent_result"], "tool_used");
     assert_eq!(diagnostics["agent_turn_status"], "succeeded");
 }
 
@@ -384,7 +384,7 @@ async fn mixed_train_and_todo_request_is_not_captured_by_todo_date_query() {
     assert_eq!(todos[0].title, "查看明天 G1 车次");
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
+        diagnostics["agent_executed_tools"],
         serde_json::json!(["get_train_schedule", "create_todo"])
     );
 }
@@ -471,7 +471,7 @@ async fn private_tool_loop_can_query_recent_rss_items_with_trusted_rendering() {
     assert_eq!(response.command.as_deref(), Some("rss"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
+        diagnostics["agent_executed_tools"],
         serde_json::json!(["get_rss_recent_items"])
     );
     assert_eq!(diagnostics["agent_turn_status"], "succeeded");
@@ -562,11 +562,11 @@ async fn group_tool_loop_exposes_rss_management_but_not_todo_when_enabled() {
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["tool_calling_enabled"], serde_json::json!(true));
     assert_eq!(
-        diagnostics["tool_loop_mode"],
+        diagnostics["agent_mode"],
         serde_json::json!("configured_whitelist")
     );
     assert_eq!(
-        diagnostics["tool_loop_enabled_tools"],
+        diagnostics["agent_enabled_tools"],
         serde_json::json!([
             "get_weather",
             "get_train_schedule",
@@ -835,7 +835,7 @@ async fn tool_loop_created_todo_survives_chat_history_save_and_records_last_acti
     assert_eq!(first_diagnostics["todo_success_verified"], true);
     assert_eq!(first_diagnostics["tool_retry_count"], 0);
     assert_eq!(
-        first_diagnostics["tool_loop_executed_tools"],
+        first_diagnostics["agent_executed_tools"],
         serde_json::json!(["create_todo"])
     );
     let session = service
@@ -887,7 +887,7 @@ async fn private_scheduled_task_phrase_is_handled_by_agent_tool_loop() {
     assert_eq!(inspector.tool_call_count(), 1);
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
+        diagnostics["agent_executed_tools"],
         serde_json::json!(["create_todo"])
     );
 }
@@ -902,8 +902,8 @@ async fn private_todo_create_phrase_is_handled_by_agent_tool_loop() {
 
     let req = private_message("新增待办，明天接老公");
     let planned = service.plan_core_respond(&req).unwrap();
-    assert_eq!(planned, RespondPlan::CompleteToolLoop);
-    assert!(planned.respond_route().unwrap().uses_tool_agent());
+    assert_eq!(planned, RespondPlan::AgentChat);
+    assert!(planned.respond_route().unwrap().uses_agent_runtime());
     let response = service.respond_with_plan(req, planned).await.unwrap();
 
     assert_eq!(response.command.as_deref(), Some("todo_create"));
@@ -912,7 +912,7 @@ async fn private_todo_create_phrase_is_handled_by_agent_tool_loop() {
     assert!(text.contains("明天接老公"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
+        diagnostics["agent_executed_tools"],
         serde_json::json!(["create_todo"])
     );
     assert_eq!(diagnostics["agent_turn_status"], "succeeded");
@@ -1745,7 +1745,7 @@ async fn list_todos_completed_date_range_receipt_uses_completed_at_snapshot() {
     assert!(!text.contains("计划昨天但完成较早"), "{text}");
     let diagnostics = response.diagnostics.as_ref().unwrap();
     assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
+        diagnostics["agent_executed_tools"],
         serde_json::json!(["list_todos"])
     );
 
@@ -1787,10 +1787,7 @@ async fn todo_create_intent_without_tool_call_does_not_leak_fake_success_reply()
     assert_eq!(diagnostics["todo_success_verified"], false);
     assert_eq!(diagnostics["tool_retry_count"], 0);
     assert_eq!(diagnostics["error_code"], "todo_success_not_verified");
-    assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
-        serde_json::json!([])
-    );
+    assert_eq!(diagnostics["agent_executed_tools"], serde_json::json!([]));
     assert!(service.task_store.list_all(&owner).unwrap().is_empty());
     let session = service
         .session_store
@@ -2064,7 +2061,7 @@ async fn todo_tool_loop_clears_third_and_fourth_details() {
     assert!(!listed_text.contains("第4条旧详情"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
+        diagnostics["agent_executed_tools"],
         serde_json::json!(["edit_todo", "edit_todo"])
     );
     assert_eq!(diagnostics["todo_success_verified"], true);
@@ -2137,10 +2134,7 @@ async fn todo_fake_success_with_followup_instruction_is_still_blocked() {
     assert_eq!(diagnostics["todo_success_claimed"], true);
     assert_eq!(diagnostics["todo_success_verified"], false);
     assert_eq!(diagnostics["error_code"], "todo_success_not_verified");
-    assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
-        serde_json::json!([])
-    );
+    assert_eq!(diagnostics["agent_executed_tools"], serde_json::json!([]));
     assert_eq!(inspector.tool_call_count(), 1);
 }
 
@@ -2162,10 +2156,7 @@ async fn todo_mixed_unsupported_and_fake_success_reply_is_still_blocked() {
     assert_eq!(diagnostics["todo_success_claimed"], true);
     assert_eq!(diagnostics["todo_success_verified"], false);
     assert_eq!(diagnostics["error_code"], "todo_success_not_verified");
-    assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
-        serde_json::json!([])
-    );
+    assert_eq!(diagnostics["agent_executed_tools"], serde_json::json!([]));
     assert_eq!(inspector.tool_call_count(), 1);
 }
 
@@ -2188,10 +2179,7 @@ async fn todo_capability_question_without_tool_call_is_not_required_tool_blocked
     assert_eq!(diagnostics["todo_success_claimed"], false);
     assert_eq!(diagnostics["todo_success_verified"], true);
     assert_eq!(diagnostics["error_code"], Value::Null);
-    assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
-        serde_json::json!([])
-    );
+    assert_eq!(diagnostics["agent_executed_tools"], serde_json::json!([]));
     assert_eq!(inspector.tool_call_count(), 1);
 }
 
@@ -2216,10 +2204,7 @@ async fn todo_unsupported_operation_reply_without_tool_call_is_not_blocked() {
     assert_eq!(diagnostics["todo_success_claimed"], false);
     assert_eq!(diagnostics["todo_success_verified"], true);
     assert_eq!(diagnostics["error_code"], Value::Null);
-    assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
-        serde_json::json!([])
-    );
+    assert_eq!(diagnostics["agent_executed_tools"], serde_json::json!([]));
 }
 
 #[tokio::test]
@@ -2243,10 +2228,7 @@ async fn todo_missing_argument_reply_without_tool_call_is_not_blocked() {
     assert_eq!(diagnostics["todo_success_claimed"], false);
     assert_eq!(diagnostics["todo_success_verified"], true);
     assert_eq!(diagnostics["error_code"], Value::Null);
-    assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
-        serde_json::json!([])
-    );
+    assert_eq!(diagnostics["agent_executed_tools"], serde_json::json!([]));
 }
 
 #[tokio::test]
@@ -2439,7 +2421,7 @@ async fn todo_internal_list_before_write_is_not_user_visible_query() {
     assert!(!text.contains("先完成\n状态：未完成"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
+        diagnostics["agent_executed_tools"],
         serde_json::json!(["list_todos", "complete_todos"])
     );
     let outcomes = diagnostics["tool_outcomes"].as_array().unwrap();
@@ -2524,7 +2506,7 @@ async fn todo_write_with_explicit_list_does_not_append_auto_related_list() {
     assert!(!text.contains("🚧 当前进行中 · 共 1 项"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
+        diagnostics["agent_executed_tools"],
         serde_json::json!(["complete_todos", "list_todos"])
     );
     assert_eq!(diagnostics["tool_outcomes"].as_array().unwrap().len(), 2);
@@ -2772,7 +2754,7 @@ async fn todo_delete_completed_pending_confirmation_is_verified_by_real_tool_res
     assert_eq!(diagnostics["todo_success_claimed"], true);
     assert_eq!(diagnostics["todo_success_verified"], true);
     assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
+        diagnostics["agent_executed_tools"],
         serde_json::json!(["delete_todos"])
     );
     let session = service
@@ -2837,7 +2819,7 @@ async fn todo_delete_completed_tool_failure_cannot_be_reported_as_success() {
         "todo_selection_not_found"
     );
     assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
+        diagnostics["agent_executed_tools"],
         serde_json::json!(["delete_todos"])
     );
     assert!(service.task_store.list_completed(&owner).unwrap().len() == 1);
@@ -3202,13 +3184,13 @@ async fn non_todo_chat_phrase_does_not_mutate_when_model_calls_no_tool() {
     assert_eq!(diagnostics["todo_success_verified"], true);
     assert_eq!(diagnostics["tool_retry_count"], 0);
     assert_eq!(diagnostics["error_code"], Value::Null);
-    assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
-        serde_json::json!([])
-    );
-    // 不确定的私聊文本默认走普通聊天；不能仅因 provider 支持工具而进入 Tool Loop。
-    assert_eq!(inspector.tool_call_count(), 0);
-    assert_eq!(inspector.requests().len(), 1);
+    assert_eq!(diagnostics["agent_executed_tools"], serde_json::json!([]));
+    // 模型可以看到工具，但本轮没有发出 Tool Call，因此不能产生 Todo 副作用。
+    assert_eq!(inspector.tool_call_count(), 1);
+    assert_eq!(inspector.requests().len(), 0);
+    assert_eq!(diagnostics["tool_calling_available"], true);
+    assert_eq!(diagnostics["tool_calling_used"], false);
+    assert_eq!(diagnostics["agent_result"], "direct_answer");
     // 待办不应被误修改。
     assert_eq!(
         service.task_store.list_pending(&owner).unwrap()[0].status,
@@ -3263,10 +3245,7 @@ async fn last_reference_complete_without_tool_blocks_fake_success_reply() {
     assert_eq!(diagnostics["todo_success_verified"], false);
     assert_eq!(diagnostics["tool_retry_count"], 0);
     assert_eq!(diagnostics["error_code"], "todo_success_not_verified");
-    assert_eq!(
-        diagnostics["tool_loop_executed_tools"],
-        serde_json::json!([])
-    );
+    assert_eq!(diagnostics["agent_executed_tools"], serde_json::json!([]));
     assert_eq!(inspector.tool_call_count(), 1);
     // 未真正调用 complete_todos，待办状态不应改变。
     assert_eq!(
@@ -3293,7 +3272,7 @@ async fn group_chat_does_not_enter_tool_loop() {
     assert_eq!(inspector.requests().len(), 1);
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["respond_route"], "plain_chat");
-    assert_eq!(diagnostics["route_reason"], "group_tool_loop_disabled");
+    assert_eq!(diagnostics["route_reason"], "group_agent_disabled");
     assert_eq!(diagnostics["route_domains"], serde_json::json!([]));
     assert_eq!(diagnostics["tool_calling_enabled"], false);
 }

--- a/qq-maid-core/src/runtime/respond/tests/support.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support.rs
@@ -11,11 +11,20 @@ use async_trait::async_trait;
 use chrono::{Duration, NaiveDate};
 use qq_maid_llm::{
     provider::{
-        ChatOutcome, LlmProvider, ToolCallingProtocol, ToolChatRequest, ToolExecutionResult,
+        AgentRunDiagnostics, AgentStopReason, ChatOutcome, LlmProvider, ToolCallingProtocol,
+        ToolChatRequest, ToolExecutionResult,
         types::{ChatRequest, ChatRole, TokenUsage},
     },
     web_search::{WebSearchExecutor, WebSearchOutcome, WebSearchRequest, WebSearchSource},
 };
+
+fn agent_tool_trace(emitted_tools: Vec<String>) -> AgentRunDiagnostics {
+    AgentRunDiagnostics {
+        emitted_tools,
+        tool_execution_attempted: true,
+        stop_reason: Some(AgentStopReason::ToolUsed),
+    }
+}
 use serde_json::{Value, json};
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -82,6 +91,10 @@ enum MockToolAction {
         reply: String,
     },
     ReplyWithoutTool {
+        reply: String,
+    },
+    RejectedToolCall {
+        name: String,
         reply: String,
     },
 }
@@ -293,6 +306,21 @@ impl MockProvider {
         self
     }
 
+    pub(super) fn with_rejected_tool_call(
+        self,
+        name: impl Into<String>,
+        reply: impl Into<String>,
+    ) -> Self {
+        self.tool_actions
+            .lock()
+            .unwrap()
+            .push(MockToolAction::RejectedToolCall {
+                name: name.into(),
+                reply: reply.into(),
+            });
+        self
+    }
+
     pub(super) fn requests(&self) -> Vec<ChatRequest> {
         self.requests.lock().unwrap().clone()
     }
@@ -450,6 +478,7 @@ impl LlmProvider for MockProvider {
                 fallback_used: false,
                 executed_tools: Vec::new(),
                 tool_results: Vec::new(),
+                agent: Default::default(),
             });
         }
         if req.metadata.get("purpose").map(String::as_str) == Some("search_query_rewrite") {
@@ -477,6 +506,7 @@ impl LlmProvider for MockProvider {
                 fallback_used: false,
                 executed_tools: Vec::new(),
                 tool_results: Vec::new(),
+                agent: Default::default(),
             });
         }
         let last_user = req
@@ -515,6 +545,7 @@ impl LlmProvider for MockProvider {
             fallback_used: false,
             executed_tools: Vec::new(),
             tool_results: Vec::new(),
+            agent: Default::default(),
         })
     }
 
@@ -582,6 +613,7 @@ impl LlmProvider for MockProvider {
                             output,
                             succeeded: true,
                         }],
+                        agent: agent_tool_trace(vec!["create_todo".to_owned()]),
                     });
                 }
                 MockToolAction::ExecuteTool {
@@ -599,6 +631,7 @@ impl LlmProvider for MockProvider {
                         })
                     });
                     let succeeded = output.get("ok").and_then(Value::as_bool) != Some(false);
+                    let emitted_tool = name.clone();
                     return Ok(ChatOutcome {
                         reply,
                         metrics: LlmMetrics {
@@ -626,6 +659,7 @@ impl LlmProvider for MockProvider {
                             output,
                             succeeded,
                         }],
+                        agent: agent_tool_trace(vec![emitted_tool]),
                     });
                 }
                 MockToolAction::ExecuteTools { calls, reply } => {
@@ -649,6 +683,7 @@ impl LlmProvider for MockProvider {
                             succeeded,
                         });
                     }
+                    let emitted_tools = executed_tools.clone();
                     return Ok(ChatOutcome {
                         reply,
                         metrics: LlmMetrics {
@@ -672,6 +707,7 @@ impl LlmProvider for MockProvider {
                         fallback_used: false,
                         executed_tools,
                         tool_results,
+                        agent: agent_tool_trace(emitted_tools),
                     });
                 }
                 MockToolAction::ReturnToolResults { results, reply } => {
@@ -679,6 +715,7 @@ impl LlmProvider for MockProvider {
                         .iter()
                         .map(|result| result.name.clone())
                         .collect::<Vec<_>>();
+                    let emitted_tools = executed_tools.clone();
                     return Ok(ChatOutcome {
                         reply,
                         metrics: LlmMetrics {
@@ -702,6 +739,7 @@ impl LlmProvider for MockProvider {
                         fallback_used: false,
                         executed_tools,
                         tool_results: results,
+                        agent: agent_tool_trace(emitted_tools),
                     });
                 }
                 MockToolAction::ReplyWithoutTool { reply } => {
@@ -728,6 +766,33 @@ impl LlmProvider for MockProvider {
                         fallback_used: false,
                         executed_tools: Vec::new(),
                         tool_results: Vec::new(),
+                        agent: Default::default(),
+                    });
+                }
+                MockToolAction::RejectedToolCall { name, reply } => {
+                    return Ok(ChatOutcome {
+                        reply,
+                        metrics: LlmMetrics {
+                            provider: "mock".to_owned(),
+                            model: req
+                                .chat
+                                .model
+                                .clone()
+                                .unwrap_or_else(|| "mock-model".to_owned()),
+                            stream: false,
+                            ttfe_ms: None,
+                            ttft_ms: None,
+                            total_latency_ms: 1,
+                        },
+                        usage: None,
+                        fallback_used: false,
+                        executed_tools: Vec::new(),
+                        tool_results: Vec::new(),
+                        agent: AgentRunDiagnostics {
+                            emitted_tools: vec![name],
+                            tool_execution_attempted: true,
+                            stop_reason: Some(AgentStopReason::Rejected),
+                        },
                     });
                 }
             }
@@ -756,6 +821,7 @@ impl LlmProvider for MockProvider {
             fallback_used: false,
             executed_tools: Vec::new(),
             tool_results: Vec::new(),
+            agent: Default::default(),
         })
     }
 

--- a/qq-maid-core/src/runtime/respond/tool_route_domains.rs
+++ b/qq-maid-core/src/runtime/respond/tool_route_domains.rs
@@ -9,9 +9,9 @@ use crate::runtime::{
 };
 
 use super::{
+    agent_route::{SemanticAssessment, SemanticRoute, ToolDomain, assessment},
     plain_chat_route,
     status_hint::{StatusAction, StatusHint, StatusSubject},
-    tool_route::{SemanticAssessment, SemanticRoute, ToolDomain, assessment},
 };
 
 pub(super) fn classify_non_todo_route(text: &str, lower: &str) -> Option<SemanticAssessment> {
@@ -65,5 +65,5 @@ pub(super) fn has_search_intent(text: &str, lower: &str) -> bool {
 }
 
 fn tool_assessment(domain: ToolDomain) -> SemanticAssessment {
-    assessment(SemanticRoute::ToolLoop, domain, "semantic_tool_intent")
+    assessment(SemanticRoute::ToolIntent, domain, "semantic_tool_intent")
 }

--- a/qq-maid-core/src/runtime/respond/tool_runtime.rs
+++ b/qq-maid-core/src/runtime/respond/tool_runtime.rs
@@ -144,6 +144,7 @@ impl ToolRuntime {
         meta: &SessionMeta,
         interaction_meta: &SessionMeta,
         output: RespondOutput,
+        context: crate::runtime::tools::agent_turn::ToolTurnContext,
     ) -> Result<ToolTurnPostprocess, LlmError> {
         postprocess_tool_turn(
             &self.session_store,
@@ -152,6 +153,7 @@ impl ToolRuntime {
             meta,
             interaction_meta,
             output,
+            context,
         )
     }
 

--- a/qq-maid-core/src/runtime/rss/scheduler.rs
+++ b/qq-maid-core/src/runtime/rss/scheduler.rs
@@ -566,6 +566,7 @@ mod tests {
                 fallback_used: false,
                 executed_tools: Vec::new(),
                 tool_results: Vec::new(),
+                agent: Default::default(),
             })
         }
 

--- a/qq-maid-core/src/runtime/tools/agent_turn.rs
+++ b/qq-maid-core/src/runtime/tools/agent_turn.rs
@@ -30,7 +30,7 @@ pub(crate) trait DomainTurnDiagnostics {
     fn guard_error_code(
         &self,
         _outcome: Option<&AgentTurnOutcome>,
-        _use_tool_loop: bool,
+        _use_agent_runtime: bool,
     ) -> Option<&'static str> {
         None
     }
@@ -70,11 +70,11 @@ impl ToolTurnDiagnostics {
     fn guard_error_code(
         &self,
         outcome: Option<&AgentTurnOutcome>,
-        use_tool_loop: bool,
+        use_agent_runtime: bool,
     ) -> Option<&'static str> {
         self.domains
             .iter()
-            .find_map(|domain| domain.guard_error_code(outcome, use_tool_loop))
+            .find_map(|domain| domain.guard_error_code(outcome, use_agent_runtime))
     }
 }
 
@@ -149,10 +149,10 @@ pub(crate) fn agent_turn_diagnostics(outcome: Option<&AgentTurnOutcome>) -> Valu
 
 pub(crate) fn tool_turn_error_code(
     outcome: Option<&AgentTurnOutcome>,
-    use_tool_loop: bool,
+    use_agent_runtime: bool,
     diagnostics: &ToolTurnDiagnostics,
 ) -> Option<&'static str> {
-    if let Some(error_code) = diagnostics.guard_error_code(outcome, use_tool_loop) {
+    if let Some(error_code) = diagnostics.guard_error_code(outcome, use_agent_runtime) {
         return Some(error_code);
     }
     if let Some(outcome) = outcome {

--- a/qq-maid-core/src/runtime/tools/agent_turn.rs
+++ b/qq-maid-core/src/runtime/tools/agent_turn.rs
@@ -24,6 +24,13 @@ use super::agent_presenters::{
 
 pub(crate) type IndexedToolOutcomes = Vec<(usize, ToolExecutionOutcome)>;
 
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct ToolTurnContext {
+    pub(crate) semantic_domain: Option<&'static str>,
+    pub(crate) status_subject: Option<&'static str>,
+    pub(crate) status_action: Option<&'static str>,
+}
+
 pub(crate) trait DomainTurnDiagnostics {
     fn log_tool_loop_results(&self, executed_tools: &[String]);
     fn extend_response_diagnostics(&self, target: &mut Map<String, Value>);
@@ -85,6 +92,7 @@ pub(crate) fn postprocess_tool_turn(
     meta: &SessionMeta,
     interaction_meta: &SessionMeta,
     mut output: RespondOutput,
+    context: ToolTurnContext,
 ) -> Result<ToolTurnPostprocess, LlmError> {
     let mut standalone_interaction = if interaction_meta.scope_key != meta.scope_key {
         Some(
@@ -106,6 +114,7 @@ pub(crate) fn postprocess_tool_turn(
             .map_err(crate::runtime::respond::common::session_error)?;
     }
 
+    let todo_guard_enabled = todo::agent_turn::should_validate_success(&context, &output);
     let validation = if outcome.can_replace_model_reply() {
         if outcome.should_preserve_model_reply() {
             apply_agent_turn_outcome_with_model_reply(&mut output, &outcome);
@@ -116,12 +125,16 @@ pub(crate) fn postprocess_tool_turn(
     } else if outcome.has_unhandled_outcome() && !outcome.outcomes.is_empty() {
         apply_agent_turn_compat_output(&mut output, &outcome);
         todo::agent_turn::success_validation_from_agent_outcome(&outcome)
-    } else {
+    } else if todo_guard_enabled {
         let validation = todo::agent_turn::validate_model_reply_success(&output);
         if !validation.passed() {
             output = todo::agent_turn::success_not_verified_output(output);
         }
         validation
+    } else {
+        todo::success_guard::TodoSuccessValidation::Passed {
+            claimed_success: false,
+        }
     };
     let diagnostics = ToolTurnDiagnostics {
         domains: vec![Box::new(todo::agent_turn::diagnostics_from_tool_results(

--- a/qq-maid-core/src/runtime/tools/rss.rs
+++ b/qq-maid-core/src/runtime/tools/rss.rs
@@ -32,7 +32,7 @@ const RSS_MANAGE_OUTPUT_TARGET_MAX_CHARS: usize = 120;
 const RSS_MANAGE_OUTPUT_SCOPE_MAX_CHARS: usize = 120;
 
 pub(crate) mod route {
-    //! RSS 普通消息 Tool Loop 路由判断。
+    //! RSS 普通消息 Agent Chat 路由判断。
 
     pub(crate) fn has_rss_intent(text: &str, lower: &str) -> bool {
         lower.contains("rss") || contains_any(text, &["订阅更新", "最近订阅", "订阅记录"])

--- a/qq-maid-core/src/runtime/tools/search.rs
+++ b/qq-maid-core/src/runtime/tools/search.rs
@@ -22,7 +22,7 @@ pub(crate) const WEB_SEARCH_QUERY_MAX_LENGTH: usize = 200;
 const WEB_SEARCH_MAX_RESULTS_LIMIT: u8 = 10;
 
 pub(crate) mod route {
-    //! 联网搜索普通消息 Tool Loop 路由判断。
+    //! 联网搜索普通消息 Agent Chat 路由判断。
     //!
     //! 本模块只表达 Search 域的显式搜索词；本地文本整理的排除规则由 respond
     //! 通用 plain_chat_route 先行判断后传入，避免 Search 域依赖 respond。

--- a/qq-maid-core/src/runtime/tools/todo/agent_turn.rs
+++ b/qq-maid-core/src/runtime/tools/todo/agent_turn.rs
@@ -14,7 +14,7 @@ use crate::{
         session::{SessionMeta, SessionRecord},
         tools::{
             TaskStore,
-            agent_turn::{DomainTurnDiagnostics, IndexedToolOutcomes},
+            agent_turn::{DomainTurnDiagnostics, IndexedToolOutcomes, ToolTurnContext},
             todo,
         },
     },
@@ -96,6 +96,18 @@ pub(crate) fn validate_model_reply_success(
     todo::success_guard::validate_todo_success_reply(&output.reply, &output.tool_results)
 }
 
+pub(crate) fn should_validate_success(context: &ToolTurnContext, output: &RespondOutput) -> bool {
+    output
+        .agent
+        .emitted_tools
+        .iter()
+        .any(|name| todo::success_guard::is_todo_write_tool(name))
+        || todo::success_guard::has_todo_write_tool_result(&output.tool_results)
+        || (context.semantic_domain == Some("todo")
+            && context.status_subject == Some("todo")
+            && matches!(context.status_action, Some("write" | "confirm" | "process")))
+}
+
 pub(crate) fn success_not_verified_output(output: RespondOutput) -> RespondOutput {
     let reply =
         todo::success_guard::todo_success_not_verified_reply_for_tool_results(&output.tool_results);
@@ -117,6 +129,7 @@ pub(crate) fn success_not_verified_output(output: RespondOutput) -> RespondOutpu
         ),
         executed_tools: output.executed_tools,
         tool_results: output.tool_results,
+        agent: output.agent,
     }
 }
 

--- a/qq-maid-core/src/runtime/tools/todo/agent_turn.rs
+++ b/qq-maid-core/src/runtime/tools/todo/agent_turn.rs
@@ -196,14 +196,14 @@ impl DomainTurnDiagnostics for TodoAgentDiagnostics {
     fn guard_error_code(
         &self,
         outcome: Option<&AgentTurnOutcome>,
-        use_tool_loop: bool,
+        use_agent_runtime: bool,
     ) -> Option<&'static str> {
-        if use_tool_loop
+        if use_agent_runtime
             && !self.validation.passed()
             && outcome.is_none_or(|outcome| outcome.outcomes.is_empty())
         {
             return Some("todo_success_not_verified");
         }
-        (use_tool_loop && !self.validation.passed()).then_some("todo_success_not_verified")
+        (use_agent_runtime && !self.validation.passed()).then_some("todo_success_not_verified")
     }
 }

--- a/qq-maid-core/src/runtime/tools/todo/common.rs
+++ b/qq-maid-core/src/runtime/tools/todo/common.rs
@@ -15,7 +15,7 @@ use crate::{
     },
 };
 
-// Tool 名常量；metadata 必须返回与 Tool Loop 路由完全一致的 name。
+// Tool 名常量；metadata 必须返回与 Agent Chat 路由完全一致的 name。
 pub(super) const LIST_TODOS_TOOL_NAME: &str = "list_todos";
 pub(super) const GET_TODO_TOOL_NAME: &str = "get_todo";
 pub(super) const CREATE_TODO_TOOL_NAME: &str = "create_todo";

--- a/qq-maid-core/src/runtime/tools/todo/success_guard.rs
+++ b/qq-maid-core/src/runtime/tools/todo/success_guard.rs
@@ -106,6 +106,12 @@ fn has_successful_todo_write_result(tool_results: &[ToolExecutionResult]) -> boo
     tool_results.iter().any(successful_todo_write_result)
 }
 
+pub(crate) fn has_todo_write_tool_result(tool_results: &[ToolExecutionResult]) -> bool {
+    tool_results
+        .iter()
+        .any(|result| is_todo_write_tool(&result.name))
+}
+
 fn successful_todo_write_result(result: &ToolExecutionResult) -> bool {
     if !result.succeeded || result_has_explicit_failure(&result.output) {
         return false;
@@ -217,6 +223,19 @@ fn structured_error_code(output: &Value) -> Option<String> {
 }
 
 fn is_todo_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "create_todo"
+            | "delete_todos"
+            | "merge_todos"
+            | "edit_todo"
+            | "complete_todos"
+            | "restore_todos"
+            | "manage_recurring_reminder"
+    )
+}
+
+pub(crate) fn is_todo_write_tool(name: &str) -> bool {
     matches!(
         name,
         "create_todo"

--- a/qq-maid-core/src/runtime/tools/train.rs
+++ b/qq-maid-core/src/runtime/tools/train.rs
@@ -19,7 +19,7 @@ const TRAIN_TOOL_NAME: &str = "get_train_schedule";
 const TRAIN_TOOL_CODE_MAX_CHARS: usize = 20;
 
 pub(crate) mod route {
-    //! 列车普通消息 Tool Loop 路由判断。
+    //! 列车普通消息 Agent Chat 路由判断。
 
     pub(crate) fn has_train_intent(text: &str, _lower: &str) -> bool {
         contains_any(

--- a/qq-maid-core/src/runtime/tools/weather.rs
+++ b/qq-maid-core/src/runtime/tools/weather.rs
@@ -20,7 +20,7 @@ const WEATHER_TOOL_CITY_MAX_CHARS: usize = 60;
 const WEATHER_TOOL_MAX_FORECAST_DAYS: u8 = 7;
 
 pub(crate) mod route {
-    //! 天气普通消息 Tool Loop 路由判断。
+    //! 天气普通消息 Agent Chat 路由判断。
     //!
     //! 只判断用户是否明确想查询天气；天气命令解析和真实查询仍分别由
     //! respond/weather_flow 与 WeatherTool 负责。

--- a/qq-maid-core/src/runtime/translation.rs
+++ b/qq-maid-core/src/runtime/translation.rs
@@ -353,6 +353,7 @@ mod tests {
                 fallback_used: false,
                 executed_tools: Vec::new(),
                 tool_results: Vec::new(),
+                agent: Default::default(),
             })
         }
 

--- a/qq-maid-core/src/service/handle.rs
+++ b/qq-maid-core/src/service/handle.rs
@@ -76,7 +76,7 @@ impl CoreService for CoreHandle {
             respond_plan,
             RespondPlan::CommandEvent
                 | RespondPlan::StreamingChat
-                | RespondPlan::CompleteToolLoop
+                | RespondPlan::AgentChat
                 | RespondPlan::WebSearch
         ) {
             // 微信服务号同步 XML 回包无法承载直出流式；这里仅对微信禁用 direct stream，

--- a/qq-maid-core/src/service/streaming.rs
+++ b/qq-maid-core/src/service/streaming.rs
@@ -26,7 +26,7 @@ use super::{
     CoreResponseStatusKind, CoreResponseStream, warn_core_error,
 };
 
-const TOOL_LOOP_RUNNING_STATUS_DELAY: Duration = Duration::from_millis(1500);
+const AGENT_RUNNING_STATUS_DELAY: Duration = Duration::from_millis(1500);
 
 #[derive(Debug, Clone)]
 pub(crate) struct ProgressStatusConfig {
@@ -65,7 +65,7 @@ pub(crate) fn start_core_response_stream(
             provider_stream_enabled,
             progress_status,
         );
-        let result = if matches!(plan, RespondPlan::CompleteToolLoop) {
+        let result = if matches!(plan, RespondPlan::AgentChat) {
             match timeout(request_timeout, respond_future).await {
                 Ok(result) => result,
                 Err(_) => Err(LlmError::timeout("request")),
@@ -116,8 +116,8 @@ async fn run_streaming_respond(
     progress_status: ProgressStatusConfig,
 ) -> Result<RespondResponse, LlmError> {
     let plan = planned.plan();
-    if matches!(plan, RespondPlan::CompleteToolLoop) {
-        return run_complete_tool_loop_respond(
+    if matches!(plan, RespondPlan::AgentChat) {
+        return run_agent_chat_respond(
             service,
             req,
             planned,
@@ -132,7 +132,7 @@ async fn run_streaming_respond(
         return run_command_event_respond(service, req, planned, tx, cancelled).await;
     }
     if matches!(plan, RespondPlan::WebSearch) && provider_stream_enabled {
-        // WebSearch 不套用 CompleteToolLoop 整体超时：联网查询复用 `/查` 的流式
+        // WebSearch 不套用 AgentChat 整体超时：联网查询复用 `/查` 的流式
         // `WebSearchTool::query_stream`，只要持续有有效片段就不被长等待窗口误杀。
         // provider 不支持流式时改由下面聚合路径走 `respond_with_plan`，
         // dispatcher 会按 WebSearch plan 聚合查询后一次性发送。
@@ -222,7 +222,7 @@ async fn run_web_search_respond(
     Ok(response)
 }
 
-async fn run_complete_tool_loop_respond(
+async fn run_agent_chat_respond(
     service: &RustRespondService,
     req: RespondRequest,
     planned: PlannedRespond,
@@ -234,7 +234,7 @@ async fn run_complete_tool_loop_respond(
     send_core_status(
         &tx,
         &cancelled,
-        CoreResponseStatusKind::ToolLoopStarted,
+        CoreResponseStatusKind::AgentStarted,
         status_hint_text(
             progress_status.audience,
             progress_status.hint,
@@ -248,7 +248,7 @@ async fn run_complete_tool_loop_respond(
         tool_loop_progress_sink(tx.clone(), cancelled.clone(), progress_status.clone());
     let finalizing_status_sent = Arc::new(AtomicBool::new(false));
     let final_delta_sink = if provider_stream_enabled {
-        Some(tool_loop_final_delta_sink(
+        Some(agent_final_delta_sink(
             tx.clone(),
             cancelled.clone(),
             progress_status.clone(),
@@ -265,12 +265,12 @@ async fn run_complete_tool_loop_respond(
     let response = loop {
         tokio::select! {
             result = &mut respond_future => break result?,
-            _ = tokio::time::sleep(TOOL_LOOP_RUNNING_STATUS_DELAY), if !running_status_sent => {
+            _ = tokio::time::sleep(AGENT_RUNNING_STATUS_DELAY), if !running_status_sent => {
                 running_status_sent = true;
                 send_core_status(
                     &tx,
                     &cancelled,
-                    CoreResponseStatusKind::ToolLoopRunning,
+                    CoreResponseStatusKind::AgentRunning,
                     status_hint_text(
                         progress_status.audience,
                         progress_status.hint,
@@ -282,31 +282,25 @@ async fn run_complete_tool_loop_respond(
         }
     };
 
-    send_tool_loop_finalizing_status_once(
-        &tx,
-        &cancelled,
-        &progress_status,
-        &finalizing_status_sent,
-    )
-    .await?;
+    send_agent_finalizing_status_once(&tx, &cancelled, &progress_status, &finalizing_status_sent)
+        .await?;
 
     debug!(
-        respond_plan = respond_plan_name(RespondPlan::CompleteToolLoop),
+        respond_plan = respond_plan_name(RespondPlan::AgentChat),
         provider_stream_enabled,
         synthetic_final_delta = false,
         response_delivery_mode =
-            output_policy_for_stream(RespondPlan::CompleteToolLoop, provider_stream_enabled)
-                .as_str(),
+            output_policy_for_stream(RespondPlan::AgentChat, provider_stream_enabled).as_str(),
         final_chars = response_visible_content(&response)
             .map(|content| content.chars().count())
             .unwrap_or_default(),
-        "core tool loop stream completed with progress status events"
+        "core agent chat completed with progress status events"
     );
 
     Ok(response)
 }
 
-async fn send_tool_loop_finalizing_status_once(
+async fn send_agent_finalizing_status_once(
     tx: &mpsc::Sender<CoreResponseEvent>,
     cancelled: &Arc<AtomicBool>,
     progress_status: &ProgressStatusConfig,
@@ -321,7 +315,7 @@ async fn send_tool_loop_finalizing_status_once(
     send_core_status(
         tx,
         cancelled,
-        CoreResponseStatusKind::ToolLoopFinalizing,
+        CoreResponseStatusKind::AgentFinalizing,
         status_hint_text(
             progress_status.audience,
             progress_status.hint,
@@ -332,7 +326,7 @@ async fn send_tool_loop_finalizing_status_once(
     .await
 }
 
-fn tool_loop_final_delta_sink(
+fn agent_final_delta_sink(
     tx: mpsc::Sender<CoreResponseEvent>,
     cancelled: Arc<AtomicBool>,
     progress_status: ProgressStatusConfig,
@@ -344,7 +338,7 @@ fn tool_loop_final_delta_sink(
         let progress_status = progress_status.clone();
         let finalizing_status_sent = finalizing_status_sent.clone();
         Box::pin(async move {
-            send_tool_loop_finalizing_status_once(
+            send_agent_finalizing_status_once(
                 &tx,
                 &cancelled,
                 &progress_status,
@@ -432,7 +426,7 @@ fn respond_plan_name(plan: RespondPlan) -> &'static str {
         RespondPlan::Immediate => "immediate",
         RespondPlan::CommandEvent => "command_event",
         RespondPlan::StreamingChat => "streaming_chat",
-        RespondPlan::CompleteToolLoop => "complete_tool_loop",
+        RespondPlan::AgentChat => "agent_chat",
         RespondPlan::WebSearch => "web_search",
     }
 }
@@ -444,10 +438,8 @@ pub(crate) fn output_policy_for_stream(
     match plan {
         RespondPlan::StreamingChat if provider_stream_enabled => CoreOutputPolicy::DirectStream,
         RespondPlan::StreamingChat => CoreOutputPolicy::CompleteThenSend,
-        RespondPlan::CompleteToolLoop if provider_stream_enabled => {
-            CoreOutputPolicy::ProgressThenStream
-        }
-        RespondPlan::CompleteToolLoop => CoreOutputPolicy::ProgressThenComplete,
+        RespondPlan::AgentChat if provider_stream_enabled => CoreOutputPolicy::ProgressThenStream,
+        RespondPlan::AgentChat => CoreOutputPolicy::ProgressThenComplete,
         // WebSearch 复用 `/查` 的流式查询能力：provider 支持流式时直出，
         // 否则聚合后一次性发送，避免长时间非流式阻塞导致业务超时。
         RespondPlan::WebSearch if provider_stream_enabled => CoreOutputPolicy::DirectStream,

--- a/qq-maid-core/src/service/tests/mod.rs
+++ b/qq-maid-core/src/service/tests/mod.rs
@@ -301,21 +301,20 @@ fn text_content_returns_none_when_output_absent() {
 }
 
 #[test]
-fn core_plan_routes_general_private_chat_to_streaming_when_tools_available() {
+fn core_plan_routes_general_private_chat_to_agent_when_tools_available() {
     let provider =
         TestProvider::replying("普通回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_tool_calling(provider, 5, true);
     let service = CoreHandle::new(state).respond_service();
     let req: RespondRequest = private_request("hello").into();
 
-    assert_eq!(
-        service.plan_core_respond(&req).unwrap(),
-        RespondPlan::StreamingChat
-    );
+    let planned = service.plan_core_respond(&req).unwrap();
+    assert_eq!(planned, RespondPlan::AgentChat);
+    assert_eq!(planned.status_hint(), StatusHint::model());
 }
 
 #[test]
-fn core_plan_routes_ambiguous_private_chat_to_streaming_when_tools_available() {
+fn core_plan_routes_ambiguous_private_chat_to_agent_when_tools_available() {
     let provider =
         TestProvider::replying("普通回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_tool_calling(provider, 5, true);
@@ -332,14 +331,14 @@ fn core_plan_routes_ambiguous_private_chat_to_streaming_when_tools_available() {
         let req: RespondRequest = private_request(input).into();
         assert_eq!(
             service.plan_core_respond(&req).unwrap(),
-            RespondPlan::StreamingChat,
+            RespondPlan::AgentChat,
             "{input}"
         );
     }
 }
 
 #[test]
-fn core_plan_routes_private_weather_message_to_complete_tool_loop_when_tools_available() {
+fn core_plan_routes_private_weather_message_to_agent_chat_when_tools_available() {
     let provider =
         TestProvider::replying("工具回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_tool_calling(provider, 5, true);
@@ -348,7 +347,11 @@ fn core_plan_routes_private_weather_message_to_complete_tool_loop_when_tools_ava
 
     assert_eq!(
         service.plan_core_respond(&req).unwrap(),
-        RespondPlan::CompleteToolLoop
+        RespondPlan::AgentChat
+    );
+    assert_ne!(
+        service.plan_core_respond(&req).unwrap().status_hint(),
+        StatusHint::model()
     );
 }
 
@@ -388,7 +391,7 @@ fn core_plan_routes_private_todo_like_messages_to_agent_tool_loop() {
         let req: RespondRequest = private_request(input).into();
         assert_eq!(
             service.plan_core_respond(&req).unwrap(),
-            RespondPlan::CompleteToolLoop,
+            RespondPlan::AgentChat,
             "{input}"
         );
     }
@@ -419,14 +422,14 @@ fn core_plan_routes_todo_context_reference_after_recent_list_to_tool_loop() {
         let req: RespondRequest = private_request(input).into();
         assert_eq!(
             service.plan_core_respond(&req).unwrap(),
-            RespondPlan::CompleteToolLoop,
+            RespondPlan::AgentChat,
             "{input}"
         );
     }
 }
 
 #[test]
-fn core_plan_keeps_weak_todo_reference_plain_without_recent_context() {
+fn core_plan_routes_weak_todo_reference_to_agent_without_recent_context() {
     let provider =
         TestProvider::replying("聊天回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_tool_calling(provider, 5, true);
@@ -442,7 +445,7 @@ fn core_plan_keeps_weak_todo_reference_plain_without_recent_context() {
         let req: RespondRequest = private_request(input).into();
         assert_eq!(
             service.plan_core_respond(&req).unwrap(),
-            RespondPlan::StreamingChat,
+            RespondPlan::AgentChat,
             "{input}"
         );
     }
@@ -521,7 +524,7 @@ fn core_plan_routes_group_chat_to_tool_loop_when_group_switch_enabled() {
 
     assert_eq!(
         service.plan_core_respond(&req).unwrap(),
-        RespondPlan::CompleteToolLoop
+        RespondPlan::AgentChat
     );
 }
 
@@ -550,7 +553,7 @@ fn core_plan_keeps_group_pasted_text_processing_as_chat_when_bot_mentioned() {
 Codex 执行报告：
 - 检查 WebSearch 路由
 - 查询工具返回：查询内容太长
-- tool_route 命中 search 关键词
+- agent_route 命中 search 关键词
 帮我整理成 issue";
     let req: RespondRequest = group_request_with_self_mention(input).into();
 
@@ -575,7 +578,7 @@ fn core_plan_does_not_route_group_search_intent_to_web_search_without_bot_mentio
 }
 
 #[test]
-fn core_plan_keeps_group_plain_chat_streaming_even_when_group_switch_enabled() {
+fn core_plan_routes_group_plain_chat_to_agent_when_group_switch_enabled() {
     let provider =
         TestProvider::replying("群聊回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_group_tool_calling(provider, 5, true, true);
@@ -584,7 +587,7 @@ fn core_plan_keeps_group_plain_chat_streaming_even_when_group_switch_enabled() {
 
     assert_eq!(
         service.plan_core_respond(&req).unwrap(),
-        RespondPlan::StreamingChat
+        RespondPlan::AgentChat
     );
 }
 
@@ -732,13 +735,13 @@ fn output_policy_names_are_consistent_across_stream_plans() {
             "ordinary_complete",
         ),
         (
-            RespondPlan::CompleteToolLoop,
+            RespondPlan::AgentChat,
             true,
             CoreOutputPolicy::ProgressThenStream,
             "progress_then_stream",
         ),
         (
-            RespondPlan::CompleteToolLoop,
+            RespondPlan::AgentChat,
             false,
             CoreOutputPolicy::ProgressThenComplete,
             "progress_then_complete",
@@ -1017,7 +1020,7 @@ async fn core_private_weather_chat_with_tool_capability_completes_without_synthe
     let Some(CoreResponseEvent::Status(status)) = stream.recv().await else {
         panic!("expected tool loop started status");
     };
-    assert_eq!(status.kind, CoreResponseStatusKind::ToolLoopStarted);
+    assert_eq!(status.kind, CoreResponseStatusKind::AgentStarted);
     assert_eq!(status.text, "小女仆正在查天气…");
 
     let Some(CoreResponseEvent::Status(status)) = stream.recv().await else {
@@ -1058,7 +1061,7 @@ async fn core_private_tool_status_uses_configured_display_name() {
         panic!("expected tool loop started status");
     };
 
-    assert_eq!(status.kind, CoreResponseStatusKind::ToolLoopStarted);
+    assert_eq!(status.kind, CoreResponseStatusKind::AgentStarted);
     assert_eq!(status.text, "助手正在查天气…");
 }
 
@@ -1080,7 +1083,7 @@ async fn core_group_tool_status_uses_short_hint() {
         panic!("expected tool loop started status");
     };
 
-    assert_eq!(status.kind, CoreResponseStatusKind::ToolLoopStarted);
+    assert_eq!(status.kind, CoreResponseStatusKind::AgentStarted);
     assert_eq!(status.text, "正在查…");
 }
 
@@ -1123,12 +1126,12 @@ async fn core_tool_loop_streams_only_final_answer_after_tool_status() {
 
     assert_eq!(deltas, vec!["最终".to_owned(), "回答".to_owned()]);
     assert_eq!(response.text_content(), Some("最终回答"));
-    assert!(status_kinds.contains(&CoreResponseStatusKind::ToolLoopStarted));
-    assert!(status_kinds.contains(&CoreResponseStatusKind::ToolLoopFinalizing));
+    assert!(status_kinds.contains(&CoreResponseStatusKind::AgentStarted));
+    assert!(status_kinds.contains(&CoreResponseStatusKind::AgentFinalizing));
     assert!(
         status_kinds
             .iter()
-            .position(|kind| *kind == CoreResponseStatusKind::ToolLoopFinalizing)
+            .position(|kind| *kind == CoreResponseStatusKind::AgentFinalizing)
             .is_some_and(|index| index > 0)
     );
     assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
@@ -1183,7 +1186,7 @@ async fn core_tool_loop_failure_is_reported_as_stream_failure_without_delta() {
     let provider = TestProvider::failing(LlmError::new(
         "tool_loop_limit",
         "tool loop exceeded maximum rounds",
-        "tool_loop",
+        "tool_intent",
     ))
     .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_tool_calling(provider.clone(), 5, true);
@@ -1269,7 +1272,7 @@ async fn core_private_simple_todo_queries_use_deterministic_path() {
 }
 
 #[tokio::test]
-async fn core_private_general_chat_with_tool_capability_uses_streaming_chat() {
+async fn core_private_general_chat_with_tool_capability_uses_agent_runtime() {
     let provider = TestProvider::replying("普通完整回复")
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_tool_calling(provider.clone(), 5, true);
@@ -1278,8 +1281,54 @@ async fn core_private_general_chat_with_tool_capability_uses_streaming_chat() {
     let response = collect_stream_completed(service.respond(private_request("晚上好")).await).await;
 
     assert_eq!(response.text_content(), Some("普通完整回复"));
-    assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
-    assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn core_private_general_chat_agent_direct_answer_streams_text_deltas() {
+    let provider = TestProvider::streaming(vec![
+        Ok(LlmStreamEvent::TextDelta("普通".to_owned())),
+        Ok(LlmStreamEvent::TextDelta("回复".to_owned())),
+        Ok(LlmStreamEvent::Completed {
+            usage: None,
+            finish_reason: None,
+            fallback_used: false,
+        }),
+    ])
+    .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let state = test_state_with_tool_calling(provider.clone(), 5, true);
+    let service = CoreHandle::new(state);
+
+    let mut stream = expect_stream(
+        service
+            .respond(private_request("聊聊 Rust 的所有权"))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(stream.output_policy(), CoreOutputPolicy::ProgressThenStream);
+
+    let mut deltas = Vec::new();
+    let response = loop {
+        let Some(event) = stream.recv().await else {
+            panic!("stream ended before completed response");
+        };
+        match event {
+            CoreResponseEvent::Status(_) => {}
+            CoreResponseEvent::TextDelta(delta) => deltas.push(delta),
+            CoreResponseEvent::Completed(response) => break response,
+            CoreResponseEvent::Failed(failure) => panic!("unexpected failure: {failure:?}"),
+        }
+    };
+
+    assert_eq!(deltas, vec!["普通".to_owned(), "回复".to_owned()]);
+    assert_eq!(response.text_content(), Some("普通回复"));
+    let diagnostics = response.diagnostics.as_ref().unwrap();
+    assert_eq!(diagnostics["tool_calling_available"], true);
+    assert_eq!(diagnostics["tool_calling_used"], false);
+    assert_eq!(diagnostics["agent_result"], "direct_answer");
+    assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/service/tests/support.rs
+++ b/qq-maid-core/src/service/tests/support.rs
@@ -487,6 +487,7 @@ fn chat_outcome(reply: &str) -> ChatOutcome {
         fallback_used: false,
         executed_tools: Vec::new(),
         tool_results: Vec::new(),
+        agent: Default::default(),
     }
 }
 

--- a/qq-maid-core/src/service/types.rs
+++ b/qq-maid-core/src/service/types.rs
@@ -189,7 +189,7 @@ pub enum CoreResponseEvent {
     Status(CoreResponseStatus),
     /// 用户可见的最终文本增量。
     ///
-    /// Tool Loop 路径只会在工具循环完成、业务校验通过并生成最终回复后发送该事件；
+    /// Agent Chat 路径只会在模型确认最终回答、业务校验通过后发送该事件；
     /// 工具参数、工具结果原文和模型中间候选文本不得通过此事件外发。
     TextDelta(String),
     Completed(Box<CoreResponse>),
@@ -206,12 +206,12 @@ pub struct CoreResponseStatus {
 pub enum CoreResponseStatusKind {
     CommandStarted,
     CommandFinished,
-    ToolLoopStarted,
-    ToolLoopRunning,
+    AgentStarted,
+    AgentRunning,
     ToolCallStarted,
     ToolCallFinished,
     ToolCallFailed,
-    ToolLoopFinalizing,
+    AgentFinalizing,
 }
 
 impl CoreResponseStatusKind {
@@ -219,12 +219,12 @@ impl CoreResponseStatusKind {
         match self {
             Self::CommandStarted => "command_started",
             Self::CommandFinished => "command_finished",
-            Self::ToolLoopStarted => "tool_loop_started",
-            Self::ToolLoopRunning => "tool_loop_running",
+            Self::AgentStarted => "agent_started",
+            Self::AgentRunning => "agent_running",
             Self::ToolCallStarted => "tool_call_started",
             Self::ToolCallFinished => "tool_call_finished",
             Self::ToolCallFailed => "tool_call_failed",
-            Self::ToolLoopFinalizing => "tool_loop_finalizing",
+            Self::AgentFinalizing => "agent_finalizing",
         }
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -1074,7 +1074,7 @@ mod tests {
     async fn disabled_stream_status_does_not_create_extra_reply() {
         let events = FakeEventStream::new([
             RespondEvent::Status(CoreResponseStatus {
-                kind: CoreResponseStatusKind::ToolLoopStarted,
+                kind: CoreResponseStatusKind::AgentStarted,
                 text: "正在处理".to_owned(),
             }),
             RespondEvent::Completed(Box::new(respond_response("最终回复"))),
@@ -1107,11 +1107,11 @@ mod tests {
     async fn disabled_stream_progress_policy_sends_one_visible_hint_then_final_reply() {
         let events = FakeEventStream::new([
             RespondEvent::Status(CoreResponseStatus {
-                kind: CoreResponseStatusKind::ToolLoopStarted,
+                kind: CoreResponseStatusKind::AgentStarted,
                 text: "小女仆正在处理…".to_owned(),
             }),
             RespondEvent::Status(CoreResponseStatus {
-                kind: CoreResponseStatusKind::ToolLoopFinalizing,
+                kind: CoreResponseStatusKind::AgentFinalizing,
                 text: "小女仆正在确认结果…".to_owned(),
             }),
             RespondEvent::Completed(Box::new(respond_response("最终回复"))),
@@ -1151,11 +1151,11 @@ mod tests {
     async fn disabled_stream_progress_then_stream_sends_one_visible_hint_then_final_reply() {
         let events = FakeEventStream::new([
             RespondEvent::Status(CoreResponseStatus {
-                kind: CoreResponseStatusKind::ToolLoopStarted,
+                kind: CoreResponseStatusKind::AgentStarted,
                 text: "小女仆正在处理…".to_owned(),
             }),
             RespondEvent::Status(CoreResponseStatus {
-                kind: CoreResponseStatusKind::ToolLoopFinalizing,
+                kind: CoreResponseStatusKind::AgentFinalizing,
                 text: "小女仆正在确认结果…".to_owned(),
             }),
             RespondEvent::TextDelta("不应外发".to_owned()),
@@ -1196,7 +1196,7 @@ mod tests {
     async fn disabled_stream_progress_status_respects_visible_progress_config() {
         let events = FakeEventStream::new([
             RespondEvent::Status(CoreResponseStatus {
-                kind: CoreResponseStatusKind::ToolLoopStarted,
+                kind: CoreResponseStatusKind::AgentStarted,
                 text: "小女仆正在处理…".to_owned(),
             }),
             RespondEvent::Completed(Box::new(respond_response("最终回复"))),

--- a/qq-maid-gateway-rs/src/gateway/stream/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests.rs
@@ -381,7 +381,7 @@ async fn active_stream_does_not_fake_ref_index_from_stream_id() {
 async fn stream_status_event_does_not_start_qq_stream_or_extra_send() {
     let events = FakeEventStream::new([
         RespondEvent::Status(CoreResponseStatus {
-            kind: CoreResponseStatusKind::ToolLoopStarted,
+            kind: CoreResponseStatusKind::AgentStarted,
             text: "正在处理".to_owned(),
         }),
         RespondEvent::Completed(Box::new(respond_response("最终回复"))),
@@ -405,11 +405,11 @@ async fn stream_status_event_does_not_start_qq_stream_or_extra_send() {
 async fn progress_policy_status_sends_one_visible_hint_then_final_reply() {
     let events = FakeEventStream::new([
         RespondEvent::Status(CoreResponseStatus {
-            kind: CoreResponseStatusKind::ToolLoopStarted,
+            kind: CoreResponseStatusKind::AgentStarted,
             text: "小女仆正在处理…".to_owned(),
         }),
         RespondEvent::Status(CoreResponseStatus {
-            kind: CoreResponseStatusKind::ToolLoopFinalizing,
+            kind: CoreResponseStatusKind::AgentFinalizing,
             text: "小女仆正在确认结果…".to_owned(),
         }),
         RespondEvent::Completed(Box::new(respond_response("最终回复"))),
@@ -440,11 +440,11 @@ async fn progress_policy_status_sends_one_visible_hint_then_final_reply() {
 async fn progress_then_stream_sends_one_visible_hint_then_streams_final_answer() {
     let events = FakeEventStream::new([
         RespondEvent::Status(CoreResponseStatus {
-            kind: CoreResponseStatusKind::ToolLoopStarted,
+            kind: CoreResponseStatusKind::AgentStarted,
             text: "小女仆正在处理…".to_owned(),
         }),
         RespondEvent::Status(CoreResponseStatus {
-            kind: CoreResponseStatusKind::ToolLoopFinalizing,
+            kind: CoreResponseStatusKind::AgentFinalizing,
             text: "小女仆正在确认结果…".to_owned(),
         }),
         RespondEvent::TextDelta("最终".to_owned()),
@@ -520,7 +520,7 @@ async fn stream_first_send_without_id_falls_back_to_completed_response() {
 async fn progress_policy_status_respects_visible_progress_config() {
     let events = FakeEventStream::new([
         RespondEvent::Status(CoreResponseStatus {
-            kind: CoreResponseStatusKind::ToolLoopStarted,
+            kind: CoreResponseStatusKind::AgentStarted,
             text: "小女仆正在处理…".to_owned(),
         }),
         RespondEvent::Completed(Box::new(respond_response("最终回复"))),

--- a/qq-maid-llm/src/agent_loop/runner.rs
+++ b/qq-maid-llm/src/agent_loop/runner.rs
@@ -14,6 +14,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
+use tokio::time::{Duration, timeout};
 use tracing::{debug, warn};
 
 use crate::{
@@ -22,7 +23,7 @@ use crate::{
     metrics::MetricsRecorder,
     provider::types::TokenUsage,
     provider::{
-        ChatOutcome,
+        AgentRunDiagnostics, AgentStopReason, ChatOutcome,
         tool_loop::{ToolLoopCall, ToolLoopExecutor},
     },
     tool::{ToolContext, ToolRegistry},
@@ -30,6 +31,9 @@ use crate::{
 
 use super::session::AgentStepSession;
 use super::types::{AgentStep, AgentToolCall, AgentToolResult};
+
+const AGENT_STREAMING_STEP_TIMEOUT: Duration = Duration::from_secs(30);
+const AGENT_NON_STREAM_STEP_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// 运行统一 Agent Loop。
 ///
@@ -64,6 +68,8 @@ pub async fn run_agent_loop(
     let recorder = MetricsRecorder::start();
     let mut executor = ToolLoopExecutor::new(&tools, &tool_context, progress_sink);
     let mut usage: Option<TokenUsage> = None;
+    let mut emitted_tools = Vec::new();
+    let mut fallback_used = false;
     // 上一轮工具执行结果；首轮为空，由 Loop 在执行后回填给下一轮 advance。
     let mut results: Vec<AgentToolResult> = Vec::new();
 
@@ -71,14 +77,17 @@ pub async fn run_agent_loop(
         // 最后一轮不允许继续工具调用；Responses 会据此设置 tool_choice=none，
         // Chat Completions 忽略此值，由下方的 max_rounds 兜底统一退出。
         let allow_tool_calls = round < max_rounds;
-        let step = advance_with_optional_streaming(
+        let advance = advance_with_optional_streaming(
             session.as_mut(),
             &results,
             allow_tool_calls,
             final_delta_sink.clone(),
+            AGENT_STREAMING_STEP_TIMEOUT,
+            AGENT_NON_STREAM_STEP_TIMEOUT,
         )
         .await?;
-        match step {
+        fallback_used |= advance.fallback_used;
+        match advance.step {
             AgentStep::FinalAnswer {
                 reply,
                 usage: step_usage,
@@ -95,9 +104,14 @@ pub async fn run_agent_loop(
                     reply,
                     metrics: recorder.finish(&provider, &model, false),
                     usage,
-                    fallback_used: false,
+                    fallback_used,
                     executed_tools: executor.executed_tools(),
                     tool_results: executor.tool_results(),
+                    agent: AgentRunDiagnostics {
+                        stop_reason: Some(agent_stop_reason(&emitted_tools, &executor)),
+                        emitted_tools,
+                        tool_execution_attempted: executor.execution_attempted(),
+                    },
                 });
             }
             AgentStep::ToolCalls {
@@ -105,6 +119,7 @@ pub async fn run_agent_loop(
                 usage: step_usage,
             } => {
                 usage = merge_usage(usage, step_usage);
+                emitted_tools.extend(calls.iter().map(|call| call.name.clone()));
                 // 已到最大轮数仍要求工具调用：统一返回 tool_loop_limit，
                 // 不再执行这一批调用，避免超出预算的副作用。
                 if round >= max_rounds {
@@ -134,36 +149,125 @@ pub async fn run_agent_loop(
     ))
 }
 
-async fn advance_with_optional_streaming(
+pub(super) async fn advance_with_optional_streaming(
     session: &mut (dyn AgentStepSession + Send),
     results: &[AgentToolResult],
     allow_tool_calls: bool,
     final_delta_sink: Option<AgentTextDeltaSink>,
-) -> Result<AgentStep, LlmError> {
+    streaming_timeout: Duration,
+    non_stream_timeout: Duration,
+) -> Result<AgentAdvance, LlmError> {
     let Some(sink) = final_delta_sink else {
-        return session.advance(results, allow_tool_calls).await;
+        return advance_non_stream_with_timeout(
+            session,
+            results,
+            allow_tool_calls,
+            non_stream_timeout,
+        )
+        .await
+        .map(|step| AgentAdvance {
+            step,
+            fallback_used: false,
+        });
     };
     let emitted_visible_delta = Arc::new(AtomicBool::new(false));
     let tracked_sink = track_visible_delta_sink(sink, emitted_visible_delta.clone());
-    match session
-        .advance_streaming(results, allow_tool_calls, tracked_sink)
-        .await
-    {
-        Ok(Some(step)) => Ok(step),
-        Ok(None) => session.advance(results, allow_tool_calls).await,
-        Err(err) if !emitted_visible_delta.load(Ordering::SeqCst) => {
-            debug!(
-                provider = session.provider(),
-                model = %session.model(),
-                allow_tool_calls,
-                error_code = err.code.as_str(),
-                error_stage = err.stage.as_str(),
-                "streaming agent advance failed before visible delta; falling back to non-stream advance"
-            );
-            session.advance(results, allow_tool_calls).await
+    let streaming = timeout(
+        streaming_timeout,
+        session.advance_streaming(results, allow_tool_calls, tracked_sink),
+    )
+    .await;
+    match streaming {
+        Ok(Ok(Some(step))) => Ok(AgentAdvance {
+            step,
+            fallback_used: false,
+        }),
+        Ok(Ok(None)) => {
+            advance_non_stream_with_timeout(session, results, allow_tool_calls, non_stream_timeout)
+                .await
+                .map(|step| AgentAdvance {
+                    step,
+                    fallback_used: false,
+                })
         }
-        Err(err) => Err(err),
+        Ok(Err(err)) if !emitted_visible_delta.load(Ordering::SeqCst) => {
+            log_streaming_fallback(session, allow_tool_calls, results, Some(&err));
+            advance_non_stream_with_timeout(session, results, allow_tool_calls, non_stream_timeout)
+                .await
+                .map(|step| AgentAdvance {
+                    step,
+                    fallback_used: true,
+                })
+        }
+        Err(_) if !emitted_visible_delta.load(Ordering::SeqCst) => {
+            log_streaming_fallback(session, allow_tool_calls, results, None);
+            advance_non_stream_with_timeout(session, results, allow_tool_calls, non_stream_timeout)
+                .await
+                .map(|step| AgentAdvance {
+                    step,
+                    fallback_used: true,
+                })
+        }
+        Ok(Err(err)) => Err(err),
+        Err(_) => Err(LlmError::timeout("agent_stream_after_delta")),
     }
+}
+
+#[derive(Debug)]
+pub(super) struct AgentAdvance {
+    pub(super) step: AgentStep,
+    pub(super) fallback_used: bool,
+}
+
+async fn advance_non_stream_with_timeout(
+    session: &mut (dyn AgentStepSession + Send),
+    results: &[AgentToolResult],
+    allow_tool_calls: bool,
+    step_timeout: Duration,
+) -> Result<AgentStep, LlmError> {
+    timeout(step_timeout, session.advance(results, allow_tool_calls))
+        .await
+        .map_err(|_| LlmError::timeout("agent_step"))?
+}
+
+fn log_streaming_fallback(
+    session: &(dyn AgentStepSession + Send),
+    allow_tool_calls: bool,
+    results: &[AgentToolResult],
+    err: Option<&LlmError>,
+) {
+    debug!(
+        provider = session.provider(),
+        model = %session.model(),
+        allow_tool_calls,
+        follows_tool_results = !results.is_empty(),
+        error_code = err.map(|item| item.code.as_str()).unwrap_or("timeout"),
+        error_stage = err.map(|item| item.stage.as_str()).unwrap_or("agent_step"),
+        "streaming agent advance stopped before visible delta; falling back once to non-stream advance"
+    );
+}
+
+fn agent_stop_reason(emitted_tools: &[String], executor: &ToolLoopExecutor<'_>) -> AgentStopReason {
+    if emitted_tools.is_empty() {
+        return AgentStopReason::DirectAnswer;
+    }
+    if executor.rejected_call() || executor.executed_tools().is_empty() {
+        return AgentStopReason::Rejected;
+    }
+    let results = executor.tool_results();
+    if results.iter().any(|result| {
+        result
+            .output
+            .get("requires_clarification")
+            .and_then(serde_json::Value::as_bool)
+            == Some(true)
+    }) {
+        return AgentStopReason::Clarify;
+    }
+    if !results.is_empty() && results.iter().all(|result| !result.succeeded) {
+        return AgentStopReason::Failed;
+    }
+    AgentStopReason::ToolUsed
 }
 
 fn track_visible_delta_sink(

--- a/qq-maid-llm/src/agent_loop/session.rs
+++ b/qq-maid-llm/src/agent_loop/session.rs
@@ -43,6 +43,8 @@ pub trait AgentStepSession: Send {
     ///   可以边接收真实 provider delta 边转发。
     /// - 如果本轮产生 tool call，不得向 `text_delta_sink` 发送任何模型草稿。
     /// - 一旦已经发送用户可见 delta，后续错误必须原样返回，不能改走非流式重放。
+    /// - 流式推进失败或超时时，会话状态必须仍可用同一批 `results` 执行一次
+    ///   `advance`；Provider 不得在流式响应完整结束前提交本轮协议状态。
     async fn advance_streaming(
         &mut self,
         _results: &[AgentToolResult],

--- a/qq-maid-llm/src/agent_loop/tests.rs
+++ b/qq-maid-llm/src/agent_loop/tests.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 use crate::error::LlmError;
-use crate::provider::types::TokenUsage;
+use crate::provider::{AgentStopReason, types::TokenUsage};
 use crate::tool::{ToolCallDependency, ToolContext, ToolMetadata, ToolOutput, ToolRegistry};
 use async_trait::async_trait;
 use serde_json::{Value, json};
@@ -46,6 +46,10 @@ enum StreamingAction {
     },
     ErrorBeforeDelta,
     ErrorAfterDelta {
+        delta: &'static str,
+    },
+    HangBeforeDelta,
+    HangAfterDelta {
         delta: &'static str,
     },
 }
@@ -129,6 +133,11 @@ impl AgentStepSession for StreamingSession {
                     "stream failed after visible delta",
                     "stream_after_delta",
                 ))
+            }
+            StreamingAction::HangBeforeDelta => std::future::pending().await,
+            StreamingAction::HangAfterDelta { delta } => {
+                text_delta_sink(delta.to_owned()).await?;
+                std::future::pending().await
             }
         }
     }
@@ -414,6 +423,44 @@ async fn streaming_tool_round_suppresses_draft_then_streams_final_answer() {
 }
 
 #[tokio::test]
+async fn fallback_after_tool_result_does_not_repeat_tool_side_effect() {
+    let calls = Arc::new(StdMutex::new(0));
+    let registry = registry_with(vec![Arc::new(CountingTool {
+        name: "echo",
+        calls: calls.clone(),
+        fail: false,
+        soft_fail: false,
+        dependency: ToolCallDependency::None,
+    }) as _]);
+    let session = Box::new(StreamingSession::scripted(
+        vec![
+            StreamingAction::ToolCallsWithBufferedDraft {
+                draft_delta: "不外显",
+                calls: vec![tool_call("echo", "c1", r#"{"value":"a"}"#)],
+            },
+            StreamingAction::ErrorBeforeDelta,
+        ],
+        vec![final_reply("fallback summary")],
+    ));
+
+    let outcome = run_agent_loop(
+        session,
+        registry,
+        test_context(),
+        3,
+        None,
+        Some(delta_sink(Arc::new(StdMutex::new(Vec::new())))),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome.reply, "fallback summary");
+    assert!(outcome.fallback_used);
+    assert_eq!(*calls.lock().unwrap(), 1);
+    assert_eq!(outcome.executed_tools, vec!["echo"]);
+}
+
+#[tokio::test]
 async fn streaming_advance_error_before_visible_delta_falls_back() {
     let registry = registry_with(vec![Arc::new(CountingTool {
         name: "echo",
@@ -473,6 +520,59 @@ async fn streaming_advance_error_after_visible_delta_does_not_fallback() {
     .unwrap_err();
 
     assert_eq!(err.stage, "stream_after_delta");
+    assert_eq!(*deltas.lock().unwrap(), vec!["半句".to_owned()]);
+    assert_eq!(*advance_calls.lock().unwrap(), 0);
+}
+
+#[tokio::test]
+async fn streaming_advance_timeout_before_visible_delta_falls_back_once() {
+    let mut session = StreamingSession::new(
+        StreamingAction::HangBeforeDelta,
+        vec![final_reply("fallback after timeout")],
+    );
+    let advance_calls = session.advance_calls.clone();
+
+    let advance = super::runner::advance_with_optional_streaming(
+        &mut session,
+        &[],
+        true,
+        Some(delta_sink(Arc::new(StdMutex::new(Vec::new())))),
+        std::time::Duration::from_millis(10),
+        std::time::Duration::from_millis(50),
+    )
+    .await
+    .unwrap();
+
+    let AgentStep::FinalAnswer { reply, .. } = advance.step else {
+        panic!("expected fallback final answer");
+    };
+    assert_eq!(reply, "fallback after timeout");
+    assert!(advance.fallback_used);
+    assert_eq!(*advance_calls.lock().unwrap(), 1);
+}
+
+#[tokio::test]
+async fn streaming_advance_timeout_after_visible_delta_does_not_fallback() {
+    let mut session = StreamingSession::new(
+        StreamingAction::HangAfterDelta { delta: "半句" },
+        vec![final_reply("fallback must not run")],
+    );
+    let advance_calls = session.advance_calls.clone();
+    let deltas = Arc::new(StdMutex::new(Vec::new()));
+
+    let err = super::runner::advance_with_optional_streaming(
+        &mut session,
+        &[],
+        false,
+        Some(delta_sink(deltas.clone())),
+        std::time::Duration::from_millis(10),
+        std::time::Duration::from_millis(50),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(err.code, "timeout");
+    assert_eq!(err.stage, "agent_stream_after_delta");
     assert_eq!(*deltas.lock().unwrap(), vec!["半句".to_owned()]);
     assert_eq!(*advance_calls.lock().unwrap(), 0);
 }
@@ -781,6 +881,65 @@ async fn soft_business_failure_marks_unsucceeded() {
     assert_eq!(outcome.reply, "noted");
     assert!(!outcome.tool_results[0].succeeded);
     assert_eq!(outcome.tool_results[0].output["error_code"], "soft_failure");
+}
+
+#[tokio::test]
+async fn unknown_tool_is_emitted_and_attempted_but_rejected() {
+    let registry = registry_with(vec![Arc::new(CountingTool {
+        name: "echo",
+        calls: Arc::new(StdMutex::new(0)),
+        fail: false,
+        soft_fail: false,
+        dependency: ToolCallDependency::None,
+    }) as _]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![tool_call("unknown_tool", "c1", r#"{"value":"a"}"#)]),
+            final_reply("无法执行该工具。"),
+        ],
+    ));
+
+    let outcome = run_agent_loop(session, registry, test_context(), 3, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.agent.emitted_tools, vec!["unknown_tool"]);
+    assert!(outcome.agent.tool_execution_attempted);
+    assert_eq!(outcome.agent.stop_reason, Some(AgentStopReason::Rejected));
+    assert!(outcome.executed_tools.is_empty());
+    assert!(outcome.tool_results.is_empty());
+}
+
+#[tokio::test]
+async fn invalid_tool_arguments_are_emitted_and_attempted_but_not_executed() {
+    let calls = Arc::new(StdMutex::new(0));
+    let registry = registry_with(vec![Arc::new(CountingTool {
+        name: "echo",
+        calls: calls.clone(),
+        fail: false,
+        soft_fail: false,
+        dependency: ToolCallDependency::None,
+    }) as _]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![tool_call("echo", "c1", "not-json")]),
+            final_reply("参数无效，未执行。"),
+        ],
+    ));
+
+    let outcome = run_agent_loop(session, registry, test_context(), 3, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.agent.emitted_tools, vec!["echo"]);
+    assert!(outcome.agent.tool_execution_attempted);
+    assert_eq!(outcome.agent.stop_reason, Some(AgentStopReason::Rejected));
+    assert!(outcome.executed_tools.is_empty());
+    assert_eq!(*calls.lock().unwrap(), 0);
 }
 
 #[tokio::test]

--- a/qq-maid-llm/src/provider/limiter.rs
+++ b/qq-maid-llm/src/provider/limiter.rs
@@ -242,6 +242,7 @@ mod tests {
                 fallback_used: false,
                 executed_tools: Vec::new(),
                 tool_results: Vec::new(),
+                agent: Default::default(),
             })
         }
 

--- a/qq-maid-llm/src/provider/mod.rs
+++ b/qq-maid-llm/src/provider/mod.rs
@@ -88,6 +88,45 @@ pub struct ChatOutcome {
     pub executed_tools: Vec<String>,
     /// Tool Loop 中实际工具输出摘要；普通聊天为空。
     pub tool_results: Vec<ToolExecutionResult>,
+    /// Agent Runtime 的结构化执行轨迹；普通聊天使用默认空轨迹。
+    pub agent: AgentRunDiagnostics,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentStopReason {
+    DirectAnswer,
+    ToolUsed,
+    Clarify,
+    Rejected,
+    Failed,
+    MaxRounds,
+    Timeout,
+    Cancelled,
+}
+
+impl AgentStopReason {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::DirectAnswer => "direct_answer",
+            Self::ToolUsed => "tool_used",
+            Self::Clarify => "clarify",
+            Self::Rejected => "rejected",
+            Self::Failed => "failed",
+            Self::MaxRounds => "max_rounds",
+            Self::Timeout => "timeout",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct AgentRunDiagnostics {
+    /// 模型返回过的结构化工具名，包含未知、未授权和参数非法的调用。
+    pub emitted_tools: Vec<String>,
+    /// 服务端是否进入过 prepare / 校验 / 执行流程。
+    pub tool_execution_attempted: bool,
+    /// Agent Runtime 的最终停止原因。
+    pub stop_reason: Option<AgentStopReason>,
 }
 
 /// 原生 Tool Calling 请求。
@@ -123,7 +162,7 @@ pub enum ToolCallingProtocol {
 /// LLM 标准聊天流事件。
 ///
 /// `Completed` 是每条流唯一的成功终止状态，usage 与 finish reason 都随终止事件返回；
-/// collector 必须继续消费到 EOF，不能因为某个 provider 提前给出 finish 标记就停止读流。
+/// Provider 在协议级完成信号已经足够定稿时应立即产出该事件，不得依赖 HTTP EOF。
 #[derive(Debug, Clone)]
 pub enum LlmStreamEvent {
     /// 模型正文增量。当前 Core/Gateway 只把它作为进程内保活和未来增量发送扩展依据。
@@ -271,6 +310,7 @@ pub async fn collect_llm_stream(
         fallback_used,
         executed_tools: Vec::new(),
         tool_results: Vec::new(),
+        agent: Default::default(),
     })
 }
 

--- a/qq-maid-llm/src/provider/openai/chat.rs
+++ b/qq-maid-llm/src/provider/openai/chat.rs
@@ -513,6 +513,7 @@ pub(crate) async fn non_stream_completion(
         fallback_used: false,
         executed_tools: Vec::new(),
         tool_results: Vec::new(),
+        agent: Default::default(),
     })
 }
 

--- a/qq-maid-llm/src/provider/openai/fallback.rs
+++ b/qq-maid-llm/src/provider/openai/fallback.rs
@@ -49,6 +49,7 @@ mod tests {
             fallback_used: false,
             executed_tools: Vec::new(),
             tool_results: Vec::new(),
+            agent: Default::default(),
         }
     }
 

--- a/qq-maid-llm/src/provider/openai/responses.rs
+++ b/qq-maid-llm/src/provider/openai/responses.rs
@@ -22,7 +22,10 @@ use super::{
         should_retry_non_stream_after_empty_stream, should_retry_non_stream_after_stream_error,
     },
     payload::openai_responses_payload,
-    stream::handle_openai_chat_stream_event,
+    stream::{
+        handle_openai_chat_stream_event, is_openai_responses_done_sentinel,
+        responses_stream_is_complete,
+    },
     transport::send_openai_responses_request,
 };
 
@@ -110,6 +113,7 @@ pub(crate) async fn openai_responses_non_stream_chat(
         fallback_used: false,
         executed_tools: Vec::new(),
         tool_results: Vec::new(),
+        agent: Default::default(),
     })
 }
 
@@ -149,6 +153,7 @@ pub(crate) async fn openai_responses_chat_stream(
             answer,
             completed_response,
             saw_completed,
+            saw_done: false,
             allow_completed_response_fallback: req.allow_completed_response_fallback,
             finished: false,
         },
@@ -166,6 +171,7 @@ struct ResponsesStreamState {
     answer: String,
     completed_response: Option<Value>,
     saw_completed: bool,
+    saw_done: bool,
     allow_completed_response_fallback: bool,
     finished: bool,
 }
@@ -181,7 +187,8 @@ async fn next_responses_stream_event(
             }) else {
                 continue;
             };
-            if is_openai_stream_done_sentinel(&event.data) {
+            if is_openai_responses_done_sentinel(&event.data) {
+                state.saw_done = true;
                 continue;
             }
             state.recorder.mark_event();
@@ -202,6 +209,32 @@ async fn next_responses_stream_event(
             return None;
         }
 
+        if responses_stream_is_complete(state.saw_completed, &state.completed_response)
+            || (state.saw_done && !state.answer.trim().is_empty())
+        {
+            if state.answer.trim().is_empty()
+                && state.allow_completed_response_fallback
+                && let Some(response) = state.completed_response.as_ref()
+                && let Some(answer) = extract_response_output_text(response)
+                && !answer.trim().is_empty()
+            {
+                // 只在没有真实 delta 时从 completed response 回补，保证最终正文来源单一。
+                state.answer = answer.clone();
+                state.recorder.mark_token();
+                return Some(Ok(LlmStreamEvent::TextDelta(answer)));
+            }
+            let usage = state
+                .completed_response
+                .as_ref()
+                .and_then(extract_response_usage);
+            state.finished = true;
+            return Some(Ok(LlmStreamEvent::Completed {
+                usage,
+                finish_reason: None,
+                fallback_used: false,
+            }));
+        }
+
         match state.response.chunk().await {
             Ok(Some(chunk)) => {
                 state.frame_buffer.extend_from_slice(&chunk);
@@ -216,7 +249,7 @@ async fn next_responses_stream_event(
                         continue;
                     };
                     state.frame_buffer.clear();
-                    if !is_openai_stream_done_sentinel(&event.data) {
+                    if !is_openai_responses_done_sentinel(&event.data) {
                         state.recorder.mark_event();
                         match handle_openai_chat_stream_event(
                             event,
@@ -270,11 +303,6 @@ async fn next_responses_stream_event(
     }
 }
 
-fn is_openai_stream_done_sentinel(data: &str) -> bool {
-    // OpenAI/兼容网关会用非 JSON 的 `[DONE]` 作为 SSE 结束哨兵，不能交给 JSON parser。
-    data.trim() == "[DONE]"
-}
-
 pub(crate) fn incomplete_stream_eof_error(message: &str, answer: &str) -> LlmError {
     let stage = if answer.trim().is_empty() {
         "stream"
@@ -298,13 +326,14 @@ mod tests {
     use super::*;
     use axum::{
         Router,
-        body::Body,
+        body::{Body, Bytes},
         extract::State,
-        http::{StatusCode, header},
+        http::{Response, StatusCode, header},
         response::IntoResponse,
         routing::post,
     };
-    use std::sync::Arc;
+    use futures::{StreamExt, stream};
+    use std::{convert::Infallible, sync::Arc, time::Duration};
     use tokio::{net::TcpListener, sync::Mutex};
 
     #[derive(Debug)]
@@ -347,6 +376,30 @@ mod tests {
         (format!("http://{addr}/v1"), state)
     }
 
+    async fn never_closing_completed_handler() -> Response<Body> {
+        let completed = Bytes::from_static(
+            b"event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"output_text\":\"prompt completion\"}}\n\n",
+        );
+        let body = Body::from_stream(
+            stream::once(async move { Ok::<Bytes, Infallible>(completed) })
+                .chain(stream::pending()),
+        );
+        Response::builder()
+            .header(header::CONTENT_TYPE, "text/event-stream")
+            .body(body)
+            .unwrap()
+    }
+
+    async fn spawn_never_closing_completed_response() -> String {
+        let app = Router::new().route("/v1/responses", post(never_closing_completed_handler));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}/v1")
+    }
+
     fn stream_req<'a>(
         client: &'a reqwest::Client,
         base_url: &'a str,
@@ -383,6 +436,24 @@ mod tests {
         assert_eq!(outcome.reply, "stream fallback");
         let state = state.lock().await;
         assert_eq!(state.calls, 1);
+    }
+
+    #[tokio::test]
+    async fn ordinary_responses_stream_finishes_on_completed_without_http_eof() {
+        let base_url = spawn_never_closing_completed_response().await;
+        let client = reqwest::Client::new();
+        let messages = [ChatMessage::user("hi")];
+        let req = stream_req(&client, &base_url, &messages);
+
+        let outcome = tokio::time::timeout(
+            Duration::from_millis(300),
+            openai_responses_stream_chat(&req),
+        )
+        .await
+        .expect("ordinary Responses stream must finish from response.completed")
+        .unwrap();
+
+        assert_eq!(outcome.reply, "prompt completion");
     }
 
     #[tokio::test]

--- a/qq-maid-llm/src/provider/openai/stream.rs
+++ b/qq-maid-llm/src/provider/openai/stream.rs
@@ -10,6 +10,21 @@ use crate::{error::LlmError, metrics::MetricsRecorder, sse::SseFrame};
 
 use super::extract::extract_completed_response;
 
+/// Responses 流只有在 `response.completed` 携带完整 response 时才能安全定稿。
+///
+/// `[DONE]` 在部分兼容网关中可能先于 `response.completed` 到达，因此它本身不能
+/// 证明 function call 参数已经完整；调用方应继续等待完整 completed response。
+pub(crate) fn responses_stream_is_complete(
+    saw_completed: bool,
+    completed_response: &Option<Value>,
+) -> bool {
+    saw_completed && completed_response.is_some()
+}
+
+pub(crate) fn is_openai_responses_done_sentinel(data: &str) -> bool {
+    data.trim() == "[DONE]"
+}
+
 /// 处理 OpenAI Responses SSE 事件。
 pub(crate) fn handle_openai_chat_stream_event(
     event: SseFrame,

--- a/qq-maid-llm/src/provider/openai/tool_loop.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop.rs
@@ -6,6 +6,8 @@
 //! 维护自己的循环。具体业务能力由上层 crate 通过 `ToolRegistry` 注册，
 //! 避免 LLM crate 反向依赖 Core。
 
+use std::collections::HashSet;
+
 use serde_json::{Value, json};
 
 use crate::{
@@ -17,7 +19,7 @@ use crate::{
     error::LlmError,
     metrics::MetricsRecorder,
     provider::types::{ChatMessage, ReasoningEffort},
-    sse::{parse_sse_frame, take_sse_frame},
+    sse::{SseFrame, parse_sse_frame, take_sse_frame},
     tool::{ToolMetadata, ToolRegistry},
 };
 
@@ -25,7 +27,10 @@ use super::{
     extract::{extract_response_output_text, extract_response_usage},
     payload::{openai_model_supports_reasoning, openai_responses_message},
     responses::{incomplete_stream_eof_error, stream_transport_error},
-    stream::handle_openai_chat_stream_event,
+    stream::{
+        handle_openai_chat_stream_event, is_openai_responses_done_sentinel,
+        responses_stream_is_complete,
+    },
     transport::send_openai_responses_request,
 };
 
@@ -214,14 +219,52 @@ async fn collect_responses_tool_loop_stream(
     let mut buffered_deltas = Vec::new();
     let mut completed_response = None;
     let mut saw_completed = false;
+    let mut active_function_calls = HashSet::new();
+    let mut completed_output_items = Vec::new();
     loop {
         while let Some(frame) = take_sse_frame(&mut frame_buffer) {
             let Some(event) = parse_sse_frame(&frame)? else {
                 continue;
             };
-            if event.data.trim() == "[DONE]" {
+            if is_openai_responses_done_sentinel(&event.data) {
+                if responses_stream_is_complete(saw_completed, &completed_response) {
+                    return finalize_responses_tool_loop_stream(
+                        input,
+                        allow_tool_calls,
+                        text_delta_sink,
+                        answer,
+                        buffered_deltas,
+                        completed_response,
+                        saw_completed,
+                    )
+                    .await;
+                }
+                if active_function_calls.is_empty()
+                    && (!completed_output_items.is_empty() || !answer.trim().is_empty())
+                {
+                    completed_response = Some(json!({
+                        "output_text": answer.clone(),
+                        "output": completed_output_items.clone(),
+                    }));
+                    saw_completed = true;
+                    return finalize_responses_tool_loop_stream(
+                        input,
+                        allow_tool_calls,
+                        text_delta_sink,
+                        answer,
+                        buffered_deltas,
+                        completed_response,
+                        saw_completed,
+                    )
+                    .await;
+                }
                 continue;
             }
+            observe_responses_function_call_event(
+                &event,
+                &mut active_function_calls,
+                &mut completed_output_items,
+            )?;
             recorder.mark_event();
             match handle_openai_chat_stream_event(
                 event,
@@ -233,6 +276,18 @@ async fn collect_responses_tool_loop_stream(
                 Some(delta) if allow_tool_calls => buffered_deltas.push(delta),
                 Some(delta) => text_delta_sink(delta).await?,
                 None => {}
+            }
+            if responses_stream_is_complete(saw_completed, &completed_response) {
+                return finalize_responses_tool_loop_stream(
+                    input,
+                    allow_tool_calls,
+                    text_delta_sink,
+                    answer,
+                    buffered_deltas,
+                    completed_response,
+                    saw_completed,
+                )
+                .await;
             }
         }
 
@@ -264,7 +319,7 @@ async fn collect_responses_tool_loop_stream(
             )
             .await;
         };
-        if event.data.trim() != "[DONE]" {
+        if !is_openai_responses_done_sentinel(&event.data) {
             recorder.mark_event();
             match handle_openai_chat_stream_event(
                 event,
@@ -290,6 +345,55 @@ async fn collect_responses_tool_loop_stream(
         saw_completed,
     )
     .await
+}
+
+fn observe_responses_function_call_event(
+    event: &SseFrame,
+    active_function_calls: &mut HashSet<u64>,
+    completed_output_items: &mut Vec<Value>,
+) -> Result<(), LlmError> {
+    let value = serde_json::from_str::<Value>(&event.data).map_err(|err| {
+        LlmError::provider(
+            format!("invalid OpenAI tool loop stream JSON: {err}"),
+            "sse",
+        )
+    })?;
+    let event_type = event
+        .event
+        .as_deref()
+        .or_else(|| value.get("type").and_then(Value::as_str))
+        .unwrap_or("");
+    let output_index = value.get("output_index").and_then(Value::as_u64);
+    match event_type {
+        "response.output_item.added" => {
+            if value
+                .get("item")
+                .and_then(|item| item.get("type"))
+                .and_then(Value::as_str)
+                == Some("function_call")
+                && let Some(index) = output_index
+            {
+                active_function_calls.insert(index);
+            }
+        }
+        "response.function_call_arguments.delta" => {
+            if let Some(index) = output_index {
+                active_function_calls.insert(index);
+            }
+        }
+        "response.output_item.done" => {
+            if let Some(item) = value.get("item")
+                && item.get("type").and_then(Value::as_str) == Some("function_call")
+            {
+                completed_output_items.push(item.clone());
+                if let Some(index) = output_index {
+                    active_function_calls.remove(&index);
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 async fn finalize_responses_tool_loop_stream(
@@ -494,11 +598,22 @@ mod tests {
     use crate::agent_loop::{AgentTextDeltaFuture, run_agent_loop};
     use crate::tool::{Tool, ToolCallDependency, ToolContext, ToolOutput};
     use async_trait::async_trait;
-    use axum::{Json, Router, extract::State, routing::post};
+    use axum::{
+        Json, Router,
+        body::{Body, Bytes},
+        extract::State,
+        http::{Response, header},
+        routing::post,
+    };
+    use futures::{StreamExt, stream};
     use serde_json::json;
-    use std::sync::{
-        Arc, Mutex as StdMutex,
-        atomic::{AtomicUsize, Ordering},
+    use std::{
+        convert::Infallible,
+        sync::{
+            Arc, Mutex as StdMutex,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::Duration,
     };
     use tokio::{net::TcpListener, sync::Mutex};
 
@@ -942,6 +1057,53 @@ mod tests {
         (format!("http://{addr}/v1"), state)
     }
 
+    async fn completed_stream_that_never_closes() -> Response<Body> {
+        let completed = Bytes::from_static(
+            b"event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"output_text\":\"direct answer\",\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"direct answer\"}]}]}}\n\n",
+        );
+        let body = Body::from_stream(
+            stream::once(async move { Ok::<Bytes, Infallible>(completed) })
+                .chain(stream::pending()),
+        );
+        Response::builder()
+            .header(header::CONTENT_TYPE, "text/event-stream")
+            .body(body)
+            .unwrap()
+    }
+
+    async fn done_stream_that_never_closes() -> Response<Body> {
+        let frames = Bytes::from_static(
+            b"event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"done answer\"}\n\ndata: [DONE]\n\n",
+        );
+        let body = Body::from_stream(
+            stream::once(async move { Ok::<Bytes, Infallible>(frames) }).chain(stream::pending()),
+        );
+        Response::builder()
+            .header(header::CONTENT_TYPE, "text/event-stream")
+            .body(body)
+            .unwrap()
+    }
+
+    async fn spawn_never_closing_completed_stream() -> String {
+        let app = Router::new().route("/v1/responses", post(completed_stream_that_never_closes));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}/v1")
+    }
+
+    async fn spawn_never_closing_done_stream() -> String {
+        let app = Router::new().route("/v1/responses", post(done_stream_that_never_closes));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}/v1")
+    }
+
     async fn spawn_multi_tool_mock() -> (String, Arc<Mutex<ToolLoopMockState>>) {
         let state = Arc::new(Mutex::new(ToolLoopMockState {
             requests: Vec::new(),
@@ -1113,6 +1275,103 @@ mod tests {
                     .as_str()
                     .is_some_and(|output| output.contains("\"weather\":\"小雨\""))
         }));
+    }
+
+    #[tokio::test]
+    async fn agent_stream_finishes_on_completed_without_waiting_for_http_eof() {
+        let base_url = spawn_never_closing_completed_stream().await;
+        let registry = ToolRegistry::new().register(WeatherToolStub).unwrap();
+        let mut session = ResponsesAgentSession::new(
+            reqwest::Client::new(),
+            "test-key".to_owned(),
+            Some(base_url),
+            "openai",
+            "gpt-test".to_owned(),
+            10 * 1024 * 1024,
+            1200,
+            None,
+            &[ChatMessage::user("小女仆测试一下")],
+            &registry,
+            None,
+        )
+        .unwrap();
+        let deltas = Arc::new(StdMutex::new(Vec::new()));
+
+        let step = tokio::time::timeout(
+            Duration::from_millis(300),
+            session.advance_streaming(&[], true, recording_delta_sink(deltas.clone())),
+        )
+        .await
+        .expect("agent step must finish from response.completed without EOF")
+        .unwrap()
+        .unwrap();
+
+        let AgentStep::FinalAnswer { reply, .. } = step else {
+            panic!("expected direct final answer");
+        };
+        assert_eq!(reply, "direct answer");
+        assert_eq!(*deltas.lock().unwrap(), vec!["direct answer".to_owned()]);
+    }
+
+    #[tokio::test]
+    async fn agent_stream_finishes_on_done_without_waiting_for_http_eof() {
+        let base_url = spawn_never_closing_done_stream().await;
+        let registry = ToolRegistry::new().register(WeatherToolStub).unwrap();
+        let mut session = ResponsesAgentSession::new(
+            reqwest::Client::new(),
+            "test-key".to_owned(),
+            Some(base_url),
+            "openai",
+            "gpt-test".to_owned(),
+            10 * 1024 * 1024,
+            1200,
+            None,
+            &[ChatMessage::user("小女仆测试一下")],
+            &registry,
+            None,
+        )
+        .unwrap();
+
+        let step = tokio::time::timeout(
+            Duration::from_millis(300),
+            session.advance_streaming(
+                &[],
+                true,
+                recording_delta_sink(Arc::new(StdMutex::new(Vec::new()))),
+            ),
+        )
+        .await
+        .expect("agent step must finish from [DONE] without EOF")
+        .unwrap()
+        .unwrap();
+
+        let AgentStep::FinalAnswer { reply, .. } = step else {
+            panic!("expected direct final answer");
+        };
+        assert_eq!(reply, "done answer");
+    }
+
+    #[test]
+    fn done_does_not_complete_an_unfinished_function_call() {
+        let mut active = HashSet::new();
+        let mut completed = Vec::new();
+        observe_responses_function_call_event(
+            &SseFrame {
+                event: Some("response.function_call_arguments.delta".to_owned()),
+                data: json!({
+                    "type": "response.function_call_arguments.delta",
+                    "output_index": 0,
+                    "delta": "{\"city\":"
+                })
+                .to_string(),
+            },
+            &mut active,
+            &mut completed,
+        )
+        .unwrap();
+
+        assert_eq!(active, HashSet::from([0]));
+        assert!(completed.is_empty());
     }
 
     #[tokio::test]

--- a/qq-maid-llm/src/provider/status.rs
+++ b/qq-maid-llm/src/provider/status.rs
@@ -293,6 +293,7 @@ async fn next_observed_stream_event(
                 fallback_used: state.fallback_used,
                 executed_tools: Vec::new(),
                 tool_results: Vec::new(),
+                agent: Default::default(),
             };
             state.status.record_success(&outcome);
             if let Some(attempt) = state.attempt.take() {
@@ -472,6 +473,7 @@ mod tests {
             fallback_used: true,
             executed_tools: Vec::new(),
             tool_results: Vec::new(),
+            agent: Default::default(),
         });
 
         let snapshot = status.snapshot();
@@ -499,6 +501,7 @@ mod tests {
             fallback_used: false,
             executed_tools: Vec::new(),
             tool_results: Vec::new(),
+            agent: Default::default(),
         });
         let success_at = status.snapshot().last_success_at;
 
@@ -628,6 +631,7 @@ mod tests {
             fallback_used: true,
             executed_tools: Vec::new(),
             tool_results: Vec::new(),
+            agent: Default::default(),
         });
         let provider = observe_provider(Arc::new(PendingProvider), status.clone());
         let request = ChatRequest {

--- a/qq-maid-llm/src/provider/tests.rs
+++ b/qq-maid-llm/src/provider/tests.rs
@@ -193,6 +193,7 @@ fn outcome(reply: &str) -> ChatOutcome {
         fallback_used: false,
         executed_tools: Vec::new(),
         tool_results: Vec::new(),
+        agent: Default::default(),
     }
 }
 

--- a/qq-maid-llm/src/provider/tool_loop.rs
+++ b/qq-maid-llm/src/provider/tool_loop.rs
@@ -20,6 +20,8 @@ pub(crate) struct ToolLoopExecutor<'a> {
     executed_tools: Vec<String>,
     tool_results: Vec<ToolExecutionResult>,
     progress_sink: Option<ToolLoopProgressSink>,
+    execution_attempted: bool,
+    rejected_call: bool,
 }
 
 pub(crate) struct ToolLoopCall<'a> {
@@ -49,6 +51,8 @@ impl<'a> ToolLoopExecutor<'a> {
             executed_tools: Vec::new(),
             tool_results: Vec::new(),
             progress_sink,
+            execution_attempted: false,
+            rejected_call: false,
         }
     }
 
@@ -57,11 +61,12 @@ impl<'a> ToolLoopExecutor<'a> {
     }
 
     pub(crate) fn prepare_call(
-        &self,
+        &mut self,
         call: ToolLoopCall<'_>,
         round: usize,
         index: usize,
     ) -> PreparedToolLoopCall {
+        self.execution_attempted = true;
         let mut context = self.base_context.clone();
         context.tool_call_id = Some(stable_tool_call_id(
             &context.task_id,
@@ -81,11 +86,6 @@ impl<'a> ToolLoopExecutor<'a> {
         let (tool_name, output, succeeded) = match call.prepared {
             Ok(prepared) => {
                 let tool_name = prepared.name.clone();
-                self.executed_tools.push(tool_name.clone());
-                self.emit_progress(ToolLoopProgressEvent::ToolCallStarted {
-                    tool_name: tool_name.clone(),
-                })
-                .await?;
                 if prepared.dependency == ToolCallDependency::PreviousCallSuccess
                     && !self.previous_call_succeeded
                 {
@@ -95,6 +95,11 @@ impl<'a> ToolLoopExecutor<'a> {
                         false,
                     )
                 } else {
+                    self.emit_progress(ToolLoopProgressEvent::ToolCallStarted {
+                        tool_name: tool_name.clone(),
+                    })
+                    .await?;
+                    self.executed_tools.push(tool_name.clone());
                     match self.tools.execute_prepared(prepared).await {
                         Ok(output) => {
                             let succeeded = tool_output_indicates_success(&output);
@@ -105,6 +110,7 @@ impl<'a> ToolLoopExecutor<'a> {
                 }
             }
             Err(err) => {
+                self.rejected_call = true;
                 self.emit_progress(ToolLoopProgressEvent::ToolCallFailed {
                     tool_name: "unknown".to_owned(),
                 })
@@ -136,6 +142,14 @@ impl<'a> ToolLoopExecutor<'a> {
 
     pub(crate) fn tool_results(&self) -> Vec<ToolExecutionResult> {
         self.tool_results.clone()
+    }
+
+    pub(crate) fn execution_attempted(&self) -> bool {
+        self.execution_attempted
+    }
+
+    pub(crate) fn rejected_call(&self) -> bool {
+        self.rejected_call
     }
 
     async fn emit_progress(&self, event: ToolLoopProgressEvent) -> Result<(), LlmError> {


### PR DESCRIPTION
## 关联 Issue

关联 #400。本 PR 是普通消息原生 Tool Agent Runtime 的第一阶段，不关闭该 Issue。

## 改动内容

- 将通过场景、Provider 能力、群聊开关和工具白名单约束的普通纯文本消息统一规划为 `AgentChat`。
- 模型在同一次原生 Tool Calling 响应中自行决定直接回答、请求澄清或发出 Tool Call，不再由关键词分类决定模型能否看到工具。
- 保留 slash、pending、固定 Web Search、确定性 Todo 查询、多模态降级等现有边界。
- 保持 Agent 直答和工具完成后的最终回答流式输出，使用 `ProgressThenStream` 和确认后的最终文本 delta。
- 将旧的 `CompleteToolLoop`、`ToolAgent` 和 `ToolLoopStarted/Running/Finalizing` 收敛为 `AgentChat`、`AgentStarted/Running/Finalizing`；真实工具执行事件仍使用 `ToolCallStarted/Finished/Failed`。
- diagnostics 区分工具能力是否可用、模型是否实际调用工具、实际执行工具和本轮结果：
  - `tool_calling_available`
  - `tool_calling_used`
  - `agent_result`
  - `agent_executed_tools`
- 同步更新 Agent Chat、Tool 二开和响应事件流文档。

## 行为影响

- `你好`、闲聊、解释和创作请求在工具能力可用时进入 Agent Chat，但模型可以直接流式回答，工具执行次数为 0。
- Todo、Weather、Train、RSS 等请求仍由模型原生 Tool Call 驱动，并继续经过服务端白名单、身份、scope、参数校验和 domain 后处理。
- 群聊 Tool Calling 未开启、Provider 不支持 Tool Calling、工具白名单为空或请求包含非文本输入时，继续使用普通聊天兼容路径。
- 普通直答使用模型思考状态提示，不显示默认工具处理提示。

## 验证

- `cargo test -p qq-maid-core --lib`：787 passed
- `cargo test -p qq-maid-gateway-rs --lib`：356 passed
- `cargo check -p qq-maid-core -p qq-maid-gateway-rs --all-features`
- `cargo clippy -p qq-maid-core -p qq-maid-gateway-rs --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

新增流式回归测试验证普通 Agent 直答按顺序输出多个 `TextDelta`，只发生一次 Agent 模型请求且没有实际工具调用。

## 后续工作

#400 中的通用 `AgentRunResult`、明确 stop reason、超时/取消结果建模及进一步减少旧语义分类代码留待后续小步 PR。
