### PR TITLE
fix: 补充 RSS 空列表添加引导

### DIFF
--- a/qq-maid-core/src/runtime/respond/rss_flow.rs
+++ b/qq-maid-core/src/runtime/respond/rss_flow.rs
@@ -467,7 +467,7 @@ fn resolve_subscription_target<'a>(
 
 fn format_rss_list_reply(subscriptions: &[RssSubscription]) -> String {
     if subscriptions.is_empty() {
-        return "当前目标没有 RSS 订阅。".to_owned();
+        return "当前目标没有 RSS 订阅。\n添加订阅：/rss add RSS地址 [名称]".to_owned();
     }
     let mut rows = vec!["RSS 订阅：".to_owned()];
     for (index, subscription) in subscriptions.iter().enumerate() {
@@ -773,6 +773,16 @@ mod tests {
         let command = parse_rss_command("/rss nope").unwrap();
         assert_eq!(command.action, "rss_help");
         assert_ne!(command.action, "rss_list");
+    }
+
+    #[test]
+    fn empty_rss_list_guides_user_to_add_subscription() {
+        let reply = format_rss_list_reply(&[]);
+
+        assert_eq!(
+            reply,
+            "当前目标没有 RSS 订阅。\n添加订阅：/rss add RSS地址 [名称]"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 修改内容

- 在 `/rss` 查询结果为空时补充添加订阅命令提示
- 新增单元测试，固定空列表回复文案

## 原因

原先空列表只提示“当前目标没有 RSS 订阅”，用户无法直接得知下一步如何添加订阅。

## 用户影响

没有订阅时会直接看到可执行命令：`/rss add RSS地址 [名称]`。

## 验证

- `cargo fmt -p qq-maid-core -- --check`
- `cargo test -p qq-maid-core empty_rss_list_guides_user_to_add_subscription`
- `cargo check -p qq-maid-core`
- `git diff --check`