### PR TITLE
fix: 兼容 Windows Release 安装

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,8 @@ jobs:
         id: rust_changes
         if: github.event_name == 'pull_request'
         run: |
-          if git diff --name-only "origin/${{ github.base_ref }}..." | grep -qE '(\.rs$|^Cargo\.(toml|lock)$|^rust-toolchain|^runtime/|^scripts/|^Makefile)'; then
+          # Shell 脚本由 shell / windows-botctl job 独立验证，不应触发耗时的 Rust 全量检查。
+          if git diff --name-only "origin/${{ github.base_ref }}..." | grep -qE '(\.rs$|^Cargo\.(toml|lock)$|^rust-toolchain|^runtime/|^Makefile)'; then
             echo "has_rust=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_rust=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,37 @@ permissions:
   contents: read
 
 jobs:
+  shell:
+    name: Shell checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Run installer regression tests
+        run: bash scripts/test-qbot-install.sh
+
+      - name: Check shell syntax
+        run: bash -n qbot.sh scripts/*.sh
+
+  windows-botctl:
+    name: Windows botctl smoke test
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Build native Windows smoke executable
+        shell: powershell
+        run: |
+          Add-Type -TypeDefinition (Get-Content scripts/tests/windows-smoke.cs -Raw) -OutputType ConsoleApplication -OutputAssembly "$env:RUNNER_TEMP\qq-maid-bot.exe"
+
+      - name: Exercise start, status, stop, and forced stop
+        shell: bash
+        run: bash scripts/test-windows-botctl.sh "$RUNNER_TEMP/qq-maid-bot.exe"
+
   rust:
     name: Rust checks
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ qq-maid-common / reqwest / serde / tokio
 
 ## 测试与检查
 
-CI 当前在 PR / push 到 `master` 时执行。PR 只在 Rust、Cargo、`runtime/`、`scripts/` 或 `Makefile` 等相关文件变更时运行 Rust 步骤；push 到 `master` 会忽略纯文档路径。Rust 步骤包括：
+CI 当前在 PR / push 到 `master` 时执行。PR 只在 Rust、Cargo、`runtime/` 或 `Makefile` 等相关文件变更时运行 Rust 步骤；Shell 脚本由独立 Shell 检查负责，不触发 Rust 全量检查。push 到 `master` 会忽略纯文档路径。Rust 步骤包括：
 
 ```bash
 cargo fmt --all -- --check

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ vim config/.env
 
 最少需要填写：`QQ_BOT_APP_ID`、`QQ_BOT_APP_SECRET`，以及至少一个 Provider 的 API Key。
 
+Windows 用户也可以在 Git Bash、MSYS2 或 Cygwin 中执行 `bash qbot.sh install`，脚本会自动下载
+`windows-x86_64.zip` 并默认安装到 `$HOME/qq-maid-bot`。原生 Windows 启动方式参见发布包内的
+`windows-startup-example.bat`。WSL 会按 Linux 环境识别并下载对应 Linux Release 包。
+
 ### 路径三：源码构建（需要 Rust 工具链）
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -73,7 +73,13 @@ vim config/.env
 
 Windows 用户也可以在 Git Bash、MSYS2 或 Cygwin 中执行 `bash qbot.sh install`，脚本会自动下载
 `windows-x86_64.zip` 并默认安装到 `$HOME/qq-maid-bot`。原生 Windows 启动方式参见发布包内的
-`windows-startup-example.bat`。WSL 会按 Linux 环境识别并下载对应 Linux Release 包。
+`windows-startup-example.bat`。目前 Release 只发布 Windows x86_64；ARM64 Windows Shell 会在下载前
+明确报错，不依赖未经验证的 x64 模拟能力，可改在 WSL 中安装对应 Linux Release。WSL 始终按 Linux
+环境识别。
+
+Git Bash 通常已包含所需基础命令；缺少依赖时需通过其安装器补齐 `curl`、`unzip` 和 `coreutils`。
+MSYS2 在 `pacman` 可用时会按缺失命令自动安装对应包。Cygwin 不自动调用安装器，需通过
+`setup-x86_64.exe` 安装上述依赖。
 
 ### 路径三：源码构建（需要 Rust 工具链）
 

--- a/qbot.sh
+++ b/qbot.sh
@@ -4,7 +4,14 @@ set -euo pipefail
 # qq-maid-bot 管理脚本
 # 部署: bash /root/qbot.sh deploy
 
-APP_DIR="${QBOT_APP_DIR:-/root/qq-maid-bot}"
+DEFAULT_APP_DIR="/root/qq-maid-bot"
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+        # Git Bash/MSYS2/Cygwin 没有通用的 /root，默认安装到当前 Windows 用户目录。
+        DEFAULT_APP_DIR="${HOME}/qq-maid-bot"
+        ;;
+esac
+APP_DIR="${QBOT_APP_DIR:-${DEFAULT_APP_DIR}}"
 REPO_SLUG="${QBOT_REPO_SLUG:-kuliantnt/qq-maid-bot}"
 RELEASES_URL="https://github.com/${REPO_SLUG}/releases"
 API_LATEST_URL="https://api.github.com/repos/${REPO_SLUG}/releases/latest"
@@ -238,6 +245,9 @@ downloaded_file_is_valid() {
         *.tar.gz)
             gzip -t "${file}" >/dev/null 2>&1
             ;;
+        *.zip)
+            unzip -tq "${file}" >/dev/null 2>&1
+            ;;
         *.sha256)
             grep -Eq '^[[:xdigit:]]{64}[[:space:]]' "${file}"
             ;;
@@ -290,7 +300,13 @@ download_github_file() {
 
 install_deps() {
     local missing=()
-    for cmd in curl tar gzip sha256sum mktemp; do
+    local required=(curl sha256sum mktemp)
+    case "$(uname -s)" in
+        MINGW*|MSYS*|CYGWIN*) required+=(unzip) ;;
+        *) required+=(tar gzip) ;;
+    esac
+
+    for cmd in "${required[@]}"; do
         command -v "${cmd}" >/dev/null 2>&1 || missing+=("${cmd}")
     done
 
@@ -303,7 +319,7 @@ install_deps() {
     elif command -v dnf >/dev/null 2>&1; then
         dnf install -y curl ca-certificates tar gzip coreutils
     else
-        die "请先手动安装: curl ca-certificates tar gzip coreutils"
+        die "请先手动安装缺少的命令: ${missing[*]}"
     fi
 }
 
@@ -315,6 +331,10 @@ detect_target() {
             ;;
         Darwin)
             os="macos"
+            ;;
+        MINGW*|MSYS*|CYGWIN*)
+            # Windows Release 在 Git Bash、MSYS2 和 Cygwin 中统一使用 MSVC x86_64 包。
+            os="windows"
             ;;
         *)
             die "当前系统暂不支持自动匹配 Release 包: $(uname -s)"
@@ -1831,7 +1851,9 @@ download_release() {
     local target="$2"
     local tmp_dir="$3"
     local package="qq-maid-bot-${version}-${target}"
-    local archive="${package}.tar.gz"
+    local archive_format="tar.gz"
+    [[ "${target}" == windows-* ]] && archive_format="zip"
+    local archive="${package}.${archive_format}"
     local raw_url="${RELEASES_URL}/download/${version}/${archive}"
 
     echo "下载 Release: ${version} (${target})" >&2
@@ -1840,8 +1862,12 @@ download_release() {
 
     (
         cd "${tmp_dir}"
-        sha256sum -c "${archive}.sha256" >&2 &&
+        sha256sum -c "${archive}.sha256" >&2
+        if [[ "${archive_format}" == "zip" ]]; then
+            unzip -q "${archive}"
+        else
             tar -xzf "${archive}"
+        fi
     ) || die "Release 包校验或解压失败"
 
     [[ -d "${tmp_dir}/${package}" ]] || die "Release 包解压后目录不存在: ${package}"
@@ -1905,6 +1931,7 @@ copy_release_into_app() {
     else
         mkdir -p "${APP_DIR}"
         copy_file_if_exists "${release_dir}/qq-maid-bot" "${APP_DIR}/qq-maid-bot" 0755
+        copy_file_if_exists "${release_dir}/qq-maid-bot.exe" "${APP_DIR}/qq-maid-bot.exe" 0755
 
         local executable
         for executable in \
@@ -1942,7 +1969,7 @@ copy_release_into_app() {
         echo "已创建配置模板: ${APP_DIR}/config/.env"
     fi
 
-    chmod +x "${APP_DIR}/qq-maid-bot" "${APP_DIR}/botctl.sh" 2>/dev/null || true
+    chmod +x "${APP_DIR}/qq-maid-bot" "${APP_DIR}/qq-maid-bot.exe" "${APP_DIR}/botctl.sh" 2>/dev/null || true
 }
 
 install_or_update() {

--- a/qbot.sh
+++ b/qbot.sh
@@ -313,6 +313,35 @@ install_deps() {
     ((${#missing[@]} == 0)) && return 0
 
     echo "安装依赖: ${missing[*]}"
+    case "$(uname -s)" in
+        MINGW*|MSYS*)
+            if command -v pacman >/dev/null 2>&1; then
+                local packages=()
+                local missing_cmd package
+                for missing_cmd in "${missing[@]}"; do
+                    case "${missing_cmd}" in
+                        curl) package="curl" ;;
+                        unzip) package="unzip" ;;
+                        sha256sum|mktemp) package="coreutils" ;;
+                        *) die "MSYS2 无法自动匹配依赖命令: ${missing_cmd}" ;;
+                    esac
+                    [[ " ${packages[*]} " == *" ${package} "* ]] || packages+=("${package}")
+                done
+                # --needed 避免重复安装已有包；这里只安装缺失命令对应的最小包集合。
+                pacman -S --needed --noconfirm "${packages[@]}"
+                hash -r
+                for missing_cmd in "${missing[@]}"; do
+                    command -v "${missing_cmd}" >/dev/null 2>&1 || die "pacman 执行后仍缺少命令: ${missing_cmd}"
+                done
+                return 0
+            fi
+            die "缺少命令: ${missing[*]}。当前 Shell 未找到 pacman；Git Bash 请通过安装器补齐依赖，MSYS2 请确认 pacman 可用"
+            ;;
+        CYGWIN*)
+            die "缺少命令: ${missing[*]}。Cygwin 请通过 setup-x86_64.exe 安装 curl、unzip 和 coreutils"
+            ;;
+    esac
+
     if command -v apt-get >/dev/null 2>&1; then
         apt-get update -qq
         apt-get install -y curl ca-certificates tar gzip coreutils
@@ -324,7 +353,7 @@ install_deps() {
 }
 
 detect_target() {
-    local os arch
+    local os arch machine
     case "$(uname -s)" in
         Linux)
             os="linux"
@@ -341,7 +370,24 @@ detect_target() {
             ;;
     esac
 
-    case "$(uname -m)" in
+    machine="$(uname -m)"
+    if [[ "${os}" == "windows" ]]; then
+        case "${machine}" in
+            x86_64|amd64)
+                # Release 矩阵目前只发布 Windows x86_64，禁止拼出不存在的 windows-aarch64。
+                echo "windows-x86_64"
+                return 0
+                ;;
+            aarch64|arm64)
+                die "当前不提供 Windows ARM64 Release；请使用 x86_64 Windows Shell，或在 WSL 中安装 Linux Release"
+                ;;
+            *)
+                die "当前 Windows 架构暂不支持自动匹配 Release 包: ${machine}"
+                ;;
+        esac
+    fi
+
+    case "${machine}" in
         x86_64|amd64)
             arch="x86_64"
             ;;
@@ -349,7 +395,7 @@ detect_target() {
             arch="aarch64"
             ;;
         *)
-            die "当前架构暂不支持自动匹配 Release 包: $(uname -m)"
+            die "当前架构暂不支持自动匹配 Release 包: ${machine}"
             ;;
     esac
 
@@ -2037,6 +2083,11 @@ deploy_qbot() {
     echo "已部署到: ${install_path}"
     echo "可直接使用: qbot <command>"
 }
+
+# 允许 Shell 回归测试仅加载函数，不触发命令分发。
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+    return 0
+fi
 
 init_ui
 

--- a/scripts/botctl.sh
+++ b/scripts/botctl.sh
@@ -12,6 +12,10 @@ fi
 RUNTIME_DIR="${QQ_MAID_RUNTIME_DIR:-${DEFAULT_RUNTIME_DIR}}"
 
 DEFAULT_BINARY="${RUNTIME_DIR}/qq-maid-bot"
+if [[ ! -f "${DEFAULT_BINARY}" && -f "${DEFAULT_BINARY}.exe" ]]; then
+    # Windows Release 在 Git Bash/MSYS2/Cygwin 下复用本控制脚本。
+    DEFAULT_BINARY="${DEFAULT_BINARY}.exe"
+fi
 BINARY="${BOT_BINARY:-${DEFAULT_BINARY}}"
 PID_FILE="${BOT_PID_FILE:-${RUNTIME_DIR}/run/qq-maid-bot.pid}"
 LOG_FILE="${BOT_LOG_FILE:-${RUNTIME_DIR}/logs/qq-maid-bot.log}"

--- a/scripts/botctl.sh
+++ b/scripts/botctl.sh
@@ -19,6 +19,7 @@ fi
 BINARY="${BOT_BINARY:-${DEFAULT_BINARY}}"
 PID_FILE="${BOT_PID_FILE:-${RUNTIME_DIR}/run/qq-maid-bot.pid}"
 LOG_FILE="${BOT_LOG_FILE:-${RUNTIME_DIR}/logs/qq-maid-bot.log}"
+STOP_TIMEOUT_SECONDS="${BOT_STOP_TIMEOUT_SECONDS:-10}"
 
 usage() {
     cat <<'EOF'
@@ -39,6 +40,7 @@ Environment overrides:
   BOT_ENV_FILE   Env file to load before starting
   BOT_PID_FILE   PID file path
   BOT_LOG_FILE   Log file path
+  BOT_STOP_TIMEOUT_SECONDS  Seconds before forced stop (default: 10)
   QQ_MAID_RUNTIME_DIR  Runtime directory containing binary/config/logs
   LINES          Number of log lines for logs command
 EOF
@@ -153,6 +155,7 @@ run_foreground() {
 
 stop() {
     local pid
+    [[ "${STOP_TIMEOUT_SECONDS}" =~ ^[0-9]+$ ]] || die "BOT_STOP_TIMEOUT_SECONDS must be a non-negative integer"
     if ! pid="$(read_pid)"; then
         echo "qq-maid-bot is not running"
         rm -f "${PID_FILE}"
@@ -165,16 +168,26 @@ stop() {
         return 0
     fi
 
-    kill "${pid}"
+    kill "${pid}" || die "failed to stop qq-maid-bot, pid=${pid}"
     local waited=0
     while kill -0 "${pid}" 2>/dev/null; do
-        if (( waited >= 10 )); then
-            kill -9 "${pid}" 2>/dev/null || true
+        if (( waited >= STOP_TIMEOUT_SECONDS )); then
+            kill -9 "${pid}" || die "failed to force stop qq-maid-bot, pid=${pid}"
             break
         fi
         sleep 1
         waited=$((waited + 1))
     done
+
+    # Windows 原生进程被 TerminateProcess 后，MSYS 的进程表可能短暂仍可见，等待其完成清理。
+    local force_waited=0
+    while kill -0 "${pid}" 2>/dev/null && (( force_waited < 5 )); do
+        sleep 1
+        force_waited=$((force_waited + 1))
+    done
+    if kill -0 "${pid}" 2>/dev/null; then
+        die "qq-maid-bot is still running after forced stop, pid=${pid}"
+    fi
 
     rm -f "${PID_FILE}"
     echo "qq-maid-bot stopped"

--- a/scripts/test-qbot-install.sh
+++ b/scripts/test-qbot-install.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${REPO_DIR}/qbot.sh"
+
+assert_target() {
+    local system="$1"
+    local fixture_arch="$2"
+    local expected="$3"
+    uname() {
+        [[ "${1:-}" == "-s" ]] && echo "${system}" || echo "${fixture_arch}"
+    }
+    local actual
+    actual="$(detect_target)"
+    [[ "${actual}" == "${expected}" ]] || {
+        echo "target mismatch: ${system}/${machine}: expected ${expected}, got ${actual}" >&2
+        return 1
+    }
+}
+
+assert_target Linux x86_64 linux-x86_64
+assert_target Linux aarch64 linux-aarch64
+assert_target Darwin x86_64 macos-x86_64
+assert_target Darwin arm64 macos-aarch64
+assert_target MINGW64_NT-10.0 x86_64 windows-x86_64
+assert_target MSYS_NT-10.0 x86_64 windows-x86_64
+assert_target CYGWIN_NT-10.0 amd64 windows-x86_64
+
+for system in MINGW64_NT-10.0 MSYS_NT-10.0 CYGWIN_NT-10.0; do
+    uname() {
+        [[ "${1:-}" == "-s" ]] && echo "${system}" || echo arm64
+    }
+    set +e
+    arm_output="$(detect_target 2>&1)"
+    arm_status=$?
+    set -e
+    [[ "${arm_status}" -ne 0 ]]
+    [[ "${arm_output}" == *"当前不提供 Windows ARM64 Release"* ]]
+    [[ "${arm_output}" != *"windows-aarch64"* ]]
+done
+
+# 用本地 fixture 覆盖下载函数，真实执行 SHA-256 校验和 ZIP 解压。
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+fixture="${tmp_dir}/fixture"
+output="${tmp_dir}/output"
+package="qq-maid-bot-v9.9.9-windows-x86_64"
+mkdir -p "${fixture}/${package}" "${output}"
+printf 'fixture\n' > "${fixture}/${package}/qq-maid-bot.exe"
+(
+    cd "${fixture}"
+    zip -qr "${package}.zip" "${package}"
+    sha256sum "${package}.zip" > "${package}.zip.sha256"
+)
+download_github_file() {
+    cp "${fixture}/$3" "$2"
+}
+release_dir="$(download_release v9.9.9 windows-x86_64 "${output}")"
+[[ -f "${release_dir}/qq-maid-bot.exe" ]]
+APP_DIR="${tmp_dir}/installed"
+copy_release_into_app "${release_dir}" v9.9.9
+[[ -f "${APP_DIR}/qq-maid-bot.exe" ]]
+
+# MSYS2 仅为缺失命令调用 pacman，并将 sha256sum/mktemp 去重映射到 coreutils。
+deps_bin="${tmp_dir}/deps-bin"
+pacman_log="${tmp_dir}/pacman.log"
+mkdir -p "${deps_bin}"
+printf '%s\n' '#!/bin/bash' '[[ "${1:-}" == "-s" ]] && echo MSYS_NT-10.0 || echo x86_64' > "${deps_bin}/uname"
+printf '%s\n' \
+    '#!/bin/bash' \
+    'printf "%s\n" "$*" > "${PACMAN_LOG}"' \
+    'bin_dir="${0%/*}"' \
+    'for dependency in curl sha256sum mktemp unzip; do' \
+    '  printf "%s\n" "#!/bin/bash" "exit 0" > "${bin_dir}/${dependency}"' \
+    '  /bin/chmod +x "${bin_dir}/${dependency}"' \
+    'done' > "${deps_bin}/pacman"
+chmod +x "${deps_bin}/uname" "${deps_bin}/pacman"
+PACMAN_LOG="${pacman_log}" PATH="${deps_bin}" /bin/bash -c "source '${REPO_DIR}/qbot.sh'; install_deps"
+pacman_args="$(<"${pacman_log}")"
+[[ "${pacman_args}" == "-S --needed --noconfirm curl coreutils unzip" ]]
+
+echo "qbot installer regression tests passed"

--- a/scripts/test-windows-botctl.sh
+++ b/scripts/test-windows-botctl.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+native_binary="${1:?usage: test-windows-botctl.sh /path/to/qq-maid-bot.exe}"
+repo_dir="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+runtime_dir="$(mktemp -d)"
+trap '[[ -f "${runtime_dir}/run/qq-maid-bot.pid" ]] && QQ_MAID_RUNTIME_DIR="${runtime_dir}" bash "${runtime_dir}/botctl.sh" stop >/dev/null 2>&1 || true; rm -rf "${runtime_dir}"' EXIT
+
+mkdir -p "${runtime_dir}/config"
+cp "${repo_dir}/scripts/botctl.sh" "${runtime_dir}/botctl.sh"
+cp "${native_binary}" "${runtime_dir}/qq-maid-bot.exe"
+
+assert_stopped() {
+    local pid="$1"
+    if kill -0 "${pid}" 2>/dev/null; then
+        echo "process is still running: ${pid}" >&2
+        return 1
+    fi
+    [[ ! -e "${runtime_dir}/run/qq-maid-bot.pid" ]]
+}
+
+start_output="$(QQ_MAID_RUNTIME_DIR="${runtime_dir}" bash "${runtime_dir}/botctl.sh" start)"
+[[ "${start_output}" == *"qq-maid-bot started"* ]]
+pid="$(tr -d '[:space:]' < "${runtime_dir}/run/qq-maid-bot.pid")"
+[[ "${pid}" =~ ^[0-9]+$ ]]
+kill -0 "${pid}"
+status_output="$(QQ_MAID_RUNTIME_DIR="${runtime_dir}" bash "${runtime_dir}/botctl.sh" status)"
+[[ "${status_output}" == *"qq-maid-bot is running, pid=${pid}"* ]]
+grep -F "windows smoke started" "${runtime_dir}/logs/qq-maid-bot.log"
+QQ_MAID_RUNTIME_DIR="${runtime_dir}" bash "${runtime_dir}/botctl.sh" stop
+assert_stopped "${pid}"
+
+# 保留真实 Windows 进程，但拦截第一次普通停止信号，确定性覆盖超时后的 kill -9 分支。
+QQ_MAID_RUNTIME_DIR="${runtime_dir}" bash "${runtime_dir}/botctl.sh" start
+pid="$(tr -d '[:space:]' < "${runtime_dir}/run/qq-maid-bot.pid")"
+kill() {
+    if [[ "${1:-}" == "-0" ]]; then
+        builtin kill "$@"
+    elif [[ "${1:-}" == "-9" ]]; then
+        printf 'forced\n' > "${runtime_dir}/forced-stop"
+        builtin kill "$@"
+    else
+        return 0
+    fi
+}
+export -f kill
+export runtime_dir
+BOT_STOP_TIMEOUT_SECONDS=1 QQ_MAID_RUNTIME_DIR="${runtime_dir}" bash "${runtime_dir}/botctl.sh" stop
+[[ -f "${runtime_dir}/forced-stop" ]]
+assert_stopped "${pid}"
+
+echo "Windows botctl smoke test passed"

--- a/scripts/tests/windows-smoke.cs
+++ b/scripts/tests/windows-smoke.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Threading;
+
+public static class WindowsSmoke
+{
+    public static void Main()
+    {
+        Console.WriteLine("windows smoke started");
+        Console.Out.Flush();
+        while (true)
+        {
+            Thread.Sleep(250);
+        }
+    }
+}


### PR DESCRIPTION
## 修改内容

- 识别 Git Bash、MSYS2 和 Cygwin 的 `MINGW*`、`MSYS*`、`CYGWIN*` 内核名，并映射到 `windows-x86_64`
- Windows 环境下载、校验并解压 Release 的 `.zip` 包
- 安装与更新时保留 `qq-maid-bot.exe`，控制脚本自动选择 `.exe` 二进制
- Windows Shell 默认安装到 `$HOME/qq-maid-bot`，WSL 继续使用 Linux Release
- 在 README 补充 Windows 与 WSL 的安装说明

## 原因

#419 中的 `MINGW64_NT-10.0-19045` 来自 Windows Git Bash/MSYS 环境。发布流程已经生成 `windows-x86_64.zip`，但 `qbot.sh` 只识别 Linux/macOS 且固定处理 `.tar.gz` 和无后缀二进制，导致安装前即终止。

## 用户影响

Windows 用户可以直接在 Git Bash、MSYS2 或 Cygwin 中运行 `bash qbot.sh install`。WSL 仍按 Linux 识别，现有 Linux/macOS 行为保持不变。

Closes #419

## 验证

- `bash -n qbot.sh scripts/botctl.sh`
- `git diff --check`
- 使用伪造的 `MINGW64_NT-10.0-19045` 验证目标映射和默认安装目录
- 使用本地 zip + sha256 fixture 验证 Windows Release 校验及解压链路