### PR TITLE
[codex] 修复 Agent 多轮工具超时后的收尾

### DIFF
--- a/qq-maid-core/src/runtime/respond/tests/support.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support.rs
@@ -22,7 +22,7 @@ fn agent_tool_trace(
     emitted_tools: Vec<String>,
     tool_results: Vec<ToolExecutionResult>,
 ) -> AgentRunDiagnostics {
-    let executed_tools = tool_results
+    let executed_tools: Vec<String> = tool_results
         .iter()
         .map(|result| result.name.clone())
         .collect();
@@ -30,6 +30,7 @@ fn agent_tool_trace(
         model_rounds: 2,
         emitted_tools,
         tool_execution_attempted: true,
+        side_effecting_tools_started: executed_tools.clone(),
         executed_tools,
         tool_results,
         tools_with_unknown_result: Vec::new(),
@@ -851,6 +852,7 @@ impl LlmProvider for MockProvider {
                             emitted_tools: vec![name],
                             tool_execution_attempted: true,
                             executed_tools: Vec::new(),
+                            side_effecting_tools_started: Vec::new(),
                             tool_results: Vec::new(),
                             tools_with_unknown_result: Vec::new(),
                             streaming_fallback_used: false,

--- a/qq-maid-core/src/runtime/tools/rss/tool.rs
+++ b/qq-maid-core/src/runtime/tools/rss/tool.rs
@@ -9,7 +9,7 @@ use serde_json::{Value, json};
 use qq_maid_common::identity_context::ConversationKind;
 #[cfg(test)]
 use qq_maid_common::identity_context::{ExecutionActorContext, ExecutionConversationContext};
-use qq_maid_llm::tool::{Tool, ToolContext, ToolMetadata, ToolOutput};
+use qq_maid_llm::tool::{Tool, ToolContext, ToolEffect, ToolMetadata, ToolOutput};
 
 use crate::{error::LlmError, runtime::group_role::is_group_owner_or_admin};
 
@@ -80,6 +80,10 @@ impl Tool for RssRecentItemsTool {
                 "additionalProperties": false
             }),
         }
+    }
+
+    fn effect(&self) -> ToolEffect {
+        ToolEffect::ReadOnly
     }
 
     async fn execute(

--- a/qq-maid-core/src/runtime/tools/search.rs
+++ b/qq-maid-core/src/runtime/tools/search.rs
@@ -16,7 +16,10 @@ use qq_maid_common::identity_context::{
 };
 use qq_maid_llm::{
     tool::{Tool, ToolContext, ToolEffect, ToolMetadata, ToolOutput, ToolTimeoutPolicy},
-    web_search::{DynWebSearchExecutor, WebSearchOutcome, WebSearchRequest, WebSearchSource},
+    web_search::{
+        DEFAULT_MAX_RESULTS, DynWebSearchExecutor, WebSearchOutcome, WebSearchRequest,
+        WebSearchSource,
+    },
 };
 
 use crate::{config::DEFAULT_REQUEST_TIMEOUT_SECONDS, error::LlmError};
@@ -242,17 +245,23 @@ impl Tool for WebSearchTool {
     }
 
     fn deduplication_key(&self, arguments: &Value) -> Option<String> {
-        arguments
-            .get("query")
-            .and_then(Value::as_str)
-            .map(|query| {
-                query
-                    .split_whitespace()
-                    .collect::<Vec<_>>()
-                    .join(" ")
-                    .to_lowercase()
-            })
-            .filter(|query| !query.is_empty())
+        let query = parse_query(arguments).ok()?;
+        let raw_question = optional_string_field(arguments, "raw_question");
+        let max_results = parse_max_results(arguments.get("max_results")).ok()?;
+        let context_size = parse_context_size(arguments.get("context_size")).ok()?;
+        let normalized_query = normalize_dedup_text(&query);
+        (!normalized_query.is_empty()).then(|| {
+            serde_json::to_string(&json!({
+                "query": normalized_query,
+                // raw_question 会进入搜索提示词；缺省时实际语义等价于 query。
+                "raw_question": normalize_dedup_text(
+                    raw_question.as_deref().unwrap_or(&query)
+                ),
+                "max_results": max_results.unwrap_or(DEFAULT_MAX_RESULTS),
+                "context_size": context_size.as_deref().unwrap_or("low"),
+            }))
+            .expect("web search deduplication key must serialize")
+        })
     }
 
     async fn execute(
@@ -267,6 +276,14 @@ impl Tool for WebSearchTool {
             .await?;
         Ok(ToolOutput::json(web_search_tool_output(&outcome)))
     }
+}
+
+fn normalize_dedup_text(value: &str) -> String {
+    value
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
 }
 
 fn request_from_arguments(
@@ -519,16 +536,46 @@ mod tests {
         let tool = WebSearchTool::new(Arc::new(MockWebSearchExecutor::default()));
 
         assert_eq!(tool.effect(), ToolEffect::ReadOnly);
+        let default_key = tool
+            .deduplication_key(&json!({"query": " Rust   News "}))
+            .unwrap();
         assert_eq!(
-            tool.deduplication_key(&json!({"query": " Rust   News "})),
-            Some("rust news".to_owned())
+            default_key,
+            tool.deduplication_key(&json!({
+                "query": "rust news",
+                "raw_question": "RUST NEWS",
+                "max_results": DEFAULT_MAX_RESULTS,
+                "context_size": "low"
+            }))
+            .unwrap()
         );
         assert_eq!(
+            default_key,
+            tool.deduplication_key(&json!({
+                "query": "rust news",
+                "raw_question": null,
+                "max_results": null,
+                "context_size": null
+            }))
+            .unwrap()
+        );
+        assert_ne!(
+            default_key,
+            tool.deduplication_key(&json!({"query": "rust news", "max_results": 3}))
+                .unwrap()
+        );
+        assert_ne!(
+            default_key,
+            tool.deduplication_key(&json!({"query": "rust news", "context_size": "high"}))
+                .unwrap()
+        );
+        assert_ne!(
+            default_key,
             tool.deduplication_key(&json!({
                 "query": "rust news",
                 "raw_question": "different context"
-            })),
-            Some("rust news".to_owned())
+            }))
+            .unwrap()
         );
     }
 

--- a/qq-maid-core/src/runtime/tools/search.rs
+++ b/qq-maid-core/src/runtime/tools/search.rs
@@ -15,7 +15,7 @@ use qq_maid_common::identity_context::{
     ConversationKind, ExecutionActorContext, ExecutionConversationContext,
 };
 use qq_maid_llm::{
-    tool::{Tool, ToolContext, ToolMetadata, ToolOutput, ToolTimeoutPolicy},
+    tool::{Tool, ToolContext, ToolEffect, ToolMetadata, ToolOutput, ToolTimeoutPolicy},
     web_search::{DynWebSearchExecutor, WebSearchOutcome, WebSearchRequest, WebSearchSource},
 };
 
@@ -235,6 +235,24 @@ impl Tool for WebSearchTool {
 
     fn timeout_policy(&self) -> ToolTimeoutPolicy {
         ToolTimeoutPolicy::ToolManaged
+    }
+
+    fn effect(&self) -> ToolEffect {
+        ToolEffect::ReadOnly
+    }
+
+    fn deduplication_key(&self, arguments: &Value) -> Option<String> {
+        arguments
+            .get("query")
+            .and_then(Value::as_str)
+            .map(|query| {
+                query
+                    .split_whitespace()
+                    .collect::<Vec<_>>()
+                    .join(" ")
+                    .to_lowercase()
+            })
+            .filter(|query| !query.is_empty())
     }
 
     async fn execute(
@@ -494,6 +512,24 @@ mod tests {
         assert_eq!(stream_calls.load(Ordering::SeqCst), 1);
         assert_eq!(output.value["answer"], "answer: Rust 新闻");
         assert_eq!(output.value["sources"][0]["url"], "https://example.com");
+    }
+
+    #[test]
+    fn web_search_tool_is_read_only_and_deduplicates_normalized_query() {
+        let tool = WebSearchTool::new(Arc::new(MockWebSearchExecutor::default()));
+
+        assert_eq!(tool.effect(), ToolEffect::ReadOnly);
+        assert_eq!(
+            tool.deduplication_key(&json!({"query": " Rust   News "})),
+            Some("rust news".to_owned())
+        );
+        assert_eq!(
+            tool.deduplication_key(&json!({
+                "query": "rust news",
+                "raw_question": "different context"
+            })),
+            Some("rust news".to_owned())
+        );
     }
 
     struct DelayedStreamExecutor {

--- a/qq-maid-core/src/runtime/tools/todo/get.rs
+++ b/qq-maid-core/src/runtime/tools/todo/get.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use serde_json::json;
 
-use qq_maid_llm::tool::{Tool, ToolContext, ToolMetadata, ToolOutput};
+use qq_maid_llm::tool::{Tool, ToolContext, ToolEffect, ToolMetadata, ToolOutput};
 
 use crate::error::LlmError;
 
@@ -44,6 +44,10 @@ impl Tool for GetTodoTool {
             description: "查询单个待办详情。用户明确说“第 N 个”时传 number 或 numbers=[N]，依赖最近一次用户实际看到的 Todo 列表或本轮 list_todos 的 visible_number；用户说“刚才那个 / 它 / 刚恢复的那个 / 刚完成的”时传 reference=\"last\"。不会接受数据库内部 ID，不会修改待办或刷新用户可见编号快照。".to_owned(),
             parameters: single_number_or_reference_schema("要查询的 visible_number"),
         }
+    }
+
+    fn effect(&self) -> ToolEffect {
+        ToolEffect::ReadOnly
     }
 
     fn prepare(

--- a/qq-maid-core/src/runtime/tools/todo/list.rs
+++ b/qq-maid-core/src/runtime/tools/todo/list.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use serde_json::json;
 
-use qq_maid_llm::tool::{Tool, ToolContext, ToolMetadata, ToolOutput};
+use qq_maid_llm::tool::{Tool, ToolContext, ToolEffect, ToolMetadata, ToolOutput};
 
 use chrono::NaiveDate;
 
@@ -60,6 +60,10 @@ impl Tool for ListTodoTool {
                 "additionalProperties": false
             }),
         }
+    }
+
+    fn effect(&self) -> ToolEffect {
+        ToolEffect::ReadOnly
     }
 
     async fn execute(

--- a/qq-maid-core/src/runtime/tools/train/tool.rs
+++ b/qq-maid-core/src/runtime/tools/train/tool.rs
@@ -12,7 +12,7 @@ use serde_json::{Value, json};
 use qq_maid_common::identity_context::{
     ConversationKind, ExecutionActorContext, ExecutionConversationContext,
 };
-use qq_maid_llm::tool::{Tool, ToolContext, ToolMetadata, ToolOutput};
+use qq_maid_llm::tool::{Tool, ToolContext, ToolEffect, ToolMetadata, ToolOutput};
 
 use crate::{
     error::LlmError,
@@ -128,6 +128,10 @@ impl Tool for TrainScheduleTool {
                 "additionalProperties": false
             }),
         }
+    }
+
+    fn effect(&self) -> ToolEffect {
+        ToolEffect::ReadOnly
     }
 
     async fn execute(

--- a/qq-maid-core/src/runtime/tools/weather/tool.rs
+++ b/qq-maid-core/src/runtime/tools/weather/tool.rs
@@ -10,7 +10,7 @@ use serde_json::{Value, json};
 use qq_maid_common::identity_context::{
     ConversationKind, ExecutionActorContext, ExecutionConversationContext,
 };
-use qq_maid_llm::tool::{Tool, ToolContext, ToolMetadata, ToolOutput};
+use qq_maid_llm::tool::{Tool, ToolContext, ToolEffect, ToolMetadata, ToolOutput};
 
 use crate::{
     error::LlmError,
@@ -124,6 +124,10 @@ impl Tool for WeatherTool {
                 "additionalProperties": false
             }),
         }
