### PR TITLE
feat: 实现 OneBot 11 文本发送与主动推送

### DIFF
--- a/qq-maid-core/src/runtime/push.rs
+++ b/qq-maid-core/src/runtime/push.rs
@@ -12,6 +12,7 @@ use std::str::FromStr;
 use crate::{identity::parse_stable_scope_key, service::VisibleEntitySnapshot};
 
 pub const QQ_OFFICIAL_PLATFORM: &str = "qq_official";
+pub const ONEBOT11_PLATFORM: &str = "onebot11";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PushTargetType {
@@ -68,6 +69,19 @@ impl PushTarget {
         Self::new(QQ_OFFICIAL_PLATFORM, None, target_type, target_id)
     }
 
+    pub fn onebot11(
+        account_id: impl Into<String>,
+        target_type: PushTargetType,
+        target_id: impl Into<String>,
+    ) -> Self {
+        Self::new(
+            ONEBOT11_PLATFORM,
+            Some(account_id.into()),
+            target_type,
+            target_id,
+        )
+    }
+
     /// 从新 stable scope 中继承 platform/account；旧 scope 或不可解析 scope 仍按 QQ 官方处理。
     ///
     /// 业务存储里 `scope_key` 只承担身份隔离语义，这里只在生成主动推送目标时读取其中
@@ -122,6 +136,29 @@ mod tests {
         assert_eq!(target.account_id, None);
         assert_eq!(target.target_id, "legacy-openid");
     }
+
+    #[test]
+    fn onebot_helper_requires_explicit_account_and_uses_gateway_platform_name() {
+        let target = PushTarget::onebot11("bot-1", PushTargetType::Group, "group-1");
+
+        assert_eq!(target.platform, ONEBOT11_PLATFORM);
+        assert_eq!(target.account_id.as_deref(), Some("bot-1"));
+        assert_eq!(target.target_type, PushTargetType::Group);
+        assert_eq!(target.target_id, "group-1");
+    }
+
+    #[test]
+    fn core_onebot_scope_is_normalized_for_gateway_routing() {
+        let target = PushTarget::from_scope_key_or_qq_official(
+            "platform:onebot:account:bot-1:private:user-1",
+            PushTargetType::Private,
+            "user-1",
+        );
+
+        assert_eq!(target.platform, ONEBOT11_PLATFORM);
+        assert_eq!(target.account_id.as_deref(), Some("bot-1"));
+        assert_eq!(target.target_id, "user-1");
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -151,10 +188,12 @@ pub trait PushSink: Send + Sync {
 
 fn clean_or_default_platform(value: String) -> String {
     let value = value.trim();
-    if value.is_empty() {
-        QQ_OFFICIAL_PLATFORM.to_owned()
-    } else {
-        value.to_owned()
+    match value {
+        "" => QQ_OFFICIAL_PLATFORM.to_owned(),
+        // CoreService 的稳定会话平台名是 `onebot`，Gateway 的协议/路由名是
+        // `onebot11`。只在投递目标边界规范化，不能改写既有 session scope。
+        "onebot" => ONEBOT11_PLATFORM.to_owned(),
+        other => other.to_owned(),
     }
 }
 

--- a/qq-maid-gateway-rs/README.md
+++ b/qq-maid-gateway-rs/README.md
@@ -38,7 +38,7 @@ flowchart LR
         delivery_target["DeliveryTarget / raw_target_id"]
         capability["ReplyCapability"]
         qq_sender["QQ sender"]
-        onebot_sender["OneBot sender（预留）"]
+        onebot_sender["OneBot text sender"]
         wechat_sender["微信 sender"]
     end
 
@@ -61,7 +61,7 @@ flowchart LR
 
 - `InboundMessage` 是 Gateway 内部的平台无关入站模型，包含 `Actor` 与 `Conversation`。QQ、OneBot、微信等协议字段只能在各自 adapter 内解析。
 - `CoreRequest` 是 Gateway 调用 Core 的稳定契约。Core 可以看到平台枚举、Actor 和 Conversation，但不理解 QQ `msg_seq`、stream id、微信 XML 字段或 OneBot CQ 片段。
-- OneBot 11 已实现默认关闭的单账号反向 WebSocket server、鉴权、生命周期/心跳、连接替换、API request/response 共用连接上下文和脱敏状态；当前仍不解析业务消息、不调用 Core，也不实现具体 sender 或主动推送路由。
+- OneBot 11 已实现默认关闭的单账号反向 WebSocket server、鉴权、生命周期/心跳、连接替换、API request/response 共用连接上下文、文本 sender 和主动推送精确路由；当前 OneBot 入口尚不调用 Core，也不实现流式或富媒体发送。
 - `scope_key` / `owner_key` 是业务隔离键，用于 Session、Pending、Memory、Todo 等状态归属，不是发送地址。
 - `ReplyTarget` / `DeliveryTarget` 保存真实投递目标，必须保留平台和 `raw_target_id`。发送逻辑只能使用投递目标调用 sender，不能从 `scope_key` 或 `owner_key` 反解析平台 ID。
 - RSS、Notification、Todo 提醒和 Push 这类主动投递也必须携带原始 delivery target；后续多平台收敛时不要把目标统一替换成 namespaced 字符串。
@@ -75,7 +75,7 @@ flowchart LR
 - Markdown 和图片保留独立 outbound 类型、payload 构造和发送入口；发送失败会 warn 并 fallback 到文本。C2C 流式回复当前固定使用 Markdown 流式载荷，首帧成功后不再补发普通全文。
 - Core 的统一通知 Worker 和 Todo 每日提醒通过进程内 `PushSink` 主动推送；RSS 只生产 Notification Outbox 任务，不再维护独立发送链路。
 - 微信服务号入口默认关闭；启用后处理 GET URL 验证、POST 明文 `text` XML、同步文本 XML 快路径，以及超出同步安全预算后的客服文本补发。客服补发按需获取 `access_token`，Markdown 会降级为 text。
-- OneBot 11 入口默认关闭；启用后只建立单账号反向 WebSocket 连接。首次账号会锁定进程内 `self_id`，同账号新连接替换旧连接，不同账号会被拒绝；连接异常不会结束监听器或其它入口。
+- OneBot 11 入口默认关闭；启用后建立单账号反向 WebSocket 连接，并通过同一连接发送私聊/群聊文本 action。首次账号会锁定进程内 `self_id`，同账号新连接替换旧连接，不同账号会被拒绝；连接异常不会结束监听器或其它入口，未完成发送会返回可重试错误。
 - 不做频道、频道私信、Ark、Embed、Keyboard、多租户或旧接入层兼容。
 - 微信服务号暂不做加密 XML、模板消息、图片语音视频、菜单事件、主动推送或流式输出；客服消息只实现慢请求文本补发。
 
@@ -106,6 +106,7 @@ flowchart LR
 - `src/gateway/platform/wechat_service.rs`：微信服务号平台字段到统一 `InboundMessage` / `CoreRequest` 的映射，以及 XML 解析和渲染 helper。
 - `src/gateway/onebot11/protocol.rs`：OneBot 11 事件、消息段、action / response、`echo`、生命周期、心跳和无精度损失 ID 类型。
 - `src/gateway/onebot11/connection.rs`：单账号活动连接、同账号替换策略和 API `echo` 关联上下文。
+- `src/gateway/onebot11/sender.rs`：`send_private_msg` / `send_group_msg` 文本 segment、真实响应校验和平台消息 ID 提取。
 - `src/gateway/onebot11/server.rs`：反向 WebSocket 监听、路径与 Bearer 鉴权、连接事件循环、超时和优雅退出。
 
 维护时应尽量保持这些边界，不要把 WebSocket 协议细节、Core 业务调用和 QQ 发送状态记录重新堆回同一个超长文件。

--- a/qq-maid-gateway-rs/src/gateway/console.rs
+++ b/qq-maid-gateway-rs/src/gateway/console.rs
@@ -150,6 +150,14 @@ impl ConsoleStatusSource for GatewayConsoleStatusSource {
 
         let onebot_configured = self.config.onebot11.access_token.is_some();
         let onebot_enabled = self.config.onebot11.enabled;
+        let onebot_capability = ReplyCapability::onebot11_text();
+        let onebot_unavailable = if !onebot_configured {
+            Some(ConsoleValueState::NotConfigured)
+        } else if !onebot_enabled {
+            Some(ConsoleValueState::Disabled)
+        } else {
+            None
+        };
         let onebot = ConsolePlatformStatus {
             id: "onebot11".to_owned(),
             label: "OneBot 11".to_owned(),
@@ -172,16 +180,15 @@ impl ConsoleStatusSource for GatewayConsoleStatusSource {
             resumed_at: None,
             capability_scopes: vec![ConsoleCapabilityScope {
                 id: "reverse_websocket".to_owned(),
-                label: "反向 WebSocket（协议底座）".to_owned(),
+                label: "反向 WebSocket".to_owned(),
                 enabled: onebot_enabled,
-                capabilities: unavailable_directional_capabilities(if !onebot_configured {
-                    ConsoleValueState::NotConfigured
-                } else if !onebot_enabled {
-                    ConsoleValueState::Disabled
-                } else {
-                    // #438 不接业务消息和发送；控制台不能把 transport 在线误报为文本能力可用。
-                    ConsoleValueState::NotAvailable
-                }),
+                capabilities: onebot_unavailable
+                    .map(unavailable_directional_capabilities)
+                    .unwrap_or(ConsoleDirectionalCapabilities {
+                        // #440 不调用 Core；仅 sender 和主动推送出站文本可用。
+                        inbound: unavailable_capabilities(ConsoleValueState::NotAvailable),
+                        outbound: reply_capabilities(onebot_capability),
+                    }),
             }],
         };
 
@@ -463,7 +470,7 @@ mod tests {
     }
 
     #[test]
-    fn onebot_foundation_reports_transport_state_without_business_capabilities() {
+    fn onebot_reports_text_only_non_streaming_outbound_capability() {
         let config = AppConfig::from_map(&HashMap::from([
             ("QQ_BOT_ENABLED".to_owned(), "false".to_owned()),
             ("ONEBOT11_ENABLED".to_owned(), "true".to_owned()),
@@ -486,6 +493,11 @@ mod tests {
             scope(onebot, "reverse_websocket").capabilities.inbound.text,
             ConsoleValueState::NotAvailable
         );
+        let outbound = &scope(onebot, "reverse_websocket").capabilities.outbound;
+        assert_eq!(outbound.text, ConsoleValueState::Supported);
+        assert_eq!(outbound.markdown, ConsoleValueState::Unsupported);
+        assert_eq!(outbound.image, ConsoleValueState::Unsupported);
+        assert_eq!(outbound.streaming, ConsoleValueState::Unsupported);
         let json = serde_json::to_string(&snapshot).unwrap();
         assert!(!json.contains("private-onebot-token"));
         assert!(!json.contains("123456123456"));

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -96,7 +96,12 @@ pub async fn run(
         )
         .await
         {
-            Ok(server) => Some(server.task),
+            Ok(server) => {
+                // sender 与反向 WebSocket 复用同一个 connection context；离线、替换和断线
+                // 都由该上下文返回真实错误，不能另建连接或伪造推送成功。
+                push_sink.bind_onebot11(onebot11::OneBotSender::new(server.connection.clone()));
+                Some(server.task)
+            }
             Err(error) => {
                 // 多入口按顺序 bind；后启动的入口失败时必须回收已启动监听器，
                 // 避免 run 返回错误后仍留下不可监督的后台任务。
@@ -118,6 +123,7 @@ pub async fn run(
             }
         }
     } else {
+        push_sink.mark_onebot11_unavailable("OneBot 11 channel is disabled");
         None
     };
     let ref_index = ref_index();

--- a/qq-maid-gateway-rs/src/gateway/onebot11/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/mod.rs
@@ -1,13 +1,15 @@
 //! OneBot 11 反向 WebSocket 单账号连接底座。
 //!
-//! 当前模块只管理协议、鉴权、连接和 API request/response 关联，不把业务事件送入 Core，
-//! 也不实现具体消息发送 action。后续 adapter 与 sender 必须复用这里的连接上下文。
+//! 当前模块管理协议、鉴权、连接、API request/response 关联和一期文本 sender，
+//! 暂不把业务事件送入 Core。后续 adapter 必须复用这里的连接与 sender 边界。
 
 mod connection;
 pub mod protocol;
+mod sender;
 mod server;
 
 pub use connection::{OneBotCallError, OneBotConnectionContext};
+pub use sender::{OneBotSendError, OneBotSendResult, OneBotSender};
 pub use server::{OneBotServerHandle, spawn_reverse_websocket_server};
 
 #[cfg(test)]

--- a/qq-maid-gateway-rs/src/gateway/onebot11/sender.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/sender.rs
@@ -1,0 +1,204 @@
+//! OneBot 11 一期文本 sender。
+//!
+//! sender 只负责把平台原始目标转换成 OneBot action，并以 API response 的真实结果
+//! 判定发送成功。消息正文始终使用 segment 数组，Core 和主动推送层不接触 CQ 码。
+
+use std::time::Instant;
+
+use serde::Deserialize;
+use serde_json::json;
+use thiserror::Error;
+use tracing::{info, warn};
+
+use crate::gateway::logging::mask_identifier;
+
+use super::{
+    OneBotCallError, OneBotConnectionContext,
+    protocol::{ActionResponse, OneBotId},
+};
+
+const SEND_PRIVATE_MSG: &str = "send_private_msg";
+const SEND_GROUP_MSG: &str = "send_group_msg";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OneBotSendResult {
+    /// OneBot 平台返回的真实消息 ID；不能与 Todo 等内部业务 ID 混用。
+    pub message_id: String,
+}
+
+#[derive(Debug, Error)]
+pub enum OneBotSendError {
+    #[error(transparent)]
+    Transport(#[from] OneBotCallError),
+    #[error(
+        "OneBot API rejected the send action: status={status}, retcode={retcode}, remote_message_present={remote_message_present}"
+    )]
+    Rejected {
+        status: String,
+        retcode: i64,
+        /// 不保存服务端错误正文，只记录其是否存在，避免后续 Outbox 日志泄漏响应内容。
+        remote_message_present: bool,
+    },
+    #[error("OneBot API send response is missing a valid data.message_id")]
+    InvalidData,
+}
+
+impl OneBotSendError {
+    fn retcode(&self) -> Option<i64> {
+        match self {
+            Self::Rejected { retcode, .. } => Some(*retcode),
+            Self::Transport(_) | Self::InvalidData => None,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct OneBotSender {
+    connection: OneBotConnectionContext,
+}
+
+impl OneBotSender {
+    pub fn new(connection: OneBotConnectionContext) -> Self {
+        Self { connection }
+    }
+
+    pub fn connected_account_id(&self) -> Option<String> {
+        self.connection
+            .connected_self_id()
+            .map(|self_id| self_id.as_str().to_owned())
+    }
+
+    pub async fn send_private_text(
+        &self,
+        user_id: &str,
+        text: &str,
+    ) -> Result<OneBotSendResult, OneBotSendError> {
+        self.send_text(SEND_PRIVATE_MSG, "user_id", user_id, text)
+            .await
+    }
+
+    pub async fn send_group_text(
+        &self,
+        group_id: &str,
+        text: &str,
+    ) -> Result<OneBotSendResult, OneBotSendError> {
+        self.send_text(SEND_GROUP_MSG, "group_id", group_id, text)
+            .await
+    }
+
+    async fn send_text(
+        &self,
+        action: &'static str,
+        target_key: &'static str,
+        target_id: &str,
+        text: &str,
+    ) -> Result<OneBotSendResult, OneBotSendError> {
+        let started = Instant::now();
+        let params = json!({
+            target_key: OneBotId::new(target_id.to_owned()).map_err(|_| OneBotSendError::InvalidData)?,
+            "message": [{"type": "text", "data": {"text": text}}]
+        });
+        let result = self
+            .connection
+            .call(action, params)
+            .await
+            .map_err(OneBotSendError::from)
+            .and_then(validate_send_response);
+        let elapsed_ms = started.elapsed().as_millis();
+        let target = mask_identifier(target_id);
+        match &result {
+            Ok(_) => info!(
+                action,
+                retcode = 0,
+                elapsed_ms,
+                target = %target,
+                "OneBot 11 text sent"
+            ),
+            Err(error) => warn!(
+                action,
+                retcode = ?error.retcode(),
+                elapsed_ms,
+                target = %target,
+                "OneBot 11 text send failed"
+            ),
+        }
+        result
+    }
+}
+
+#[derive(Deserialize)]
+struct SendMessageData {
+    message_id: OneBotId,
+}
+
+fn validate_send_response(response: ActionResponse) -> Result<OneBotSendResult, OneBotSendError> {
+    if response.status != "ok" || response.retcode != 0 {
+        return Err(OneBotSendError::Rejected {
+            // status 由远端提供，错误链可能进入 Outbox 日志；只保留协议分类，
+            // 不回显任意字符串或完整 response envelope。
+            status: if response.status == "ok" {
+                "ok".to_owned()
+            } else {
+                "non-ok".to_owned()
+            },
+            retcode: response.retcode,
+            remote_message_present: response
+                .wording
+                .as_deref()
+                .or(response.message.as_deref())
+                .is_some_and(|message| !message.trim().is_empty()),
+        });
+    }
+    let data: SendMessageData =
+        serde_json::from_value(response.data).map_err(|_| OneBotSendError::InvalidData)?;
+    Ok(OneBotSendResult {
+        message_id: data.message_id.as_str().to_owned(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::gateway::onebot11::protocol::Echo;
+
+    fn response(status: &str, retcode: i64, data: serde_json::Value) -> ActionResponse {
+        ActionResponse {
+            status: status.to_owned(),
+            retcode,
+            data,
+            message: None,
+            wording: None,
+            echo: Some(Echo(json!("echo"))),
+        }
+    }
+
+    #[test]
+    fn accepts_numeric_or_string_message_id() {
+        let numeric =
+            validate_send_response(response("ok", 0, json!({"message_id": 123}))).unwrap();
+        let text = validate_send_response(response("ok", 0, json!({"message_id": "456"}))).unwrap();
+
+        assert_eq!(numeric.message_id, "123");
+        assert_eq!(text.message_id, "456");
+    }
+
+    #[test]
+    fn rejects_failed_status_nonzero_retcode_and_missing_message_id() {
+        let status =
+            validate_send_response(response("failed", 0, json!({"message_id": 1}))).unwrap_err();
+        let retcode = validate_send_response(response("failed", 1404, json!(null))).unwrap_err();
+        let missing = validate_send_response(response("ok", 0, json!({}))).unwrap_err();
+
+        assert!(matches!(
+            status,
+            OneBotSendError::Rejected { retcode: 0, .. }
+        ));
+        assert!(matches!(
+            retcode,
+            OneBotSendError::Rejected { retcode: 1404, .. }
+        ));
+        assert!(matches!(missing, OneBotSendError::InvalidData));
+    }
+}

--- a/qq-maid-gateway-rs/src/gateway/onebot11/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/tests.rs
@@ -22,7 +22,8 @@ use crate::{
 };
 
 use super::{
-    OneBotCallError, OneBotConnectionContext, OneBotServerHandle, spawn_reverse_websocket_server,
+    OneBotCallError, OneBotConnectionContext, OneBotSendError, OneBotSender, OneBotServerHandle,
+    spawn_reverse_websocket_server,
 };
 
 const TOKEN: &str = "test-onebot-access-token";
@@ -206,6 +207,191 @@ async fn lifecycle_heartbeat_and_api_response_share_one_connection() {
         .unwrap();
     let response = call.await.unwrap().unwrap();
     assert_eq!(response.data, json!({"online": true}));
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn concurrent_text_sends_use_unique_echo_and_complete_out_of_order() {
+    let (handle, _runtime, shutdown) = spawn_server().await;
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    let sender = OneBotSender::new(handle.connection.clone());
+    let private_sender = sender.clone();
+    let private = tokio::spawn(async move {
+        private_sender
+            .send_private_text("20002", "private body")
+            .await
+    });
+    let group = tokio::spawn(async move { sender.send_group_text("30003", "group body").await });
+
+    let first = next_action_request(&mut client).await;
+    let second = next_action_request(&mut client).await;
+    assert_ne!(first.echo, second.echo);
+    for request in [&first, &second] {
+        let (target_key, target_id, body) = match request.action.as_str() {
+            "send_private_msg" => ("user_id", "20002", "private body"),
+            "send_group_msg" => ("group_id", "30003", "group body"),
+            action => panic!("unexpected action {action}"),
+        };
+        assert_eq!(request.params[target_key], json!(target_id));
+        assert_eq!(
+            request.params["message"],
+            json!([{"type": "text", "data": {"text": body}}])
+        );
+    }
+
+    for request in [&second, &first] {
+        let message_id = if request.action == "send_private_msg" {
+            json!(90001)
+        } else {
+            json!("90002")
+        };
+        client
+            .send(Message::Text(
+                serde_json::to_string(&action_response(request, json!({"message_id": message_id})))
+                    .unwrap()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+    }
+
+    assert_eq!(private.await.unwrap().unwrap().message_id, "90001");
+    assert_eq!(group.await.unwrap().unwrap().message_id, "90002");
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn unknown_echo_does_not_complete_pending_send() {
+    let (handle, _runtime, shutdown) = spawn_server().await;
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    let sender = OneBotSender::new(handle.connection.clone());
+    let mut send = tokio::spawn(async move { sender.send_private_text("20002", "hello").await });
+    let request = next_action_request(&mut client).await;
+    let mut unknown = action_response(&request, json!({"message_id": 1}));
+    unknown.echo = Some(crate::gateway::onebot11::protocol::Echo(json!("unknown")));
+    client
+        .send(Message::Text(
+            serde_json::to_string(&unknown).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), &mut send)
+            .await
+            .is_err()
+    );
+
+    client
+        .send(Message::Text(
+            serde_json::to_string(&action_response(&request, json!({"message_id": "real-id"})))
+                .unwrap()
+                .into(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(send.await.unwrap().unwrap().message_id, "real-id");
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn sender_propagates_retcode_failure_without_forging_success() {
+    let (handle, _runtime, shutdown) = spawn_server().await;
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    let sender = OneBotSender::new(handle.connection.clone());
+    let send = tokio::spawn(async move { sender.send_group_text("30003", "hello").await });
+    let request = next_action_request(&mut client).await;
+    client
+        .send(Message::Text(
+            json!({
+                "status": "failed",
+                "retcode": 1404,
+                "data": null,
+                "message": "failed remotely",
+                "wording": "target unavailable",
+                "echo": request.echo
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+
+    assert!(matches!(
+        send.await.unwrap(),
+        Err(OneBotSendError::Rejected {
+            retcode: 1404,
+            remote_message_present: true,
+            ..
+        })
+    ));
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn sender_returns_explicit_offline_and_disconnect_errors() {
+    let (handle, _runtime, shutdown) = spawn_server().await;
+    let sender = OneBotSender::new(handle.connection.clone());
+    assert!(matches!(
+        sender.send_private_text("20002", "offline").await,
+        Err(OneBotSendError::Transport(OneBotCallError::NotConnected))
+    ));
+
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    let pending_sender = sender.clone();
+    let pending = tokio::spawn(async move {
+        pending_sender
+            .send_private_text("20002", "disconnect")
+            .await
+    });
+    let _request = next_action_request(&mut client).await;
+    client.close(None).await.unwrap();
+    assert!(matches!(
+        pending.await.unwrap(),
+        Err(OneBotSendError::Transport(
+            OneBotCallError::ConnectionClosed
+        ))
+    ));
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn sender_propagates_action_timeout() {
+    let mut config = test_config();
+    config.request_timeout = Duration::from_millis(50);
+    let runtime = GatewayRuntimeStatus::new();
+    let shutdown = CancellationToken::new();
+    let handle = spawn_reverse_websocket_server(config, runtime, shutdown.clone())
+        .await
+        .unwrap();
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    let sender = OneBotSender::new(handle.connection.clone());
+    let send = tokio::spawn(async move { sender.send_private_text("20002", "timeout").await });
+    let _request = next_action_request(&mut client).await;
+
+    assert!(matches!(
+        send.await.unwrap(),
+        Err(OneBotSendError::Transport(OneBotCallError::Timeout))
+    ));
 
     shutdown.cancel();
     handle.task.await.unwrap().unwrap();

--- a/qq-maid-gateway-rs/src/gateway/outbound.rs
+++ b/qq-maid-gateway-rs/src/gateway/outbound.rs
@@ -76,6 +76,30 @@ impl ReplyTarget {
         }
     }
 
+    #[allow(dead_code)]
+    pub(crate) fn onebot_private(
+        target_id: impl Into<String>,
+        source_message_id: Option<String>,
+    ) -> Self {
+        Self::Private {
+            platform: Platform::OneBot11,
+            target_id: target_id.into(),
+            source_message_id,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn onebot_group(
+        target_id: impl Into<String>,
+        source_message_id: Option<String>,
+    ) -> Self {
+        Self::Group {
+            platform: Platform::OneBot11,
+            target_id: target_id.into(),
+            source_message_id,
+        }
+    }
+
     pub(crate) fn to_qq_c2c_target(&self) -> Option<C2cReplyTarget> {
         match self {
             Self::Private {
@@ -203,6 +227,33 @@ impl ReplyCapability {
                         .markdown_chunk_soft_limit
                         .max(config.text_chunk_soft_limit),
                 ),
+                reply_timeout: None,
+            },
+            long_running_strategy: LongRunningReplyStrategy::KeepAsyncDelivery,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn onebot11_text() -> Self {
+        Self {
+            platform: Platform::OneBot11,
+            render: RenderProfile {
+                supports_text: true,
+                supports_markdown: false,
+                supports_image: false,
+                supports_attachment: false,
+                unsupported_fallback: UnsupportedCapabilityFallback::UseText,
+            },
+            supports_quote_original: false,
+            supports_at_mention: false,
+            supports_multi_part: false,
+            image_delivery_implemented: false,
+            supports_synchronous_reply: false,
+            supports_asynchronous_reply: true,
+            streaming_delivery_implemented: false,
+            supports_streaming: false,
+            limits: ReplyLimits {
+                single_message_chars: None,
                 reply_timeout: None,
             },
             long_running_strategy: LongRunningReplyStrategy::KeepAsyncDelivery,
@@ -488,5 +539,22 @@ mod tests {
             capability.limits.reply_timeout,
             Some(Duration::from_secs(5))
         );
+    }
+
+    #[test]
+    fn onebot_capability_is_text_only_async_and_non_streaming() {
+        let capability = ReplyCapability::onebot11_text();
+
+        assert_eq!(capability.platform, Platform::OneBot11);
+        assert!(capability.render.supports_text);
+        assert!(!capability.render.supports_markdown);
+        assert!(!capability.render.supports_image);
+        assert_eq!(
+            capability.render.unsupported_fallback,
+            UnsupportedCapabilityFallback::UseText
+        );
+        assert!(capability.supports_delivery_mode(DeliveryMode::AsynchronousReply));
+        assert!(!capability.supports_delivery_mode(DeliveryMode::SynchronousReply));
+        assert!(!capability.supports_delivery_mode(DeliveryMode::Streaming));
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/push.rs
+++ b/qq-maid-gateway-rs/src/gateway/push.rs
@@ -1,7 +1,7 @@
 //! Gateway 进程内主动推送实现。
 //!
-//! Core 只通过 `PushSink` 交付推送意图；本模块负责 QQ 平台发送、Markdown
-//! 失败后的文本 fallback、发送状态记录，以及群推送成功后的 BotOutboundCache 回填。
+//! Core 只通过 `PushSink` 交付推送意图；本模块按 platform/account 精确选择 sender。
+//! QQ 官方继续负责 Markdown fallback 和群消息缓存；OneBot 只发送纯文本 segment。
 
 use std::{
     sync::{Arc, Mutex},
@@ -10,9 +10,10 @@ use std::{
 
 use async_trait::async_trait;
 use qq_maid_core::runtime::push::{
-    PushError, PushIntent, PushResult, PushSink, PushTargetType, QQ_OFFICIAL_PLATFORM,
+    ONEBOT11_PLATFORM, PushError, PushIntent, PushResult, PushSink, PushTargetType,
+    QQ_OFFICIAL_PLATFORM,
 };
-use tokio::{sync::Notify, time::timeout};
+use tokio::{sync::Notify, time::Instant};
 use tracing::{info, warn};
 
 use crate::{
@@ -20,8 +21,12 @@ use crate::{
         QqApiClient, SendMessageIds, SendResult, build_c2c_text_payload, build_group_text_payload,
     },
     gateway::{
-        BotOutboundCache, logging::mask_identifier, ping::GatewayRuntimeStatus,
-        platform::ConversationTarget, ref_index::SharedRefIndex,
+        BotOutboundCache,
+        logging::mask_identifier,
+        onebot11::{OneBotSendError, OneBotSendResult, OneBotSender},
+        ping::GatewayRuntimeStatus,
+        platform::ConversationTarget,
+        ref_index::SharedRefIndex,
     },
     markdown::MarkdownPayload,
 };
@@ -60,9 +65,27 @@ pub struct GatewayPushSink {
 }
 
 #[derive(Clone)]
-enum GatewayPushState {
+struct GatewayPushState {
+    qq_official: PushChannelState<GatewayPushRuntime>,
+    onebot11: PushChannelState<OneBotPushRuntime>,
+}
+
+#[derive(Clone)]
+enum PushChannelState<T> {
     Pending,
-    Bound(GatewayPushRuntime),
+    Bound(T),
+    Unavailable(&'static str),
+}
+
+#[derive(Clone)]
+enum RoutedPushRuntime {
+    QqOfficial(GatewayPushRuntime),
+    OneBot11(OneBotPushRuntime),
+}
+
+enum RouteSnapshot {
+    Pending,
+    Bound(RoutedPushRuntime),
     Unavailable(&'static str),
 }
 
@@ -75,6 +98,49 @@ struct GatewayPushRuntime {
     ref_index: SharedRefIndex,
 }
 
+#[async_trait]
+trait PushOneBotSender: Send + Sync {
+    fn connected_account_id(&self) -> Option<String>;
+    async fn send_private_text(
+        &self,
+        target_id: &str,
+        text: &str,
+    ) -> Result<OneBotSendResult, OneBotSendError>;
+    async fn send_group_text(
+        &self,
+        target_id: &str,
+        text: &str,
+    ) -> Result<OneBotSendResult, OneBotSendError>;
+}
+
+#[async_trait]
+impl PushOneBotSender for OneBotSender {
+    fn connected_account_id(&self) -> Option<String> {
+        OneBotSender::connected_account_id(self)
+    }
+
+    async fn send_private_text(
+        &self,
+        target_id: &str,
+        text: &str,
+    ) -> Result<OneBotSendResult, OneBotSendError> {
+        OneBotSender::send_private_text(self, target_id, text).await
+    }
+
+    async fn send_group_text(
+        &self,
+        target_id: &str,
+        text: &str,
+    ) -> Result<OneBotSendResult, OneBotSendError> {
+        OneBotSender::send_group_text(self, target_id, text).await
+    }
+}
+
+#[derive(Clone)]
+struct OneBotPushRuntime {
+    sender: Arc<dyn PushOneBotSender>,
+}
+
 #[derive(Debug)]
 struct PushSendOutcome {
     ids: SendMessageIds,
@@ -84,7 +150,10 @@ struct PushSendOutcome {
 impl GatewayPushSink {
     pub fn unbound() -> Self {
         Self {
-            inner: Arc::new(Mutex::new(GatewayPushState::Pending)),
+            inner: Arc::new(Mutex::new(GatewayPushState {
+                qq_official: PushChannelState::Pending,
+                onebot11: PushChannelState::Pending,
+            })),
             ready: Arc::new(Notify::new()),
         }
     }
@@ -99,7 +168,7 @@ impl GatewayPushSink {
     ) {
         // Core scheduler 可能在 Gateway 首次连接 QQ 前启动，因此 sink 需要先存在；
         // 真正发送前必须已绑定运行期上下文，否则返回可观测错误而不是静默丢消息。
-        *self.inner.lock().unwrap() = GatewayPushState::Bound(GatewayPushRuntime {
+        self.inner.lock().unwrap().qq_official = PushChannelState::Bound(GatewayPushRuntime {
             api,
             qq_official_account_id: qq_official_account_id.into(),
             runtime,
@@ -110,37 +179,65 @@ impl GatewayPushSink {
     }
 
     pub(crate) fn mark_qq_official_unavailable(&self, summary: &'static str) {
-        *self.inner.lock().unwrap() = GatewayPushState::Unavailable(summary);
+        self.inner.lock().unwrap().qq_official = PushChannelState::Unavailable(summary);
         self.ready.notify_waiters();
     }
 
-    async fn runtime(&self) -> Result<GatewayPushRuntime, PushError> {
-        match self.inner.lock().unwrap().clone() {
-            GatewayPushState::Bound(runtime) => return Ok(runtime),
-            GatewayPushState::Unavailable(summary) => {
+    pub(crate) fn bind_onebot11(&self, sender: OneBotSender) {
+        self.bind_onebot_sender(Arc::new(sender));
+    }
+
+    fn bind_onebot_sender(&self, sender: Arc<dyn PushOneBotSender>) {
+        self.inner.lock().unwrap().onebot11 = PushChannelState::Bound(OneBotPushRuntime { sender });
+        self.ready.notify_waiters();
+    }
+
+    pub(crate) fn mark_onebot11_unavailable(&self, summary: &'static str) {
+        self.inner.lock().unwrap().onebot11 = PushChannelState::Unavailable(summary);
+        self.ready.notify_waiters();
+    }
+
+    async fn runtime(&self, platform: &str) -> Result<RoutedPushRuntime, PushError> {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            // 先创建 waiter 再读取状态，避免 bind 恰好发生在状态读取和等待之间时漏通知。
+            let notified = self.ready.notified();
+            match self.route_snapshot(platform)? {
+                RouteSnapshot::Bound(runtime) => return Ok(runtime),
+                RouteSnapshot::Unavailable(summary) => {
+                    return Err(PushError::Failed {
+                        summary: summary.to_owned(),
+                    });
+                }
+                RouteSnapshot::Pending => {}
+            }
+            if tokio::time::timeout_at(deadline, notified).await.is_err() {
                 return Err(PushError::Failed {
-                    summary: summary.to_owned(),
+                    summary: format!("gateway push sink for `{platform}` is not ready"),
                 });
             }
-            GatewayPushState::Pending => {}
         }
+    }
 
-        // 统一进程启动时 Core 的 RSS / Todo 定时器和 QQ Gateway 连接并行启动。
-        // 首次推送如果撞上 Gateway 尚未 bind，等待一小段时间可避免把正常启动竞态记成推送失败。
-        let notified = self.ready.notified();
-        if timeout(Duration::from_secs(30), notified).await.is_err() {
-            return Err(PushError::Failed {
-                summary: "gateway push sink is not ready".to_owned(),
-            });
-        }
-
-        match self.inner.lock().unwrap().clone() {
-            GatewayPushState::Bound(runtime) => Ok(runtime),
-            GatewayPushState::Unavailable(summary) => Err(PushError::Failed {
-                summary: summary.to_owned(),
+    fn route_snapshot(&self, platform: &str) -> Result<RouteSnapshot, PushError> {
+        let state = self.inner.lock().unwrap();
+        match platform {
+            QQ_OFFICIAL_PLATFORM => Ok(match &state.qq_official {
+                PushChannelState::Pending => RouteSnapshot::Pending,
+                PushChannelState::Bound(runtime) => {
+                    RouteSnapshot::Bound(RoutedPushRuntime::QqOfficial(runtime.clone()))
+                }
+                PushChannelState::Unavailable(summary) => RouteSnapshot::Unavailable(summary),
             }),
-            GatewayPushState::Pending => Err(PushError::Failed {
-                summary: "gateway push sink is not ready".to_owned(),
+            ONEBOT11_PLATFORM => Ok(match &state.onebot11 {
+                PushChannelState::Pending => RouteSnapshot::Pending,
+                PushChannelState::Bound(runtime) => {
+                    RouteSnapshot::Bound(RoutedPushRuntime::OneBot11(runtime.clone()))
+                }
+                PushChannelState::Unavailable(summary) => RouteSnapshot::Unavailable(summary),
+            }),
+            other => Err(PushError::Failed {
+                summary: format!("push platform `{other}` is not supported by gateway"),
             }),
         }
     }
@@ -149,8 +246,73 @@ impl GatewayPushSink {
 #[async_trait]
 impl PushSink for GatewayPushSink {
     async fn push(&self, intent: PushIntent) -> Result<PushResult, PushError> {
-        let runtime = self.runtime().await?;
-        runtime.push(intent).await
+        let platform = intent.target.platform.trim();
+        match self.runtime(platform).await? {
+            RoutedPushRuntime::QqOfficial(runtime) => runtime.push(intent).await,
+            RoutedPushRuntime::OneBot11(runtime) => runtime.push(intent).await,
+        }
+    }
+}
+
+impl OneBotPushRuntime {
+    async fn push(&self, intent: PushIntent) -> Result<PushResult, PushError> {
+        let target_id = intent.target.target_id.trim();
+        let text = intent.text.trim();
+        if target_id.is_empty() || text.is_empty() {
+            return Err(PushError::Failed {
+                summary: "target_id and text are required".to_owned(),
+            });
+        }
+        let target_account = intent
+            .target
+            .account_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|account| !account.is_empty())
+            .ok_or_else(|| PushError::Failed {
+                summary: "onebot11 push target account_id is required".to_owned(),
+            })?;
+        let connected_account =
+            self.sender
+                .connected_account_id()
+                .ok_or_else(|| PushError::Failed {
+                    summary: "OneBot 11 account is offline".to_owned(),
+                })?;
+        if target_account != connected_account {
+            return Err(PushError::Failed {
+                summary: "push target account does not match connected OneBot 11 account"
+                    .to_owned(),
+            });
+        }
+
+        // OneBot 一期只有 text segment；Markdown、图片等结构化意图统一使用上游已生成的
+        // 纯文本 fallback，不能把 QQ Markdown payload 或 CQ 码带入 sender。
+        let fallback_text = intent
+            .fallback_text
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(text);
+        let delivered_text = if matches!(intent.message_type.trim(), "" | "text") {
+            text
+        } else {
+            fallback_text
+        };
+        let result = match intent.target.target_type {
+            PushTargetType::Private => {
+                self.sender
+                    .send_private_text(target_id, delivered_text)
+                    .await
+            }
+            PushTargetType::Group => self.sender.send_group_text(target_id, delivered_text).await,
+        }
+        .map_err(|error| PushError::Failed {
+            // sender 的错误摘要不会包含消息正文、token 或完整 response envelope。
+            summary: error.to_string(),
+        })?;
+        Ok(PushResult {
+            message_id: Some(result.message_id),
+        })
     }
 }
 
@@ -402,6 +564,73 @@ mod tests {
         }
     }
 
+    struct MockOneBotSender {
+        account_id: Option<String>,
+        calls: Mutex<Vec<String>>,
+        fail: bool,
+    }
+
+    impl MockOneBotSender {
+        fn connected(account_id: &str) -> Self {
+            Self {
+                account_id: Some(account_id.to_owned()),
+                calls: Mutex::new(Vec::new()),
+                fail: false,
+            }
+        }
+
+        fn calls(&self) -> Vec<String> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl PushOneBotSender for MockOneBotSender {
+        fn connected_account_id(&self) -> Option<String> {
+            self.account_id.clone()
+        }
+
+        async fn send_private_text(
+            &self,
+            target_id: &str,
+            text: &str,
+        ) -> Result<OneBotSendResult, OneBotSendError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("private:{target_id}:{text}"));
+            if self.fail {
+                Err(OneBotSendError::Transport(
+                    crate::gateway::onebot11::OneBotCallError::ConnectionClosed,
+                ))
+            } else {
+                Ok(OneBotSendResult {
+                    message_id: "ob-private-1".to_owned(),
+                })
+            }
+        }
+
+        async fn send_group_text(
+            &self,
+            target_id: &str,
+            text: &str,
+        ) -> Result<OneBotSendResult, OneBotSendError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("group:{target_id}:{text}"));
+            if self.fail {
+                Err(OneBotSendError::Transport(
+                    crate::gateway::onebot11::OneBotCallError::ConnectionClosed,
+                ))
+            } else {
+                Ok(OneBotSendResult {
+                    message_id: "ob-group-1".to_owned(),
+                })
+            }
+        }
+    }
+
     #[async_trait]
     impl PushQqSender for MockPushSender {
         async fn send_c2c_text(&self, target_id: &str, text: &str) -> SendResult {
@@ -525,6 +754,144 @@ mod tests {
         let err = sink.push(intent).await.unwrap_err();
 
         assert!(err.to_string().contains("QQ official channel is not bound"));
+    }
+
+    #[tokio::test]
+    async fn onebot_push_routes_independently_when_qq_is_unavailable() {
+        let sink = GatewayPushSink::unbound();
+        sink.mark_qq_official_unavailable("QQ official channel is not bound");
+        let sender = Arc::new(MockOneBotSender::connected("bot-1"));
+        sink.bind_onebot_sender(sender.clone());
+        let intent = PushIntent {
+            target: PushTarget::onebot11("bot-1", PushTargetType::Private, "user-1"),
+            text: "# Markdown".to_owned(),
+            fallback_text: Some("纯文本".to_owned()),
+            message_type: "markdown".to_owned(),
+            visible_entity_snapshot: None,
+        };
+
+        let result = sink.push(intent).await.unwrap();
+
+        assert_eq!(result.message_id.as_deref(), Some("ob-private-1"));
+        assert_eq!(sender.calls(), vec!["private:user-1:纯文本"]);
+    }
+
+    #[tokio::test]
+    async fn onebot_group_push_routes_to_group_action_sender() {
+        let sink = GatewayPushSink::unbound();
+        let sender = Arc::new(MockOneBotSender::connected("bot-1"));
+        sink.bind_onebot_sender(sender.clone());
+
+        let result = sink
+            .push(PushIntent {
+                target: PushTarget::onebot11("bot-1", PushTargetType::Group, "group-1"),
+                text: "group text".to_owned(),
+                fallback_text: None,
+                message_type: "text".to_owned(),
+                visible_entity_snapshot: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.message_id.as_deref(), Some("ob-group-1"));
+        assert_eq!(sender.calls(), vec!["group:group-1:group text"]);
+    }
+
+    #[tokio::test]
+    async fn onebot_push_rejects_offline_missing_or_wrong_account_without_sending() {
+        let missing_account_sender = Arc::new(MockOneBotSender::connected("bot-1"));
+        let runtime = OneBotPushRuntime {
+            sender: missing_account_sender.clone(),
+        };
+        let base = PushIntent {
+            target: PushTarget::new(ONEBOT11_PLATFORM, None, PushTargetType::Group, "group-1"),
+            text: "hello".to_owned(),
+            fallback_text: None,
+            message_type: "text".to_owned(),
+            visible_entity_snapshot: None,
+        };
+        let missing = runtime.push(base.clone()).await.unwrap_err();
+        assert!(missing.to_string().contains("account_id is required"));
+
+        let wrong = runtime
+            .push(PushIntent {
+                target: PushTarget::new(
+                    ONEBOT11_PLATFORM,
+                    Some("bot-2".to_owned()),
+                    PushTargetType::Group,
+                    "group-1",
+                ),
+                ..base.clone()
+            })
+            .await
+            .unwrap_err();
+        assert!(wrong.to_string().contains("does not match"));
+        assert!(missing_account_sender.calls().is_empty());
+
+        let offline = OneBotPushRuntime {
+            sender: Arc::new(MockOneBotSender {
+                account_id: None,
+                calls: Mutex::new(Vec::new()),
+                fail: false,
+            }),
+        }
+        .push(PushIntent {
+            target: PushTarget::new(
+                ONEBOT11_PLATFORM,
+                Some("bot-1".to_owned()),
+                PushTargetType::Group,
+                "group-1",
+            ),
+            ..base
+        })
+        .await
+        .unwrap_err();
+        assert!(offline.to_string().contains("offline"));
+    }
+
+    #[tokio::test]
+    async fn qq_target_never_falls_through_to_bound_onebot_sender() {
+        let sink = GatewayPushSink::unbound();
+        sink.mark_qq_official_unavailable("QQ official channel is not bound");
+        let sender = Arc::new(MockOneBotSender::connected("bot-1"));
+        sink.bind_onebot_sender(sender.clone());
+
+        let err = sink
+            .push(PushIntent {
+                target: PushTarget::qq_official(PushTargetType::Private, "user-1"),
+                text: "hello".to_owned(),
+                fallback_text: None,
+                message_type: "text".to_owned(),
+                visible_entity_snapshot: None,
+            })
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("QQ official channel is not bound"));
+        assert!(sender.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn onebot_transport_failure_is_propagated_for_outbox_retry() {
+        let sink = GatewayPushSink::unbound();
+        sink.bind_onebot_sender(Arc::new(MockOneBotSender {
+            account_id: Some("bot-1".to_owned()),
+            calls: Mutex::new(Vec::new()),
+            fail: true,
+        }));
+
+        let err = sink
+            .push(PushIntent {
+                target: PushTarget::onebot11("bot-1", PushTargetType::Private, "user-1"),
+                text: "hello".to_owned(),
+                fallback_text: None,
+                message_type: "text".to_owned(),
+                visible_entity_snapshot: None,
+            })
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("outbound queue is closed"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 背景

OneBot 11 反向 WebSocket 已具备单账号连接和通用 action/echo 上下文，但尚无真实文本 sender，主动推送也只能走 QQ 官方 sender，无法依据 OneBot API response 判定投递结果。

## 变更

- 新增 `send_private_msg` / `send_group_msg` 文本 sender，统一使用消息 segment 数组。
- 复用活动 WebSocket 的并发安全 echo/pending 机制，严格检查 `status`、`retcode`、错误信息存在性和 `data.message_id`。
- 支持数字/字符串平台 `message_id`，超时、断线、离线、响应失败或数据缺失均返回真实错误。
- 新增 OneBot text-only、非流式 ReplyCapability，并在控制台展示出站文本能力。
- 将 Gateway PushSink 改为 QQ 官方 / OneBot 独立绑定、按 `platform + account_id` 精确路由；QQ 未绑定不会阻断 OneBot，错误目标不会误落到其它 sender。
- 在 PushTarget 边界将 Core 稳定 scope 平台名 `onebot` 规范化为 Gateway 路由名 `onebot11`，并提供 `PushTarget::onebot11` helper。
- 更新 Gateway README 的 sender、主动推送和源码边界说明。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p qq-maid-gateway-rs --all-features`（416 passed）
- `cargo check -p qq-maid-gateway-rs --all-features`
- `cargo test -p qq-maid-core --all-features`（825 passed）
- `cargo clippy -p qq-maid-gateway-rs -p qq-maid-core --all-targets --all-features -- -D warnings`
- `git diff --check`

fake WebSocket 测试覆盖并发乱序 echo、未知 echo、私聊/群聊 segment payload、数字/字符串 message_id、retcode、超时、断线和离线；push mock 覆盖精确账号路由、私聊/群聊、Markdown 纯文本 fallback、QQ unavailable 隔离和可重试失败。

## 合并提示

#439 同样会更新 `qq-maid-gateway-rs/README.md` 和 `onebot11/mod.rs`。两项改动职责独立，但后合入的 PR 可能需要按合并顺序 rebase 并保留双方文档事实。

Closes #440