### PR TITLE
feat: 完成 OneBot 11 文本入站与发送

### DIFF
--- a/qq-maid-core/src/runtime/push.rs
+++ b/qq-maid-core/src/runtime/push.rs
@@ -12,6 +12,7 @@ use std::str::FromStr;
 use crate::{identity::parse_stable_scope_key, service::VisibleEntitySnapshot};
 
 pub const QQ_OFFICIAL_PLATFORM: &str = "qq_official";
+pub const ONEBOT11_PLATFORM: &str = "onebot11";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PushTargetType {
@@ -68,6 +69,19 @@ impl PushTarget {
         Self::new(QQ_OFFICIAL_PLATFORM, None, target_type, target_id)
     }
 
+    pub fn onebot11(
+        account_id: impl Into<String>,
+        target_type: PushTargetType,
+        target_id: impl Into<String>,
+    ) -> Self {
+        Self::new(
+            ONEBOT11_PLATFORM,
+            Some(account_id.into()),
+            target_type,
+            target_id,
+        )
+    }
+
     /// 从新 stable scope 中继承 platform/account；旧 scope 或不可解析 scope 仍按 QQ 官方处理。
     ///
     /// 业务存储里 `scope_key` 只承担身份隔离语义，这里只在生成主动推送目标时读取其中
@@ -122,6 +136,29 @@ mod tests {
         assert_eq!(target.account_id, None);
         assert_eq!(target.target_id, "legacy-openid");
     }
+
+    #[test]
+    fn onebot_helper_requires_explicit_account_and_uses_gateway_platform_name() {
+        let target = PushTarget::onebot11("bot-1", PushTargetType::Group, "group-1");
+
+        assert_eq!(target.platform, ONEBOT11_PLATFORM);
+        assert_eq!(target.account_id.as_deref(), Some("bot-1"));
+        assert_eq!(target.target_type, PushTargetType::Group);
+        assert_eq!(target.target_id, "group-1");
+    }
+
+    #[test]
+    fn core_onebot_scope_is_normalized_for_gateway_routing() {
+        let target = PushTarget::from_scope_key_or_qq_official(
+            "platform:onebot:account:bot-1:private:user-1",
+            PushTargetType::Private,
+            "user-1",
+        );
+
+        assert_eq!(target.platform, ONEBOT11_PLATFORM);
+        assert_eq!(target.account_id.as_deref(), Some("bot-1"));
+        assert_eq!(target.target_id, "user-1");
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -151,10 +188,12 @@ pub trait PushSink: Send + Sync {
 
 fn clean_or_default_platform(value: String) -> String {
     let value = value.trim();
-    if value.is_empty() {
-        QQ_OFFICIAL_PLATFORM.to_owned()
-    } else {
-        value.to_owned()
+    match value {
+        "" => QQ_OFFICIAL_PLATFORM.to_owned(),
+        // CoreService 的稳定会话平台名是 `onebot`，Gateway 的协议/路由名是
+        // `onebot11`。只在投递目标边界规范化，不能改写既有 session scope。
+        "onebot" => ONEBOT11_PLATFORM.to_owned(),
+        other => other.to_owned(),
     }
 }
 

--- a/qq-maid-gateway-rs/README.md
+++ b/qq-maid-gateway-rs/README.md
@@ -38,7 +38,7 @@ flowchart LR
         delivery_target["DeliveryTarget / raw_target_id"]
         capability["ReplyCapability"]
         qq_sender["QQ sender"]
-        onebot_sender["OneBot sender（预留）"]
+        onebot_sender["OneBot text sender"]
         wechat_sender["微信 sender"]
     end
 
@@ -61,7 +61,7 @@ flowchart LR
 
 - `InboundMessage` 是 Gateway 内部的平台无关入站模型，包含 `Actor` 与 `Conversation`。QQ、OneBot、微信等协议字段只能在各自 adapter 内解析。
 - `CoreRequest` 是 Gateway 调用 Core 的稳定契约。Core 可以看到平台枚举、Actor 和 Conversation，但不理解 QQ `msg_seq`、stream id、微信 XML 字段或 OneBot CQ 片段。
-- OneBot 11 已实现默认关闭的单账号反向 WebSocket server、鉴权、生命周期/心跳、连接替换、API request/response 共用连接上下文、文本与结构化 at 入站 adapter 和脱敏状态。本入站 adapter 只产出统一模型，当前不调用 Core；出站 sender 与主动推送路由由独立模块负责。
+- OneBot 11 已实现默认关闭的单账号反向 WebSocket server、鉴权、生命周期/心跳、连接替换、API request/response 共用连接上下文、文本与结构化 at 入站 adapter、文本 sender、主动推送精确路由和脱敏状态；当前 OneBot 入口尚不调用 Core，也不实现流式或富媒体发送。
 - `scope_key` / `owner_key` 是业务隔离键，用于 Session、Pending、Memory、Todo 等状态归属，不是发送地址。
 - `ReplyTarget` / `DeliveryTarget` 保存真实投递目标，必须保留平台和 `raw_target_id`。发送逻辑只能使用投递目标调用 sender，不能从 `scope_key` 或 `owner_key` 反解析平台 ID。
 - RSS、Notification、Todo 提醒和 Push 这类主动投递也必须携带原始 delivery target；后续多平台收敛时不要把目标统一替换成 namespaced 字符串。
@@ -75,7 +75,7 @@ flowchart LR
 - Markdown 和图片保留独立 outbound 类型、payload 构造和发送入口；发送失败会 warn 并 fallback 到文本。C2C 流式回复当前固定使用 Markdown 流式载荷，首帧成功后不再补发普通全文。
 - Core 的统一通知 Worker 和 Todo 每日提醒通过进程内 `PushSink` 主动推送；RSS 只生产 Notification Outbox 任务，不再维护独立发送链路。
 - 微信服务号入口默认关闭；启用后处理 GET URL 验证、POST 明文 `text` XML、同步文本 XML 快路径，以及超出同步安全预算后的客服文本补发。客服补发按需获取 `access_token`，Markdown 会降级为 text。
-- OneBot 11 入口默认关闭；启用后建立单账号反向 WebSocket 连接，并安全适配私聊文本和明确 at 当前机器人的群聊文本。本 adapter 不负责调用 Core 或发送回复。首次账号会锁定进程内 `self_id`，同账号新连接替换旧连接，不同账号会被拒绝；连接异常不会结束监听器或其它入口。
+- OneBot 11 入口默认关闭；启用后建立单账号反向 WebSocket 连接，安全适配私聊文本和明确 at 当前机器人的群聊文本，并通过同一连接发送私聊/群聊文本 action；当前尚不调用 Core。首次账号会锁定进程内 `self_id`，同账号新连接替换旧连接，不同账号会被拒绝；连接异常不会结束监听器或其它入口，未完成发送会返回可重试错误。
 - 不做频道、频道私信、Ark、Embed、Keyboard、多租户或旧接入层兼容。
 - 微信服务号暂不做加密 XML、模板消息、图片语音视频、菜单事件、主动推送或流式输出；客服消息只实现慢请求文本补发。
 
@@ -107,6 +107,7 @@ flowchart LR
 - `src/gateway/platform/onebot11.rs`：OneBot 11 私聊、群聊、结构化 at 与文本 segment 到统一 `InboundMessage` 的映射和一期触发过滤。
 - `src/gateway/onebot11/protocol.rs`：OneBot 11 事件、消息段、action / response、`echo`、生命周期、心跳和无精度损失 ID 类型。
 - `src/gateway/onebot11/connection.rs`：单账号活动连接、同账号替换策略和 API `echo` 关联上下文。
+- `src/gateway/onebot11/sender.rs`：`send_private_msg` / `send_group_msg` 文本 segment、真实响应校验和平台消息 ID 提取。
 - `src/gateway/onebot11/server.rs`：反向 WebSocket 监听、路径与 Bearer 鉴权、连接事件循环、超时和优雅退出。
 
 维护时应尽量保持这些边界，不要把 WebSocket 协议细节、Core 业务调用和 QQ 发送状态记录重新堆回同一个超长文件。

--- a/qq-maid-gateway-rs/README.md
+++ b/qq-maid-gateway-rs/README.md
@@ -14,7 +14,7 @@ flowchart LR
 
     subgraph adapters["平台 adapter"]
         qq_adapter["qq_official adapter"]
-        onebot_adapter["onebot adapter（预留）"]
+        onebot_adapter["onebot text / at adapter"]
         wechat_adapter["wechat_service adapter"]
     end
 
@@ -61,7 +61,7 @@ flowchart LR
 
 - `InboundMessage` 是 Gateway 内部的平台无关入站模型，包含 `Actor` 与 `Conversation`。QQ、OneBot、微信等协议字段只能在各自 adapter 内解析。
 - `CoreRequest` 是 Gateway 调用 Core 的稳定契约。Core 可以看到平台枚举、Actor 和 Conversation，但不理解 QQ `msg_seq`、stream id、微信 XML 字段或 OneBot CQ 片段。
-- OneBot 11 已实现默认关闭的单账号反向 WebSocket server、鉴权、生命周期/心跳、连接替换、API request/response 共用连接上下文和脱敏状态；当前仍不解析业务消息、不调用 Core，也不实现具体 sender 或主动推送路由。
+- OneBot 11 已实现默认关闭的单账号反向 WebSocket server、鉴权、生命周期/心跳、连接替换、API request/response 共用连接上下文、文本与结构化 at 入站 adapter 和脱敏状态。本入站 adapter 只产出统一模型，当前不调用 Core；出站 sender 与主动推送路由由独立模块负责。
 - `scope_key` / `owner_key` 是业务隔离键，用于 Session、Pending、Memory、Todo 等状态归属，不是发送地址。
 - `ReplyTarget` / `DeliveryTarget` 保存真实投递目标，必须保留平台和 `raw_target_id`。发送逻辑只能使用投递目标调用 sender，不能从 `scope_key` 或 `owner_key` 反解析平台 ID。
 - RSS、Notification、Todo 提醒和 Push 这类主动投递也必须携带原始 delivery target；后续多平台收敛时不要把目标统一替换成 namespaced 字符串。
@@ -75,7 +75,7 @@ flowchart LR
 - Markdown 和图片保留独立 outbound 类型、payload 构造和发送入口；发送失败会 warn 并 fallback 到文本。C2C 流式回复当前固定使用 Markdown 流式载荷，首帧成功后不再补发普通全文。
 - Core 的统一通知 Worker 和 Todo 每日提醒通过进程内 `PushSink` 主动推送；RSS 只生产 Notification Outbox 任务，不再维护独立发送链路。
 - 微信服务号入口默认关闭；启用后处理 GET URL 验证、POST 明文 `text` XML、同步文本 XML 快路径，以及超出同步安全预算后的客服文本补发。客服补发按需获取 `access_token`，Markdown 会降级为 text。
-- OneBot 11 入口默认关闭；启用后只建立单账号反向 WebSocket 连接。首次账号会锁定进程内 `self_id`，同账号新连接替换旧连接，不同账号会被拒绝；连接异常不会结束监听器或其它入口。
+- OneBot 11 入口默认关闭；启用后建立单账号反向 WebSocket 连接，并安全适配私聊文本和明确 at 当前机器人的群聊文本。本 adapter 不负责调用 Core 或发送回复。首次账号会锁定进程内 `self_id`，同账号新连接替换旧连接，不同账号会被拒绝；连接异常不会结束监听器或其它入口。
 - 不做频道、频道私信、Ark、Embed、Keyboard、多租户或旧接入层兼容。
 - 微信服务号暂不做加密 XML、模板消息、图片语音视频、菜单事件、主动推送或流式输出；客服消息只实现慢请求文本补发。
 
@@ -104,6 +104,7 @@ flowchart LR
 - `src/gateway/push.rs`：进程内主动推送实现。
 - `src/gateway/wechat_service.rs`：微信服务号文本回调 HTTP 入口，负责签名校验、明文 XML 解析、Core 调用、同步 XML 回复、慢请求去重和客服文本补发。
 - `src/gateway/platform/wechat_service.rs`：微信服务号平台字段到统一 `InboundMessage` / `CoreRequest` 的映射，以及 XML 解析和渲染 helper。
+- `src/gateway/platform/onebot11.rs`：OneBot 11 私聊、群聊、结构化 at 与文本 segment 到统一 `InboundMessage` 的映射和一期触发过滤。
 - `src/gateway/onebot11/protocol.rs`：OneBot 11 事件、消息段、action / response、`echo`、生命周期、心跳和无精度损失 ID 类型。
 - `src/gateway/onebot11/connection.rs`：单账号活动连接、同账号替换策略和 API `echo` 关联上下文。
 - `src/gateway/onebot11/server.rs`：反向 WebSocket 监听、路径与 Bearer 鉴权、连接事件循环、超时和优雅退出。

--- a/qq-maid-gateway-rs/src/gateway/console.rs
+++ b/qq-maid-gateway-rs/src/gateway/console.rs
@@ -150,6 +150,14 @@ impl ConsoleStatusSource for GatewayConsoleStatusSource {
 
         let onebot_configured = self.config.onebot11.access_token.is_some();
         let onebot_enabled = self.config.onebot11.enabled;
+        let onebot_capability = ReplyCapability::onebot11_text();
+        let onebot_unavailable = if !onebot_configured {
+            Some(ConsoleValueState::NotConfigured)
+        } else if !onebot_enabled {
+            Some(ConsoleValueState::Disabled)
+        } else {
+            None
+        };
         let onebot = ConsolePlatformStatus {
             id: "onebot11".to_owned(),
             label: "OneBot 11".to_owned(),
@@ -172,16 +180,15 @@ impl ConsoleStatusSource for GatewayConsoleStatusSource {
             resumed_at: None,
             capability_scopes: vec![ConsoleCapabilityScope {
                 id: "reverse_websocket".to_owned(),
-                label: "反向 WebSocket（协议底座）".to_owned(),
+                label: "反向 WebSocket".to_owned(),
                 enabled: onebot_enabled,
-                capabilities: unavailable_directional_capabilities(if !onebot_configured {
-                    ConsoleValueState::NotConfigured
-                } else if !onebot_enabled {
-                    ConsoleValueState::Disabled
-                } else {
-                    // #438 不接业务消息和发送；控制台不能把 transport 在线误报为文本能力可用。
-                    ConsoleValueState::NotAvailable
-                }),
+                capabilities: onebot_unavailable
+                    .map(unavailable_directional_capabilities)
+                    .unwrap_or(ConsoleDirectionalCapabilities {
+                        // #440 不调用 Core；仅 sender 和主动推送出站文本可用。
+                        inbound: unavailable_capabilities(ConsoleValueState::NotAvailable),
+                        outbound: reply_capabilities(onebot_capability),
+                    }),
             }],
         };
 
@@ -463,7 +470,7 @@ mod tests {
     }
 
     #[test]
-    fn onebot_foundation_reports_transport_state_without_business_capabilities() {
+    fn onebot_reports_text_only_non_streaming_outbound_capability() {
         let config = AppConfig::from_map(&HashMap::from([
             ("QQ_BOT_ENABLED".to_owned(), "false".to_owned()),
             ("ONEBOT11_ENABLED".to_owned(), "true".to_owned()),
@@ -486,6 +493,11 @@ mod tests {
             scope(onebot, "reverse_websocket").capabilities.inbound.text,
             ConsoleValueState::NotAvailable
         );
+        let outbound = &scope(onebot, "reverse_websocket").capabilities.outbound;
+        assert_eq!(outbound.text, ConsoleValueState::Supported);
+        assert_eq!(outbound.markdown, ConsoleValueState::Unsupported);
+        assert_eq!(outbound.image, ConsoleValueState::Unsupported);
+        assert_eq!(outbound.streaming, ConsoleValueState::Unsupported);
         let json = serde_json::to_string(&snapshot).unwrap();
         assert!(!json.contains("private-onebot-token"));
         assert!(!json.contains("123456123456"));

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -96,7 +96,12 @@ pub async fn run(
         )
         .await
         {
-            Ok(server) => Some(server.task),
+            Ok(server) => {
+                // sender 与反向 WebSocket 复用同一个 connection context；离线、替换和断线
+                // 都由该上下文返回真实错误，不能另建连接或伪造推送成功。
+                push_sink.bind_onebot11(onebot11::OneBotSender::new(server.connection.clone()));
+                Some(server.task)
+            }
             Err(error) => {
                 // 多入口按顺序 bind；后启动的入口失败时必须回收已启动监听器，
                 // 避免 run 返回错误后仍留下不可监督的后台任务。
@@ -118,6 +123,7 @@ pub async fn run(
             }
         }
     } else {
+        push_sink.mark_onebot11_unavailable("OneBot 11 channel is disabled");
         None
     };
     let ref_index = ref_index();

--- a/qq-maid-gateway-rs/src/gateway/onebot11/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/mod.rs
@@ -1,13 +1,15 @@
 //! OneBot 11 反向 WebSocket 单账号连接底座。
 //!
-//! 当前模块只管理协议、鉴权、连接和 API request/response 关联，不把业务事件送入 Core，
-//! 也不实现具体消息发送 action。后续 adapter 与 sender 必须复用这里的连接上下文。
+//! 当前模块管理协议、鉴权、连接、API request/response 关联和一期文本 sender，
+//! 暂不把业务事件送入 Core。后续 adapter 必须复用这里的连接与 sender 边界。
 
 mod connection;
 pub mod protocol;
+mod sender;
 mod server;
 
 pub use connection::{OneBotCallError, OneBotConnectionContext};
+pub use sender::{OneBotSendError, OneBotSendResult, OneBotSender};
 pub use server::{OneBotServerHandle, spawn_reverse_websocket_server};
 
 #[cfg(test)]

--- a/qq-maid-gateway-rs/src/gateway/onebot11/protocol.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/protocol.rs
@@ -10,8 +10,9 @@ use serde_json::Value;
 
 /// OneBot 的账号、群和用户 ID 允许使用 JSON 数字或字符串。
 ///
-/// 内部统一保存十进制/原始字符串，避免经过 `f64` 导致大整数精度损失；序列化时使用
-/// JSON 字符串，OneBot 11 实现通常同时接受两种形式。
+/// 内部统一保存十进制/原始字符串，避免经过 `f64` 导致大整数精度损失。通用序列化仍
+/// 保留字符串形式；发送 action 的 `user_id`/`group_id` 必须在 sender 边界转换为 JSON
+/// number，不能直接依赖本类型的序列化结果。
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct OneBotId(String);
 

--- a/qq-maid-gateway-rs/src/gateway/onebot11/protocol.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/protocol.rs
@@ -1,7 +1,7 @@
 //! OneBot 11 最小协议模型。
 //!
-//! 一期只消费生命周期、心跳和 API response；消息事件与消息段先保留为协议类型，
-//! 后续 adapter 可以在本模块边界内继续解析，不能把原始 JSON 泄漏到 Core。
+//! 一期消费生命周期、心跳、API response 与消息 segment 数组；具体入站映射由平台
+//! adapter 完成，不能把原始 JSON 泄漏到 Core。
 
 use std::{collections::BTreeMap, fmt};
 

--- a/qq-maid-gateway-rs/src/gateway/onebot11/sender.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/sender.rs
@@ -6,7 +6,7 @@
 use std::time::Instant;
 
 use serde::Deserialize;
-use serde_json::json;
+use serde_json::{Number, Value, json};
 use thiserror::Error;
 use tracing::{info, warn};
 
@@ -41,13 +41,15 @@ pub enum OneBotSendError {
     },
     #[error("OneBot API send response is missing a valid data.message_id")]
     InvalidData,
+    #[error("invalid OneBot target ID: expected a decimal unsigned 64-bit integer")]
+    InvalidTargetId,
 }
 
 impl OneBotSendError {
     fn retcode(&self) -> Option<i64> {
         match self {
             Self::Rejected { retcode, .. } => Some(*retcode),
-            Self::Transport(_) | Self::InvalidData => None,
+            Self::Transport(_) | Self::InvalidData | Self::InvalidTargetId => None,
         }
     }
 }
@@ -94,8 +96,11 @@ impl OneBotSender {
         text: &str,
     ) -> Result<OneBotSendResult, OneBotSendError> {
         let started = Instant::now();
+        let target_id = parse_target_id(target_id)?;
         let params = json!({
-            target_key: OneBotId::new(target_id.to_owned()).map_err(|_| OneBotSendError::InvalidData)?,
+            // OneBot 11 的发送 action 要求 user_id/group_id 为 JSON number；这里直接从
+            // 十进制字符串解析为 u64，不能经过 f64，否则较大 ID 会丢失精度。
+            target_key: Value::Number(Number::from(target_id)),
             "message": [{"type": "text", "data": {"text": text}}]
         });
         let result = self
@@ -105,7 +110,7 @@ impl OneBotSender {
             .map_err(OneBotSendError::from)
             .and_then(validate_send_response);
         let elapsed_ms = started.elapsed().as_millis();
-        let target = mask_identifier(target_id);
+        let target = mask_identifier(&target_id.to_string());
         match &result {
             Ok(_) => info!(
                 action,
@@ -124,6 +129,15 @@ impl OneBotSender {
         }
         result
     }
+}
+
+fn parse_target_id(target_id: &str) -> Result<u64, OneBotSendError> {
+    if target_id.is_empty() || !target_id.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(OneBotSendError::InvalidTargetId);
+    }
+    target_id
+        .parse::<u64>()
+        .map_err(|_| OneBotSendError::InvalidTargetId)
 }
 
 #[derive(Deserialize)]
@@ -182,6 +196,18 @@ mod tests {
 
         assert_eq!(numeric.message_id, "123");
         assert_eq!(text.message_id, "456");
+    }
+
+    #[test]
+    fn target_id_requires_decimal_u64_without_float_conversion() {
+        assert_eq!(parse_target_id("18446744073709551615").unwrap(), u64::MAX);
+
+        for invalid in ["", "abc", "-1", "+1", " 1", "18446744073709551616"] {
+            assert!(matches!(
+                parse_target_id(invalid),
+                Err(OneBotSendError::InvalidTargetId)
+            ));
+        }
     }
 
     #[test]

--- a/qq-maid-gateway-rs/src/gateway/onebot11/sender.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/sender.rs
@@ -1,0 +1,204 @@
+//! OneBot 11 一期文本 sender。
+//!
+//! sender 只负责把平台原始目标转换成 OneBot action，并以 API response 的真实结果
+//! 判定发送成功。消息正文始终使用 segment 数组，Core 和主动推送层不接触 CQ 码。
+
+use std::time::Instant;
+
+use serde::Deserialize;
+use serde_json::json;
+use thiserror::Error;
+use tracing::{info, warn};
+
+use crate::gateway::logging::mask_identifier;
+
+use super::{
+    OneBotCallError, OneBotConnectionContext,
+    protocol::{ActionResponse, OneBotId},
+};
+
+const SEND_PRIVATE_MSG: &str = "send_private_msg";
+const SEND_GROUP_MSG: &str = "send_group_msg";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OneBotSendResult {
+    /// OneBot 平台返回的真实消息 ID；不能与 Todo 等内部业务 ID 混用。
+    pub message_id: String,
+}
+
+#[derive(Debug, Error)]
+pub enum OneBotSendError {
+    #[error(transparent)]
+    Transport(#[from] OneBotCallError),
+    #[error(
+        "OneBot API rejected the send action: status={status}, retcode={retcode}, remote_message_present={remote_message_present}"
+    )]
+    Rejected {
+        status: String,
+        retcode: i64,
+        /// 不保存服务端错误正文，只记录其是否存在，避免后续 Outbox 日志泄漏响应内容。
+        remote_message_present: bool,
+    },
+    #[error("OneBot API send response is missing a valid data.message_id")]
+    InvalidData,
+}
+
+impl OneBotSendError {
+    fn retcode(&self) -> Option<i64> {
+        match self {
+            Self::Rejected { retcode, .. } => Some(*retcode),
+            Self::Transport(_) | Self::InvalidData => None,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct OneBotSender {
+    connection: OneBotConnectionContext,
+}
+
+impl OneBotSender {
+    pub fn new(connection: OneBotConnectionContext) -> Self {
+        Self { connection }
+    }
+
+    pub fn connected_account_id(&self) -> Option<String> {
+        self.connection
+            .connected_self_id()
+            .map(|self_id| self_id.as_str().to_owned())
+    }
+
+    pub async fn send_private_text(
+        &self,
+        user_id: &str,
+        text: &str,
+    ) -> Result<OneBotSendResult, OneBotSendError> {
+        self.send_text(SEND_PRIVATE_MSG, "user_id", user_id, text)
+            .await
+    }
+
+    pub async fn send_group_text(
+        &self,
+        group_id: &str,
+        text: &str,
+    ) -> Result<OneBotSendResult, OneBotSendError> {
+        self.send_text(SEND_GROUP_MSG, "group_id", group_id, text)
+            .await
+    }
+
+    async fn send_text(
+        &self,
+        action: &'static str,
+        target_key: &'static str,
+        target_id: &str,
+        text: &str,
+    ) -> Result<OneBotSendResult, OneBotSendError> {
+        let started = Instant::now();
+        let params = json!({
+            target_key: OneBotId::new(target_id.to_owned()).map_err(|_| OneBotSendError::InvalidData)?,
+            "message": [{"type": "text", "data": {"text": text}}]
+        });
+        let result = self
+            .connection
+            .call(action, params)
+            .await
+            .map_err(OneBotSendError::from)
+            .and_then(validate_send_response);
+        let elapsed_ms = started.elapsed().as_millis();
+        let target = mask_identifier(target_id);
+        match &result {
+            Ok(_) => info!(
+                action,
+                retcode = 0,
+                elapsed_ms,
+                target = %target,
+                "OneBot 11 text sent"
+            ),
+            Err(error) => warn!(
+                action,
+                retcode = ?error.retcode(),
+                elapsed_ms,
+                target = %target,
+                "OneBot 11 text send failed"
+            ),
+        }
+        result
+    }
+}
+
+#[derive(Deserialize)]
+struct SendMessageData {
+    message_id: OneBotId,
+}
+
+fn validate_send_response(response: ActionResponse) -> Result<OneBotSendResult, OneBotSendError> {
+    if response.status != "ok" || response.retcode != 0 {
+        return Err(OneBotSendError::Rejected {
+            // status 由远端提供，错误链可能进入 Outbox 日志；只保留协议分类，
+            // 不回显任意字符串或完整 response envelope。
+            status: if response.status == "ok" {
+                "ok".to_owned()
+            } else {
+                "non-ok".to_owned()
+            },
+            retcode: response.retcode,
+            remote_message_present: response
+                .wording
+                .as_deref()
+                .or(response.message.as_deref())
+                .is_some_and(|message| !message.trim().is_empty()),
+        });
+    }
+    let data: SendMessageData =
+        serde_json::from_value(response.data).map_err(|_| OneBotSendError::InvalidData)?;
+    Ok(OneBotSendResult {
+        message_id: data.message_id.as_str().to_owned(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::gateway::onebot11::protocol::Echo;
+
+    fn response(status: &str, retcode: i64, data: serde_json::Value) -> ActionResponse {
+        ActionResponse {
+            status: status.to_owned(),
+            retcode,
+            data,
+            message: None,
+            wording: None,
+            echo: Some(Echo(json!("echo"))),
+        }
+    }
+
+    #[test]
+    fn accepts_numeric_or_string_message_id() {
+        let numeric =
+            validate_send_response(response("ok", 0, json!({"message_id": 123}))).unwrap();
+        let text = validate_send_response(response("ok", 0, json!({"message_id": "456"}))).unwrap();
+
+        assert_eq!(numeric.message_id, "123");
+        assert_eq!(text.message_id, "456");
+    }
+
+    #[test]
+    fn rejects_failed_status_nonzero_retcode_and_missing_message_id() {
+        let status =
+            validate_send_response(response("failed", 0, json!({"message_id": 1}))).unwrap_err();
+        let retcode = validate_send_response(response("failed", 1404, json!(null))).unwrap_err();
+        let missing = validate_send_response(response("ok", 0, json!({}))).unwrap_err();
+
+        assert!(matches!(
+            status,
+            OneBotSendError::Rejected { retcode: 0, .. }
+        ));
+        assert!(matches!(
+            retcode,
+            OneBotSendError::Rejected { retcode: 1404, .. }
+        ));
+        assert!(matches!(missing, OneBotSendError::InvalidData));
+    }
+}

--- a/qq-maid-gateway-rs/src/gateway/onebot11/server.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/server.rs
@@ -20,7 +20,11 @@ use tracing::{debug, info, warn};
 
 use crate::{
     config::OneBot11Config,
-    gateway::{logging::mask_identifier, ping::GatewayRuntimeStatus},
+    gateway::{
+        logging::mask_identifier,
+        ping::GatewayRuntimeStatus,
+        platform::onebot11::{OneBotInboundOutcome, inbound_from_event},
+    },
 };
 
 use super::{
@@ -340,6 +344,19 @@ async fn handle_message(
         }
     } else if event.is_lifecycle() {
         debug!(sub_type = ?event.sub_type, "received OneBot 11 lifecycle event");
+    } else {
+        match inbound_from_event(&event) {
+            OneBotInboundOutcome::Message(inbound) => debug!(
+                conversation = inbound.conversation.kind(),
+                text_parts = inbound.input_parts.len(),
+                mentions = inbound.mentions.len(),
+                "adapted OneBot 11 inbound message"
+            ),
+            OneBotInboundOutcome::Ignored(reason) => debug!(
+                reason = reason.as_str(),
+                "ignored OneBot 11 event before core dispatch"
+            ),
+        }
     }
     MessageOutcome::Continue
 }

--- a/qq-maid-gateway-rs/src/gateway/onebot11/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/tests.rs
@@ -22,7 +22,8 @@ use crate::{
 };
 
 use super::{
-    OneBotCallError, OneBotConnectionContext, OneBotServerHandle, spawn_reverse_websocket_server,
+    OneBotCallError, OneBotConnectionContext, OneBotSendError, OneBotSender, OneBotServerHandle,
+    spawn_reverse_websocket_server,
 };
 
 const TOKEN: &str = "test-onebot-access-token";
@@ -206,6 +207,191 @@ async fn lifecycle_heartbeat_and_api_response_share_one_connection() {
         .unwrap();
     let response = call.await.unwrap().unwrap();
     assert_eq!(response.data, json!({"online": true}));
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn concurrent_text_sends_use_unique_echo_and_complete_out_of_order() {
+    let (handle, _runtime, shutdown) = spawn_server().await;
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    let sender = OneBotSender::new(handle.connection.clone());
+    let private_sender = sender.clone();
+    let private = tokio::spawn(async move {
+        private_sender
+            .send_private_text("20002", "private body")
+            .await
+    });
+    let group = tokio::spawn(async move { sender.send_group_text("30003", "group body").await });
+
+    let first = next_action_request(&mut client).await;
+    let second = next_action_request(&mut client).await;
+    assert_ne!(first.echo, second.echo);
+    for request in [&first, &second] {
+        let (target_key, target_id, body) = match request.action.as_str() {
+            "send_private_msg" => ("user_id", "20002", "private body"),
+            "send_group_msg" => ("group_id", "30003", "group body"),
+            action => panic!("unexpected action {action}"),
+        };
+        assert_eq!(request.params[target_key], json!(target_id));
+        assert_eq!(
+            request.params["message"],
+            json!([{"type": "text", "data": {"text": body}}])
+        );
+    }
+
+    for request in [&second, &first] {
+        let message_id = if request.action == "send_private_msg" {
+            json!(90001)
+        } else {
+            json!("90002")
+        };
+        client
+            .send(Message::Text(
+                serde_json::to_string(&action_response(request, json!({"message_id": message_id})))
+                    .unwrap()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+    }
+
+    assert_eq!(private.await.unwrap().unwrap().message_id, "90001");
+    assert_eq!(group.await.unwrap().unwrap().message_id, "90002");
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn unknown_echo_does_not_complete_pending_send() {
+    let (handle, _runtime, shutdown) = spawn_server().await;
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    let sender = OneBotSender::new(handle.connection.clone());
+    let mut send = tokio::spawn(async move { sender.send_private_text("20002", "hello").await });
+    let request = next_action_request(&mut client).await;
+    let mut unknown = action_response(&request, json!({"message_id": 1}));
+    unknown.echo = Some(crate::gateway::onebot11::protocol::Echo(json!("unknown")));
+    client
+        .send(Message::Text(
+            serde_json::to_string(&unknown).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), &mut send)
+            .await
+            .is_err()
+    );
+
+    client
+        .send(Message::Text(
+            serde_json::to_string(&action_response(&request, json!({"message_id": "real-id"})))
+                .unwrap()
+                .into(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(send.await.unwrap().unwrap().message_id, "real-id");
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn sender_propagates_retcode_failure_without_forging_success() {
+    let (handle, _runtime, shutdown) = spawn_server().await;
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    let sender = OneBotSender::new(handle.connection.clone());
+    let send = tokio::spawn(async move { sender.send_group_text("30003", "hello").await });
+    let request = next_action_request(&mut client).await;
+    client
+        .send(Message::Text(
+            json!({
+                "status": "failed",
+                "retcode": 1404,
+                "data": null,
+                "message": "failed remotely",
+                "wording": "target unavailable",
+                "echo": request.echo
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+
+    assert!(matches!(
+        send.await.unwrap(),
+        Err(OneBotSendError::Rejected {
+            retcode: 1404,
+            remote_message_present: true,
+            ..
+        })
+    ));
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn sender_returns_explicit_offline_and_disconnect_errors() {
+    let (handle, _runtime, shutdown) = spawn_server().await;
+    let sender = OneBotSender::new(handle.connection.clone());
+    assert!(matches!(
+        sender.send_private_text("20002", "offline").await,
+        Err(OneBotSendError::Transport(OneBotCallError::NotConnected))
+    ));
+
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    let pending_sender = sender.clone();
+    let pending = tokio::spawn(async move {
+        pending_sender
+            .send_private_text("20002", "disconnect")
+            .await
+    });
+    let _request = next_action_request(&mut client).await;
+    client.close(None).await.unwrap();
+    assert!(matches!(
+        pending.await.unwrap(),
+        Err(OneBotSendError::Transport(
+            OneBotCallError::ConnectionClosed
+        ))
+    ));
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn sender_propagates_action_timeout() {
+    let mut config = test_config();
+    config.request_timeout = Duration::from_millis(50);
+    let runtime = GatewayRuntimeStatus::new();
+    let shutdown = CancellationToken::new();
+    let handle = spawn_reverse_websocket_server(config, runtime, shutdown.clone())
+        .await
+        .unwrap();
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    let sender = OneBotSender::new(handle.connection.clone());
+    let send = tokio::spawn(async move { sender.send_private_text("20002", "timeout").await });
+    let _request = next_action_request(&mut client).await;
+
+    assert!(matches!(
+        send.await.unwrap(),
+        Err(OneBotSendError::Transport(OneBotCallError::Timeout))
+    ));
 
     shutdown.cancel();
     handle.task.await.unwrap().unwrap();

--- a/qq-maid-gateway-rs/src/gateway/onebot11/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/tests.rs
@@ -232,11 +232,12 @@ async fn concurrent_text_sends_use_unique_echo_and_complete_out_of_order() {
     assert_ne!(first.echo, second.echo);
     for request in [&first, &second] {
         let (target_key, target_id, body) = match request.action.as_str() {
-            "send_private_msg" => ("user_id", "20002", "private body"),
-            "send_group_msg" => ("group_id", "30003", "group body"),
+            "send_private_msg" => ("user_id", 20002_u64, "private body"),
+            "send_group_msg" => ("group_id", 30003_u64, "group body"),
             action => panic!("unexpected action {action}"),
         };
         assert_eq!(request.params[target_key], json!(target_id));
+        assert!(request.params[target_key].is_u64());
         assert_eq!(
             request.params["message"],
             json!([{"type": "text", "data": {"text": body}}])
@@ -261,6 +262,59 @@ async fn concurrent_text_sends_use_unique_echo_and_complete_out_of_order() {
 
     assert_eq!(private.await.unwrap().unwrap().message_id, "90001");
     assert_eq!(group.await.unwrap().unwrap().message_id, "90002");
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn large_target_id_is_sent_as_exact_json_number() {
+    let (handle, _runtime, shutdown) = spawn_server().await;
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    let sender = OneBotSender::new(handle.connection.clone());
+    let send = tokio::spawn(async move {
+        sender
+            .send_private_text("18446744073709551615", "large target")
+            .await
+    });
+
+    let request = next_action_request(&mut client).await;
+    assert_eq!(request.params["user_id"], json!(u64::MAX));
+    assert_eq!(request.params["user_id"].as_u64(), Some(u64::MAX));
+    client
+        .send(Message::Text(
+            serde_json::to_string(&action_response(&request, json!({"message_id": "90003"})))
+                .unwrap()
+                .into(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(send.await.unwrap().unwrap().message_id, "90003");
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn invalid_target_id_returns_error_without_writing_action() {
+    let (handle, _runtime, shutdown) = spawn_server().await;
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    let sender = OneBotSender::new(handle.connection.clone());
+
+    assert!(matches!(
+        sender.send_group_text("not-a-number", "invalid").await,
+        Err(OneBotSendError::InvalidTargetId)
+    ));
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), client.next())
+            .await
+            .is_err(),
+        "无效目标 ID 不应向 WebSocket 写入 action"
+    );
 
     shutdown.cancel();
     handle.task.await.unwrap().unwrap();

--- a/qq-maid-gateway-rs/src/gateway/outbound.rs
+++ b/qq-maid-gateway-rs/src/gateway/outbound.rs
@@ -76,6 +76,30 @@ impl ReplyTarget {
         }
     }
 
+    #[allow(dead_code)]
+    pub(crate) fn onebot_private(
+        target_id: impl Into<String>,
+        source_message_id: Option<String>,
+    ) -> Self {
+        Self::Private {
+            platform: Platform::OneBot11,
+            target_id: target_id.into(),
+            source_message_id,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn onebot_group(
+        target_id: impl Into<String>,
+        source_message_id: Option<String>,
+    ) -> Self {
+        Self::Group {
+            platform: Platform::OneBot11,
+            target_id: target_id.into(),
+            source_message_id,
+        }
+    }
+
     pub(crate) fn to_qq_c2c_target(&self) -> Option<C2cReplyTarget> {
         match self {
             Self::Private {
@@ -203,6 +227,33 @@ impl ReplyCapability {
                         .markdown_chunk_soft_limit
                         .max(config.text_chunk_soft_limit),
                 ),
+                reply_timeout: None,
+            },
+            long_running_strategy: LongRunningReplyStrategy::KeepAsyncDelivery,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn onebot11_text() -> Self {
+        Self {
+            platform: Platform::OneBot11,
+            render: RenderProfile {
+                supports_text: true,
+                supports_markdown: false,
+                supports_image: false,
+                supports_attachment: false,
+                unsupported_fallback: UnsupportedCapabilityFallback::UseText,
+            },
+            supports_quote_original: false,
+            supports_at_mention: false,
+            supports_multi_part: false,
+            image_delivery_implemented: false,
+            supports_synchronous_reply: false,
+            supports_asynchronous_reply: true,
+            streaming_delivery_implemented: false,
+            supports_streaming: false,
+            limits: ReplyLimits {
+                single_message_chars: None,
                 reply_timeout: None,
             },
             long_running_strategy: LongRunningReplyStrategy::KeepAsyncDelivery,
@@ -488,5 +539,22 @@ mod tests {
             capability.limits.reply_timeout,
             Some(Duration::from_secs(5))
         );
+    }
+
+    #[test]
+    fn onebot_capability_is_text_only_async_and_non_streaming() {
+        let capability = ReplyCapability::onebot11_text();
+
+        assert_eq!(capability.platform, Platform::OneBot11);
+        assert!(capability.render.supports_text);
+        assert!(!capability.render.supports_markdown);
+        assert!(!capability.render.supports_image);
+        assert_eq!(
+            capability.render.unsupported_fallback,
+            UnsupportedCapabilityFallback::UseText
+        );
+        assert!(capability.supports_delivery_mode(DeliveryMode::AsynchronousReply));
+        assert!(!capability.supports_delivery_mode(DeliveryMode::SynchronousReply));
+        assert!(!capability.supports_delivery_mode(DeliveryMode::Streaming));
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/platform/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/mod.rs
@@ -6,6 +6,7 @@
 mod core;
 pub(crate) mod member_enrich;
 mod model;
+pub(crate) mod onebot11;
 pub(crate) mod qq_official;
 pub(crate) mod wechat_service;
 

--- a/qq-maid-gateway-rs/src/gateway/platform/model.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/model.rs
@@ -12,8 +12,7 @@ use qq_maid_core::service::VisibleEntitySnapshot;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Platform {
     QqOfficial,
-    // 后续 OneBot 11 adapter 接入后会由对应协议转换层构造。
-    #[allow(dead_code)]
+    // 仅由 OneBot 11 adapter 在协议边界完成转换后构造。
     OneBot11,
     // 后续微信服务号 adapter 接入后会由 XML 回调转换层构造。
     #[allow(dead_code)]

--- a/qq-maid-gateway-rs/src/gateway/platform/onebot11.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/onebot11.rs
@@ -1,0 +1,607 @@
+//! OneBot 11 消息事件到统一入站模型的 adapter。
+//!
+//! 本模块只处理一期文本、结构化 `at` 与触发语义。CQ 字符串、媒体、引用和业务回复
+//! 分别由后续任务处理，不能把 OneBot 原始字段泄漏到 Core。
+
+use qq_maid_common::{
+    identity_context::{IdentitySource, MentionConfidence, MentionIdentity, MessageActorContext},
+    input_part::MessageInputPart,
+};
+use serde_json::{Map, Value};
+
+use crate::gateway::onebot11::protocol::{MessageSegment, OneBotEvent, OneBotMessage};
+
+use super::model::{Actor, ConversationTarget, GroupMemberRoleKind, InboundMessage, Platform};
+
+/// OneBot 事件的 adapter 结果。被忽略的事件保留稳定分类，便于调用方做限量结构化观测，
+/// 但不得记录消息正文或完整 ID。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum OneBotInboundOutcome {
+    Message(Box<InboundMessage>),
+    Ignored(OneBotIgnoreReason),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OneBotIgnoreReason {
+    NonMessageEvent,
+    MessageSent,
+    UnsupportedMessageType,
+    UnsupportedMessageEncoding,
+    MissingUserId,
+    MissingGroupId,
+    MissingMessageId,
+    MissingMessage,
+    SelfMessage,
+    GroupNotTriggered,
+}
+
+impl OneBotIgnoreReason {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::NonMessageEvent => "non_message_event",
+            Self::MessageSent => "message_sent",
+            Self::UnsupportedMessageType => "unsupported_message_type",
+            Self::UnsupportedMessageEncoding => "unsupported_message_encoding",
+            Self::MissingUserId => "missing_user_id",
+            Self::MissingGroupId => "missing_group_id",
+            Self::MissingMessageId => "missing_message_id",
+            Self::MissingMessage => "missing_message",
+            Self::SelfMessage => "self_message",
+            Self::GroupNotTriggered => "group_not_triggered",
+        }
+    }
+}
+
+/// 将已通过协议层反序列化的事件适配为统一入站消息。
+///
+/// 一期群聊只接受明确 `at` 当前 `self_id` 的消息；当前账号自己发送的 `message` 和
+/// `message_sent` 均被过滤，避免后续聊天闭环形成回声循环。
+pub(crate) fn inbound_from_event(event: &OneBotEvent) -> OneBotInboundOutcome {
+    if event.post_type == "message_sent" {
+        return OneBotInboundOutcome::Ignored(OneBotIgnoreReason::MessageSent);
+    }
+    if event.post_type != "message" {
+        return OneBotInboundOutcome::Ignored(OneBotIgnoreReason::NonMessageEvent);
+    }
+
+    let message_type = match event.message_type.as_deref() {
+        Some("private") => MessageType::Private,
+        Some("group") => MessageType::Group,
+        _ => {
+            return OneBotInboundOutcome::Ignored(OneBotIgnoreReason::UnsupportedMessageType);
+        }
+    };
+    let Some(user_id) = event_id(event, "user_id").or_else(|| sender_id(event)) else {
+        return OneBotInboundOutcome::Ignored(OneBotIgnoreReason::MissingUserId);
+    };
+    if user_id == event.self_id.as_str() {
+        return OneBotInboundOutcome::Ignored(OneBotIgnoreReason::SelfMessage);
+    }
+    let Some(message_id) = event_id(event, "message_id") else {
+        return OneBotInboundOutcome::Ignored(OneBotIgnoreReason::MissingMessageId);
+    };
+    let Some(message) = event.message.as_ref() else {
+        return OneBotInboundOutcome::Ignored(OneBotIgnoreReason::MissingMessage);
+    };
+    let OneBotMessage::Segments(segments) = message else {
+        // 一期内部格式只接受 segment 数组，不能把 CQ 字符串解析扩散到核心链路。
+        return OneBotInboundOutcome::Ignored(OneBotIgnoreReason::UnsupportedMessageEncoding);
+    };
+
+    let parsed = parse_segments(segments, event.self_id.as_str());
+    let conversation = match message_type {
+        MessageType::Private => ConversationTarget::Private {
+            target_id: user_id.clone(),
+        },
+        MessageType::Group => {
+            if !parsed.mentioned_bot {
+                return OneBotInboundOutcome::Ignored(OneBotIgnoreReason::GroupNotTriggered);
+            }
+            let Some(group_id) = event_id(event, "group_id") else {
+                return OneBotInboundOutcome::Ignored(OneBotIgnoreReason::MissingGroupId);
+            };
+            ConversationTarget::Group {
+                target_id: group_id,
+            }
+        }
+    };
+
+    OneBotInboundOutcome::Message(Box::new(InboundMessage {
+        platform: Platform::OneBot11,
+        account_id: Some(event.self_id.as_str().to_owned()),
+        conversation,
+        actor: Actor {
+            sender_id: Some(user_id),
+            union_id: None,
+            display_name: sender_display_name(event),
+            group_member_role: (message_type == MessageType::Group)
+                .then(|| sender_role(event))
+                .flatten(),
+            is_bot: false,
+            source: IdentitySource::Event,
+        },
+        message_id,
+        current_msg_idx: None,
+        timestamp: event.time.map(|time| time.to_string()),
+        text: parsed.text,
+        input_parts: parsed.input_parts,
+        attachments: Vec::new(),
+        quoted: None,
+        visible_entity_snapshot: None,
+        mentions: parsed.mentions,
+        mentioned_bot: parsed.mentioned_bot,
+    }))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MessageType {
+    Private,
+    Group,
+}
+
+#[derive(Debug)]
+struct ParsedSegments {
+    text: String,
+    input_parts: Vec<MessageInputPart>,
+    mentions: Vec<MentionIdentity>,
+    mentioned_bot: bool,
+}
+
+fn parse_segments(segments: &[MessageSegment], self_id: &str) -> ParsedSegments {
+    let mut text = String::new();
+    let mut mentions = Vec::new();
+    let mut mentioned_bot = false;
+
+    for segment in segments {
+        match segment.kind.as_str() {
+            "text" => {
+                let Some(value) = segment.data.get("text").and_then(Value::as_str) else {
+                    continue;
+                };
+                text.push_str(value);
+            }
+            "at" => {
+                let Some(target_id) = segment.data.get("qq").and_then(id_from_value) else {
+                    continue;
+                };
+                let is_self = target_id == self_id;
+                mentioned_bot |= is_self;
+                mentions.push(mention_identity(target_id, is_self));
+                // `at` 当前机器人只用于触发，普通 `at` 也由 mentions 表达；二者均不伪造成
+                // MessageInputPart::Text，因此正文只保留平台原始 text segment 的顺序。
+            }
+            _ => {
+                // 未知 segment 仅降级忽略当前段，不能导致整条文本消息反序列化失败。
+            }
+        }
+    }
+
+    // OneBot 相邻 text segment 在协议上共同组成一段正文；合并为单一 input part，
+    // 避免通用 Core renderer 将多个 part 用换行连接后改变原文。
+    let input_parts = if text.is_empty() {
+        Vec::new()
+    } else {
+        vec![MessageInputPart::text(text.clone())]
+    };
+    ParsedSegments {
+        text,
+        input_parts,
+        mentions,
+        mentioned_bot,
+    }
+}
+
+fn mention_identity(target_id: String, is_self: bool) -> MentionIdentity {
+    let is_all = target_id == "all";
+    MentionIdentity {
+        raw_text: if is_self {
+            Some("@当前机器人".to_owned())
+        } else if is_all {
+            Some("@全体成员".to_owned())
+        } else {
+            None
+        },
+        target: MessageActorContext {
+            user_id: (!is_all).then_some(target_id),
+            display_name: is_all.then(|| "全体成员".to_owned()),
+            display_name_source: is_all.then(|| "event".to_owned()),
+            is_bot: is_self.then_some(true),
+            source: IdentitySource::Event,
+            ..Default::default()
+        },
+        is_self,
+        confidence: MentionConfidence::Event,
+    }
+}
+
+fn event_id(event: &OneBotEvent, field: &str) -> Option<String> {
+    event.extra.get(field).and_then(id_from_value)
+}
+
+fn sender(event: &OneBotEvent) -> Option<&Map<String, Value>> {
+    event.extra.get("sender").and_then(Value::as_object)
+}
+
+fn sender_id(event: &OneBotEvent) -> Option<String> {
+    sender(event)?.get("user_id").and_then(id_from_value)
+}
+
+fn sender_display_name(event: &OneBotEvent) -> Option<String> {
+    let sender = sender(event)?;
+    ["card", "nickname"]
+        .into_iter()
+        .filter_map(|field| sender.get(field).and_then(Value::as_str))
+        .map(str::trim)
+        .find(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn sender_role(event: &OneBotEvent) -> Option<GroupMemberRoleKind> {
+    let role = sender(event)?.get("role")?.as_str()?.trim();
+    if role.is_empty() {
+        return None;
+    }
+    Some(match role {
+        "owner" => GroupMemberRoleKind::Owner,
+        "admin" => GroupMemberRoleKind::Admin,
+        "member" => GroupMemberRoleKind::Member,
+        _ => GroupMemberRoleKind::Unknown,
+    })
+}
+
+fn id_from_value(value: &Value) -> Option<String> {
+    match value {
+        Value::String(value) => {
+            let value = value.trim();
+            (!value.is_empty()).then(|| value.to_owned())
+        }
+        Value::Number(value) if value.is_i64() || value.is_u64() => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use serde_json::{Value, json};
+
+    use super::*;
+    use crate::gateway::{
+        dedupe::MessageDedupe,
+        platform::{core_scope_key, render_text_for_core},
+    };
+
+    fn event(value: Value) -> OneBotEvent {
+        serde_json::from_value(value).unwrap()
+    }
+
+    fn message(outcome: OneBotInboundOutcome) -> InboundMessage {
+        let OneBotInboundOutcome::Message(message) = outcome else {
+            panic!("expected adapted message, got {outcome:?}");
+        };
+        *message
+    }
+
+    fn ignored(outcome: OneBotInboundOutcome) -> OneBotIgnoreReason {
+        let OneBotInboundOutcome::Ignored(reason) = outcome else {
+            panic!("expected ignored event, got {outcome:?}");
+        };
+        reason
+    }
+
+    fn private_event(self_id: Value, user_id: Value, message_id: Value) -> OneBotEvent {
+        event(json!({
+            "time": 1720000000,
+            "self_id": self_id,
+            "post_type": "message",
+            "message_type": "private",
+            "user_id": user_id,
+            "message_id": message_id,
+            "sender": {"nickname": "测试用户"},
+            "message": [
+                {"type": "text", "data": {"text": "你好"}},
+                {"type": "text", "data": {"text": "，世界"}}
+            ]
+        }))
+    }
+
+    fn group_event(message: Value) -> OneBotEvent {
+        event(json!({
+            "time": 1720000001,
+            "self_id": "10001",
+            "post_type": "message",
+            "message_type": "group",
+            "user_id": "20002",
+            "group_id": "30003",
+            "message_id": "40004",
+            "sender": {"card": "群名片", "nickname": "昵称", "role": "admin"},
+            "message": message
+        }))
+    }
+
+    #[test]
+    fn private_text_accepts_numeric_and_string_ids() {
+        let cases = [
+            (json!(10001), json!(20002), json!(30003)),
+            (json!("10001"), json!("20002"), json!("30003")),
+        ];
+
+        for (self_id, user_id, message_id) in cases {
+            let inbound = message(inbound_from_event(&private_event(
+                self_id, user_id, message_id,
+            )));
+            assert_eq!(inbound.platform, Platform::OneBot11);
+            assert_eq!(inbound.account_id.as_deref(), Some("10001"));
+            assert_eq!(
+                inbound.conversation,
+                ConversationTarget::Private {
+                    target_id: "20002".to_owned()
+                }
+            );
+            assert_eq!(inbound.actor.sender_id.as_deref(), Some("20002"));
+            assert_eq!(inbound.actor.display_name.as_deref(), Some("测试用户"));
+            assert_eq!(inbound.message_id, "30003");
+            assert_eq!(inbound.timestamp.as_deref(), Some("1720000000"));
+            assert_eq!(inbound.text, "你好，世界");
+            assert_eq!(
+                inbound
+                    .input_parts
+                    .iter()
+                    .filter_map(MessageInputPart::text_content)
+                    .collect::<Vec<_>>(),
+                vec!["你好，世界"]
+            );
+            assert_eq!(render_text_for_core(&inbound), inbound.text);
+            assert_eq!(
+                core_scope_key(&inbound).unwrap(),
+                "platform:onebot:account:10001:private:20002"
+            );
+        }
+    }
+
+    #[test]
+    fn group_trigger_table_distinguishes_self_at_other_at_and_self_message() {
+        let cases = [
+            (
+                "at current bot",
+                group_event(json!([
+                    {"type": "at", "data": {"qq": 10001}},
+                    {"type": "text", "data": {"text": " 请帮忙"}}
+                ])),
+                None,
+            ),
+            (
+                "not triggered",
+                group_event(json!([{"type": "text", "data": {"text": "路过"}}])),
+                Some(OneBotIgnoreReason::GroupNotTriggered),
+            ),
+            (
+                "at another member",
+                group_event(json!([
+                    {"type": "at", "data": {"qq": "90009"}},
+                    {"type": "text", "data": {"text": " 看一下"}}
+                ])),
+                Some(OneBotIgnoreReason::GroupNotTriggered),
+            ),
+            (
+                "self message",
+                event(json!({
+                    "self_id": "10001",
+                    "post_type": "message",
+                    "message_type": "group",
+                    "user_id": "10001",
+                    "group_id": "30003",
+                    "message_id": "40004",
+                    "message": [{"type": "at", "data": {"qq": "10001"}}]
+                })),
+                Some(OneBotIgnoreReason::SelfMessage),
+            ),
+        ];
+
+        for (name, event, expected_ignored) in cases {
+            let outcome = inbound_from_event(&event);
+            match expected_ignored {
+                Some(reason) => assert_eq!(ignored(outcome), reason, "{name}"),
+                None => {
+                    let inbound = message(outcome);
+                    assert_eq!(
+                        inbound.conversation,
+                        ConversationTarget::Group {
+                            target_id: "30003".to_owned()
+                        },
+                        "{name}"
+                    );
+                    assert!(inbound.mentioned_bot, "{name}");
+                    assert_eq!(inbound.text, " 请帮忙", "{name}");
+                    assert_eq!(
+                        inbound.actor.group_member_role,
+                        Some(GroupMemberRoleKind::Admin),
+                        "{name}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn removes_only_trigger_at_and_preserves_ordered_text_and_mentions() {
+        let inbound = message(inbound_from_event(&group_event(json!([
+            {"type": "text", "data": {"text": "请"}},
+            {"type": "at", "data": {"qq": "10001"}},
+            {"type": "text", "data": {"text": "帮"}},
+            {"type": "at", "data": {"qq": 90009}},
+            {"type": "text", "data": {"text": "看看"}}
+        ]))));
+
+        assert_eq!(inbound.text, "请帮看看");
+        assert_eq!(
+            inbound
+                .input_parts
+                .iter()
+                .filter_map(MessageInputPart::text_content)
+                .collect::<Vec<_>>(),
+            vec!["请帮看看"]
+        );
+        assert_eq!(render_text_for_core(&inbound), inbound.text);
+        assert_eq!(inbound.mentions.len(), 2);
+        assert!(inbound.mentions[0].is_self);
+        assert_eq!(inbound.mentions[0].target.user_id.as_deref(), Some("10001"));
+        assert!(!inbound.mentions[1].is_self);
+        assert_eq!(inbound.mentions[1].target.user_id.as_deref(), Some("90009"));
+        assert_eq!(inbound.mentions[1].target.display_name, None);
+        assert_eq!(inbound.mentions[1].target.is_bot, None);
+    }
+
+    #[test]
+    fn sender_role_table_maps_known_values_and_marks_unknown_value() {
+        let cases = [
+            ("owner", GroupMemberRoleKind::Owner),
+            ("admin", GroupMemberRoleKind::Admin),
+            ("member", GroupMemberRoleKind::Member),
+            ("future_role", GroupMemberRoleKind::Unknown),
+        ];
+
+        for (role, expected) in cases {
+            let inbound = message(inbound_from_event(&event(json!({
+                "self_id": "10001",
+                "post_type": "message",
+                "message_type": "group",
+                "user_id": "20002",
+                "group_id": "30003",
+                "message_id": role,
+                "sender": {"role": role},
+                "message": [{"type": "at", "data": {"qq": "10001"}}]
+            }))));
+            assert_eq!(inbound.actor.group_member_role, Some(expected), "{role}");
+        }
+    }
+
+    #[test]
+    fn empty_text_and_unknown_segment_degrade_without_dropping_message() {
+        let empty = message(inbound_from_event(&event(json!({
+            "self_id": "10001",
+            "post_type": "message",
+            "message_type": "private",
+            "user_id": "20002",
+            "message_id": "empty",
+            "message": [{"type": "text", "data": {"text": ""}}]
+        }))));
+        assert!(empty.text.is_empty());
+        assert!(empty.input_parts.is_empty());
+
+        let unknown = message(inbound_from_event(&event(json!({
+            "self_id": "10001",
+            "post_type": "message",
+            "message_type": "private",
+            "user_id": "20002",
+            "message_id": "unknown",
+            "message": [
+                {"type": "future_segment", "data": {"anything": {"nested": true}}},
+                {"type": "text", "data": {"text": "仍可处理"}}
+            ]
+        }))));
+        assert_eq!(unknown.text, "仍可处理");
+        assert_eq!(unknown.input_parts.len(), 1);
+    }
+
+    #[test]
+    fn unknown_events_message_sent_and_cq_strings_are_safely_ignored() {
+        let cases = [
+            (
+                event(json!({
+                    "self_id": "10001",
+                    "post_type": "notice",
+                    "notice_type": "group_recall"
+                })),
+                OneBotIgnoreReason::NonMessageEvent,
+            ),
+            (
+                event(json!({
+                    "self_id": "10001",
+                    "post_type": "message_sent",
+                    "message_type": "private",
+                    "user_id": "20002",
+                    "message_id": "sent",
+                    "message": [{"type": "text", "data": {"text": "echo"}}]
+                })),
+                OneBotIgnoreReason::MessageSent,
+            ),
+            (
+                event(json!({
+                    "self_id": "10001",
+                    "post_type": "message",
+                    "message_type": "private",
+                    "user_id": "20002",
+                    "message_id": "cq",
+                    "message": "hello[CQ:at,qq=10001]"
+                })),
+                OneBotIgnoreReason::UnsupportedMessageEncoding,
+            ),
+        ];
+
+        for (event, reason) in cases {
+            assert_eq!(ignored(inbound_from_event(&event)), reason);
+        }
+    }
+
+    #[test]
+    fn dedupe_key_is_stable_for_duplicates_and_isolated_by_account_and_conversation() {
+        let base = message(inbound_from_event(&private_event(
+            json!(10001),
+            json!(20002),
+            json!(30003),
+        )));
+        let duplicate = message(inbound_from_event(&private_event(
+            json!("10001"),
+            json!("20002"),
+            json!("30003"),
+        )));
+        let other_account = message(inbound_from_event(&private_event(
+            json!(10002),
+            json!(20002),
+            json!(30003),
+        )));
+        let group = message(inbound_from_event(&event(json!({
+            "self_id": "10001",
+            "post_type": "message",
+            "message_type": "group",
+            "user_id": "20002",
+            "group_id": "90009",
+            "message_id": "30003",
+            "message": [{"type": "at", "data": {"qq": "10001"}}]
+        }))));
+        let other_group = message(inbound_from_event(&event(json!({
+            "self_id": "10001",
+            "post_type": "message",
+            "message_type": "group",
+            "user_id": "20002",
+            "group_id": "90010",
+            "message_id": "30003",
+            "message": [{"type": "at", "data": {"qq": "10001"}}]
+        }))));
+
+        let base_key = base.dedupe_message_key().unwrap();
+        assert_eq!(
+            duplicate.dedupe_message_key().as_deref(),
+            Some(base_key.as_str())
+        );
+        assert_ne!(
+            other_account.dedupe_message_key().as_deref(),
+            Some(base_key.as_str())
+        );
+        assert_ne!(
+            group.dedupe_message_key().as_deref(),
+            Some(base_key.as_str())
+        );
+        assert_ne!(other_group.dedupe_message_key(), group.dedupe_message_key());
+
+        let dedupe = MessageDedupe::new(Duration::from_secs(10));
+        let now = Instant::now();
+        assert!(!dedupe.check_and_insert_many([base_key.clone()], now));
+        assert!(dedupe.check_and_insert_many([base_key], now));
+        assert!(!dedupe.check_and_insert_many([other_account.dedupe_message_key().unwrap()], now));
+        assert!(!dedupe.check_and_insert_many([group.dedupe_message_key().unwrap()], now));
+        assert!(!dedupe.check_and_insert_many([other_group.dedupe_message_key().unwrap()], now));
+    }
+}

--- a/qq-maid-gateway-rs/src/gateway/push.rs
+++ b/qq-maid-gateway-rs/src/gateway/push.rs
@@ -1,7 +1,7 @@
 //! Gateway 进程内主动推送实现。
 //!
-//! Core 只通过 `PushSink` 交付推送意图；本模块负责 QQ 平台发送、Markdown
-//! 失败后的文本 fallback、发送状态记录，以及群推送成功后的 BotOutboundCache 回填。
+//! Core 只通过 `PushSink` 交付推送意图；本模块按 platform/account 精确选择 sender。
+//! QQ 官方继续负责 Markdown fallback 和群消息缓存；OneBot 只发送纯文本 segment。
 
 use std::{
     sync::{Arc, Mutex},
@@ -10,9 +10,10 @@ use std::{
 
 use async_trait::async_trait;
 use qq_maid_core::runtime::push::{
-    PushError, PushIntent, PushResult, PushSink, PushTargetType, QQ_OFFICIAL_PLATFORM,
+    ONEBOT11_PLATFORM, PushError, PushIntent, PushResult, PushSink, PushTargetType,
+    QQ_OFFICIAL_PLATFORM,
 };
-use tokio::{sync::Notify, time::timeout};
+use tokio::{sync::Notify, time::Instant};
 use tracing::{info, warn};
 
 use crate::{
@@ -20,8 +21,12 @@ use crate::{
         QqApiClient, SendMessageIds, SendResult, build_c2c_text_payload, build_group_text_payload,
     },
     gateway::{
-        BotOutboundCache, logging::mask_identifier, ping::GatewayRuntimeStatus,
-        platform::ConversationTarget, ref_index::SharedRefIndex,
+        BotOutboundCache,
+        logging::mask_identifier,
+        onebot11::{OneBotSendError, OneBotSendResult, OneBotSender},
+        ping::GatewayRuntimeStatus,
+        platform::ConversationTarget,
+        ref_index::SharedRefIndex,
     },
     markdown::MarkdownPayload,
 };
@@ -60,9 +65,27 @@ pub struct GatewayPushSink {
 }
 
 #[derive(Clone)]
-enum GatewayPushState {
+struct GatewayPushState {
+    qq_official: PushChannelState<GatewayPushRuntime>,
+    onebot11: PushChannelState<OneBotPushRuntime>,
+}
+
+#[derive(Clone)]
+enum PushChannelState<T> {
     Pending,
-    Bound(GatewayPushRuntime),
+    Bound(T),
+    Unavailable(&'static str),
+}
+
+#[derive(Clone)]
+enum RoutedPushRuntime {
+    QqOfficial(GatewayPushRuntime),
+    OneBot11(OneBotPushRuntime),
+}
+
+enum RouteSnapshot {
+    Pending,
+    Bound(RoutedPushRuntime),
     Unavailable(&'static str),
 }
 
@@ -75,6 +98,49 @@ struct GatewayPushRuntime {
     ref_index: SharedRefIndex,
 }
 
+#[async_trait]
+trait PushOneBotSender: Send + Sync {
+    fn connected_account_id(&self) -> Option<String>;
+    async fn send_private_text(
+        &self,
+        target_id: &str,
+        text: &str,
+    ) -> Result<OneBotSendResult, OneBotSendError>;
+    async fn send_group_text(
+        &self,
+        target_id: &str,
+        text: &str,
+    ) -> Result<OneBotSendResult, OneBotSendError>;
+}
+
+#[async_trait]
+impl PushOneBotSender for OneBotSender {
+    fn connected_account_id(&self) -> Option<String> {
+        OneBotSender::connected_account_id(self)
+    }
+
+    async fn send_private_text(
+        &self,
+        target_id: &str,
+        text: &str,
+    ) -> Result<OneBotSendResult, OneBotSendError> {
+        OneBotSender::send_private_text(self, target_id, text).await
+    }
+
+    async fn send_group_text(
+        &self,
+        target_id: &str,
+        text: &str,
+    ) -> Result<OneBotSendResult, OneBotSendError> {
+        OneBotSender::send_group_text(self, target_id, text).await
+    }
+}
+
+#[derive(Clone)]
+struct OneBotPushRuntime {
+    sender: Arc<dyn PushOneBotSender>,
+}
+
 #[derive(Debug)]
 struct PushSendOutcome {
     ids: SendMessageIds,
@@ -84,7 +150,10 @@ struct PushSendOutcome {
 impl GatewayPushSink {
     pub fn unbound() -> Self {
         Self {
-            inner: Arc::new(Mutex::new(GatewayPushState::Pending)),
+            inner: Arc::new(Mutex::new(GatewayPushState {
+                qq_official: PushChannelState::Pending,
+                onebot11: PushChannelState::Pending,
+            })),
             ready: Arc::new(Notify::new()),
         }
     }
@@ -99,7 +168,7 @@ impl GatewayPushSink {
     ) {
         // Core scheduler 可能在 Gateway 首次连接 QQ 前启动，因此 sink 需要先存在；
         // 真正发送前必须已绑定运行期上下文，否则返回可观测错误而不是静默丢消息。
-        *self.inner.lock().unwrap() = GatewayPushState::Bound(GatewayPushRuntime {
+        self.inner.lock().unwrap().qq_official = PushChannelState::Bound(GatewayPushRuntime {
             api,
             qq_official_account_id: qq_official_account_id.into(),
             runtime,
@@ -110,37 +179,65 @@ impl GatewayPushSink {
     }
 
     pub(crate) fn mark_qq_official_unavailable(&self, summary: &'static str) {
-        *self.inner.lock().unwrap() = GatewayPushState::Unavailable(summary);
+        self.inner.lock().unwrap().qq_official = PushChannelState::Unavailable(summary);
         self.ready.notify_waiters();
     }
 
-    async fn runtime(&self) -> Result<GatewayPushRuntime, PushError> {
-        match self.inner.lock().unwrap().clone() {
-            GatewayPushState::Bound(runtime) => return Ok(runtime),
-            GatewayPushState::Unavailable(summary) => {
+    pub(crate) fn bind_onebot11(&self, sender: OneBotSender) {
+        self.bind_onebot_sender(Arc::new(sender));
+    }
+
+    fn bind_onebot_sender(&self, sender: Arc<dyn PushOneBotSender>) {
+        self.inner.lock().unwrap().onebot11 = PushChannelState::Bound(OneBotPushRuntime { sender });
+        self.ready.notify_waiters();
+    }
+
+    pub(crate) fn mark_onebot11_unavailable(&self, summary: &'static str) {
+        self.inner.lock().unwrap().onebot11 = PushChannelState::Unavailable(summary);
+        self.ready.notify_waiters();
+    }
+
+    async fn runtime(&self, platform: &str) -> Result<RoutedPushRuntime, PushError> {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            // 先创建 waiter 再读取状态，避免 bind 恰好发生在状态读取和等待之间时漏通知。
+            let notified = self.ready.notified();
+            match self.route_snapshot(platform)? {
+                RouteSnapshot::Bound(runtime) => return Ok(runtime),
+                RouteSnapshot::Unavailable(summary) => {
+                    return Err(PushError::Failed {
+                        summary: summary.to_owned(),
+                    });
+                }
+                RouteSnapshot::Pending => {}
+            }
+            if tokio::time::timeout_at(deadline, notified).await.is_err() {
                 return Err(PushError::Failed {
-                    summary: summary.to_owned(),
+                    summary: format!("gateway push sink for `{platform}` is not ready"),
                 });
             }
-            GatewayPushState::Pending => {}
         }
+    }
 
-        // 统一进程启动时 Core 的 RSS / Todo 定时器和 QQ Gateway 连接并行启动。
-        // 首次推送如果撞上 Gateway 尚未 bind，等待一小段时间可避免把正常启动竞态记成推送失败。
-        let notified = self.ready.notified();
-        if timeout(Duration::from_secs(30), notified).await.is_err() {
-            return Err(PushError::Failed {
-                summary: "gateway push sink is not ready".to_owned(),
-            });
-        }
-
-        match self.inner.lock().unwrap().clone() {
-            GatewayPushState::Bound(runtime) => Ok(runtime),
-            GatewayPushState::Unavailable(summary) => Err(PushError::Failed {
-                summary: summary.to_owned(),
+    fn route_snapshot(&self, platform: &str) -> Result<RouteSnapshot, PushError> {
+        let state = self.inner.lock().unwrap();
+        match platform {
+            QQ_OFFICIAL_PLATFORM => Ok(match &state.qq_official {
+                PushChannelState::Pending => RouteSnapshot::Pending,
+                PushChannelState::Bound(runtime) => {
+                    RouteSnapshot::Bound(RoutedPushRuntime::QqOfficial(runtime.clone()))
+                }
+                PushChannelState::Unavailable(summary) => RouteSnapshot::Unavailable(summary),
             }),
-            GatewayPushState::Pending => Err(PushError::Failed {
-                summary: "gateway push sink is not ready".to_owned(),
+            ONEBOT11_PLATFORM => Ok(match &state.onebot11 {
+                PushChannelState::Pending => RouteSnapshot::Pending,
+                PushChannelState::Bound(runtime) => {
+                    RouteSnapshot::Bound(RoutedPushRuntime::OneBot11(runtime.clone()))
+                }
+                PushChannelState::Unavailable(summary) => RouteSnapshot::Unavailable(summary),
+            }),
+            other => Err(PushError::Failed {
+                summary: format!("push platform `{other}` is not supported by gateway"),
             }),
         }
     }
@@ -149,8 +246,73 @@ impl GatewayPushSink {
 #[async_trait]
 impl PushSink for GatewayPushSink {
     async fn push(&self, intent: PushIntent) -> Result<PushResult, PushError> {
-        let runtime = self.runtime().await?;
-        runtime.push(intent).await
+        let platform = intent.target.platform.trim();
+        match self.runtime(platform).await? {
+            RoutedPushRuntime::QqOfficial(runtime) => runtime.push(intent).await,
+            RoutedPushRuntime::OneBot11(runtime) => runtime.push(intent).await,
+        }
+    }
+}
+
+impl OneBotPushRuntime {
+    async fn push(&self, intent: PushIntent) -> Result<PushResult, PushError> {
+        let target_id = intent.target.target_id.trim();
+        let text = intent.text.trim();
+        if target_id.is_empty() || text.is_empty() {
+            return Err(PushError::Failed {
+                summary: "target_id and text are required".to_owned(),
+            });
+        }
+        let target_account = intent
+            .target
+            .account_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|account| !account.is_empty())
+            .ok_or_else(|| PushError::Failed {
+                summary: "onebot11 push target account_id is required".to_owned(),
+            })?;
+        let connected_account =
+            self.sender
+                .connected_account_id()
+                .ok_or_else(|| PushError::Failed {
+                    summary: "OneBot 11 account is offline".to_owned(),
+                })?;
+        if target_account != connected_account {
+            return Err(PushError::Failed {
+                summary: "push target account does not match connected OneBot 11 account"
+                    .to_owned(),
+            });
+        }
+
+        // OneBot 一期只有 text segment；Markdown、图片等结构化意图统一使用上游已生成的
+        // 纯文本 fallback，不能把 QQ Markdown payload 或 CQ 码带入 sender。
+        let fallback_text = intent
+            .fallback_text
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(text);
+        let delivered_text = if matches!(intent.message_type.trim(), "" | "text") {
+            text
+        } else {
+            fallback_text
+        };
+        let result = match intent.target.target_type {
+            PushTargetType::Private => {
+                self.sender
+                    .send_private_text(target_id, delivered_text)
+                    .await
+            }
+            PushTargetType::Group => self.sender.send_group_text(target_id, delivered_text).await,
+        }
+        .map_err(|error| PushError::Failed {
+            // sender 的错误摘要不会包含消息正文、token 或完整 response envelope。
+            summary: error.to_string(),
+        })?;
+        Ok(PushResult {
+            message_id: Some(result.message_id),
+        })
     }
 }
 
@@ -402,6 +564,73 @@ mod tests {
         }
     }
 
+    struct MockOneBotSender {
+        account_id: Option<String>,
+        calls: Mutex<Vec<String>>,
+        fail: bool,
+    }
+
+    impl MockOneBotSender {
+        fn connected(account_id: &str) -> Self {
+            Self {
+                account_id: Some(account_id.to_owned()),
+                calls: Mutex::new(Vec::new()),
+                fail: false,
+            }
+        }
+
+        fn calls(&self) -> Vec<String> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl PushOneBotSender for MockOneBotSender {
+        fn connected_account_id(&self) -> Option<String> {
+            self.account_id.clone()
+        }
+
+        async fn send_private_text(
+            &self,
+            target_id: &str,
+            text: &str,
+        ) -> Result<OneBotSendResult, OneBotSendError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("private:{target_id}:{text}"));
+            if self.fail {
+                Err(OneBotSendError::Transport(
+                    crate::gateway::onebot11::OneBotCallError::ConnectionClosed,
+                ))
+            } else {
+                Ok(OneBotSendResult {
+                    message_id: "ob-private-1".to_owned(),
+                })
+            }
+        }
+
+        async fn send_group_text(
+            &self,
+            target_id: &str,
+            text: &str,
+        ) -> Result<OneBotSendResult, OneBotSendError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("group:{target_id}:{text}"));
+            if self.fail {
+                Err(OneBotSendError::Transport(
+                    crate::gateway::onebot11::OneBotCallError::ConnectionClosed,
+                ))
+            } else {
+                Ok(OneBotSendResult {
+                    message_id: "ob-group-1".to_owned(),
+                })
+            }
+        }
+    }
+
     #[async_trait]
     impl PushQqSender for MockPushSender {
         async fn send_c2c_text(&self, target_id: &str, text: &str) -> SendResult {
@@ -525,6 +754,144 @@ mod tests {
         let err = sink.push(intent).await.unwrap_err();
 
         assert!(err.to_string().contains("QQ official channel is not bound"));
+    }
+
+    #[tokio::test]
+    async fn onebot_push_routes_independently_when_qq_is_unavailable() {
+        let sink = GatewayPushSink::unbound();
+        sink.mark_qq_official_unavailable("QQ official channel is not bound");
+        let sender = Arc::new(MockOneBotSender::connected("bot-1"));
+        sink.bind_onebot_sender(sender.clone());
+        let intent = PushIntent {
+            target: PushTarget::onebot11("bot-1", PushTargetType::Private, "user-1"),
+            text: "# Markdown".to_owned(),
+            fallback_text: Some("纯文本".to_owned()),
+            message_type: "markdown".to_owned(),
+            visible_entity_snapshot: None,
+        };
+
+        let result = sink.push(intent).await.unwrap();
+
+        assert_eq!(result.message_id.as_deref(), Some("ob-private-1"));
+        assert_eq!(sender.calls(), vec!["private:user-1:纯文本"]);
+    }
+
+    #[tokio::test]
+    async fn onebot_group_push_routes_to_group_action_sender() {
+        let sink = GatewayPushSink::unbound();
+        let sender = Arc::new(MockOneBotSender::connected("bot-1"));
+        sink.bind_onebot_sender(sender.clone());
+
+        let result = sink
+            .push(PushIntent {
+                target: PushTarget::onebot11("bot-1", PushTargetType::Group, "group-1"),
+                text: "group text".to_owned(),
+                fallback_text: None,
+                message_type: "text".to_owned(),
+                visible_entity_snapshot: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.message_id.as_deref(), Some("ob-group-1"));
+        assert_eq!(sender.calls(), vec!["group:group-1:group text"]);
+    }
+
+    #[tokio::test]
+    async fn onebot_push_rejects_offline_missing_or_wrong_account_without_sending() {
+        let missing_account_sender = Arc::new(MockOneBotSender::connected("bot-1"));
+        let runtime = OneBotPushRuntime {
+            sender: missing_account_sender.clone(),
+        };
+        let base = PushIntent {
+            target: PushTarget::new(ONEBOT11_PLATFORM, None, PushTargetType::Group, "group-1"),
+            text: "hello".to_owned(),
+            fallback_text: None,
+            message_type: "text".to_owned(),
+            visible_entity_snapshot: None,
+        };
+        let missing = runtime.push(base.clone()).await.unwrap_err();
+        assert!(missing.to_string().contains("account_id is required"));
+
+        let wrong = runtime
+            .push(PushIntent {
+                target: PushTarget::new(
+                    ONEBOT11_PLATFORM,
+                    Some("bot-2".to_owned()),
+                    PushTargetType::Group,
+                    "group-1",
+                ),
+                ..base.clone()
+            })
+            .await
+            .unwrap_err();
+        assert!(wrong.to_string().contains("does not match"));
+        assert!(missing_account_sender.calls().is_empty());
+
+        let offline = OneBotPushRuntime {
+            sender: Arc::new(MockOneBotSender {
+                account_id: None,
+                calls: Mutex::new(Vec::new()),
+                fail: false,
+            }),
+        }
+        .push(PushIntent {
+            target: PushTarget::new(
+                ONEBOT11_PLATFORM,
+                Some("bot-1".to_owned()),
+                PushTargetType::Group,
+                "group-1",
+            ),
+            ..base
+        })
+        .await
+        .unwrap_err();
+        assert!(offline.to_string().contains("offline"));
+    }
+
+    #[tokio::test]
+    async fn qq_target_never_falls_through_to_bound_onebot_sender() {
+        let sink = GatewayPushSink::unbound();
+        sink.mark_qq_official_unavailable("QQ official channel is not bound");
+        let sender = Arc::new(MockOneBotSender::connected("bot-1"));
+        sink.bind_onebot_sender(sender.clone());
+
+        let err = sink
+            .push(PushIntent {
+                target: PushTarget::qq_official(PushTargetType::Private, "user-1"),
+                text: "hello".to_owned(),
+                fallback_text: None,
+                message_type: "text".to_owned(),
+                visible_entity_snapshot: None,
+            })
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("QQ official channel is not bound"));
+        assert!(sender.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn onebot_transport_failure_is_propagated_for_outbox_retry() {
+        let sink = GatewayPushSink::unbound();
+        sink.bind_onebot_sender(Arc::new(MockOneBotSender {
+            account_id: Some("bot-1".to_owned()),
+            calls: Mutex::new(Vec::new()),
+            fail: true,
+        }));
+
+        let err = sink
+            .push(PushIntent {
+                target: PushTarget::onebot11("bot-1", PushTargetType::Private, "user-1"),
+                text: "hello".to_owned(),
+                fallback_text: None,
+                message_type: "text".to_owned(),
+                visible_entity_snapshot: None,
+            })
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("outbound queue is closed"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 变更内容

本 PR 在同一 OneBot 11 功能分支内完成文本入站与文本出站两条相邻能力：

- 新增私聊/群聊消息 adapter，将数字或字符串 ID、sender、文本 segment 和结构化 `at` 映射为平台无关 `InboundMessage`。
- 群聊仅接受明确 `at` 当前 `self_id` 的消息，过滤自身消息与 `message_sent`；未知事件、CQ 字符串和未知 segment 安全忽略或降级。
- 文本 segment 按原顺序合并，普通 at 只作为结构化 mention 上下文表达，不伪造昵称或机器人身份。
- 新增 `send_private_msg` / `send_group_msg` 文本 sender，使用 segment 数组并严格校验 `status`、`retcode`、`data.message_id`。
- 复用反向 WebSocket 的 echo/pending/generation 机制，保证并发乱序响应、超时、断线和连接替换都返回真实结果。
- 将 Gateway PushSink 改为 QQ 官方与 OneBot 独立绑定，按 `platform + account_id` 精确路由；失败返回 `PushError` 供 Notification Outbox 重试。
- 在投递目标边界将 Core 稳定 scope 平台名 `onebot` 规范化为 Gateway 路由名 `onebot11`，不改写已有 session scope。
- 新增 OneBot text-only、非流式 ReplyCapability 和控制台能力，并更新 Gateway README。

## 边界

当前 OneBot 入口仍不调用 Core，因此不形成完整聊天闭环；该部分由后续 #441 负责。本 PR 不实现 CQ 字符串内部格式、流式输出、富媒体、多账号或真实平台管理 API。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p qq-maid-gateway-rs --all-features`（组合分支 423 passed）
- `cargo check -p qq-maid-gateway-rs --all-features`
- `cargo test -p qq-maid-core --all-features`（825 passed）
- `cargo clippy -p qq-maid-gateway-rs -p qq-maid-core --all-targets --all-features -- -D warnings`
- `git diff --check origin/master...HEAD`

fake WebSocket 测试覆盖并发乱序 echo、未知 echo、私聊/群聊 payload、数字/字符串 message_id、retcode、超时、断线与离线；adapter/push 测试覆盖账号、私聊/群聊、不同群的隔离、Markdown 纯文本 fallback、错账号和跨 sender 防误路由。

Closes #439
Closes #440
