### PR TITLE
[codex] 修复 Agent 流式回退与状态提示

### DIFF
--- a/qq-maid-core/src/runtime/respond/agent_route.rs
+++ b/qq-maid-core/src/runtime/respond/agent_route.rs
@@ -100,6 +100,10 @@ impl AgentRouteDecision {
         matches!(self.route, RespondRoute::AgentChat)
     }
 
+    pub(super) const fn should_emit_eager_status(self) -> bool {
+        matches!(self.semantic_route, SemanticRoute::ToolIntent)
+    }
+
     pub(super) fn domains(self) -> Vec<&'static str> {
         if matches!(self.domain, ToolDomain::Unknown) {
             Vec::new()

--- a/qq-maid-core/src/runtime/respond/mod.rs
+++ b/qq-maid-core/src/runtime/respond/mod.rs
@@ -220,6 +220,15 @@ impl PlannedRespond {
             .and_then(|decision| decision.status_hint)
             .unwrap_or_else(StatusHint::model)
     }
+
+    /// 只有路由层识别出明确工具状态提示时才提前展示 Agent 进度。
+    /// 普通聊天仍进入 AgentChat，但应等真实工具事件后再展示处理状态。
+    pub(crate) fn should_emit_eager_agent_status(self) -> bool {
+        matches!(self.plan, RespondPlan::AgentChat)
+            && self
+                .respond_route
+                .is_some_and(agent_route::AgentRouteDecision::should_emit_eager_status)
+    }
 }
 
 impl PartialEq<RespondPlan> for PlannedRespond {

--- a/qq-maid-core/src/service/streaming.rs
+++ b/qq-maid-core/src/service/streaming.rs
@@ -231,21 +231,29 @@ async fn run_agent_chat_respond(
     progress_status: ProgressStatusConfig,
     provider_stream_enabled: bool,
 ) -> Result<RespondResponse, LlmError> {
-    send_core_status(
-        &tx,
-        &cancelled,
-        CoreResponseStatusKind::AgentStarted,
-        status_hint_text(
-            progress_status.audience,
-            progress_status.hint,
-            StatusPhase::Started,
-            &progress_status.display_name,
-        ),
-    )
-    .await?;
+    let eager_agent_status = planned.should_emit_eager_agent_status();
+    if eager_agent_status {
+        send_core_status(
+            &tx,
+            &cancelled,
+            CoreResponseStatusKind::AgentStarted,
+            status_hint_text(
+                progress_status.audience,
+                progress_status.hint,
+                StatusPhase::Started,
+                &progress_status.display_name,
+            ),
+        )
+        .await?;
+    }
 
-    let progress_sink =
-        tool_loop_progress_sink(tx.clone(), cancelled.clone(), progress_status.clone());
+    let tool_activity_started = Arc::new(AtomicBool::new(false));
+    let progress_sink = tool_loop_progress_sink(
+        tx.clone(),
+        cancelled.clone(),
+        progress_status.clone(),
+        tool_activity_started.clone(),
+    );
     let finalizing_status_sent = Arc::new(AtomicBool::new(false));
     let final_delta_sink = if provider_stream_enabled {
         Some(agent_final_delta_sink(
@@ -253,6 +261,8 @@ async fn run_agent_chat_respond(
             cancelled.clone(),
             progress_status.clone(),
             finalizing_status_sent.clone(),
+            eager_agent_status,
+            tool_activity_started.clone(),
         ))
     } else {
         None
@@ -265,7 +275,7 @@ async fn run_agent_chat_respond(
     let response = loop {
         tokio::select! {
             result = &mut respond_future => break result?,
-            _ = tokio::time::sleep(AGENT_RUNNING_STATUS_DELAY), if !running_status_sent => {
+            _ = tokio::time::sleep(AGENT_RUNNING_STATUS_DELAY), if eager_agent_status && !running_status_sent => {
                 running_status_sent = true;
                 send_core_status(
                     &tx,
@@ -282,8 +292,15 @@ async fn run_agent_chat_respond(
         }
     };
 
-    send_agent_finalizing_status_once(&tx, &cancelled, &progress_status, &finalizing_status_sent)
-        .await?;
+    send_agent_finalizing_status_once(
+        &tx,
+        &cancelled,
+        &progress_status,
+        &finalizing_status_sent,
+        eager_agent_status,
+        &tool_activity_started,
+    )
+    .await?;
 
     debug!(
         respond_plan = respond_plan_name(RespondPlan::AgentChat),
@@ -305,7 +322,12 @@ async fn send_agent_finalizing_status_once(
     cancelled: &Arc<AtomicBool>,
     progress_status: &ProgressStatusConfig,
     finalizing_status_sent: &Arc<AtomicBool>,
+    eager_agent_status: bool,
+    tool_activity_started: &Arc<AtomicBool>,
 ) -> Result<(), LlmError> {
+    if !eager_agent_status && !tool_activity_started.load(Ordering::SeqCst) {
+        return Ok(());
+    }
     if finalizing_status_sent
         .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
         .is_err()
@@ -331,18 +353,23 @@ fn agent_final_delta_sink(
     cancelled: Arc<AtomicBool>,
     progress_status: ProgressStatusConfig,
     finalizing_status_sent: Arc<AtomicBool>,
+    eager_agent_status: bool,
+    tool_activity_started: Arc<AtomicBool>,
 ) -> AgentTextDeltaSink {
     Arc::new(move |delta| {
         let tx = tx.clone();
         let cancelled = cancelled.clone();
         let progress_status = progress_status.clone();
         let finalizing_status_sent = finalizing_status_sent.clone();
+        let tool_activity_started = tool_activity_started.clone();
         Box::pin(async move {
             send_agent_finalizing_status_once(
                 &tx,
                 &cancelled,
                 &progress_status,
                 &finalizing_status_sent,
+                eager_agent_status,
+                &tool_activity_started,
             )
             .await?;
             send_core_delta(&tx, &cancelled, delta).await
@@ -381,12 +408,15 @@ fn tool_loop_progress_sink(
     tx: mpsc::Sender<CoreResponseEvent>,
     cancelled: Arc<AtomicBool>,
     progress_status: ProgressStatusConfig,
+    tool_activity_started: Arc<AtomicBool>,
 ) -> ToolLoopProgressSink {
     std::sync::Arc::new(move |event| {
         let tx = tx.clone();
         let cancelled = cancelled.clone();
         let progress_status = progress_status.clone();
+        let tool_activity_started = tool_activity_started.clone();
         Box::pin(async move {
+            tool_activity_started.store(true, Ordering::SeqCst);
             let (kind, phase) = match event {
                 ToolLoopProgressEvent::ToolCallStarted { .. } => (
                     CoreResponseStatusKind::ToolCallStarted,

--- a/qq-maid-core/src/service/tests/mod.rs
+++ b/qq-maid-core/src/service/tests/mod.rs
@@ -1296,7 +1296,8 @@ async fn core_private_general_chat_agent_direct_answer_streams_text_deltas() {
             fallback_used: false,
         }),
     ])
-    .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+    .without_tool_progress();
     let state = test_state_with_tool_calling(provider.clone(), 5, true);
     let service = CoreHandle::new(state);
 
@@ -1308,19 +1309,21 @@ async fn core_private_general_chat_agent_direct_answer_streams_text_deltas() {
     );
     assert_eq!(stream.output_policy(), CoreOutputPolicy::ProgressThenStream);
 
+    let mut statuses = Vec::new();
     let mut deltas = Vec::new();
     let response = loop {
         let Some(event) = stream.recv().await else {
             panic!("stream ended before completed response");
         };
         match event {
-            CoreResponseEvent::Status(_) => {}
+            CoreResponseEvent::Status(status) => statuses.push(status.kind),
             CoreResponseEvent::TextDelta(delta) => deltas.push(delta),
             CoreResponseEvent::Completed(response) => break response,
             CoreResponseEvent::Failed(failure) => panic!("unexpected failure: {failure:?}"),
         }
     };
 
+    assert!(statuses.is_empty());
     assert_eq!(deltas, vec!["普通".to_owned(), "回复".to_owned()]);
     assert_eq!(response.text_content(), Some("普通回复"));
     let diagnostics = response.diagnostics.as_ref().unwrap();

--- a/qq-maid-core/src/service/tests/support.rs
+++ b/qq-maid-core/src/service/tests/support.rs
@@ -122,6 +122,7 @@ pub(super) struct TestProvider {
     pub(super) tool_calls: Arc<AtomicUsize>,
     tool_protocol: Option<ToolCallingProtocol>,
     stream_enabled: bool,
+    emit_tool_progress: bool,
 }
 
 impl TestProvider {
@@ -152,6 +153,7 @@ impl TestProvider {
             tool_calls: Arc::new(AtomicUsize::new(0)),
             tool_protocol: None,
             stream_enabled: false,
+            emit_tool_progress: true,
         }
     }
 
@@ -162,6 +164,11 @@ impl TestProvider {
 
     pub(super) fn with_tool_protocol(mut self, protocol: ToolCallingProtocol) -> Self {
         self.tool_protocol = Some(protocol);
+        self
+    }
+
+    pub(super) fn without_tool_progress(mut self) -> Self {
+        self.emit_tool_progress = false;
         self
     }
 
@@ -249,7 +256,9 @@ impl LlmProvider for TestProvider {
         self.tool_calls.fetch_add(1, Ordering::SeqCst);
         let progress_sink = req.progress_sink.clone();
         self.requests.lock().unwrap().push(req.chat);
-        if let Some(sink) = progress_sink {
+        if self.emit_tool_progress
+            && let Some(sink) = progress_sink
+        {
             sink(ToolLoopProgressEvent::ToolCallStarted {
                 tool_name: "mock_tool".to_owned(),
             })

--- a/qq-maid-llm/src/agent_loop/mod.rs
+++ b/qq-maid-llm/src/agent_loop/mod.rs
@@ -41,7 +41,7 @@ pub mod session;
 pub mod types;
 
 pub use runner::run_agent_loop;
-pub use session::AgentStepSession;
+pub use session::{AgentStepSession, AgentStreamingDiagnostics};
 pub use types::{
     AgentSessionRequest, AgentStep, AgentTextDeltaFuture, AgentTextDeltaSink, AgentToolCall,
     AgentToolResult, ToolLoopProgressEvent, ToolLoopProgressFuture, ToolLoopProgressSink,

--- a/qq-maid-llm/src/agent_loop/runner.rs
+++ b/qq-maid-llm/src/agent_loop/runner.rs
@@ -11,9 +11,11 @@
 
 use std::sync::{
     Arc,
-    atomic::{AtomicBool, Ordering},
+    atomic::{AtomicBool, AtomicUsize, Ordering},
 };
+use std::time::Instant;
 
+use futures::future::{Either, select};
 use tokio::time::{Duration, timeout};
 use tracing::{debug, warn};
 
@@ -32,7 +34,8 @@ use crate::{
 use super::session::AgentStepSession;
 use super::types::{AgentStep, AgentToolCall, AgentToolResult};
 
-const AGENT_STREAMING_STEP_TIMEOUT: Duration = Duration::from_secs(30);
+// 只限制首个有效流事件；开始出流后由 Core 的整体请求预算接管。
+const AGENT_STREAMING_FIRST_ACTIVITY_TIMEOUT: Duration = Duration::from_secs(30);
 const AGENT_NON_STREAM_STEP_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// 运行统一 Agent Loop。
@@ -82,8 +85,9 @@ pub async fn run_agent_loop(
             &results,
             allow_tool_calls,
             final_delta_sink.clone(),
-            AGENT_STREAMING_STEP_TIMEOUT,
+            AGENT_STREAMING_FIRST_ACTIVITY_TIMEOUT,
             AGENT_NON_STREAM_STEP_TIMEOUT,
+            round,
         )
         .await?;
         fallback_used |= advance.fallback_used;
@@ -156,6 +160,7 @@ pub(super) async fn advance_with_optional_streaming(
     final_delta_sink: Option<AgentTextDeltaSink>,
     streaming_timeout: Duration,
     non_stream_timeout: Duration,
+    round: usize,
 ) -> Result<AgentAdvance, LlmError> {
     let Some(sink) = final_delta_sink else {
         return advance_non_stream_with_timeout(
@@ -172,44 +177,115 @@ pub(super) async fn advance_with_optional_streaming(
     };
     let emitted_visible_delta = Arc::new(AtomicBool::new(false));
     let tracked_sink = track_visible_delta_sink(sink, emitted_visible_delta.clone());
-    let streaming = timeout(
+    let activity_counter = session.streaming_activity_counter();
+    let streaming_started = Instant::now();
+    let streaming = advance_streaming_until_complete_or_first_activity_timeout(
+        session,
+        results,
+        allow_tool_calls,
+        tracked_sink,
+        activity_counter,
         streaming_timeout,
-        session.advance_streaming(results, allow_tool_calls, tracked_sink),
     )
     .await;
+    let streaming_elapsed_ms = streaming_started.elapsed().as_millis();
     match streaming {
-        Ok(Ok(Some(step))) => Ok(AgentAdvance {
+        StreamingAttempt::Completed(Ok(Some(step))) => Ok(AgentAdvance {
             step,
             fallback_used: false,
         }),
-        Ok(Ok(None)) => {
-            advance_non_stream_with_timeout(session, results, allow_tool_calls, non_stream_timeout)
-                .await
-                .map(|step| AgentAdvance {
-                    step,
-                    fallback_used: false,
-                })
+        StreamingAttempt::Completed(Ok(None)) => {
+            fallback_to_non_stream(
+                session,
+                results,
+                allow_tool_calls,
+                non_stream_timeout,
+                round,
+                streaming_elapsed_ms,
+                "advance_streaming_none",
+                None,
+                false,
+            )
+            .await
         }
-        Ok(Err(err)) if !emitted_visible_delta.load(Ordering::SeqCst) => {
-            log_streaming_fallback(session, allow_tool_calls, results, Some(&err));
-            advance_non_stream_with_timeout(session, results, allow_tool_calls, non_stream_timeout)
-                .await
-                .map(|step| AgentAdvance {
-                    step,
-                    fallback_used: true,
-                })
+        StreamingAttempt::Completed(Err(err)) if !emitted_visible_delta.load(Ordering::SeqCst) => {
+            let diagnostics = session.streaming_diagnostics();
+            let fallback_reason = diagnostics
+                .fallback_reason
+                .as_deref()
+                .unwrap_or_else(|| classify_streaming_error(&err));
+            fallback_to_non_stream(
+                session,
+                results,
+                allow_tool_calls,
+                non_stream_timeout,
+                round,
+                streaming_elapsed_ms,
+                fallback_reason,
+                Some(&err),
+                true,
+            )
+            .await
         }
-        Err(_) if !emitted_visible_delta.load(Ordering::SeqCst) => {
-            log_streaming_fallback(session, allow_tool_calls, results, None);
-            advance_non_stream_with_timeout(session, results, allow_tool_calls, non_stream_timeout)
-                .await
-                .map(|step| AgentAdvance {
-                    step,
-                    fallback_used: true,
-                })
+        StreamingAttempt::FirstActivityTimedOut
+            if !emitted_visible_delta.load(Ordering::SeqCst) =>
+        {
+            fallback_to_non_stream(
+                session,
+                results,
+                allow_tool_calls,
+                non_stream_timeout,
+                round,
+                streaming_elapsed_ms,
+                "streaming_step_timeout",
+                None,
+                true,
+            )
+            .await
         }
-        Ok(Err(err)) => Err(err),
-        Err(_) => Err(LlmError::timeout("agent_stream_after_delta")),
+        StreamingAttempt::Completed(Err(err)) => Err(err),
+        StreamingAttempt::FirstActivityTimedOut => {
+            Err(LlmError::timeout("agent_stream_after_delta"))
+        }
+    }
+}
+
+enum StreamingAttempt {
+    Completed(Result<Option<AgentStep>, LlmError>),
+    FirstActivityTimedOut,
+}
+
+async fn advance_streaming_until_complete_or_first_activity_timeout(
+    session: &mut (dyn AgentStepSession + Send),
+    results: &[AgentToolResult],
+    allow_tool_calls: bool,
+    tracked_sink: AgentTextDeltaSink,
+    activity_counter: Option<Arc<AtomicUsize>>,
+    first_activity_timeout: Duration,
+) -> StreamingAttempt {
+    let Some(activity_counter) = activity_counter else {
+        return match timeout(
+            first_activity_timeout,
+            session.advance_streaming(results, allow_tool_calls, tracked_sink),
+        )
+        .await
+        {
+            Ok(result) => StreamingAttempt::Completed(result),
+            Err(_) => StreamingAttempt::FirstActivityTimedOut,
+        };
+    };
+
+    let streaming = Box::pin(session.advance_streaming(results, allow_tool_calls, tracked_sink));
+    let deadline = Box::pin(tokio::time::sleep(first_activity_timeout));
+    match select(streaming, deadline).await {
+        Either::Left((result, _)) => StreamingAttempt::Completed(result),
+        Either::Right((_, streaming)) => {
+            if activity_counter.load(Ordering::SeqCst) > 0 {
+                StreamingAttempt::Completed(streaming.await)
+            } else {
+                StreamingAttempt::FirstActivityTimedOut
+            }
+        }
     }
 }
 
@@ -230,21 +306,56 @@ async fn advance_non_stream_with_timeout(
         .map_err(|_| LlmError::timeout("agent_step"))?
 }
 
-fn log_streaming_fallback(
-    session: &(dyn AgentStepSession + Send),
-    allow_tool_calls: bool,
+#[allow(clippy::too_many_arguments)]
+async fn fallback_to_non_stream(
+    session: &mut (dyn AgentStepSession + Send),
     results: &[AgentToolResult],
+    allow_tool_calls: bool,
+    non_stream_timeout: Duration,
+    round: usize,
+    streaming_elapsed_ms: u128,
+    fallback_reason: &str,
     err: Option<&LlmError>,
-) {
-    debug!(
+    fallback_used: bool,
+) -> Result<AgentAdvance, LlmError> {
+    let diagnostics = session.streaming_diagnostics();
+    let fallback_started = Instant::now();
+    let result =
+        advance_non_stream_with_timeout(session, results, allow_tool_calls, non_stream_timeout)
+            .await;
+    let non_stream_fallback_elapsed_ms = fallback_started.elapsed().as_millis();
+    tracing::info!(
         provider = session.provider(),
         model = %session.model(),
+        round,
         allow_tool_calls,
         follows_tool_results = !results.is_empty(),
-        error_code = err.map(|item| item.code.as_str()).unwrap_or("timeout"),
-        error_stage = err.map(|item| item.stage.as_str()).unwrap_or("agent_step"),
-        "streaming agent advance stopped before visible delta; falling back once to non-stream advance"
+        streaming_elapsed_ms,
+        fallback_reason,
+        error_code = err.map(|item| item.code.as_str()).unwrap_or("none"),
+        error_stage = err.map(|item| item.stage.as_str()).unwrap_or("none"),
+        chunk_count = diagnostics.chunk_count,
+        sse_event_count = diagnostics.sse_event_count,
+        saw_done = diagnostics.saw_done,
+        saw_completed = diagnostics.saw_completed,
+        buffered_delta_count = diagnostics.buffered_delta_count,
+        active_function_call_count = diagnostics.active_function_call_count,
+        non_stream_fallback_elapsed_ms,
+        non_stream_fallback_succeeded = result.is_ok(),
+        "streaming agent fallback completed"
     );
+    result.map(|step| AgentAdvance {
+        step,
+        fallback_used,
+    })
+}
+
+fn classify_streaming_error(err: &LlmError) -> &'static str {
+    if err.code == "http_error" || err.stage == "http" || err.stage == "sse" {
+        "http_sse_parse_error"
+    } else {
+        "provider_error_other"
+    }
 }
 
 fn agent_stop_reason(emitted_tools: &[String], executor: &ToolLoopExecutor<'_>) -> AgentStopReason {

--- a/qq-maid-llm/src/agent_loop/session.rs
+++ b/qq-maid-llm/src/agent_loop/session.rs
@@ -9,9 +9,25 @@
 //! **不应**在此决定最大轮数或 Loop 退出条件——那是 [`run_agent_loop`](super::runner::run_agent_loop)
 //! 的统一职责。这也是 #138 的核心收敛点：不同 Provider 不再各自决定退出条件。
 
+use std::sync::{Arc, atomic::AtomicUsize};
+
 use crate::error::LlmError;
 
 use super::types::{AgentStep, AgentTextDeltaSink, AgentToolResult};
+
+/// 单次 Agent 流式推进的脱敏诊断快照。
+///
+/// 这里只允许保存协议状态与计数，不得保存正文、SSE 原文、工具参数或鉴权信息。
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AgentStreamingDiagnostics {
+    pub fallback_reason: Option<String>,
+    pub chunk_count: usize,
+    pub sse_event_count: usize,
+    pub saw_done: bool,
+    pub saw_completed: bool,
+    pub buffered_delta_count: usize,
+    pub active_function_call_count: usize,
+}
 
 /// Provider 侧单步会话：把各自协议的一次模型请求转换为统一 `AgentStep`。
 #[async_trait::async_trait]
@@ -20,6 +36,15 @@ pub trait AgentStepSession: Send {
     fn provider(&self) -> &str;
     /// 本会话实际使用的模型名（已解析前缀，用于 metrics）。
     fn model(&self) -> &str;
+    /// 返回最近一次流式推进的脱敏协议诊断。
+    fn streaming_diagnostics(&self) -> AgentStreamingDiagnostics {
+        AgentStreamingDiagnostics::default()
+    }
+    /// 可选的流活动计数器。Provider 每收到一个有效协议事件即递增，
+    /// runner 用它区分“首包超时”和“已经开始传输但尚未完成”。
+    fn streaming_activity_counter(&self) -> Option<Arc<AtomicUsize>> {
+        None
+    }
     /// 用上一轮工具执行结果推进一步。
     ///
     /// - `results`：上一轮工具执行结果；首轮为空切片。

--- a/qq-maid-llm/src/agent_loop/tests.rs
+++ b/qq-maid-llm/src/agent_loop/tests.rs
@@ -493,6 +493,26 @@ async fn streaming_advance_error_before_visible_delta_falls_back() {
 }
 
 #[tokio::test]
+async fn unsupported_streaming_advance_falls_back_without_marking_failure() {
+    let mut session = ScriptedSession::new("mock", "m", vec![final_reply("fallback")]);
+
+    let advance = super::runner::advance_with_optional_streaming(
+        &mut session,
+        &[],
+        true,
+        Some(delta_sink(Arc::new(StdMutex::new(Vec::new())))),
+        std::time::Duration::from_millis(50),
+        std::time::Duration::from_millis(50),
+        0,
+    )
+    .await
+    .unwrap();
+
+    assert!(!advance.fallback_used);
+    assert!(matches!(advance.step, AgentStep::FinalAnswer { .. }));
+}
+
+#[tokio::test]
 async fn streaming_advance_error_after_visible_delta_does_not_fallback() {
     let registry = registry_with(vec![Arc::new(CountingTool {
         name: "echo",
@@ -539,6 +559,7 @@ async fn streaming_advance_timeout_before_visible_delta_falls_back_once() {
         Some(delta_sink(Arc::new(StdMutex::new(Vec::new())))),
         std::time::Duration::from_millis(10),
         std::time::Duration::from_millis(50),
+        0,
     )
     .await
     .unwrap();
@@ -567,6 +588,7 @@ async fn streaming_advance_timeout_after_visible_delta_does_not_fallback() {
         Some(delta_sink(deltas.clone())),
         std::time::Duration::from_millis(10),
         std::time::Duration::from_millis(50),
+        0,
     )
     .await
     .unwrap_err();

--- a/qq-maid-llm/src/provider/openai/tool_loop.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop.rs
@@ -6,12 +6,21 @@
 //! 维护自己的循环。具体业务能力由上层 crate 通过 `ToolRegistry` 注册，
 //! 避免 LLM crate 反向依赖 Core。
 
-use std::collections::HashSet;
+use std::{
+    collections::HashSet,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 
 use serde_json::{Value, json};
 
 use crate::{
-    agent_loop::{AgentStep, AgentStepSession, AgentTextDeltaSink, AgentToolCall, AgentToolResult},
+    agent_loop::{
+        AgentStep, AgentStepSession, AgentStreamingDiagnostics, AgentTextDeltaSink, AgentToolCall,
+        AgentToolResult,
+    },
     context_budget::{
         BudgetItemKind, ContextBudgetConfig, ensure_required_budget, estimated_json_chars,
         log_budget_report,
@@ -50,6 +59,8 @@ pub(crate) struct ResponsesAgentSession {
     input: Vec<Value>,
     tool_defs: Vec<Value>,
     context_budget: Option<ContextBudgetConfig>,
+    streaming_diagnostics: Arc<Mutex<AgentStreamingDiagnostics>>,
+    streaming_activity_counter: Arc<AtomicUsize>,
 }
 
 impl ResponsesAgentSession {
@@ -80,6 +91,8 @@ impl ResponsesAgentSession {
             input,
             tool_defs,
             context_budget,
+            streaming_diagnostics: Arc::new(Mutex::new(AgentStreamingDiagnostics::default())),
+            streaming_activity_counter: Arc::new(AtomicUsize::new(0)),
         })
     }
 }
@@ -92,6 +105,17 @@ impl AgentStepSession for ResponsesAgentSession {
 
     fn model(&self) -> &str {
         &self.model
+    }
+
+    fn streaming_diagnostics(&self) -> AgentStreamingDiagnostics {
+        self.streaming_diagnostics
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    fn streaming_activity_counter(&self) -> Option<Arc<AtomicUsize>> {
+        Some(self.streaming_activity_counter.clone())
     }
 
     async fn advance(
@@ -109,6 +133,7 @@ impl AgentStepSession for ResponsesAgentSession {
             self.max_output_tokens,
             self.reasoning_effort,
             allow_tool_calls,
+            false,
         );
         enforce_tool_loop_budget(self.context_budget, &payload)?;
         let response = send_openai_responses_request(
@@ -159,6 +184,11 @@ impl AgentStepSession for ResponsesAgentSession {
         allow_tool_calls: bool,
         text_delta_sink: AgentTextDeltaSink,
     ) -> Result<Option<AgentStep>, LlmError> {
+        replace_streaming_diagnostics(
+            &self.streaming_diagnostics,
+            AgentStreamingDiagnostics::default(),
+        );
+        self.streaming_activity_counter.store(0, Ordering::SeqCst);
         let mut input = self.input.clone();
         append_tool_results(&mut input, results);
         let payload = openai_tool_loop_payload(
@@ -168,6 +198,7 @@ impl AgentStepSession for ResponsesAgentSession {
             self.max_output_tokens,
             self.reasoning_effort,
             allow_tool_calls,
+            true,
         );
         enforce_tool_loop_budget(self.context_budget, &payload)?;
         let response = send_openai_responses_request(
@@ -183,8 +214,14 @@ impl AgentStepSession for ResponsesAgentSession {
             &mut input,
             allow_tool_calls,
             text_delta_sink,
+            self.streaming_diagnostics.clone(),
+            self.streaming_activity_counter.clone(),
         )
-        .await?;
+        .await;
+        if let Err(err) = &step {
+            classify_responses_stream_failure(&self.streaming_diagnostics, err);
+        }
+        let step = step?;
         self.input = input;
         Ok(Some(step))
     }
@@ -212,6 +249,8 @@ async fn collect_responses_tool_loop_stream(
     input: &mut Vec<Value>,
     allow_tool_calls: bool,
     text_delta_sink: AgentTextDeltaSink,
+    diagnostics: Arc<Mutex<AgentStreamingDiagnostics>>,
+    activity_counter: Arc<AtomicUsize>,
 ) -> Result<AgentStep, LlmError> {
     let mut frame_buffer = Vec::new();
     let mut recorder = MetricsRecorder::start();
@@ -223,11 +262,24 @@ async fn collect_responses_tool_loop_stream(
     let mut completed_output_items = Vec::new();
     loop {
         while let Some(frame) = take_sse_frame(&mut frame_buffer) {
-            let Some(event) = parse_sse_frame(&frame)? else {
+            let Some(event) = parse_sse_frame(&frame).map_err(|err| {
+                set_streaming_fallback_reason(&diagnostics, "http_sse_parse_error");
+                err
+            })?
+            else {
                 continue;
             };
+            update_streaming_diagnostics(&diagnostics, |item| item.sse_event_count += 1);
+            activity_counter.fetch_add(1, Ordering::SeqCst);
             if is_openai_responses_done_sentinel(&event.data) {
+                update_streaming_diagnostics(&diagnostics, |item| item.saw_done = true);
                 if responses_stream_is_complete(saw_completed, &completed_response) {
+                    sync_responses_stream_diagnostics(
+                        &diagnostics,
+                        saw_completed,
+                        buffered_deltas.len(),
+                        active_function_calls.len(),
+                    );
                     return finalize_responses_tool_loop_stream(
                         input,
                         allow_tool_calls,
@@ -247,6 +299,12 @@ async fn collect_responses_tool_loop_stream(
                         "output": completed_output_items.clone(),
                     }));
                     saw_completed = true;
+                    sync_responses_stream_diagnostics(
+                        &diagnostics,
+                        saw_completed,
+                        buffered_deltas.len(),
+                        active_function_calls.len(),
+                    );
                     return finalize_responses_tool_loop_stream(
                         input,
                         allow_tool_calls,
@@ -264,7 +322,11 @@ async fn collect_responses_tool_loop_stream(
                 &event,
                 &mut active_function_calls,
                 &mut completed_output_items,
-            )?;
+            )
+            .map_err(|err| {
+                set_streaming_fallback_reason(&diagnostics, "http_sse_parse_error");
+                err
+            })?;
             recorder.mark_event();
             match handle_openai_chat_stream_event(
                 event,
@@ -272,11 +334,23 @@ async fn collect_responses_tool_loop_stream(
                 &mut answer,
                 &mut completed_response,
                 &mut saw_completed,
-            )? {
+            )
+            .map_err(|err| {
+                if err.stage == "sse" && err.message.starts_with("invalid ") {
+                    set_streaming_fallback_reason(&diagnostics, "http_sse_parse_error");
+                }
+                err
+            })? {
                 Some(delta) if allow_tool_calls => buffered_deltas.push(delta),
                 Some(delta) => text_delta_sink(delta).await?,
                 None => {}
             }
+            sync_responses_stream_diagnostics(
+                &diagnostics,
+                saw_completed,
+                buffered_deltas.len(),
+                active_function_calls.len(),
+            );
             if responses_stream_is_complete(saw_completed, &completed_response) {
                 return finalize_responses_tool_loop_stream(
                     input,
@@ -293,10 +367,12 @@ async fn collect_responses_tool_loop_stream(
 
         match response.chunk().await {
             Ok(Some(chunk)) => {
+                update_streaming_diagnostics(&diagnostics, |item| item.chunk_count += 1);
                 frame_buffer.extend_from_slice(&chunk);
             }
             Ok(None) => break,
             Err(err) => {
+                set_streaming_fallback_reason(&diagnostics, "http_sse_parse_error");
                 return Err(stream_transport_error(
                     format!("OpenAI tool loop stream failed: {err}"),
                     &answer,
@@ -306,7 +382,11 @@ async fn collect_responses_tool_loop_stream(
     }
 
     if !frame_buffer.is_empty() {
-        let Some(event) = parse_sse_frame(&frame_buffer)? else {
+        let Some(event) = parse_sse_frame(&frame_buffer).map_err(|err| {
+            set_streaming_fallback_reason(&diagnostics, "http_sse_parse_error");
+            err
+        })?
+        else {
             frame_buffer.clear();
             return finalize_responses_tool_loop_stream(
                 input,
@@ -319,6 +399,11 @@ async fn collect_responses_tool_loop_stream(
             )
             .await;
         };
+        update_streaming_diagnostics(&diagnostics, |item| item.sse_event_count += 1);
+        activity_counter.fetch_add(1, Ordering::SeqCst);
+        if is_openai_responses_done_sentinel(&event.data) {
+            update_streaming_diagnostics(&diagnostics, |item| item.saw_done = true);
+        }
         if !is_openai_responses_done_sentinel(&event.data) {
             recorder.mark_event();
             match handle_openai_chat_stream_event(
@@ -335,6 +420,13 @@ async fn collect_responses_tool_loop_stream(
         }
     }
 
+    sync_responses_stream_diagnostics(
+        &diagnostics,
+        saw_completed,
+        buffered_deltas.len(),
+        active_function_calls.len(),
+    );
+
     finalize_responses_tool_loop_stream(
         input,
         allow_tool_calls,
@@ -345,6 +437,74 @@ async fn collect_responses_tool_loop_stream(
         saw_completed,
     )
     .await
+}
+
+fn update_streaming_diagnostics(
+    diagnostics: &Arc<Mutex<AgentStreamingDiagnostics>>,
+    update: impl FnOnce(&mut AgentStreamingDiagnostics),
+) {
+    let mut diagnostics = diagnostics
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    update(&mut diagnostics);
+}
+
+fn replace_streaming_diagnostics(
+    diagnostics: &Arc<Mutex<AgentStreamingDiagnostics>>,
+    replacement: AgentStreamingDiagnostics,
+) {
+    update_streaming_diagnostics(diagnostics, |item| *item = replacement);
+}
+
+fn set_streaming_fallback_reason(
+    diagnostics: &Arc<Mutex<AgentStreamingDiagnostics>>,
+    fallback_reason: &str,
+) {
+    update_streaming_diagnostics(diagnostics, |item| {
+        if item.fallback_reason.is_none() {
+            item.fallback_reason = Some(fallback_reason.to_owned());
+        }
+    });
+}
+
+fn sync_responses_stream_diagnostics(
+    diagnostics: &Arc<Mutex<AgentStreamingDiagnostics>>,
+    saw_completed: bool,
+    buffered_delta_count: usize,
+    active_function_call_count: usize,
+) {
+    update_streaming_diagnostics(diagnostics, |item| {
+        item.saw_completed = saw_completed;
+        item.buffered_delta_count = buffered_delta_count;
+        item.active_function_call_count = active_function_call_count;
+    });
+}
+
+fn classify_responses_stream_failure(
+    diagnostics: &Arc<Mutex<AgentStreamingDiagnostics>>,
+    err: &LlmError,
+) {
+    update_streaming_diagnostics(diagnostics, |item| {
+        if item.fallback_reason.is_some() {
+            return;
+        }
+        let reason = if item.saw_completed {
+            "completed_response_incomplete"
+        } else if item.saw_done {
+            "done_without_safe_completion"
+        } else if err.message.contains("before response.completed") {
+            if item.sse_event_count == 0 {
+                "sse_early_eof"
+            } else {
+                "missing_response_completed"
+            }
+        } else if err.code == "http_error" || err.stage == "http" {
+            "http_sse_parse_error"
+        } else {
+            "provider_error_other"
+        };
+        item.fallback_reason = Some(reason.to_owned());
+    });
 }
 
 fn observe_responses_function_call_event(
@@ -528,6 +688,7 @@ fn openai_tool_loop_payload(
     max_output_tokens: u64,
     reasoning_effort: Option<ReasoningEffort>,
     allow_tool_calls: bool,
+    stream: bool,
 ) -> Value {
     let mut payload = json!({
         "model": model,
@@ -542,6 +703,9 @@ fn openai_tool_loop_payload(
     }
     if !allow_tool_calls {
         payload["tool_choice"] = json!("none");
+    }
+    if stream {
+        payload["stream"] = json!(true);
     }
     payload
 }
@@ -1196,10 +1360,27 @@ mod tests {
             1200,
             None,
             true,
+            false,
         );
 
         assert_eq!(payload["parallel_tool_calls"], false);
         assert!(payload.get("tool_choice").is_none());
+        assert!(payload.get("stream").is_none());
+    }
+
+    #[test]
+    fn streaming_payload_enables_responses_stream() {
+        let payload = openai_tool_loop_payload(
+            &[json!({"role": "user", "content": "test"})],
+            &[json!({"type": "function", "name": "get_weather"})],
+            "gpt-test",
+            1200,
+            None,
+            true,
+            true,
+        );
+
+        assert_eq!(payload["stream"], true);
     }
 
     #[test]
@@ -1211,6 +1392,7 @@ mod tests {
             1200,
             Some(ReasoningEffort::High),
             true,
+            false,
         );
 
         assert_eq!(payload["reasoning"]["effort"], "high");
@@ -1225,6 +1407,7 @@ mod tests {
             1200,
             Some(ReasoningEffort::High),
             true,
+            false,
         );
 
         assert!(payload.get("reasoning").is_none());
@@ -1311,6 +1494,11 @@ mod tests {
         };
         assert_eq!(reply, "direct answer");
         assert_eq!(*deltas.lock().unwrap(), vec!["direct answer".to_owned()]);
+        let diagnostics = session.streaming_diagnostics();
+        assert!(diagnostics.chunk_count >= 1);
+        assert!(diagnostics.sse_event_count >= 1);
+        assert!(diagnostics.saw_completed);
+        assert!(!diagnostics.saw_done);
     }
 
     #[tokio::test]
@@ -1349,6 +1537,11 @@ mod tests {
             panic!("expected direct final answer");
         };
         assert_eq!(reply, "done answer");
+        let diagnostics = session.streaming_diagnostics();
+        assert!(diagnostics.chunk_count >= 1);
+        assert_eq!(diagnostics.sse_event_count, 2);
+        assert!(diagnostics.saw_done);
+        assert!(diagnostics.saw_completed);
     }
 
     #[test]

--- a/qq-maid-llm/src/provider/openai/tool_loop.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop.rs
@@ -262,9 +262,8 @@ async fn collect_responses_tool_loop_stream(
     let mut completed_output_items = Vec::new();
     loop {
         while let Some(frame) = take_sse_frame(&mut frame_buffer) {
-            let Some(event) = parse_sse_frame(&frame).map_err(|err| {
+            let Some(event) = parse_sse_frame(&frame).inspect_err(|_| {
                 set_streaming_fallback_reason(&diagnostics, "http_sse_parse_error");
-                err
             })?
             else {
                 continue;
@@ -323,9 +322,8 @@ async fn collect_responses_tool_loop_stream(
                 &mut active_function_calls,
                 &mut completed_output_items,
             )
-            .map_err(|err| {
+            .inspect_err(|_| {
                 set_streaming_fallback_reason(&diagnostics, "http_sse_parse_error");
-                err
             })?;
             recorder.mark_event();
             match handle_openai_chat_stream_event(
@@ -335,11 +333,10 @@ async fn collect_responses_tool_loop_stream(
                 &mut completed_response,
                 &mut saw_completed,
             )
-            .map_err(|err| {
+            .inspect_err(|err| {
                 if err.stage == "sse" && err.message.starts_with("invalid ") {
                     set_streaming_fallback_reason(&diagnostics, "http_sse_parse_error");
                 }
-                err
             })? {
                 Some(delta) if allow_tool_calls => buffered_deltas.push(delta),
                 Some(delta) => text_delta_sink(delta).await?,
@@ -382,9 +379,8 @@ async fn collect_responses_tool_loop_stream(
     }
 
     if !frame_buffer.is_empty() {
-        let Some(event) = parse_sse_frame(&frame_buffer).map_err(|err| {
+        let Some(event) = parse_sse_frame(&frame_buffer).inspect_err(|_| {
             set_streaming_fallback_reason(&diagnostics, "http_sse_parse_error");
-            err
         })?
         else {
             frame_buffer.clear();


### PR DESCRIPTION
## 改动说明

- 为 OpenAI Responses Agent Tool Loop 显式启用流式请求，并补充脱敏的流活动诊断。
- 将 Agent 流式超时收敛为“首个有效事件超时”，开始出流后交由 Core 整体请求预算管理。
- 仅在明确工具意图或真实工具活动发生后发送 Agent 进度状态，普通直答不再出现多余状态提示。
- 补充流式回退、诊断状态和普通直答状态行为测试。

## 原因

此前 Tool Loop 流式请求未显式携带 `stream: true`，且单步固定超时可能中断已经开始传输的响应；同时普通 Agent 直答也会提前展示工具处理状态，造成不准确的用户反馈。

## 影响

- Agent 直答保持直接流式输出，不显示虚假的工具进度。
- 流式协议在首个有效事件后不会被单步 30 秒超时截断。
- 流式失败回退日志增加脱敏计数与原因，便于排障，不记录正文、工具参数或鉴权信息。

## 验证

- `cargo fmt --all -- --check`
- `git diff --check`
- `make test-core`
  - `qq-maid-llm`: 214 tests passed
  - `qq-maid-core`: 789 tests passed
  - Common/LLM/Core `cargo check` passed