+    }
+
+    fn effect(&self) -> ToolEffect {
+        ToolEffect::ReadOnly
     }
 
     async fn execute(

--- a/qq-maid-core/src/service/streaming.rs
+++ b/qq-maid-core/src/service/streaming.rs
@@ -10,7 +10,7 @@ use tokio::{sync::mpsc, time::timeout};
 use tracing::{debug, warn};
 
 use qq_maid_llm::agent_loop::{
-    AgentRunHandle, AgentStopReason, AgentTextDeltaFuture, AgentTextDeltaSink,
+    AgentRunDiagnostics, AgentRunHandle, AgentStopReason, AgentTextDeltaFuture, AgentTextDeltaSink,
     ToolLoopProgressEvent, ToolLoopProgressSink,
 };
 use qq_maid_llm::tool::DEFAULT_TOOL_TIMEOUT;
@@ -100,11 +100,12 @@ pub(crate) fn start_core_response_stream(
                     if let Some(handle) = &producer_agent_run_handle {
                         handle.cancel(AgentStopReason::Timeout);
                     }
-                    // 取消只阻止后续模型轮次和尚未启动的工具；已启动工具保留其自身
-                    // timeout 完成可信结果。清理预算耗尽后 abort，unknown 轨迹继续保留。
-                    if timeout(DEFAULT_TOOL_TIMEOUT, &mut task).await.is_err() {
-                        task.abort();
-                    }
+                    let needs_side_effect_cleanup = producer_agent_run_handle
+                        .as_ref()
+                        .is_some_and(|handle| needs_side_effect_cleanup(&handle.snapshot()));
+                    // 结果未知的写操作保留有限清理窗口，避免中断后伪装成未执行；
+                    // 纯只读调用可立即取消，不额外占用副作用工具的 15 秒预算。
+                    cleanup_timed_out_agent_task(&mut task, needs_side_effect_cleanup).await;
                     Err(producer_agent_run_handle
                         .as_ref()
                         .map(|handle| err.clone().with_agent(handle.snapshot()))
@@ -166,6 +167,26 @@ pub(crate) fn start_core_response_stream(
         output_policy,
         agent_run_handle,
     }
+}
+
+fn needs_side_effect_cleanup(diagnostics: &AgentRunDiagnostics) -> bool {
+    diagnostics.tools_with_unknown_result.iter().any(|tool| {
+        diagnostics
+            .side_effecting_tools_started
+            .iter()
+            .any(|started| started == tool)
+    })
+}
+
+async fn cleanup_timed_out_agent_task<T>(
+    task: &mut tokio::task::JoinHandle<T>,
+    needs_side_effect_cleanup: bool,
+) {
+    if needs_side_effect_cleanup && timeout(DEFAULT_TOOL_TIMEOUT, &mut *task).await.is_ok() {
+        return;
+    }
+    task.abort();
+    let _ = task.await;
 }
 
 async fn run_streaming_respond(
@@ -554,5 +575,58 @@ pub(crate) fn output_policy_for_stream(
         RespondPlan::WebSearch => CoreOutputPolicy::CompleteThenSend,
         RespondPlan::CommandEvent => CoreOutputPolicy::CompleteThenSend,
         RespondPlan::Immediate => CoreOutputPolicy::CompleteThenSend,
+    }
+}
+
+#[cfg(test)]
+mod cleanup_tests {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        time::Duration,
+    };
+
+    use qq_maid_llm::agent_loop::AgentRunDiagnostics;
+
+    use super::{cleanup_timed_out_agent_task, needs_side_effect_cleanup};
+
+    #[tokio::test]
+    async fn read_only_timeout_cleanup_aborts_without_side_effect_window() {
+        let diagnostics = AgentRunDiagnostics {
+            executed_tools: vec!["web_search".to_owned()],
+            ..AgentRunDiagnostics::default()
+        };
+        assert!(!needs_side_effect_cleanup(&diagnostics));
+        let mut task = tokio::spawn(std::future::pending::<()>());
+
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            cleanup_timed_out_agent_task(&mut task, false),
+        )
+        .await
+        .expect("read-only cleanup must not wait for the side-effect timeout");
+    }
+
+    #[tokio::test]
+    async fn unknown_side_effect_cleanup_keeps_limited_completion_window() {
+        let diagnostics = AgentRunDiagnostics {
+            executed_tools: vec!["write_tool".to_owned()],
+            side_effecting_tools_started: vec!["write_tool".to_owned()],
+            tools_with_unknown_result: vec!["write_tool".to_owned()],
+            ..AgentRunDiagnostics::default()
+        };
+        assert!(needs_side_effect_cleanup(&diagnostics));
+        let completed = Arc::new(AtomicBool::new(false));
+        let task_completed = completed.clone();
+        let mut task = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(30)).await;
+            task_completed.store(true, Ordering::SeqCst);
+        });
+
+        cleanup_timed_out_agent_task(&mut task, true).await;
+
+        assert!(completed.load(Ordering::SeqCst));
     }
 }

--- a/qq-maid-core/src/service/streaming.rs
+++ b/qq-maid-core/src/service/streaming.rs
@@ -29,6 +29,7 @@ use super::{
 };
 
 const AGENT_RUNNING_STATUS_DELAY: Duration = Duration::from_millis(1500);
