### PR TITLE
[codex] 修复 Agent 搜索与工具回执回归

### DIFF
--- a/qq-maid-core/src/runtime/respond/agent_route.rs
+++ b/qq-maid-core/src/runtime/respond/agent_route.rs
@@ -214,10 +214,6 @@ pub(super) fn route_agent_chat(req: &RespondRequest, ctx: AgentRouteContext) -> 
     )
 }
 
-pub(super) fn has_search_intent(text: &str, lower: &str) -> bool {
-    tool_route_domains::has_search_intent(text, lower)
-}
-
 fn decision(
     route: RespondRoute,
     semantic_route: SemanticRoute,
@@ -411,7 +407,10 @@ WebSearch tool timeout
 
         for input in [codex_output, log_output] {
             let lower = input.to_ascii_lowercase();
-            assert!(!has_search_intent(input, &lower), "{input}");
+            assert!(
+                !tool_route_domains::has_search_intent(input, &lower),
+                "{input}"
+            );
             let decision = route_agent_chat(&request(input), context());
             assert_ne!(decision.domain, ToolDomain::Search, "{input}");
             assert_ne!(
@@ -433,7 +432,10 @@ WebSearch tool timeout
             "最新的 Rust 版本是什么",
         ] {
             let lower = input.to_ascii_lowercase();
-            assert!(has_search_intent(input, &lower), "{input}");
+            assert!(
+                tool_route_domains::has_search_intent(input, &lower),
+                "{input}"
+            );
         }
     }
 

--- a/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
@@ -190,9 +190,10 @@ impl RustRespondService {
             status_subject: respond_route.status_hint.map(|hint| hint.subject.as_str()),
             status_action: respond_route.status_hint.map(|hint| hint.action.as_str()),
         };
+        let mut agent_finalization_error = None;
         let (output, agent_turn_outcome, tool_turn_diagnostics) = if use_agent_runtime {
             let tools = self.tool_runtime.registry_for_chat(&policy, &req)?;
-            let output = service
+            let output = match service
                 .respond_with_tools(
                     chat_req,
                     tools,
@@ -201,7 +202,29 @@ impl RustRespondService {
                     final_delta_sink,
                     run_handle,
                 )
-                .await?;
+                .await
+            {
+                Ok(output) => output,
+                Err(err) => {
+                    let Some(output) = self
+                        .tool_runtime
+                        .recover_output_after_agent_failure(&err, &policy.main_model)
+                    else {
+                        return Err(err);
+                    };
+                    tracing::warn!(
+                        error_code = %err.code,
+                        error_stage = %err.stage,
+                        agent_executed_tools = ?err
+                            .agent
+                            .as_deref()
+                            .map(|agent| &agent.executed_tools),
+                        "agent final reply failed after verified tool execution; using domain fallback"
+                    );
+                    agent_finalization_error = Some(err.as_info());
+                    output
+                }
+            };
 
             let mut latest_session = self
                 .session_store
@@ -243,6 +266,7 @@ impl RustRespondService {
 
         let reply = output.reply.clone();
         let executed_tools = output.agent.executed_tools.clone();
+        let used_search = executed_tools.iter().any(|tool| tool == "web_search");
         let tool_call_emitted = !output.agent.emitted_tools.is_empty();
         let tool_execution_attempted = output.agent.tool_execution_attempted;
         let agent_model_rounds = output.agent.model_rounds;
@@ -284,7 +308,7 @@ impl RustRespondService {
             "used_memory": used_memory,
             "used_knowledge": used_knowledge,
             "knowledge_hit_count": knowledge_context.hit_count,
-            "used_search": false,
+            "used_search": used_search,
             "respond_route": respond_route.route.as_str(),
             "route_reason": respond_route.reason,
             "route_domains": respond_route.domains(),
@@ -302,6 +326,15 @@ impl RustRespondService {
             "agent_executed_tools": executed_tools,
             "agent_model_rounds": agent_model_rounds,
             "agent_streaming_fallback_used": agent_streaming_fallback_used,
+            "agent_finalization_fallback_used": agent_finalization_error.is_some(),
+            "agent_finalization_error_code": agent_finalization_error
+                .as_ref()
+                .map(|error| json!(&error.code))
+                .unwrap_or(Value::Null),
+            "agent_finalization_error_stage": agent_finalization_error
+                .as_ref()
+                .map(|error| json!(&error.stage))
+                .unwrap_or(Value::Null),
             "agent_tool_results": agent_tool_results,
             "agent_turn_status": agent_diagnostics["agent_turn_status"].clone(),
             "tool_outcomes": agent_diagnostics["tool_outcomes"].clone(),

--- a/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
@@ -191,8 +191,10 @@ impl RustRespondService {
             status_action: respond_route.status_hint.map(|hint| hint.action.as_str()),
         };
         let mut agent_finalization_error = None;
+        let mut agent_exposed_tools = Vec::new();
         let (output, agent_turn_outcome, tool_turn_diagnostics) = if use_agent_runtime {
-            let tools = self.tool_runtime.registry_for_chat(&policy, &req)?;
+            let (tools, exposed_tools) = self.tool_runtime.registry_for_chat(&policy, &req)?;
+            agent_exposed_tools = exposed_tools;
             let output = match service
                 .respond_with_tools(
                     chat_req,
@@ -321,7 +323,10 @@ impl RustRespondService {
             "stop_reason": agent_result,
             "tool_calling_enabled": use_agent_runtime,
             "agent_mode": if use_agent_runtime { json!("configured_whitelist") } else { Value::Null },
-            "agent_enabled_tools": if use_agent_runtime { json!(&policy.enabled_tools) } else { Value::Null },
+            "agent_configured_tools": if use_agent_runtime { json!(&policy.enabled_tools) } else { Value::Null },
+            "agent_exposed_tools": if use_agent_runtime { json!(&agent_exposed_tools) } else { Value::Null },
+            // 保留旧字段兼容现有 diagnostics 消费方，但语义修正为本轮实际暴露集合。
+            "agent_enabled_tools": if use_agent_runtime { json!(&agent_exposed_tools) } else { Value::Null },
             "agent_policy": policy.diagnostic_summary(),
             "agent_executed_tools": executed_tools,
             "agent_model_rounds": agent_model_rounds,

--- a/qq-maid-core/src/runtime/respond/command_dispatcher.rs
+++ b/qq-maid-core/src/runtime/respond/command_dispatcher.rs
@@ -6,7 +6,7 @@
 use crate::error::LlmError;
 
 use super::{
-    PlannedRespond, RespondPlan, RespondRequest, RespondResponse, RustRespondService,
+    PlannedRespond, RespondRequest, RespondResponse, RustRespondService,
     chat_flow::PreparedChat,
     common::session_error,
     interaction_state::{
@@ -37,7 +37,6 @@ impl<'a> CommandDispatcher<'a> {
         mut req: RespondRequest,
         planned: PlannedRespond,
     ) -> Result<DispatchOutcome, LlmError> {
-        let plan = planned.plan();
         let user_text = req.effective_user_text();
         let meta = respond_meta(&req);
         let interaction_meta = respond_interaction_meta(&req);
@@ -157,16 +156,7 @@ impl<'a> CommandDispatcher<'a> {
             )));
         }
 
-        // 检查是否为联网搜索指令（如 "/查 关键词"）。当 router 已判定为
-        // WebSearch 时，自然语言搜索意图也必须复用同一聚合查询路径。
-        if matches!(plan, RespondPlan::WebSearch) {
-            let command = search_flow::web_search_command_for_plan(&user_text);
-            return Ok(DispatchOutcome::Respond(Box::new(
-                self.service
-                    .handle_web_search_command(command, &req, &mut session)
-                    .await?,
-            )));
-        }
+        // 检查是否为联网搜索指令（如 "/查 关键词"）。
         if let Some(command) = search_flow::parse_web_search_command(&user_text) {
             return Ok(DispatchOutcome::Respond(Box::new(
                 self.service

--- a/qq-maid-core/src/runtime/respond/mod.rs
+++ b/qq-maid-core/src/runtime/respond/mod.rs
@@ -150,11 +150,10 @@ pub(crate) enum RespondPlan {
     CommandEvent,
     StreamingChat,
     AgentChat,
-    /// 显式联网查询路径：`/查` 或明确对机器人发起的搜索意图。
+    /// 显式联网查询路径，仅用于 `/查`、`/查询`、`/search` 等专用入口。
     ///
-    /// 该路径独立于 Agent Chat 路由：群聊只要 @ 机器人并命中搜索意图即触发，
-    /// 不依赖 Tool Loop 开关；查询复用 `/查` 的 `WebSearchTool::query_stream`
-    /// 流式能力，避免长时间非流式阻塞导致超时。
+    /// 普通自然语言搜索请求进入 AgentChat，由模型结合上下文决定是否调用
+    /// `web_search`；显式命令继续复用原有流式查询和错误处理能力。
     WebSearch,
 }
 
@@ -502,11 +501,9 @@ impl RustRespondService {
 
     /// `RespondPlan::WebSearch` 的流式编放入口。
     ///
-    /// 当 plan 已被 router 判定为 WebSearch 时调用：显式 `/查` 走原有
-    /// `handle_web_search_command_stream`；自然语言搜索意图（如“联网查询下今日 ai 新闻”
-    /// ）不再退化成普通聊天，而是合成查询并复用 `WebSearchTool::query_stream`，
-    /// 避免长时间非流式阻塞导致业务超时。会话加载与 pending 优先级沿用 `respond_stream`，
-    /// 不重复各自重建状态机。
+    /// 当显式 `/查` 等命令被 router 判定为 WebSearch 时调用，复用
+    /// `handle_web_search_command_stream` 的查询、流式输出和错误处理。会话加载与
+    /// pending 优先级沿用 `respond_stream`，不重复各自重建状态机。
     pub(crate) async fn respond_web_search_stream<F>(
         &self,
         req: RespondRequest,
@@ -561,7 +558,13 @@ impl RustRespondService {
                 .map_err(session_error)?,
         };
 
-        let command = search_flow::web_search_command_for_plan(&user_text);
+        let command = search_flow::parse_web_search_command(&user_text).ok_or_else(|| {
+            LlmError::new(
+                "web_search_command_missing",
+                "web search plan requires an explicit search command",
+                "router",
+            )
+        })?;
         self.handle_web_search_command_stream(command, &req, &mut session, on_delta)
             .await
     }

--- a/qq-maid-core/src/runtime/respond/mod.rs
+++ b/qq-maid-core/src/runtime/respond/mod.rs
@@ -4,7 +4,7 @@
 //! 发来的 `RespondRequest`，根据请求类型和会话状态将其分派到对应的子处理
 //! 模块（聊天、翻译、待办、记忆、天气、搜索、会话管理），最终返回 `RespondResponse`。
 
-use std::{future::Future, pin::Pin};
+use std::{future::Future, pin::Pin, time::Duration};
 
 use qq_maid_llm::{
     agent_loop::ToolLoopProgressSink, context_budget::ContextBudgetConfig,
@@ -134,6 +134,8 @@ pub struct RespondServiceOptions {
     pub context_budget: ContextBudgetConfig,
     /// 单项 Tool 输出最大字符数，单独注入 ToolRegistry，不混入上下文预算。
     pub tool_result_max_chars: usize,
+    /// Agent `web_search` 等待首个非空搜索增量的超时。
+    pub web_search_first_activity_timeout: Duration,
     /// 私聊状态提示使用的前台称呼。
     pub status_display_name: String,
     /// 统一 Agent 场景策略。
@@ -320,6 +322,7 @@ impl RustRespondService {
             options.rss_summary_max_chars,
             options.rss_seen_retention,
             options.tool_result_max_chars,
+            options.web_search_first_activity_timeout,
         );
         Self {
             provider,

--- a/qq-maid-core/src/runtime/respond/router.rs
+++ b/qq-maid-core/src/runtime/respond/router.rs
@@ -77,16 +77,6 @@ impl<'a> RespondRouter<'a> {
             ));
         }
 
-        // 在进入 Agent Chat 路由前，先拦截“明确对机器人发起的搜索意图”。
-        // 群聊未 @ 机器人时 Gateway 已在入站阶段过滤，Core 侧不再二次判定；
-        // 但为安全起见，群聊仍要求存在 directed_to_bot 信号才自动联网查询，
-        // 避免出现“查/搜索”等词就触发。私聊天然视为明确发起。
-        if agent_route::has_search_intent(trimmed, &trimmed.to_ascii_lowercase())
-            && directed_to_bot(req)
-        {
-            return Ok(PlannedRespond::web_search());
-        }
-
         // 先保护已有确定性命令和自然语言 Todo 查询，避免简单列表查询绕过
         // `handle_todo_flow()` 进入模型 Tool Loop，回归同义词和默认过滤语义。
         let classification = classify_inbound_with_active(
@@ -225,26 +215,6 @@ impl RustRespondService {
     ) -> Result<CoreInboundClassification, LlmError> {
         RespondRouter::new(self).classify_inbound(req)
     }
-}
-
-/// 判断消息是否明确对机器人发起，用于普通聊天搜索意图是否进入 WebSearch。
-///
-/// 复用 Gateway 已归一化的 `message_context.mentions[].is_self` 信号，不重复解析
-/// 群聊 @ 文本。群聊只有存在 @ 当前机器人的 mention 才算明确发起；私聊天然为真。
-/// Gateway 入站过滤已保证群聊无 @ 机器人消息不会进入 Core respond，本判断主要作为
-/// Core 内部安全边界，避免直接构造 `RespondRequest` 的调用方误触发联网查询。
-fn directed_to_bot(req: &RespondRequest) -> bool {
-    let is_group = req
-        .group_id
-        .as_deref()
-        .is_some_and(|value| !value.trim().is_empty());
-    if !is_group {
-        return true;
-    }
-    req.message_context
-        .as_ref()
-        .map(|context| context.mentions.iter().any(|mention| mention.is_self))
-        .unwrap_or(false)
 }
 
 fn is_event_wrapped_command(text: &str) -> bool {

--- a/qq-maid-core/src/runtime/respond/search_flow.rs
+++ b/qq-maid-core/src/runtime/respond/search_flow.rs
@@ -295,16 +295,6 @@ pub(super) fn parse_web_search_command(text: &str) -> Option<ParsedCommand> {
     parse_compact_web_search_command(text)
 }
 
-/// 在 router 已判定 `RespondPlan::WebSearch` 后，将输入统一转换为 web_search 命令。
-/// 显式 `/查` 保留原命令；自然语言搜索意图用原话作为 query 复用同一查询流程。
-pub(super) fn web_search_command_for_plan(text: &str) -> ParsedCommand {
-    parse_web_search_command(text).unwrap_or_else(|| ParsedCommand {
-        action: "web_search".to_owned(),
-        argument: text.trim().to_owned(),
-        raw_command: "查".to_owned(),
-    })
-}
-
 fn web_search_raw_question(command_text: &str, req: &RespondRequest) -> String {
     let Some(quoted_context) = quoted_search_context(req) else {
         return command_text.to_owned();

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -1,9 +1,13 @@
-use std::{fs, sync::Arc};
+use std::fs;
 
 use qq_maid_llm::provider::{ToolCallingProtocol, ToolExecutionResult, types::ChatRole};
 use serde_json::Value;
 
-use crate::runtime::respond::{PlannedRespond, RespondPlan};
+use crate::runtime::respond::{
+    PlannedRespond, RespondPlan,
+    agent_route::{RespondRoute, SemanticRoute, ToolDomain},
+    status_hint::{StatusAction, StatusHint, StatusSubject},
+};
 
 use super::{
     super::{
@@ -644,14 +648,28 @@ async fn group_tool_loop_exposes_rss_management_but_not_todo_when_enabled() {
 }
 
 #[tokio::test]
-async fn private_search_intent_routes_to_web_search_plan() {
-    let service = test_service_with_provider_and_tool_calling(MockProvider::new(), true);
+async fn private_natural_search_intent_routes_to_agent_chat_with_search_semantics() {
+    let provider = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(provider, true);
 
-    // 普通聊天命中搜索意图且明确对机器人发起（私聊天然为真）时，
-    // 不再进入 Tool Loop，而是走显式 WebSearch 流式路径。
-    for input in ["联网查询下今日 ai 新闻", "查一下今天 AI 新闻"] {
-        let plan = service.plan_core_respond(&private_message(input)).unwrap();
-        assert_eq!(plan, RespondPlan::WebSearch, "{input}");
+    for input in ["联网查一下", "联网查询下今日 ai 新闻", "查一下今天 AI 新闻"]
+    {
+        let planned = service.plan_core_respond(&private_message(input)).unwrap();
+        assert_eq!(planned, RespondPlan::AgentChat, "{input}");
+
+        let decision = planned.respond_route().unwrap();
+        assert_eq!(decision.route, RespondRoute::AgentChat, "{input}");
+        assert_eq!(
+            decision.semantic_route,
+            SemanticRoute::ToolIntent,
+            "{input}"
+        );
+        assert_eq!(decision.domain, ToolDomain::Search, "{input}");
+        assert_eq!(
+            decision.status_hint,
+            Some(StatusHint::new(StatusSubject::Tool, StatusAction::Query)),
+            "{input}"
+        );
     }
 }
 
@@ -670,49 +688,11 @@ Codex 分析结果：
 }
 
 #[tokio::test]
-async fn private_search_intent_web_search_stream_reuses_query_stream() {
-    let deltas = Arc::new(std::sync::Mutex::new(Vec::new()));
-    let collected = deltas.clone();
-    let service = test_service_with_provider_and_tool_calling(MockProvider::new(), true);
-
-    let response = service
-        .respond_web_search_stream(
-            private_message("联网查询下今日 ai 新闻"),
-            move |delta| {
-                let collected = collected.clone();
-                Box::pin(async move {
-                    collected.lock().unwrap().push(delta);
-                    Ok(())
-                })
-            },
-        )
-        .await
-        .unwrap();
-
-    // 复用 `/查` 的流式查询：先发 “正在联网查询中…” 进度，再发结果。
-    let received = deltas.lock().unwrap().clone();
-    assert!(
-        received
-            .first()
-            .is_some_and(|delta| delta.contains("正在联网查询中"))
-    );
-    assert!(
-        received
-            .iter()
-            .any(|delta| delta.contains("联网查询下今日 ai 新闻"))
-    );
-    let text = response.text.as_deref().unwrap();
-    assert!(text.starts_with("【联网查询】"));
-    assert!(text.contains("联网查询下今日 ai 新闻"));
-    assert_eq!(response.command.as_deref(), Some("web_search"));
-}
-
-#[tokio::test]
 async fn private_explicit_search_command_routes_to_web_search_plan() {
     let service = test_service_with_provider_and_tool_calling(MockProvider::new(), true);
 
     let plan = service
-        .plan_core_respond(&private_message("/查 今日 ai 新闻"))
+        .plan_core_respond(&private_message("/查 台风巴威"))
         .unwrap();
     assert_eq!(plan, RespondPlan::WebSearch);
 }

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -128,6 +128,7 @@ async fn private_general_chat_with_tool_capability_uses_agent_direct_answer() {
     assert_eq!(diagnostics["tool_calling_enabled"], serde_json::json!(true));
     assert_eq!(diagnostics["tool_calling_available"], true);
     assert_eq!(diagnostics["tool_calling_used"], false);
+    assert_eq!(diagnostics["used_search"], false);
     assert_eq!(diagnostics["agent_result"], "direct_answer");
     assert_eq!(diagnostics["agent_executed_tools"], serde_json::json!([]));
     assert_eq!(diagnostics["agent_model_rounds"], 1);
@@ -138,14 +139,14 @@ async fn private_general_chat_with_tool_capability_uses_agent_direct_answer() {
 }
 
 #[tokio::test]
-async fn rejected_tool_call_is_not_reported_as_direct_answer() {
+async fn rejected_web_search_call_is_not_reported_as_used_search() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
-        .with_rejected_tool_call("unknown_tool", "这个工具不可用。");
+        .with_rejected_tool_call("web_search", "搜索参数无效。");
     let service = test_service_with_provider_and_tool_calling(inspector, true);
 
     let response = service
-        .respond(private_message("尝试一个不存在的工具"))
+        .respond(private_message("尝试联网搜索"))
         .await
         .unwrap();
 
@@ -153,6 +154,7 @@ async fn rejected_tool_call_is_not_reported_as_direct_answer() {
     assert_eq!(diagnostics["tool_calling_available"], true);
     assert_eq!(diagnostics["tool_call_emitted"], true);
     assert_eq!(diagnostics["tool_execution_attempted"], true);
+    assert_eq!(diagnostics["used_search"], false);
     assert_eq!(diagnostics["agent_executed_tools"], serde_json::json!([]));
     assert_eq!(diagnostics["agent_result"], "rejected");
     assert_eq!(diagnostics["stop_reason"], "rejected");
@@ -781,7 +783,7 @@ async fn last_reference_rejects_owner_mismatch_and_missing_todo() {
         .unwrap();
 
     service
-        .respond(private_message("杭州今天要带伞吗"))
+        .respond(private_message("恢复刚才完成的待办"))
         .await
         .unwrap();
     let tool_request = inspector.tool_requests().remove(0);
@@ -2483,6 +2485,89 @@ async fn todo_internal_list_before_write_is_not_user_visible_query() {
     assert_eq!(snapshot.query_type, "list");
     assert_eq!(snapshot.result_ids.len(), 1);
     assert_eq!(inspector.tool_call_count(), 1);
+}
+
+#[tokio::test]
+async fn todo_write_result_is_returned_when_final_agent_round_fails() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_calls_then_error(
+            vec![(
+                "complete_todos",
+                r#"{"numbers":[1],"selection_text":null,"reference":null}"#,
+            )],
+            crate::error::LlmError::new(
+                "context_budget_exceeded",
+                "tool loop context budget exceeded",
+                "tool_loop",
+            ),
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let todo = service
+        .task_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "确认线上回执".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                reminder_at: None,
+                time_precision: TodoTimePrecision::None,
+                recurrence_kind: crate::runtime::tools::todo::TodoRecurrenceKind::None,
+                recurrence_interval_days: 0,
+                recurrence_interval: 0,
+                recurrence_unit: crate::runtime::tools::todo::TodoRecurrenceUnit::Day,
+            },
+        )
+        .unwrap();
+
+    service.respond(private_message("/todo")).await.unwrap();
+    let response = service
+        .respond(private_message("完成第一条待办"))
+        .await
+        .unwrap();
+
+    assert!(response.ok);
+    assert!(
+        response
+            .text
+            .as_deref()
+            .is_some_and(|text| text.contains("✅ 已完成待办") && text.contains("确认线上回执"))
+    );
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["agent_finalization_fallback_used"], true);
+    assert_eq!(
+        diagnostics["agent_finalization_error_code"],
+        "context_budget_exceeded"
+    );
+    assert_eq!(
+        diagnostics["agent_executed_tools"],
+        serde_json::json!(["complete_todos"])
+    );
+    assert_eq!(inspector.tool_call_count(), 1);
+    assert!(service.task_store.list_pending(&owner).unwrap().is_empty());
+    assert_eq!(
+        service
+            .task_store
+            .list_completed(&owner)
+            .unwrap()
+            .into_iter()
+            .map(|item| item.id)
+            .collect::<Vec<_>>(),
+        vec![todo.id]
+    );
+
+    let exposed_tools = inspector.tool_requests()[0]
+        .tools
+        .metadata()
+        .into_iter()
+        .map(|tool| tool.name)
+        .collect::<Vec<_>>();
+    assert!(exposed_tools.contains(&"complete_todos".to_owned()));
+    assert!(!exposed_tools.contains(&"restore_todos".to_owned()));
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tests/search.rs
+++ b/qq-maid-core/src/runtime/respond/tests/search.rs
@@ -126,6 +126,7 @@ async fn natural_search_agent_can_call_web_search_without_router_rewrite() {
     assert_eq!(diagnostics["respond_route"], "agent_chat");
     assert_eq!(diagnostics["route_semantic"], "tool_intent");
     assert_eq!(diagnostics["route_domains"], serde_json::json!(["search"]));
+    assert_eq!(diagnostics["used_search"], true);
     assert_eq!(
         diagnostics["agent_executed_tools"],
         serde_json::json!(["web_search"])

--- a/qq-maid-core/src/runtime/respond/tests/search.rs
+++ b/qq-maid-core/src/runtime/respond/tests/search.rs
@@ -5,6 +5,7 @@ use std::sync::{
 
 use async_trait::async_trait;
 use qq_maid_common::input_part::QuotedMessageContext;
+use qq_maid_llm::provider::ToolCallingProtocol;
 use qq_maid_llm::web_search::{
     WebSearchExecutor, WebSearchOutcome, WebSearchRequest, WebSearchSource,
 };
@@ -72,6 +73,63 @@ impl WebSearchExecutor for RecordingWebSearchExecutor {
     fn provider_name(&self) -> &'static str {
         "recording-query"
     }
+}
+
+#[tokio::test]
+async fn natural_search_agent_can_call_web_search_without_router_rewrite() {
+    let provider = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json(
+            "web_search",
+            r#"{"query":"台风巴威","raw_question":"可以联网查一下","max_results":null,"context_size":null}"#,
+            "根据联网结果回答",
+        );
+    let inspector = provider.clone();
+    let executor = RecordingWebSearchExecutor::default();
+    let requests = executor.requests();
+    let (service, _base) =
+        test_service_with_provider_base_title_query_weather_train_models_and_options(
+            provider,
+            None,
+            Arc::new(executor),
+            Arc::new(MockWeatherExecutor::new()),
+            Arc::new(MockTrainExecutor::new()),
+            TestModelOptions {
+                todo_model: None,
+                memory_model: None,
+                compact_model: None,
+                translation_model: None,
+            },
+            TestToolCallingOptions {
+                enabled: true,
+                group_enabled: false,
+                group_enabled_tools: None,
+            },
+        );
+
+    let response = service
+        .respond(private_message("可以联网查一下"))
+        .await
+        .unwrap();
+
+    assert!(response.text.as_deref().is_some_and(
+        |text| text.contains("web answer: 台风巴威") && text.contains("根据联网结果回答")
+    ));
+    let requests = requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].query, "台风巴威");
+    assert!(inspector.requests().iter().all(|request| {
+        request.metadata.get("purpose").map(String::as_str) != Some("search_query_rewrite")
+    }));
+
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["respond_route"], "agent_chat");
+    assert_eq!(diagnostics["route_semantic"], "tool_intent");
+    assert_eq!(diagnostics["route_domains"], serde_json::json!(["search"]));
+    assert_eq!(
+        diagnostics["agent_executed_tools"],
+        serde_json::json!(["web_search"])
+    );
 }
 
 fn recording_search_outcome(query: &str, provider: &str) -> WebSearchOutcome {

--- a/qq-maid-core/src/runtime/respond/tests/support.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support.rs
@@ -106,6 +106,10 @@ enum MockToolAction {
         calls: Vec<(String, String)>,
         reply: String,
     },
+    ExecuteToolsThenFail {
+        calls: Vec<(String, String)>,
+        error: LlmError,
+    },
     ReturnToolResults {
         results: Vec<ToolExecutionResult>,
         reply: String,
@@ -297,6 +301,24 @@ impl MockProvider {
                     .map(|(name, arguments)| (name.to_owned(), arguments.to_owned()))
                     .collect(),
                 reply: reply.into(),
+            });
+        self
+    }
+
+    pub(super) fn with_tool_calls_then_error(
+        self,
+        calls: Vec<(&str, &str)>,
+        error: LlmError,
+    ) -> Self {
+        self.tool_actions
+            .lock()
+            .unwrap()
+            .push(MockToolAction::ExecuteToolsThenFail {
+                calls: calls
+                    .into_iter()
+                    .map(|(name, arguments)| (name.to_owned(), arguments.to_owned()))
+                    .collect(),
+                error,
             });
         self
     }
@@ -719,6 +741,32 @@ impl LlmProvider for MockProvider {
                         fallback_used: false,
                         agent: agent_tool_trace(emitted_tools, tool_results),
                     });
+                }
+                MockToolAction::ExecuteToolsThenFail { calls, error } => {
+                    let mut executed_tools = Vec::new();
+                    let mut tool_results = Vec::new();
+                    for (name, arguments) in calls {
+                        let output = req
+                            .tools
+                            .execute_json(&req.tool_context, &name, &arguments)
+                            .await?;
+                        let output = serde_json::from_str::<Value>(&output).unwrap_or_else(|_| {
+                            json!({
+                                "raw": output,
+                            })
+                        });
+                        let succeeded = output.get("ok").and_then(Value::as_bool) != Some(false);
+                        executed_tools.push(name.clone());
+                        tool_results.push(qq_maid_llm::provider::ToolExecutionResult {
+                            name,
+                            output,
+                            succeeded,
+                        });
+                    }
+                    let mut diagnostics = agent_tool_trace(executed_tools, tool_results);
+                    diagnostics.model_rounds = 4;
+                    diagnostics.stop_reason = Some(AgentStopReason::Failed);
+                    return Err(error.with_agent(diagnostics));
                 }
                 MockToolAction::ReturnToolResults { results, reply } => {
                     let emitted_tools = results
@@ -2038,6 +2086,9 @@ pub(super) fn test_service_with_provider_base_title_query_weather_train_models_a
                     as usize,
             },
             tool_result_max_chars: crate::config::DEFAULT_AGENT_TOOL_RESULT_CHAR_LIMIT as usize,
+            web_search_first_activity_timeout: std::time::Duration::from_secs(
+                crate::config::DEFAULT_REQUEST_TIMEOUT_SECONDS,
+            ),
             status_display_name: crate::config::DEFAULT_STATUS_DISPLAY_NAME.to_owned(),
             agent_config: {
                 let config = test_agent_config(tool_calling.enabled, tool_calling.group_enabled);

--- a/qq-maid-core/src/runtime/respond/tests/todo_tool_loop.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo_tool_loop.rs
@@ -72,7 +72,7 @@ async fn private_tool_loop_registers_todo_tools_and_keeps_internal_ids_hidden() 
     create_private_todo(&service, "检查机器人日志");
 
     service
-        .respond(private_message("杭州今天要带伞吗"))
+        .respond(private_message("恢复刚才完成的待办"))
         .await
         .unwrap();
     let tool_request = inspector.tool_requests().remove(0);

--- a/qq-maid-core/src/runtime/respond/tests/todo_tool_loop.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo_tool_loop.rs
@@ -2,7 +2,11 @@ use serde_json::json;
 
 use crate::runtime::respond::{RespondRequest, common::empty_respond_request};
 use crate::runtime::session::SessionMeta;
-use crate::runtime::tools::todo::{TodoItemDraft, TodoStatus, TodoTimePrecision};
+use crate::runtime::tools::todo::{
+    TodoItemDraft, TodoStatus, TodoTimePrecision, todo_item_visible_entity_snapshot,
+};
+use crate::service::VisibleEntitySnapshot;
+use qq_maid_common::input_part::QuotedMessageContext;
 use qq_maid_llm::provider::{ToolCallingProtocol, ToolExecutionResult};
 
 use super::support::*;
@@ -64,6 +68,22 @@ fn group_todo_draft(title: &str) -> TodoItemDraft {
     }
 }
 
+fn quoted_todo_reminder_request(
+    text: &str,
+    visible_entity_snapshot: VisibleEntitySnapshot,
+) -> RespondRequest {
+    let mut req = private_message(text);
+    req.quoted = Some(QuotedMessageContext {
+        reference_id: Some("todo-reminder-message-1".to_owned()),
+        lookup_found: true,
+        from_bot: Some(true),
+        text_summary: Some("待办提醒".to_owned()),
+        ..QuotedMessageContext::default()
+    });
+    req.visible_entity_snapshot = Some(visible_entity_snapshot);
+    req
+}
+
 #[tokio::test]
 async fn private_tool_loop_registers_todo_tools_and_keeps_internal_ids_hidden() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
@@ -102,6 +122,166 @@ async fn private_tool_loop_registers_todo_tools_and_keeps_internal_ids_hidden() 
     assert_eq!(last_action.title, "检查机器人日志");
     assert_eq!(last_action.action, "restored");
     assert_eq!(last_action.resulting_status, TodoStatus::Pending);
+}
+
+#[tokio::test]
+async fn quoted_todo_reminder_completion_uses_request_whitelist_and_survives_final_failure() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_calls_then_error(
+            vec![(
+                "complete_todos",
+                r#"{"numbers":[1],"selection_text":null,"reference":null}"#,
+            )],
+            crate::error::LlmError::new(
+                "context_budget_exceeded",
+                "tool loop context budget exceeded",
+                "tool_loop",
+            ),
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = private_todo_owner();
+    let untouched = create_private_todo(&service, "不应被完成的待办");
+    let quoted = create_private_todo(&service, "引用提醒中的待办");
+    let snapshot = todo_item_visible_entity_snapshot(
+        "qq_official",
+        None,
+        "private:u1",
+        &owner,
+        &quoted,
+        Some("todo_reminder"),
+    )
+    .expect("missing quoted reminder snapshot");
+
+    // 不依赖“第一条”等 session 编号，只允许引用快照把工具参数 1 映射到被引用 Todo。
+    let response = service
+        .respond(quoted_todo_reminder_request("完成待办", snapshot))
+        .await
+        .expect("quoted completion registry should be constructed");
+
+    assert!(response.ok);
+    assert!(response.text.as_deref().is_some_and(|text| {
+        text.contains("✅ 已完成待办") && text.contains("引用提醒中的待办")
+    }));
+    let tool_requests = inspector.tool_requests();
+    assert_eq!(tool_requests.len(), 1);
+    let exposed_tools = tool_requests[0]
+        .tools
+        .metadata()
+        .into_iter()
+        .map(|tool| tool.name)
+        .collect::<Vec<_>>();
+    assert!(exposed_tools.contains(&"complete_todos".to_owned()));
+    assert!(!exposed_tools.contains(&"restore_todos".to_owned()));
+
+    let diagnostics = response.diagnostics.expect("missing diagnostics");
+    assert!(
+        diagnostics["agent_configured_tools"]
+            .as_array()
+            .is_some_and(|tools| tools.iter().any(|tool| tool == "restore_todos"))
+    );
+    assert_eq!(
+        diagnostics["agent_exposed_tools"],
+        diagnostics["agent_enabled_tools"]
+    );
+    assert!(
+        !diagnostics["agent_exposed_tools"]
+            .as_array()
+            .expect("agent_exposed_tools should be an array")
+            .iter()
+            .any(|tool| tool == "restore_todos")
+    );
+    assert_eq!(diagnostics["agent_finalization_fallback_used"], true);
+    assert_eq!(
+        diagnostics["agent_finalization_error_code"],
+        "context_budget_exceeded"
+    );
+    assert_eq!(
+        diagnostics["agent_executed_tools"],
+        json!(["complete_todos"])
+    );
+    assert_eq!(inspector.tool_call_count(), 1);
+    assert_eq!(
+        service
+            .task_store
+            .get_by_id(&owner, &quoted.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Completed
+    );
+    assert_eq!(
+        service
+            .task_store
+            .get_by_id(&owner, &untouched.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
+}
+
+#[tokio::test]
+async fn quoted_completed_todo_restore_remains_exposed_and_uses_same_scope() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json(
+            "restore_todos",
+            r#"{"numbers":[1],"selection_text":null,"reference":null}"#,
+            "已恢复引用的待办",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = private_todo_owner();
+    let untouched = create_private_todo(&service, "不应被恢复的待办");
+    let quoted = create_private_todo(&service, "引用的已完成待办");
+    service.task_store.complete(&owner, &untouched.id).unwrap();
+    service.task_store.complete(&owner, &quoted.id).unwrap();
+    let snapshot = todo_item_visible_entity_snapshot(
+        "qq_official",
+        None,
+        "private:u1",
+        &owner,
+        &quoted,
+        Some("todo_reminder"),
+    )
+    .expect("missing quoted completed snapshot");
+
+    let response = service
+        .respond(quoted_todo_reminder_request("恢复这条待办", snapshot))
+        .await
+        .expect("quoted restore registry should be constructed");
+
+    let exposed_tools = inspector.tool_requests()[0]
+        .tools
+        .metadata()
+        .into_iter()
+        .map(|tool| tool.name)
+        .collect::<Vec<_>>();
+    assert!(exposed_tools.contains(&"restore_todos".to_owned()));
+    assert!(
+        response.diagnostics.unwrap()["agent_exposed_tools"]
+            .as_array()
+            .is_some_and(|tools| tools.iter().any(|tool| tool == "restore_todos"))
+    );
+    assert_eq!(
+        service
+            .task_store
+            .get_by_id(&owner, &quoted.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
+    assert_eq!(
+        service
+            .task_store
+            .get_by_id(&owner, &untouched.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Completed
+    );
+    assert_eq!(inspector.tool_call_count(), 1);
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tool_runtime.rs
+++ b/qq-maid-core/src/runtime/respond/tool_runtime.rs
@@ -127,13 +127,16 @@ impl ToolRuntime {
         &self,
         policy: &ResolvedAgentPolicy,
         req: &RespondRequest,
-    ) -> Result<ToolRegistry, LlmError> {
+    ) -> Result<(ToolRegistry, Vec<String>), LlmError> {
         let user_text = req.effective_user_text();
         let tool_names =
             todo::tool_policy::enabled_tool_names_for_request(&policy.enabled_tools, &user_text);
         let mut registry = self.registry.subset(&tool_names)?;
-        self.replace_scoped_tools_from_request(&mut registry, &policy.enabled_tools, req)?;
-        Ok(registry)
+        // subset、请求级 scoped 替换和 diagnostics 必须共享同一份过滤结果，
+        // 避免 scoped 阶段重新尝试替换本轮已禁止暴露的工具。
+        self.replace_scoped_tools_from_request(&mut registry, &tool_names, req)?;
+        let exposed_tools = tool_names.into_iter().map(str::to_owned).collect();
+        Ok((registry, exposed_tools))
     }
 
     pub(crate) fn registry_for_tool_name(&self, tool_name: &str) -> Result<ToolRegistry, LlmError> {
@@ -170,7 +173,7 @@ impl ToolRuntime {
     fn replace_scoped_tools_from_request(
         &self,
         registry: &mut ToolRegistry,
-        enabled_tools: &[String],
+        enabled_tools: &[&str],
         req: &RespondRequest,
     ) -> Result<(), LlmError> {
         let quoted_bot_lookup = req

--- a/qq-maid-core/src/runtime/respond/tool_runtime.rs
+++ b/qq-maid-core/src/runtime/respond/tool_runtime.rs
@@ -3,7 +3,7 @@
 //! 负责构造服务端白名单 ToolRegistry，并按聊天场景裁剪模型可见工具。
 //! Tool 是否成功仍以真实工具执行结果为准，本模块不生成业务成功文案。
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use crate::{
     config::ResolvedAgentPolicy,
@@ -15,7 +15,7 @@ use crate::{
         ManageRecurringReminderTool, MergeTodoTool, RestoreTodoTool, RssManageSubscriptionsTool,
         RssRecentItemsTool, TaskStore, TodoScopedToolInputs, ToolTurnPostprocess,
         TrainScheduleTool, WeatherTool, WebSearchTool, postprocess_tool_turn,
-        replace_scoped_todo_tools_from_visible_snapshot,
+        replace_scoped_todo_tools_from_visible_snapshot, todo,
     },
     storage::notification::NotificationOutboxStore,
 };
@@ -39,6 +39,7 @@ impl ToolRuntime {
         rss_summary_max_chars: usize,
         rss_seen_retention: usize,
         tool_result_max_chars: usize,
+        web_search_first_activity_timeout: Duration,
     ) -> Self {
         let mut registry =
             ToolRegistry::new().with_limits(DEFAULT_TOOL_TIMEOUT, tool_result_max_chars);
@@ -54,7 +55,10 @@ impl ToolRuntime {
                 rss_summary_max_chars,
                 rss_seen_retention,
             )),
-            Arc::new(WebSearchTool::new(executors.query_executor.clone())),
+            Arc::new(
+                WebSearchTool::new(executors.query_executor.clone())
+                    .with_first_activity_timeout(web_search_first_activity_timeout),
+            ),
             Arc::new(ListTodoTool::new(
                 stores.task_store.clone(),
                 stores.session_store.clone(),
@@ -124,11 +128,9 @@ impl ToolRuntime {
         policy: &ResolvedAgentPolicy,
         req: &RespondRequest,
     ) -> Result<ToolRegistry, LlmError> {
-        let tool_names = policy
-            .enabled_tools
-            .iter()
-            .map(String::as_str)
-            .collect::<Vec<_>>();
+        let user_text = req.effective_user_text();
+        let tool_names =
+            todo::tool_policy::enabled_tool_names_for_request(&policy.enabled_tools, &user_text);
         let mut registry = self.registry.subset(&tool_names)?;
         self.replace_scoped_tools_from_request(&mut registry, &policy.enabled_tools, req)?;
         Ok(registry)
@@ -155,6 +157,14 @@ impl ToolRuntime {
             output,
             context,
         )
+    }
+
+    pub(crate) fn recover_output_after_agent_failure(
+        &self,
+        err: &LlmError,
+        model: &str,
+    ) -> Option<RespondOutput> {
+        todo::agent_turn::fallback_output_after_agent_failure(err, model)
     }
 
     fn replace_scoped_tools_from_request(

--- a/qq-maid-core/src/runtime/tools/search.rs
+++ b/qq-maid-core/src/runtime/tools/search.rs
@@ -4,18 +4,18 @@
 //! 服务端白名单 ToolRegistry。`/查` 只作为显式触发入口，仍在 respond/search_flow.rs
 //! 负责参数兼容、session 记录和用户可见错误文案。
 
-use std::{future::Future, pin::Pin};
+use std::{future::Future, pin::Pin, time::Duration};
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
-use tokio::sync::mpsc;
+use tokio::{sync::mpsc, time::timeout};
 
 use qq_maid_llm::{
-    tool::{Tool, ToolContext, ToolMetadata, ToolOutput},
+    tool::{Tool, ToolContext, ToolMetadata, ToolOutput, ToolTimeoutPolicy},
     web_search::{DynWebSearchExecutor, WebSearchOutcome, WebSearchRequest, WebSearchSource},
 };
 
-use crate::error::LlmError;
+use crate::{config::DEFAULT_REQUEST_TIMEOUT_SECONDS, error::LlmError};
 
 pub(crate) const WEB_SEARCH_TOOL_NAME: &str = "web_search";
 pub(crate) const WEB_SEARCH_QUERY_MAX_LENGTH: usize = 200;
@@ -101,11 +101,21 @@ pub struct WebSearchToolRequest {
 #[derive(Clone)]
 pub struct WebSearchTool {
     executor: DynWebSearchExecutor,
+    first_activity_timeout: Duration,
 }
 
 impl WebSearchTool {
     pub fn new(executor: DynWebSearchExecutor) -> Self {
-        Self { executor }
+        Self {
+            executor,
+            first_activity_timeout: Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECONDS),
+        }
+    }
+
+    /// Agent 搜索首个非空增量沿用请求级超时，不使用通用 Tool 的 15 秒绝对超时。
+    pub fn with_first_activity_timeout(mut self, timeout: Duration) -> Self {
+        self.first_activity_timeout = timeout;
+        self
     }
 
     pub async fn query(&self, req: WebSearchToolRequest) -> Result<WebSearchOutcome, LlmError> {
@@ -144,6 +154,46 @@ impl WebSearchTool {
             LlmError::provider(format!("web search stream task failed: {err}"), "internal")
         })?
     }
+
+    async fn query_stream_for_agent(
+        &self,
+        req: WebSearchToolRequest,
+    ) -> Result<WebSearchOutcome, LlmError> {
+        let (delta_tx, mut delta_rx) = mpsc::channel(16);
+        let query = self.query_stream(req, delta_tx);
+        tokio::pin!(query);
+
+        let first_event = timeout(self.first_activity_timeout, async {
+            loop {
+                tokio::select! {
+                    result = &mut query => return Some(result),
+                    delta = delta_rx.recv() => match delta {
+                        Some(delta) if !delta.is_empty() => return None,
+                        Some(_) => {}
+                        None => return Some(query.as_mut().await),
+                    }
+                }
+            }
+        })
+        .await
+        .map_err(|_| LlmError::new("timeout", "web search first activity timed out", "tool"))?;
+        if let Some(result) = first_event {
+            return result;
+        }
+
+        // 首字之后继续排空 SSE 增量，避免发送端背压；搜索 provider 与 Core 的请求级
+        // 超时继续负责最终兜底，不再套通用 Tool 的绝对 15 秒限制。
+        loop {
+            tokio::select! {
+                result = &mut query => return result,
+                delta = delta_rx.recv() => {
+                    if delta.is_none() {
+                        return query.as_mut().await;
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -179,13 +229,19 @@ impl Tool for WebSearchTool {
         }
     }
 
+    fn timeout_policy(&self) -> ToolTimeoutPolicy {
+        ToolTimeoutPolicy::ToolManaged
+    }
+
     async fn execute(
         &self,
         context: ToolContext,
         arguments: Value,
     ) -> Result<ToolOutput, LlmError> {
         let outcome = self
-            .query(request_from_arguments(&context, &arguments)?)
+            // Agent 最终回复仍由模型统一生成，但搜索上游必须复用 `/查` 的 SSE 路径，
+            // 不能因进入 Tool Loop 退化成完整非流请求。
+            .query_stream_for_agent(request_from_arguments(&context, &arguments)?)
             .await?;
         Ok(ToolOutput::json(web_search_tool_output(&outcome)))
     }
@@ -329,17 +385,27 @@ fn web_search_source_json(source: &WebSearchSource) -> Value {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
+    use std::{
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::Duration,
+    };
 
     use async_trait::async_trait;
 
-    use qq_maid_llm::web_search::WebSearchExecutor;
+    use qq_maid_llm::{
+        tool::{DEFAULT_TOOL_OUTPUT_MAX_CHARS, ToolRegistry},
+        web_search::WebSearchExecutor,
+    };
 
     use super::*;
 
     #[derive(Clone, Default)]
     struct MockWebSearchExecutor {
         requests: Arc<Mutex<Vec<WebSearchRequest>>>,
+        stream_calls: Arc<AtomicUsize>,
     }
 
     #[async_trait]
@@ -356,6 +422,17 @@ mod tests {
                 provider: "mock-query".to_owned(),
                 elapsed_ms: 12,
             })
+        }
+
+        async fn query_stream(
+            &self,
+            req: WebSearchRequest,
+            delta_tx: mpsc::Sender<String>,
+        ) -> Result<WebSearchOutcome, LlmError> {
+            self.stream_calls.fetch_add(1, Ordering::SeqCst);
+            let outcome = self.query(req).await?;
+            let _ = delta_tx.send(outcome.answer.clone()).await;
+            Ok(outcome)
         }
 
         fn provider_name(&self) -> &'static str {
@@ -377,6 +454,7 @@ mod tests {
     async fn web_search_tool_reuses_query_executor() {
         let executor = MockWebSearchExecutor::default();
         let requests = executor.requests.clone();
+        let stream_calls = executor.stream_calls.clone();
         let tool = WebSearchTool::new(Arc::new(executor));
 
         let output = tool
@@ -400,8 +478,94 @@ mod tests {
         assert_eq!(requests[0].max_results, Some(3));
         assert_eq!(requests[0].context_size.as_deref(), Some("medium"));
         assert_eq!(requests[0].model_override.as_deref(), Some("gpt-search"));
+        assert_eq!(stream_calls.load(Ordering::SeqCst), 1);
         assert_eq!(output.value["answer"], "answer: Rust 新闻");
         assert_eq!(output.value["sources"][0]["url"], "https://example.com");
+    }
+
+    struct DelayedStreamExecutor {
+        first_delta_delay: Duration,
+        completion_delay: Duration,
+    }
+
+    #[async_trait]
+    impl WebSearchExecutor for DelayedStreamExecutor {
+        async fn query(&self, _req: WebSearchRequest) -> Result<WebSearchOutcome, LlmError> {
+            Err(LlmError::provider(
+                "agent web search must use streaming",
+                "test",
+            ))
+        }
+
+        async fn query_stream(
+            &self,
+            req: WebSearchRequest,
+            delta_tx: mpsc::Sender<String>,
+        ) -> Result<WebSearchOutcome, LlmError> {
+            tokio::time::sleep(self.first_delta_delay).await;
+            let _ = delta_tx.send("首字".to_owned()).await;
+            tokio::time::sleep(self.completion_delay).await;
+            Ok(WebSearchOutcome {
+                answer: format!("answer: {}", req.query),
+                sources: Vec::new(),
+                provider: "delayed-stream".to_owned(),
+                elapsed_ms: 0,
+            })
+        }
+
+        fn provider_name(&self) -> &'static str {
+            "delayed-stream"
+        }
+    }
+
+    fn agent_search_arguments() -> &'static str {
+        r#"{"query":"台风巴威","raw_question":"台风到哪里了","max_results":null,"context_size":null}"#
+    }
+
+    #[tokio::test]
+    async fn agent_web_search_times_out_only_before_first_activity() {
+        let tool = WebSearchTool::new(Arc::new(DelayedStreamExecutor {
+            first_delta_delay: Duration::from_millis(5),
+            completion_delay: Duration::from_millis(30),
+        }))
+        .with_first_activity_timeout(Duration::from_millis(10));
+        let registry = ToolRegistry::new()
+            .with_limits(Duration::from_millis(10), DEFAULT_TOOL_OUTPUT_MAX_CHARS)
+            .register(tool)
+            .unwrap();
+
+        let output = registry
+            .execute_json(
+                &test_context(),
+                WEB_SEARCH_TOOL_NAME,
+                agent_search_arguments(),
+            )
+            .await
+            .unwrap();
+
+        assert!(output.contains("answer: 台风巴威"));
+    }
+
+    #[tokio::test]
+    async fn agent_web_search_rejects_missing_first_activity() {
+        let tool = WebSearchTool::new(Arc::new(DelayedStreamExecutor {
+            first_delta_delay: Duration::from_millis(30),
+            completion_delay: Duration::ZERO,
+        }))
+        .with_first_activity_timeout(Duration::from_millis(10));
+        let registry = ToolRegistry::new().register(tool).unwrap();
+
+        let err = registry
+            .execute_json(
+                &test_context(),
+                WEB_SEARCH_TOOL_NAME,
+                agent_search_arguments(),
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, "timeout");
+        assert_eq!(err.message, "web search first activity timed out");
     }
 
     #[tokio::test]

--- a/qq-maid-core/src/runtime/tools/todo/agent_turn.rs
+++ b/qq-maid-core/src/runtime/tools/todo/agent_turn.rs
@@ -1,6 +1,6 @@
 //! Todo 接入通用 Tool Turn 后处理的 domain adapter。
 
-use qq_maid_llm::provider::ToolExecutionResult;
+use qq_maid_llm::provider::{AgentStopReason, ToolExecutionResult};
 use serde_json::{Map, Value, json};
 
 use crate::{
@@ -106,6 +106,52 @@ pub(crate) fn should_validate_success(context: &ToolTurnContext, output: &Respon
         || (context.semantic_domain == Some("todo")
             && context.status_subject == Some("todo")
             && matches!(context.status_action, Some("write" | "confirm" | "process")))
+}
+
+/// 最终模型轮次失败后，只在 Todo 写工具已有可信结果时构造确定性回执输入。
+///
+/// 这里不重跑工具，也不根据模型文案猜测成功；后续仍由通用 Tool Turn 投影读取
+/// `tool_results`，按真实数据库结果生成用户可见回执。
+pub(crate) fn fallback_output_after_agent_failure(
+    err: &LlmError,
+    model: &str,
+) -> Option<RespondOutput> {
+    let agent = err.agent.as_deref()?;
+    if matches!(
+        agent.stop_reason,
+        Some(AgentStopReason::Cancelled | AgentStopReason::Timeout)
+    ) || !agent.tools_with_unknown_result.is_empty()
+    {
+        return None;
+    }
+    let write_tool_started = agent
+        .executed_tools
+        .iter()
+        .any(|name| todo::success_guard::is_todo_write_tool(name));
+    if !write_tool_started || !todo::success_guard::has_todo_write_tool_result(&agent.tool_results)
+    {
+        return None;
+    }
+
+    let reply = "待办工具已经执行，以下回执来自真实工具结果。".to_owned();
+    Some(RespondOutput {
+        reply: reply.clone(),
+        text: reply.clone(),
+        markdown: None,
+        chat: ChatResponse::ok(
+            reply,
+            LlmMetrics {
+                provider: "rust".to_owned(),
+                model: format!("{model}:todo-tool-result-fallback"),
+                stream: false,
+                ttfe_ms: None,
+                ttft_ms: None,
+                total_latency_ms: 0,
+            },
+            None,
+        ),
+        agent: agent.clone(),
+    })
 }
 
 pub(crate) fn success_not_verified_output(output: RespondOutput) -> RespondOutput {

--- a/qq-maid-core/src/runtime/tools/todo/mod.rs
+++ b/qq-maid-core/src/runtime/tools/todo/mod.rs
@@ -33,6 +33,7 @@ pub(crate) mod status;
 pub(crate) mod storage;
 pub(crate) mod success_guard;
 pub(crate) mod template;
+pub(crate) mod tool_policy;
 pub(crate) mod visible_entity;
 
 mod complete;

--- a/qq-maid-core/src/runtime/tools/todo/tool_policy.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tool_policy.rs
@@ -1,0 +1,81 @@
+//! Todo Tool 的请求级暴露策略。
+//!
+//! 模型只能在用户本轮明确表达对应意图时看到高风险逆向工具，避免模型在完成流程中
+//! 自行“纠错”或回滚已经发生的持久化修改。
+
+const RESTORE_INTENT_MARKERS: &[&str] = &[
+    "恢复",
+    "还原",
+    "改回未完成",
+    "设回未完成",
+    "重新设为未完成",
+    "重新打开",
+    "重新开启",
+    "撤销完成",
+    "撤回完成",
+    "取消完成",
+    "undo",
+];
+
+const NEGATED_RESTORE_MARKERS: &[&str] = &["不恢复", "不要恢复", "别恢复", "无需恢复"];
+
+pub(crate) fn restore_tool_allowed(user_text: &str) -> bool {
+    let normalized = user_text.trim().to_ascii_lowercase();
+    let negated = NEGATED_RESTORE_MARKERS
+        .iter()
+        .any(|marker| normalized.contains(marker));
+    let explicit_marker = RESTORE_INTENT_MARKERS
+        .iter()
+        .any(|marker| normalized.contains(marker));
+    let undo_completion = ["撤销", "撤回", "取消"]
+        .iter()
+        .any(|marker| normalized.contains(marker))
+        && normalized.contains("完成");
+    !negated && (explicit_marker || undo_completion)
+}
+
+pub(crate) fn enabled_tool_names_for_request<'a>(
+    enabled_tools: &'a [String],
+    user_text: &str,
+) -> Vec<&'a str> {
+    let restore_allowed = restore_tool_allowed(user_text);
+    enabled_tools
+        .iter()
+        .filter(|name| name.as_str() != "restore_todos" || restore_allowed)
+        .map(String::as_str)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::restore_tool_allowed;
+
+    #[test]
+    fn restore_tool_requires_explicit_restore_intent() {
+        for text in ["完成待办", "把第一条标记完成", "完成它，然后列出待办"] {
+            assert!(!restore_tool_allowed(text), "{text}");
+        }
+        for text in [
+            "恢复第一条待办",
+            "撤销刚才的完成",
+            "把它改回未完成",
+            "undo last todo",
+        ] {
+            assert!(restore_tool_allowed(text), "{text}");
+        }
+        assert!(!restore_tool_allowed("不要恢复，继续完成第一条"));
+    }
+
+    #[test]
+    fn completion_request_excludes_restore_tool_from_whitelist() {
+        let enabled = vec!["complete_todos".to_owned(), "restore_todos".to_owned()];
+        assert_eq!(
+            super::enabled_tool_names_for_request(&enabled, "完成待办"),
+            ["complete_todos"]
+        );
+        assert_eq!(
+            super::enabled_tool_names_for_request(&enabled, "撤销刚才的完成"),
+            ["complete_todos", "restore_todos"]
+        );
+    }
+}

--- a/qq-maid-core/src/runtime/tools/todo/visible_entity.rs
+++ b/qq-maid-core/src/runtime/tools/todo/visible_entity.rs
@@ -110,7 +110,7 @@ pub(crate) fn todo_selection_scope_from_visible_snapshot(
 
 pub(crate) struct TodoScopedToolInputs<'a> {
     pub registry: &'a mut ToolRegistry,
-    pub enabled_tools: &'a [String],
+    pub enabled_tools: &'a [&'a str],
     pub todo_store: &'a TodoStore,
     pub session_store: &'a crate::runtime::session::SessionStore,
     pub notification_store: &'a NotificationOutboxStore,
@@ -191,13 +191,13 @@ fn todo_single_visible_entity_snapshot(
 
 fn replace_scoped_todo_tools(
     registry: &mut ToolRegistry,
-    enabled_tools: &[String],
+    enabled_tools: &[&str],
     todo_store: &TodoStore,
     session_store: &crate::runtime::session::SessionStore,
     notification_store: &NotificationOutboxStore,
     scope: VisibleEntitySelectionScope,
 ) -> Result<(), LlmError> {
-    let enabled = |name: &str| enabled_tools.iter().any(|tool| tool == name);
+    let enabled = |name: &str| enabled_tools.contains(&name);
     if enabled("get_todo") {
         registry.replace(std::sync::Arc::new(
             GetTodoTool::new(todo_store.clone(), session_store.clone())

--- a/qq-maid-core/src/service/handle.rs
+++ b/qq-maid-core/src/service/handle.rs
@@ -301,6 +301,7 @@ fn respond_options(config: &AppConfig) -> RespondServiceOptions {
         tool_calling_max_rounds: config.tool_calling_max_rounds as usize,
         context_budget: config.context_budget,
         tool_result_max_chars: config.tool_result_max_chars,
+        web_search_first_activity_timeout: Duration::from_secs(config.request_timeout_seconds),
         status_display_name: config.status_display_name.clone(),
         agent_config: config.agent_config.clone(),
     }

--- a/qq-maid-core/src/service/tests/mod.rs
+++ b/qq-maid-core/src/service/tests/mod.rs
@@ -557,22 +557,22 @@ fn core_plan_routes_group_chat_to_tool_loop_when_group_switch_enabled() {
 }
 
 #[test]
-fn core_plan_routes_group_search_intent_to_web_search_when_bot_mentioned() {
-    // 群聊 @机器人 + 搜索意图走显式 WebSearch，即使群聊 Tool Loop 关闭也不依赖该开关。
+fn core_plan_keeps_group_natural_search_on_chat_route_when_agent_disabled() {
+    // 自然语言搜索不再绕过群聊 Agent 开关；关闭时保持普通 StreamingChat。
     let provider =
         TestProvider::replying("群聊回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_group_tool_calling(provider, 5, false, false);
     let service = CoreHandle::new(state).respond_service();
-    let req: RespondRequest = group_request_with_self_mention("联网查询下今日 ai 新闻").into();
+    let req: RespondRequest = group_request("联网查询下今日 ai 新闻").into();
 
     assert_eq!(
         service.plan_core_respond(&req).unwrap(),
-        RespondPlan::WebSearch
+        RespondPlan::StreamingChat
     );
 }
 
 #[test]
-fn core_plan_keeps_group_pasted_text_processing_as_chat_when_bot_mentioned() {
+fn core_plan_keeps_group_pasted_text_processing_as_chat() {
     let provider =
         TestProvider::replying("群聊回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_group_tool_calling(provider, 5, false, false);
@@ -583,26 +583,12 @@ Codex 执行报告：
 - 查询工具返回：查询内容太长
 - agent_route 命中 search 关键词
 帮我整理成 issue";
-    let req: RespondRequest = group_request_with_self_mention(input).into();
+    let req: RespondRequest = group_request(input).into();
 
     assert_eq!(
         service.plan_core_respond(&req).unwrap(),
         RespondPlan::StreamingChat
     );
-}
-
-#[test]
-fn core_plan_does_not_route_group_search_intent_to_web_search_without_bot_mention() {
-    // 群聊未 @机器人时，仅出现“联网查询 / 搜索”等词不应自动触发 WebSearch；
-    // 保留原有路由（这里 Tool Loop 关闭，回落 StreamingChat）。
-    let provider =
-        TestProvider::replying("群聊回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
-    let state = test_state_with_group_tool_calling(provider, 5, false, false);
-    let service = CoreHandle::new(state).respond_service();
-    let req: RespondRequest = group_request("联网查询下今日 ai 新闻").into();
-
-    let plan = service.plan_core_respond(&req).unwrap();
-    assert_ne!(plan, RespondPlan::WebSearch);
 }
 
 #[test]
@@ -926,7 +912,7 @@ async fn wechat_service_chat_completes_without_direct_stream() {
 }
 
 #[tokio::test]
-async fn core_web_search_private_intent_uses_query_when_provider_stream_disabled() {
+async fn core_web_search_private_command_uses_query_when_provider_stream_disabled() {
     let provider = TestProvider::replying("普通聊天不应调用");
     let query_executor = MockWebSearchExecutor::default();
     let state =
@@ -935,7 +921,7 @@ async fn core_web_search_private_intent_uses_query_when_provider_stream_disabled
 
     let mut stream = expect_stream(
         service
-            .respond(private_request("联网查询下今日 ai 新闻"))
+            .respond(private_request("/查 今日 ai 新闻"))
             .await
             .unwrap(),
     );
@@ -952,15 +938,15 @@ async fn core_web_search_private_intent_uses_query_when_provider_stream_disabled
     assert!(
         response
             .text_content()
-            .is_some_and(|text| text.contains("web answer: 联网查询下今日 ai 新闻"))
+            .is_some_and(|text| text.contains("web answer: 今日 ai 新闻"))
     );
     assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
     let requests = query_executor.requests();
     assert_eq!(requests.len(), 1);
-    assert_eq!(requests[0].query, "联网查询下今日 ai 新闻");
+    assert_eq!(requests[0].query, "今日 ai 新闻");
     assert_eq!(
         requests[0].raw_question.as_deref(),
-        Some("/查 联网查询下今日 ai 新闻")
+        Some("/查 今日 ai 新闻")
     );
 }
 
@@ -974,7 +960,7 @@ async fn core_web_search_wechat_sync_path_uses_query() {
 
     let mut stream = expect_stream(
         service
-            .respond(wechat_service_request("联网查询下今日 ai 新闻"))
+            .respond(wechat_service_request("/search 今日 ai 新闻"))
             .await
             .unwrap(),
     );
@@ -991,12 +977,12 @@ async fn core_web_search_wechat_sync_path_uses_query() {
     assert!(
         response
             .text_content()
-            .is_some_and(|text| text.contains("web answer: 联网查询下今日 ai 新闻"))
+            .is_some_and(|text| text.contains("web answer: 今日 ai 新闻"))
     );
     assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
     let requests = query_executor.requests();
     assert_eq!(requests.len(), 1);
-    assert_eq!(requests[0].query, "联网查询下今日 ai 新闻");
+    assert_eq!(requests[0].query, "今日 ai 新闻");
 }
 
 #[tokio::test]
@@ -1006,7 +992,7 @@ async fn core_web_search_query_raw_question_includes_quoted_context() {
     let state =
         test_state_with_query_executor(provider.clone(), 5, Arc::new(query_executor.clone()));
     let service = CoreHandle::new(state);
-    let mut request = private_request("联网查询下这件事的最新进展");
+    let mut request = private_request("/查询 这件事的最新进展");
     request.quoted = Some(QuotedMessageContext {
         lookup_found: true,
         text_summary: Some("Rust 1.90 发布候选版已经开放测试".to_owned()),
@@ -1020,9 +1006,9 @@ async fn core_web_search_query_raw_question_includes_quoted_context() {
     assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
     let requests = query_executor.requests();
     assert_eq!(requests.len(), 1);
-    assert_eq!(requests[0].query, "联网查询下这件事的最新进展");
+    assert_eq!(requests[0].query, "这件事的最新进展");
     let raw_question = requests[0].raw_question.as_deref().unwrap();
-    assert!(raw_question.contains("/查 联网查询下这件事的最新进展"));
+    assert!(raw_question.contains("/查询 这件事的最新进展"));
     assert!(raw_question.contains("引用消息上下文"));
     assert!(raw_question.contains("引用文本：Rust 1.90 发布候选版已经开放测试"));
 }

--- a/qq-maid-core/src/service/tests/support.rs
+++ b/qq-maid-core/src/service/tests/support.rs
@@ -7,9 +7,7 @@ use std::{
     time::Duration,
 };
 
-use qq_maid_common::identity_context::{
-    IdentitySource, MentionConfidence, MentionIdentity, MessageActorContext,
-};
+use qq_maid_common::identity_context::IdentitySource;
 use qq_maid_llm::{
     agent_loop::{
         AgentStep, AgentStepSession, AgentToolCall, AgentToolResult, ToolLoopProgressEvent,
@@ -504,18 +502,6 @@ pub(super) fn group_request(text: &str) -> CoreRequest {
             group_id: "g1".to_owned(),
         },
     }
-}
-
-/// 构造命中 `@当前机器人` mention 的群聊请求，用于验证群聊显式 WebSearch 路径。
-pub(super) fn group_request_with_self_mention(text: &str) -> CoreRequest {
-    let mut request = group_request(text);
-    request.mentions = vec![MentionIdentity {
-        raw_text: Some("@当前机器人".to_owned()),
-        target: MessageActorContext::default(),
-        is_self: true,
-        confidence: MentionConfidence::Event,
-    }];
-    request
 }
 
 pub(super) fn wechat_service_request(text: &str) -> CoreRequest {

--- a/qq-maid-llm/src/provider/openai/chat_tool_loop.rs
+++ b/qq-maid-llm/src/provider/openai/chat_tool_loop.rs
@@ -222,10 +222,16 @@ fn enforce_tool_loop_budget(
     };
     // Chat Completions 的 assistant tool_calls 与对应 tool messages 必须成组保留；
     // 首期只做完整 payload 检查，不静默删除任何工具轮次。
+    // 只估算模型实际可见的 messages 与 tools，排除 stream、model、max_tokens
+    // 等传输控制字段，避免在上下文预算临界点误报超限。
+    let model_context = json!({
+        "messages": payload.get("messages"),
+        "tools": payload.get("tools"),
+    });
     let report = ensure_required_budget(
         config,
         BudgetItemKind::ToolLoopAtomicTurn,
-        estimated_json_chars(payload, "tool_loop")?,
+        estimated_json_chars(&model_context, "tool_loop")?,
         "tool_loop",
     )?;
     log_budget_report("chat_completions_tool_loop", &report);
@@ -1120,6 +1126,39 @@ mod tests {
         assert_eq!(err.code, "context_budget_exceeded");
         assert_eq!(err.stage, "tool_loop");
         assert!(state.lock().await.requests.is_empty());
+    }
+
+    #[test]
+    fn tool_loop_budget_ignores_transport_only_payload_fields() {
+        let messages = vec![json!({"role": "user", "content": "完成待办"})];
+        let tools = vec![json!({
+            "type": "function",
+            "function": {
+                "name": "list_todos",
+                "description": "列出待办",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        })];
+        let payload = chat_completions_tool_loop_payload(
+            &messages,
+            &tools,
+            &"model-name-that-must-not-count".repeat(20),
+            1200,
+            true,
+        );
+        let model_context = json!({"messages": messages, "tools": tools});
+        let model_context_chars = estimated_json_chars(&model_context, "tool_loop").unwrap();
+        assert!(estimated_json_chars(&payload, "tool_loop").unwrap() > model_context_chars);
+
+        enforce_tool_loop_budget(
+            Some(ContextBudgetConfig {
+                context_window_chars: model_context_chars + 20,
+                output_reserve_chars: 20,
+                protected_recent_turns: 0,
+            }),
+            &payload,
+        )
+        .unwrap();
     }
 
     #[tokio::test]

--- a/qq-maid-llm/src/provider/openai/tool_loop.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop.rs
@@ -633,10 +633,16 @@ fn enforce_tool_loop_budget(
     };
     // Responses Tool Loop 首期不拆分、不淘汰已进入循环的结构化轮次；
     // 工具结果增长依靠单项结果上限和 max_rounds 控制，超预算时显式失败。
+    // 只估算模型实际可见的 input 与 tools；model、stream、输出上限等 HTTP
+    // 传输字段不占模型上下文，计入它们会在预算边界产生几十字符的误判。
+    let model_context = json!({
+        "input": payload.get("input"),
+        "tools": payload.get("tools"),
+    });
     let report = ensure_required_budget(
         config,
         BudgetItemKind::ToolLoopAtomicTurn,
-        estimated_json_chars(payload, "tool_loop")?,
+        estimated_json_chars(&model_context, "tool_loop")?,
         "tool_loop",
     )?;
     log_budget_report("responses_tool_loop", &report);
@@ -1602,6 +1608,42 @@ mod tests {
         assert_eq!(err.code, "context_budget_exceeded");
         assert_eq!(err.stage, "tool_loop");
         assert!(state.lock().await.requests.is_empty());
+    }
+
+    #[test]
+    fn tool_loop_budget_ignores_transport_only_payload_fields() {
+        let input = vec![json!({
+            "role": "user",
+            "content": [{"type": "input_text", "text": "完成待办"}],
+        })];
+        let tools = vec![json!({
+            "type": "function",
+            "name": "list_todos",
+            "description": "列出待办",
+            "parameters": {"type": "object", "properties": {}},
+        })];
+        let payload = openai_tool_loop_payload(
+            &input,
+            &tools,
+            &"model-name-that-must-not-count".repeat(20),
+            1200,
+            None,
+            true,
+            true,
+        );
+        let model_context = json!({"input": input, "tools": tools});
+        let model_context_chars = estimated_json_chars(&model_context, "tool_loop").unwrap();
+        assert!(estimated_json_chars(&payload, "tool_loop").unwrap() > model_context_chars);
+
+        enforce_tool_loop_budget(
+            Some(ContextBudgetConfig {
+                context_window_chars: model_context_chars + 20,
+                output_reserve_chars: 20,
+                protected_recent_turns: 0,
+            }),
+            &payload,
+        )
+        .unwrap();
     }
 
     #[tokio::test]

--- a/qq-maid-llm/src/tool.rs
+++ b/qq-maid-llm/src/tool.rs
@@ -18,6 +18,15 @@ pub const MIN_TOOL_OUTPUT_MAX_CHARS: usize = r#"{"truncated":true}"#.len();
 /// 单个 Tool 默认超时时间。
 pub const DEFAULT_TOOL_TIMEOUT: Duration = Duration::from_secs(15);
 
+/// Tool 执行超时策略。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolTimeoutPolicy {
+    /// 沿用 ToolRegistry 的统一绝对超时。
+    RegistryDefault,
+    /// 工具内部自行维护超时边界，注册表不再套第二层绝对超时。
+    ToolManaged,
+}
+
 /// Tool 元数据，直接映射到 OpenAI Responses function tool schema。
 #[derive(Debug, Clone)]
 pub struct ToolMetadata {
@@ -97,6 +106,10 @@ impl ToolPreparation {
 pub trait Tool: Send + Sync {
     /// 返回工具元数据。
     fn metadata(&self) -> ToolMetadata;
+    /// 返回工具执行超时策略。
+    fn timeout_policy(&self) -> ToolTimeoutPolicy {
+        ToolTimeoutPolicy::RegistryDefault
+    }
     /// 执行前的本地预处理。
     ///
     /// 默认直接沿用模型参数；有状态工具可在这里把用户可见编号预绑定成稳定内部 ID，
@@ -274,14 +287,15 @@ impl ToolRegistry {
     }
 
     pub async fn execute_prepared(&self, prepared: PreparedToolCall) -> Result<String, LlmError> {
-        let output = timeout(
-            self.timeout,
-            prepared
-                .tool
-                .execute(prepared.context.clone(), prepared.arguments),
-        )
-        .await
-        .map_err(|_| LlmError::new("timeout", "tool execution timed out", "tool"))??;
+        let execution = prepared
+            .tool
+            .execute(prepared.context.clone(), prepared.arguments);
+        let output = match prepared.tool.timeout_policy() {
+            ToolTimeoutPolicy::RegistryDefault => timeout(self.timeout, execution)
+                .await
+                .map_err(|_| LlmError::new("timeout", "tool execution timed out", "tool"))??,
+            ToolTimeoutPolicy::ToolManaged => execution.await?,
+        };
         let serialized = serde_json::to_string(&output.value).map_err(|err| {
             LlmError::new(
                 "tool_output_error",


### PR DESCRIPTION
## 修改内容

- 自然语言搜索继续进入 AgentChat，由模型决定是否调用白名单 `web_search`；显式 `/查` 路径保持不变。
- AgentChat diagnostics 根据可信 `executed_tools` 设置 `used_search`，仅实际启动 `web_search` 时为 `true`。
- Agent 内 `web_search` 恢复 SSE 查询，按首个非空搜索增量使用请求级超时，不再被通用 Tool 的 15 秒绝对超时提前终止。
- Tool Loop 上下文预算只估算模型可见的 `input/messages + tools`，排除 `stream`、`model`、输出上限等传输字段。
- Todo 写工具已有可信结果但最终模型回复失败时，复用 Todo 领域投影生成确定性回执，不重复执行工具，并记录 finalization fallback diagnostics。
- `restore_todos` 仅在用户明确表达恢复、撤销完成或改回未完成时进入请求级工具白名单，防止完成流程被模型自行回滚。

## 根因

PR 初版将自然语言搜索迁入 Agent Tool Loop 后，`WebSearchTool::execute` 仍调用非流式 `query()`，并继承通用 Tool 的 15 秒绝对超时，导致线上搜索在模型首轮和末轮之间超时。

Todo 故障中的 `42048` 与 `42034` 相差 14 个字符，正好对应流式 payload 的 `"stream":true`。预算器误把 HTTP 传输字段算入模型上下文，导致实际模型可见内容未超限却被本地永久拒绝。最终轮次失败时，已有 Todo 工具结果未进入现有确定性投影，因此用户只看到处理中状态。

`restore_todos` 此前始终暴露在私聊 Agent 白名单中；用户只表达“完成待办”时，模型仍有机会自行选择恢复工具。现在由 Todo 领域请求级策略阻止该路径。

## 行为影响

- 普通 Agent 直接回答、未发出搜索、或搜索仅 emitted 但未执行时，`used_search` 保持 `false`。
- 自然语言搜索实际执行 `web_search` 时，`used_search == true` 且 `agent_executed_tools` 包含 `web_search`。
- 搜索首字到达后继续消费 SSE；HTTP 与 Core 请求级超时仍负责最终兜底。
- Todo 写入后的最终生成失败不会伪造结果，也不会重跑工具；回执完全基于已记录的真实 Tool result。
- 取消、整体超时或结果未知的 Todo 调用不会被兜底改写为成功。

Fixes #418

## 验证

- `cargo fmt --all -- --check`
- `make test-llm`：236 tests passed
- `make test-core`：808 tests passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `git diff --check`
