### PR TITLE
feat: 建立 OneBot 11 配置与反向 WebSocket 连接底座

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -127,8 +128,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <p><sub>Rust 单进程 · 约 25 MiB 常驻内存 · 默认空闲时 3 个线程 · Provider 无关 Agent Loop · 多模态输入 · 主动推送 · 模型自动降级</sub></p>
 </div>
 
-> 💡 仓库早期以 QQ 机器人为主，因此仍保留 `qq-maid-bot` 名称。当前项目正在从 QQ 官方机器人演进为多入口平台型小女仆机器人；OneBot 11 仍处于架构预留和规划阶段，尚未接入。
+> 💡 仓库早期以 QQ 机器人为主，因此仍保留 `qq-maid-bot` 名称。当前项目正在从 QQ 官方机器人演进为多入口平台型小女仆机器人；OneBot 11 已具备一期反向 WebSocket 连接底座，业务消息接入和发送能力仍在后续阶段。
 
 小女仆机器人使用 Rust 构建，当前主入口是 QQ 官方机器人接口，并提供可选微信服务号文本入口。它不是简单地把消息转发给大模型，而是把长期会话、受控记忆、Todo、RSS、知识检索、联网查询、QQ 图片理解、引用上下文、Agent Loop、工具调用和主动推送装进同一个可维护的 Agent 底座里。
 
@@ -70,7 +70,7 @@ vim config/.env
 ./botctl.sh status
 ```
 
-最少需要配置一个入口渠道，以及至少一个 Provider 的 API Key。使用 QQ 时同时填写 `QQ_BOT_APP_ID`、`QQ_BOT_APP_SECRET`；微信-only 部署可留空两项并按下文启用微信服务号。
+最少需要配置一个入口渠道，以及至少一个 Provider 的 API Key。使用 QQ 时同时填写 `QQ_BOT_APP_ID`、`QQ_BOT_APP_SECRET`；微信-only 或 OneBot 11 连接底座部署可留空两项并启用对应入口。OneBot 一期尚不处理业务消息。
 
 Windows 用户也可以在 Git Bash、MSYS2 或 Cygwin 中执行 `bash qbot.sh install`，脚本会自动下载
 `windows-x86_64.zip` 并默认安装到 `$HOME/qq-maid-bot`。原生 Windows 启动方式参见发布包内的
@@ -184,7 +184,7 @@ runtime/botctl.sh status
 | --- | --- | --- |
 | QQ 官方机器人 | ✅ 主要入口 | C2C 和群聊，支持图片理解、流式回复、typing 状态 |
 | 微信服务号 | ⚡ 可选 text-only | 默认关闭；支持同步文本回复和慢请求客服补发，需反向代理 |
-| OneBot 11 | 📋 规划中 | 已保留平台模型和边界预留，尚未实现可用接入 |
+| OneBot 11 | 🧱 一期底座 | 单账号反向 WebSocket、鉴权、心跳和连接上下文已实现；业务 adapter / sender 待后续任务 |
 
 ## 架构概览
 
@@ -211,7 +211,7 @@ flowchart LR
 
 | Crate | 职责 |
 | --- | --- |
-| `qq-maid-gateway-rs/` | QQ 事件接收、消息聚合、typing、流式与普通回复、图片下载；可选微信服务号文本回调 |
+| `qq-maid-gateway-rs/` | QQ 事件接收、消息聚合、typing、流式与普通回复、图片下载；可选微信服务号文本回调和 OneBot 11 连接底座 |
 | `qq-maid-core/` | CoreService、会话、记忆、知识库、Todo、RSS、业务 Tool、可信结果编排 |
 | `qq-maid-llm/` | 模型协议、Provider 路由、fallback、SSE、Agent Loop、Tool Loop 和健康观测 |
 | `qq-maid-common/` | 身份上下文、输入输出结构、Markdown 安全转换、脱敏、时间与文本等无业务状态的共享工具 |

--- a/qq-maid-gateway-rs/Cargo.toml
+++ b/qq-maid-gateway-rs/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-axum = "0.8"
+axum = { version = "0.8", features = ["ws"] }
 dotenvy = "0.15"
 futures-util = "0.3"
 fastrand = "2"

--- a/qq-maid-gateway-rs/README.md
+++ b/qq-maid-gateway-rs/README.md
@@ -1,6 +1,6 @@
 # Rust 平台入口与 QQ 文本网关
 
-`qq-maid-gateway-rs/` 是 Rust 平台入口层，当前主入口是 QQ 官方 C2C / 群 at / 普通群文本接入，并包含可选微信服务号文本回调。旧 Python bot 接入层已经移除；新平台接入能力优先放到本 gateway 的 adapter / sender 边界，业务能力优先放到 `qq-maid-core/`。
+`qq-maid-gateway-rs/` 是 Rust 平台入口层，当前主入口是 QQ 官方 C2C / 群 at / 普通群文本接入，并包含可选微信服务号文本回调和 OneBot 11 反向 WebSocket 连接底座。旧 Python bot 接入层已经移除；新平台接入能力优先放到本 gateway 的 adapter / sender 边界，业务能力优先放到 `qq-maid-core/`。
 
 ## 多平台入口边界
 
@@ -8,7 +8,7 @@
 flowchart LR
     subgraph platform_in["平台入口"]
         qq["QQ 官方 Gateway"]
-        onebot["OneBot 入口（规划中）"]
+        onebot["OneBot 11 反向 WebSocket<br/>连接底座"]
         wechat["微信回调入口"]
     end
 
@@ -61,7 +61,7 @@ flowchart LR
 
 - `InboundMessage` 是 Gateway 内部的平台无关入站模型，包含 `Actor` 与 `Conversation`。QQ、OneBot、微信等协议字段只能在各自 adapter 内解析。
 - `CoreRequest` 是 Gateway 调用 Core 的稳定契约。Core 可以看到平台枚举、Actor 和 Conversation，但不理解 QQ `msg_seq`、stream id、微信 XML 字段或 OneBot CQ 片段。
-- OneBot 11 目前只有平台模型和边界预留，尚未实现反向 WebSocket server、事件 adapter、API sender 或主动推送路由。
+- OneBot 11 已实现默认关闭的单账号反向 WebSocket server、鉴权、生命周期/心跳、连接替换、API request/response 共用连接上下文和脱敏状态；当前仍不解析业务消息、不调用 Core，也不实现具体 sender 或主动推送路由。
 - `scope_key` / `owner_key` 是业务隔离键，用于 Session、Pending、Memory、Todo 等状态归属，不是发送地址。
 - `ReplyTarget` / `DeliveryTarget` 保存真实投递目标，必须保留平台和 `raw_target_id`。发送逻辑只能使用投递目标调用 sender，不能从 `scope_key` 或 `owner_key` 反解析平台 ID。
 - RSS、Notification、Todo 提醒和 Push 这类主动投递也必须携带原始 delivery target；后续多平台收敛时不要把目标统一替换成 namespaced 字符串。
@@ -75,6 +75,7 @@ flowchart LR
 - Markdown 和图片保留独立 outbound 类型、payload 构造和发送入口；发送失败会 warn 并 fallback 到文本。C2C 流式回复当前固定使用 Markdown 流式载荷，首帧成功后不再补发普通全文。
 - Core 的统一通知 Worker 和 Todo 每日提醒通过进程内 `PushSink` 主动推送；RSS 只生产 Notification Outbox 任务，不再维护独立发送链路。
 - 微信服务号入口默认关闭；启用后处理 GET URL 验证、POST 明文 `text` XML、同步文本 XML 快路径，以及超出同步安全预算后的客服文本补发。客服补发按需获取 `access_token`，Markdown 会降级为 text。
+- OneBot 11 入口默认关闭；启用后只建立单账号反向 WebSocket 连接。首次账号会锁定进程内 `self_id`，同账号新连接替换旧连接，不同账号会被拒绝；连接异常不会结束监听器或其它入口。
 - 不做频道、频道私信、Ark、Embed、Keyboard、多租户或旧接入层兼容。
 - 微信服务号暂不做加密 XML、模板消息、图片语音视频、菜单事件、主动推送或流式输出；客服消息只实现慢请求文本补发。
 
@@ -103,6 +104,9 @@ flowchart LR
 - `src/gateway/push.rs`：进程内主动推送实现。
 - `src/gateway/wechat_service.rs`：微信服务号文本回调 HTTP 入口，负责签名校验、明文 XML 解析、Core 调用、同步 XML 回复、慢请求去重和客服文本补发。
 - `src/gateway/platform/wechat_service.rs`：微信服务号平台字段到统一 `InboundMessage` / `CoreRequest` 的映射，以及 XML 解析和渲染 helper。
+- `src/gateway/onebot11/protocol.rs`：OneBot 11 事件、消息段、action / response、`echo`、生命周期、心跳和无精度损失 ID 类型。
+- `src/gateway/onebot11/connection.rs`：单账号活动连接、同账号替换策略和 API `echo` 关联上下文。
+- `src/gateway/onebot11/server.rs`：反向 WebSocket 监听、路径与 Bearer 鉴权、连接事件循环、超时和优雅退出。
 
 维护时应尽量保持这些边界，不要把 WebSocket 协议细节、Core 业务调用和 QQ 发送状态记录重新堆回同一个超长文件。
 
@@ -135,7 +139,7 @@ QQ_MAID_BOT_MENTION_IDS=
 RUST_LOG=info,qq_maid_gateway_rs=debug
 ```
 
-`QQ_BOT_APP_ID` 与 `QQ_BOT_APP_SECRET` 必须成对配置；两项均缺失表示 QQ 官方 Bot 未绑定。此时不会创建 Token、API client、Gateway 或重连任务，微信服务号仍可独立运行。凭证存在时可用 `QQ_BOT_ENABLED=false` 暂时禁用；旧配置未设置该开关时仍默认启用。配置由启动时读取，`qbot config bot --unbind`、`--disable` 和重新绑定都需重启生效。
+`QQ_BOT_APP_ID` 与 `QQ_BOT_APP_SECRET` 必须成对配置；两项均缺失表示 QQ 官方 Bot 未绑定。此时不会创建 Token、API client、Gateway 或重连任务，微信服务号或 OneBot 11 仍可独立运行。凭证存在时可用 `QQ_BOT_ENABLED=false` 暂时禁用；旧配置未设置该开关时仍默认启用。配置由启动时读取，`qbot config bot --unbind`、`--disable` 和重新绑定都需重启生效。
 
 兼容旧变量名：
 
@@ -151,6 +155,20 @@ QQ_SECRET=你的QQ机器人AppSecret
 普通群消息会过滤自己发送的消息、可识别的其它机器人消息、空内容/无附件消息和重复 `message_id`，并使用群级与群成员级内存冷却避免刷屏；但发送给 Core 的 `scope_key` 仍保持群会话维度，actor 仅表示群内发言人，避免同一个用户的私聊与群聊 session / pending / visible snapshot / ref_index 串用。只有 QQ 官方实际推送且 payload 带 `current_msg_idx / msg_idx` 的群消息，才能提前登记到运行期 ref_index；平台未推送或缺字段时，后续引用只能依赖当前引用事件 payload 兜底或已有索引。
 
 `QQ_MAID_C2C_VISIBLE_PROGRESS_STATUS_ENABLED` 控制私聊 Tool Loop 的可见进度文本，默认开启，只在 Core 输出策略为 `progress_then_complete` / `progress_then_stream` 时发送一次受控短提示。它不是 QQ 原生 typing 状态；原生 typing 由 `QQ_MAID_AGENT_TYPING_ENABLED` / `QQ_MAID_AGENT_TYPING_DELAY_MS` 单独控制。
+
+OneBot 11 连接底座最小配置：
+
+```env
+ONEBOT11_ENABLED=false
+ONEBOT11_BIND_HOST=127.0.0.1
+ONEBOT11_BIND_PORT=8789
+ONEBOT11_WEBSOCKET_PATH=/onebot/v11/ws
+ONEBOT11_ACCESS_TOKEN=
+ONEBOT11_REQUEST_TIMEOUT_MS=10000
+ONEBOT11_MAX_MESSAGE_BYTES=1048576
+```
+
+启用时 `ONEBOT11_ACCESS_TOKEN` 必填，客户端需携带 `Authorization: Bearer <token>`；推荐保持回环地址监听。`X-Self-ID` 可以在握手时上报，也可由首个合法事件上报。`/ping all` 和控制台只显示 token 是否配置、监听/连接状态、脱敏 `self_id`、最近心跳与断开摘要，不输出完整 QQ 号、token 或消息正文。一期不处理业务消息，也不提供文本发送。
 
 微信服务号最小配置：
 

--- a/qq-maid-gateway-rs/src/config/mod.rs
+++ b/qq-maid-gateway-rs/src/config/mod.rs
@@ -33,6 +33,13 @@ pub const DEFAULT_WECHAT_SERVICE_BIND_PORT: u16 = 8788;
 pub const DEFAULT_WECHAT_SERVICE_CALLBACK_PATH: &str = "/wechat/service";
 pub const DEFAULT_WECHAT_SERVICE_REPLY_TIMEOUT_MS: u64 = 4000;
 pub const DEFAULT_WECHAT_SERVICE_API_BASE: &str = "https://api.weixin.qq.com";
+pub const DEFAULT_ONEBOT11_BIND_HOST: &str = "127.0.0.1";
+pub const DEFAULT_ONEBOT11_BIND_PORT: u16 = 8789;
+pub const DEFAULT_ONEBOT11_WEBSOCKET_PATH: &str = "/onebot/v11/ws";
+pub const DEFAULT_ONEBOT11_REQUEST_TIMEOUT_MS: u64 = 10_000;
+pub const DEFAULT_ONEBOT11_MAX_MESSAGE_BYTES: u64 = 1024 * 1024;
+pub const MIN_ONEBOT11_MAX_MESSAGE_BYTES: u64 = 1024;
+pub const MAX_ONEBOT11_MAX_MESSAGE_BYTES: u64 = 16 * 1024 * 1024;
 pub const DEFAULT_MEDIA_DIR: &str = "media/inbound";
 pub const DEFAULT_MEDIA_DOWNLOAD_TIMEOUT_MS: u64 = 10_000;
 pub const DEFAULT_MEDIA_MAX_BYTES: u64 = 10 * 1024 * 1024;
