### PR TITLE
fix: Gateway 地址获取失败时退避重试

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,6 +1500,7 @@ dependencies = [
  "async-trait",
  "axum",
  "dotenvy",
+ "fastrand",
  "futures-util",
  "qq-maid-common",
  "qq-maid-core",

--- a/qq-maid-gateway-rs/Cargo.toml
+++ b/qq-maid-gateway-rs/Cargo.toml
@@ -10,6 +10,7 @@ async-trait = "0.1"
 axum = "0.8"
 dotenvy = "0.15"
 futures-util = "0.3"
+fastrand = "2"
 qq-maid-core = { path = "../qq-maid-core" }
 qq-maid-common = { path = "../qq-maid-common" }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }

--- a/qq-maid-gateway-rs/src/auth.rs
+++ b/qq-maid-gateway-rs/src/auth.rs
@@ -45,11 +45,26 @@ pub enum AccessTokenSnapshotState {
 #[derive(Debug, Error)]
 pub enum AuthError {
     #[error("QQ token request failed: {0}")]
-    Http(#[from] reqwest::Error),
+    Request(reqwest::Error),
     #[error("QQ token endpoint returned {status}")]
-    Status { status: StatusCode, body: String },
+    Status { status: StatusCode },
     #[error("QQ token response missing access_token or expires_in")]
     InvalidResponse,
+}
+
+impl AuthError {
+    /// Token 刷新只重试远端瞬时故障；鉴权 4xx 与成功但无效的认证响应必须尽快暴露。
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            Self::Request(error) => !error.is_builder() && !error.is_redirect(),
+            Self::Status { status } => is_retryable_status(*status),
+            Self::InvalidResponse => false,
+        }
+    }
+}
+
+fn is_retryable_status(status: StatusCode) -> bool {
+    matches!(status.as_u16(), 408 | 425 | 429) || status.is_server_error()
 }
 
 #[derive(Debug, Serialize)]
@@ -145,15 +160,23 @@ impl AccessTokenManager {
                 client_secret: &self.inner.app_secret,
             })
             .send()
-            .await?;
+            .await
+            .map_err(AuthError::Request)?;
 
         let status = response.status();
         if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            return Err(AuthError::Status { status, body });
+            // Token 错误正文可能包含平台诊断或认证相关内容，分类只需要状态码，不保留正文。
+            return Err(AuthError::Status { status });
         }
 
