### PR TITLE
feat: 支持解绑 QQ 官方机器人渠道

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Run installer regression tests
-        run: bash scripts/test-qbot-install.sh
+        run: |
+          bash scripts/test-qbot-install.sh
+          bash scripts/test-qbot-config.sh
 
       - name: Check shell syntax
         run: bash -n qbot.sh scripts/*.sh

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ vim config/.env
 ./botctl.sh status
 ```
 
-最少需要填写：`QQ_BOT_APP_ID`、`QQ_BOT_APP_SECRET`，以及至少一个 Provider 的 API Key。
+最少需要配置一个入口渠道，以及至少一个 Provider 的 API Key。使用 QQ 时同时填写 `QQ_BOT_APP_ID`、`QQ_BOT_APP_SECRET`；微信-only 部署可留空两项并按下文启用微信服务号。
 
 Windows 用户也可以在 Git Bash、MSYS2 或 Cygwin 中执行 `bash qbot.sh install`，脚本会自动下载
 `windows-x86_64.zip` 并默认安装到 `$HOME/qq-maid-bot`。原生 Windows 启动方式参见发布包内的

--- a/qbot.sh
+++ b/qbot.sh
@@ -1503,7 +1503,7 @@ config_bot_interactive() {
 
 config_bot_cmd() {
     local app_id="" app_secret="" sandbox="" display_name="" group_mode="" active_keywords="" mention_ids=""
-    local binding_action=""
+    local binding_action="" effective_app_id="" effective_app_secret=""
 
     if (($# == 0)); then
         config_bot_interactive
@@ -1513,14 +1513,17 @@ config_bot_cmd() {
     while (($# > 0)); do
         case "$1" in
             --unbind)
+                [[ -z "${binding_action}" ]] || die "--enable、--disable、--unbind 互斥，只能指定一个"
                 binding_action="unbind"
                 shift
                 ;;
             --disable)
+                [[ -z "${binding_action}" ]] || die "--enable、--disable、--unbind 互斥，只能指定一个"
                 binding_action="disable"
                 shift
                 ;;
             --enable)
+                [[ -z "${binding_action}" ]] || die "--enable、--disable、--unbind 互斥，只能指定一个"
                 binding_action="enable"
                 shift
                 ;;
@@ -1590,6 +1593,13 @@ config_bot_cmd() {
         esac
     done
 
+    if [[ -n "${group_mode}" ]]; then
+        case "${group_mode}" in
+            off|command|mention|active) ;;
+            *) die "--group-mode 只能是 off/command/mention/active" ;;
+        esac
+    fi
+
     if [[ "${binding_action}" == "unbind" ]]; then
         [[ -z "${app_id}" && -z "${app_secret}" ]] || die "--unbind 不能与 --app-id/--app-secret 同时使用"
         unset_env_var QQ_BOT_APP_ID
@@ -1602,18 +1612,21 @@ config_bot_cmd() {
         return 0
     fi
 
-    [[ "${binding_action}" == "disable" ]] && set_env_var QQ_BOT_ENABLED false && ui_out_status "${UI_YELLOW}" "已禁用:" "QQ 官方 Bot（凭证保留，重启后生效）"
-    [[ "${binding_action}" == "enable" ]] && set_env_var QQ_BOT_ENABLED true && ui_out_status "${UI_GREEN}" "已启用:" "QQ 官方 Bot（重启后生效）"
-
-    if [[ -n "${group_mode}" ]]; then
-        case "${group_mode}" in
-            off|command|mention|active) ;;
-            *) die "--group-mode 只能是 off/command/mention/active" ;;
-        esac
+    if [[ "${binding_action}" == "enable" ]]; then
+        # 必须按命令执行后的有效配置验真：本次参数优先，其次读取新变量，再兼容旧别名。
+        effective_app_id="${app_id}"
+        [[ -n "${effective_app_id}" ]] || effective_app_id="$(get_real_env_var QQ_BOT_APP_ID)"
+        [[ -n "${effective_app_id}" ]] || effective_app_id="$(get_real_env_var QQ_APPID)"
+        effective_app_secret="${app_secret}"
+        [[ -n "${effective_app_secret}" ]] || effective_app_secret="$(get_real_env_var QQ_BOT_APP_SECRET)"
+        [[ -n "${effective_app_secret}" ]] || effective_app_secret="$(get_real_env_var QQ_SECRET)"
+        [[ -n "${effective_app_id}" && -n "${effective_app_secret}" ]] || die "--enable 需要完整 QQ 凭证，请同时配置 AppID 和 AppSecret"
     fi
 
     [[ -n "${app_id}" ]] && set_env_var QQ_BOT_APP_ID "${app_id}" && ui_out_status "${UI_GREEN}" "已设置:" "QQ_BOT_APP_ID"
     [[ -n "${app_secret}" ]] && set_env_var QQ_BOT_APP_SECRET "${app_secret}" && ui_out_status "${UI_GREEN}" "已设置:" "QQ_BOT_APP_SECRET"
+    [[ "${binding_action}" == "disable" ]] && set_env_var QQ_BOT_ENABLED false && ui_out_status "${UI_YELLOW}" "已禁用:" "QQ 官方 Bot（凭证保留，重启后生效）"
+    [[ "${binding_action}" == "enable" ]] && set_env_var QQ_BOT_ENABLED true && ui_out_status "${UI_GREEN}" "已启用:" "QQ 官方 Bot（重启后生效）"
     if [[ -z "${binding_action}" && -n "${app_id}" && -n "${app_secret}" ]]; then
         set_env_var QQ_BOT_ENABLED true
     fi

--- a/qbot.sh
+++ b/qbot.sh
@@ -123,6 +123,7 @@ usage() {
 
 常用配置:
   qbot config bot --app-id 123 --app-secret xxx --sandbox false
+  qbot config bot --unbind    解除 QQ 官方 Bot 绑定（重启后生效）
   qbot config ai --provider openai --api-key sk-xxx --model gpt-5.6-luna
   qbot config ai --provider auto --api-key sk-xxx --base-url https://你的兼容网关 --model openai:gpt-5.6-luna
   qbot config ai --provider deepseek --api-key sk-xxx --model deepseek-chat
@@ -491,6 +492,7 @@ config_usage() {
 
   qbot config bot                         交互式配置 QQ Bot 信息
   qbot config bot --app-id ID --app-secret SECRET [--sandbox true|false]
+                  [--enable|--disable|--unbind]
                   [--display-name 名称] [--group-mode off|command|mention|active]
                   [--active-keywords 关键词] [--mention-ids IDS]
 
@@ -503,6 +505,7 @@ config_usage() {
 
 示例:
   qbot config bot --app-id 1020xxxx --app-secret xxxxxx --sandbox false
+  qbot config bot --unbind
   qbot config ai --provider openai --api-key sk-xxx --model gpt-5.6-luna
   qbot config ai --provider auto --api-key sk-xxx --base-url https://你的兼容网关 --model openai:gpt-5.6-luna
   qbot config ai --provider deepseek --api-key sk-xxx --model deepseek-chat
@@ -619,6 +622,24 @@ set_env_var() {
         }
     ' "${file}" > "${tmp}"
 
+    mv "${tmp}" "${file}"
+    [[ -n "${owner}" && -n "${group}" ]] && chown "${owner}:${group}" "${file}" 2>/dev/null || true
+    [[ -n "${mode}" ]] && chmod "${mode}" "${file}" 2>/dev/null || true
+}
+
+unset_env_var() {
+    local key="$1"
+    local file tmp owner group mode
+
+    validate_env_key "${key}"
+    file="$(ensure_config_env_file)"
+    backup_config_file_once "${file}"
+    tmp="${file}.tmp.$$"
+    owner="$(stat -c '%u' "${file}" 2>/dev/null || echo "")"
+    group="$(stat -c '%g' "${file}" 2>/dev/null || echo "")"
+    mode="$(stat -c '%a' "${file}" 2>/dev/null || echo "")"
+
+    awk -v key="${key}" '$0 !~ "^[[:space:]]*" key "=" { print }' "${file}" > "${tmp}"
     mv "${tmp}" "${file}"
     [[ -n "${owner}" && -n "${group}" ]] && chown "${owner}:${group}" "${file}" 2>/dev/null || true
     [[ -n "${mode}" ]] && chmod "${mode}" "${file}" 2>/dev/null || true
@@ -893,6 +914,7 @@ config_show_cmd() {
 
     if ((${#keys[@]} == 0)); then
         keys=(
+            QQ_BOT_ENABLED
             QQ_BOT_APP_ID
             QQ_BOT_APP_SECRET
             QQ_BOT_SANDBOX
@@ -1481,6 +1503,7 @@ config_bot_interactive() {
 
 config_bot_cmd() {
     local app_id="" app_secret="" sandbox="" display_name="" group_mode="" active_keywords="" mention_ids=""
+    local binding_action=""
 
     if (($# == 0)); then
         config_bot_interactive
@@ -1489,6 +1512,18 @@ config_bot_cmd() {
 
     while (($# > 0)); do
         case "$1" in
+            --unbind)
+                binding_action="unbind"
+                shift
+                ;;
+            --disable)
+                binding_action="disable"
+                shift
+                ;;
+            --enable)
+                binding_action="enable"
+                shift
+                ;;
             --app-id)
                 app_id="$(take_next_arg "$1" "${2:-}")"
                 shift 2
@@ -1555,6 +1590,21 @@ config_bot_cmd() {
         esac
     done
 
+    if [[ "${binding_action}" == "unbind" ]]; then
+        [[ -z "${app_id}" && -z "${app_secret}" ]] || die "--unbind 不能与 --app-id/--app-secret 同时使用"
+        unset_env_var QQ_BOT_APP_ID
+        unset_env_var QQ_BOT_APP_SECRET
+        unset_env_var QQ_APPID
+        unset_env_var QQ_SECRET
+        set_env_var QQ_BOT_ENABLED true
+        ui_out_status "${UI_YELLOW}" "已解绑:" "QQ 官方 Bot；微信及业务数据未修改，重启后生效"
+        config_done_hint
+        return 0
+    fi
+
+    [[ "${binding_action}" == "disable" ]] && set_env_var QQ_BOT_ENABLED false && ui_out_status "${UI_YELLOW}" "已禁用:" "QQ 官方 Bot（凭证保留，重启后生效）"
+    [[ "${binding_action}" == "enable" ]] && set_env_var QQ_BOT_ENABLED true && ui_out_status "${UI_GREEN}" "已启用:" "QQ 官方 Bot（重启后生效）"
+
     if [[ -n "${group_mode}" ]]; then
         case "${group_mode}" in
             off|command|mention|active) ;;
@@ -1564,6 +1614,9 @@ config_bot_cmd() {
 
     [[ -n "${app_id}" ]] && set_env_var QQ_BOT_APP_ID "${app_id}" && ui_out_status "${UI_GREEN}" "已设置:" "QQ_BOT_APP_ID"
     [[ -n "${app_secret}" ]] && set_env_var QQ_BOT_APP_SECRET "${app_secret}" && ui_out_status "${UI_GREEN}" "已设置:" "QQ_BOT_APP_SECRET"
+    if [[ -z "${binding_action}" && -n "${app_id}" && -n "${app_secret}" ]]; then
+        set_env_var QQ_BOT_ENABLED true
+    fi
     [[ -n "${sandbox}" ]] && set_env_var QQ_BOT_SANDBOX "${sandbox}" && ui_out_status "${UI_GREEN}" "已设置:" "QQ_BOT_SANDBOX"
     [[ -n "${display_name}" ]] && set_env_var QQ_MAID_STATUS_DISPLAY_NAME "${display_name}" && ui_out_status "${UI_GREEN}" "已设置:" "QQ_MAID_STATUS_DISPLAY_NAME"
     [[ -n "${group_mode}" ]] && set_env_var QQ_MAID_GROUP_MESSAGE_MODE "${group_mode}" && ui_out_status "${UI_GREEN}" "已设置:" "QQ_MAID_GROUP_MESSAGE_MODE"

--- a/qq-maid-gateway-rs/README.md
+++ b/qq-maid-gateway-rs/README.md
@@ -119,6 +119,7 @@ cp runtime/config/.env.example runtime/config/.env
 主要变量：
 
 ```env
+QQ_BOT_ENABLED=true
 QQ_BOT_APP_ID=你的QQ机器人AppID
 QQ_BOT_APP_SECRET=你的QQ机器人AppSecret
 QQ_BOT_SANDBOX=false
@@ -133,6 +134,8 @@ QQ_MAID_GROUP_ACTIVE_KEYWORDS=小女仆
 QQ_MAID_BOT_MENTION_IDS=
 RUST_LOG=info,qq_maid_gateway_rs=debug
 ```
+
+`QQ_BOT_APP_ID` 与 `QQ_BOT_APP_SECRET` 必须成对配置；两项均缺失表示 QQ 官方 Bot 未绑定。此时不会创建 Token、API client、Gateway 或重连任务，微信服务号仍可独立运行。凭证存在时可用 `QQ_BOT_ENABLED=false` 暂时禁用；旧配置未设置该开关时仍默认启用。配置由启动时读取，`qbot config bot --unbind`、`--disable` 和重新绑定都需重启生效。
 
 兼容旧变量名：
 

--- a/qq-maid-gateway-rs/src/app/mod.rs
+++ b/qq-maid-gateway-rs/src/app/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     respond::RespondClient,
 };
 
-/// 应用入口：加载本地配置、初始化 tracing，并启动 QQ gateway 主循环。
+/// 应用入口：加载本地配置、初始化 tracing，并启动已启用的渠道。
 pub async fn run() -> anyhow::Result<()> {
     anyhow::bail!("qq-maid-gateway-rs 不再支持独立 HTTP Core 模式，请通过统一 qq-maid-bot 入口启动")
 }
@@ -78,6 +78,7 @@ pub fn init_tracing() -> anyhow::Result<()> {
 
 fn log_startup(config: &AppConfig) {
     info!(
+        qq_official_state = ?config.qq_official_binding_state(),
         api_base = %config.api_base,
         sandbox = config.sandbox,
         enable_markdown = config.enable_markdown,

--- a/qq-maid-gateway-rs/src/config/mod.rs
+++ b/qq-maid-gateway-rs/src/config/mod.rs
@@ -1,4 +1,4 @@
-//! 网关配置模块。从环境变量加载 QQ AppID、AppSecret、gateway API 地址和回调开关。
+//! 网关配置模块。从环境变量加载可选 QQ 官方 Bot 绑定、Gateway API 地址和回调开关。
 
 use std::{collections::HashMap, path::PathBuf, time::Duration};
 
@@ -51,8 +51,11 @@ pub enum GroupMessageMode {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AppConfig {
-    pub app_id: String,
-    pub app_secret: String,
+    /// QQ 官方 Bot 是否启用。凭证成对存在时默认启用，保持旧配置行为。
+    pub qq_official_enabled: bool,
+    /// QQ 官方 Bot 凭证必须成对存在；`None` 表示渠道未绑定，不使用空串占位。
+    pub app_id: Option<String>,
+    pub app_secret: Option<String>,
     pub bot_mention_ids: Vec<String>,
     pub sandbox: bool,
     pub api_base: String,
@@ -134,10 +137,15 @@ pub struct AgentTypingConfig {
     pub delay: Duration,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QqOfficialBindingState {
+    Unbound,
+    Disabled,
+    Enabled,
+}
+
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum ConfigError {
-    #[error("missing required environment variable {0}")]
-    MissingRequired(&'static str),
     #[error("invalid boolean value for {name}: {value}")]
     InvalidBool { name: &'static str, value: String },
     #[error("invalid integer value for {name}: {value}")]
@@ -164,6 +172,10 @@ pub enum ConfigError {
         "MESSAGE_AGGREGATION_QUIET_MS must be less than or equal to MESSAGE_AGGREGATION_MAX_WAIT_MS"
     )]
     InvalidAggregationWindow,
+    #[error(
+        "QQ official credentials must be configured together; missing environment variable {missing}"
+    )]
+    IncompleteQqOfficialCredentials { missing: &'static str },
 }
 
 impl AppConfig {
@@ -177,8 +189,22 @@ impl AppConfig {
     }
 
     pub fn from_map(env: &HashMap<String, String>) -> Result<Self, ConfigError> {
-        let app_id = required(env, "QQ_BOT_APP_ID", Some("QQ_APPID"))?;
-        let app_secret = required(env, "QQ_BOT_APP_SECRET", Some("QQ_SECRET"))?;
+        let qq_official_enabled = parse_bool(env, "QQ_BOT_ENABLED")?.unwrap_or(true);
+        let app_id = optional_with_alias(env, "QQ_BOT_APP_ID", Some("QQ_APPID"));
+        let app_secret = optional_with_alias(env, "QQ_BOT_APP_SECRET", Some("QQ_SECRET"));
+        match (&app_id, &app_secret) {
+            (Some(_), Some(_)) | (None, None) => {}
+            (None, Some(_)) => {
+                return Err(ConfigError::IncompleteQqOfficialCredentials {
+                    missing: "QQ_BOT_APP_ID",
+                });
+            }
+            (Some(_), None) => {
+                return Err(ConfigError::IncompleteQqOfficialCredentials {
+                    missing: "QQ_BOT_APP_SECRET",
+                });
+            }
+        }
         let bot_mention_ids = parse_csv(env, "QQ_MAID_BOT_MENTION_IDS", &[]);
         let sandbox = parse_bool(env, "QQ_BOT_SANDBOX")?.unwrap_or(false);
         let default_api_base = if sandbox {
@@ -267,6 +293,7 @@ impl AppConfig {
         )?;
         let wechat_service = parse_wechat_service_config(env)?;
         Ok(Self {
+            qq_official_enabled,
             app_id,
             app_secret,
             bot_mention_ids,
@@ -296,6 +323,24 @@ impl AppConfig {
             media_max_bytes,
             wechat_service,
         })
+    }
+
+    pub fn qq_official_binding_state(&self) -> QqOfficialBindingState {
+        if self.app_id.is_none() {
+            QqOfficialBindingState::Unbound
+        } else if self.qq_official_enabled {
+            QqOfficialBindingState::Enabled
+        } else {
+            QqOfficialBindingState::Disabled
+        }
+    }
+
+    /// 只有已绑定且启用时才向初始化链路提供凭证，防止误建 Token/Gateway 任务。
+    pub fn enabled_qq_official_credentials(&self) -> Option<(&str, &str)> {
+        if self.qq_official_binding_state() != QqOfficialBindingState::Enabled {
+            return None;
+        }
+        Some((self.app_id.as_deref()?, self.app_secret.as_deref()?))
     }
 }
 
@@ -414,14 +459,6 @@ fn parse_message_aggregation_config(
             100_000,
         )?,
     })
-}
-
-fn required(
-    env: &HashMap<String, String>,
-    name: &'static str,
-    alias: Option<&'static str>,
-) -> Result<String, ConfigError> {
-    optional_with_alias(env, name, alias).ok_or(ConfigError::MissingRequired(name))
 }
 
 fn optional(env: &HashMap<String, String>, name: &'static str) -> Option<String> {
@@ -570,15 +607,20 @@ mod tests {
     }
 
     #[test]
-    fn loads_defaults_with_required_values() {
+    fn loads_defaults_with_bound_credentials() {
         let config = AppConfig::from_map(&env(&[
             ("QQ_BOT_APP_ID", "appid"),
             ("QQ_BOT_APP_SECRET", "secret"),
         ]))
         .unwrap();
 
-        assert_eq!(config.app_id, "appid");
-        assert_eq!(config.app_secret, "secret");
+        assert_eq!(config.app_id.as_deref(), Some("appid"));
+        assert_eq!(config.app_secret.as_deref(), Some("secret"));
+        assert!(config.qq_official_enabled);
+        assert_eq!(
+            config.qq_official_binding_state(),
+            QqOfficialBindingState::Enabled
+        );
         assert!(!config.sandbox);
         assert_eq!(config.api_base, DEFAULT_PROD_API_BASE);
         assert_eq!(
@@ -742,8 +784,8 @@ mod tests {
         ]))
         .unwrap();
 
-        assert_eq!(config.app_id, "old-appid");
-        assert_eq!(config.app_secret, "old-secret");
+        assert_eq!(config.app_id.as_deref(), Some("old-appid"));
+        assert_eq!(config.app_secret.as_deref(), Some("old-secret"));
     }
 
     #[test]
@@ -756,8 +798,8 @@ mod tests {
         ]))
         .unwrap();
 
-        assert_eq!(config.app_id, "new-appid");
-        assert_eq!(config.app_secret, "new-secret");
+        assert_eq!(config.app_id.as_deref(), Some("new-appid"));
+        assert_eq!(config.app_secret.as_deref(), Some("new-secret"));
     }
 
     #[test]
@@ -856,7 +898,36 @@ mod tests {
         );
     }
 
-    /// 合并 2 个 config 错误路径测试为表驱动测试。
+    #[test]
+    fn qq_official_binding_states_are_explicit_and_keep_wechat_independent() {
+        let unbound = AppConfig::from_map(&env(&[
+            ("WECHAT_SERVICE_ENABLED", "true"),
+            ("WECHAT_SERVICE_TOKEN", "wechat-token"),
+        ]))
+        .unwrap();
+        assert_eq!(
+            unbound.qq_official_binding_state(),
+            QqOfficialBindingState::Unbound
+        );
+        assert!(unbound.enabled_qq_official_credentials().is_none());
+        assert!(unbound.wechat_service.enabled);
+
+        let disabled =
+            AppConfig::from_map(&env_with_creds(&[("QQ_BOT_ENABLED", "false")])).unwrap();
+        assert_eq!(
+            disabled.qq_official_binding_state(),
+            QqOfficialBindingState::Disabled
+        );
+        assert!(disabled.enabled_qq_official_credentials().is_none());
+
+        let enabled = AppConfig::from_map(&env_with_creds(&[])).unwrap();
+        assert_eq!(
+            enabled.enabled_qq_official_credentials(),
+            Some(("appid", "secret"))
+        );
+    }
+
+    /// 合并 config 错误路径测试为表驱动测试。
     #[test]
     fn config_errors_reported() {
         struct Case {
@@ -867,9 +938,18 @@ mod tests {
 
         let cases = [
             Case {
-                name: "requires_credentials",
-                map: HashMap::new(),
-                expected_err: ConfigError::MissingRequired("QQ_BOT_APP_ID"),
+                name: "rejects_app_id_without_secret",
+                map: env(&[("QQ_BOT_APP_ID", "appid")]),
+                expected_err: ConfigError::IncompleteQqOfficialCredentials {
+                    missing: "QQ_BOT_APP_SECRET",
+                },
+            },
+            Case {
+                name: "rejects_secret_without_app_id",
+                map: env(&[("QQ_BOT_APP_SECRET", "secret")]),
+                expected_err: ConfigError::IncompleteQqOfficialCredentials {
+                    missing: "QQ_BOT_APP_ID",
+                },
             },
             Case {
                 name: "rejects_invalid_verbose_log_boolean",

--- a/qq-maid-gateway-rs/src/gateway/aggregator/actor.rs
+++ b/qq-maid-gateway-rs/src/gateway/aggregator/actor.rs
@@ -853,8 +853,9 @@ mod tests {
     #[test]
     fn key_for_builds_private_scope_key_parts() {
         let config = AppConfig {
-            app_id: "appid".to_owned(),
-            app_secret: "secret".to_owned(),
+            qq_official_enabled: true,
+            app_id: Some("appid".to_owned()),
+            app_secret: Some("secret".to_owned()),
             bot_mention_ids: Vec::new(),
             sandbox: false,
             api_base: "https://example.test".to_owned(),
@@ -894,7 +895,7 @@ mod tests {
         let (command_tx, command_rx) = mpsc::channel(8);
         let actor = AggregatorActor {
             config: config.message_aggregation.clone(),
-            bot_instance: config.app_id,
+            bot_instance: config.app_id.expect("test QQ credentials"),
             respond: RespondClient::new(Arc::new(NoopCore)),
             dispatcher: Arc::new(NoopDispatcher),
             dedupe: Arc::new(MessageDedupe::new(Duration::from_secs(60))),

--- a/qq-maid-gateway-rs/src/gateway/aggregator/handle.rs
+++ b/qq-maid-gateway-rs/src/gateway/aggregator/handle.rs
@@ -140,6 +140,7 @@ pub(in crate::gateway) struct MessageAggregator {
 impl MessageAggregator {
     pub(in crate::gateway) fn new(
         config: AppConfig,
+        bot_instance: String,
         respond: RespondClient,
         dispatcher: MessageDispatcherHandle,
         dedupe: Arc<MessageDedupe>,
@@ -147,6 +148,7 @@ impl MessageAggregator {
     ) -> Self {
         Self::new_with_dispatcher(
             config,
+            bot_instance,
             respond,
             Arc::new(dispatcher),
             dedupe,
@@ -156,6 +158,7 @@ impl MessageAggregator {
 
     pub(in crate::gateway) fn new_with_dispatcher(
         config: AppConfig,
+        bot_instance: String,
         respond: RespondClient,
         dispatcher: Arc<dyn AggregationDispatcher>,
         dedupe: Arc<MessageDedupe>,
@@ -169,7 +172,7 @@ impl MessageAggregator {
         let (command_tx, command_rx) = mpsc::channel(capacity);
         let actor = AggregatorActor {
             config: config.message_aggregation.clone(),
-            bot_instance: config.app_id,
+            bot_instance,
             respond,
             dispatcher,
             dedupe,

--- a/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
@@ -282,8 +282,9 @@ struct Harness {
 
 fn test_config() -> AppConfig {
     AppConfig {
-        app_id: "appid".to_owned(),
-        app_secret: "secret".to_owned(),
+        qq_official_enabled: true,
+        app_id: Some("appid".to_owned()),
+        app_secret: Some("secret".to_owned()),
         bot_mention_ids: Vec::new(),
         sandbox: false,
         api_base: "https://example.test".to_owned(),
@@ -327,6 +328,7 @@ fn harness_with_config(config: AppConfig) -> Harness {
 }
 
 fn harness_with_config_and_dedupe_ttl(config: AppConfig, dedupe_ttl: Duration) -> Harness {
+    let bot_instance = config.app_id.clone().expect("test QQ credentials");
     let core = Arc::new(MockCore::default());
     let dispatcher = Arc::new(MockDispatcher {
         core: core.clone(),
@@ -335,6 +337,7 @@ fn harness_with_config_and_dedupe_ttl(config: AppConfig, dedupe_ttl: Duration) -
     let dedupe = Arc::new(MessageDedupe::new(dedupe_ttl));
     let aggregator = MessageAggregator::new_with_dispatcher(
         config,
+        bot_instance,
         RespondClient::new(core.clone()),
         dispatcher.clone(),
         dedupe.clone(),

--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -5,6 +5,7 @@
 
 use std::{future::Future, pin::Pin};
 
+use anyhow::Context;
 use tracing::{debug, info, warn};
 
 use super::{
@@ -109,7 +110,7 @@ pub(super) fn record_c2c_bot_outbound_refs(
     for sent_id in sent_ids.into_iter() {
         index.insert_bot_outbound(
             platform::Platform::QqOfficial,
-            Some(&config.app_id),
+            config.app_id.as_deref(),
             &inbound.conversation,
             sent_id.ref_index_lookup_id().map(str::to_owned),
             text,
@@ -286,7 +287,10 @@ pub(super) async fn handle_c2c_message(
         &reqwest::Client::new(),
         &MediaFetchContext {
             platform: "qq_official",
-            app_id: config.app_id.clone(),
+            app_id: config
+                .app_id
+                .clone()
+                .context("QQ C2C handler requires a bound channel")?,
             peer_id: message.user_openid.clone(),
             root_dir: config.media_dir.clone(),
             timeout: config.media_download_timeout,
@@ -821,7 +825,7 @@ mod tests {
             media_summaries: Vec::new(),
         });
         let mut inbound = platform::qq_official::inbound_from_c2c(&message);
-        inbound.account_id = Some(config.app_id.clone());
+        inbound.account_id = config.app_id.clone();
         ref_index.lock().unwrap().enrich_inbound(&mut inbound);
         inbound
             .quoted
@@ -832,8 +836,9 @@ mod tests {
 
     fn test_config() -> AppConfig {
         AppConfig {
-            app_id: "app".to_owned(),
-            app_secret: "secret".to_owned(),
+            qq_official_enabled: true,
+            app_id: Some("app".to_owned()),
+            app_secret: Some("secret".to_owned()),
             bot_mention_ids: Vec::new(),
             sandbox: false,
             api_base: "https://example.test".to_owned(),

--- a/qq-maid-gateway-rs/src/gateway/console.rs
+++ b/qq-maid-gateway-rs/src/gateway/console.rs
@@ -6,7 +6,7 @@ use qq_maid_core::http::console::{
     ConsoleValueState, path_storage,
 };
 
-use crate::config::{AppConfig, GroupMessageMode};
+use crate::config::{AppConfig, GroupMessageMode, QqOfficialBindingState};
 
 use super::{outbound::ReplyCapability, ping::GatewayRuntimeStatus};
 
@@ -27,7 +27,11 @@ impl ConsoleStatusSource for GatewayConsoleStatusSource {
         let runtime = self.runtime.snapshot();
         let qq_c2c_capability = ReplyCapability::qq_official_c2c(&self.config);
         let qq_group_capability = ReplyCapability::qq_official_group(&self.config);
-        let qq_group_enabled = self.config.group_message_mode != GroupMessageMode::Off;
+        let qq_binding_state = self.config.qq_official_binding_state();
+        let qq_configured = qq_binding_state != QqOfficialBindingState::Unbound;
+        let qq_enabled = qq_binding_state == QqOfficialBindingState::Enabled;
+        let qq_group_enabled =
+            qq_enabled && self.config.group_message_mode != GroupMessageMode::Off;
         let last_event_at = latest_time([
             runtime.last_c2c_received_at.as_deref(),
             runtime.last_heartbeat_ack_at.as_deref(),
@@ -40,7 +44,11 @@ impl ConsoleStatusSource for GatewayConsoleStatusSource {
             runtime.last_respond_failure_at.as_deref(),
             runtime.last_respond_failure_summary.as_deref(),
         );
-        let qq_state = if runtime.state_error.is_some() {
+        let qq_state = if !qq_configured {
+            ConsoleRuntimeState::NotConfigured
+        } else if !qq_enabled {
+            ConsoleRuntimeState::NotAvailable
+        } else if runtime.state_error.is_some() {
             ConsoleRuntimeState::Unknown
         } else if runtime.qq_connected {
             ConsoleRuntimeState::Online
@@ -50,8 +58,8 @@ impl ConsoleStatusSource for GatewayConsoleStatusSource {
         let qq = ConsolePlatformStatus {
             id: "qq_official".to_owned(),
             label: "QQ 官方 Gateway".to_owned(),
-            configured: true,
-            enabled: true,
+            configured: qq_configured,
+            enabled: qq_enabled,
             state: qq_state,
             last_event_at,
             last_error_summary,
@@ -61,23 +69,31 @@ impl ConsoleStatusSource for GatewayConsoleStatusSource {
                 ConsoleCapabilityScope {
                     id: "c2c".to_owned(),
                     label: "私聊 / C2C".to_owned(),
-                    enabled: true,
-                    capabilities: ConsoleDirectionalCapabilities {
-                        inbound: qq_inbound_capabilities(),
-                        outbound: qq_outbound_capabilities(qq_c2c_capability),
+                    enabled: qq_enabled,
+                    capabilities: if !qq_configured {
+                        unavailable_directional_capabilities(ConsoleValueState::NotConfigured)
+                    } else if !qq_enabled {
+                        unavailable_directional_capabilities(ConsoleValueState::Disabled)
+                    } else {
+                        ConsoleDirectionalCapabilities {
+                            inbound: qq_inbound_capabilities(),
+                            outbound: qq_outbound_capabilities(qq_c2c_capability),
+                        }
                     },
                 },
                 ConsoleCapabilityScope {
                     id: "group".to_owned(),
                     label: "群聊 / Group".to_owned(),
                     enabled: qq_group_enabled,
-                    capabilities: if qq_group_enabled {
+                    capabilities: if !qq_configured {
+                        unavailable_directional_capabilities(ConsoleValueState::NotConfigured)
+                    } else if !qq_enabled || !qq_group_enabled {
+                        unavailable_directional_capabilities(ConsoleValueState::Disabled)
+                    } else {
                         ConsoleDirectionalCapabilities {
                             inbound: qq_inbound_capabilities(),
                             outbound: qq_outbound_capabilities(qq_group_capability),
                         }
-                    } else {
-                        unavailable_directional_capabilities(ConsoleValueState::Disabled)
                     },
                 },
             ],
@@ -291,6 +307,42 @@ mod tests {
         let json = serde_json::to_string(&snapshot).unwrap();
         assert!(!json.contains("private-app-id"));
         assert!(!json.contains("private-secret"));
+    }
+
+    #[test]
+    fn qq_unbound_and_disabled_are_not_reported_as_runtime_failures() {
+        let unbound = AppConfig::from_map(&HashMap::from([
+            ("WECHAT_SERVICE_ENABLED".to_owned(), "true".to_owned()),
+            ("WECHAT_SERVICE_TOKEN".to_owned(), "wechat-token".to_owned()),
+        ]))
+        .unwrap();
+        let snapshot =
+            GatewayConsoleStatusSource::new(unbound, GatewayRuntimeStatus::new()).snapshot();
+        let qq = platform(&snapshot, "qq_official");
+        assert!(!qq.configured);
+        assert!(!qq.enabled);
+        assert_eq!(qq.state, ConsoleRuntimeState::NotConfigured);
+        assert_eq!(
+            scope(qq, "c2c").capabilities.outbound.text,
+            ConsoleValueState::NotConfigured
+        );
+
+        let disabled = AppConfig::from_map(&HashMap::from([
+            ("QQ_BOT_APP_ID".to_owned(), "private-app-id".to_owned()),
+            ("QQ_BOT_APP_SECRET".to_owned(), "private-secret".to_owned()),
+            ("QQ_BOT_ENABLED".to_owned(), "false".to_owned()),
+        ]))
+        .unwrap();
+        let snapshot =
+            GatewayConsoleStatusSource::new(disabled, GatewayRuntimeStatus::new()).snapshot();
+        let qq = platform(&snapshot, "qq_official");
+        assert!(qq.configured);
+        assert!(!qq.enabled);
+        assert_eq!(qq.state, ConsoleRuntimeState::NotAvailable);
+        assert_eq!(
+            scope(qq, "c2c").capabilities.outbound.text,
+            ConsoleValueState::Disabled
+        );
     }
 
     fn snapshot_with(entries: &[(&str, &str)]) -> ConsoleExternalSnapshot {

--- a/qq-maid-gateway-rs/src/gateway/dispatcher/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/dispatcher/tests.rs
@@ -129,8 +129,9 @@ impl MessageHandler for RecordingHandler {
 
 fn test_config() -> AppConfig {
     AppConfig {
-        app_id: "appid".to_owned(),
-        app_secret: "secret".to_owned(),
+        qq_official_enabled: true,
+        app_id: Some("appid".to_owned()),
+        app_secret: Some("secret".to_owned()),
         bot_mention_ids: Vec::new(),
         sandbox: false,
         api_base: "http://127.0.0.1:1".to_owned(),
@@ -246,8 +247,8 @@ fn test_actor_with_handler(
     let (reject_tx, reject_rx) = mpsc::channel(32);
     let auth = AccessTokenManager::new(
         reqwest::Client::new(),
-        config.app_id.clone(),
-        config.app_secret.clone(),
+        config.app_id.clone().expect("test QQ app id"),
+        config.app_secret.clone().expect("test QQ app secret"),
         config.token_refresh_margin,
     );
     let api = QqApiClient::new(reqwest::Client::new(), config.api_base.clone(), auth);

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -8,6 +8,7 @@ use std::{
     time::Instant,
 };
 
+use anyhow::Context;
 use tracing::{debug, info, warn};
 
 const EMPTY_GROUP_REPLY_FALLBACK_TEXT: &str = "唔，小女仆刚刚没整理出可用回复。可以再说一次。";
@@ -208,7 +209,10 @@ pub(super) async fn handle_group_message(
         &reqwest::Client::new(),
         &MediaFetchContext {
             platform: "qq_official",
-            app_id: config.app_id.clone(),
+            app_id: config
+                .app_id
+                .clone()
+                .context("QQ group handler requires a bound channel")?,
             peer_id: message.group_openid.clone(),
             root_dir: config.media_dir.clone(),
             timeout: config.media_download_timeout,
@@ -409,7 +413,7 @@ fn record_group_bot_outbound_send(
     let inbound = platform::qq_official::inbound_from_group(message);
     ref_index.lock().unwrap().insert_bot_outbound(
         platform::Platform::QqOfficial,
-        Some(&config.app_id),
+        config.app_id.as_deref(),
         &inbound.conversation,
         sent_ids.ref_index_lookup_id().map(str::to_owned),
         text,
@@ -548,8 +552,9 @@ mod tests {
 
     fn test_config() -> AppConfig {
         AppConfig {
-            app_id: "app".to_owned(),
-            app_secret: "secret".to_owned(),
+            qq_official_enabled: true,
+            app_id: Some("app".to_owned()),
+            app_secret: Some("secret".to_owned()),
             bot_mention_ids: Vec::new(),
             sandbox: false,
             api_base: "http://127.0.0.1:1".to_owned(),
@@ -1165,7 +1170,7 @@ mod tests {
         ));
 
         let mut inbound = platform::qq_official::inbound_from_group(&quoted);
-        inbound.account_id = Some(config.app_id.clone());
+        inbound.account_id = config.app_id.clone();
         ref_index.lock().unwrap().enrich_inbound(&mut inbound);
         let quoted_context = inbound.quoted.as_ref().unwrap();
         assert!(quoted_context.lookup_found);
@@ -1219,7 +1224,7 @@ mod tests {
             media_summaries: Vec::new(),
         });
         let mut inbound = platform::qq_official::inbound_from_group(&quoted);
-        inbound.account_id = Some(config.app_id.clone());
+        inbound.account_id = config.app_id.clone();
         ref_index.lock().unwrap().enrich_inbound(&mut inbound);
 
         let quoted_context = inbound.quoted.as_ref().unwrap();
@@ -1265,7 +1270,7 @@ mod tests {
                 .contains_ref_index_id("qq_msg_only")
         );
         let mut message_only_quote = platform::qq_official::inbound_from_group(&message);
-        message_only_quote.account_id = Some(config.app_id.clone());
+        message_only_quote.account_id = config.app_id.clone();
         message_only_quote.quoted = Some(qq_maid_common::input_part::QuotedMessageContext {
             ref_msg_idx: Some("qq_msg_only".to_owned()),
             ..Default::default()

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -29,9 +29,10 @@ use std::{
 };
 
 use aggregator::MessageAggregator;
-use anyhow::Context;
+use anyhow::{Context, anyhow, bail};
 use bot_identity::BotIdentity;
 use dispatcher::MessageDispatcher;
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
@@ -54,6 +55,10 @@ use crate::{
 };
 
 const DEDUPE_TTL: Duration = Duration::from_secs(10 * 60);
+type ChannelTask = JoinHandle<anyhow::Result<()>>;
+
+const QQ_OFFICIAL_CHANNEL: &str = "QQ official gateway";
+const WECHAT_SERVICE_CHANNEL: &str = "wechat service callback";
 
 /// QQ 网关主循环：初始化所有共享组件后，反复获取网关地址并建立 WebSocket 连接。
 /// 连接断开或失败后会等待 `RECONNECT_DELAY` 后重连，从而保证长期在线。
@@ -64,7 +69,7 @@ pub async fn run(
     runtime: GatewayRuntimeStatus,
     shutdown_token: CancellationToken,
 ) -> anyhow::Result<()> {
-    // 微信与 QQ 共用 Core，但生命周期相互独立；QQ 未绑定时也必须先启动微信监听。
+    // 微信与 QQ 共用 Core；监听器只创建一次，之后统一交给渠道监督器管理生命周期。
     let dedupe = Arc::new(MessageDedupe::new(DEDUPE_TTL));
     let wechat_service_handle = if config.wechat_service.enabled {
         Some(
@@ -81,19 +86,16 @@ pub async fn run(
         None
     };
     let ref_index = ref_index();
-    let result = match config.qq_official_binding_state() {
-        QqOfficialBindingState::Enabled => {
-            run_qq_official(
-                config,
-                respond,
-                push_sink,
-                runtime,
-                shutdown_token,
-                dedupe,
-                ref_index,
-            )
-            .await
-        }
+    let qq_official_handle = match config.qq_official_binding_state() {
+        QqOfficialBindingState::Enabled => Some(tokio::spawn(run_qq_official(
+            config,
+            respond,
+            push_sink,
+            runtime,
+            shutdown_token.clone(),
+            dedupe,
+            ref_index,
+        ))),
         QqOfficialBindingState::Unbound => {
             push_sink.mark_qq_official_unavailable("QQ official channel is not bound");
             info!(
@@ -101,8 +103,7 @@ pub async fn run(
                 state = "unbound",
                 "skipping channel initialization"
             );
-            shutdown_token.cancelled().await;
-            Ok(())
+            None
         }
         QqOfficialBindingState::Disabled => {
             push_sink.mark_qq_official_unavailable("QQ official channel is disabled");
@@ -111,14 +112,127 @@ pub async fn run(
                 state = "disabled",
                 "skipping channel initialization"
             );
-            shutdown_token.cancelled().await;
-            Ok(())
+            None
         }
     };
-    if let Some(handle) = wechat_service_handle {
-        let _ = handle.await;
+
+    supervise_channels(qq_official_handle, wechat_service_handle, shutdown_token).await
+}
+
+/// 同时监督所有已启用入口。渠道在全局取消前结束属于故障；故障会先取消共享令牌，
+/// 再等待其他渠道完成必要清理，并优先返回最先触发退出的原始错误。
+async fn supervise_channels(
+    qq_official: Option<ChannelTask>,
+    wechat_service: Option<ChannelTask>,
+    shutdown_token: CancellationToken,
+) -> anyhow::Result<()> {
+    match (qq_official, wechat_service) {
+        (Some(qq_official), Some(wechat_service)) => {
+            supervise_channel_pair(qq_official, wechat_service, shutdown_token).await
+        }
+        (Some(qq_official), None) => {
+            supervise_single_channel(QQ_OFFICIAL_CHANNEL, qq_official, shutdown_token).await
+        }
+        (None, Some(wechat_service)) => {
+            supervise_single_channel(WECHAT_SERVICE_CHANNEL, wechat_service, shutdown_token).await
+        }
+        (None, None) => {
+            bail!("no enabled gateway channel configured; enable QQ official or wechat service")
+        }
     }
-    result
+}
+
+async fn supervise_single_channel(
+    channel_name: &'static str,
+    mut task: ChannelTask,
+    shutdown_token: CancellationToken,
+) -> anyhow::Result<()> {
+    tokio::select! {
+        _ = shutdown_token.cancelled() => {
+            channel_task_result(channel_name, task.await, true)
+        }
+        result = &mut task => {
+            let shutdown_requested = shutdown_token.is_cancelled();
+            if !shutdown_requested {
+                shutdown_token.cancel();
+            }
+            channel_task_result(channel_name, result, shutdown_requested)
+        }
+    }
+}
+
+enum FirstChannelExit {
+    Shutdown,
+    QqOfficial(Result<anyhow::Result<()>, tokio::task::JoinError>),
+    WechatService(Result<anyhow::Result<()>, tokio::task::JoinError>),
+}
+
+async fn supervise_channel_pair(
+    mut qq_official: ChannelTask,
+    mut wechat_service: ChannelTask,
+    shutdown_token: CancellationToken,
+) -> anyhow::Result<()> {
+    let first_exit = tokio::select! {
+        _ = shutdown_token.cancelled() => FirstChannelExit::Shutdown,
+        result = &mut qq_official => FirstChannelExit::QqOfficial(result),
+        result = &mut wechat_service => FirstChannelExit::WechatService(result),
+    };
+
+    match first_exit {
+        FirstChannelExit::Shutdown => {
+            let (qq_result, wechat_result) = tokio::join!(qq_official, wechat_service);
+            finish_channel_results(
+                channel_task_result(QQ_OFFICIAL_CHANNEL, qq_result, true),
+                channel_task_result(WECHAT_SERVICE_CHANNEL, wechat_result, true),
+            )
+        }
+        FirstChannelExit::QqOfficial(result) => {
+            let shutdown_requested = shutdown_token.is_cancelled();
+            let primary = channel_task_result(QQ_OFFICIAL_CHANNEL, result, shutdown_requested);
+            if !shutdown_requested {
+                shutdown_token.cancel();
+            }
+            let secondary = channel_task_result(WECHAT_SERVICE_CHANNEL, wechat_service.await, true);
+            finish_channel_results(primary, secondary)
+        }
+        FirstChannelExit::WechatService(result) => {
+            let shutdown_requested = shutdown_token.is_cancelled();
+            let primary = channel_task_result(WECHAT_SERVICE_CHANNEL, result, shutdown_requested);
+            if !shutdown_requested {
+                shutdown_token.cancel();
+            }
+            let secondary = channel_task_result(QQ_OFFICIAL_CHANNEL, qq_official.await, true);
+            finish_channel_results(primary, secondary)
+        }
+    }
+}
+
+fn channel_task_result(
+    channel_name: &'static str,
+    result: Result<anyhow::Result<()>, tokio::task::JoinError>,
+    shutdown_requested: bool,
+) -> anyhow::Result<()> {
+    match result {
+        Ok(Ok(())) if shutdown_requested => Ok(()),
+        Ok(Ok(())) => Err(anyhow!("{channel_name} exited unexpectedly")),
+        // 渠道内部错误保持为首要错误返回，统一入口仍可看到原始错误链。
+        Ok(Err(error)) => Err(error),
+        Err(error) => Err(anyhow!("{channel_name} task join failed: {error}")),
+    }
+}
+
+fn finish_channel_results(
+    primary: anyhow::Result<()>,
+    secondary: anyhow::Result<()>,
+) -> anyhow::Result<()> {
+    match (primary, secondary) {
+        (Err(primary), Err(secondary)) => {
+            warn!(error = %secondary, "secondary channel failed while gateway was stopping");
+            Err(primary)
+        }
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+        (Ok(()), Ok(())) => Ok(()),
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -187,9 +301,9 @@ async fn run_qq_official(
     let aggregator_handle = aggregator.handle();
     let mut gateway_fetch_backoff = GatewayFetchBackoff::default();
 
-    loop {
+    let result = loop {
         if shutdown_token.is_cancelled() {
-            break;
+            break Ok(());
         }
         info!(api_base = %config.api_base, "fetching QQ gateway url");
         // 每次重连前重新获取网关地址，避免 IP/调度发生变化后仍连旧地址
@@ -202,8 +316,8 @@ async fn run_qq_official(
         .await
         {
             Ok(GatewayFetchOutcome::Url(url)) => url,
-            Ok(GatewayFetchOutcome::Shutdown) => break,
-            Err(error) => return Err(error).context("fetch QQ gateway url"),
+            Ok(GatewayFetchOutcome::Shutdown) => break Ok(()),
+            Err(error) => break Err(error).context("fetch QQ gateway url"),
         };
         info!("fetched QQ gateway url");
 
@@ -230,14 +344,14 @@ async fn run_qq_official(
 
         // 等待一段时间再重连，避免频繁重试给服务端带来压力
         tokio::select! {
-            _ = shutdown_token.cancelled() => break,
+            _ = shutdown_token.cancelled() => break Ok(()),
             _ = tokio::time::sleep(protocol::reconnect_delay()) => {}
         }
-    }
+    };
 
     aggregator.shutdown().await;
     dispatcher.shutdown().await;
-    Ok(())
+    result
 }
 
 #[cfg(test)]
@@ -251,9 +365,23 @@ mod tests {
             CoreRespondOutput, CoreService, UpstreamStatusSnapshot,
         },
     };
-    use std::collections::HashMap;
+    use std::{
+        collections::HashMap,
+        sync::atomic::{AtomicBool, Ordering},
+    };
 
     struct NoopCore;
+
+    fn task_waiting_for_shutdown(
+        shutdown: CancellationToken,
+        cleaned_up: Arc<AtomicBool>,
+    ) -> ChannelTask {
+        tokio::spawn(async move {
+            shutdown.cancelled().await;
+            cleaned_up.store(true, Ordering::SeqCst);
+            Ok(())
+        })
+    }
 
     #[async_trait]
     impl CoreService for NoopCore {
@@ -291,7 +419,7 @@ mod tests {
         let shutdown = CancellationToken::new();
         shutdown.cancel();
 
-        run(
+        let error = run(
             config,
             RespondClient::new(Arc::new(NoopCore)),
             push_sink,
@@ -299,7 +427,8 @@ mod tests {
             shutdown,
         )
         .await
-        .unwrap();
+        .unwrap_err();
+        assert!(error.to_string().contains("no enabled gateway channel"));
 
         let err = push_probe
             .push(PushIntent {
@@ -312,6 +441,100 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("not bound"));
+    }
+
+    #[tokio::test]
+    async fn qq_failure_cancels_wechat_and_returns_original_error() {
+        let shutdown = CancellationToken::new();
+        let wechat_cleaned_up = Arc::new(AtomicBool::new(false));
+        let qq_official = tokio::spawn(async { Err(anyhow!("fatal QQ gateway error")) });
+        let wechat_service =
+            task_waiting_for_shutdown(shutdown.clone(), Arc::clone(&wechat_cleaned_up));
+
+        let error = tokio::time::timeout(
+            Duration::from_secs(2),
+            supervise_channels(Some(qq_official), Some(wechat_service), shutdown.clone()),
+        )
+        .await
+        .expect("channel supervision must not deadlock")
+        .unwrap_err();
+
+        assert_eq!(error.to_string(), "fatal QQ gateway error");
+        assert!(shutdown.is_cancelled());
+        assert!(wechat_cleaned_up.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn wechat_only_internal_error_is_returned() {
+        let shutdown = CancellationToken::new();
+        let wechat_service = tokio::spawn(async { Err(anyhow!("wechat serve failed")) });
+
+        let error = supervise_channels(None, Some(wechat_service), shutdown.clone())
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.to_string(), "wechat serve failed");
+        assert!(shutdown.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn wechat_join_error_is_not_ignored() {
+        let shutdown = CancellationToken::new();
+        let wechat_service = tokio::spawn(async {
+            panic!("wechat task panic");
+            #[allow(unreachable_code)]
+            Ok::<(), anyhow::Error>(())
+        });
+
+        let error = supervise_channels(None, Some(wechat_service), shutdown.clone())
+            .await
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("wechat service callback task join failed")
+        );
+        assert!(error.to_string().contains("wechat task panic"));
+        assert!(shutdown.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn wechat_clean_exit_before_shutdown_is_an_error() {
+        let shutdown = CancellationToken::new();
+        let wechat_service = tokio::spawn(async { Ok(()) });
+
+        let error = supervise_channels(None, Some(wechat_service), shutdown.clone())
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "wechat service callback exited unexpectedly"
+        );
+        assert!(shutdown.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn global_shutdown_cleans_up_both_channels_without_error() {
+        let shutdown = CancellationToken::new();
+        let qq_cleaned_up = Arc::new(AtomicBool::new(false));
+        let wechat_cleaned_up = Arc::new(AtomicBool::new(false));
+        let qq_official = task_waiting_for_shutdown(shutdown.clone(), Arc::clone(&qq_cleaned_up));
+        let wechat_service =
+            task_waiting_for_shutdown(shutdown.clone(), Arc::clone(&wechat_cleaned_up));
+
+        shutdown.cancel();
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            supervise_channels(Some(qq_official), Some(wechat_service), shutdown),
+        )
+        .await
+        .expect("cancelled channels must finish promptly")
+        .unwrap();
+
+        assert!(qq_cleaned_up.load(Ordering::SeqCst));
+        assert!(wechat_cleaned_up.load(Ordering::SeqCst));
     }
 
     #[tokio::test]

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -43,11 +43,14 @@ use group_filter::GroupCooldowns;
 use ping::GatewayRuntimeStatus;
 use protocol::ResumeState;
 use push::GatewayPushSink;
-use ref_index::ref_index;
+use ref_index::{SharedRefIndex, ref_index};
 use retry::{GatewayFetchBackoff, GatewayFetchOutcome, fetch_gateway_url_with_retry};
 
 use crate::{
-    api::QqApiClient, auth::AccessTokenManager, config::AppConfig, respond::RespondClient,
+    api::QqApiClient,
+    auth::AccessTokenManager,
+    config::{AppConfig, QqOfficialBindingState},
+    respond::RespondClient,
 };
 
 const DEDUPE_TTL: Duration = Duration::from_secs(10 * 60);
@@ -61,19 +64,8 @@ pub async fn run(
     runtime: GatewayRuntimeStatus,
     shutdown_token: CancellationToken,
 ) -> anyhow::Result<()> {
-    let respond = respond.with_qq_official_account_id(config.app_id.clone());
-    let http_client = reqwest::Client::new();
-    let auth = AccessTokenManager::new(
-        http_client.clone(),
-        config.app_id.clone(),
-        config.app_secret.clone(),
-        config.token_refresh_margin,
-    );
-    let api = QqApiClient::new(http_client.clone(), config.api_base.clone(), auth.clone());
-    // 消息去重器，用于防止短时间内重复处理同一条 C2C 消息
+    // 微信与 QQ 共用 Core，但生命周期相互独立；QQ 未绑定时也必须先启动微信监听。
     let dedupe = Arc::new(MessageDedupe::new(DEDUPE_TTL));
-    // 运行时状态由统一入口创建，使 /ping 与 8787 控制台读取同一份进程内快照。
-    let ref_index = ref_index();
     let wechat_service_handle = if config.wechat_service.enabled {
         Some(
             wechat_service::spawn_callback_server(
@@ -88,17 +80,82 @@ pub async fn run(
     } else {
         None
     };
+    let ref_index = ref_index();
+    let result = match config.qq_official_binding_state() {
+        QqOfficialBindingState::Enabled => {
+            run_qq_official(
+                config,
+                respond,
+                push_sink,
+                runtime,
+                shutdown_token,
+                dedupe,
+                ref_index,
+            )
+            .await
+        }
+        QqOfficialBindingState::Unbound => {
+            push_sink.mark_qq_official_unavailable("QQ official channel is not bound");
+            info!(
+                channel = "qq_official",
+                state = "unbound",
+                "skipping channel initialization"
+            );
+            shutdown_token.cancelled().await;
+            Ok(())
+        }
+        QqOfficialBindingState::Disabled => {
+            push_sink.mark_qq_official_unavailable("QQ official channel is disabled");
+            info!(
+                channel = "qq_official",
+                state = "disabled",
+                "skipping channel initialization"
+            );
+            shutdown_token.cancelled().await;
+            Ok(())
+        }
+    };
+    if let Some(handle) = wechat_service_handle {
+        let _ = handle.await;
+    }
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_qq_official(
+    config: AppConfig,
+    respond: RespondClient,
+    push_sink: GatewayPushSink,
+    runtime: GatewayRuntimeStatus,
+    shutdown_token: CancellationToken,
+    dedupe: Arc<MessageDedupe>,
+    ref_index: SharedRefIndex,
+) -> anyhow::Result<()> {
+    let (app_id, app_secret) = config
+        .enabled_qq_official_credentials()
+        .context("QQ official channel enabled without credentials")?;
+    let app_id = app_id.to_owned();
+    let app_secret = app_secret.to_owned();
+    let respond = respond.with_qq_official_account_id(app_id.clone());
+    let http_client = reqwest::Client::new();
+    let auth = AccessTokenManager::new(
+        http_client.clone(),
+        app_id.clone(),
+        app_secret,
+        config.token_refresh_margin,
+    );
+    let api = QqApiClient::new(http_client.clone(), config.api_base.clone(), auth.clone());
     let group_outbound_cache = Arc::new(Mutex::new(BotOutboundCache::default()));
     // 主动推送已经进程内化；Core 通过 PushSink 进入这里，仍由 Gateway 负责 QQ 发送。
     push_sink.bind(
         api.clone(),
-        config.app_id.clone(),
+        app_id.clone(),
         runtime.clone(),
         group_outbound_cache.clone(),
         ref_index.clone(),
     );
     let group_cooldowns = Arc::new(Mutex::new(GroupCooldowns::default()));
-    let bot_identity = Arc::new(BotIdentity::new(&config.app_id, &config.bot_mention_ids));
+    let bot_identity = Arc::new(BotIdentity::new(&app_id, &config.bot_mention_ids));
     // 断线续连所需的状态（session_id + seq）
     let mut resume = ResumeState::default();
     // 聚合器必须先 flush 到 Dispatcher，不能让全局 shutdown 同时取消两者。
@@ -121,6 +178,7 @@ pub async fn run(
     let dispatcher_handle = dispatcher.handle();
     let aggregator = MessageAggregator::new(
         config.clone(),
+        app_id,
         respond.clone(),
         dispatcher_handle,
         dedupe.clone(),
@@ -179,8 +237,114 @@ pub async fn run(
 
     aggregator.shutdown().await;
     dispatcher.shutdown().await;
-    if let Some(handle) = wechat_service_handle {
-        let _ = handle.await;
-    }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use qq_maid_core::{
+        runtime::push::{PushIntent, PushSink, PushTarget, PushTargetType},
+        service::{
+            CoreError, CoreHealthSnapshot, CoreInboundClassification, CoreRequest,
+            CoreRespondOutput, CoreService, UpstreamStatusSnapshot,
+        },
+    };
+    use std::collections::HashMap;
+
+    struct NoopCore;
+
+    #[async_trait]
+    impl CoreService for NoopCore {
+        async fn respond(&self, _request: CoreRequest) -> Result<CoreRespondOutput, CoreError> {
+            unreachable!("unbound QQ startup must not dispatch messages")
+        }
+
+        async fn classify_inbound(
+            &self,
+            _request: CoreRequest,
+        ) -> Result<CoreInboundClassification, CoreError> {
+            unreachable!("unbound QQ startup must not classify messages")
+        }
+
+        async fn upstream_check(&self) -> Result<(), CoreError> {
+            Ok(())
+        }
+
+        fn health_snapshot(&self) -> CoreHealthSnapshot {
+            CoreHealthSnapshot {
+                ok: true,
+                provider: "test".to_owned(),
+                model: "test".to_owned(),
+                stream: false,
+                upstream: UpstreamStatusSnapshot::default(),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn unbound_qq_skips_gateway_and_marks_sender_unavailable() {
+        let config = AppConfig::from_map(&HashMap::new()).unwrap();
+        let push_sink = GatewayPushSink::unbound();
+        let push_probe = push_sink.clone();
+        let shutdown = CancellationToken::new();
+        shutdown.cancel();
+
+        run(
+            config,
+            RespondClient::new(Arc::new(NoopCore)),
+            push_sink,
+            GatewayRuntimeStatus::new(),
+            shutdown,
+        )
+        .await
+        .unwrap();
+
+        let err = push_probe
+            .push(PushIntent {
+                target: PushTarget::qq_official(PushTargetType::Private, "user-1"),
+                text: "hello".to_owned(),
+                fallback_text: None,
+                message_type: "text".to_owned(),
+                visible_entity_snapshot: None,
+            })
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("not bound"));
+    }
+
+    #[tokio::test]
+    async fn wechat_listener_starts_when_qq_is_unbound() {
+        let config = AppConfig::from_map(&HashMap::from([
+            ("WECHAT_SERVICE_ENABLED".to_owned(), "true".to_owned()),
+            ("WECHAT_SERVICE_TOKEN".to_owned(), "wechat-token".to_owned()),
+            ("WECHAT_SERVICE_BIND_PORT".to_owned(), "0".to_owned()),
+        ]))
+        .unwrap();
+        let runtime = GatewayRuntimeStatus::new();
+        let observed_runtime = runtime.clone();
+        let shutdown = CancellationToken::new();
+        let stop = shutdown.clone();
+        let task = tokio::spawn(run(
+            config,
+            RespondClient::new(Arc::new(NoopCore)),
+            GatewayPushSink::unbound(),
+            runtime,
+            shutdown,
+        ));
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !observed_runtime.snapshot().wechat_service_listening {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert!(!observed_runtime.snapshot().qq_connected);
+
+        stop.cancel();
+        task.await.unwrap().unwrap();
+        assert!(!observed_runtime.snapshot().wechat_service_listening);
+    }
 }

--- a/qq-maid-gateway-rs/src/gateway/outbound.rs
+++ b/qq-maid-gateway-rs/src/gateway/outbound.rs
@@ -365,8 +365,9 @@ mod tests {
 
     fn test_config() -> AppConfig {
         AppConfig {
-            app_id: "app".to_owned(),
-            app_secret: "secret".to_owned(),
+            qq_official_enabled: true,
+            app_id: Some("app".to_owned()),
+            app_secret: Some("secret".to_owned()),
             bot_mention_ids: Vec::new(),
             sandbox: false,
             api_base: "https://example.test".to_owned(),

--- a/qq-maid-gateway-rs/src/gateway/ping/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/ping/tests.rs
@@ -16,8 +16,9 @@ use super::{
 
 fn config() -> AppConfig {
     AppConfig {
-        app_id: "appid".to_owned(),
-        app_secret: "app-secret-value".to_owned(),
+        qq_official_enabled: true,
+        app_id: Some("appid".to_owned()),
+        app_secret: Some("app-secret-value".to_owned()),
         bot_mention_ids: Vec::new(),
         sandbox: false,
         api_base: "https://api.sgroup.qq.com".to_owned(),

--- a/qq-maid-gateway-rs/src/gateway/push.rs
+++ b/qq-maid-gateway-rs/src/gateway/push.rs
@@ -55,8 +55,15 @@ impl PushQqSender for QqApiClient {
 
 #[derive(Clone)]
 pub struct GatewayPushSink {
-    inner: Arc<Mutex<Option<GatewayPushRuntime>>>,
+    inner: Arc<Mutex<GatewayPushState>>,
     ready: Arc<Notify>,
+}
+
+#[derive(Clone)]
+enum GatewayPushState {
+    Pending,
+    Bound(GatewayPushRuntime),
+    Unavailable(&'static str),
 }
 
 #[derive(Clone)]
@@ -77,7 +84,7 @@ struct PushSendOutcome {
 impl GatewayPushSink {
     pub fn unbound() -> Self {
         Self {
-            inner: Arc::new(Mutex::new(None)),
+            inner: Arc::new(Mutex::new(GatewayPushState::Pending)),
             ready: Arc::new(Notify::new()),
         }
     }
@@ -92,7 +99,7 @@ impl GatewayPushSink {
     ) {
         // Core scheduler 可能在 Gateway 首次连接 QQ 前启动，因此 sink 需要先存在；
         // 真正发送前必须已绑定运行期上下文，否则返回可观测错误而不是静默丢消息。
-        *self.inner.lock().unwrap() = Some(GatewayPushRuntime {
+        *self.inner.lock().unwrap() = GatewayPushState::Bound(GatewayPushRuntime {
             api,
             qq_official_account_id: qq_official_account_id.into(),
             runtime,
@@ -102,9 +109,20 @@ impl GatewayPushSink {
         self.ready.notify_waiters();
     }
 
+    pub(crate) fn mark_qq_official_unavailable(&self, summary: &'static str) {
+        *self.inner.lock().unwrap() = GatewayPushState::Unavailable(summary);
+        self.ready.notify_waiters();
+    }
+
     async fn runtime(&self) -> Result<GatewayPushRuntime, PushError> {
-        if let Some(runtime) = self.inner.lock().unwrap().clone() {
-            return Ok(runtime);
+        match self.inner.lock().unwrap().clone() {
+            GatewayPushState::Bound(runtime) => return Ok(runtime),
+            GatewayPushState::Unavailable(summary) => {
+                return Err(PushError::Failed {
+                    summary: summary.to_owned(),
+                });
+            }
+            GatewayPushState::Pending => {}
         }
 
         // 统一进程启动时 Core 的 RSS / Todo 定时器和 QQ Gateway 连接并行启动。
@@ -116,13 +134,15 @@ impl GatewayPushSink {
             });
         }
 
-        self.inner
-            .lock()
-            .unwrap()
-            .clone()
-            .ok_or_else(|| PushError::Failed {
+        match self.inner.lock().unwrap().clone() {
+            GatewayPushState::Bound(runtime) => Ok(runtime),
+            GatewayPushState::Unavailable(summary) => Err(PushError::Failed {
+                summary: summary.to_owned(),
+            }),
+            GatewayPushState::Pending => Err(PushError::Failed {
                 summary: "gateway push sink is not ready".to_owned(),
-            })
+            }),
+        }
     }
 }
 
@@ -488,6 +508,23 @@ mod tests {
         };
         ref_index.lock().unwrap().enrich_inbound(&mut quoted);
         quoted.quoted.unwrap()
+    }
+
+    #[tokio::test]
+    async fn unavailable_qq_channel_returns_immediate_explicit_error() {
+        let sink = GatewayPushSink::unbound();
+        sink.mark_qq_official_unavailable("QQ official channel is not bound");
+        let intent = PushIntent {
+            target: PushTarget::qq_official(PushTargetType::Private, "user-1"),
+            text: "hello".to_owned(),
+            fallback_text: None,
+            message_type: "text".to_owned(),
+            visible_entity_snapshot: None,
+        };
+
+        let err = sink.push(intent).await.unwrap_err();
+
+        assert!(err.to_string().contains("QQ official channel is not bound"));
     }
 
     #[tokio::test]

--- a/qq-maid-gateway-rs/src/gateway/stream/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests.rs
@@ -240,7 +240,7 @@ fn quoted_lookup_found(
         media_summaries: Vec::new(),
     });
     let mut inbound = crate::gateway::platform::qq_official::inbound_from_c2c(&message);
-    inbound.account_id = Some(config.app_id.clone());
+    inbound.account_id = config.app_id.clone();
     ref_index.lock().unwrap().enrich_inbound(&mut inbound);
     inbound
         .quoted
@@ -251,8 +251,9 @@ fn quoted_lookup_found(
 
 fn test_config() -> AppConfig {
     AppConfig {
-        app_id: "app".to_owned(),
-        app_secret: "secret".to_owned(),
+        qq_official_enabled: true,
+        app_id: Some("app".to_owned()),
+        app_secret: Some("secret".to_owned()),
         bot_mention_ids: Vec::new(),
         sandbox: false,
         api_base: "https://example.test".to_owned(),

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -39,9 +39,25 @@ runtime/
 cp config/.env.example config/.env
 ```
 
-编辑 `runtime/config/.env`，填写 QQ 官方机器人、模型 Provider、天气和 RSS 等必要配置。默认 `runtime/config/agent.toml` 维护非敏感 Agent 策略，并将私聊、群聊、辅助任务和搜索路线统一到 OpenAI GPT-5.6 Luna；`.env` 继续保存 `OPENAI_API_KEY`、Base URL、旧兼容兜底模型和运行参数。如不希望模型在普通私聊中主动调用工具，优先修改 `[scenes.private].tool_calling_enabled=false`。未显式配置 `PROMPT_DIR` 时，Core 使用默认 `config/prompts`；默认目录缺少真实 prompt 文件时会回退到内置通用 prompt。显式配置 `PROMPT_DIR` 后，缺文件或空文件会作为配置错误处理。
+编辑 `runtime/config/.env`，填写至少一个入口渠道和模型 Provider 等必要配置。QQ 官方机器人凭证现在是可选绑定；微信-only 部署可以不填写 QQ AppID/AppSecret。默认 `runtime/config/agent.toml` 维护非敏感 Agent 策略，并将私聊、群聊、辅助任务和搜索路线统一到 OpenAI GPT-5.6 Luna；`.env` 继续保存 `OPENAI_API_KEY`、Base URL、旧兼容兜底模型和运行参数。如不希望模型在普通私聊中主动调用工具，优先修改 `[scenes.private].tool_calling_enabled=false`。未显式配置 `PROMPT_DIR` 时，Core 使用默认 `config/prompts`；默认目录缺少真实 prompt 文件时会回退到内置通用 prompt。显式配置 `PROMPT_DIR` 后，缺文件或空文件会作为配置错误处理。
 
 Rust 进程按当前工作目录依次尝试加载 `config/.env` 和 `.env`。`make run` 和部署控制脚本都会以 `runtime/` 作为工作目录启动，因此默认相对路径都按 `runtime/` 解析。
+
+### QQ 官方 Bot 绑定管理
+
+- `QQ_BOT_APP_ID` 与 `QQ_BOT_APP_SECRET` 同时存在：已绑定；`QQ_BOT_ENABLED=true` 时启动 QQ Gateway。
+- 两项都不存在：未绑定。进程跳过 QQ Token 获取、Gateway 连接和重连，不影响微信入口、主体及 SQLite 业务数据。
+- 凭证存在且 `QQ_BOT_ENABLED=false`：已禁用。凭证保留，QQ 不初始化。
+- 只配置其中一项属于错误配置，启动时会明确报错，避免使用残缺凭证。
+
+现有安装可执行 `qbot config bot --unbind` 解绑，或执行 `qbot config bot --disable` 暂停；两者均需重启进程生效。解绑命令只从 `.env` 删除 QQ 新旧凭证键，不修改微信配置、`APP_DB_FILE`、会话、待办、记忆或 RSS 数据。重新绑定可执行：
+
+```bash
+qbot config bot --app-id 你的AppID --app-secret 你的AppSecret
+qbot restart
+```
+
+控制台会分别展示未绑定（`not_configured`）、已禁用（`not_available`）、已绑定但离线（`offline`）和运行中（`online`）。未绑定与已禁用不是健康故障。当前配置管理只在启动时读取，因此不支持运行期间热解绑。
 
 常用外部路径变量：
 

--- a/runtime/config/.env.example
+++ b/runtime/config/.env.example
@@ -1,25 +1,16 @@
 # =============================================================================
-# 必填基础配置
+# 入口渠道与 AI 配置
 # =============================================================================
 # 生产环境请复制为 config/.env 后再填写；不要提交真实 .env。
-QQ_BOT_APP_ID=你的QQ机器人AppID
-QQ_BOT_APP_SECRET=你的QQ机器人AppSecret
-
-# 至少配置一个被模型路线引用的 Provider API Key。
-OPENAI_API_KEY=你的OpenAI_API_Key
-DEEPSEEK_API_KEY=
-BIGMODEL_API_KEY=
-GEMINI_API_KEY=
-MIMO_API_KEY=
-
-# 天气能力需要和风天气 Key；如果不使用天气，也建议保留占位便于诊断提示明确。
-QWEATHER_API_KEY=你的和风天气APIKey
-QWEATHER_API_HOST=https://你的和风天气APIHost
-QWEATHER_GEO_HOST=
 
 # =============================================================================
-# QQ Gateway
+# QQ 官方机器人（可选）
 # =============================================================================
+# QQ 官方 Bot 凭证必须同时填写；两项都留空表示“未绑定”，不会启动 Token/Gateway 任务。
+# 保留凭证但临时停用时设置 QQ_BOT_ENABLED=false。
+QQ_BOT_ENABLED=true
+QQ_BOT_APP_ID=
+QQ_BOT_APP_SECRET=
 QQ_BOT_SANDBOX=false
 # QQ_BOT_API_BASE=https://api.sgroup.qq.com
 QQ_BOT_TOKEN_REFRESH_MARGIN_SECONDS=60
@@ -67,7 +58,7 @@ QQ_MAID_GROUP_ACTIVE_KEYWORDS=小女仆
 QQ_MAID_BOT_MENTION_IDS=
 
 # =============================================================================
-# 微信服务号 Gateway（最小文本同步回复，默认关闭）
+# 微信测试号 / 服务号 Gateway（可选，默认关闭）
 # =============================================================================
 # 开启后 Gateway 会额外监听 WECHAT_SERVICE_BIND_HOST:WECHAT_SERVICE_BIND_PORT，
 # 微信开发者后台回调 URL 指向反向代理后的 WECHAT_SERVICE_CALLBACK_PATH。
@@ -94,22 +85,6 @@ WECHAT_SERVICE_REPLY_TIMEOUT_MS=4000
 WECHAT_SERVICE_BIND_HOST=127.0.0.1
 WECHAT_SERVICE_BIND_PORT=8788
 WECHAT_SERVICE_CALLBACK_PATH=/wechat/service
-
-# =============================================================================
-# 会话排队与消息聚合
-# =============================================================================
-CONVERSATION_QUEUE_CAPACITY=16
-MAX_ACTIVE_CONVERSATION_WORKERS=64
-CONVERSATION_WORKER_IDLE_TIMEOUT_SECS=300
-
-# 私聊短窗口聚合；命令、pending、/ping、附件和群聊不会被延迟。
-MESSAGE_AGGREGATION_PRIVATE_ENABLED=true
-MESSAGE_AGGREGATION_GROUP_ENABLED=false
-MESSAGE_AGGREGATION_QUIET_MS=1200
-MESSAGE_AGGREGATION_MAX_WAIT_MS=3000
-MESSAGE_AGGREGATION_MAX_MESSAGES=10
-MESSAGE_AGGREGATION_MAX_CHARS=12000
-MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS=1024
 
 # =============================================================================
 # 模型路由与 Agent 策略
@@ -160,6 +135,13 @@ TRANSLATION_MODEL=
 # =============================================================================
 # Provider 参数
 # =============================================================================
+# 至少配置一个被模型路线引用的 Provider API Key。
+OPENAI_API_KEY=你的OpenAI_API_Key
+DEEPSEEK_API_KEY=
+BIGMODEL_API_KEY=
+GEMINI_API_KEY=
+MIMO_API_KEY=
+
 # OpenAI / OpenAI 兼容接口。
 OPENAI_BASE_URL=
 # 多地址用逗号分隔；取第一个非空地址，优先级高于 OPENAI_BASE_URL。
@@ -209,6 +191,30 @@ AGENT_TOOL_RESULT_CHAR_LIMIT=4000
 
 LLM_SERVER_HOST=127.0.0.1
 LLM_SERVER_PORT=8787
+
+# =============================================================================
+# 会话排队与消息聚合
+# =============================================================================
+CONVERSATION_QUEUE_CAPACITY=16
+MAX_ACTIVE_CONVERSATION_WORKERS=64
+CONVERSATION_WORKER_IDLE_TIMEOUT_SECS=300
+
+# 私聊短窗口聚合；命令、pending、/ping、附件和群聊不会被延迟。
+MESSAGE_AGGREGATION_PRIVATE_ENABLED=true
+MESSAGE_AGGREGATION_GROUP_ENABLED=false
+MESSAGE_AGGREGATION_QUIET_MS=1200
+MESSAGE_AGGREGATION_MAX_WAIT_MS=3000
+MESSAGE_AGGREGATION_MAX_MESSAGES=10
+MESSAGE_AGGREGATION_MAX_CHARS=12000
+MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS=1024
+
+# =============================================================================
+# 天气能力
+# =============================================================================
+# 如果不使用天气，也建议保留占位，便于诊断提示明确。
+QWEATHER_API_KEY=你的和风天气Key
+QWEATHER_API_HOST=https://你的和风天气APIHost
+QWEATHER_GEO_HOST=
 
 # =============================================================================
 # 本地或受控内网只读管理面板；不要把 8787 裸露到公网

--- a/scripts/test-qbot-config.sh
+++ b/scripts/test-qbot-config.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TMP_ROOT}"' EXIT
+
+new_fixture() {
+    local name="$1"
+    local app_dir="${TMP_ROOT}/${name}"
+    mkdir -p "${app_dir}/config"
+    : > "${app_dir}/config/.env"
+    echo "${app_dir}"
+}
+
+run_config_bot() {
+    local app_dir="$1"
+    shift
+    QBOT_APP_DIR="${app_dir}" \
+        QBOT_CONFIG_NO_BACKUP=1 \
+        QBOT_NO_CLEAR=1 \
+        NO_COLOR=1 \
+        bash "${REPO_DIR}/qbot.sh" config bot "$@"
+}
+
+assert_config_value() {
+    local app_dir="$1"
+    local expected="$2"
+    grep -Fqx "${expected}" "${app_dir}/config/.env"
+}
+
+assert_config_absent() {
+    local app_dir="$1"
+    local key="$2"
+    ! grep -Eq "^[[:space:]]*${key}=" "${app_dir}/config/.env"
+}
+
+for args in "--enable --disable" "--unbind --disable" "--unbind --enable"; do
+    app_dir="$(new_fixture "mutual-${args// /-}")"
+    set +e
+    output="$(run_config_bot "${app_dir}" ${args} 2>&1)"
+    status=$?
+    set -e
+    [[ "${status}" -ne 0 ]]
+    [[ "${output}" == *"--enable、--disable、--unbind 互斥"* ]]
+done
+
+app_dir="$(new_fixture enable-without-credentials)"
+set +e
+output="$(run_config_bot "${app_dir}" --enable 2>&1)"
+status=$?
+set -e
+[[ "${status}" -ne 0 ]]
+[[ "${output}" == *"--enable 需要完整 QQ 凭证"* ]]
+[[ "${output}" != *"已启用:"* ]]
+assert_config_absent "${app_dir}" QQ_BOT_ENABLED
+
+app_dir="$(new_fixture enable-existing-credentials)"
+printf '%s\n' "QQ_BOT_APP_ID='existing-id'" "QQ_BOT_APP_SECRET='existing-secret'" > "${app_dir}/config/.env"
+output="$(run_config_bot "${app_dir}" --enable)"
+[[ "${output}" == *"已启用:"* ]]
+assert_config_value "${app_dir}" "QQ_BOT_ENABLED='true'"
+
+app_dir="$(new_fixture enable-legacy-credentials)"
+printf '%s\n' "QQ_APPID='legacy-id'" "QQ_SECRET='legacy-secret'" > "${app_dir}/config/.env"
+run_config_bot "${app_dir}" --enable >/dev/null
+assert_config_value "${app_dir}" "QQ_BOT_ENABLED='true'"
+
+app_dir="$(new_fixture enable-new-credentials)"
+output="$(run_config_bot "${app_dir}" --enable --app-id new-id --app-secret new-secret)"
+[[ "${output}" == *"已启用:"* ]]
+assert_config_value "${app_dir}" "QQ_BOT_APP_ID='new-id'"
+assert_config_value "${app_dir}" "QQ_BOT_APP_SECRET='new-secret'"
+assert_config_value "${app_dir}" "QQ_BOT_ENABLED='true'"
+
+app_dir="$(new_fixture complete-credentials-default-enable)"
+run_config_bot "${app_dir}" --app-id default-id --app-secret default-secret >/dev/null
+assert_config_value "${app_dir}" "QQ_BOT_ENABLED='true'"
+
+app_dir="$(new_fixture disable-preserves-credentials)"
+printf '%s\n' "QQ_BOT_APP_ID='kept-id'" "QQ_BOT_APP_SECRET='kept-secret'" > "${app_dir}/config/.env"
+run_config_bot "${app_dir}" --disable >/dev/null
+assert_config_value "${app_dir}" "QQ_BOT_APP_ID='kept-id'"
+assert_config_value "${app_dir}" "QQ_BOT_APP_SECRET='kept-secret'"
+assert_config_value "${app_dir}" "QQ_BOT_ENABLED='false'"
+
+app_dir="$(new_fixture unbind-preserves-other-config)"
+printf '%s\n' \
+    "QQ_BOT_APP_ID='new-id'" \
+    "QQ_BOT_APP_SECRET='new-secret'" \
+    "QQ_APPID='legacy-id'" \
+    "QQ_SECRET='legacy-secret'" \
+    "WECHAT_SERVICE_ENABLED='true'" \
+    "APP_DB_FILE='data/storage/app.db'" > "${app_dir}/config/.env"
+run_config_bot "${app_dir}" --unbind >/dev/null
+assert_config_absent "${app_dir}" QQ_BOT_APP_ID
+assert_config_absent "${app_dir}" QQ_BOT_APP_SECRET
+assert_config_absent "${app_dir}" QQ_APPID
+assert_config_absent "${app_dir}" QQ_SECRET
+assert_config_value "${app_dir}" "WECHAT_SERVICE_ENABLED='true'"
+assert_config_value "${app_dir}" "APP_DB_FILE='data/storage/app.db'"
+
+echo "qbot config bot regression tests passed"

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,18 +33,19 @@ async fn main() -> anyhow::Result<()> {
     let core_config = CoreConfig::from_env()?;
     let gateway_env = std::env::vars().collect::<HashMap<_, _>>();
     let gateway_config = GatewayConfig::from_map(&gateway_env)?;
-    let rebaseline_report =
-        rebaseline_qq_official_identity(&core_config.app_db_file, &gateway_config.app_id)?;
-    if rebaseline_report.changed() {
-        info!(
-            sessions = rebaseline_report.sessions,
-            session_active = rebaseline_report.session_active,
-            memories = rebaseline_report.memories,
-            todos = rebaseline_report.todos,
-            rss_subscriptions = rebaseline_report.rss_subscriptions,
-            rss_duplicates_removed = rebaseline_report.rss_duplicates_removed,
-            "已完成旧 QQ 业务归属键归一"
-        );
+    if let Some(app_id) = gateway_config.app_id.as_deref() {
+        let rebaseline_report = rebaseline_qq_official_identity(&core_config.app_db_file, app_id)?;
+        if rebaseline_report.changed() {
+            info!(
+                sessions = rebaseline_report.sessions,
+                session_active = rebaseline_report.session_active,
+                memories = rebaseline_report.memories,
+                todos = rebaseline_report.todos,
+                rss_subscriptions = rebaseline_report.rss_subscriptions,
+                rss_duplicates_removed = rebaseline_report.rss_duplicates_removed,
+                "已完成旧 QQ 业务归属键归一"
+            );
+        }
     }
 
     let push_sink = GatewayPushSink::unbound();
@@ -68,8 +69,12 @@ async fn main() -> anyhow::Result<()> {
             })
             .await
     });
-    let respond = RespondClient::new(Arc::new(core_handle))
-        .with_qq_official_account_id(&gateway_config.app_id);
+    let respond = match gateway_config.app_id.as_deref() {
+        Some(app_id) => {
+            RespondClient::new(Arc::new(core_handle)).with_qq_official_account_id(app_id)
+        }
+        None => RespondClient::new(Arc::new(core_handle)),
+    };
     info!("Core 已完成进程内初始化，开始启动 Gateway");
     let shutdown_token = CancellationToken::new();
     let gateway_shutdown = shutdown_token.clone();


### PR DESCRIPTION
## 变更说明

- 将 QQ 官方 Bot 凭证改为成对的可选绑定，支持未绑定、已禁用、已启用三种配置状态。
- QQ 未绑定或禁用时，微信回调仍可独立启动，并跳过 Token、API client、Gateway WebSocket、Dispatcher 与重连循环。
- 统一监督 QQ 官方 Gateway、微信 callback server 与全局取消信号；任一已启用渠道提前退出都会取消其他渠道、等待清理并向统一入口返回原始错误。
- QQ 不可重试错误会在 Aggregator、Dispatcher 依次关闭后返回，不再因等待微信任务形成循环等待。
- 主动推送到未绑定/已禁用 QQ 渠道时立即返回明确错误，不跨账号或跨渠道降级。
- 在只读控制台中区分未绑定、禁用、离线和在线状态；未绑定不作为运行故障。
- 扩展现有 `qbot config bot`：支持 `--unbind`、`--disable`、`--enable`，三项互斥；`--enable` 会按修改后的新旧兼容凭证验真，避免虚假成功。

## 根因与修复

此前 Gateway 先启动微信任务，再同步等待 QQ 主循环，QQ 返回后又无条件等待微信；微信只在共享 `CancellationToken` 被取消后退出，而统一入口只有看到 Gateway 结束后才取消该令牌，因此 QQ 不可重试错误无法上抛。微信-only 模式也没有监督微信任务的意外退出。

现在顶层根据实际启用组合监督两个渠道和全局取消：

- 双渠道：任一渠道提前退出时取消共享令牌，等待另一渠道清理，返回首个退出原因；无错误提前退出也视为故障。
- QQ-only：保留原重连模型，不可重试错误直接上抛。
- 微信-only：微信任务成为主运行任务，内部错误、JoinError 或无错误提前结束都会终止 Gateway。
- 两个入口均未启用：按现有“至少一个入口渠道”产品约定返回明确配置错误。
- 正常取消：QQ 停止入站后按 Aggregator → Dispatcher 顺序关闭，微信执行 graceful shutdown。

## 兼容性

- 旧配置包含完整 QQ 凭证时默认保持启用。
- 两项 QQ 凭证均缺失表示未绑定；只缺一项会明确报配置错误。
- `QQ_BOT_ENABLED=false` 保留凭证但禁用 QQ。
- 解绑删除 QQ 新旧凭证键，不修改微信配置、SQLite schema 或业务数据。
- 配置仍在启动时读取，不引入运行时热绑定、多租户或多 QQ 账号模型。

## 验证

- `bash -n qbot.sh scripts/*.sh`
- `bash scripts/test-qbot-install.sh`
- `bash scripts/test-qbot-config.sh`
- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace --release --all-features`
- `git diff --check`

新增回归覆盖 QQ 异常取消微信、微信-only 内部错误、微信 JoinError、渠道无错误提前退出、双渠道全局取消清理，以及配置状态参数互斥、无凭证启用失败、新旧已有凭证启用和本次提供完整凭证启用。

未使用真实 QQ / 微信凭证进行平台网络连接验证。