@@ -89,6 +96,33 @@ pub struct AppConfig {
     pub media_max_bytes: u64,
     /// 微信服务号最小文本回调入口；默认关闭，不影响现有 QQ Gateway。
     pub wechat_service: WechatServiceConfig,
+    /// OneBot 11 反向 WebSocket 单账号入口；一期只建立连接底座，不进入 Core。
+    pub onebot11: OneBot11Config,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OneBot11Config {
+    pub enabled: bool,
+    pub bind_host: String,
+    pub bind_port: u16,
+    pub websocket_path: String,
+    pub access_token: Option<String>,
+    pub request_timeout: Duration,
+    pub max_message_bytes: usize,
+}
+
+impl Default for OneBot11Config {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bind_host: DEFAULT_ONEBOT11_BIND_HOST.to_owned(),
+            bind_port: DEFAULT_ONEBOT11_BIND_PORT,
+            websocket_path: DEFAULT_ONEBOT11_WEBSOCKET_PATH.to_owned(),
+            access_token: None,
+            request_timeout: Duration::from_millis(DEFAULT_ONEBOT11_REQUEST_TIMEOUT_MS),
+            max_message_bytes: DEFAULT_ONEBOT11_MAX_MESSAGE_BYTES as usize,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -292,6 +326,7 @@ impl AppConfig {
             MAX_MEDIA_MAX_BYTES,
         )?;
         let wechat_service = parse_wechat_service_config(env)?;
+        let onebot11 = parse_onebot11_config(env)?;
         Ok(Self {
             qq_official_enabled,
             app_id,
@@ -322,6 +357,7 @@ impl AppConfig {
             media_download_timeout,
             media_max_bytes,
             wechat_service,
+            onebot11,
         })
     }
 
@@ -342,6 +378,60 @@ impl AppConfig {
         }
         Some((self.app_id.as_deref()?, self.app_secret.as_deref()?))
     }
+}
+
+fn parse_onebot11_config(env: &HashMap<String, String>) -> Result<OneBot11Config, ConfigError> {
+    let enabled = parse_bool(env, "ONEBOT11_ENABLED")?.unwrap_or(false);
+    let access_token = optional(env, "ONEBOT11_ACCESS_TOKEN");
+    if enabled && access_token.is_none() {
+        return Err(ConfigError::MissingRequiredWhenEnabled {
+            name: "ONEBOT11_ACCESS_TOKEN",
+            enabled_by: "ONEBOT11_ENABLED",
+        });
+    }
+    let websocket_path = optional(env, "ONEBOT11_WEBSOCKET_PATH")
+        .unwrap_or_else(|| DEFAULT_ONEBOT11_WEBSOCKET_PATH.to_owned());
+    let invalid_static_path = !websocket_path.starts_with('/')
+        || websocket_path.contains(['?', '#', '{', '}', '*'])
+        || websocket_path.contains(char::is_whitespace);
+    if invalid_static_path {
+        return Err(ConfigError::InvalidHttpPath {
+            name: "ONEBOT11_WEBSOCKET_PATH",
+            value: websocket_path,
+        });
+    }
+    let bind_port = parse_ranged_u64(
+        env,
+        "ONEBOT11_BIND_PORT",
+        u64::from(DEFAULT_ONEBOT11_BIND_PORT),
+        1,
+        u64::from(u16::MAX),
+    )? as u16;
+    let request_timeout_ms = parse_ranged_u64(
+        env,
+        "ONEBOT11_REQUEST_TIMEOUT_MS",
+        DEFAULT_ONEBOT11_REQUEST_TIMEOUT_MS,
+        100,
+        120_000,
+    )?;
+    let max_message_bytes = parse_ranged_u64(
+        env,
+        "ONEBOT11_MAX_MESSAGE_BYTES",
+        DEFAULT_ONEBOT11_MAX_MESSAGE_BYTES,
+        MIN_ONEBOT11_MAX_MESSAGE_BYTES,
+        MAX_ONEBOT11_MAX_MESSAGE_BYTES,
+    )?;
+
+    Ok(OneBot11Config {
+        enabled,
+        bind_host: optional(env, "ONEBOT11_BIND_HOST")
+            .unwrap_or_else(|| DEFAULT_ONEBOT11_BIND_HOST.to_owned()),
+        bind_port,
+        websocket_path,
+        access_token,
+        request_timeout: Duration::from_millis(request_timeout_ms),
+        max_message_bytes: max_message_bytes as usize,
+    })
 }
 
 fn parse_wechat_service_config(
@@ -587,511 +677,4 @@ fn parse_ranged_usize(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn env(pairs: &[(&str, &str)]) -> HashMap<String, String> {
-        pairs
-            .iter()
-            .map(|(key, value)| ((*key).to_owned(), (*value).to_owned()))
-            .collect()
-    }
-
-    /// 带必填 credentials 的 env 构造 helper，消除 5 处重复的 ("QQ_BOT_APP_ID", ...) 输入。
-    fn env_with_creds(pairs: &[(&str, &str)]) -> HashMap<String, String> {
-        let mut map = env(&[("QQ_BOT_APP_ID", "appid"), ("QQ_BOT_APP_SECRET", "secret")]);
-        for (k, v) in pairs {
-            map.insert((*k).to_owned(), (*v).to_owned());
-        }
-        map
-    }
-
-    #[test]
-    fn loads_defaults_with_bound_credentials() {
-        let config = AppConfig::from_map(&env(&[
-            ("QQ_BOT_APP_ID", "appid"),
-            ("QQ_BOT_APP_SECRET", "secret"),
-        ]))
-        .unwrap();
-
-        assert_eq!(config.app_id.as_deref(), Some("appid"));
-        assert_eq!(config.app_secret.as_deref(), Some("secret"));
-        assert!(config.qq_official_enabled);
-        assert_eq!(
-            config.qq_official_binding_state(),
-            QqOfficialBindingState::Enabled
-        );
-        assert!(!config.sandbox);
-        assert_eq!(config.api_base, DEFAULT_PROD_API_BASE);
-        assert_eq!(
-            config.token_refresh_margin,
-            Duration::from_secs(DEFAULT_TOKEN_REFRESH_MARGIN_SECONDS)
-        );
-        assert!(config.enable_markdown);
-        assert!(!config.enable_image);
-        assert!(config.bot_mention_ids.is_empty());
-        assert!(!config.enable_group_messages);
-        assert!(!config.verbose_log);
-        // 成员详情补全默认开启（生产生效），失败降级不阻断主回复。
-        assert!(config.member_detail_enrich_enabled);
-        assert_eq!(config.group_message_mode, GroupMessageMode::Mention);
-        assert_eq!(config.group_active_keywords, vec!["小女仆"]);
-        assert_eq!(config.media_dir, PathBuf::from(DEFAULT_MEDIA_DIR));
-        assert_eq!(
-            config.media_download_timeout,
-            Duration::from_millis(DEFAULT_MEDIA_DOWNLOAD_TIMEOUT_MS)
-        );
-        assert_eq!(config.media_max_bytes, DEFAULT_MEDIA_MAX_BYTES);
-        assert_eq!(
-            config.conversation_queue_capacity,
-            DEFAULT_CONVERSATION_QUEUE_CAPACITY
-        );
-        assert_eq!(
-            config.max_active_conversation_workers,
-            DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS
-        );
-        assert_eq!(
-            config.conversation_worker_idle_timeout,
-            Duration::from_secs(DEFAULT_CONVERSATION_WORKER_IDLE_TIMEOUT_SECS)
-        );
-        assert_eq!(
-            config.message_aggregation,
-            MessageAggregationConfig {
-                private_enabled: true,
-                group_enabled: false,
-                quiet: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_QUIET_MS),
-                max_wait: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS),
-                max_messages: DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES,
-                max_chars: DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS,
-                max_active_keys: DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS,
-            }
-        );
-        assert_eq!(
-            config.c2c_final_reply_stream_enabled,
-            DEFAULT_C2C_FINAL_REPLY_STREAM_ENABLED
-        );
-        assert_eq!(
-            config.c2c_visible_progress_status_enabled,
-            DEFAULT_C2C_VISIBLE_PROGRESS_STATUS_ENABLED
-        );
-        assert_eq!(
-            config.agent_typing,
-            AgentTypingConfig {
-                enabled: DEFAULT_AGENT_TYPING_ENABLED,
-                delay: Duration::from_millis(DEFAULT_AGENT_TYPING_DELAY_MS),
-            }
-        );
-        assert_eq!(
-            config.markdown_chunk_soft_limit,
-            DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT
-        );
-        assert_eq!(config.text_chunk_soft_limit, DEFAULT_TEXT_CHUNK_SOFT_LIMIT);
-        assert_eq!(
-            config.wechat_service,
-            WechatServiceConfig {
-                enabled: false,
-                token: None,
-                app_id: None,
-                app_secret: None,
-                bind_host: DEFAULT_WECHAT_SERVICE_BIND_HOST.to_owned(),
-                bind_port: DEFAULT_WECHAT_SERVICE_BIND_PORT,
-                callback_path: DEFAULT_WECHAT_SERVICE_CALLBACK_PATH.to_owned(),
-                reply_timeout: Duration::from_millis(DEFAULT_WECHAT_SERVICE_REPLY_TIMEOUT_MS),
-                api_base: DEFAULT_WECHAT_SERVICE_API_BASE.to_owned(),
-            }
-        );
-    }
-
-    #[test]
-    fn parses_group_message_mode() {
-        for (raw, expected) in [
-            ("off", GroupMessageMode::Off),
-            ("command", GroupMessageMode::Command),
-            ("mention", GroupMessageMode::Mention),
-            ("active", GroupMessageMode::Active),
-        ] {
-            let config =
-                AppConfig::from_map(&env_with_creds(&[("QQ_MAID_GROUP_MESSAGE_MODE", raw)]))
-                    .unwrap();
-            assert_eq!(config.group_message_mode, expected);
-        }
-    }
-
-    #[test]
-    fn group_message_mode_prefers_new_variable_over_legacy_bool() {
-        let config = AppConfig::from_map(&env_with_creds(&[
-            ("QQ_MAID_GROUP_MESSAGE_MODE", "command"),
-            ("QQ_MAID_ENABLE_GROUP_MESSAGES", "true"),
-        ]))
-        .unwrap();
-
-        assert_eq!(config.group_message_mode, GroupMessageMode::Command);
-    }
-
-    #[test]
-    fn legacy_group_messages_bool_maps_to_active_or_off() {
-        let enabled = AppConfig::from_map(&env_with_creds(&[(
-            "QQ_MAID_ENABLE_GROUP_MESSAGES",
-            "true",
-        )]))
-        .unwrap();
-        let disabled = AppConfig::from_map(&env_with_creds(&[(
-            "QQ_MAID_ENABLE_GROUP_MESSAGES",
-            "false",
-        )]))
-        .unwrap();
-
-        assert_eq!(enabled.group_message_mode, GroupMessageMode::Active);
-        assert_eq!(disabled.group_message_mode, GroupMessageMode::Off);
-    }
-
-    #[test]
-    fn group_message_mode_defaults_to_mention_when_no_legacy_bool_is_set() {
-        let config = AppConfig::from_map(&env_with_creds(&[])).unwrap();
-
-        assert_eq!(config.group_message_mode, GroupMessageMode::Mention);
-    }
-
-    #[test]
-    fn group_active_keywords_default_to_maid_keyword_and_parse_csv() {
-        let defaulted = AppConfig::from_map(&env_with_creds(&[])).unwrap();
-        let custom = AppConfig::from_map(&env_with_creds(&[(
-            "QQ_MAID_GROUP_ACTIVE_KEYWORDS",
-            " 小女仆, bot ,  ,召唤",
-        )]))
-        .unwrap();
-
-        assert_eq!(defaulted.group_active_keywords, vec!["小女仆"]);
-        assert_eq!(custom.group_active_keywords, vec!["小女仆", "bot", "召唤"]);
-    }
-
-    #[test]
-    fn bot_mention_ids_parse_csv() {
-        let config = AppConfig::from_map(&env_with_creds(&[(
-            "QQ_MAID_BOT_MENTION_IDS",
-            " bot-openid, member-openid , ",
-        )]))
-        .unwrap();
-
-        assert_eq!(config.bot_mention_ids, vec!["bot-openid", "member-openid"]);
-    }
-
-    #[test]
-    fn supports_legacy_qq_variable_aliases() {
-        let config = AppConfig::from_map(&env(&[
-            ("QQ_APPID", "old-appid"),
-            ("QQ_SECRET", "old-secret"),
-        ]))
-        .unwrap();
-
-        assert_eq!(config.app_id.as_deref(), Some("old-appid"));
-        assert_eq!(config.app_secret.as_deref(), Some("old-secret"));
-    }
-
-    #[test]
-    fn primary_variables_win_over_aliases() {
-        let config = AppConfig::from_map(&env(&[
-            ("QQ_BOT_APP_ID", "new-appid"),
-            ("QQ_BOT_APP_SECRET", "new-secret"),
-            ("QQ_APPID", "old-appid"),
-            ("QQ_SECRET", "old-secret"),
-        ]))
-        .unwrap();
-
-        assert_eq!(config.app_id.as_deref(), Some("new-appid"));
-        assert_eq!(config.app_secret.as_deref(), Some("new-secret"));
-    }
-
-    #[test]
-    fn loads_optional_values() {
-        let config = AppConfig::from_map(&env_with_creds(&[
-            ("QQ_BOT_SANDBOX", "yes"),
-            ("QQ_BOT_API_BASE", "https://example.test/"),
-            ("QQ_BOT_TOKEN_REFRESH_MARGIN_SECONDS", "120"),
-            ("QQ_MAID_BOT_MENTION_IDS", "bot-openid,member-openid"),
-            ("QQ_MAID_ENABLE_MARKDOWN", "true"),
-            ("QQ_MAID_ENABLE_IMAGE", "1"),
-            ("QQ_MAID_ENABLE_GROUP_MESSAGES", "yes"),
-            ("QQ_MAID_GATEWAY_VERBOSE_LOG", "on"),
-            ("CONVERSATION_QUEUE_CAPACITY", "24"),
-            ("MAX_ACTIVE_CONVERSATION_WORKERS", "96"),
-            ("CONVERSATION_WORKER_IDLE_TIMEOUT_SECS", "600"),
-            ("MESSAGE_AGGREGATION_PRIVATE_ENABLED", "false"),
-            ("MESSAGE_AGGREGATION_QUIET_MS", "800"),
-            ("MESSAGE_AGGREGATION_MAX_WAIT_MS", "2000"),
-            ("MESSAGE_AGGREGATION_MAX_MESSAGES", "5"),
-            ("MESSAGE_AGGREGATION_MAX_CHARS", "4096"),
-            ("MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS", "32"),
-            ("QQ_MAID_C2C_FINAL_REPLY_STREAM_ENABLED", "true"),
-            ("QQ_MAID_C2C_VISIBLE_PROGRESS_STATUS_ENABLED", "false"),
-            ("QQ_MAID_AGENT_TYPING_ENABLED", "false"),
-            ("QQ_MAID_AGENT_TYPING_DELAY_MS", "1500"),
-            ("QQ_MAID_MEDIA_MAX_BYTES", "1048576"),
-            ("QQ_MARKDOWN_CHUNK_SOFT_LIMIT", "1600"),
-            ("QQ_TEXT_CHUNK_SOFT_LIMIT", "1500"),
-            ("WECHAT_SERVICE_ENABLED", "true"),
-            ("WECHAT_SERVICE_TOKEN", "wechat-token"),
-            ("WECHAT_SERVICE_APP_ID", "wx-app"),
-            ("WECHAT_SERVICE_APP_SECRET", "wx-secret"),
-            ("WECHAT_SERVICE_BIND_HOST", "0.0.0.0"),
-            ("WECHAT_SERVICE_BIND_PORT", "19090"),
-            ("WECHAT_SERVICE_CALLBACK_PATH", "/wx/callback"),
-            ("WECHAT_SERVICE_REPLY_TIMEOUT_MS", "3500"),
-            (
-                "WECHAT_SERVICE_API_BASE",
-                "https://wechat-api.example.test/",
-            ),
-        ]))
-        .unwrap();
-
-        assert!(config.sandbox);
-        assert_eq!(config.api_base, "https://example.test");
-        assert_eq!(config.token_refresh_margin, Duration::from_secs(120));
-        assert_eq!(config.bot_mention_ids, vec!["bot-openid", "member-openid"]);
-        assert!(config.enable_markdown);
-        assert!(config.enable_image);
-        assert!(config.enable_group_messages);
-        assert!(config.verbose_log);
-        assert_eq!(config.conversation_queue_capacity, 24);
-        assert_eq!(config.max_active_conversation_workers, 96);
-        assert_eq!(
-            config.conversation_worker_idle_timeout,
-            Duration::from_secs(600)
-        );
-        assert_eq!(
-            config.message_aggregation,
-            MessageAggregationConfig {
-                private_enabled: false,
-                group_enabled: false,
-                quiet: Duration::from_millis(800),
-                max_wait: Duration::from_millis(2000),
-                max_messages: 5,
-                max_chars: 4096,
-                max_active_keys: 32,
-            }
-        );
-        assert!(config.c2c_final_reply_stream_enabled);
-        assert!(!config.c2c_visible_progress_status_enabled);
-        assert_eq!(
-            config.agent_typing,
-            AgentTypingConfig {
-                enabled: false,
-                delay: Duration::from_millis(1500),
-            }
-        );
-        assert_eq!(config.markdown_chunk_soft_limit, 1600);
-        assert_eq!(config.text_chunk_soft_limit, 1500);
-        assert_eq!(config.media_max_bytes, 1_048_576);
-        assert_eq!(
-            config.wechat_service,
-            WechatServiceConfig {
-                enabled: true,
-                token: Some("wechat-token".to_owned()),
-                app_id: Some("wx-app".to_owned()),
-                app_secret: Some("wx-secret".to_owned()),
-                bind_host: "0.0.0.0".to_owned(),
-                bind_port: 19090,
-                callback_path: "/wx/callback".to_owned(),
-                reply_timeout: Duration::from_millis(3500),
-                api_base: "https://wechat-api.example.test".to_owned(),
-            }
-        );
-    }
-
-    #[test]
-    fn qq_official_binding_states_are_explicit_and_keep_wechat_independent() {
-        let unbound = AppConfig::from_map(&env(&[
-            ("WECHAT_SERVICE_ENABLED", "true"),
-            ("WECHAT_SERVICE_TOKEN", "wechat-token"),
-        ]))
-        .unwrap();
-        assert_eq!(
-            unbound.qq_official_binding_state(),
-            QqOfficialBindingState::Unbound
-        );
-        assert!(unbound.enabled_qq_official_credentials().is_none());
-        assert!(unbound.wechat_service.enabled);
-
-        let disabled =
-            AppConfig::from_map(&env_with_creds(&[("QQ_BOT_ENABLED", "false")])).unwrap();
-        assert_eq!(
-            disabled.qq_official_binding_state(),
-            QqOfficialBindingState::Disabled
-        );
-        assert!(disabled.enabled_qq_official_credentials().is_none());
-
-        let enabled = AppConfig::from_map(&env_with_creds(&[])).unwrap();
-        assert_eq!(
-            enabled.enabled_qq_official_credentials(),
-            Some(("appid", "secret"))
-        );
-    }
-
-    /// 合并 config 错误路径测试为表驱动测试。
-    #[test]
-    fn config_errors_reported() {
-        struct Case {
-            name: &'static str,
-            map: HashMap<String, String>,
-            expected_err: ConfigError,
-        }
-
-        let cases = [
-            Case {
-                name: "rejects_app_id_without_secret",
-                map: env(&[("QQ_BOT_APP_ID", "appid")]),
-                expected_err: ConfigError::IncompleteQqOfficialCredentials {
-                    missing: "QQ_BOT_APP_SECRET",
-                },
-            },
-            Case {
-                name: "rejects_secret_without_app_id",
-                map: env(&[("QQ_BOT_APP_SECRET", "secret")]),
-                expected_err: ConfigError::IncompleteQqOfficialCredentials {
-                    missing: "QQ_BOT_APP_ID",
-                },
-            },
-            Case {
-                name: "rejects_invalid_verbose_log_boolean",
-                map: env_with_creds(&[("QQ_MAID_GATEWAY_VERBOSE_LOG", "sometimes")]),
-                expected_err: ConfigError::InvalidBool {
-                    name: "QQ_MAID_GATEWAY_VERBOSE_LOG",
-                    value: "sometimes".to_owned(),
-                },
-            },
-            Case {
-                name: "rejects_zero_conversation_queue_capacity",
-                map: env_with_creds(&[("CONVERSATION_QUEUE_CAPACITY", "0")]),
-                expected_err: ConfigError::IntegerOutOfRange {
-                    name: "CONVERSATION_QUEUE_CAPACITY",
-                    value: 0,
-                    min: 1,
-                    max: 256,
-                },
-            },
-            Case {
-                name: "rejects_group_message_aggregation",
-                map: env_with_creds(&[("MESSAGE_AGGREGATION_GROUP_ENABLED", "true")]),
-                expected_err: ConfigError::UnsupportedEnabled {
-                    name: "MESSAGE_AGGREGATION_GROUP_ENABLED",
-                },
-            },
-            Case {
-                name: "rejects_media_max_bytes_below_minimum",
-                map: env_with_creds(&[("QQ_MAID_MEDIA_MAX_BYTES", "1024")]),
-                expected_err: ConfigError::IntegerOutOfRange {
-                    name: "QQ_MAID_MEDIA_MAX_BYTES",
-                    value: 1024,
-                    min: MIN_MEDIA_MAX_BYTES,
-                    max: MAX_MEDIA_MAX_BYTES,
-                },
-            },
-            Case {
-                name: "rejects_quiet_window_larger_than_max_wait",
-                map: env_with_creds(&[
-                    ("MESSAGE_AGGREGATION_QUIET_MS", "3001"),
-                    ("MESSAGE_AGGREGATION_MAX_WAIT_MS", "3000"),
-                ]),
-                expected_err: ConfigError::InvalidAggregationWindow,
-            },
-            Case {
-                name: "rejects_chunk_soft_limit_below_minimum",
-                map: env_with_creds(&[("QQ_MARKDOWN_CHUNK_SOFT_LIMIT", "16")]),
-                expected_err: ConfigError::IntegerOutOfRange {
-                    name: "QQ_MARKDOWN_CHUNK_SOFT_LIMIT",
-                    value: 16,
-                    min: MIN_CHUNK_SOFT_LIMIT as u64,
-                    max: 64_000,
-                },
-            },
-            Case {
-                name: "rejects_agent_typing_delay_below_minimum",
-                map: env_with_creds(&[("QQ_MAID_AGENT_TYPING_DELAY_MS", "10")]),
-                expected_err: ConfigError::IntegerOutOfRange {
-                    name: "QQ_MAID_AGENT_TYPING_DELAY_MS",
-                    value: 10,
-                    min: 100,
-                    max: 60_000,
-                },
-            },
-            Case {
-                name: "requires_wechat_token_when_enabled",
-                map: env_with_creds(&[("WECHAT_SERVICE_ENABLED", "true")]),
-                expected_err: ConfigError::MissingRequiredWhenEnabled {
-                    name: "WECHAT_SERVICE_TOKEN",
-                    enabled_by: "WECHAT_SERVICE_ENABLED",
-                },
-            },
-            Case {
-                name: "rejects_relative_wechat_callback_path",
-                map: env_with_creds(&[
-                    ("WECHAT_SERVICE_ENABLED", "true"),
-                    ("WECHAT_SERVICE_TOKEN", "token"),
-                    ("WECHAT_SERVICE_CALLBACK_PATH", "wechat"),
-                ]),
-                expected_err: ConfigError::InvalidHttpPath {
-                    name: "WECHAT_SERVICE_CALLBACK_PATH",
-                    value: "wechat".to_owned(),
-                },
-            },
-            Case {
-                name: "rejects_too_large_wechat_reply_timeout",
-                map: env_with_creds(&[
-                    ("WECHAT_SERVICE_ENABLED", "true"),
-                    ("WECHAT_SERVICE_TOKEN", "token"),
-                    ("WECHAT_SERVICE_REPLY_TIMEOUT_MS", "5000"),
-                ]),
-                expected_err: ConfigError::IntegerOutOfRange {
-                    name: "WECHAT_SERVICE_REPLY_TIMEOUT_MS",
-                    value: 5000,
-                    min: 500,
-                    max: 4500,
-                },
-            },
-        ];
-
-        for case in &cases {
-            let err = match AppConfig::from_map(&case.map) {
-                Err(e) => e,
-                Ok(_) => panic!("case '{}' failed: expected Err, got Ok", case.name),
-            };
-            assert_eq!(
-                err, case.expected_err,
-                "case '{}' failed: error mismatch",
-                case.name
-            );
-        }
-    }
-
-    #[test]
-    fn parses_verbose_log_boolean_values() {
-        for raw in ["true", "1", "yes", "on"] {
-            let config =
-                AppConfig::from_map(&env_with_creds(&[("QQ_MAID_GATEWAY_VERBOSE_LOG", raw)]))
-                    .unwrap();
-            assert!(config.verbose_log, "{raw} should enable verbose logging");
-        }
-
-        for raw in ["false", "0", "no", "off"] {
-            let config =
-                AppConfig::from_map(&env_with_creds(&[("QQ_MAID_GATEWAY_VERBOSE_LOG", raw)]))
-                    .unwrap();
-            assert!(!config.verbose_log, "{raw} should disable verbose logging");
-        }
-    }
-
-    #[test]
-    fn member_detail_enrich_enabled_defaults_true_and_can_be_disabled() {
-        // 默认开启（生产生效）。
-        let config = AppConfig::from_map(&env_with_creds(&[])).unwrap();
-        assert!(config.member_detail_enrich_enabled);
-
-        // 环境变量可关闭。
-        let config = AppConfig::from_map(&env_with_creds(&[(
-            "QQ_MAID_MEMBER_DETAIL_ENRICH_ENABLED",
-            "false",
-        )]))
-        .unwrap();
-        assert!(!config.member_detail_enrich_enabled);
-    }
-}
+mod tests;