-        let token = response.json::<TokenResponse>().await?;
+        let token = response.json::<TokenResponse>().await.map_err(|error| {
+            if error.is_decode() {
+                AuthError::InvalidResponse
+            } else {
+                // 已收到 2xx 响应头后，响应体仍可能因连接重置或超时读取失败。
+                AuthError::Request(error)
+            }
+        })?;
         let access_token = token.access_token.filter(|value| !value.trim().is_empty());
         let expires_in = token.expires_in.filter(|value| *value > 0);
         let (Some(access_token), Some(expires_in)) = (access_token, expires_in) else {
@@ -306,5 +329,46 @@ mod tests {
 
         assert_eq!(snapshot.state, AccessTokenSnapshotState::RefreshDue);
         assert!(snapshot.expires_in_seconds.unwrap_or_default() <= 30);
+    }
+
+    #[test]
+    fn token_status_retry_classification_is_explicit() {
+        for status in [
+            StatusCode::REQUEST_TIMEOUT,
+            StatusCode::TOO_EARLY,
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::BAD_GATEWAY,
+        ] {
+            assert!(AuthError::Status { status }.is_retryable(), "{status}");
+        }
+
+        for status in [
+            StatusCode::BAD_REQUEST,
+            StatusCode::UNAUTHORIZED,
+            StatusCode::FORBIDDEN,
+            StatusCode::NOT_FOUND,
+        ] {
+            assert!(!AuthError::Status { status }.is_retryable(), "{status}");
+        }
+        assert!(!AuthError::InvalidResponse.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn token_network_error_is_retryable_and_safe_to_format() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let request_error = reqwest::Client::new()
+            .get(format!("http://{address}/token"))
+            .send()
+            .await
+            .unwrap_err();
+        let error = AuthError::Request(request_error);
+        let rendered = error.to_string();
+
+        assert!(error.is_retryable());
+        assert!(!rendered.contains("app-secret"));
+        assert!(!rendered.contains("QQBot"));
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod platform;
 mod protocol;
 pub mod push;
 mod ref_index;
+mod retry;
 mod stream;
 mod typing;
 mod wechat_service;
@@ -43,6 +44,7 @@ use ping::GatewayRuntimeStatus;
 use protocol::ResumeState;
 use push::GatewayPushSink;
 use ref_index::ref_index;
+use retry::{GatewayFetchBackoff, GatewayFetchOutcome, fetch_gateway_url_with_retry};
 
 use crate::{
     api::QqApiClient, auth::AccessTokenManager, config::AppConfig, respond::RespondClient,
@@ -125,6 +127,7 @@ pub async fn run(
         aggregator_shutdown,
     );
     let aggregator_handle = aggregator.handle();
+    let mut gateway_fetch_backoff = GatewayFetchBackoff::default();
 
     loop {
         if shutdown_token.is_cancelled() {
@@ -132,19 +135,19 @@ pub async fn run(
         }
         info!(api_base = %config.api_base, "fetching QQ gateway url");
         // 每次重连前重新获取网关地址，避免 IP/调度发生变化后仍连旧地址
-        let gateway_url = match tokio::select! {
-            _ = shutdown_token.cancelled() => break,
-            result = protocol::fetch_gateway_url(&http_client, &config, &auth) => result,
-        } {
-            Ok(url) => {
-                info!("fetched QQ gateway url");
-                url
-            }
-            Err(err) => {
-                warn!(error = %err, "failed to fetch QQ gateway url");
-                return Err(err).context("fetch QQ gateway url");
-            }
+        let gateway_url = match fetch_gateway_url_with_retry(
+            &shutdown_token,
+            &mut gateway_fetch_backoff,
+            || protocol::fetch_gateway_url(&http_client, &config, &auth),
+            || fastrand::i16(-20..=20),
+        )
+        .await
+        {
+            Ok(GatewayFetchOutcome::Url(url)) => url,
+            Ok(GatewayFetchOutcome::Shutdown) => break,
+            Err(error) => return Err(error).context("fetch QQ gateway url"),
         };
+        info!("fetched QQ gateway url");
 
         match protocol::run_gateway_once(
             &gateway_url,

--- a/qq-maid-gateway-rs/src/gateway/protocol.rs
+++ b/qq-maid-gateway-rs/src/gateway/protocol.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use anyhow::{Context, anyhow};
 use futures_util::{SinkExt, StreamExt};
+use reqwest::{StatusCode, Url};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use tokio::time::{MissedTickBehavior, interval};
@@ -17,13 +18,44 @@ use tracing::{debug, info, warn};
 use super::bot_identity::SharedBotIdentity;
 use super::{aggregator::MessageAggregatorHandle, ping::GatewayRuntimeStatus};
 use crate::{
-    auth::AccessTokenManager,
+    auth::{AccessTokenManager, AuthError},
     config::{AppConfig, GroupMessageMode},
     event::{
         EVENT_C2C_MESSAGE_CREATE, EVENT_GROUP_AT_MESSAGE_CREATE, EVENT_GROUP_MESSAGE_CREATE,
         GatewayEnvelope, parse_c2c_message, parse_group_message,
     },
 };
+
+#[derive(Debug, thiserror::Error)]
+pub(super) enum FetchGatewayUrlError {
+    #[error("invalid QQ gateway endpoint URL")]
+    InvalidEndpoint,
+    #[error("QQ gateway authorization failed: {0}")]
+    Auth(#[from] AuthError),
+    #[error("QQ gateway request failed: {0}")]
+    Request(reqwest::Error),
+    #[error("QQ gateway endpoint returned {status}")]
+    Status { status: StatusCode },
+    #[error("QQ gateway endpoint returned an invalid response")]
+    InvalidResponse,
+}
+
+impl FetchGatewayUrlError {
+    pub(super) fn is_retryable(&self) -> bool {
+        match self {
+            Self::InvalidEndpoint => false,
+            Self::Auth(error) => error.is_retryable(),
+            Self::Request(error) => !error.is_builder() && !error.is_redirect(),
+            Self::Status { status } => is_retryable_status(*status),
+            // Gateway 调度端偶发空响应或非 JSON 响应时，重新获取地址即可恢复。
+            Self::InvalidResponse => true,
+        }
+    }
+}
+
+fn is_retryable_status(status: StatusCode) -> bool {
+    matches!(status.as_u16(), 408 | 425 | 429) || status.is_server_error()
+}
 
 const OP_DISPATCH: u64 = 0;
 const OP_HEARTBEAT: u64 = 1;
@@ -57,20 +89,27 @@ pub(super) async fn fetch_gateway_url(
     client: &reqwest::Client,
     config: &AppConfig,
     auth: &AccessTokenManager,
-) -> anyhow::Result<String> {
+) -> Result<String, FetchGatewayUrlError> {
+    let endpoint = Url::parse(&format!("{}/gateway", config.api_base))
+        .map_err(|_| FetchGatewayUrlError::InvalidEndpoint)?;
+    let authorization = auth.authorization_header().await?;
     let response = client
-        .get(format!("{}/gateway", config.api_base))
-        .header("Authorization", auth.authorization_header().await?)
+        .get(endpoint)
+        .header("Authorization", authorization)
         .send()
-        .await?;
+        .await
+        .map_err(FetchGatewayUrlError::Request)?;
     let status = response.status();
     if !status.is_success() {
-        return Err(anyhow!("QQ gateway endpoint returned {status}"));
+        return Err(FetchGatewayUrlError::Status { status });
     }
 
-    let gateway = response.json::<GatewayUrlResponse>().await?;
+    let gateway = response
+        .json::<GatewayUrlResponse>()
+        .await
+        .map_err(|_| FetchGatewayUrlError::InvalidResponse)?;
     if gateway.url.trim().is_empty() {
-        return Err(anyhow!("QQ gateway endpoint returned empty url"));
+        return Err(FetchGatewayUrlError::InvalidResponse);
     }
     Ok(gateway.url)
 }
@@ -362,5 +401,39 @@ mod tests {
             gateway_intents(GroupMessageMode::Command),
             C2C_MESSAGE_INTENTS | GROUP_MESSAGE_INTENTS
         );
+    }
+
+    #[test]
+    fn gateway_status_retry_classification_is_explicit() {
+        for status in [
+            StatusCode::REQUEST_TIMEOUT,
+            StatusCode::TOO_EARLY,
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::SERVICE_UNAVAILABLE,
+        ] {
+            assert!(
+                FetchGatewayUrlError::Status { status }.is_retryable(),
+                "{status}"
+            );
+        }
+
+        for status in [
+            StatusCode::BAD_REQUEST,
+            StatusCode::UNAUTHORIZED,
+            StatusCode::FORBIDDEN,
+            StatusCode::NOT_FOUND,
+        ] {
+            assert!(
+                !FetchGatewayUrlError::Status { status }.is_retryable(),
+                "{status}"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_gateway_response_is_retryable_but_invalid_endpoint_is_not() {
+        assert!(FetchGatewayUrlError::InvalidResponse.is_retryable());
+        assert!(!FetchGatewayUrlError::InvalidEndpoint.is_retryable());
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/retry.rs
+++ b/qq-maid-gateway-rs/src/gateway/retry.rs
@@ -1,0 +1,256 @@
+//! QQ Gateway 地址获取阶段的错误退避与可取消重试。
+
+use std::{future::Future, time::Duration};
+
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+use super::protocol::FetchGatewayUrlError;
+
+const BACKOFF_SECONDS: [u64; 4] = [5, 10, 30, 60];
+const MAX_BACKOFF: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Default)]
+pub(super) struct GatewayFetchBackoff {
+    consecutive_failures: u32,
+}
+
+impl GatewayFetchBackoff {
+    pub(super) fn consecutive_failures(&self) -> u32 {
+        self.consecutive_failures
+    }
+
+    pub(super) fn record_failure(&mut self, jitter_percent: i16) -> Duration {
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        let index = self
+            .consecutive_failures
+            .saturating_sub(1)
+            .min((BACKOFF_SECONDS.len() - 1) as u32) as usize;
+        let base_millis = Duration::from_secs(BACKOFF_SECONDS[index]).as_millis() as u64;
+        let factor = (100_i64 + i64::from(jitter_percent.clamp(-20, 20))) as u64;
+        // 任务约束中的 60 秒是实际等待上限；因此 jitter 后再次封顶，第四档落在 48～60 秒。
+        Duration::from_millis(base_millis.saturating_mul(factor) / 100).min(MAX_BACKOFF)
+    }
+
+    pub(super) fn reset(&mut self) -> u32 {
+        let previous = self.consecutive_failures;
+        self.consecutive_failures = 0;
+        previous
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum GatewayFetchOutcome {
+    Url(String),
+    Shutdown,
+}
+
+/// 将远端瞬时故障留在 Gateway 生命周期内处理，同时让 shutdown 能打断请求或退避等待。
+pub(super) async fn fetch_gateway_url_with_retry<F, Fut, J>(
+    shutdown_token: &CancellationToken,
+    backoff: &mut GatewayFetchBackoff,
+    mut fetch: F,
+    mut jitter_percent: J,
+) -> Result<GatewayFetchOutcome, FetchGatewayUrlError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<String, FetchGatewayUrlError>>,
+    J: FnMut() -> i16,
+{
+    loop {
+        let result = tokio::select! {
+            _ = shutdown_token.cancelled() => return Ok(GatewayFetchOutcome::Shutdown),
+            result = fetch() => result,
+        };
+
+        match result {
+            Ok(url) => {
+                let recovered_failures = backoff.reset();
+                if recovered_failures > 0 {
+                    info!(
+                        recovered_failures,
+                        "QQ gateway url fetch recovered after transient failures"
+                    );
+                }
+                return Ok(GatewayFetchOutcome::Url(url));
+            }
+            Err(error) if error.is_retryable() => {
+                let delay = backoff.record_failure(jitter_percent());
+                warn!(
+                    error = %error,
+                    consecutive_failures = backoff.consecutive_failures(),
+                    retry_after_ms = delay.as_millis(),
+                    retryable = true,
+                    "failed to fetch QQ gateway url; retrying"
+                );
+                tokio::select! {
+                    _ = shutdown_token.cancelled() => return Ok(GatewayFetchOutcome::Shutdown),
+                    _ = tokio::time::sleep(delay) => {}
+                }
+            }
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    consecutive_failures = backoff.consecutive_failures().saturating_add(1),
+                    retryable = false,
+                    "failed to fetch QQ gateway url; not retrying"
+                );
+                return Err(error);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::VecDeque,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+
+    use reqwest::StatusCode;
+
+    use super::*;
+
+    #[test]
+    fn backoff_sequence_is_capped_and_reset_after_success() {
+        let mut backoff = GatewayFetchBackoff::default();
+        let delays = (0..6)
+            .map(|_| backoff.record_failure(0))
+            .collect::<Vec<_>>();
+
+        assert_eq!(delays, [5, 10, 30, 60, 60, 60].map(Duration::from_secs));
+        assert_eq!(backoff.record_failure(20), Duration::from_secs(60));
+        assert_eq!(backoff.reset(), 7);
+        assert_eq!(backoff.consecutive_failures(), 0);
+        assert_eq!(backoff.record_failure(0), Duration::from_secs(5));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn gateway_500_is_retried_then_success_resets_backoff() {
+        let shutdown = CancellationToken::new();
+        let mut results = VecDeque::from([
+            Err(FetchGatewayUrlError::Status {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+            }),
+            Ok("wss://gateway.example.test".to_owned()),
+        ]);
+        let handle = tokio::spawn(async move {
+            let mut backoff = GatewayFetchBackoff::default();
+            let outcome = fetch_gateway_url_with_retry(
+                &shutdown,
+                &mut backoff,
+                || std::future::ready(results.pop_front().expect("test result")),
+                || 0,
+            )
+            .await;
+            (outcome, backoff)
+        });
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        let (outcome, backoff) = handle.await.unwrap();
+        assert_eq!(
+            outcome.unwrap(),
+            GatewayFetchOutcome::Url("wss://gateway.example.test".to_owned())
+        );
+        assert_eq!(backoff.consecutive_failures(), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn gateway_network_error_is_retried_then_success() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let request_error = reqwest::Client::new()
+            .get(format!("http://{address}/gateway"))
+            .send()
+            .await
+            .unwrap_err();
+        let shutdown = CancellationToken::new();
+        let mut results = VecDeque::from([
+            Err(FetchGatewayUrlError::Request(request_error)),
+            Ok("wss://gateway.example.test".to_owned()),
+        ]);
+        let handle = tokio::spawn(async move {
+            let mut backoff = GatewayFetchBackoff::default();
+            fetch_gateway_url_with_retry(
+                &shutdown,
+                &mut backoff,
+                || std::future::ready(results.pop_front().expect("test result")),
+                || 0,
+            )
+            .await
+        });
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        assert!(matches!(
+            handle.await.unwrap().unwrap(),
+            GatewayFetchOutcome::Url(_)
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_interrupts_backoff_without_another_fetch() {
+        let shutdown = CancellationToken::new();
+        let cancel = shutdown.clone();
+        let fetches = Arc::new(AtomicUsize::new(0));
+        let fetch_count = fetches.clone();
+        let handle = tokio::spawn(async move {
+            let mut backoff = GatewayFetchBackoff::default();
+            fetch_gateway_url_with_retry(
+                &shutdown,
+                &mut backoff,
+                || {
+                    fetch_count.fetch_add(1, Ordering::SeqCst);
+                    std::future::ready(Err(FetchGatewayUrlError::Status {
+                        status: StatusCode::SERVICE_UNAVAILABLE,
+                    }))
+                },
+                || 0,
+            )
+            .await
+        });
+        tokio::task::yield_now().await;
+
+        cancel.cancel();
+
+        assert_eq!(
+            handle.await.unwrap().unwrap(),
+            GatewayFetchOutcome::Shutdown
+        );
+        assert_eq!(fetches.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn ordinary_4xx_returns_without_retrying() {
+        let shutdown = CancellationToken::new();
+        let fetches = Arc::new(AtomicUsize::new(0));
+        let fetch_count = fetches.clone();
+        let mut backoff = GatewayFetchBackoff::default();
+
+        let error = fetch_gateway_url_with_retry(
+            &shutdown,
+            &mut backoff,
+            || {
+                fetch_count.fetch_add(1, Ordering::SeqCst);
+                std::future::ready(Err(FetchGatewayUrlError::Status {
+                    status: StatusCode::UNAUTHORIZED,
+                }))
+            },
+            || 0,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            FetchGatewayUrlError::Status {
+                status: StatusCode::UNAUTHORIZED
+            }
+        ));
+        assert_eq!(fetches.load(Ordering::SeqCst), 1);
+    }
+}


### PR DESCRIPTION
## 修改内容

- 为 QQ Gateway 地址获取和 Token 刷新引入类型化错误分类
- 在 Gateway 生命周期内部对远端瞬时错误执行 5/10/30/60 秒退避，并加入 ±20% jitter，实际等待硬封顶 60 秒
- 使用 shutdown token 同时中断请求和退避等待
- 成功恢复后重置连续失败计数并记录恢复日志
- 避免保留或记录 Token 接口错误响应正文

## 根因

WebSocket 断线本身会进入重连，但重新获取 `/gateway` 地址时的任意错误会从 Gateway 顶层循环直接返回。统一入口将 Gateway 任务结束视为进程级故障，因此 DNS、HTTP 500 或 Token 刷新瞬时失败会导致整个进程退出。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p qq-maid-gateway-rs`（370 项）
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `make test`
- `cargo test --workspace --all-features`
- `cargo build --workspace --release --all-features`
- `git diff --check`

`scripts/validate-runtime.sh check` 因本机服务未启动、127.0.0.1:8787 无法连接而未通过。未进行真实 QQ 网络验证。