+const PARTIAL_RESPONSE_TIMEOUT_SUFFIX: &str = "\n\n（处理耗时过长，本次回答未完整完成。）";
 
 #[derive(Debug, Clone)]
 pub(crate) struct ProgressStatusConfig {
@@ -41,6 +42,7 @@ pub(crate) struct ProgressStatusConfig {
 struct AgentStreamControl {
     cancelled: Arc<AtomicBool>,
     run_handle: Option<AgentRunHandle>,
+    visible_text_sent: Arc<AtomicBool>,
 }
 
 pub(crate) fn start_core_response_stream(
@@ -57,8 +59,11 @@ pub(crate) fn start_core_response_stream(
     let producer_cancelled = cancelled.clone();
     let scope_key = req.scope_key.clone();
     let plan = planned.plan();
-    let agent_run_handle = matches!(plan, RespondPlan::AgentRuntime).then(AgentRunHandle::default);
+    let agent_run_handle = matches!(plan, RespondPlan::AgentRuntime)
+        .then(|| AgentRunHandle::with_timeout(request_timeout));
     let producer_agent_run_handle = agent_run_handle.clone();
+    let visible_text_sent = Arc::new(AtomicBool::new(false));
+    let producer_visible_text_sent = visible_text_sent.clone();
     tokio::spawn(async move {
         if producer_cancelled.load(Ordering::SeqCst) {
             let _ = tx
@@ -77,6 +82,7 @@ pub(crate) fn start_core_response_stream(
                 AgentStreamControl {
                     cancelled: producer_cancelled.clone(),
                     run_handle: producer_agent_run_handle.clone(),
+                    visible_text_sent: producer_visible_text_sent.clone(),
                 },
                 provider_stream_enabled,
                 progress_status,
@@ -114,6 +120,7 @@ pub(crate) fn start_core_response_stream(
                 AgentStreamControl {
                     cancelled: producer_cancelled.clone(),
                     run_handle: producer_agent_run_handle.clone(),
+                    visible_text_sent: producer_visible_text_sent.clone(),
                 },
                 provider_stream_enabled,
                 progress_status,
@@ -139,6 +146,13 @@ pub(crate) fn start_core_response_stream(
             }
             Err(err) => {
                 warn_core_error(&scope_key, &err);
+                if err.code == "timeout" && producer_visible_text_sent.load(Ordering::SeqCst) {
+                    let _ = tx
+                        .send(CoreResponseEvent::TextDelta(
+                            PARTIAL_RESPONSE_TIMEOUT_SUFFIX.to_owned(),
+                        ))
+                        .await;
+                }
                 CoreResponseEvent::Failed(CoreRespondFailure::from_llm_error(&err))
             }
         };
@@ -282,6 +296,7 @@ async fn run_agent_runtime_respond(
 ) -> Result<RespondResponse, LlmError> {
     let cancelled = control.cancelled;
     let agent_run_handle = control.run_handle;
+    let visible_text_sent = control.visible_text_sent;
     let eager_agent_status = planned.should_emit_eager_agent_status();
     if eager_agent_status {
         send_core_status(
@@ -314,6 +329,7 @@ async fn run_agent_runtime_respond(
             finalizing_status_sent.clone(),
             eager_agent_status,
             tool_activity_started.clone(),
+            visible_text_sent,
         ))
     } else {
         None
@@ -411,6 +427,7 @@ fn agent_final_delta_sink(
     finalizing_status_sent: Arc<AtomicBool>,
     eager_agent_status: bool,
     tool_activity_started: Arc<AtomicBool>,
+    visible_text_sent: Arc<AtomicBool>,
 ) -> AgentTextDeltaSink {
     Arc::new(move |delta| {
         let tx = tx.clone();
@@ -418,6 +435,7 @@ fn agent_final_delta_sink(
         let progress_status = progress_status.clone();
         let finalizing_status_sent = finalizing_status_sent.clone();
         let tool_activity_started = tool_activity_started.clone();
+        let visible_text_sent = visible_text_sent.clone();
         Box::pin(async move {
             send_agent_finalizing_status_once(
                 &tx,
@@ -428,7 +446,9 @@ fn agent_final_delta_sink(
                 &tool_activity_started,
             )
             .await?;
-            send_core_delta(&tx, &cancelled, delta).await
+            send_core_delta(&tx, &cancelled, delta).await?;
+            visible_text_sent.store(true, Ordering::SeqCst);
+            Ok(())
         }) as AgentTextDeltaFuture
     })
 }

--- a/qq-maid-core/src/service/tests/mod.rs
+++ b/qq-maid-core/src/service/tests/mod.rs
@@ -1207,6 +1207,7 @@ async fn core_tool_loop_timeout_after_delta_appends_visible_termination_notice()
     let mut state = test_state_with_tool_calling(provider, 1, true);
     state.config.request_timeout_seconds = 1;
     let service = CoreHandle::new(state);
+    let started_at = std::time::Instant::now();
     let mut stream = expect_stream(
         service
             .respond(private_request("帮我处理一下"))
@@ -1230,8 +1231,11 @@ async fn core_tool_loop_timeout_after_delta_appends_visible_termination_notice()
     };
 
     assert_eq!(failure.kind, CoreFailureKind::LlmTimeout);
+    assert_eq!(deltas.len(), 2);
     assert_eq!(deltas[0], "部分回答");
     assert!(deltas[1].contains("本次回答未完整完成"));
+    assert!(started_at.elapsed() < Duration::from_secs(3));
+    assert!(stream.recv().await.is_none());
 }
 
 #[tokio::test]
@@ -1286,7 +1290,7 @@ async fn core_tool_loop_stream_preserves_request_timeout_for_background_complete
 }
 
 #[tokio::test]
-async fn core_timeout_during_tool_keeps_result_and_stops_next_model_round() {
+async fn core_timeout_during_read_only_tool_aborts_quickly_and_stops_next_model_round() {
     let started = Arc::new(Notify::new());
     let release = Arc::new(Notify::new());
     let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -1310,10 +1314,13 @@ async fn core_timeout_during_tool_keeps_result_and_stops_next_model_round() {
     tokio::time::timeout(Duration::from_secs(1), started.notified())
         .await
         .expect("tool did not start");
-    // 保持工具跨过 Core request timeout，再释放真实工具结果供受控清理收集。
-    tokio::time::sleep(Duration::from_millis(1100)).await;
-    release.notify_one();
-    let failure = collect_failure_without_text_delta(&mut stream).await;
+    let timeout_started = std::time::Instant::now();
+    let failure = tokio::time::timeout(
+        Duration::from_secs(2),
+        collect_failure_without_text_delta(&mut stream),
+    )
+    .await
+    .expect("read-only timeout cleanup must not wait for the tool timeout");
 
     assert_eq!(failure.kind, CoreFailureKind::LlmTimeout);
     let diagnostics = failure.agent.expect("missing agent diagnostics");
@@ -1323,9 +1330,10 @@ async fn core_timeout_during_tool_keeps_result_and_stops_next_model_round() {
     );
     assert_eq!(diagnostics.model_rounds, 1);
     assert_eq!(diagnostics.executed_tools, ["get_weather"]);
-    assert_eq!(diagnostics.tool_results.len(), 1);
+    assert!(diagnostics.tool_results.is_empty());
     assert!(diagnostics.tools_with_unknown_result.is_empty());
     assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert!(timeout_started.elapsed() < Duration::from_secs(2));
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/service/tests/mod.rs
+++ b/qq-maid-core/src/service/tests/mod.rs
@@ -1201,6 +1201,40 @@ async fn core_tool_loop_stream_failure_after_delta_does_not_complete_or_replay()
 }
 
 #[tokio::test]
+async fn core_tool_loop_timeout_after_delta_appends_visible_termination_notice() {
+    let provider = TestProvider::partial_then_delayed("部分回答", Duration::from_secs(2))
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let mut state = test_state_with_tool_calling(provider, 1, true);
+    state.config.request_timeout_seconds = 1;
+    let service = CoreHandle::new(state);
+    let mut stream = expect_stream(
+        service
+            .respond(private_request("帮我处理一下"))
+            .await
+            .unwrap(),
+    );
+
+    let mut deltas = Vec::new();
+    let failure = loop {
+        let Some(event) = stream.recv().await else {
+            panic!("stream ended before failure");
+        };
+        match event {
+            CoreResponseEvent::Status(_) => {}
+            CoreResponseEvent::TextDelta(delta) => deltas.push(delta),
+            CoreResponseEvent::Failed(failure) => break failure,
+            CoreResponseEvent::Completed(response) => {
+                panic!("unexpected completed response after timeout: {response:?}");
+            }
+        }
+    };
+
+    assert_eq!(failure.kind, CoreFailureKind::LlmTimeout);
+    assert_eq!(deltas[0], "部分回答");
+    assert!(deltas[1].contains("本次回答未完整完成"));
+}
+
+#[tokio::test]
 async fn core_tool_loop_failure_is_reported_as_stream_failure_without_delta() {
     let provider = TestProvider::failing(LlmError::new(
         "tool_loop_limit",

--- a/qq-maid-core/src/service/tests/support.rs
+++ b/qq-maid-core/src/service/tests/support.rs
@@ -115,6 +115,7 @@ enum ProviderBehavior {
     Stream(Vec<Result<LlmStreamEvent, LlmError>>),
     Error(LlmError),
     Delayed { reply: String, delay: Duration },
+    PartialThenDelayed { delta: String, delay: Duration },
     AgentWeatherThenFinal,
 }
 
@@ -186,6 +187,14 @@ impl TestProvider {
         })
     }
 
+    pub(super) fn partial_then_delayed(delta: &str, delay: Duration) -> Self {
+        Self::new(ProviderBehavior::PartialThenDelayed {
+            delta: delta.to_owned(),
+            delay,
+        })
+        .with_stream_enabled(true)
+    }
+
     pub(super) fn agent_weather_then_final() -> Self {
         Self::new(ProviderBehavior::AgentWeatherThenFinal)
     }
@@ -244,6 +253,10 @@ impl LlmProvider for TestProvider {
                 tokio::time::sleep(*delay).await;
                 Ok(chat_outcome(reply))
             }
+            ProviderBehavior::PartialThenDelayed { delta, delay } => {
+                tokio::time::sleep(*delay).await;
+                Ok(chat_outcome(delta))
+            }
             ProviderBehavior::AgentWeatherThenFinal => {
                 unreachable!("agent behavior uses chat_with_tools")
             }
@@ -288,6 +301,25 @@ impl LlmProvider for TestProvider {
                                 }),
                                 (2, String::new(), delay),
                             ));
+                        }
+                        None
+                    },
+                )))
+            }
+            ProviderBehavior::PartialThenDelayed { delta, delay } => {
+                let delta = delta.clone();
+                let delay = *delay;
+                Ok(Box::pin(futures::stream::unfold(
+                    (0_u8, delta, delay),
+                    |(state, delta, delay)| async move {
+                        if state == 0 {
+                            return Some((
+                                Ok(LlmStreamEvent::TextDelta(delta)),
+                                (1, String::new(), delay),
+                            ));
+                        }
+                        if state == 1 {
+                            tokio::time::sleep(delay).await;
                         }
                         None
                     },
@@ -353,6 +385,13 @@ impl LlmProvider for TestProvider {
             ProviderBehavior::Delayed { reply, delay } => {
                 tokio::time::sleep(*delay).await;
                 Ok(chat_outcome(reply))
+            }
+            ProviderBehavior::PartialThenDelayed { delta, delay } => {
+                if let Some(sink) = req.final_delta_sink.as_ref() {
+                    sink(delta.clone()).await?;
+                }
+                tokio::time::sleep(*delay).await;
+                Ok(chat_outcome(delta))
             }
             ProviderBehavior::AgentWeatherThenFinal => {
                 unreachable!("agent behavior returned before mock progress")

--- a/qq-maid-llm/src/agent_loop/runner.rs
+++ b/qq-maid-llm/src/agent_loop/runner.rs
@@ -29,7 +29,7 @@ use crate::{
     provider::types::TokenUsage,
     provider::{
         ChatOutcome,
-        tool_loop::{ToolLoopCall, ToolLoopExecutor},
+        tool_loop::{ToolCallStartDecision, ToolLoopCall, ToolLoopExecutor},
     },
     tool::{ToolContext, ToolRegistry},
 };
@@ -131,6 +131,7 @@ pub(super) async fn run_agent_loop_with_timeouts(
     let mut usage: Option<TokenUsage> = None;
     let mut emitted_tools = Vec::new();
     let mut fallback_used = false;
+    let mut force_finalization_without_tools = false;
     // 上一轮工具执行结果；首轮为空，由 Loop 在执行后回填给下一轮 advance。
     let mut results: Vec<AgentToolResult> = Vec::new();
 
@@ -151,8 +152,9 @@ pub(super) async fn run_agent_loop_with_timeouts(
         }
         // 最后一轮或最终回答预算阶段都在协议层显式禁用工具；Provider 若忽略
         // tool_choice=none，下面会直接受控终止，不能再开启模型轮次。
-        let preserve_finalization_budget =
-            !results.is_empty() && run_handle.should_preserve_finalization_budget();
+        let preserve_finalization_budget = force_finalization_without_tools
+            || (run_handle.has_trusted_tool_result_since(attempt_baseline.tool_results)
+                && run_handle.should_preserve_finalization_budget());
         let allow_tool_calls = round < max_rounds && !preserve_finalization_budget;
         debug!(
             provider = provider.as_str(),
@@ -304,13 +306,43 @@ pub(super) async fn run_agent_loop_with_timeouts(
                         attempt_baseline,
                     ));
                 }
-                results =
+                // 模型请求本身可能消耗掉大部分请求预算；进入工具批次前必须用同一
+                // deadline 重新判断，不能沿用模型轮次开始前的旧结论。
+                let batch_budget_reserved = run_handle.should_preserve_finalization_budget();
+                let has_trusted_result =
+                    run_handle.has_trusted_tool_result_since(attempt_baseline.tool_results);
+                if batch_budget_reserved && !has_trusted_result {
+                    let tool = calls
+                        .first()
+                        .map(|call| call.name.as_str())
+                        .unwrap_or("none");
+                    warn!(
+                        tool,
+                        round,
+                        remaining_budget_ms =
+                            run_handle.remaining_budget().map(|value| value.as_millis()),
+                        skipped_for_finalization_reserve = true,
+                        has_trusted_result,
+                        "agent tool batch rejected because only finalization budget remains"
+                    );
+                    return Err(agent_error(
+                        finalization_budget_error(),
+                        &run_handle,
+                        &executor,
+                        AgentStopReason::Failed,
+                        attempt_baseline,
+                    ));
+                }
+                force_finalization_without_tools |= batch_budget_reserved;
+                let batch =
                     execute_tool_batch(&calls, round, &mut executor, &run_handle, attempt_baseline)
                         .await
                         .map_err(|err| {
                             let reason = stop_reason_for_error(&err);
                             agent_error(err, &run_handle, &executor, reason, attempt_baseline)
                         })?;
+                results = batch.results;
+                force_finalization_without_tools |= batch.skipped_for_finalization;
                 sync_diagnostics(&run_handle, &executor, &emitted_tools, attempt_baseline);
             }
         }
@@ -653,7 +685,7 @@ async fn execute_tool_batch(
     executor: &mut ToolLoopExecutor<'_>,
     run_handle: &AgentRunHandle,
     baseline: AgentAttemptBaseline,
-) -> Result<Vec<AgentToolResult>, LlmError> {
+) -> Result<ToolBatchOutcome, LlmError> {
     executor.reset_dependency_chain();
     let prepared_calls = calls
         .iter()
@@ -671,11 +703,34 @@ async fn execute_tool_batch(
         })
         .collect::<Vec<_>>();
     let mut results = Vec::with_capacity(calls.len());
+    let mut skipped_for_finalization = false;
     for (call, prepared) in calls.iter().zip(prepared_calls) {
         let tool_started_at = Instant::now();
         let output = executor
             .execute_prepared_call(
                 prepared,
+                |tool_name, _effect| {
+                    let has_trusted_result =
+                        run_handle.has_trusted_tool_result_since(baseline.tool_results);
+                    let reserve_reached = run_handle.should_preserve_finalization_budget();
+                    debug!(
+                        tool = tool_name,
+                        round,
+                        remaining_budget_ms =
+                            run_handle.remaining_budget().map(|value| value.as_millis()),
+                        skipped_for_finalization_reserve = reserve_reached,
+                        has_trusted_result,
+                        "checked agent tool start budget"
+                    );
+                    if !reserve_reached {
+                        return Ok(ToolCallStartDecision::Execute);
+                    }
+                    if has_trusted_result {
+                        Ok(ToolCallStartDecision::SkipForFinalAnswer)
+                    } else {
+                        Err(finalization_budget_error())
+                    }
+                },
                 |tool_name, effect| run_handle.try_start_tool(tool_name, effect),
                 |result| run_handle.record_tool_result(result),
             )
@@ -692,12 +747,29 @@ async fn execute_tool_batch(
         let emitted_tools = snapshot.emitted_tools[baseline.emitted_tools..].to_vec();
         sync_diagnostics(run_handle, executor, &emitted_tools, baseline);
         let output = output?;
+        skipped_for_finalization |= output.skipped_for_finalization;
         results.push(AgentToolResult {
             call_id: call.call_id.clone(),
             output: output.output,
         });
     }
-    Ok(results)
+    Ok(ToolBatchOutcome {
+        results,
+        skipped_for_finalization,
+    })
+}
+
+struct ToolBatchOutcome {
+    results: Vec<AgentToolResult>,
+    skipped_for_finalization: bool,
+}
+
+fn finalization_budget_error() -> LlmError {
+    LlmError::new(
+        "request_budget_reserved_for_final_answer",
+        "request budget is insufficient to start a tool and no trusted tool result is available",
+        "tool_loop",
+    )
 }
 
 /// 合并多轮 token 用量；任一缺失时保留另一侧。

--- a/qq-maid-llm/src/agent_loop/runner.rs
+++ b/qq-maid-llm/src/agent_loop/runner.rs
@@ -344,6 +344,31 @@ pub(super) async fn run_agent_loop_with_timeouts(
                 results = batch.results;
                 force_finalization_without_tools |= batch.skipped_for_finalization;
                 sync_diagnostics(&run_handle, &executor, &emitted_tools, attempt_baseline);
+                // 工具启动时预算可能充足，但执行完成后已经进入最终回答预留区。
+                // 此时必须基于刚同步的真实结果重新判断，不能沿用批次启动前的状态。
+                let preserve_after_batch = run_handle.should_preserve_finalization_budget();
+                let has_trusted_result_after_batch =
+                    run_handle.has_trusted_tool_result_since(attempt_baseline.tool_results);
+                if preserve_after_batch {
+                    if has_trusted_result_after_batch {
+                        force_finalization_without_tools = true;
+                    } else {
+                        warn!(
+                            round,
+                            remaining_budget_ms =
+                                run_handle.remaining_budget().map(|value| value.as_millis()),
+                            has_trusted_result = false,
+                            "agent tool batch exhausted tool budget without a trusted result"
+                        );
+                        return Err(agent_error(
+                            finalization_budget_error(),
+                            &run_handle,
+                            &executor,
+                            AgentStopReason::Failed,
+                            attempt_baseline,
+                        ));
+                    }
+                }
             }
         }
     }

--- a/qq-maid-llm/src/agent_loop/runner.rs
+++ b/qq-maid-llm/src/agent_loop/runner.rs
@@ -149,8 +149,8 @@ pub(super) async fn run_agent_loop_with_timeouts(
                 attempt_baseline,
             ));
         }
-        // 最后一轮不允许继续工具调用；Responses 会据此设置 tool_choice=none，
-        // Chat Completions 忽略此值，由下方的 max_rounds 兜底统一退出。
+        // 最后一轮或最终回答预算阶段都在协议层显式禁用工具；Provider 若忽略
+        // tool_choice=none，下面会直接受控终止，不能再开启模型轮次。
         let preserve_finalization_budget =
             !results.is_empty() && run_handle.should_preserve_finalization_budget();
         let allow_tool_calls = round < max_rounds && !preserve_finalization_budget;
@@ -251,6 +251,36 @@ pub(super) async fn run_agent_loop_with_timeouts(
                         .truncate(attempt_baseline.emitted_tools);
                     diagnostics.emitted_tools.extend_from_slice(&emitted_tools);
                 });
+                if !allow_tool_calls {
+                    let (code, message, reason) = if preserve_finalization_budget {
+                        (
+                            "tool_calls_disabled",
+                            "provider returned tool calls while final answer budget disabled tools",
+                            AgentStopReason::Failed,
+                        )
+                    } else {
+                        (
+                            "tool_loop_limit",
+                            "tool loop returned tool calls when tool calls are disabled",
+                            AgentStopReason::MaxRounds,
+                        )
+                    };
+                    warn!(
+                        provider = provider.as_str(),
+                        model = %model,
+                        round,
+                        preserve_finalization_budget,
+                        tool_call_count = calls.len(),
+                        "provider returned tool calls after tools were disabled"
+                    );
+                    return Err(agent_error(
+                        LlmError::new(code, message, "tool_loop"),
+                        &run_handle,
+                        &executor,
+                        reason,
+                        attempt_baseline,
+                    ));
+                }
                 // 已到最大轮数仍要求工具调用：统一返回 tool_loop_limit，
                 // 不再执行这一批调用，避免超出预算的副作用。
                 if round >= max_rounds {
@@ -273,28 +303,6 @@ pub(super) async fn run_agent_loop_with_timeouts(
                         AgentStopReason::MaxRounds,
                         attempt_baseline,
                     ));
-                }
-                if !executor.tool_results().is_empty()
-                    && run_handle.should_preserve_finalization_budget()
-                {
-                    warn!(
-                        provider = provider.as_str(),
-                        model = %model,
-                        round,
-                        remaining_budget_ms = run_handle
-                            .remaining_budget()
-                            .map(|value| value.as_millis()),
-                        tool_call_count = calls.len(),
-                        "agent tool batch skipped to preserve finalization budget"
-                    );
-                    results = calls
-                        .iter()
-                        .map(|call| AgentToolResult {
-                            call_id: call.call_id.clone(),
-                            output: r#"{"ok":false,"skipped":true,"reason":"request_budget_reserved_for_final_answer"}"#.to_owned(),
-                        })
-                        .collect();
-                    continue;
                 }
                 results =
                     execute_tool_batch(&calls, round, &mut executor, &run_handle, attempt_baseline)

--- a/qq-maid-llm/src/agent_loop/runner.rs
+++ b/qq-maid-llm/src/agent_loop/runner.rs
@@ -151,7 +151,18 @@ pub(super) async fn run_agent_loop_with_timeouts(
         }
         // 最后一轮不允许继续工具调用；Responses 会据此设置 tool_choice=none，
         // Chat Completions 忽略此值，由下方的 max_rounds 兜底统一退出。
-        let allow_tool_calls = round < max_rounds;
+        let preserve_finalization_budget =
+            !results.is_empty() && run_handle.should_preserve_finalization_budget();
+        let allow_tool_calls = round < max_rounds && !preserve_finalization_budget;
+        debug!(
+            provider = provider.as_str(),
+            model = %model,
+            round,
+            allow_tool_calls,
+            preserve_finalization_budget,
+            remaining_budget_ms = run_handle.remaining_budget().map(|value| value.as_millis()),
+            "starting agent model round"
+        );
         let advance_future = advance_with_optional_streaming(
             session.as_mut(),
             &results,
@@ -161,6 +172,7 @@ pub(super) async fn run_agent_loop_with_timeouts(
             non_stream_timeout,
             round,
         );
+        let model_round_started = Instant::now();
         let advance_future = Box::pin(advance_future);
         let cancellation = Box::pin(run_handle.cancelled());
         let advance_result = match select(advance_future, cancellation).await {
@@ -171,6 +183,15 @@ pub(super) async fn run_agent_loop_with_timeouts(
                 "agent_loop",
             )),
         };
+        debug!(
+            provider = provider.as_str(),
+            model = %model,
+            round,
+            model_round_elapsed_ms = model_round_started.elapsed().as_millis(),
+            model_round_succeeded = advance_result.is_ok(),
+            remaining_budget_ms = run_handle.remaining_budget().map(|value| value.as_millis()),
+            "agent model round completed"
+        );
         let advance = match advance_result {
             Ok(advance) => advance,
             Err(err) => {
@@ -252,6 +273,28 @@ pub(super) async fn run_agent_loop_with_timeouts(
                         AgentStopReason::MaxRounds,
                         attempt_baseline,
                     ));
+                }
+                if !executor.tool_results().is_empty()
+                    && run_handle.should_preserve_finalization_budget()
+                {
+                    warn!(
+                        provider = provider.as_str(),
+                        model = %model,
+                        round,
+                        remaining_budget_ms = run_handle
+                            .remaining_budget()
+                            .map(|value| value.as_millis()),
+                        tool_call_count = calls.len(),
+                        "agent tool batch skipped to preserve finalization budget"
+                    );
+                    results = calls
+                        .iter()
+                        .map(|call| AgentToolResult {
+                            call_id: call.call_id.clone(),
+                            output: r#"{"ok":false,"skipped":true,"reason":"request_budget_reserved_for_final_answer"}"#.to_owned(),
+                        })
+                        .collect();
+                    continue;
                 }
                 results =
                     execute_tool_batch(&calls, round, &mut executor, &run_handle, attempt_baseline)
@@ -621,13 +664,22 @@ async fn execute_tool_batch(
         .collect::<Vec<_>>();
     let mut results = Vec::with_capacity(calls.len());
     for (call, prepared) in calls.iter().zip(prepared_calls) {
+        let tool_started_at = Instant::now();
         let output = executor
             .execute_prepared_call(
                 prepared,
-                |tool_name| run_handle.try_start_tool(tool_name),
+                |tool_name, effect| run_handle.try_start_tool(tool_name, effect),
                 |result| run_handle.record_tool_result(result),
             )
             .await;
+        debug!(
+            tool = call.name,
+            round,
+            tool_elapsed_ms = tool_started_at.elapsed().as_millis(),
+            tool_succeeded = output.is_ok(),
+            remaining_budget_ms = run_handle.remaining_budget().map(|value| value.as_millis()),
+            "agent tool call completed"
+        );
         let snapshot = run_handle.snapshot();
         let emitted_tools = snapshot.emitted_tools[baseline.emitted_tools..].to_vec();
         sync_diagnostics(run_handle, executor, &emitted_tools, baseline);

--- a/qq-maid-llm/src/agent_loop/session.rs
+++ b/qq-maid-llm/src/agent_loop/session.rs
@@ -48,9 +48,9 @@ pub trait AgentStepSession: Send {
     /// 用上一轮工具执行结果推进一步。
     ///
     /// - `results`：上一轮工具执行结果；首轮为空切片。
-    /// - `allow_tool_calls`：是否允许本轮产生工具调用。当为 `false` 时，
-    ///   Responses 可设置 `tool_choice=none`；Chat Completions 等不支持
-    ///   显式关闭的协议可忽略此参数，由 `run_agent_loop` 统一兜底最大轮数。
+    /// - `allow_tool_calls`：是否允许本轮产生工具调用。当为 `false` 时，协议层
+    ///   必须显式设置等价于 `tool_choice=none` 的禁用选项；Provider 违反约束仍
+    ///   返回工具调用时，由 `run_agent_loop` 受控终止。
     async fn advance(
         &mut self,
         results: &[AgentToolResult],

--- a/qq-maid-llm/src/agent_loop/tests.rs
+++ b/qq-maid-llm/src/agent_loop/tests.rs
@@ -297,6 +297,11 @@ struct SlowReadOnlyTool {
     delay: std::time::Duration,
 }
 
+struct SlowFailingReadOnlyTool {
+    calls: Arc<StdMutex<usize>>,
+    delay: std::time::Duration,
+}
+
 struct NamedSlowReadOnlyTool {
     name: &'static str,
     calls: Arc<StdMutex<usize>>,
@@ -356,6 +361,36 @@ impl crate::tool::Tool for SlowReadOnlyTool {
         tokio::time::sleep(self.delay).await;
         Ok(ToolOutput::json(json!({
             "ok": true,
+            "value": arguments["value"],
+        })))
+    }
+}
+
+#[async_trait]
+impl crate::tool::Tool for SlowFailingReadOnlyTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            name: "search".to_owned(),
+            description: "failing read-only search".to_owned(),
+            parameters: json!({
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+                "required": ["value"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn effect(&self) -> ToolEffect {
+        ToolEffect::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: ToolContext, arguments: Value) -> Result<ToolOutput, LlmError> {
+        *self.calls.lock().unwrap() += 1;
+        tokio::time::sleep(self.delay).await;
+        Ok(ToolOutput::json(json!({
+            "ok": false,
+            "error_code": "search_failed",
             "value": arguments["value"],
         })))
     }
@@ -797,6 +832,52 @@ async fn remaining_budget_forces_final_round_without_more_tools() {
     let observed = observed.lock().unwrap();
     assert!(observed[0].1);
     assert!(!observed[1].1);
+}
+
+#[tokio::test]
+async fn failed_tool_entering_finalization_reserve_stops_without_another_model_round() {
+    let calls = Arc::new(StdMutex::new(0));
+    let registry = registry_with(vec![Arc::new(SlowFailingReadOnlyTool {
+        calls: calls.clone(),
+        delay: std::time::Duration::from_millis(320),
+    }) as _]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![tool_call("search", "c1", r#"{"value":"rust"}"#)]),
+            final_reply("must not run"),
+        ],
+    ));
+    let observed = session.observed.clone();
+    let handle = AgentRunHandle::with_timeout(std::time::Duration::from_millis(400));
+
+    let err = run_agent_loop_with_handle(
+        session,
+        registry,
+        test_context(),
+        3,
+        None,
+        None,
+        Some(handle),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(err.code, "request_budget_reserved_for_final_answer");
+    assert_eq!(err.stage, "tool_loop");
+    assert_eq!(*calls.lock().unwrap(), 1);
+    assert_eq!(observed.lock().unwrap().len(), 1);
+    let diagnostics = err.agent.expect("missing agent diagnostics");
+    assert_eq!(diagnostics.model_rounds, 1);
+    assert_eq!(diagnostics.executed_tools, ["search"]);
+    assert_eq!(diagnostics.tool_results.len(), 1);
+    assert!(
+        diagnostics
+            .tool_results
+            .iter()
+            .all(|result| !result.succeeded)
+    );
 }
 
 #[tokio::test]

--- a/qq-maid-llm/src/agent_loop/tests.rs
+++ b/qq-maid-llm/src/agent_loop/tests.rs
@@ -618,33 +618,55 @@ async fn fallback_after_tool_result_does_not_repeat_tool_side_effect() {
 }
 
 #[tokio::test]
-async fn duplicate_read_only_tool_call_is_skipped_without_marking_side_effect() {
+async fn duplicate_read_only_tool_call_replays_success_and_keeps_dependency_chain() {
     let calls = Arc::new(StdMutex::new(0));
-    let registry = registry_with(vec![Arc::new(SlowReadOnlyTool {
-        calls: calls.clone(),
-        delay: std::time::Duration::ZERO,
-    }) as _]);
+    let dependent_calls = Arc::new(StdMutex::new(0));
+    let registry = registry_with(vec![
+        Arc::new(SlowReadOnlyTool {
+            calls: calls.clone(),
+            delay: std::time::Duration::ZERO,
+        }) as _,
+        Arc::new(CountingTool {
+            name: "dependent",
+            calls: dependent_calls.clone(),
+            fail: false,
+            soft_fail: false,
+            dependency: ToolCallDependency::PreviousCallSuccess,
+        }) as _,
+    ]);
     let session = Box::new(ScriptedSession::new(
         "mock",
         "m",
         vec![
             tool_calls(vec![tool_call("search", "c1", r#"{"value":"rust"}"#)]),
-            tool_calls(vec![tool_call("search", "c2", r#"{"value":"rust"}"#)]),
+            tool_calls(vec![
+                tool_call("search", "c2", r#"{"value":"rust"}"#),
+                tool_call("dependent", "c3", r#"{"value":"continue"}"#),
+            ]),
             final_reply("done"),
         ],
     ));
     let observed = session.observed.clone();
-
     let outcome = run_agent_loop(session, registry, test_context(), 3, None, None)
         .await
         .unwrap();
 
     assert_eq!(*calls.lock().unwrap(), 1);
-    assert_eq!(outcome.agent.executed_tools, ["search"]);
-    assert!(outcome.agent.side_effecting_tools_started.is_empty());
+    assert_eq!(*dependent_calls.lock().unwrap(), 1);
+    assert_eq!(outcome.agent.executed_tools, ["search", "dependent"]);
+    assert_eq!(outcome.agent.side_effecting_tools_started, ["dependent"]);
     assert!(outcome.agent.tools_with_unknown_result.is_empty());
+    assert_eq!(outcome.agent.tool_results.len(), 3);
+    assert!(
+        outcome
+            .agent
+            .tool_results
+            .iter()
+            .all(|result| result.succeeded)
+    );
     let observed = observed.lock().unwrap();
-    assert!(observed[2].0[0].output.contains("duplicate_read_only_call"));
+    assert_eq!(observed[1].0[0].output, observed[2].0[0].output);
+    assert!(observed[2].0[1].output.contains("continue"));
 }
 
 #[tokio::test]
@@ -718,6 +740,49 @@ async fn remaining_budget_forces_final_round_without_more_tools() {
     assert_eq!(*calls.lock().unwrap(), 1);
     let observed = observed.lock().unwrap();
     assert!(observed[0].1);
+    assert!(!observed[1].1);
+}
+
+#[tokio::test]
+async fn finalization_budget_rejects_provider_tool_calls_without_another_round() {
+    let calls = Arc::new(StdMutex::new(0));
+    let registry = registry_with(vec![Arc::new(SlowReadOnlyTool {
+        calls: calls.clone(),
+        delay: std::time::Duration::from_millis(65),
+    }) as _]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![tool_call("search", "c1", r#"{"value":"rust"}"#)]),
+            tool_calls(vec![tool_call("search", "c2", r#"{"value":"again"}"#)]),
+            final_reply("must not run"),
+        ],
+    ));
+    let observed = session.observed.clone();
+    let handle = AgentRunHandle::with_timeout(std::time::Duration::from_millis(80));
+
+    let err = run_agent_loop_with_handle(
+        session,
+        registry,
+        test_context(),
+        3,
+        None,
+        None,
+        Some(handle),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(err.code, "tool_calls_disabled");
+    assert_eq!(err.stage, "tool_loop");
+    assert_eq!(*calls.lock().unwrap(), 1);
+    let diagnostics = err.agent.expect("missing agent diagnostics");
+    assert_eq!(diagnostics.model_rounds, 2);
+    assert_eq!(diagnostics.stop_reason, Some(AgentStopReason::Failed));
+    assert_eq!(diagnostics.executed_tools, ["search"]);
+    let observed = observed.lock().unwrap();
+    assert_eq!(observed.len(), 2);
     assert!(!observed[1].1);
 }
 

--- a/qq-maid-llm/src/agent_loop/tests.rs
+++ b/qq-maid-llm/src/agent_loop/tests.rs
@@ -47,6 +47,7 @@ struct ScriptedSession {
     provider: &'static str,
     model: &'static str,
     script: Vec<AgentStep>,
+    delays: Vec<std::time::Duration>,
     observed: Arc<StdMutex<Vec<(Vec<AgentToolResult>, bool)>>>,
 }
 
@@ -164,6 +165,23 @@ impl ScriptedSession {
             provider,
             model,
             script,
+            delays: Vec::new(),
+            observed: Arc::new(StdMutex::new(Vec::new())),
+        }
+    }
+
+    fn with_delays(
+        provider: &'static str,
+        model: &'static str,
+        script: Vec<AgentStep>,
+        delays: Vec<std::time::Duration>,
+    ) -> Self {
+        assert_eq!(script.len(), delays.len());
+        Self {
+            provider,
+            model,
+            script,
+            delays,
             observed: Arc::new(StdMutex::new(Vec::new())),
         }
     }
@@ -186,6 +204,9 @@ impl AgentStepSession for ScriptedSession {
             .lock()
             .unwrap()
             .push((results.to_vec(), allow_tool_calls));
+        if !self.delays.is_empty() {
+            tokio::time::sleep(self.delays.remove(0)).await;
+        }
         Ok(self.script.remove(0))
     }
 }
@@ -274,6 +295,41 @@ struct CountingTool {
 struct SlowReadOnlyTool {
     calls: Arc<StdMutex<usize>>,
     delay: std::time::Duration,
+}
+
+struct NamedSlowReadOnlyTool {
+    name: &'static str,
+    calls: Arc<StdMutex<usize>>,
+    delay: std::time::Duration,
+}
+
+#[async_trait]
+impl crate::tool::Tool for NamedSlowReadOnlyTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            name: self.name.to_owned(),
+            description: "named read-only tool".to_owned(),
+            parameters: json!({
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+                "required": ["value"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn effect(&self) -> ToolEffect {
+        ToolEffect::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: ToolContext, arguments: Value) -> Result<ToolOutput, LlmError> {
+        *self.calls.lock().unwrap() += 1;
+        tokio::time::sleep(self.delay).await;
+        Ok(ToolOutput::json(json!({
+            "ok": true,
+            "value": arguments["value"],
+        })))
+    }
 }
 
 #[async_trait]
@@ -784,6 +840,200 @@ async fn finalization_budget_rejects_provider_tool_calls_without_another_round()
     let observed = observed.lock().unwrap();
     assert_eq!(observed.len(), 2);
     assert!(!observed[1].1);
+}
+
+#[tokio::test]
+async fn model_round_exhausting_tool_budget_rejects_first_tool_without_waiting_for_it() {
+    let calls = Arc::new(StdMutex::new(0));
+    let registry = registry_with(vec![Arc::new(SlowReadOnlyTool {
+        calls: calls.clone(),
+        delay: std::time::Duration::from_secs(5),
+    }) as _]);
+    let session = Box::new(ScriptedSession::with_delays(
+        "mock",
+        "m",
+        vec![tool_calls(vec![tool_call(
+            "search",
+            "c1",
+            r#"{"value":"rust"}"#,
+        )])],
+        vec![std::time::Duration::from_millis(320)],
+    ));
+    let handle = AgentRunHandle::with_timeout(std::time::Duration::from_millis(400));
+
+    let err = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        run_agent_loop_with_handle(
+            session,
+            registry,
+            test_context(),
+            3,
+            None,
+            None,
+            Some(handle),
+        ),
+    )
+    .await
+    .expect("tool timeout must not be awaited")
+    .unwrap_err();
+
+    assert_eq!(err.code, "request_budget_reserved_for_final_answer");
+    assert_eq!(err.stage, "tool_loop");
+    assert_eq!(*calls.lock().unwrap(), 0);
+    let diagnostics = err.agent.expect("missing agent diagnostics");
+    assert!(diagnostics.executed_tools.is_empty());
+    assert!(diagnostics.tool_results.is_empty());
+}
+
+#[tokio::test]
+async fn finalization_reserve_between_read_only_tools_skips_rest_and_forces_final_answer() {
+    let first_calls = Arc::new(StdMutex::new(0));
+    let second_calls = Arc::new(StdMutex::new(0));
+    let registry = registry_with(vec![
+        Arc::new(NamedSlowReadOnlyTool {
+            name: "first_search",
+            calls: first_calls.clone(),
+            delay: std::time::Duration::from_millis(320),
+        }) as _,
+        Arc::new(NamedSlowReadOnlyTool {
+            name: "second_search",
+            calls: second_calls.clone(),
+            delay: std::time::Duration::ZERO,
+        }) as _,
+    ]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![
+                tool_call("first_search", "c1", r#"{"value":"first"}"#),
+                tool_call("second_search", "c2", r#"{"value":"second"}"#),
+            ]),
+            final_reply("基于第一项结果收尾"),
+        ],
+    ));
+    let observed = session.observed.clone();
+    let handle = AgentRunHandle::with_timeout(std::time::Duration::from_millis(400));
+
+    let outcome = run_agent_loop_with_handle(
+        session,
+        registry,
+        test_context(),
+        3,
+        None,
+        None,
+        Some(handle),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome.reply, "基于第一项结果收尾");
+    assert_eq!(*first_calls.lock().unwrap(), 1);
+    assert_eq!(*second_calls.lock().unwrap(), 0);
+    assert_eq!(outcome.agent.executed_tools, ["first_search"]);
+    let observed = observed.lock().unwrap();
+    assert!(!observed[1].1);
+    let skipped: Value = serde_json::from_str(&observed[1].0[1].output).unwrap();
+    assert_eq!(skipped["ok"], false);
+    assert_eq!(skipped["skipped"], true);
+    assert_eq!(
+        skipped["reason"],
+        "request_budget_reserved_for_final_answer"
+    );
+}
+
+#[tokio::test]
+async fn finalization_reserve_after_query_prevents_side_effecting_tool_start() {
+    let query_calls = Arc::new(StdMutex::new(0));
+    let write_calls = Arc::new(StdMutex::new(0));
+    let registry = registry_with(vec![
+        Arc::new(NamedSlowReadOnlyTool {
+            name: "query",
+            calls: query_calls.clone(),
+            delay: std::time::Duration::from_millis(320),
+        }) as _,
+        Arc::new(CountingTool {
+            name: "write",
+            calls: write_calls.clone(),
+            fail: false,
+            soft_fail: false,
+            dependency: ToolCallDependency::None,
+        }) as _,
+    ]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![
+                tool_call("query", "c1", r#"{"value":"read"}"#),
+                tool_call("write", "c2", r#"{"value":"must-not-write"}"#),
+            ]),
+            final_reply("只基于查询结果收尾"),
+        ],
+    ));
+    let handle = AgentRunHandle::with_timeout(std::time::Duration::from_millis(400));
+
+    let outcome = run_agent_loop_with_handle(
+        session,
+        registry,
+        test_context(),
+        3,
+        None,
+        None,
+        Some(handle),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(*query_calls.lock().unwrap(), 1);
+    assert_eq!(*write_calls.lock().unwrap(), 0);
+    assert_eq!(outcome.agent.executed_tools, ["query"]);
+    assert!(outcome.agent.side_effecting_tools_started.is_empty());
+}
+
+#[tokio::test]
+async fn read_only_cache_hit_replays_at_budget_boundary_without_real_execution() {
+    let calls = Arc::new(StdMutex::new(0));
+    let registry = registry_with(vec![Arc::new(SlowReadOnlyTool {
+        calls: calls.clone(),
+        delay: std::time::Duration::ZERO,
+    }) as _]);
+    let session = Box::new(ScriptedSession::with_delays(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![tool_call("search", "c1", r#"{"value":"rust"}"#)]),
+            tool_calls(vec![tool_call("search", "c2", r#"{"value":"rust"}"#)]),
+            final_reply("使用缓存结果收尾"),
+        ],
+        vec![
+            std::time::Duration::ZERO,
+            std::time::Duration::from_millis(320),
+            std::time::Duration::ZERO,
+        ],
+    ));
+    let observed = session.observed.clone();
+    let handle = AgentRunHandle::with_timeout(std::time::Duration::from_millis(400));
+
+    let outcome = run_agent_loop_with_handle(
+        session,
+        registry,
+        test_context(),
+        3,
+        None,
+        None,
+        Some(handle),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome.reply, "使用缓存结果收尾");
+    assert_eq!(*calls.lock().unwrap(), 1);
+    assert_eq!(outcome.agent.executed_tools, ["search"]);
+    assert_eq!(outcome.agent.tool_results.len(), 2);
+    let observed = observed.lock().unwrap();
+    assert_eq!(observed[1].0[0].output, observed[2].0[0].output);
+    assert!(!observed[2].1);
 }
 
 #[tokio::test]

--- a/qq-maid-llm/src/agent_loop/tests.rs
+++ b/qq-maid-llm/src/agent_loop/tests.rs
@@ -8,7 +8,9 @@
 use super::*;
 use crate::error::LlmError;
 use crate::provider::{AgentStopReason, types::TokenUsage};
-use crate::tool::{ToolCallDependency, ToolContext, ToolMetadata, ToolOutput, ToolRegistry};
+use crate::tool::{
+    ToolCallDependency, ToolContext, ToolEffect, ToolMetadata, ToolOutput, ToolRegistry,
+};
 use async_trait::async_trait;
 use qq_maid_common::identity_context::{
     ConversationKind, ExecutionActorContext, ExecutionConversationContext,
@@ -267,6 +269,40 @@ struct CountingTool {
     fail: bool,
     soft_fail: bool,
     dependency: ToolCallDependency,
+}
+
+struct SlowReadOnlyTool {
+    calls: Arc<StdMutex<usize>>,
+    delay: std::time::Duration,
+}
+
+#[async_trait]
+impl crate::tool::Tool for SlowReadOnlyTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            name: "search".to_owned(),
+            description: "read-only search".to_owned(),
+            parameters: json!({
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+                "required": ["value"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn effect(&self) -> ToolEffect {
+        ToolEffect::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: ToolContext, arguments: Value) -> Result<ToolOutput, LlmError> {
+        *self.calls.lock().unwrap() += 1;
+        tokio::time::sleep(self.delay).await;
+        Ok(ToolOutput::json(json!({
+            "ok": true,
+            "value": arguments["value"],
+        })))
+    }
 }
 
 struct ClarificationTool;
@@ -579,6 +615,110 @@ async fn fallback_after_tool_result_does_not_repeat_tool_side_effect() {
     assert!(outcome.fallback_used);
     assert_eq!(*calls.lock().unwrap(), 1);
     assert_eq!(outcome.agent.executed_tools, vec!["echo"]);
+}
+
+#[tokio::test]
+async fn duplicate_read_only_tool_call_is_skipped_without_marking_side_effect() {
+    let calls = Arc::new(StdMutex::new(0));
+    let registry = registry_with(vec![Arc::new(SlowReadOnlyTool {
+        calls: calls.clone(),
+        delay: std::time::Duration::ZERO,
+    }) as _]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![tool_call("search", "c1", r#"{"value":"rust"}"#)]),
+            tool_calls(vec![tool_call("search", "c2", r#"{"value":"rust"}"#)]),
+            final_reply("done"),
+        ],
+    ));
+    let observed = session.observed.clone();
+
+    let outcome = run_agent_loop(session, registry, test_context(), 3, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(*calls.lock().unwrap(), 1);
+    assert_eq!(outcome.agent.executed_tools, ["search"]);
+    assert!(outcome.agent.side_effecting_tools_started.is_empty());
+    assert!(outcome.agent.tools_with_unknown_result.is_empty());
+    let observed = observed.lock().unwrap();
+    assert!(observed[2].0[0].output.contains("duplicate_read_only_call"));
+}
+
+#[tokio::test]
+async fn side_effecting_tool_invalidates_read_only_deduplication() {
+    let search_calls = Arc::new(StdMutex::new(0));
+    let write_calls = Arc::new(StdMutex::new(0));
+    let registry = registry_with(vec![
+        Arc::new(SlowReadOnlyTool {
+            calls: search_calls.clone(),
+            delay: std::time::Duration::ZERO,
+        }) as _,
+        Arc::new(CountingTool {
+            name: "echo",
+            calls: write_calls.clone(),
+            fail: false,
+            soft_fail: false,
+            dependency: ToolCallDependency::None,
+        }) as _,
+    ]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![tool_call("search", "c1", r#"{"value":"rust"}"#)]),
+            tool_calls(vec![tool_call("echo", "c2", r#"{"value":"write"}"#)]),
+            tool_calls(vec![tool_call("search", "c3", r#"{"value":"rust"}"#)]),
+            final_reply("done"),
+        ],
+    ));
+
+    let outcome = run_agent_loop(session, registry, test_context(), 4, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(*search_calls.lock().unwrap(), 2);
+    assert_eq!(*write_calls.lock().unwrap(), 1);
+    assert_eq!(outcome.agent.side_effecting_tools_started, ["echo"]);
+}
+
+#[tokio::test]
+async fn remaining_budget_forces_final_round_without_more_tools() {
+    let calls = Arc::new(StdMutex::new(0));
+    let registry = registry_with(vec![Arc::new(SlowReadOnlyTool {
+        calls: calls.clone(),
+        delay: std::time::Duration::from_millis(28),
+    }) as _]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![tool_call("search", "c1", r#"{"value":"rust"}"#)]),
+            final_reply("已有结果的简短收尾"),
+        ],
+    ));
+    let observed = session.observed.clone();
+    let handle = AgentRunHandle::with_timeout(std::time::Duration::from_millis(30));
+
+    let outcome = run_agent_loop_with_handle(
+        session,
+        registry,
+        test_context(),
+        3,
+        None,
+        None,
+        Some(handle),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome.reply, "已有结果的简短收尾");
+    assert_eq!(*calls.lock().unwrap(), 1);
+    let observed = observed.lock().unwrap();
+    assert!(observed[0].1);
+    assert!(!observed[1].1);
 }
 
 #[tokio::test]

--- a/qq-maid-llm/src/agent_loop/types.rs
+++ b/qq-maid-llm/src/agent_loop/types.rs
@@ -8,6 +8,7 @@ use std::{
     future::Future,
     pin::Pin,
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use crate::error::LlmError;
@@ -15,7 +16,9 @@ use crate::provider::types::{ChatRequest, TokenUsage};
 use crate::tool::ToolRegistry;
 use serde::Serialize;
 use serde_json::Value;
-use tokio::sync::Notify;
+use tokio::{sync::Notify, time::Instant};
+
+const MAX_FINALIZATION_RESERVE: Duration = Duration::from_secs(5);
 
 /// Tool Loop 中单次工具执行的结果摘要。
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -64,6 +67,8 @@ pub struct AgentRunDiagnostics {
     pub tool_execution_attempted: bool,
     /// 整次请求中已实际开始执行的工具名，跨候选累计；参数校验失败或启动前取消不计入。
     pub executed_tools: Vec<String>,
+    /// 已实际开始执行且可能修改外部状态的工具名。
+    pub side_effecting_tools_started: Vec<String>,
     /// 已经形成可信结果的工具执行摘要。
     pub tool_results: Vec<ToolExecutionResult>,
     /// 已开始但尚未形成可信结果的工具名。
@@ -88,6 +93,8 @@ pub struct AgentRunHandle {
 struct AgentRunState {
     diagnostics: AgentRunDiagnostics,
     pending_attempt: Option<AgentAttemptBaseline>,
+    deadline: Option<Instant>,
+    finalization_reserve: Duration,
 }
 
 impl Default for AgentRunHandle {
@@ -100,6 +107,19 @@ impl Default for AgentRunHandle {
 }
 
 impl AgentRunHandle {
+    /// 创建带统一请求截止时间的运行句柄，并为最后一轮无工具回答预留一小段预算。
+    pub fn with_timeout(request_timeout: Duration) -> Self {
+        let reserve = std::cmp::min(MAX_FINALIZATION_RESERVE, request_timeout / 4);
+        Self {
+            state: Arc::new(Mutex::new(AgentRunState {
+                deadline: Some(Instant::now() + request_timeout),
+                finalization_reserve: reserve,
+                ..AgentRunState::default()
+            })),
+            cancel_notify: Arc::new(Notify::new()),
+        }
+    }
+
     pub fn snapshot(&self) -> AgentRunDiagnostics {
         self.state
             .lock()
@@ -204,7 +224,11 @@ impl AgentRunHandle {
     }
 
     /// 检查外部终止并原子记录工具已经越过副作用启动边界。
-    pub(crate) fn try_start_tool(&self, tool_name: &str) -> Result<(), LlmError> {
+    pub(crate) fn try_start_tool(
+        &self,
+        tool_name: &str,
+        effect: crate::tool::ToolEffect,
+    ) -> Result<(), LlmError> {
         let mut state = self
             .state
             .lock()
@@ -214,11 +238,39 @@ impl AgentRunHandle {
                 .with_agent(state.diagnostics.clone()));
         }
         state.diagnostics.executed_tools.push(tool_name.to_owned());
-        state
-            .diagnostics
-            .tools_with_unknown_result
-            .push(tool_name.to_owned());
+        if effect == crate::tool::ToolEffect::SideEffecting {
+            state
+                .diagnostics
+                .side_effecting_tools_started
+                .push(tool_name.to_owned());
+            state
+                .diagnostics
+                .tools_with_unknown_result
+                .push(tool_name.to_owned());
+        }
         Ok(())
+    }
+
+    /// 当前剩余请求预算；未配置 deadline 的兼容调用返回 None。
+    pub fn remaining_budget(&self) -> Option<Duration> {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state
+            .deadline
+            .map(|deadline| deadline.saturating_duration_since(Instant::now()))
+    }
+
+    /// 是否应停止继续调用工具，把剩余时间留给基于已有结果的简短收尾。
+    pub(crate) fn should_preserve_finalization_budget(&self) -> bool {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.deadline.is_some_and(|deadline| {
+            deadline.saturating_duration_since(Instant::now()) <= state.finalization_reserve
+        })
     }
 
     /// 工具真实结果先写入共享轨迹，再投递完成进度，避免 sink 失败遮蔽结果。

--- a/qq-maid-llm/src/agent_loop/types.rs
+++ b/qq-maid-llm/src/agent_loop/types.rs
@@ -273,6 +273,17 @@ impl AgentRunHandle {
         })
     }
 
+    /// 是否已经获得至少一个可以支撑最终回答的成功工具结果。
+    pub(crate) fn has_trusted_tool_result_since(&self, baseline: usize) -> bool {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.diagnostics.tool_results[baseline..]
+            .iter()
+            .any(|result| result.succeeded)
+    }
+
     /// 工具真实结果先写入共享轨迹，再投递完成进度，避免 sink 失败遮蔽结果。
     pub(crate) fn record_tool_result(&self, result: ToolExecutionResult) {
         self.update(|diagnostics| {

--- a/qq-maid-llm/src/provider/openai/chat_tool_loop.rs
+++ b/qq-maid-llm/src/provider/openai/chat_tool_loop.rs
@@ -83,10 +83,8 @@ impl AgentStepSession for ChatCompletionsAgentSession {
     async fn advance(
         &mut self,
         results: &[AgentToolResult],
-        _allow_tool_calls: bool,
+        allow_tool_calls: bool,
     ) -> Result<AgentStep, LlmError> {
-        // Chat Completions 不支持显式 tool_choice=none 的兼容交集，忽略
-        // allow_tool_calls；最大轮数由 run_agent_loop 统一兜底。
         // 回填上一轮工具执行结果（首轮 results 为空，跳过）。
         append_tool_results(&mut self.messages, results);
 
@@ -95,6 +93,7 @@ impl AgentStepSession for ChatCompletionsAgentSession {
             &self.tool_defs,
             &self.model,
             self.max_output_tokens,
+            allow_tool_calls,
             false,
         );
         enforce_tool_loop_budget(self.context_budget, &payload)?;
@@ -152,6 +151,7 @@ impl AgentStepSession for ChatCompletionsAgentSession {
             &self.tool_defs,
             &self.model,
             self.max_output_tokens,
+            allow_tool_calls,
             true,
         );
         enforce_tool_loop_budget(self.context_budget, &payload)?;
@@ -259,6 +259,7 @@ fn chat_completions_tool_loop_payload(
     tools: &[Value],
     model: &str,
     max_output_tokens: u64,
+    allow_tool_calls: bool,
     stream: bool,
 ) -> Value {
     json!({
@@ -266,8 +267,7 @@ fn chat_completions_tool_loop_payload(
         "messages": messages,
         "max_tokens": max_output_tokens,
         "tools": tools,
-        // BigModel 文档当前写明仅支持 auto，这里统一固定成兼容交集。
-        "tool_choice": "auto",
+        "tool_choice": if allow_tool_calls { "auto" } else { "none" },
         "stream": stream,
     })
 }
@@ -1145,6 +1145,7 @@ mod tests {
             &"model-name-that-must-not-count".repeat(20),
             1200,
             true,
+            true,
         );
         let model_context = json!({"messages": messages, "tools": tools});
         let model_context_chars = estimated_json_chars(&model_context, "tool_loop").unwrap();
@@ -1159,6 +1160,20 @@ mod tests {
             &payload,
         )
         .unwrap();
+    }
+
+    #[test]
+    fn payload_disables_tool_calls_explicitly() {
+        let payload = chat_completions_tool_loop_payload(
+            &[json!({"role": "user", "content": "总结已有结果"})],
+            &[json!({"type": "function", "function": {"name": "search"}})],
+            "test-model",
+            1200,
+            false,
+            false,
+        );
+
+        assert_eq!(payload["tool_choice"], "none");
     }
 
     #[tokio::test]

--- a/qq-maid-llm/src/provider/openai/tool_loop.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop.rs
@@ -1380,6 +1380,21 @@ mod tests {
     }
 
     #[test]
+    fn payload_disables_tool_calls_explicitly() {
+        let payload = openai_tool_loop_payload(
+            &[json!({"role": "user", "content": "总结已有结果"})],
+            &[json!({"type": "function", "name": "search"})],
+            "gpt-test",
+            1200,
+            None,
+            false,
+            false,
+        );
+
+        assert_eq!(payload["tool_choice"], "none");
+    }
+
+    #[test]
     fn streaming_payload_enables_responses_stream() {
         let payload = openai_tool_loop_payload(
             &[json!({"role": "user", "content": "test"})],

--- a/qq-maid-llm/src/provider/routing.rs
+++ b/qq-maid-llm/src/provider/routing.rs
@@ -329,7 +329,7 @@ impl LlmProvider for ModelRouteProvider {
                     let visible_delta_sent = visible_final_delta_sent.load(Ordering::SeqCst);
                     let tool_side_effect_started = {
                         let diagnostics = run_handle.snapshot();
-                        !diagnostics.executed_tools.is_empty()
+                        !diagnostics.side_effecting_tools_started.is_empty()
                             || !diagnostics.tools_with_unknown_result.is_empty()
                     };
                     let fallback = index + 1 < candidates.len()

--- a/qq-maid-llm/src/provider/tool_loop.rs
+++ b/qq-maid-llm/src/provider/tool_loop.rs
@@ -36,6 +36,12 @@ pub(crate) struct ToolLoopCall<'a> {
 
 pub(crate) struct ToolLoopCallOutput {
     pub(crate) output: String,
+    pub(crate) skipped_for_finalization: bool,
+}
+
+pub(crate) enum ToolCallStartDecision {
+    Execute,
+    SkipForFinalAnswer,
 }
 
 pub(crate) struct PreparedToolLoopCall {
@@ -89,6 +95,7 @@ impl<'a> ToolLoopExecutor<'a> {
     pub(crate) async fn execute_prepared_call(
         &mut self,
         call: PreparedToolLoopCall,
+        before_start: impl FnOnce(&str, ToolEffect) -> Result<ToolCallStartDecision, LlmError>,
         on_started: impl FnOnce(&str, ToolEffect) -> Result<(), LlmError>,
         on_result: impl FnOnce(ToolExecutionResult),
     ) -> Result<ToolLoopCallOutput, LlmError> {
@@ -96,6 +103,7 @@ impl<'a> ToolLoopExecutor<'a> {
             tool_name: requested_tool_name,
             prepared,
         } = call;
+        let mut skipped_for_finalization = false;
         let (tool_name, output, succeeded) = match prepared {
             Ok(prepared) => {
                 let tool_name = prepared.name.clone();
@@ -120,28 +128,40 @@ impl<'a> ToolLoopExecutor<'a> {
                         false,
                     )
                 } else {
-                    self.emit_progress(ToolLoopProgressEvent::ToolCallStarted {
-                        tool_name: tool_name.clone(),
-                    })
-                    .await?;
-                    // progress await 返回后仍需在共享生命周期锁内重新检查取消；只有
-                    // 原子启动转换成功，才创建工具 future 并越过副作用边界。
-                    on_started(&tool_name, prepared.effect)?;
-                    if prepared.effect == ToolEffect::SideEffecting {
-                        // 写操作可能改变后续查询结果；只读去重只能跨越没有状态变化的
-                        // 连续查询段，不能让“查询 -> 修改 -> 再查询”复用旧判断。
-                        self.completed_read_only_calls.clear();
-                    }
-                    self.executed_tools.push(tool_name.clone());
-                    match self.tools.execute_prepared(prepared).await {
-                        Ok(output) => {
-                            let succeeded = tool_output_indicates_success(&output);
-                            if succeeded && let Some(key) = read_only_key {
-                                self.completed_read_only_calls.insert(key, output.clone());
-                            }
-                            (tool_name, output, succeeded)
+                    match before_start(&tool_name, prepared.effect)? {
+                        ToolCallStartDecision::SkipForFinalAnswer => {
+                            skipped_for_finalization = true;
+                            (
+                                tool_name,
+                                tool_skip_output("request_budget_reserved_for_final_answer"),
+                                false,
+                            )
                         }
-                        Err(err) => (tool_name, tool_error_output(&err), false),
+                        ToolCallStartDecision::Execute => {
+                            self.emit_progress(ToolLoopProgressEvent::ToolCallStarted {
+                                tool_name: tool_name.clone(),
+                            })
+                            .await?;
+                            // progress await 返回后仍需在共享生命周期锁内重新检查取消；只有
+                            // 原子启动转换成功，才创建工具 future 并越过副作用边界。
+                            on_started(&tool_name, prepared.effect)?;
+                            if prepared.effect == ToolEffect::SideEffecting {
+                                // 写操作可能改变后续查询结果；只读去重只能跨越没有状态变化的
+                                // 连续查询段，不能让“查询 -> 修改 -> 再查询”复用旧判断。
+                                self.completed_read_only_calls.clear();
+                            }
+                            self.executed_tools.push(tool_name.clone());
+                            match self.tools.execute_prepared(prepared).await {
+                                Ok(output) => {
+                                    let succeeded = tool_output_indicates_success(&output);
+                                    if succeeded && let Some(key) = read_only_key {
+                                        self.completed_read_only_calls.insert(key, output.clone());
+                                    }
+                                    (tool_name, output, succeeded)
+                                }
+                                Err(err) => (tool_name, tool_error_output(&err), false),
+                            }
+                        }
                     }
                 }
             }
@@ -165,7 +185,10 @@ impl<'a> ToolLoopExecutor<'a> {
         // 工具已经完成后先落可信轨迹，再通知上层；receiver 此时关闭不能抹掉结果。
         on_result(result);
         self.emit_progress(event).await?;
-        Ok(ToolLoopCallOutput { output })
+        Ok(ToolLoopCallOutput {
+            output,
+            skipped_for_finalization,
+        })
     }
 
     pub(crate) fn executed_tools(&self) -> Vec<String> {

--- a/qq-maid-llm/src/provider/tool_loop.rs
+++ b/qq-maid-llm/src/provider/tool_loop.rs
@@ -4,13 +4,15 @@
 //! 工具准备、执行失败、依赖跳过、结果轨迹和稳定调用 ID 在这里统一维护，
 //! 避免 Responses 与 Chat Completions 两条协议分支各自漂移。
 
+use std::collections::HashSet;
+
 use serde_json::{Value, json};
 
 use crate::{
     agent_loop::{ToolLoopProgressEvent, ToolLoopProgressSink},
     error::LlmError,
     provider::ToolExecutionResult,
-    tool::{PreparedToolCall, ToolCallDependency, ToolContext, ToolRegistry},
+    tool::{PreparedToolCall, ToolCallDependency, ToolContext, ToolEffect, ToolRegistry},
 };
 
 pub(crate) struct ToolLoopExecutor<'a> {
@@ -22,6 +24,7 @@ pub(crate) struct ToolLoopExecutor<'a> {
     progress_sink: Option<ToolLoopProgressSink>,
     execution_attempted: bool,
     rejected_call: bool,
+    completed_read_only_calls: HashSet<String>,
 }
 
 pub(crate) struct ToolLoopCall<'a> {
@@ -54,6 +57,7 @@ impl<'a> ToolLoopExecutor<'a> {
             progress_sink,
             execution_attempted: false,
             rejected_call: false,
+            completed_read_only_calls: HashSet::new(),
         }
     }
 
@@ -84,7 +88,7 @@ impl<'a> ToolLoopExecutor<'a> {
     pub(crate) async fn execute_prepared_call(
         &mut self,
         call: PreparedToolLoopCall,
-        on_started: impl FnOnce(&str) -> Result<(), LlmError>,
+        on_started: impl FnOnce(&str, ToolEffect) -> Result<(), LlmError>,
         on_result: impl FnOnce(ToolExecutionResult),
     ) -> Result<ToolLoopCallOutput, LlmError> {
         let PreparedToolLoopCall {
@@ -94,7 +98,20 @@ impl<'a> ToolLoopExecutor<'a> {
         let (tool_name, output, succeeded) = match prepared {
             Ok(prepared) => {
                 let tool_name = prepared.name.clone();
-                if prepared.dependency == ToolCallDependency::PreviousCallSuccess
+                let read_only_key = prepared
+                    .deduplication_key
+                    .as_ref()
+                    .map(|key| format!("{}:{key}", prepared.name));
+                if read_only_key
+                    .as_ref()
+                    .is_some_and(|key| self.completed_read_only_calls.contains(key))
+                {
+                    (
+                        tool_name,
+                        tool_skip_output("duplicate_read_only_call"),
+                        false,
+                    )
+                } else if prepared.dependency == ToolCallDependency::PreviousCallSuccess
                     && !self.previous_call_succeeded
                 {
                     (
@@ -109,11 +126,19 @@ impl<'a> ToolLoopExecutor<'a> {
                     .await?;
                     // progress await 返回后仍需在共享生命周期锁内重新检查取消；只有
                     // 原子启动转换成功，才创建工具 future 并越过副作用边界。
-                    on_started(&tool_name)?;
+                    on_started(&tool_name, prepared.effect)?;
+                    if prepared.effect == ToolEffect::SideEffecting {
+                        // 写操作可能改变后续查询结果；只读去重只能跨越没有状态变化的
+                        // 连续查询段，不能让“查询 -> 修改 -> 再查询”复用旧判断。
+                        self.completed_read_only_calls.clear();
+                    }
                     self.executed_tools.push(tool_name.clone());
                     match self.tools.execute_prepared(prepared).await {
                         Ok(output) => {
                             let succeeded = tool_output_indicates_success(&output);
+                            if succeeded && let Some(key) = read_only_key {
+                                self.completed_read_only_calls.insert(key);
+                            }
                             (tool_name, output, succeeded)
                         }
                         Err(err) => (tool_name, tool_error_output(&err), false),

--- a/qq-maid-llm/src/provider/tool_loop.rs
+++ b/qq-maid-llm/src/provider/tool_loop.rs
@@ -4,9 +4,10 @@
 //! 工具准备、执行失败、依赖跳过、结果轨迹和稳定调用 ID 在这里统一维护，
 //! 避免 Responses 与 Chat Completions 两条协议分支各自漂移。
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use serde_json::{Value, json};
+use tracing::debug;
 
 use crate::{
     agent_loop::{ToolLoopProgressEvent, ToolLoopProgressSink},
@@ -24,7 +25,7 @@ pub(crate) struct ToolLoopExecutor<'a> {
     progress_sink: Option<ToolLoopProgressSink>,
     execution_attempted: bool,
     rejected_call: bool,
-    completed_read_only_calls: HashSet<String>,
+    completed_read_only_calls: HashMap<String, String>,
 }
 
 pub(crate) struct ToolLoopCall<'a> {
@@ -57,7 +58,7 @@ impl<'a> ToolLoopExecutor<'a> {
             progress_sink,
             execution_attempted: false,
             rejected_call: false,
-            completed_read_only_calls: HashSet::new(),
+            completed_read_only_calls: HashMap::new(),
         }
     }
 
@@ -102,15 +103,14 @@ impl<'a> ToolLoopExecutor<'a> {
                     .deduplication_key
                     .as_ref()
                     .map(|key| format!("{}:{key}", prepared.name));
-                if read_only_key
+                if let Some(cached_output) = read_only_key
                     .as_ref()
-                    .is_some_and(|key| self.completed_read_only_calls.contains(key))
+                    .and_then(|key| self.completed_read_only_calls.get(key))
                 {
-                    (
-                        tool_name,
-                        tool_skip_output("duplicate_read_only_call"),
-                        false,
-                    )
+                    // 缓存只保存已明确成功的只读结果；回放原始输出，避免模型把去重
+                    // 误判为失败，也不能把缓存命中计作一次真实工具执行。
+                    debug!(tool = %tool_name, "agent read-only tool cache hit");
+                    (tool_name, cached_output.clone(), true)
                 } else if prepared.dependency == ToolCallDependency::PreviousCallSuccess
                     && !self.previous_call_succeeded
                 {
@@ -137,7 +137,7 @@ impl<'a> ToolLoopExecutor<'a> {
                         Ok(output) => {
                             let succeeded = tool_output_indicates_success(&output);
                             if succeeded && let Some(key) = read_only_key {
-                                self.completed_read_only_calls.insert(key);
+                                self.completed_read_only_calls.insert(key, output.clone());
                             }
                             (tool_name, output, succeeded)
                         }

--- a/qq-maid-llm/src/tool.rs
+++ b/qq-maid-llm/src/tool.rs
@@ -30,6 +30,16 @@ pub enum ToolTimeoutPolicy {
     ToolManaged,
 }
 
+/// Tool 对外部状态的影响类型。
+///
+/// 默认按有副作用处理，只有明确只读的查询工具才应覆盖为 [`ReadOnly`](Self::ReadOnly)，
+/// 避免候选回退或取消清理阶段重复执行写操作。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolEffect {
+    ReadOnly,
+    SideEffecting,
+}
+
 /// Tool 元数据，直接映射到 OpenAI Responses function tool schema。
 #[derive(Debug, Clone)]
 pub struct ToolMetadata {
@@ -114,6 +124,16 @@ pub trait Tool: Send + Sync {
     fn timeout_policy(&self) -> ToolTimeoutPolicy {
         ToolTimeoutPolicy::RegistryDefault
     }
+    /// 返回工具是否可能修改外部状态；默认保守视为有副作用。
+    fn effect(&self) -> ToolEffect {
+        ToolEffect::SideEffecting
+    }
+    /// 返回同一请求内只读调用的去重键；写入类工具默认不参与自动去重。
+    fn deduplication_key(&self, arguments: &Value) -> Option<String> {
+        (self.effect() == ToolEffect::ReadOnly)
+            .then(|| serde_json::to_string(arguments).ok())
+            .flatten()
+    }
     /// 执行前的本地预处理。
     ///
     /// 默认直接沿用模型参数；有状态工具可在这里把用户可见编号预绑定成稳定内部 ID，
@@ -143,6 +163,10 @@ pub struct PreparedToolCall {
     pub context: ToolContext,
     /// 预处理后的参数。
     pub arguments: Value,
+    /// 工具的读写语义，用于取消、候选回退和重复调用控制。
+    pub effect: ToolEffect,
+    /// 同一 Agent 请求内的只读调用去重键。
+    pub deduplication_key: Option<String>,
     /// 与同轮前一项调用的依赖关系。
     pub dependency: ToolCallDependency,
 }
@@ -281,7 +305,11 @@ impl ToolRegistry {
             )
         })?;
         let preparation = tool.prepare(context, arguments)?;
+        let effect = tool.effect();
+        let deduplication_key = tool.deduplication_key(&preparation.arguments);
         Ok(PreparedToolCall {
+            effect,
+            deduplication_key,
             tool,
             name: name.to_owned(),
             context: context.clone(),


### PR DESCRIPTION
## 修改内容

- 为 Agent 运行句柄增加统一请求 deadline 和收尾预留预算；保留模型轮次开始前的预算判断，并在模型返回 ToolCalls 后、进入工具批次前以及每个真实工具启动前重新检查剩余预算。
- 已有可信工具结果时，进入 finalization reserve 后不再启动剩余真实工具，为未执行调用回填 `request_budget_reserved_for_final_answer` 结构化跳过结果，并强制下一轮使用 `tool_choice=none` 完成最终收尾；尚无可信结果时返回稳定的预算不足错误。
- 增加 Tool 读写语义与只读调用去重键。`web_search` 去重键包含归一化后的 `query`、`raw_question`、`max_results` 和 `context_size`；天气、列车、Todo 查询和 RSS 最近条目明确标记为只读；写工具开始后会清空只读去重缓存。
- 缓存命中的只读工具继续原样回放，不计入真实 `executed_tools`，也不会被预算边界误判为工具已启动。
- 候选回退只把真正的副作用工具视为已开始副作用，避免只读查询被错误阻止回退；已经越过启动边界的副作用工具继续保留 unknown result 和有限清理窗口。
- 部分正文已经流出后发生硬超时时，追加通用、可理解的终止提示，同时仍返回失败事件，不切换候选或重放完整回答。
- 增加模型轮次、工具耗时和工具启动预算诊断日志，记录 tool、round、remaining_budget_ms、是否因 finalization reserve 跳过及当前是否已有可信结果。

## 根因

Agent 最终回答预算原先只在模型轮次开始前判断。模型请求本身耗时较长后，仍可能在预算不足时启动首个工具；同一批较早工具耗尽预算后，后续工具也会继续启动，最终撞上 Core 外层硬超时。

## 验证

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`

新增自动化测试覆盖：首轮模型耗尽工具预算、同批只读工具中途进入 reserve、查询后禁止启动副作用写工具、预算边界缓存回放、慢工具失败后进入 reserve 且不再启动下一轮模型；现有只读缓存、`tool_choice=none` 违规、只读快速取消、副作用清理窗口和单次超时终止提示测试继续通过。

Closes #428