--- a/qq-maid-gateway-rs/src/config/tests.rs
+++ b/qq-maid-gateway-rs/src/config/tests.rs
@@ -1,0 +1,593 @@
+use super::*;
+
+fn env(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+    pairs
+        .iter()
+        .map(|(key, value)| ((*key).to_owned(), (*value).to_owned()))
+        .collect()
+}
+
+/// 带必填 credentials 的 env 构造 helper，消除 5 处重复的 ("QQ_BOT_APP_ID", ...) 输入。
+fn env_with_creds(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+    let mut map = env(&[("QQ_BOT_APP_ID", "appid"), ("QQ_BOT_APP_SECRET", "secret")]);
+    for (k, v) in pairs {
+        map.insert((*k).to_owned(), (*v).to_owned());
+    }
+    map
+}
+
+#[test]
+fn loads_defaults_with_bound_credentials() {
+    let config = AppConfig::from_map(&env(&[
+        ("QQ_BOT_APP_ID", "appid"),
+        ("QQ_BOT_APP_SECRET", "secret"),
+    ]))
+    .unwrap();
+
+    assert_eq!(config.app_id.as_deref(), Some("appid"));
+    assert_eq!(config.app_secret.as_deref(), Some("secret"));
+    assert!(config.qq_official_enabled);
+    assert_eq!(
+        config.qq_official_binding_state(),
+        QqOfficialBindingState::Enabled
+    );
+    assert!(!config.sandbox);
+    assert_eq!(config.api_base, DEFAULT_PROD_API_BASE);
+    assert_eq!(
+        config.token_refresh_margin,
+        Duration::from_secs(DEFAULT_TOKEN_REFRESH_MARGIN_SECONDS)
+    );
+    assert!(config.enable_markdown);
+    assert!(!config.enable_image);
+    assert!(config.bot_mention_ids.is_empty());
+    assert!(!config.enable_group_messages);
+    assert!(!config.verbose_log);
+    // 成员详情补全默认开启（生产生效），失败降级不阻断主回复。
+    assert!(config.member_detail_enrich_enabled);
+    assert_eq!(config.group_message_mode, GroupMessageMode::Mention);
+    assert_eq!(config.group_active_keywords, vec!["小女仆"]);
+    assert_eq!(config.media_dir, PathBuf::from(DEFAULT_MEDIA_DIR));
+    assert_eq!(
+        config.media_download_timeout,
+        Duration::from_millis(DEFAULT_MEDIA_DOWNLOAD_TIMEOUT_MS)
+    );
+    assert_eq!(config.media_max_bytes, DEFAULT_MEDIA_MAX_BYTES);
+    assert_eq!(
+        config.conversation_queue_capacity,
+        DEFAULT_CONVERSATION_QUEUE_CAPACITY
+    );
+    assert_eq!(
+        config.max_active_conversation_workers,
+        DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS
+    );
+    assert_eq!(
+        config.conversation_worker_idle_timeout,
+        Duration::from_secs(DEFAULT_CONVERSATION_WORKER_IDLE_TIMEOUT_SECS)
+    );
+    assert_eq!(
+        config.message_aggregation,
+        MessageAggregationConfig {
+            private_enabled: true,
+            group_enabled: false,
+            quiet: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_QUIET_MS),
+            max_wait: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS),
+            max_messages: DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES,
+            max_chars: DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS,
+            max_active_keys: DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS,
+        }
+    );
+    assert_eq!(
+        config.c2c_final_reply_stream_enabled,
+        DEFAULT_C2C_FINAL_REPLY_STREAM_ENABLED
+    );
+    assert_eq!(
+        config.c2c_visible_progress_status_enabled,
+        DEFAULT_C2C_VISIBLE_PROGRESS_STATUS_ENABLED
+    );
+    assert_eq!(
+        config.agent_typing,
+        AgentTypingConfig {
+            enabled: DEFAULT_AGENT_TYPING_ENABLED,
+            delay: Duration::from_millis(DEFAULT_AGENT_TYPING_DELAY_MS),
+        }
+    );
+    assert_eq!(
+        config.markdown_chunk_soft_limit,
+        DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT
+    );
+    assert_eq!(config.text_chunk_soft_limit, DEFAULT_TEXT_CHUNK_SOFT_LIMIT);
+    assert_eq!(
+        config.wechat_service,
+        WechatServiceConfig {
+            enabled: false,
+            token: None,
+            app_id: None,
+            app_secret: None,
+            bind_host: DEFAULT_WECHAT_SERVICE_BIND_HOST.to_owned(),
+            bind_port: DEFAULT_WECHAT_SERVICE_BIND_PORT,
+            callback_path: DEFAULT_WECHAT_SERVICE_CALLBACK_PATH.to_owned(),
+            reply_timeout: Duration::from_millis(DEFAULT_WECHAT_SERVICE_REPLY_TIMEOUT_MS),
+            api_base: DEFAULT_WECHAT_SERVICE_API_BASE.to_owned(),
+        }
+    );
+    assert_eq!(config.onebot11, OneBot11Config::default());
+}
+
+#[test]
+fn loads_onebot11_single_account_config_without_qq_credentials() {
+    let config = AppConfig::from_map(&env(&[
+        ("QQ_BOT_ENABLED", "false"),
+        ("ONEBOT11_ENABLED", "true"),
+        ("ONEBOT11_ACCESS_TOKEN", "onebot-token"),
+        ("ONEBOT11_BIND_HOST", "0.0.0.0"),
+        ("ONEBOT11_BIND_PORT", "19091"),
+        ("ONEBOT11_WEBSOCKET_PATH", "/reverse/ws"),
+        ("ONEBOT11_REQUEST_TIMEOUT_MS", "2500"),
+        ("ONEBOT11_MAX_MESSAGE_BYTES", "2097152"),
+    ]))
+    .unwrap();
+
+    assert_eq!(
+        config.qq_official_binding_state(),
+        QqOfficialBindingState::Unbound
+    );
+    assert_eq!(
+        config.onebot11,
+        OneBot11Config {
+            enabled: true,
+            bind_host: "0.0.0.0".to_owned(),
+            bind_port: 19091,
+            websocket_path: "/reverse/ws".to_owned(),
+            access_token: Some("onebot-token".to_owned()),
+            request_timeout: Duration::from_millis(2500),
+            max_message_bytes: 2 * 1024 * 1024,
+        }
+    );
+}
+
+#[test]
+fn rejects_invalid_onebot11_configuration() {
+    let cases = [
+        (
+            env(&[("ONEBOT11_ENABLED", "true")]),
+            ConfigError::MissingRequiredWhenEnabled {
+                name: "ONEBOT11_ACCESS_TOKEN",
+                enabled_by: "ONEBOT11_ENABLED",
+            },
+        ),
+        (
+            env(&[("ONEBOT11_WEBSOCKET_PATH", "reverse/ws")]),
+            ConfigError::InvalidHttpPath {
+                name: "ONEBOT11_WEBSOCKET_PATH",
+                value: "reverse/ws".to_owned(),
+            },
+        ),
+        (
+            env(&[("ONEBOT11_WEBSOCKET_PATH", "/reverse/{account}")]),
+            ConfigError::InvalidHttpPath {
+                name: "ONEBOT11_WEBSOCKET_PATH",
+                value: "/reverse/{account}".to_owned(),
+            },
+        ),
+        (
+            env(&[("ONEBOT11_BIND_PORT", "0")]),
+            ConfigError::IntegerOutOfRange {
+                name: "ONEBOT11_BIND_PORT",
+                value: 0,
+                min: 1,
+                max: u16::MAX as u64,
+            },
+        ),
+        (
+            env(&[("ONEBOT11_REQUEST_TIMEOUT_MS", "99")]),
+            ConfigError::IntegerOutOfRange {
+                name: "ONEBOT11_REQUEST_TIMEOUT_MS",
+                value: 99,
+                min: 100,
+                max: 120_000,
+            },
+        ),
+        (
+            env(&[("ONEBOT11_MAX_MESSAGE_BYTES", "512")]),
+            ConfigError::IntegerOutOfRange {
+                name: "ONEBOT11_MAX_MESSAGE_BYTES",
+                value: 512,
+                min: MIN_ONEBOT11_MAX_MESSAGE_BYTES,
+                max: MAX_ONEBOT11_MAX_MESSAGE_BYTES,
+            },
+        ),
+    ];
+
+    for (map, expected) in cases {
+        assert_eq!(AppConfig::from_map(&map).unwrap_err(), expected);
+    }
+}
+
+#[test]
+fn parses_group_message_mode() {
+    for (raw, expected) in [
+        ("off", GroupMessageMode::Off),
+        ("command", GroupMessageMode::Command),
+        ("mention", GroupMessageMode::Mention),
+        ("active", GroupMessageMode::Active),
+    ] {
+        let config =
+            AppConfig::from_map(&env_with_creds(&[("QQ_MAID_GROUP_MESSAGE_MODE", raw)])).unwrap();
+        assert_eq!(config.group_message_mode, expected);
+    }
+}
+
+#[test]
+fn group_message_mode_prefers_new_variable_over_legacy_bool() {
+    let config = AppConfig::from_map(&env_with_creds(&[
+        ("QQ_MAID_GROUP_MESSAGE_MODE", "command"),
+        ("QQ_MAID_ENABLE_GROUP_MESSAGES", "true"),
+    ]))
+    .unwrap();
+
+    assert_eq!(config.group_message_mode, GroupMessageMode::Command);
+}
+
+#[test]
+fn legacy_group_messages_bool_maps_to_active_or_off() {
+    let enabled = AppConfig::from_map(&env_with_creds(&[(
+        "QQ_MAID_ENABLE_GROUP_MESSAGES",
+        "true",
+    )]))
+    .unwrap();
+    let disabled = AppConfig::from_map(&env_with_creds(&[(
+        "QQ_MAID_ENABLE_GROUP_MESSAGES",
+        "false",
+    )]))
+    .unwrap();
+
+    assert_eq!(enabled.group_message_mode, GroupMessageMode::Active);
+    assert_eq!(disabled.group_message_mode, GroupMessageMode::Off);
+}
+
+#[test]
+fn group_message_mode_defaults_to_mention_when_no_legacy_bool_is_set() {
+    let config = AppConfig::from_map(&env_with_creds(&[])).unwrap();
+
+    assert_eq!(config.group_message_mode, GroupMessageMode::Mention);
+}
+
+#[test]
+fn group_active_keywords_default_to_maid_keyword_and_parse_csv() {
+    let defaulted = AppConfig::from_map(&env_with_creds(&[])).unwrap();
+    let custom = AppConfig::from_map(&env_with_creds(&[(
+        "QQ_MAID_GROUP_ACTIVE_KEYWORDS",
+        " 小女仆, bot ,  ,召唤",
+    )]))
+    .unwrap();
+
+    assert_eq!(defaulted.group_active_keywords, vec!["小女仆"]);
+    assert_eq!(custom.group_active_keywords, vec!["小女仆", "bot", "召唤"]);
+}
+
+#[test]
+fn bot_mention_ids_parse_csv() {
+    let config = AppConfig::from_map(&env_with_creds(&[(
+        "QQ_MAID_BOT_MENTION_IDS",
+        " bot-openid, member-openid , ",
+    )]))
+    .unwrap();
+
+    assert_eq!(config.bot_mention_ids, vec!["bot-openid", "member-openid"]);
+}
+
+#[test]
+fn supports_legacy_qq_variable_aliases() {
+    let config = AppConfig::from_map(&env(&[
+        ("QQ_APPID", "old-appid"),
+        ("QQ_SECRET", "old-secret"),
+    ]))
+    .unwrap();
+
+    assert_eq!(config.app_id.as_deref(), Some("old-appid"));
+    assert_eq!(config.app_secret.as_deref(), Some("old-secret"));
+}
+
+#[test]
+fn primary_variables_win_over_aliases() {
+    let config = AppConfig::from_map(&env(&[
+        ("QQ_BOT_APP_ID", "new-appid"),
+        ("QQ_BOT_APP_SECRET", "new-secret"),
+        ("QQ_APPID", "old-appid"),
+        ("QQ_SECRET", "old-secret"),
+    ]))
+    .unwrap();
+
+    assert_eq!(config.app_id.as_deref(), Some("new-appid"));
+    assert_eq!(config.app_secret.as_deref(), Some("new-secret"));
+}
+
+#[test]
+fn loads_optional_values() {
+    let config = AppConfig::from_map(&env_with_creds(&[
+        ("QQ_BOT_SANDBOX", "yes"),
+        ("QQ_BOT_API_BASE", "https://example.test/"),
+        ("QQ_BOT_TOKEN_REFRESH_MARGIN_SECONDS", "120"),
+        ("QQ_MAID_BOT_MENTION_IDS", "bot-openid,member-openid"),
+        ("QQ_MAID_ENABLE_MARKDOWN", "true"),
+        ("QQ_MAID_ENABLE_IMAGE", "1"),
+        ("QQ_MAID_ENABLE_GROUP_MESSAGES", "yes"),
+        ("QQ_MAID_GATEWAY_VERBOSE_LOG", "on"),
+        ("CONVERSATION_QUEUE_CAPACITY", "24"),
+        ("MAX_ACTIVE_CONVERSATION_WORKERS", "96"),
+        ("CONVERSATION_WORKER_IDLE_TIMEOUT_SECS", "600"),
+        ("MESSAGE_AGGREGATION_PRIVATE_ENABLED", "false"),
+        ("MESSAGE_AGGREGATION_QUIET_MS", "800"),
+        ("MESSAGE_AGGREGATION_MAX_WAIT_MS", "2000"),
+        ("MESSAGE_AGGREGATION_MAX_MESSAGES", "5"),
+        ("MESSAGE_AGGREGATION_MAX_CHARS", "4096"),
+        ("MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS", "32"),
+        ("QQ_MAID_C2C_FINAL_REPLY_STREAM_ENABLED", "true"),
+        ("QQ_MAID_C2C_VISIBLE_PROGRESS_STATUS_ENABLED", "false"),
+        ("QQ_MAID_AGENT_TYPING_ENABLED", "false"),
+        ("QQ_MAID_AGENT_TYPING_DELAY_MS", "1500"),
+        ("QQ_MAID_MEDIA_MAX_BYTES", "1048576"),
+        ("QQ_MARKDOWN_CHUNK_SOFT_LIMIT", "1600"),
+        ("QQ_TEXT_CHUNK_SOFT_LIMIT", "1500"),
+        ("WECHAT_SERVICE_ENABLED", "true"),
+        ("WECHAT_SERVICE_TOKEN", "wechat-token"),
+        ("WECHAT_SERVICE_APP_ID", "wx-app"),
+        ("WECHAT_SERVICE_APP_SECRET", "wx-secret"),
+        ("WECHAT_SERVICE_BIND_HOST", "0.0.0.0"),
+        ("WECHAT_SERVICE_BIND_PORT", "19090"),
+        ("WECHAT_SERVICE_CALLBACK_PATH", "/wx/callback"),
+        ("WECHAT_SERVICE_REPLY_TIMEOUT_MS", "3500"),
+        (
+            "WECHAT_SERVICE_API_BASE",
+            "https://wechat-api.example.test/",
+        ),
+    ]))
+    .unwrap();
+
+    assert!(config.sandbox);
+    assert_eq!(config.api_base, "https://example.test");
+    assert_eq!(config.token_refresh_margin, Duration::from_secs(120));
+    assert_eq!(config.bot_mention_ids, vec!["bot-openid", "member-openid"]);
+    assert!(config.enable_markdown);
+    assert!(config.enable_image);
+    assert!(config.enable_group_messages);
+    assert!(config.verbose_log);
+    assert_eq!(config.conversation_queue_capacity, 24);
+    assert_eq!(config.max_active_conversation_workers, 96);
+    assert_eq!(
+        config.conversation_worker_idle_timeout,
+        Duration::from_secs(600)
+    );
+    assert_eq!(
+        config.message_aggregation,
+        MessageAggregationConfig {
+            private_enabled: false,
+            group_enabled: false,
+            quiet: Duration::from_millis(800),
+            max_wait: Duration::from_millis(2000),
+            max_messages: 5,
+            max_chars: 4096,
+            max_active_keys: 32,
+        }
+    );
+    assert!(config.c2c_final_reply_stream_enabled);
+    assert!(!config.c2c_visible_progress_status_enabled);
+    assert_eq!(
+        config.agent_typing,
+        AgentTypingConfig {
+            enabled: false,
+            delay: Duration::from_millis(1500),
+        }
+    );
+    assert_eq!(config.markdown_chunk_soft_limit, 1600);
+    assert_eq!(config.text_chunk_soft_limit, 1500);
+    assert_eq!(config.media_max_bytes, 1_048_576);
+    assert_eq!(
+        config.wechat_service,
+        WechatServiceConfig {
+            enabled: true,
+            token: Some("wechat-token".to_owned()),
+            app_id: Some("wx-app".to_owned()),
+            app_secret: Some("wx-secret".to_owned()),
+            bind_host: "0.0.0.0".to_owned(),
+            bind_port: 19090,
+            callback_path: "/wx/callback".to_owned(),
+            reply_timeout: Duration::from_millis(3500),
+            api_base: "https://wechat-api.example.test".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn qq_official_binding_states_are_explicit_and_keep_wechat_independent() {
+    let unbound = AppConfig::from_map(&env(&[
+        ("WECHAT_SERVICE_ENABLED", "true"),
+        ("WECHAT_SERVICE_TOKEN", "wechat-token"),
+    ]))
+    .unwrap();
+    assert_eq!(
+        unbound.qq_official_binding_state(),
+        QqOfficialBindingState::Unbound
+    );
+    assert!(unbound.enabled_qq_official_credentials().is_none());
+    assert!(unbound.wechat_service.enabled);
+
+    let disabled = AppConfig::from_map(&env_with_creds(&[("QQ_BOT_ENABLED", "false")])).unwrap();
+    assert_eq!(
+        disabled.qq_official_binding_state(),
+        QqOfficialBindingState::Disabled
+    );
+    assert!(disabled.enabled_qq_official_credentials().is_none());
+
+    let enabled = AppConfig::from_map(&env_with_creds(&[])).unwrap();
+    assert_eq!(
+        enabled.enabled_qq_official_credentials(),
+        Some(("appid", "secret"))
+    );
+}
+
+/// 合并 config 错误路径测试为表驱动测试。
+#[test]
+fn config_errors_reported() {
+    struct Case {
+        name: &'static str,
+        map: HashMap<String, String>,
+        expected_err: ConfigError,
+    }
+
+    let cases = [
+        Case {
+            name: "rejects_app_id_without_secret",
+            map: env(&[("QQ_BOT_APP_ID", "appid")]),
+            expected_err: ConfigError::IncompleteQqOfficialCredentials {
+                missing: "QQ_BOT_APP_SECRET",
+            },
+        },
+        Case {
+            name: "rejects_secret_without_app_id",
+            map: env(&[("QQ_BOT_APP_SECRET", "secret")]),
+            expected_err: ConfigError::IncompleteQqOfficialCredentials {
+                missing: "QQ_BOT_APP_ID",
+            },
+        },
+        Case {
+            name: "rejects_invalid_verbose_log_boolean",
+            map: env_with_creds(&[("QQ_MAID_GATEWAY_VERBOSE_LOG", "sometimes")]),
+            expected_err: ConfigError::InvalidBool {
+                name: "QQ_MAID_GATEWAY_VERBOSE_LOG",
+                value: "sometimes".to_owned(),
+            },
+        },
+        Case {
+            name: "rejects_zero_conversation_queue_capacity",
+            map: env_with_creds(&[("CONVERSATION_QUEUE_CAPACITY", "0")]),
+            expected_err: ConfigError::IntegerOutOfRange {
+                name: "CONVERSATION_QUEUE_CAPACITY",
+                value: 0,
+                min: 1,
+                max: 256,
+            },
+        },
+        Case {
+            name: "rejects_group_message_aggregation",
+            map: env_with_creds(&[("MESSAGE_AGGREGATION_GROUP_ENABLED", "true")]),
+            expected_err: ConfigError::UnsupportedEnabled {
+                name: "MESSAGE_AGGREGATION_GROUP_ENABLED",
+            },
+        },
+        Case {
+            name: "rejects_media_max_bytes_below_minimum",
+            map: env_with_creds(&[("QQ_MAID_MEDIA_MAX_BYTES", "1024")]),
+            expected_err: ConfigError::IntegerOutOfRange {
+                name: "QQ_MAID_MEDIA_MAX_BYTES",
+                value: 1024,
+                min: MIN_MEDIA_MAX_BYTES,
+                max: MAX_MEDIA_MAX_BYTES,
+            },
+        },
+        Case {
+            name: "rejects_quiet_window_larger_than_max_wait",
+            map: env_with_creds(&[
+                ("MESSAGE_AGGREGATION_QUIET_MS", "3001"),
+                ("MESSAGE_AGGREGATION_MAX_WAIT_MS", "3000"),
+            ]),
+            expected_err: ConfigError::InvalidAggregationWindow,
+        },
+        Case {
+            name: "rejects_chunk_soft_limit_below_minimum",
+            map: env_with_creds(&[("QQ_MARKDOWN_CHUNK_SOFT_LIMIT", "16")]),
+            expected_err: ConfigError::IntegerOutOfRange {
+                name: "QQ_MARKDOWN_CHUNK_SOFT_LIMIT",
+                value: 16,
+                min: MIN_CHUNK_SOFT_LIMIT as u64,
+                max: 64_000,
+            },
+        },
+        Case {
+            name: "rejects_agent_typing_delay_below_minimum",
+            map: env_with_creds(&[("QQ_MAID_AGENT_TYPING_DELAY_MS", "10")]),
+            expected_err: ConfigError::IntegerOutOfRange {
+                name: "QQ_MAID_AGENT_TYPING_DELAY_MS",
+                value: 10,
+                min: 100,
+                max: 60_000,
+            },
+        },
+        Case {
+            name: "requires_wechat_token_when_enabled",
+            map: env_with_creds(&[("WECHAT_SERVICE_ENABLED", "true")]),
+            expected_err: ConfigError::MissingRequiredWhenEnabled {
+                name: "WECHAT_SERVICE_TOKEN",
+                enabled_by: "WECHAT_SERVICE_ENABLED",
+            },
+        },
+        Case {
+            name: "rejects_relative_wechat_callback_path",
+            map: env_with_creds(&[
+                ("WECHAT_SERVICE_ENABLED", "true"),
+                ("WECHAT_SERVICE_TOKEN", "token"),
+                ("WECHAT_SERVICE_CALLBACK_PATH", "wechat"),
+            ]),
+            expected_err: ConfigError::InvalidHttpPath {
+                name: "WECHAT_SERVICE_CALLBACK_PATH",
+                value: "wechat".to_owned(),
+            },
+        },
+        Case {
+            name: "rejects_too_large_wechat_reply_timeout",
+            map: env_with_creds(&[
+                ("WECHAT_SERVICE_ENABLED", "true"),
+                ("WECHAT_SERVICE_TOKEN", "token"),
+                ("WECHAT_SERVICE_REPLY_TIMEOUT_MS", "5000"),
+            ]),
+            expected_err: ConfigError::IntegerOutOfRange {
+                name: "WECHAT_SERVICE_REPLY_TIMEOUT_MS",
+                value: 5000,
+                min: 500,
+                max: 4500,
+            },
+        },
+    ];
+
+    for case in &cases {
+        let err = match AppConfig::from_map(&case.map) {
+            Err(e) => e,
+            Ok(_) => panic!("case '{}' failed: expected Err, got Ok", case.name),
+        };
+        assert_eq!(
+            err, case.expected_err,
+            "case '{}' failed: error mismatch",
+            case.name
+        );
+    }
+}
+
+#[test]
+fn parses_verbose_log_boolean_values() {
+    for raw in ["true", "1", "yes", "on"] {
+        let config =
+            AppConfig::from_map(&env_with_creds(&[("QQ_MAID_GATEWAY_VERBOSE_LOG", raw)])).unwrap();
+        assert!(config.verbose_log, "{raw} should enable verbose logging");
+    }
+
+    for raw in ["false", "0", "no", "off"] {
+        let config =
+            AppConfig::from_map(&env_with_creds(&[("QQ_MAID_GATEWAY_VERBOSE_LOG", raw)])).unwrap();
+        assert!(!config.verbose_log, "{raw} should disable verbose logging");
+    }
+}
+
+#[test]
+fn member_detail_enrich_enabled_defaults_true_and_can_be_disabled() {
+    // 默认开启（生产生效）。
+    let config = AppConfig::from_map(&env_with_creds(&[])).unwrap();
+    assert!(config.member_detail_enrich_enabled);
+
+    // 环境变量可关闭。
+    let config = AppConfig::from_map(&env_with_creds(&[(
+        "QQ_MAID_MEMBER_DETAIL_ENRICH_ENABLED",
+        "false",
+    )]))
+    .unwrap();
+    assert!(!config.member_detail_enrich_enabled);
+}

--- a/qq-maid-gateway-rs/src/gateway/aggregator/actor.rs
+++ b/qq-maid-gateway-rs/src/gateway/aggregator/actor.rs
@@ -891,6 +891,7 @@ mod tests {
             media_download_timeout: Duration::from_secs(10),
             media_max_bytes: crate::config::DEFAULT_MEDIA_MAX_BYTES,
             wechat_service: crate::config::WechatServiceConfig::default(),
+            onebot11: crate::config::OneBot11Config::default(),
         };
         let (command_tx, command_rx) = mpsc::channel(8);
         let actor = AggregatorActor {

--- a/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
@@ -320,6 +320,7 @@ fn test_config() -> AppConfig {
         media_download_timeout: Duration::from_secs(10),
         media_max_bytes: crate::config::DEFAULT_MEDIA_MAX_BYTES,
         wechat_service: crate::config::WechatServiceConfig::default(),
+        onebot11: crate::config::OneBot11Config::default(),
     }
 }
 

--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -874,6 +874,7 @@ mod tests {
             media_download_timeout: Duration::from_secs(10),
             media_max_bytes: DEFAULT_MEDIA_MAX_BYTES,
             wechat_service: crate::config::WechatServiceConfig::default(),
+            onebot11: crate::config::OneBot11Config::default(),
         }
     }
 

--- a/qq-maid-gateway-rs/src/gateway/console.rs
+++ b/qq-maid-gateway-rs/src/gateway/console.rs
@@ -148,8 +148,45 @@ impl ConsoleStatusSource for GatewayConsoleStatusSource {
             }],
         };
 
+        let onebot_configured = self.config.onebot11.access_token.is_some();
+        let onebot_enabled = self.config.onebot11.enabled;
+        let onebot = ConsolePlatformStatus {
+            id: "onebot11".to_owned(),
+            label: "OneBot 11".to_owned(),
+            configured: onebot_configured,
+            enabled: onebot_enabled,
+            state: if !onebot_configured {
+                ConsoleRuntimeState::NotConfigured
+            } else if !onebot_enabled {
+                ConsoleRuntimeState::NotAvailable
+            } else if runtime.onebot_connected {
+                ConsoleRuntimeState::Online
+            } else if runtime.onebot_listening {
+                ConsoleRuntimeState::Available
+            } else {
+                ConsoleRuntimeState::Offline
+            },
+            last_event_at: runtime.last_onebot_heartbeat_at,
+            last_error_summary: runtime.last_onebot_disconnect_summary,
+            ready_at: None,
+            resumed_at: None,
+            capability_scopes: vec![ConsoleCapabilityScope {
+                id: "reverse_websocket".to_owned(),
+                label: "反向 WebSocket（协议底座）".to_owned(),
+                enabled: onebot_enabled,
+                capabilities: unavailable_directional_capabilities(if !onebot_configured {
+                    ConsoleValueState::NotConfigured
+                } else if !onebot_enabled {
+                    ConsoleValueState::Disabled
+                } else {
+                    // #438 不接业务消息和发送；控制台不能把 transport 在线误报为文本能力可用。
+                    ConsoleValueState::NotAvailable
+                }),
+            }],
+        };
+
         ConsoleExternalSnapshot {
-            platforms: vec![qq, wechat],
+            platforms: vec![qq, wechat, onebot],
             storage: vec![path_storage(
                 "attachments",
                 "入站附件目录",
@@ -423,6 +460,35 @@ mod tests {
             capabilities.inbound.streaming,
             ConsoleValueState::Unsupported
         );
+    }
+
+    #[test]
+    fn onebot_foundation_reports_transport_state_without_business_capabilities() {
+        let config = AppConfig::from_map(&HashMap::from([
+            ("QQ_BOT_ENABLED".to_owned(), "false".to_owned()),
+            ("ONEBOT11_ENABLED".to_owned(), "true".to_owned()),
+            (
+                "ONEBOT11_ACCESS_TOKEN".to_owned(),
+                "private-onebot-token".to_owned(),
+            ),
+        ]))
+        .unwrap();
+        let runtime = GatewayRuntimeStatus::new();
+        runtime.record_onebot_listening();
+        runtime.record_onebot_connected("******123456".to_owned(), false);
+        let snapshot = GatewayConsoleStatusSource::new(config, runtime).snapshot();
+        let onebot = platform(&snapshot, "onebot11");
+
+        assert!(onebot.configured);
+        assert!(onebot.enabled);
+        assert_eq!(onebot.state, ConsoleRuntimeState::Online);
+        assert_eq!(
+            scope(onebot, "reverse_websocket").capabilities.inbound.text,
+            ConsoleValueState::NotAvailable
+        );
+        let json = serde_json::to_string(&snapshot).unwrap();
+        assert!(!json.contains("private-onebot-token"));
+        assert!(!json.contains("123456123456"));
     }
 
     #[test]

--- a/qq-maid-gateway-rs/src/gateway/dispatcher/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/dispatcher/tests.rs
@@ -167,6 +167,7 @@ fn test_config() -> AppConfig {
         media_download_timeout: Duration::from_secs(10),
         media_max_bytes: crate::config::DEFAULT_MEDIA_MAX_BYTES,
         wechat_service: crate::config::WechatServiceConfig::default(),
+        onebot11: crate::config::OneBot11Config::default(),
     }
 }
 

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -590,6 +590,7 @@ mod tests {
             media_download_timeout: Duration::from_secs(10),
             media_max_bytes: DEFAULT_MEDIA_MAX_BYTES,
             wechat_service: crate::config::WechatServiceConfig::default(),
+            onebot11: crate::config::OneBot11Config::default(),
         }
     }
 

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -12,6 +12,7 @@ mod group;
 mod group_filter;
 pub mod logging;
 mod media_fetch;
+pub mod onebot11;
 pub(crate) mod outbound;
 pub mod ping;
 pub(crate) mod platform;
@@ -32,6 +33,7 @@ use aggregator::MessageAggregator;
 use anyhow::{Context, anyhow, bail};
 use bot_identity::BotIdentity;
 use dispatcher::MessageDispatcher;
+use futures_util::{StreamExt, stream::FuturesUnordered};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -59,6 +61,7 @@ type ChannelTask = JoinHandle<anyhow::Result<()>>;
 
 const QQ_OFFICIAL_CHANNEL: &str = "QQ official gateway";
 const WECHAT_SERVICE_CHANNEL: &str = "wechat service callback";
+const ONEBOT11_CHANNEL: &str = "OneBot 11 reverse WebSocket";
 
 /// QQ 网关主循环：初始化所有共享组件后，反复获取网关地址并建立 WebSocket 连接。
 /// 连接断开或失败后会等待 `RECONNECT_DELAY` 后重连，从而保证长期在线。
@@ -71,7 +74,7 @@ pub async fn run(
 ) -> anyhow::Result<()> {
     // 微信与 QQ 共用 Core；监听器只创建一次，之后统一交给渠道监督器管理生命周期。
     let dedupe = Arc::new(MessageDedupe::new(DEDUPE_TTL));
-    let wechat_service_handle = if config.wechat_service.enabled {
+    let mut wechat_service_handle = if config.wechat_service.enabled {
         Some(
             wechat_service::spawn_callback_server(
                 config.wechat_service.clone(),
@@ -82,6 +85,38 @@ pub async fn run(
             )
             .await?,
         )
+    } else {
+        None
+    };
+    let onebot11_handle = if config.onebot11.enabled {
+        match onebot11::spawn_reverse_websocket_server(
+            config.onebot11.clone(),
+            runtime.clone(),
+            shutdown_token.clone(),
+        )
+        .await
+        {
+            Ok(server) => Some(server.task),
+            Err(error) => {
+                // 多入口按顺序 bind；后启动的入口失败时必须回收已启动监听器，
+                // 避免 run 返回错误后仍留下不可监督的后台任务。
+                shutdown_token.cancel();
+                if let Some(wechat_service) = wechat_service_handle.take() {
+                    match wechat_service.await {
+                        Ok(Ok(())) => {}
+                        Ok(Err(cleanup_error)) => warn!(
+                            error = %cleanup_error,
+                            "wechat service cleanup after OneBot startup failure returned an error"
+                        ),
+                        Err(join_error) => warn!(
+                            error = %join_error,
+                            "wechat service cleanup after OneBot startup failure failed"
+                        ),
+                    }
+                }
+                return Err(error);
+            }
+        }
     } else {
         None
     };
@@ -116,97 +151,71 @@ pub async fn run(
         }
     };
 
-    supervise_channels(qq_official_handle, wechat_service_handle, shutdown_token).await
+    supervise_all_channels(
+        qq_official_handle,
+        wechat_service_handle,
+        onebot11_handle,
+        shutdown_token,
+    )
+    .await
 }
 
 /// 同时监督所有已启用入口。渠道在全局取消前结束属于故障；故障会先取消共享令牌，
 /// 再等待其他渠道完成必要清理，并优先返回最先触发退出的原始错误。
+async fn supervise_all_channels(
+    qq_official: Option<ChannelTask>,
+    wechat_service: Option<ChannelTask>,
+    onebot11: Option<ChannelTask>,
+    shutdown_token: CancellationToken,
+) -> anyhow::Result<()> {
+    let mut configured = Vec::new();
+    if let Some(task) = qq_official {
+        configured.push((QQ_OFFICIAL_CHANNEL, task));
+    }
+    if let Some(task) = wechat_service {
+        configured.push((WECHAT_SERVICE_CHANNEL, task));
+    }
+    if let Some(task) = onebot11 {
+        configured.push((ONEBOT11_CHANNEL, task));
+    }
+    if configured.is_empty() {
+        bail!(
+            "no enabled gateway channel configured; enable QQ official, wechat service, or OneBot 11"
+        );
+    }
+
+    let channels = FuturesUnordered::new();
+    for (name, task) in configured {
+        channels.push(async move { (name, task.await) });
+    }
+    tokio::pin!(channels);
+    let first_exit = tokio::select! {
+        _ = shutdown_token.cancelled() => None,
+        result = channels.next() => result,
+    };
+    let mut outcome = if let Some((name, result)) = first_exit {
+        let shutdown_requested = shutdown_token.is_cancelled();
+        if !shutdown_requested {
+            shutdown_token.cancel();
+        }
+        channel_task_result(name, result, shutdown_requested)
+    } else {
+        Ok(())
+    };
+    while let Some((name, result)) = channels.next().await {
+        outcome = finish_channel_results(outcome, channel_task_result(name, result, true));
+    }
+    outcome
+}
+
+#[cfg(test)]
 async fn supervise_channels(
     qq_official: Option<ChannelTask>,
     wechat_service: Option<ChannelTask>,
     shutdown_token: CancellationToken,
 ) -> anyhow::Result<()> {
-    match (qq_official, wechat_service) {
-        (Some(qq_official), Some(wechat_service)) => {
-            supervise_channel_pair(qq_official, wechat_service, shutdown_token).await
-        }
-        (Some(qq_official), None) => {
-            supervise_single_channel(QQ_OFFICIAL_CHANNEL, qq_official, shutdown_token).await
-        }
-        (None, Some(wechat_service)) => {
-            supervise_single_channel(WECHAT_SERVICE_CHANNEL, wechat_service, shutdown_token).await
-        }
-        (None, None) => {
-            bail!("no enabled gateway channel configured; enable QQ official or wechat service")
-        }
-    }
+    supervise_all_channels(qq_official, wechat_service, None, shutdown_token).await
 }
-
-async fn supervise_single_channel(
-    channel_name: &'static str,
-    mut task: ChannelTask,
-    shutdown_token: CancellationToken,
-) -> anyhow::Result<()> {
-    tokio::select! {
-        _ = shutdown_token.cancelled() => {
-            channel_task_result(channel_name, task.await, true)
-        }
-        result = &mut task => {
-            let shutdown_requested = shutdown_token.is_cancelled();
-            if !shutdown_requested {
-                shutdown_token.cancel();
-            }
-            channel_task_result(channel_name, result, shutdown_requested)
-        }
-    }
-}
-
-enum FirstChannelExit {
-    Shutdown,
-    QqOfficial(Result<anyhow::Result<()>, tokio::task::JoinError>),
-    WechatService(Result<anyhow::Result<()>, tokio::task::JoinError>),
-}
-
-async fn supervise_channel_pair(
-    mut qq_official: ChannelTask,
-    mut wechat_service: ChannelTask,
-    shutdown_token: CancellationToken,
-) -> anyhow::Result<()> {
-    let first_exit = tokio::select! {
-        _ = shutdown_token.cancelled() => FirstChannelExit::Shutdown,
-        result = &mut qq_official => FirstChannelExit::QqOfficial(result),
-        result = &mut wechat_service => FirstChannelExit::WechatService(result),
-    };
-
-    match first_exit {
-        FirstChannelExit::Shutdown => {
-            let (qq_result, wechat_result) = tokio::join!(qq_official, wechat_service);
-            finish_channel_results(
-                channel_task_result(QQ_OFFICIAL_CHANNEL, qq_result, true),
-                channel_task_result(WECHAT_SERVICE_CHANNEL, wechat_result, true),
-            )
-        }
-        FirstChannelExit::QqOfficial(result) => {
-            let shutdown_requested = shutdown_token.is_cancelled();
-            let primary = channel_task_result(QQ_OFFICIAL_CHANNEL, result, shutdown_requested);
-            if !shutdown_requested {
-                shutdown_token.cancel();
-            }
-            let secondary = channel_task_result(WECHAT_SERVICE_CHANNEL, wechat_service.await, true);
-            finish_channel_results(primary, secondary)
-        }
-        FirstChannelExit::WechatService(result) => {
-            let shutdown_requested = shutdown_token.is_cancelled();
-            let primary = channel_task_result(WECHAT_SERVICE_CHANNEL, result, shutdown_requested);
-            if !shutdown_requested {
-                shutdown_token.cancel();
-            }
-            let secondary = channel_task_result(QQ_OFFICIAL_CHANNEL, qq_official.await, true);
-            finish_channel_results(primary, secondary)
-        }
-    }
-}
-
 fn channel_task_result(
     channel_name: &'static str,
     result: Result<anyhow::Result<()>, tokio::task::JoinError>,
@@ -538,6 +547,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn global_shutdown_cleans_up_three_channels_without_error() {
+        let shutdown = CancellationToken::new();
+        let qq_cleaned_up = Arc::new(AtomicBool::new(false));
+        let wechat_cleaned_up = Arc::new(AtomicBool::new(false));
+        let onebot_cleaned_up = Arc::new(AtomicBool::new(false));
+        let qq_official = task_waiting_for_shutdown(shutdown.clone(), Arc::clone(&qq_cleaned_up));
+        let wechat_service =
+            task_waiting_for_shutdown(shutdown.clone(), Arc::clone(&wechat_cleaned_up));
+        let onebot11 = task_waiting_for_shutdown(shutdown.clone(), Arc::clone(&onebot_cleaned_up));
+
+        shutdown.cancel();
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            supervise_all_channels(
+                Some(qq_official),
+                Some(wechat_service),
+                Some(onebot11),
+                shutdown,
+            ),
+        )
+        .await
+        .expect("cancelled channels must finish promptly")
+        .unwrap();
+
+        assert!(qq_cleaned_up.load(Ordering::SeqCst));
+        assert!(wechat_cleaned_up.load(Ordering::SeqCst));
+        assert!(onebot_cleaned_up.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
     async fn wechat_listener_starts_when_qq_is_unbound() {
         let config = AppConfig::from_map(&HashMap::from([
             ("WECHAT_SERVICE_ENABLED".to_owned(), "true".to_owned()),
@@ -569,5 +608,79 @@ mod tests {
         stop.cancel();
         task.await.unwrap().unwrap();
         assert!(!observed_runtime.snapshot().wechat_service_listening);
+    }
+
+    #[tokio::test]
+    async fn onebot_listener_starts_when_qq_is_unbound() {
+        let mut config = AppConfig::from_map(&HashMap::from([(
+            "QQ_BOT_ENABLED".to_owned(),
+            "false".to_owned(),
+        )]))
+        .unwrap();
+        config.onebot11 = crate::config::OneBot11Config {
+            enabled: true,
+            bind_port: 0,
+            access_token: Some("test-token".to_owned()),
+            ..crate::config::OneBot11Config::default()
+        };
+        let runtime = GatewayRuntimeStatus::new();
+        let observed_runtime = runtime.clone();
+        let shutdown = CancellationToken::new();
+        let stop = shutdown.clone();
+        let task = tokio::spawn(run(
+            config,
+            RespondClient::new(Arc::new(NoopCore)),
+            GatewayPushSink::unbound(),
+            runtime,
+            shutdown,
+        ));
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !observed_runtime.snapshot().onebot_listening {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert!(!observed_runtime.snapshot().qq_connected);
+
+        stop.cancel();
+        task.await.unwrap().unwrap();
+        assert!(!observed_runtime.snapshot().onebot_listening);
+    }
+
+    #[tokio::test]
+    async fn onebot_bind_failure_cleans_up_started_wechat_listener() {
+        let occupied = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let occupied_port = occupied.local_addr().unwrap().port();
+        let mut config = AppConfig::from_map(&HashMap::from([
+            ("QQ_BOT_ENABLED".to_owned(), "false".to_owned()),
+            ("WECHAT_SERVICE_ENABLED".to_owned(), "true".to_owned()),
+            ("WECHAT_SERVICE_TOKEN".to_owned(), "wechat-token".to_owned()),
+            ("WECHAT_SERVICE_BIND_PORT".to_owned(), "0".to_owned()),
+        ]))
+        .unwrap();
+        config.onebot11 = crate::config::OneBot11Config {
+            enabled: true,
+            bind_port: occupied_port,
+            access_token: Some("test-token".to_owned()),
+            ..crate::config::OneBot11Config::default()
+        };
+        let runtime = GatewayRuntimeStatus::new();
+        let observed_runtime = runtime.clone();
+
+        let error = run(
+            config,
+            RespondClient::new(Arc::new(NoopCore)),
+            GatewayPushSink::unbound(),
+            runtime,
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("bind OneBot 11"));
+        assert!(!observed_runtime.snapshot().wechat_service_listening);
+        assert!(!observed_runtime.snapshot().onebot_listening);
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/onebot11/connection.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/connection.rs
@@ -11,7 +11,10 @@ use std::{
 
 use serde_json::Value;
 use thiserror::Error;
-use tokio::sync::{mpsc, oneshot};
+use tokio::{
+    sync::{mpsc, oneshot},
+    time::Instant,
+};
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
@@ -32,9 +35,14 @@ pub enum OneBotCallError {
 #[derive(Clone)]
 pub struct OneBotConnectionContext {
     state: Arc<Mutex<ConnectionState>>,
-    pending: Arc<Mutex<HashMap<String, oneshot::Sender<ActionResponse>>>>,
+    pending: Arc<Mutex<HashMap<String, PendingRequest>>>,
     next_echo: Arc<AtomicU64>,
     request_timeout: Duration,
+}
+
+struct PendingRequest {
+    generation: u64,
+    response: oneshot::Sender<ActionResponse>,
 }
 
 #[derive(Default)]
@@ -55,6 +63,7 @@ pub(super) struct Registration {
     pub(super) replaced_existing: bool,
 }
 
+#[derive(Debug)]
 pub(super) enum RegistrationError {
     AccountMismatch { expected: OneBotId },
     StateUnavailable,
@@ -77,6 +86,9 @@ impl OneBotConnectionContext {
         action: impl Into<String>,
         params: Value,
     ) -> Result<ActionResponse, OneBotCallError> {
+        // request_timeout 是调用方看到的完整 API 调用预算，必须同时覆盖发送队列等待
+        // 与响应等待，避免 outbound 拥塞时永远卡在进入 response timeout 之前。
+        let deadline = Instant::now() + self.request_timeout;
         let echo = format!(
             "qq-maid-onebot-{}",
             self.next_echo.fetch_add(1, Ordering::Relaxed)
@@ -102,7 +114,13 @@ impl OneBotConnectionContext {
         self.pending
             .lock()
             .map_err(|_| OneBotCallError::ConnectionClosed)?
-            .insert(echo.clone(), response_tx);
+            .insert(
+                echo.clone(),
+                PendingRequest {
+                    generation,
+                    response: response_tx,
+                },
+            );
         let still_current = self.state.lock().ok().is_some_and(|state| {
             state
                 .active
@@ -110,18 +128,27 @@ impl OneBotConnectionContext {
                 .is_some_and(|active| active.generation == generation)
         });
         if !still_current {
-            self.remove_pending(&echo);
+            self.remove_pending(&echo, generation);
             return Err(OneBotCallError::ConnectionClosed);
         }
-        if outbound.send(payload).await.is_err() {
-            self.remove_pending(&echo);
-            return Err(OneBotCallError::ConnectionClosed);
-        }
-        match tokio::time::timeout(self.request_timeout, response_rx).await {
+        let result = tokio::time::timeout_at(deadline, async {
+            outbound
+                .send(payload)
+                .await
+                .map_err(|_| OneBotCallError::ConnectionClosed)?;
+            response_rx
+                .await
+                .map_err(|_| OneBotCallError::ConnectionClosed)
+        })
+        .await;
+        match result {
             Ok(Ok(response)) => Ok(response),
-            Ok(Err(_)) => Err(OneBotCallError::ConnectionClosed),
+            Ok(Err(error)) => {
+                self.remove_pending(&echo, generation);
+                Err(error)
+            }
             Err(_) => {
-                self.remove_pending(&echo);
+                self.remove_pending(&echo, generation);
                 Err(OneBotCallError::Timeout)
             }
         }
@@ -157,10 +184,12 @@ impl OneBotConnectionContext {
         if state.expected_self_id.is_none() {
             state.expected_self_id = Some(self_id);
         }
-        let replaced_existing = state.active.is_some();
-        if let Some(active) = state.active.take() {
+        let replaced_generation = state.active.take().map(|active| {
+            let generation = active.generation;
             active.replaced.cancel();
-        }
+            generation
+        });
+        let replaced_existing = replaced_generation.is_some();
         state.generation = state.generation.wrapping_add(1).max(1);
         let generation = state.generation;
         state.active = Some(ActiveConnection {
@@ -168,10 +197,10 @@ impl OneBotConnectionContext {
             outbound,
             replaced,
         });
-        drop(state);
-        if replaced_existing && let Ok(mut pending) = self.pending.lock() {
-            // 旧连接上的 action 不可能由新连接可靠完成；立刻释放等待方，避免全部拖到超时。
-            pending.clear();
+        if let Some(replaced_generation) = replaced_generation {
+            // 保持 state 锁直到旧 generation 的 pending 清理完成：新调用此时还无法取得
+            // 新 generation，因而不会在替换清理与新 active 发布之间被误取消。
+            self.cancel_pending_generation(replaced_generation);
         }
         Ok(Registration {
             generation,
@@ -189,31 +218,101 @@ impl OneBotConnectionContext {
             .is_some_and(|active| active.generation == generation);
         if owns_active {
             state.active = None;
-            if let Ok(mut pending) = self.pending.lock() {
-                pending.clear();
-            }
+            self.cancel_pending_generation(generation);
         }
         owns_active
     }
 
-    pub(super) fn dispatch_response(&self, response: ActionResponse) {
+    pub(super) fn dispatch_response(&self, generation: u64, response: ActionResponse) {
         let Some(Echo(Value::String(echo))) = response.echo.as_ref() else {
             debug!("ignoring OneBot API response without string echo");
             return;
         };
-        if let Some(sender) = self
-            .pending
-            .lock()
-            .ok()
-            .and_then(|mut pending| pending.remove(echo))
-        {
+        let Ok(state) = self.state.lock() else {
+            return;
+        };
+        let is_current = state
+            .active
+            .as_ref()
+            .is_some_and(|active| active.generation == generation);
+        if !is_current {
+            debug!(
+                generation,
+                "ignoring OneBot API response from stale connection"
+            );
+            return;
+        }
+        let sender = self.pending.lock().ok().and_then(|mut pending| {
+            let belongs_to_generation = pending
+                .get(echo)
+                .is_some_and(|request| request.generation == generation);
+            belongs_to_generation
+                .then(|| pending.remove(echo))
+                .flatten()
+                .map(|request| request.response)
+        });
+        drop(state);
+        if let Some(sender) = sender {
             let _ = sender.send(response);
         }
     }
 
-    fn remove_pending(&self, echo: &str) {
+    fn remove_pending(&self, echo: &str, generation: u64) {
         if let Ok(mut pending) = self.pending.lock() {
-            pending.remove(echo);
+            let belongs_to_generation = pending
+                .get(echo)
+                .is_some_and(|request| request.generation == generation);
+            if belongs_to_generation {
+                pending.remove(echo);
+            }
         }
+    }
+
+    fn cancel_pending_generation(&self, generation: u64) {
+        if let Ok(mut pending) = self.pending.lock() {
+            // 旧连接上的 action 不可能由新连接可靠完成；只释放旧 generation 的等待方，
+            // 不能影响替换后已经创建的新请求。
+            pending.retain(|_, request| request.generation != generation);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replacement_cleanup_only_cancels_old_generation_pending() {
+        let context = OneBotConnectionContext::new(Duration::from_secs(1));
+        let (old_tx, mut old_rx) = oneshot::channel();
+        let (current_tx, mut current_rx) = oneshot::channel();
+        context.pending.lock().unwrap().insert(
+            "old".to_owned(),
+            PendingRequest {
+                generation: 1,
+                response: old_tx,
+            },
+        );
+        context.pending.lock().unwrap().insert(
+            "current".to_owned(),
+            PendingRequest {
+                generation: 2,
+                response: current_tx,
+            },
+        );
+
+        context.cancel_pending_generation(1);
+
+        assert!(matches!(
+            old_rx.try_recv(),
+            Err(oneshot::error::TryRecvError::Closed)
+        ));
+        assert!(matches!(
+            current_rx.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
+        let pending = context.pending.lock().unwrap();
+        assert!(!pending.contains_key("old"));
+        assert!(pending.contains_key("current"));
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/onebot11/connection.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/connection.rs
@@ -1,0 +1,219 @@
+//! 活动连接、echo 关联和后续 API sender 共用的 transport 上下文。
+
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use serde_json::Value;
+use thiserror::Error;
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+
+use super::protocol::{ActionRequest, ActionResponse, Echo, OneBotId};
+
+#[derive(Debug, Error)]
+pub enum OneBotCallError {
+    #[error("OneBot client is not connected")]
+    NotConnected,
+    #[error("OneBot connection outbound queue is closed")]
+    ConnectionClosed,
+    #[error("OneBot API request timed out")]
+    Timeout,
+    #[error("failed to encode OneBot API request: {0}")]
+    Encode(#[from] serde_json::Error),
+}
+
+#[derive(Clone)]
+pub struct OneBotConnectionContext {
+    state: Arc<Mutex<ConnectionState>>,
+    pending: Arc<Mutex<HashMap<String, oneshot::Sender<ActionResponse>>>>,
+    next_echo: Arc<AtomicU64>,
+    request_timeout: Duration,
+}
+
+#[derive(Default)]
+struct ConnectionState {
+    expected_self_id: Option<OneBotId>,
+    generation: u64,
+    active: Option<ActiveConnection>,
+}
+
+struct ActiveConnection {
+    generation: u64,
+    outbound: mpsc::Sender<String>,
+    replaced: CancellationToken,
+}
+
+pub(super) struct Registration {
+    pub(super) generation: u64,
+    pub(super) replaced_existing: bool,
+}
+
+pub(super) enum RegistrationError {
+    AccountMismatch { expected: OneBotId },
+    StateUnavailable,
+}
+
+impl OneBotConnectionContext {
+    pub fn new(request_timeout: Duration) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(ConnectionState::default())),
+            pending: Arc::new(Mutex::new(HashMap::new())),
+            next_echo: Arc::new(AtomicU64::new(1)),
+            request_timeout,
+        }
+    }
+
+    /// 通过当前活动 WebSocket 调用 OneBot action。具体 sender 后续只需封装 action/params，
+    /// 不应创建第二条 transport 或自行维护 echo 表。
+    pub async fn call(
+        &self,
+        action: impl Into<String>,
+        params: Value,
+    ) -> Result<ActionResponse, OneBotCallError> {
+        let echo = format!(
+            "qq-maid-onebot-{}",
+            self.next_echo.fetch_add(1, Ordering::Relaxed)
+        );
+        let request = ActionRequest {
+            action: action.into(),
+            params,
+            echo: Echo(Value::String(echo.clone())),
+        };
+        let payload = serde_json::to_string(&request)?;
+        let (generation, outbound) = self
+            .state
+            .lock()
+            .ok()
+            .and_then(|state| {
+                state
+                    .active
+                    .as_ref()
+                    .map(|active| (active.generation, active.outbound.clone()))
+            })
+            .ok_or(OneBotCallError::NotConnected)?;
+        let (response_tx, response_rx) = oneshot::channel();
+        self.pending
+            .lock()
+            .map_err(|_| OneBotCallError::ConnectionClosed)?
+            .insert(echo.clone(), response_tx);
+        let still_current = self.state.lock().ok().is_some_and(|state| {
+            state
+                .active
+                .as_ref()
+                .is_some_and(|active| active.generation == generation)
+        });
+        if !still_current {
+            self.remove_pending(&echo);
+            return Err(OneBotCallError::ConnectionClosed);
+        }
+        if outbound.send(payload).await.is_err() {
+            self.remove_pending(&echo);
+            return Err(OneBotCallError::ConnectionClosed);
+        }
+        match tokio::time::timeout(self.request_timeout, response_rx).await {
+            Ok(Ok(response)) => Ok(response),
+            Ok(Err(_)) => Err(OneBotCallError::ConnectionClosed),
+            Err(_) => {
+                self.remove_pending(&echo);
+                Err(OneBotCallError::Timeout)
+            }
+        }
+    }
+
+    pub fn connected_self_id(&self) -> Option<OneBotId> {
+        self.state.lock().ok().and_then(|state| {
+            state
+                .active
+                .as_ref()
+                .and(state.expected_self_id.as_ref())
+                .cloned()
+        })
+    }
+
+    pub(super) fn register(
+        &self,
+        self_id: OneBotId,
+        outbound: mpsc::Sender<String>,
+        replaced: CancellationToken,
+    ) -> Result<Registration, RegistrationError> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| RegistrationError::StateUnavailable)?;
+        if let Some(expected) = state.expected_self_id.as_ref()
+            && expected != &self_id
+        {
+            return Err(RegistrationError::AccountMismatch {
+                expected: expected.clone(),
+            });
+        }
+        if state.expected_self_id.is_none() {
+            state.expected_self_id = Some(self_id);
+        }
+        let replaced_existing = state.active.is_some();
+        if let Some(active) = state.active.take() {
+            active.replaced.cancel();
+        }
+        state.generation = state.generation.wrapping_add(1).max(1);
+        let generation = state.generation;
+        state.active = Some(ActiveConnection {
+            generation,
+            outbound,
+            replaced,
+        });
+        drop(state);
+        if replaced_existing && let Ok(mut pending) = self.pending.lock() {
+            // 旧连接上的 action 不可能由新连接可靠完成；立刻释放等待方，避免全部拖到超时。
+            pending.clear();
+        }
+        Ok(Registration {
+            generation,
+            replaced_existing,
+        })
+    }
+
+    pub(super) fn unregister(&self, generation: u64) -> bool {
+        let Ok(mut state) = self.state.lock() else {
+            return false;
+        };
+        let owns_active = state
+            .active
+            .as_ref()
+            .is_some_and(|active| active.generation == generation);
+        if owns_active {
+            state.active = None;
+            if let Ok(mut pending) = self.pending.lock() {
+                pending.clear();
+            }
+        }
+        owns_active
+    }
+
+    pub(super) fn dispatch_response(&self, response: ActionResponse) {
+        let Some(Echo(Value::String(echo))) = response.echo.as_ref() else {
+            debug!("ignoring OneBot API response without string echo");
+            return;
+        };
+        if let Some(sender) = self
+            .pending
+            .lock()
+            .ok()
+            .and_then(|mut pending| pending.remove(echo))
+        {
+            let _ = sender.send(response);
+        }
+    }
+
+    fn remove_pending(&self, echo: &str) {
+        if let Ok(mut pending) = self.pending.lock() {
+            pending.remove(echo);
+        }
+    }
+}

--- a/qq-maid-gateway-rs/src/gateway/onebot11/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/mod.rs
@@ -1,0 +1,14 @@
+//! OneBot 11 反向 WebSocket 单账号连接底座。
+//!
+//! 当前模块只管理协议、鉴权、连接和 API request/response 关联，不把业务事件送入 Core，
+//! 也不实现具体消息发送 action。后续 adapter 与 sender 必须复用这里的连接上下文。
+
+mod connection;
+pub mod protocol;
+mod server;
+
+pub use connection::{OneBotCallError, OneBotConnectionContext};
+pub use server::{OneBotServerHandle, spawn_reverse_websocket_server};
+
+#[cfg(test)]
+mod tests;

--- a/qq-maid-gateway-rs/src/gateway/onebot11/protocol.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/protocol.rs
@@ -1,0 +1,239 @@
+//! OneBot 11 最小协议模型。
+//!
+//! 一期只消费生命周期、心跳和 API response；消息事件与消息段先保留为协议类型，
+//! 后续 adapter 可以在本模块边界内继续解析，不能把原始 JSON 泄漏到 Core。
+
+use std::{collections::BTreeMap, fmt};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Visitor};
+use serde_json::Value;
+
+/// OneBot 的账号、群和用户 ID 允许使用 JSON 数字或字符串。
+///
+/// 内部统一保存十进制/原始字符串，避免经过 `f64` 导致大整数精度损失；序列化时使用
+/// JSON 字符串，OneBot 11 实现通常同时接受两种形式。
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct OneBotId(String);
+
+impl OneBotId {
+    pub fn new(value: impl Into<String>) -> Result<Self, &'static str> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err("OneBot ID must not be empty");
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for OneBotId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("OneBotId(REDACTED)")
+    }
+}
+
+impl Serialize for OneBotId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for OneBotId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct IdVisitor;
+
+        impl Visitor<'_> for IdVisitor {
+            type Value = OneBotId;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a non-empty string or integer OneBot ID")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                OneBotId::new(value).map_err(E::custom)
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                OneBotId::new(value).map_err(E::custom)
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(OneBotId(value.to_string()))
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(OneBotId(value.to_string()))
+            }
+        }
+
+        deserializer.deserialize_any(IdVisitor)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MessageSegment {
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[serde(default)]
+    pub data: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum OneBotMessage {
+    Segments(Vec<MessageSegment>),
+    CqCode(String),
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct OneBotEvent {
+    #[serde(default)]
+    pub time: Option<i64>,
+    pub self_id: OneBotId,
+    pub post_type: String,
+    #[serde(default)]
+    pub message_type: Option<String>,
+    #[serde(default)]
+    pub notice_type: Option<String>,
+    #[serde(default)]
+    pub request_type: Option<String>,
+    #[serde(default)]
+    pub meta_event_type: Option<String>,
+    #[serde(default)]
+    pub sub_type: Option<String>,
+    #[serde(default)]
+    pub interval: Option<u64>,
+    #[serde(default)]
+    pub status: Option<Value>,
+    #[serde(default)]
+    pub message: Option<OneBotMessage>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, Value>,
+}
+
+impl OneBotEvent {
+    pub fn is_heartbeat(&self) -> bool {
+        self.post_type == "meta_event" && self.meta_event_type.as_deref() == Some("heartbeat")
+    }
+
+    pub fn is_lifecycle(&self) -> bool {
+        self.post_type == "meta_event" && self.meta_event_type.as_deref() == Some("lifecycle")
+    }
+}
+
+/// `echo` 在 OneBot 11 中可以是任意 JSON 值，必须原样关联请求与响应。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(transparent)]
+pub struct Echo(pub Value);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ActionRequest {
+    pub action: String,
+    #[serde(default)]
+    pub params: Value,
+    pub echo: Echo,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ActionResponse {
+    pub status: String,
+    pub retcode: i64,
+    #[serde(default)]
+    pub data: Value,
+    #[serde(default)]
+    pub message: Option<String>,
+    #[serde(default)]
+    pub wording: Option<String>,
+    #[serde(default)]
+    pub echo: Option<Echo>,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn id_accepts_string_or_integer_without_precision_loss() {
+        let numeric: OneBotId = serde_json::from_str("18446744073709551615").unwrap();
+        let text: OneBotId = serde_json::from_str("\"18446744073709551615\"").unwrap();
+
+        assert_eq!(numeric.as_str(), "18446744073709551615");
+        assert_eq!(numeric, text);
+        assert_eq!(
+            serde_json::to_value(numeric).unwrap(),
+            json!("18446744073709551615")
+        );
+    }
+
+    #[test]
+    fn parses_lifecycle_heartbeat_and_message_segments() {
+        let heartbeat: OneBotEvent = serde_json::from_value(json!({
+            "time": 1,
+            "self_id": 123456789012345678_u64,
+            "post_type": "meta_event",
+            "meta_event_type": "heartbeat",
+            "status": {"online": true},
+            "interval": 5000
+        }))
+        .unwrap();
+        assert!(heartbeat.is_heartbeat());
+        assert_eq!(heartbeat.self_id.as_str(), "123456789012345678");
+
+        let message: OneBotEvent = serde_json::from_value(json!({
+            "self_id": "42",
+            "post_type": "message",
+            "message_type": "private",
+            "message": [{"type": "text", "data": {"text": "hello"}}]
+        }))
+        .unwrap();
+        let Some(OneBotMessage::Segments(segments)) = message.message else {
+            panic!("expected array message segments");
+        };
+        assert_eq!(segments[0].kind, "text");
+
+        let cq_message: OneBotEvent = serde_json::from_value(json!({
+            "self_id": "42",
+            "post_type": "message",
+            "message_type": "private",
+            "message": "hello[CQ:image,file=test.jpg]"
+        }))
+        .unwrap();
+        assert!(matches!(cq_message.message, Some(OneBotMessage::CqCode(_))));
+    }
+
+    #[test]
+    fn action_response_preserves_echo_value() {
+        let response: ActionResponse = serde_json::from_value(json!({
+            "status": "ok",
+            "retcode": 0,
+            "data": {"user_id": "42"},
+            "echo": {"request": 7}
+        }))
+        .unwrap();
+
+        assert_eq!(response.echo, Some(Echo(json!({"request": 7}))));
+    }
+}

--- a/qq-maid-gateway-rs/src/gateway/onebot11/server.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/server.rs
@@ -1,0 +1,389 @@
+//! 反向 WebSocket 监听器、鉴权和单连接事件循环。
+
+use std::{net::SocketAddr, time::Duration};
+
+use anyhow::{Context, bail};
+use axum::{
+    Router,
+    extract::{
+        State, WebSocketUpgrade,
+        ws::{CloseFrame, Message, WebSocket, close_code},
+    },
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+};
+use serde_json::Value;
+use tokio::{net::TcpListener, sync::mpsc, task::JoinHandle, time::Instant};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::{
+    config::OneBot11Config,
+    gateway::{logging::mask_identifier, ping::GatewayRuntimeStatus},
+};
+
+use super::{
+    connection::{OneBotConnectionContext, Registration, RegistrationError},
+    protocol::{ActionResponse, OneBotEvent, OneBotId},
+};
+
+const AUTHORIZATION: &str = "authorization";
+const X_SELF_ID: &str = "x-self-id";
+const OUTBOUND_QUEUE_CAPACITY: usize = 64;
+
+pub struct OneBotServerHandle {
+    pub local_addr: SocketAddr,
+    pub connection: OneBotConnectionContext,
+    pub task: JoinHandle<anyhow::Result<()>>,
+}
+
+#[derive(Clone)]
+struct ServerState {
+    config: OneBot11Config,
+    connection: OneBotConnectionContext,
+    runtime: GatewayRuntimeStatus,
+    shutdown: CancellationToken,
+}
+
+/// 先完成 bind 再返回，调用方可把 task 纳入 Gateway 顶层监督；客户端连接错误由 Axum
+/// 独立 handler 隔离，不会让监听器或其它平台渠道退出。
+pub async fn spawn_reverse_websocket_server(
+    config: OneBot11Config,
+    runtime: GatewayRuntimeStatus,
+    shutdown: CancellationToken,
+) -> anyhow::Result<OneBotServerHandle> {
+    if !config.enabled {
+        bail!("OneBot 11 reverse WebSocket server is disabled");
+    }
+    if config.access_token.is_none() {
+        bail!("OneBot 11 access token is required when enabled");
+    }
+    let addr: SocketAddr = format!("{}:{}", config.bind_host, config.bind_port)
+        .parse()
+        .context("parse OneBot 11 reverse WebSocket bind addr")?;
+    let listener = TcpListener::bind(addr)
+        .await
+        .context("bind OneBot 11 reverse WebSocket listener")?;
+    let local_addr = listener
+        .local_addr()
+        .context("read OneBot 11 listener address")?;
+    let path = config.websocket_path.clone();
+    let connection = OneBotConnectionContext::new(config.request_timeout);
+    let state = ServerState {
+        config,
+        connection: connection.clone(),
+        runtime: runtime.clone(),
+        shutdown: shutdown.clone(),
+    };
+    let app = Router::new()
+        .route(&path, get(upgrade_websocket))
+        .with_state(state);
+
+    info!(%local_addr, path = %path, "OneBot 11 reverse WebSocket listening");
+    runtime.record_onebot_listening();
+    let task = tokio::spawn(async move {
+        let result = axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                shutdown.cancelled().await;
+            })
+            .await
+            .context("serve OneBot 11 reverse WebSocket");
+        runtime.record_onebot_stopped();
+        result
+    });
+
+    Ok(OneBotServerHandle {
+        local_addr,
+        connection,
+        task,
+    })
+}
+
+async fn upgrade_websocket(
+    State(state): State<ServerState>,
+    headers: HeaderMap,
+    websocket: WebSocketUpgrade,
+) -> Response {
+    if !authorized(&state.config, &headers) {
+        warn!("rejected unauthorized OneBot 11 WebSocket connection");
+        return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+    }
+    let header_self_id = match headers.get(X_SELF_ID) {
+        Some(value) => match value
+            .to_str()
+            .ok()
+            .and_then(|value| OneBotId::new(value.to_owned()).ok())
+        {
+            Some(self_id) => Some(self_id),
+            None => return (StatusCode::BAD_REQUEST, "invalid x-self-id").into_response(),
+        },
+        None => None,
+    };
+    let max_message_bytes = state.config.max_message_bytes;
+    websocket
+        .max_message_size(max_message_bytes)
+        .max_frame_size(max_message_bytes)
+        .on_upgrade(move |socket| handle_socket(socket, state, header_self_id))
+}
+
+fn authorized(config: &OneBot11Config, headers: &HeaderMap) -> bool {
+    let Some(expected) = config.access_token.as_deref() else {
+        return false;
+    };
+    let expected = format!("Bearer {expected}");
+    headers
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value == expected)
+}
+
+async fn handle_socket(
+    mut socket: WebSocket,
+    state: ServerState,
+    header_self_id: Option<OneBotId>,
+) {
+    let (outbound_tx, mut outbound_rx) = mpsc::channel(OUTBOUND_QUEUE_CAPACITY);
+    let replaced = CancellationToken::new();
+    let mut registration = None;
+    let mut identity_deadline = Some(Instant::now() + state.config.request_timeout);
+    let mut heartbeat_deadline = None;
+    let mut disconnect_summary = "client disconnected";
+
+    if let Some(self_id) = header_self_id {
+        match register_connection(&state, self_id, outbound_tx.clone(), replaced.clone()) {
+            Ok(registered) => {
+                registration = Some(registered);
+                identity_deadline = None;
+            }
+            Err(summary) => {
+                close_socket(&mut socket, close_code::POLICY, summary).await;
+                return;
+            }
+        }
+    }
+
+    loop {
+        let next_deadline = identity_deadline.or(heartbeat_deadline);
+        tokio::select! {
+            biased;
+            _ = state.shutdown.cancelled() => {
+                disconnect_summary = "gateway shutdown";
+                close_socket(&mut socket, close_code::AWAY, "gateway shutdown").await;
+                break;
+            }
+            _ = replaced.cancelled() => {
+                disconnect_summary = "replaced by newer connection";
+                close_socket(&mut socket, close_code::POLICY, "replaced by newer connection").await;
+                break;
+            }
+            _ = wait_for_deadline(next_deadline), if next_deadline.is_some() => {
+                disconnect_summary = if registration.is_some() {
+                    "heartbeat timed out"
+                } else {
+                    "self_id report timed out"
+                };
+                close_socket(&mut socket, close_code::POLICY, disconnect_summary).await;
+                break;
+            }
+            outbound = outbound_rx.recv() => {
+                let Some(payload) = outbound else {
+                    disconnect_summary = "outbound channel closed";
+                    break;
+                };
+                if socket.send(Message::Text(payload.into())).await.is_err() {
+                    disconnect_summary = "WebSocket send failed";
+                    break;
+                }
+            }
+            incoming = socket.recv() => {
+                let Some(incoming) = incoming else {
+                    break;
+                };
+                let message = match incoming {
+                    Ok(message) => message,
+                    Err(error) => {
+                        // tungstenite 会在分配受限消息体前拒绝超限帧；这里只将错误归类成固定摘要，
+                        // 不把可能携带连接细节的底层错误文本写入运行状态。
+                        disconnect_summary = if error
+                            .to_string()
+                            .to_ascii_lowercase()
+                            .contains("message too long")
+                        {
+                            "message too large"
+                        } else {
+                            "WebSocket receive failed"
+                        };
+                        break;
+                    }
+                };
+                match handle_message(
+                    &mut socket,
+                    &state,
+                    message,
+                    &outbound_tx,
+                    &replaced,
+                    &mut registration,
+                    &mut identity_deadline,
+                    &mut heartbeat_deadline,
+                ).await {
+                    MessageOutcome::Continue => {}
+                    MessageOutcome::Disconnect(summary) => {
+                        disconnect_summary = summary;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(registration) = registration
+        && state.connection.unregister(registration.generation)
+    {
+        state.runtime.record_onebot_disconnected(disconnect_summary);
+        info!(reason = disconnect_summary, "OneBot 11 client disconnected");
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn handle_message(
+    socket: &mut WebSocket,
+    state: &ServerState,
+    message: Message,
+    outbound: &mpsc::Sender<String>,
+    replaced: &CancellationToken,
+    registration: &mut Option<Registration>,
+    identity_deadline: &mut Option<Instant>,
+    heartbeat_deadline: &mut Option<Instant>,
+) -> MessageOutcome {
+    let text = match message {
+        Message::Text(text) => text,
+        Message::Ping(payload) => {
+            if socket.send(Message::Pong(payload)).await.is_err() {
+                return MessageOutcome::Disconnect("WebSocket pong failed");
+            }
+            return MessageOutcome::Continue;
+        }
+        Message::Pong(_) => return MessageOutcome::Continue,
+        Message::Close(_) => return MessageOutcome::Disconnect("client closed connection"),
+        Message::Binary(_) => {
+            close_socket(socket, close_code::UNSUPPORTED, "text frames required").await;
+            return MessageOutcome::Disconnect("unsupported binary frame");
+        }
+    };
+    if text.len() > state.config.max_message_bytes {
+        close_socket(socket, close_code::SIZE, "message too large").await;
+        return MessageOutcome::Disconnect("message too large");
+    }
+    let value: Value = match serde_json::from_str(text.as_str()) {
+        Ok(value) => value,
+        Err(_) => {
+            warn!("closing OneBot 11 connection after invalid JSON");
+            close_socket(socket, close_code::INVALID, "invalid JSON").await;
+            return MessageOutcome::Disconnect("invalid JSON");
+        }
+    };
+    if value.get("echo").is_some() && value.get("retcode").is_some() {
+        let response = match serde_json::from_value::<ActionResponse>(value) {
+            Ok(response) => response,
+            Err(_) => {
+                close_socket(socket, close_code::INVALID, "invalid API response").await;
+                return MessageOutcome::Disconnect("invalid API response");
+            }
+        };
+        state.connection.dispatch_response(response);
+        return MessageOutcome::Continue;
+    }
+    let event = match serde_json::from_value::<OneBotEvent>(value) {
+        Ok(event) => event,
+        Err(_) => {
+            close_socket(socket, close_code::INVALID, "invalid OneBot event").await;
+            return MessageOutcome::Disconnect("invalid OneBot event");
+        }
+    };
+
+    if registration.is_none() {
+        match register_connection(
+            state,
+            event.self_id.clone(),
+            outbound.clone(),
+            replaced.clone(),
+        ) {
+            Ok(registered) => {
+                *registration = Some(registered);
+                *identity_deadline = None;
+            }
+            Err(summary) => {
+                close_socket(socket, close_code::POLICY, summary).await;
+                return MessageOutcome::Disconnect(summary);
+            }
+        }
+    } else if state.connection.connected_self_id().as_ref() != Some(&event.self_id) {
+        close_socket(socket, close_code::POLICY, "self_id changed").await;
+        return MessageOutcome::Disconnect("self_id changed");
+    }
+
+    if event.is_heartbeat() {
+        state.runtime.record_onebot_heartbeat();
+        if let Some(interval_ms) = event.interval {
+            let heartbeat_budget = Duration::from_millis(interval_ms.saturating_mul(2))
+                .max(state.config.request_timeout);
+            *heartbeat_deadline = Some(Instant::now() + heartbeat_budget);
+        }
+    } else if event.is_lifecycle() {
+        debug!(sub_type = ?event.sub_type, "received OneBot 11 lifecycle event");
+    }
+    MessageOutcome::Continue
+}
+
+fn register_connection(
+    state: &ServerState,
+    self_id: OneBotId,
+    outbound: mpsc::Sender<String>,
+    replaced: CancellationToken,
+) -> Result<Registration, &'static str> {
+    let masked = mask_identifier(self_id.as_str());
+    match state.connection.register(self_id, outbound, replaced) {
+        Ok(registration) => {
+            state
+                .runtime
+                .record_onebot_connected(masked, registration.replaced_existing);
+            info!(
+                self_id = %state.runtime.snapshot().onebot_self_id_summary.as_deref().unwrap_or("unknown"),
+                replaced_existing = registration.replaced_existing,
+                "OneBot 11 client connected"
+            );
+            Ok(registration)
+        }
+        Err(RegistrationError::AccountMismatch { expected }) => {
+            warn!(
+                expected = %mask_identifier(expected.as_str()),
+                received = %masked,
+                "rejected OneBot 11 connection for a different account"
+            );
+            Err("different self_id is not allowed")
+        }
+        Err(RegistrationError::StateUnavailable) => Err("connection state unavailable"),
+    }
+}
+
+async fn wait_for_deadline(deadline: Option<Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => std::future::pending().await,
+    }
+}
+
+async fn close_socket(socket: &mut WebSocket, code: u16, reason: &'static str) {
+    let _ = socket
+        .send(Message::Close(Some(CloseFrame {
+            code,
+            reason: reason.into(),
+        })))
+        .await;
+}
+
+enum MessageOutcome {
+    Continue,
+    Disconnect(&'static str),
+}

--- a/qq-maid-gateway-rs/src/gateway/onebot11/server.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/server.rs
@@ -147,6 +147,8 @@ async fn handle_socket(
     let replaced = CancellationToken::new();
     let mut registration = None;
     let mut identity_deadline = Some(Instant::now() + state.config.request_timeout);
+    // OneBot 11 heartbeat 在当前接入中是可选能力：连接只上报 self_id 也可长期存活；
+    // 仅在收到首个 heartbeat 后，才按客户端声明的 interval 启动连续心跳监督。
     let mut heartbeat_deadline = None;
     let mut disconnect_summary = "client disconnected";
 
@@ -291,7 +293,13 @@ async fn handle_message(
                 return MessageOutcome::Disconnect("invalid API response");
             }
         };
-        state.connection.dispatch_response(response);
+        let Some(registration) = registration.as_ref() else {
+            debug!("ignoring OneBot API response before self_id registration");
+            return MessageOutcome::Continue;
+        };
+        state
+            .connection
+            .dispatch_response(registration.generation, response);
         return MessageOutcome::Continue;
     }
     let event = match serde_json::from_value::<OneBotEvent>(value) {

--- a/qq-maid-gateway-rs/src/gateway/onebot11/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/tests.rs
@@ -2,7 +2,7 @@ use std::{net::SocketAddr, time::Duration};
 
 use futures_util::{SinkExt, StreamExt};
 use serde_json::{Value, json};
-use tokio::net::TcpStream;
+use tokio::{net::TcpStream, sync::mpsc, time::Instant};
 use tokio_tungstenite::{
     MaybeTlsStream, WebSocketStream, connect_async,
     tungstenite::{
@@ -15,10 +15,15 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     config::OneBot11Config,
-    gateway::{onebot11::protocol::ActionRequest, ping::GatewayRuntimeStatus},
+    gateway::{
+        onebot11::protocol::{ActionRequest, ActionResponse, OneBotId},
+        ping::GatewayRuntimeStatus,
+    },
 };
 
-use super::{OneBotCallError, OneBotServerHandle, spawn_reverse_websocket_server};
+use super::{
+    OneBotCallError, OneBotConnectionContext, OneBotServerHandle, spawn_reverse_websocket_server,
+};
 
 const TOKEN: &str = "test-onebot-access-token";
 const PATH: &str = "/onebot/v11/ws";
@@ -89,6 +94,24 @@ async fn next_close(socket: &mut ClientSocket) -> Option<String> {
     })
     .await
     .unwrap()
+}
+
+async fn next_action_request(socket: &mut ClientSocket) -> ActionRequest {
+    match socket.next().await.unwrap().unwrap() {
+        Message::Text(payload) => serde_json::from_str(&payload).unwrap(),
+        other => panic!("expected text action request, got {other:?}"),
+    }
+}
+
+fn action_response(request: &ActionRequest, data: Value) -> ActionResponse {
+    ActionResponse {
+        status: "ok".to_owned(),
+        retcode: 0,
+        data,
+        message: None,
+        wording: None,
+        echo: Some(request.echo.clone()),
+    }
 }
 
 #[tokio::test]
@@ -167,10 +190,7 @@ async fn lifecycle_heartbeat_and_api_response_share_one_connection() {
 
     let connection = handle.connection.clone();
     let call = tokio::spawn(async move { connection.call("get_status", json!({})).await });
-    let request = match client.next().await.unwrap().unwrap() {
-        Message::Text(payload) => serde_json::from_str::<ActionRequest>(&payload).unwrap(),
-        other => panic!("expected text action request, got {other:?}"),
-    };
+    let request = next_action_request(&mut client).await;
     client
         .send(Message::Text(
             json!({
@@ -186,6 +206,143 @@ async fn lifecycle_heartbeat_and_api_response_share_one_connection() {
         .unwrap();
     let response = call.await.unwrap().unwrap();
     assert_eq!(response.data, json!({"online": true}));
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn unregistered_connection_cannot_complete_active_request_with_forged_echo() {
+    let (handle, _runtime, shutdown) = spawn_server().await;
+    let mut active = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    let mut unregistered = connect(handle.local_addr, PATH, TOKEN, None).await.unwrap();
+
+    let connection = handle.connection.clone();
+    let mut call = tokio::spawn(async move { connection.call("get_status", json!({})).await });
+    let request = next_action_request(&mut active).await;
+    unregistered
+        .send(Message::Text(
+            serde_json::to_string(&action_response(&request, json!({"forged": true})))
+                .unwrap()
+                .into(),
+        ))
+        .await
+        .unwrap();
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), &mut call)
+            .await
+            .is_err(),
+        "未注册连接伪造的 echo 不应完成活动请求"
+    );
+    active
+        .send(Message::Text(
+            serde_json::to_string(&action_response(&request, json!({"forged": false})))
+                .unwrap()
+                .into(),
+        ))
+        .await
+        .unwrap();
+    let response = call.await.unwrap().unwrap();
+    assert_eq!(response.data, json!({"forged": false}));
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn stale_generation_response_cannot_complete_current_request() {
+    let context = OneBotConnectionContext::new(Duration::from_millis(500));
+    let self_id = OneBotId::new("10001").unwrap();
+    let (old_outbound, mut old_requests) = mpsc::channel(1);
+    let old_registration = context
+        .register(self_id.clone(), old_outbound, CancellationToken::new())
+        .unwrap();
+    let old_context = context.clone();
+    let old_call = tokio::spawn(async move { old_context.call("get_status", json!({})).await });
+    let _old_request: ActionRequest =
+        serde_json::from_str(&old_requests.recv().await.unwrap()).unwrap();
+
+    let (current_outbound, mut current_requests) = mpsc::channel(1);
+    let current_registration = context
+        .register(self_id, current_outbound, CancellationToken::new())
+        .unwrap();
+    assert!(matches!(
+        old_call.await.unwrap(),
+        Err(OneBotCallError::ConnectionClosed)
+    ));
+
+    let current_context = context.clone();
+    let mut current_call =
+        tokio::spawn(async move { current_context.call("get_status", json!({})).await });
+    let current_request: ActionRequest =
+        serde_json::from_str(&current_requests.recv().await.unwrap()).unwrap();
+    context.dispatch_response(
+        old_registration.generation,
+        action_response(&current_request, json!({"generation": "old"})),
+    );
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), &mut current_call)
+            .await
+            .is_err(),
+        "旧 generation 的 response 不应完成当前请求"
+    );
+
+    context.dispatch_response(
+        current_registration.generation,
+        action_response(&current_request, json!({"generation": "current"})),
+    );
+    let response = current_call.await.unwrap().unwrap();
+    assert_eq!(response.data, json!({"generation": "current"}));
+}
+
+#[tokio::test]
+async fn outbound_queue_wait_is_included_in_request_timeout() {
+    let request_timeout = Duration::from_millis(50);
+    let context = OneBotConnectionContext::new(request_timeout);
+    let (outbound, _requests) = mpsc::channel(1);
+    outbound.send("occupied".to_owned()).await.unwrap();
+    context
+        .register(
+            OneBotId::new("10001").unwrap(),
+            outbound,
+            CancellationToken::new(),
+        )
+        .unwrap();
+
+    let started = Instant::now();
+    let result = tokio::time::timeout(
+        Duration::from_millis(500),
+        context.call("get_status", json!({})),
+    )
+    .await
+    .expect("call 应由 request_timeout 自行结束，而不是持续阻塞在 outbound 队列");
+
+    assert!(matches!(result, Err(OneBotCallError::Timeout)));
+    assert!(started.elapsed() < Duration::from_millis(500));
+}
+
+#[tokio::test]
+async fn heartbeat_is_optional_until_client_sends_first_heartbeat() {
+    let mut config = test_config();
+    config.request_timeout = Duration::from_millis(50);
+    let runtime = GatewayRuntimeStatus::new();
+    let shutdown = CancellationToken::new();
+    let handle = spawn_reverse_websocket_server(config, runtime.clone(), shutdown.clone())
+        .await
+        .unwrap();
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    assert!(runtime.snapshot().onebot_connected);
+    let connection = handle.connection.clone();
+    let call = tokio::spawn(async move { connection.call("get_status", json!({})).await });
+    assert_eq!(next_action_request(&mut client).await.action, "get_status");
+    assert!(matches!(call.await.unwrap(), Err(OneBotCallError::Timeout)));
 
     shutdown.cancel();
     handle.task.await.unwrap().unwrap();

--- a/qq-maid-gateway-rs/src/gateway/onebot11/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/tests.rs
@@ -1,0 +1,363 @@
+use std::{net::SocketAddr, time::Duration};
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{Value, json};
+use tokio::net::TcpStream;
+use tokio_tungstenite::{
+    MaybeTlsStream, WebSocketStream, connect_async,
+    tungstenite::{
+        Message,
+        client::IntoClientRequest,
+        http::{HeaderValue, StatusCode},
+    },
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    config::OneBot11Config,
+    gateway::{onebot11::protocol::ActionRequest, ping::GatewayRuntimeStatus},
+};
+
+use super::{OneBotCallError, OneBotServerHandle, spawn_reverse_websocket_server};
+
+const TOKEN: &str = "test-onebot-access-token";
+const PATH: &str = "/onebot/v11/ws";
+type ClientSocket = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+fn test_config() -> OneBot11Config {
+    OneBot11Config {
+        enabled: true,
+        bind_host: "127.0.0.1".to_owned(),
+        bind_port: 0,
+        websocket_path: PATH.to_owned(),
+        access_token: Some(TOKEN.to_owned()),
+        request_timeout: Duration::from_millis(500),
+        max_message_bytes: 1024,
+    }
+}
+
+async fn spawn_server() -> (OneBotServerHandle, GatewayRuntimeStatus, CancellationToken) {
+    let runtime = GatewayRuntimeStatus::new();
+    let shutdown = CancellationToken::new();
+    let handle = spawn_reverse_websocket_server(test_config(), runtime.clone(), shutdown.clone())
+        .await
+        .unwrap();
+    (handle, runtime, shutdown)
+}
+
+async fn connect(
+    addr: SocketAddr,
+    path: &str,
+    token: &str,
+    self_id: Option<&str>,
+) -> Result<ClientSocket, tokio_tungstenite::tungstenite::Error> {
+    let mut request = format!("ws://{addr}{path}").into_client_request().unwrap();
+    request.headers_mut().insert(
+        "authorization",
+        HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+    );
+    if let Some(self_id) = self_id {
+        request
+            .headers_mut()
+            .insert("x-self-id", HeaderValue::from_str(self_id).unwrap());
+    }
+    connect_async(request).await.map(|(socket, _)| socket)
+}
+
+async fn wait_until(mut predicate: impl FnMut() -> bool) {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while !predicate() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+}
+
+async fn next_close(socket: &mut ClientSocket) -> Option<String> {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while let Some(message) = socket.next().await {
+            match message {
+                Ok(Message::Close(frame)) => {
+                    return frame.map(|frame| frame.reason.to_string());
+                }
+                Err(_) => return None,
+                _ => {}
+            }
+        }
+        None
+    })
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn rejects_wrong_token_and_wrong_path_without_stopping_listener() {
+    let (handle, runtime, shutdown) = spawn_server().await;
+
+    let auth_error = connect(handle.local_addr, PATH, "wrong-token", Some("10001"))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        auth_error,
+        tokio_tungstenite::tungstenite::Error::Http(response)
+            if response.status() == StatusCode::UNAUTHORIZED
+    ));
+    let path_error = connect(handle.local_addr, "/wrong", TOKEN, Some("10001"))
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        path_error,
+        tokio_tungstenite::tungstenite::Error::Http(response)
+            if response.status() == StatusCode::NOT_FOUND
+    ));
+
+    assert!(runtime.snapshot().onebot_listening);
+    let _valid = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    wait_until(|| runtime.snapshot().onebot_connected).await;
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+    assert!(!runtime.snapshot().onebot_listening);
+    assert!(!runtime.snapshot().onebot_connected);
+}
+
+#[tokio::test]
+async fn lifecycle_heartbeat_and_api_response_share_one_connection() {
+    let (handle, runtime, shutdown) = spawn_server().await;
+    let mut client = connect(handle.local_addr, PATH, TOKEN, None).await.unwrap();
+    client
+        .send(Message::Text(
+            json!({
+                "time": 1,
+                "self_id": 123456789012345678_u64,
+                "post_type": "meta_event",
+                "meta_event_type": "lifecycle",
+                "sub_type": "connect"
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+    client
+        .send(Message::Text(
+            json!({
+                "time": 2,
+                "self_id": "123456789012345678",
+                "post_type": "meta_event",
+                "meta_event_type": "heartbeat",
+                "interval": 1000,
+                "status": {"online": true}
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+    wait_until(|| runtime.snapshot().last_onebot_heartbeat_at.is_some()).await;
+    let snapshot = runtime.snapshot();
+    assert!(snapshot.onebot_connected);
+    assert_eq!(
+        snapshot.onebot_self_id_summary.as_deref(),
+        Some("******345678")
+    );
+
+    let connection = handle.connection.clone();
+    let call = tokio::spawn(async move { connection.call("get_status", json!({})).await });
+    let request = match client.next().await.unwrap().unwrap() {
+        Message::Text(payload) => serde_json::from_str::<ActionRequest>(&payload).unwrap(),
+        other => panic!("expected text action request, got {other:?}"),
+    };
+    client
+        .send(Message::Text(
+            json!({
+                "status": "ok",
+                "retcode": 0,
+                "data": {"online": true},
+                "echo": request.echo
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+    let response = call.await.unwrap().unwrap();
+    assert_eq!(response.data, json!({"online": true}));
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn same_account_replaces_old_connection_and_different_account_is_rejected() {
+    let (handle, runtime, shutdown) = spawn_server().await;
+    let mut first = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    wait_until(|| runtime.snapshot().onebot_connected).await;
+
+    let connection = handle.connection.clone();
+    let pending_call = tokio::spawn(async move { connection.call("get_status", json!({})).await });
+    assert!(matches!(
+        first.next().await.unwrap().unwrap(),
+        Message::Text(_)
+    ));
+    let _second = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    assert!(matches!(
+        pending_call.await.unwrap(),
+        Err(OneBotCallError::ConnectionClosed)
+    ));
+    assert_eq!(
+        next_close(&mut first).await.as_deref(),
+        Some("replaced by newer connection")
+    );
+    wait_until(|| runtime.snapshot().last_onebot_replaced_at.is_some()).await;
+    assert!(runtime.snapshot().onebot_connected);
+
+    let mut mismatch = connect(handle.local_addr, PATH, TOKEN, Some("20002"))
+        .await
+        .unwrap();
+    assert_eq!(
+        next_close(&mut mismatch).await.as_deref(),
+        Some("different self_id is not allowed")
+    );
+    assert!(runtime.snapshot().onebot_connected);
+    assert_eq!(
+        handle.connection.connected_self_id().unwrap().as_str(),
+        "10001"
+    );
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn invalid_json_is_isolated_and_client_can_reconnect() {
+    let (handle, runtime, shutdown) = spawn_server().await;
+    let mut invalid = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    invalid
+        .send(Message::Text("{not-json".into()))
+        .await
+        .unwrap();
+    assert_eq!(
+        next_close(&mut invalid).await.as_deref(),
+        Some("invalid JSON")
+    );
+    wait_until(|| !runtime.snapshot().onebot_connected).await;
+    assert_eq!(
+        runtime.snapshot().last_onebot_disconnect_summary.as_deref(),
+        Some("invalid JSON")
+    );
+    assert!(runtime.snapshot().onebot_listening);
+
+    let _reconnected = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    wait_until(|| runtime.snapshot().onebot_connected).await;
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn heartbeat_timeout_closes_only_the_client() {
+    let mut config = test_config();
+    config.request_timeout = Duration::from_millis(100);
+    let runtime = GatewayRuntimeStatus::new();
+    let shutdown = CancellationToken::new();
+    let handle = spawn_reverse_websocket_server(config, runtime.clone(), shutdown.clone())
+        .await
+        .unwrap();
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    client
+        .send(Message::Text(
+            json!({
+                "self_id": "10001",
+                "post_type": "meta_event",
+                "meta_event_type": "heartbeat",
+                "interval": 10,
+                "status": {"online": true}
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        next_close(&mut client).await.as_deref(),
+        Some("heartbeat timed out")
+    );
+    assert!(runtime.snapshot().onebot_listening);
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn api_request_timeout_does_not_drop_healthy_connection() {
+    let mut config = test_config();
+    config.request_timeout = Duration::from_millis(100);
+    let runtime = GatewayRuntimeStatus::new();
+    let shutdown = CancellationToken::new();
+    let handle = spawn_reverse_websocket_server(config, runtime.clone(), shutdown.clone())
+        .await
+        .unwrap();
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    wait_until(|| runtime.snapshot().onebot_connected).await;
+
+    let connection = handle.connection.clone();
+    let call = tokio::spawn(async move { connection.call("get_status", json!({})).await });
+    assert!(matches!(
+        client.next().await.unwrap().unwrap(),
+        Message::Text(_)
+    ));
+    assert!(matches!(call.await.unwrap(), Err(OneBotCallError::Timeout)));
+    assert!(runtime.snapshot().onebot_connected);
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn oversized_message_is_rejected_without_stopping_listener() {
+    let (handle, runtime, shutdown) = spawn_server().await;
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    client
+        .send(Message::Text("x".repeat(2048).into()))
+        .await
+        .unwrap();
+    let _ = next_close(&mut client).await;
+    wait_until(|| !runtime.snapshot().onebot_connected).await;
+    assert_eq!(
+        runtime.snapshot().last_onebot_disconnect_summary.as_deref(),
+        Some("message too large")
+    );
+    assert!(runtime.snapshot().onebot_listening);
+
+    let _reconnected = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    wait_until(|| runtime.snapshot().onebot_connected).await;
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[test]
+fn test_payload_helpers_do_not_require_float_id_round_trip() {
+    let value: Value = serde_json::from_str("123456789012345678").unwrap();
+    assert!(value.is_u64());
+}

--- a/qq-maid-gateway-rs/src/gateway/outbound.rs
+++ b/qq-maid-gateway-rs/src/gateway/outbound.rs
@@ -403,6 +403,7 @@ mod tests {
             media_download_timeout: Duration::from_secs(10),
             media_max_bytes: crate::config::DEFAULT_MEDIA_MAX_BYTES,
             wechat_service: crate::config::WechatServiceConfig::default(),
+            onebot11: crate::config::OneBot11Config::default(),
         }
     }
 

--- a/qq-maid-gateway-rs/src/gateway/ping/render.rs
+++ b/qq-maid-gateway-rs/src/gateway/ping/render.rs
@@ -4,7 +4,7 @@ use qq_maid_common::time_context::{
 
 use crate::{
     auth::{AccessTokenSnapshot, AccessTokenSnapshotState},
-    config::{AppConfig, WechatServiceConfig},
+    config::{AppConfig, OneBot11Config, WechatServiceConfig},
     gateway::{
         event::C2cMessage,
         logging::{mask_identifier, mask_scope_key},
@@ -134,6 +134,8 @@ fn render_ping_debug_details(
     lines.extend(render_debug_config(config, token_snapshot));
     lines.push(String::new());
     lines.extend(render_debug_wechat_service(&config.wechat_service));
+    lines.push(String::new());
+    lines.extend(render_debug_onebot11(&config.onebot11, snapshot));
     lines
 }
 
@@ -337,6 +339,46 @@ fn render_debug_wechat_service(config: &WechatServiceConfig) -> Vec<String> {
             .to_owned(),
         "- 暂不支持：加密 XML、模板消息、图片/语音/视频、菜单事件、主动推送、流式输出"
             .to_owned(),
+    ]
+}
+
+fn render_debug_onebot11(
+    config: &OneBot11Config,
+    snapshot: &GatewayRuntimeSnapshot,
+) -> Vec<String> {
+    vec![
+        "### OneBot 11".to_owned(),
+        format!("- 入口：{}", bool_text(config.enabled)),
+        format!("- 监听：{}", bool_text(snapshot.onebot_listening)),
+        format!("- 连接：{}", bool_text(snapshot.onebot_connected)),
+        format!("- bind：{}:{}", config.bind_host, config.bind_port),
+        format!("- websocket path：{}", config.websocket_path),
+        format!(
+            "- access token：{}",
+            secret_state_text(config.access_token.as_deref())
+        ),
+        format!(
+            "- self_id：{}",
+            option_text(snapshot.onebot_self_id_summary.as_deref())
+        ),
+        format!(
+            "- 最近心跳：{}",
+            diagnostic_time_option_text(snapshot.last_onebot_heartbeat_at.as_deref())
+        ),
+        format!(
+            "- 最近断开：{}",
+            diagnostic_time_option_text(snapshot.last_onebot_disconnected_at.as_deref())
+        ),
+        format!(
+            "- 断开摘要：{}",
+            option_text(snapshot.last_onebot_disconnect_summary.as_deref())
+        ),
+        format!(
+            "- request timeout：{}ms",
+            config.request_timeout.as_millis()
+        ),
+        format!("- max message bytes：{}", config.max_message_bytes),
+        "- 当前范围：连接与协议底座；消息 adapter / sender 尚未启用".to_owned(),
     ]
 }
 

--- a/qq-maid-gateway-rs/src/gateway/ping/status.rs
+++ b/qq-maid-gateway-rs/src/gateway/ping/status.rs
@@ -23,6 +23,15 @@ pub struct GatewayRuntimeSnapshot {
     pub qq_connected: bool,
     /// 微信服务号回调监听器是否已成功绑定且服务任务尚未退出。
     pub wechat_service_listening: bool,
+    /// OneBot 11 监听器与活动客户端分开记录，客户端异常断开不会等同于渠道退出。
+    pub onebot_listening: bool,
+    pub onebot_connected: bool,
+    /// 只保存脱敏后的 `self_id` 摘要，不能通过运行状态还原完整 QQ 号。
+    pub onebot_self_id_summary: Option<String>,
+    pub last_onebot_heartbeat_at: Option<String>,
+    pub last_onebot_disconnected_at: Option<String>,
+    pub last_onebot_disconnect_summary: Option<String>,
+    pub last_onebot_replaced_at: Option<String>,
     pub last_gateway_connected_at: Option<String>,
     pub last_ready_at: Option<String>,
     pub last_resumed_at: Option<String>,
@@ -88,6 +97,42 @@ impl GatewayRuntimeStatus {
 
     pub fn record_wechat_service_stopped(&self) {
         self.update_state(|state| state.wechat_service_listening = false);
+    }
+
+    pub fn record_onebot_listening(&self) {
+        self.update_state(|state| state.onebot_listening = true);
+    }
+
+    pub fn record_onebot_stopped(&self) {
+        self.update_state(|state| {
+            state.onebot_listening = false;
+            state.onebot_connected = false;
+        });
+    }
+
+    pub fn record_onebot_connected(&self, self_id_summary: String, replaced_existing: bool) {
+        self.update_state(|state| {
+            state.onebot_connected = true;
+            state.onebot_self_id_summary = Some(self_id_summary);
+            state.last_onebot_disconnect_summary = None;
+            if replaced_existing {
+                state.last_onebot_replaced_at = Some(now_unix_seconds_marker());
+            }
+        });
+    }
+
+    pub fn record_onebot_heartbeat(&self) {
+        self.update_state(|state| {
+            state.last_onebot_heartbeat_at = Some(now_unix_seconds_marker());
+        });
+    }
+
+    pub fn record_onebot_disconnected(&self, summary: impl Into<String>) {
+        self.update_state(|state| {
+            state.onebot_connected = false;
+            state.last_onebot_disconnected_at = Some(now_unix_seconds_marker());
+            state.last_onebot_disconnect_summary = Some(compact_summary(summary.into()));
+        });
     }
 
     pub fn record_ready(&self) {

--- a/qq-maid-gateway-rs/src/gateway/ping/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/ping/tests.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use crate::{
     auth::{AccessTokenManager, AccessTokenSnapshot, AccessTokenSnapshotState},
-    config::{AgentTypingConfig, AppConfig, WechatServiceConfig},
+    config::{AgentTypingConfig, AppConfig, OneBot11Config, WechatServiceConfig},
     gateway::event::C2cMessage,
 };
 use qq_maid_core::service::{CoreHealthSnapshot, UpstreamStatusSnapshot};
@@ -54,6 +54,7 @@ fn config() -> AppConfig {
         media_download_timeout: Duration::from_secs(10),
         media_max_bytes: crate::config::DEFAULT_MEDIA_MAX_BYTES,
         wechat_service: crate::config::WechatServiceConfig::default(),
+        onebot11: crate::config::OneBot11Config::default(),
     }
 }
 
@@ -136,6 +137,10 @@ fn runtime_records_recent_events_without_full_message_id() {
     runtime.record_respond_failure("http status 500\nwith details");
     runtime.record_qq_send_success();
     runtime.record_qq_send_failure("request failed timeout with a long but safe summary");
+    runtime.record_onebot_listening();
+    runtime.record_onebot_connected("******123456".to_owned(), false);
+    runtime.record_onebot_heartbeat();
+    runtime.record_onebot_disconnected("invalid JSON");
 
     let snapshot = runtime.snapshot();
 
@@ -163,6 +168,17 @@ fn runtime_records_recent_events_without_full_message_id() {
     );
     assert!(snapshot.last_qq_send_success_at.is_some());
     assert!(snapshot.last_qq_send_failure_at.is_some());
+    assert!(snapshot.onebot_listening);
+    assert!(!snapshot.onebot_connected);
+    assert_eq!(
+        snapshot.onebot_self_id_summary.as_deref(),
+        Some("******123456")
+    );
+    assert!(snapshot.last_onebot_heartbeat_at.is_some());
+    assert_eq!(
+        snapshot.last_onebot_disconnect_summary.as_deref(),
+        Some("invalid JSON")
+    );
 
     runtime.record_gateway_connected();
     runtime.record_wechat_service_listening();
@@ -294,6 +310,9 @@ fn renders_ping_all_with_debug_details_without_secrets() {
     assert!(reply.contains("当前 scope_key：private:******123456"));
     assert!(reply.contains("访问令牌缓存：cached, expires_in=120s"));
     assert!(reply.contains("### 微信服务号"));
+    assert!(reply.contains("### OneBot 11"));
+    assert!(reply.contains("- access token：missing"));
+    assert!(reply.contains("- 当前范围：连接与协议底座；消息 adapter / sender 尚未启用"));
     assert!(reply.contains("- 入口：disabled"));
     assert!(reply.contains("- 监听：127.0.0.1:8788"));
     assert!(reply.contains("- callback path：/wechat/service"));
@@ -313,6 +332,39 @@ fn renders_ping_all_with_debug_details_without_secrets() {
     assert!(!reply.contains("real-token"));
     assert!(!reply.contains("app-secret-value"));
     assert!(!reply.contains("Authorization"));
+}
+
+#[test]
+fn renders_onebot_security_summary_without_token_or_full_self_id() {
+    let mut config = config();
+    config.onebot11 = OneBot11Config {
+        enabled: true,
+        access_token: Some("real-onebot-token".to_owned()),
+        ..OneBot11Config::default()
+    };
+    let runtime = GatewayRuntimeStatus::new_for_test();
+    runtime.record_onebot_listening();
+    runtime.record_onebot_connected("******345678".to_owned(), false);
+    runtime.record_onebot_heartbeat();
+
+    let reply = render_c2c_ping_reply_at(
+        &message_with_content("/ping all"),
+        &config,
+        &runtime,
+        &token_snapshot(),
+        &health("ok(in-process)", LlmUpstreamSnapshot::Unverified),
+        PingMode::All,
+        1200,
+    );
+
+    assert!(reply.contains("### OneBot 11"));
+    assert!(reply.contains("- 入口：enabled"));
+    assert!(reply.contains("- 监听：enabled"));
+    assert!(reply.contains("- 连接：enabled"));
+    assert!(reply.contains("- access token：configured"));
+    assert!(reply.contains("- self_id：******345678"));
+    assert!(!reply.contains("real-onebot-token"));
+    assert!(!reply.contains("123456345678"));
 }
 
 #[test]

--- a/qq-maid-gateway-rs/src/gateway/stream/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests.rs
@@ -289,6 +289,7 @@ fn test_config() -> AppConfig {
         media_download_timeout: Duration::from_secs(10),
         media_max_bytes: crate::config::DEFAULT_MEDIA_MAX_BYTES,
         wechat_service: crate::config::WechatServiceConfig::default(),
+        onebot11: crate::config::OneBot11Config::default(),
     }
 }
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -83,6 +83,24 @@ KNOWLEDGE_DIR=/opt/qqbot/private/config/knowledge
 APP_DB_FILE=/opt/qqbot/data/app.db
 ```
 
+## OneBot 11 反向 WebSocket 连接底座
+
+OneBot 11 入口默认关闭，一期只提供单账号反向 WebSocket 的监听、Bearer 鉴权、生命周期/心跳、断线重连承接和后续 API sender 可复用的连接上下文；不会把业务消息送入 Core，也不会发送消息。
+
+```env
+ONEBOT11_ENABLED=true
+ONEBOT11_BIND_HOST=127.0.0.1
+ONEBOT11_BIND_PORT=8789
+ONEBOT11_WEBSOCKET_PATH=/onebot/v11/ws
+ONEBOT11_ACCESS_TOKEN=请使用独立随机值
+ONEBOT11_REQUEST_TIMEOUT_MS=10000
+ONEBOT11_MAX_MESSAGE_BYTES=1048576
+```
+
+OneBot 实现应以反向 WebSocket 客户端连接 `ws://127.0.0.1:8789/onebot/v11/ws`，并携带 `Authorization: Bearer <ONEBOT11_ACCESS_TOKEN>`。推荐只监听回环或受控内网；如需跨主机连接，应同时配置防火墙或受控隧道。首个账号会锁定当前进程的 `self_id`：同账号新连接替换旧连接，不同账号拒绝，重启进程后重新学习。运行状态只保存脱敏 `self_id`、是否监听/连接、最近心跳和固定断开摘要。
+
+QQ 凭证可留空，因此 OneBot-only 配置能启动监听；但一期没有业务 adapter，收到消息事件也不会回复。完整变量和默认值以 [`config/.env.example`](./config/.env.example) 为准。
+
 ## 微信服务号文本回调配置
 
 微信服务号入口是 Gateway 的可选能力，默认关闭。它实现“微信服务号收到文本消息 -> 同步 XML 文本回复”的快路径；当 Core 处理超过同步安全预算时，会先结束微信 HTTP 响应，避免微信侧超时重试导致重复执行。若已配置 AppID / AppSecret，则后台完成后通过客服文本消息补发最终结果。

--- a/runtime/config/.env.example
+++ b/runtime/config/.env.example
@@ -58,6 +58,22 @@ QQ_MAID_GROUP_ACTIVE_KEYWORDS=小女仆
 QQ_MAID_BOT_MENTION_IDS=
 
 # =============================================================================
+# OneBot 11 反向 WebSocket（可选，默认关闭）
+# =============================================================================
+# 一期只建立单账号连接与协议底座，不会把消息送入 Core，也不会发送消息。
+# OneBot 实现作为客户端连接 ws://ONEBOT11_BIND_HOST:ONEBOT11_BIND_PORT/ONEBOT11_WEBSOCKET_PATH，
+# Authorization 必须使用 Bearer ONEBOT11_ACCESS_TOKEN；不要提交真实 token。
+ONEBOT11_ENABLED=false
+ONEBOT11_BIND_HOST=127.0.0.1
+ONEBOT11_BIND_PORT=8789
+ONEBOT11_WEBSOCKET_PATH=/onebot/v11/ws
+ONEBOT11_ACCESS_TOKEN=
+# 用于首个 self_id 上报和后续 API request/response；范围 100..120000ms。
+ONEBOT11_REQUEST_TIMEOUT_MS=10000
+# 单条 WebSocket 消息上限，范围 1KiB..16MiB，默认 1MiB。
+ONEBOT11_MAX_MESSAGE_BYTES=1048576
+
+# =============================================================================
 # 微信测试号 / 服务号 Gateway（可选，默认关闭）
 # =============================================================================
 # 开启后 Gateway 会额外监听 WECHAT_SERVICE_BIND_HOST:WECHAT_SERVICE_BIND_PORT，


### PR DESCRIPTION
## 概要

- 增加默认关闭的 OneBot 11 单账号配置，覆盖监听地址、端口、静态 path、access token、请求超时和消息大小上限；支持不配置 QQ 凭证的 OneBot-only 启动
- 增加 OneBot 11 事件、消息段、action / response、echo、生命周期和心跳协议类型，ID 兼容 JSON 数字或字符串并以无精度损失的字符串形式保存
- 实现反向 WebSocket 服务端、Bearer 鉴权、首个 self_id 锁定、同账号新连接替换旧连接、异账号拒绝、心跳/请求超时、异常隔离和优雅退出
- 提供 adapter / sender 可复用的连接上下文和 API echo 关联，不在本期接入 Core 或实现消息发送
- 将 OneBot 纳入 QQ/微信共用的通用渠道监督，补充启动失败回滚、脱敏运行状态、/ping all、控制台摘要和配置文档
- 按职责拆分 OneBot protocol / connection / server / tests，并将原 1000+ 行配置文件中的测试迁至独立文件

## 连接策略

- 进程内首次识别的 self_id 作为单账号锁
- 同 self_id 新连接替换旧连接，并立即终止旧连接上的 pending API 请求
- 不同 self_id 连接返回策略关闭帧；只有重启进程后才会重新学习账号
- 单客户端非法 JSON、超大消息、超时或断开不会终止监听器及其它入口

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy -p qq-maid-gateway-rs --all-targets --all-features -- -D warnings`
- `cargo test -p qq-maid-gateway-rs --all-features`（398 passed）
- `cargo check -p qq-maid-gateway-rs --all-features`
- `cargo build -p qq-maid-gateway-rs --release --all-features`
- `git diff --check`

## 非目标

本 PR 不解析 OneBot 业务消息、不调用 Core、不实现文本发送或主动推送，也不支持多账号、OneBot 12、正向 WebSocket 或 HTTP webhook。

Closes #438