### PR TITLE
feat: 打通 OneBot Core 聊天闭环

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <p><sub>Rust 单进程 · 约 25 MiB 常驻内存 · 默认空闲时 3 个线程 · Provider 无关 Agent Loop · 多模态输入 · 主动推送 · 模型自动降级</sub></p>
 </div>
 
-> 💡 仓库早期以 QQ 机器人为主，因此仍保留 `qq-maid-bot` 名称。当前项目正在从 QQ 官方机器人演进为多入口平台型小女仆机器人；OneBot 11 已具备一期反向 WebSocket 连接底座，业务消息接入和发送能力仍在后续阶段。
+> 💡 仓库早期以 QQ 机器人为主，因此仍保留 `qq-maid-bot` 名称。当前项目正在从 QQ 官方机器人演进为多入口平台型小女仆机器人；OneBot 11 已具备一期反向 WebSocket 文本聊天闭环。
 
 小女仆机器人使用 Rust 构建，当前主入口是 QQ 官方机器人接口，并提供可选微信服务号文本入口。它不是简单地把消息转发给大模型，而是把长期会话、受控记忆、Todo、RSS、知识检索、联网查询、QQ 图片理解、引用上下文、Agent Loop、工具调用和主动推送装进同一个可维护的 Agent 底座里。
 
@@ -70,7 +70,7 @@ vim config/.env
 ./botctl.sh status
 ```
 
-最少需要配置一个入口渠道，以及至少一个 Provider 的 API Key。使用 QQ 时同时填写 `QQ_BOT_APP_ID`、`QQ_BOT_APP_SECRET`；微信-only 或 OneBot 11 连接底座部署可留空两项并启用对应入口。OneBot 一期尚不处理业务消息。
+最少需要配置一个入口渠道，以及至少一个 Provider 的 API Key。使用 QQ 官方入口时同时填写 `QQ_BOT_APP_ID`、`QQ_BOT_APP_SECRET`；微信-only 或 OneBot 11 部署可留空两项并启用对应入口。
 
 Windows 用户也可以在 Git Bash、MSYS2 或 Cygwin 中执行 `bash qbot.sh install`，脚本会自动下载
 `windows-x86_64.zip` 并默认安装到 `$HOME/qq-maid-bot`。原生 Windows 启动方式参见发布包内的
@@ -184,13 +184,13 @@ runtime/botctl.sh status
 | --- | --- | --- |
 | QQ 官方机器人 | ✅ 主要入口 | C2C 和群聊，支持图片理解、流式回复、typing 状态 |
 | 微信服务号 | ⚡ 可选 text-only | 默认关闭；支持同步文本回复和慢请求客服补发，需反向代理 |
-| OneBot 11 | 🧱 一期底座 | 单账号反向 WebSocket、鉴权、心跳和连接上下文已实现；业务 adapter / sender 待后续任务 |
+| OneBot 11 | ⚡ 一期 text-only | 单账号反向 WebSocket；支持私聊、群聊 @、Core 命令/聊天、文本回复和主动推送，不向平台流式发送 |
 
 ## 架构概览
 
 ```mermaid
 flowchart LR
-    platform["QQ / 微信<br/>后续 OneBot"] --> gateway["Gateway<br/>接入 / 过滤 / 去重 / 媒体取回"]
+    platform["QQ / OneBot / 微信"] --> gateway["Gateway<br/>接入 / 过滤 / 去重 / 媒体取回"]
     gateway --> request["CoreRequest<br/>统一消息请求"]
 
     agent["Agent Loop<br/>理解意图 / 调模型 / 调工具 / 汇总结果"]
@@ -211,7 +211,7 @@ flowchart LR
 
 | Crate | 职责 |
 | --- | --- |
-| `qq-maid-gateway-rs/` | QQ 事件接收、消息聚合、typing、流式与普通回复、图片下载；可选微信服务号文本回调和 OneBot 11 连接底座 |
+| `qq-maid-gateway-rs/` | QQ 事件接收、消息聚合、typing、流式与普通回复、图片下载；可选微信服务号文本回调和 OneBot 11 text-only 聊天入口 |
 | `qq-maid-core/` | CoreService、会话、记忆、知识库、Todo、RSS、业务 Tool、可信结果编排 |
 | `qq-maid-llm/` | 模型协议、Provider 路由、fallback、SSE、Agent Loop、Tool Loop 和健康观测 |
 | `qq-maid-common/` | 身份上下文、输入输出结构、Markdown 安全转换、脱敏、时间与文本等无业务状态的共享工具 |

--- a/qq-maid-core/src/service/tests/mod.rs
+++ b/qq-maid-core/src/service/tests/mod.rs
@@ -831,6 +831,47 @@ async fn core_help_command_is_wrapped_as_response_events() {
 }
 
 #[tokio::test]
+async fn onebot_commands_use_real_core_and_account_scoped_conversation() {
+    let provider =
+        TestProvider::replying("unused").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let state = test_state_with_tool_calling(provider.clone(), 5, true);
+    let service = CoreHandle::new(state);
+    let mut request = private_request("/new OneBot 回归");
+    request.platform = Platform::OneBot;
+    request.account_id = Some("10001".to_owned());
+    request.actor.user_id = Some("20002".to_owned());
+    request.conversation = CoreConversation::Private {
+        peer_id: "20002".to_owned(),
+    };
+
+    assert_eq!(
+        request.scope_key(),
+        "platform:onebot:account:10001:private:20002"
+    );
+    let new_response = match service.respond(request.clone()).await.unwrap() {
+        CoreRespondOutput::Complete(response) => *response,
+        CoreRespondOutput::Stream(mut stream) => {
+            collect_completed_without_text_delta(&mut stream).await
+        }
+    };
+    assert_eq!(new_response.command.as_deref(), Some("new"));
+    assert!(new_response.session_id.is_some());
+
+    request.text = "/help".to_owned();
+    let mut stream = expect_stream(service.respond(request).await.unwrap());
+    let response = collect_completed_without_text_delta(&mut stream).await;
+
+    assert_eq!(response.command.as_deref(), Some("help"));
+    assert!(
+        response
+            .text_content()
+            .is_some_and(|text| text.starts_with("女仆长助手"))
+    );
+    assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
 async fn core_command_event_failure_does_not_send_finished_or_completed() {
     let provider = TestProvider::failing(LlmError::provider("compact unavailable", "provider"))
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);

--- a/qq-maid-gateway-rs/README.md
+++ b/qq-maid-gateway-rs/README.md
@@ -1,6 +1,6 @@
 # Rust 平台入口与 QQ 文本网关
 
-`qq-maid-gateway-rs/` 是 Rust 平台入口层，当前主入口是 QQ 官方 C2C / 群 at / 普通群文本接入，并包含可选微信服务号文本回调和 OneBot 11 反向 WebSocket 连接底座。旧 Python bot 接入层已经移除；新平台接入能力优先放到本 gateway 的 adapter / sender 边界，业务能力优先放到 `qq-maid-core/`。
+`qq-maid-gateway-rs/` 是 Rust 平台入口层，当前主入口是 QQ 官方 C2C / 群 at / 普通群文本接入，并包含可选微信服务号文本回调和 OneBot 11 反向 WebSocket text-only 聊天入口。旧 Python bot 接入层已经移除；新平台接入能力优先放到本 gateway 的 adapter / sender 边界，业务能力优先放到 `qq-maid-core/`。
 
 ## 多平台入口边界
 
@@ -8,7 +8,7 @@
 flowchart LR
     subgraph platform_in["平台入口"]
         qq["QQ 官方 Gateway"]
-        onebot["OneBot 11 反向 WebSocket<br/>连接底座"]
+        onebot["OneBot 11 反向 WebSocket<br/>text-only 聊天"]
         wechat["微信回调入口"]
     end
 
@@ -61,7 +61,7 @@ flowchart LR
 
 - `InboundMessage` 是 Gateway 内部的平台无关入站模型，包含 `Actor` 与 `Conversation`。QQ、OneBot、微信等协议字段只能在各自 adapter 内解析。
 - `CoreRequest` 是 Gateway 调用 Core 的稳定契约。Core 可以看到平台枚举、Actor 和 Conversation，但不理解 QQ `msg_seq`、stream id、微信 XML 字段或 OneBot CQ 片段。
-- OneBot 11 已实现默认关闭的单账号反向 WebSocket server、鉴权、生命周期/心跳、连接替换、API request/response 共用连接上下文、文本与结构化 at 入站 adapter、文本 sender、主动推送精确路由和脱敏状态；当前 OneBot 入口尚不调用 Core，也不实现流式或富媒体发送。
+- OneBot 11 已实现默认关闭的单账号反向 WebSocket server、鉴权、生命周期/心跳、连接替换、API request/response 共用连接上下文、文本与结构化 at 入站 adapter、Core/Command 编排、文本 sender、主动推送精确路由和脱敏状态；Core stream 只在可信 `Completed` 后发送一条最终文本，不向 OneBot 平台发送 status/delta，也不实现富媒体发送。
 - `scope_key` / `owner_key` 是业务隔离键，用于 Session、Pending、Memory、Todo 等状态归属，不是发送地址。
 - `ReplyTarget` / `DeliveryTarget` 保存真实投递目标，必须保留平台和 `raw_target_id`。发送逻辑只能使用投递目标调用 sender，不能从 `scope_key` 或 `owner_key` 反解析平台 ID。
 - RSS、Notification、Todo 提醒和 Push 这类主动投递也必须携带原始 delivery target；后续多平台收敛时不要把目标统一替换成 namespaced 字符串。
@@ -75,7 +75,7 @@ flowchart LR
 - Markdown 和图片保留独立 outbound 类型、payload 构造和发送入口；发送失败会 warn 并 fallback 到文本。C2C 流式回复当前固定使用 Markdown 流式载荷，首帧成功后不再补发普通全文。
 - Core 的统一通知 Worker 和 Todo 每日提醒通过进程内 `PushSink` 主动推送；RSS 只生产 Notification Outbox 任务，不再维护独立发送链路。
 - 微信服务号入口默认关闭；启用后处理 GET URL 验证、POST 明文 `text` XML、同步文本 XML 快路径，以及超出同步安全预算后的客服文本补发。客服补发按需获取 `access_token`，Markdown 会降级为 text。
-- OneBot 11 入口默认关闭；启用后建立单账号反向 WebSocket 连接，安全适配私聊文本和明确 at 当前机器人的群聊文本，并通过同一连接发送私聊/群聊文本 action；当前尚不调用 Core。首次账号会锁定进程内 `self_id`，同账号新连接替换旧连接，不同账号会被拒绝；连接异常不会结束监听器或其它入口，未完成发送会返回可重试错误。
+- OneBot 11 入口默认关闭；启用后建立单账号反向 WebSocket 连接，安全适配私聊文本和明确 at 当前机器人的群聊文本，复用同一 Core 的命令、会话和既有场景策略，并通过同一连接发送私聊/群聊文本 action。首次账号会锁定进程内 `self_id`，同账号新连接替换旧连接，不同账号会被拒绝；连接异常不会结束监听器或其它入口，未完成发送会返回可重试错误。
 - 不做频道、频道私信、Ark、Embed、Keyboard、多租户或旧接入层兼容。
 - 微信服务号暂不做加密 XML、模板消息、图片语音视频、菜单事件、主动推送或流式输出；客服消息只实现慢请求文本补发。
 
@@ -105,6 +105,7 @@ flowchart LR
 - `src/gateway/wechat_service.rs`：微信服务号文本回调 HTTP 入口，负责签名校验、明文 XML 解析、Core 调用、同步 XML 回复、慢请求去重和客服文本补发。
 - `src/gateway/platform/wechat_service.rs`：微信服务号平台字段到统一 `InboundMessage` / `CoreRequest` 的映射，以及 XML 解析和渲染 helper。
 - `src/gateway/platform/onebot11.rs`：OneBot 11 私聊、群聊、结构化 at 与文本 segment 到统一 `InboundMessage` 的映射和一期触发过滤。
+- `src/gateway/onebot11/dispatch.rs`：去重后的 OneBot 入站到 Core、非流式最终回复收口、结构化 output 文本降级和 sender 调用编排。
 - `src/gateway/onebot11/protocol.rs`：OneBot 11 事件、消息段、action / response、`echo`、生命周期、心跳和无精度损失 ID 类型。
 - `src/gateway/onebot11/connection.rs`：单账号活动连接、同账号替换策略和 API `echo` 关联上下文。
 - `src/gateway/onebot11/sender.rs`：`send_private_msg` / `send_group_msg` 文本 segment、真实响应校验和平台消息 ID 提取。
@@ -158,7 +159,7 @@ QQ_SECRET=你的QQ机器人AppSecret
 
 `QQ_MAID_C2C_VISIBLE_PROGRESS_STATUS_ENABLED` 控制私聊 Tool Loop 的可见进度文本，默认开启，只在 Core 输出策略为 `progress_then_complete` / `progress_then_stream` 时发送一次受控短提示。它不是 QQ 原生 typing 状态；原生 typing 由 `QQ_MAID_AGENT_TYPING_ENABLED` / `QQ_MAID_AGENT_TYPING_DELAY_MS` 单独控制。
 
-OneBot 11 连接底座最小配置：
+OneBot 11 text-only 入口最小配置：
 
 ```env
 ONEBOT11_ENABLED=false
@@ -170,7 +171,7 @@ ONEBOT11_REQUEST_TIMEOUT_MS=10000
 ONEBOT11_MAX_MESSAGE_BYTES=1048576
 ```
 
-启用时 `ONEBOT11_ACCESS_TOKEN` 必填，客户端需携带 `Authorization: Bearer <token>`；推荐保持回环地址监听。`X-Self-ID` 可以在握手时上报，也可由首个合法事件上报。`/ping all` 和控制台只显示 token 是否配置、监听/连接状态、脱敏 `self_id`、最近心跳与断开摘要，不输出完整 QQ 号、token 或消息正文。一期不处理业务消息，也不提供文本发送。
+启用时 `ONEBOT11_ACCESS_TOKEN` 必填，客户端需携带 `Authorization: Bearer <token>`；推荐保持回环地址监听。`X-Self-ID` 可以在握手时上报，也可由首个合法事件上报。`/ping all` 和控制台只显示 token 是否配置、监听/连接状态、脱敏 `self_id`、最近心跳与断开摘要，不输出完整 QQ 号、token 或消息正文。一期支持私聊文本、明确 at 当前机器人的群聊文本、Core 命令/聊天和文本发送；引用、媒体与平台流式输出仍不支持。
 
 微信服务号最小配置：
 

--- a/qq-maid-gateway-rs/README.md
+++ b/qq-maid-gateway-rs/README.md
@@ -75,7 +75,7 @@ flowchart LR
 - Markdown 和图片保留独立 outbound 类型、payload 构造和发送入口；发送失败会 warn 并 fallback 到文本。C2C 流式回复当前固定使用 Markdown 流式载荷，首帧成功后不再补发普通全文。
 - Core 的统一通知 Worker 和 Todo 每日提醒通过进程内 `PushSink` 主动推送；RSS 只生产 Notification Outbox 任务，不再维护独立发送链路。
 - 微信服务号入口默认关闭；启用后处理 GET URL 验证、POST 明文 `text` XML、同步文本 XML 快路径，以及超出同步安全预算后的客服文本补发。客服补发按需获取 `access_token`，Markdown 会降级为 text。
-- OneBot 11 入口默认关闭；启用后建立单账号反向 WebSocket 连接，安全适配私聊文本和明确 at 当前机器人的群聊文本，复用同一 Core 的命令、会话和既有场景策略，并通过同一连接发送私聊/群聊文本 action。首次账号会锁定进程内 `self_id`，同账号新连接替换旧连接，不同账号会被拒绝；连接异常不会结束监听器或其它入口，未完成发送会返回可重试错误。
+- OneBot 11 入口默认关闭；启用后建立单账号反向 WebSocket 连接，安全适配私聊文本和明确 at 当前机器人的群聊文本，复用同一 Core 的命令、会话和既有场景策略，并通过同一连接发送私聊/群聊文本 action。入站按权威 Core scope 使用统一会话调度配置，同 scope 串行、不同 scope 并发，并具备有界队列、活动 scope 上限、idle 回收和 shutdown cancel。首次账号会锁定进程内 `self_id`，同账号新连接替换旧连接，不同账号会被拒绝；连接异常不会结束监听器或其它入口，未完成发送会返回可重试错误。
 - 不做频道、频道私信、Ark、Embed、Keyboard、多租户或旧接入层兼容。
 - 微信服务号暂不做加密 XML、模板消息、图片语音视频、菜单事件、主动推送或流式输出；客服消息只实现慢请求文本补发。
 

--- a/qq-maid-gateway-rs/src/config/mod.rs
+++ b/qq-maid-gateway-rs/src/config/mod.rs
@@ -96,7 +96,7 @@ pub struct AppConfig {
     pub media_max_bytes: u64,
     /// 微信服务号最小文本回调入口；默认关闭，不影响现有 QQ Gateway。
     pub wechat_service: WechatServiceConfig,
-    /// OneBot 11 反向 WebSocket 单账号入口；一期只建立连接底座，不进入 Core。
+    /// OneBot 11 反向 WebSocket 单账号 text-only 入口；复用 Core，不向平台流式发送。
     pub onebot11: OneBot11Config,
 }
 

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -91,6 +91,8 @@ pub async fn run(
     let onebot11_handle = if config.onebot11.enabled {
         match onebot11::spawn_reverse_websocket_server(
             config.onebot11.clone(),
+            respond.clone(),
+            dedupe.clone(),
             runtime.clone(),
             shutdown_token.clone(),
         )

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -90,7 +90,7 @@ pub async fn run(
     };
     let onebot11_handle = if config.onebot11.enabled {
         match onebot11::spawn_reverse_websocket_server(
-            config.onebot11.clone(),
+            config.clone(),
             respond.clone(),
             dedupe.clone(),
             runtime.clone(),

--- a/qq-maid-gateway-rs/src/gateway/onebot11/dispatch.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/dispatch.rs
@@ -1,0 +1,563 @@
+//! OneBot 11 入站到 Core 与文本 sender 的最小闭环。
+//!
+//! 本模块只编排统一入站模型、CoreService、结构化输出渲染和 OneBot sender；命令、
+//! Todo、Memory、Pending 与 Tool Loop 仍完全由 Core 的既有场景策略决定。
+
+use std::{future::Future, pin::Pin, sync::Arc, time::Instant};
+
+use async_trait::async_trait;
+use qq_maid_core::service::{
+    CoreFailureKind, CoreRespondFailure, CoreResponse, CoreResponseEvent, CoreResponseStream,
+};
+use thiserror::Error;
+use tracing::{debug, warn};
+
+use crate::{
+    gateway::{
+        dedupe::MessageDedupe,
+        platform::{self, ConversationTarget, InboundMessage},
+    },
+    render::render_respond_response_for_profile,
+    respond::{RespondClient, RespondError, RespondTransport, respond_error_to_qq_text},
+};
+
+use super::{OneBotSendError, OneBotSendResult, OneBotSender};
+
+const STREAM_FAILED_TEXT: &str = "处理失败，请稍后再试。";
+const STREAM_TIMEOUT_TEXT: &str = "LLM 服务处理超时，请稍后再试";
+const STREAM_CANCELLED_TEXT: &str = "本次处理已取消，请重新发送消息。";
+const EMPTY_REPLY_TEXT: &str = "唔，小女仆刚刚没整理出可用回复。可以再说一次。";
+
+type EventFuture<'a> = Pin<Box<dyn Future<Output = Option<CoreResponseEvent>> + Send + 'a>>;
+
+/// Core 流事件的最小抽象，使 OneBot 非流式收口逻辑可使用 fake Core 覆盖。
+trait OneBotResponseEventStream: Send {
+    fn recv_event<'a>(&'a mut self) -> EventFuture<'a>;
+}
+
+impl OneBotResponseEventStream for CoreResponseStream {
+    fn recv_event<'a>(&'a mut self) -> EventFuture<'a> {
+        Box::pin(async move { self.recv().await })
+    }
+}
+
+enum OneBotCoreTransport {
+    Complete(Box<CoreResponse>),
+    Stream(Box<dyn OneBotResponseEventStream>),
+}
+
+#[async_trait]
+trait OneBotCoreResponder: Send + Sync {
+    async fn respond(
+        &self,
+        inbound: &InboundMessage,
+        content: String,
+    ) -> Result<OneBotCoreTransport, RespondError>;
+}
+
+#[async_trait]
+impl OneBotCoreResponder for RespondClient {
+    async fn respond(
+        &self,
+        inbound: &InboundMessage,
+        content: String,
+    ) -> Result<OneBotCoreTransport, RespondError> {
+        match self.respond_inbound(inbound, content).await? {
+            RespondTransport::Complete(response) => Ok(OneBotCoreTransport::Complete(response)),
+            RespondTransport::Stream(stream) => Ok(OneBotCoreTransport::Stream(Box::new(stream))),
+        }
+    }
+}
+
+#[async_trait]
+trait OneBotReplySender: Send + Sync {
+    async fn send_private_text(
+        &self,
+        user_id: &str,
+        text: &str,
+    ) -> Result<OneBotSendResult, OneBotSendError>;
+
+    async fn send_group_text(
+        &self,
+        group_id: &str,
+        text: &str,
+    ) -> Result<OneBotSendResult, OneBotSendError>;
+}
+
+#[async_trait]
+impl OneBotReplySender for OneBotSender {
+    async fn send_private_text(
+        &self,
+        user_id: &str,
+        text: &str,
+    ) -> Result<OneBotSendResult, OneBotSendError> {
+        OneBotSender::send_private_text(self, user_id, text).await
+    }
+
+    async fn send_group_text(
+        &self,
+        group_id: &str,
+        text: &str,
+    ) -> Result<OneBotSendResult, OneBotSendError> {
+        OneBotSender::send_group_text(self, group_id, text).await
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum OneBotDispatchOutcome {
+    Sent,
+    Duplicate,
+}
+
+#[derive(Debug, Error)]
+pub(super) enum OneBotDispatchError {
+    #[error("OneBot Core request failed: {summary}")]
+    Core { summary: String },
+    #[error("OneBot Core stream failed: {kind:?}")]
+    StreamFailed { kind: CoreFailureKind },
+    #[error("OneBot Core stream ended without a terminal event")]
+    StreamEnded,
+    #[error("OneBot Core response did not contain visible text")]
+    EmptyResponse,
+    #[error(transparent)]
+    Send(#[from] OneBotSendError),
+}
+
+#[derive(Clone)]
+pub(super) struct OneBotInboundDispatcher {
+    core: Arc<dyn OneBotCoreResponder>,
+    sender: Arc<dyn OneBotReplySender>,
+    dedupe: Arc<MessageDedupe>,
+}
+
+impl OneBotInboundDispatcher {
+    pub(super) fn new(
+        respond: RespondClient,
+        sender: OneBotSender,
+        dedupe: Arc<MessageDedupe>,
+    ) -> Self {
+        Self {
+            core: Arc::new(respond),
+            sender: Arc::new(sender),
+            dedupe,
+        }
+    }
+
+    pub(super) async fn dispatch(
+        &self,
+        inbound: InboundMessage,
+    ) -> Result<OneBotDispatchOutcome, OneBotDispatchError> {
+        let Some(dedupe_key) = inbound.dedupe_message_key() else {
+            return self.dispatch_reserved(inbound).await;
+        };
+        let reservation = match self.dedupe.reserve_many([dedupe_key], Instant::now()) {
+            Ok(reservation) => reservation,
+            Err(_) => return Ok(OneBotDispatchOutcome::Duplicate),
+        };
+        // OneBot 重投不能重复触发 Core 内的持久化副作用；消息一旦进入 Core 就固定提交去重。
+        reservation.commit();
+        self.dispatch_reserved(inbound).await
+    }
+
+    async fn dispatch_reserved(
+        &self,
+        inbound: InboundMessage,
+    ) -> Result<OneBotDispatchOutcome, OneBotDispatchError> {
+        let content = platform::render_text_for_core(&inbound);
+        let transport = match self.core.respond(&inbound, content).await {
+            Ok(transport) => transport,
+            Err(error) => {
+                let summary = error.log_summary();
+                let visible = respond_error_to_qq_text(&error);
+                self.send_text(&inbound, &visible).await?;
+                return Err(OneBotDispatchError::Core { summary });
+            }
+        };
+        let response = match complete_response(transport).await {
+            Ok(response) => response,
+            Err(CompletionError::Failed(failure)) => {
+                let kind = failure.kind;
+                self.send_text(&inbound, stream_failure_text(&failure))
+                    .await?;
+                return Err(OneBotDispatchError::StreamFailed { kind });
+            }
+            Err(CompletionError::Ended) => {
+                self.send_text(&inbound, STREAM_FAILED_TEXT).await?;
+                return Err(OneBotDispatchError::StreamEnded);
+            }
+        };
+        let capability = crate::gateway::outbound::ReplyCapability::onebot11_text();
+        let Some(outbound) = render_respond_response_for_profile(&response, &capability.render)
+        else {
+            self.send_text(&inbound, EMPTY_REPLY_TEXT).await?;
+            return Err(OneBotDispatchError::EmptyResponse);
+        };
+        let text = outbound.fallback_text();
+        if text.trim().is_empty() {
+            self.send_text(&inbound, EMPTY_REPLY_TEXT).await?;
+            return Err(OneBotDispatchError::EmptyResponse);
+        }
+        self.send_text(&inbound, text).await?;
+        Ok(OneBotDispatchOutcome::Sent)
+    }
+
+    async fn send_text(
+        &self,
+        inbound: &InboundMessage,
+        text: &str,
+    ) -> Result<OneBotSendResult, OneBotSendError> {
+        match &inbound.conversation {
+            ConversationTarget::Private { target_id } => {
+                self.sender.send_private_text(target_id, text).await
+            }
+            ConversationTarget::Group { target_id } => {
+                self.sender.send_group_text(target_id, text).await
+            }
+            ConversationTarget::Channel { .. } | ConversationTarget::ServiceAccount { .. } => {
+                // OneBot 一期 adapter 不会构造这两类目标；若未来边界变化，必须显式失败。
+                Err(OneBotSendError::InvalidTargetId)
+            }
+        }
+    }
+
+    pub(super) fn log_result(result: Result<OneBotDispatchOutcome, OneBotDispatchError>) {
+        match result {
+            Ok(OneBotDispatchOutcome::Sent) => debug!("OneBot 11 reply dispatch completed"),
+            Ok(OneBotDispatchOutcome::Duplicate) => {
+                debug!("ignored duplicate OneBot 11 message before Core dispatch")
+            }
+            Err(error) => warn!(error = %error, "OneBot 11 reply dispatch failed"),
+        }
+    }
+}
+
+enum CompletionError {
+    Failed(CoreRespondFailure),
+    Ended,
+}
+
+async fn complete_response(
+    transport: OneBotCoreTransport,
+) -> Result<Box<CoreResponse>, CompletionError> {
+    match transport {
+        OneBotCoreTransport::Complete(response) => Ok(response),
+        OneBotCoreTransport::Stream(mut stream) => {
+            while let Some(event) = stream.recv_event().await {
+                match event {
+                    // OneBot 一期只发送可信 Completed；status/delta 一律不触发平台发送。
+                    CoreResponseEvent::Status(_) | CoreResponseEvent::TextDelta(_) => {}
+                    CoreResponseEvent::Completed(response) => return Ok(response),
+                    CoreResponseEvent::Failed(failure) => {
+                        return Err(CompletionError::Failed(failure));
+                    }
+                }
+            }
+            Err(CompletionError::Ended)
+        }
+    }
+}
+
+fn stream_failure_text(failure: &CoreRespondFailure) -> &'static str {
+    match failure.kind {
+        CoreFailureKind::SearchTimeout | CoreFailureKind::LlmTimeout => STREAM_TIMEOUT_TEXT,
+        CoreFailureKind::Cancelled => STREAM_CANCELLED_TEXT,
+        CoreFailureKind::SearchFailed | CoreFailureKind::LlmFailed | CoreFailureKind::Internal => {
+            STREAM_FAILED_TEXT
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::VecDeque, sync::Mutex};
+
+    use qq_maid_common::{identity_context::IdentitySource, input_part::MessageInputPart};
+    use qq_maid_core::service::{
+        AssistantOutput, CoreError, CoreResponseStatus, CoreResponseStatusKind,
+    };
+
+    use super::*;
+    use crate::gateway::{
+        onebot11::OneBotCallError,
+        platform::{Actor, Platform},
+    };
+
+    struct FakeStream {
+        events: VecDeque<CoreResponseEvent>,
+    }
+
+    impl OneBotResponseEventStream for FakeStream {
+        fn recv_event<'a>(&'a mut self) -> EventFuture<'a> {
+            Box::pin(async move { self.events.pop_front() })
+        }
+    }
+
+    struct FakeCore {
+        outputs: Mutex<VecDeque<Result<OneBotCoreTransport, RespondError>>>,
+        calls: Mutex<Vec<(String, String)>>,
+    }
+
+    #[async_trait]
+    impl OneBotCoreResponder for FakeCore {
+        async fn respond(
+            &self,
+            inbound: &InboundMessage,
+            content: String,
+        ) -> Result<OneBotCoreTransport, RespondError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((inbound.message_id.clone(), content));
+            self.outputs.lock().unwrap().pop_front().unwrap()
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeSender {
+        sent: Mutex<Vec<(String, String, String)>>,
+        fail: bool,
+    }
+
+    #[async_trait]
+    impl OneBotReplySender for FakeSender {
+        async fn send_private_text(
+            &self,
+            user_id: &str,
+            text: &str,
+        ) -> Result<OneBotSendResult, OneBotSendError> {
+            self.send("private", user_id, text)
+        }
+
+        async fn send_group_text(
+            &self,
+            group_id: &str,
+            text: &str,
+        ) -> Result<OneBotSendResult, OneBotSendError> {
+            self.send("group", group_id, text)
+        }
+    }
+
+    impl FakeSender {
+        fn send(
+            &self,
+            kind: &str,
+            target: &str,
+            text: &str,
+        ) -> Result<OneBotSendResult, OneBotSendError> {
+            if self.fail {
+                return Err(OneBotSendError::Transport(OneBotCallError::NotConnected));
+            }
+            self.sent
+                .lock()
+                .unwrap()
+                .push((kind.to_owned(), target.to_owned(), text.to_owned()));
+            Ok(OneBotSendResult {
+                message_id: "sent-1".to_owned(),
+            })
+        }
+    }
+
+    fn response(text: Option<&str>) -> Box<CoreResponse> {
+        Box::new(CoreResponse {
+            output: text.map(AssistantOutput::text),
+            handled: Some(true),
+            session_id: None,
+            command: None,
+            diagnostics: None,
+            visible_entity_snapshot: None,
+        })
+    }
+
+    fn inbound(message_id: &str, group: bool) -> InboundMessage {
+        InboundMessage {
+            platform: Platform::OneBot11,
+            account_id: Some("10001".to_owned()),
+            conversation: if group {
+                ConversationTarget::Group {
+                    target_id: "30003".to_owned(),
+                }
+            } else {
+                ConversationTarget::Private {
+                    target_id: "20002".to_owned(),
+                }
+            },
+            actor: Actor {
+                sender_id: Some("20002".to_owned()),
+                union_id: None,
+                display_name: None,
+                group_member_role: None,
+                is_bot: false,
+                source: IdentitySource::Event,
+            },
+            message_id: message_id.to_owned(),
+            current_msg_idx: None,
+            timestamp: None,
+            text: "/help".to_owned(),
+            input_parts: vec![MessageInputPart::text("/help")],
+            attachments: Vec::new(),
+            quoted: None,
+            visible_entity_snapshot: None,
+            mentions: Vec::new(),
+            mentioned_bot: group,
+        }
+    }
+
+    fn dispatcher(
+        outputs: Vec<Result<OneBotCoreTransport, RespondError>>,
+        sender: Arc<FakeSender>,
+    ) -> (OneBotInboundDispatcher, Arc<FakeCore>) {
+        let core = Arc::new(FakeCore {
+            outputs: Mutex::new(outputs.into()),
+            calls: Mutex::new(Vec::new()),
+        });
+        (
+            OneBotInboundDispatcher {
+                core: core.clone(),
+                sender,
+                dedupe: Arc::new(MessageDedupe::new(std::time::Duration::from_secs(60))),
+            },
+            core,
+        )
+    }
+
+    #[tokio::test]
+    async fn complete_private_and_group_responses_send_once() {
+        for group in [false, true] {
+            let sender = Arc::new(FakeSender::default());
+            let (dispatcher, core) = dispatcher(
+                vec![Ok(OneBotCoreTransport::Complete(response(Some(
+                    "命令结果",
+                ))))],
+                sender.clone(),
+            );
+
+            assert_eq!(
+                dispatcher.dispatch(inbound("m1", group)).await.unwrap(),
+                OneBotDispatchOutcome::Sent
+            );
+            assert_eq!(core.calls.lock().unwrap().len(), 1);
+            assert_eq!(sender.sent.lock().unwrap().len(), 1);
+            assert_eq!(sender.sent.lock().unwrap()[0].2, "命令结果");
+        }
+    }
+
+    #[tokio::test]
+    async fn stream_ignores_status_and_delta_then_sends_only_completed_body() {
+        let stream = FakeStream {
+            events: VecDeque::from([
+                CoreResponseEvent::Status(CoreResponseStatus {
+                    kind: CoreResponseStatusKind::CommandStarted,
+                    text: "正在处理".to_owned(),
+                }),
+                CoreResponseEvent::TextDelta("不能提前发送".to_owned()),
+                CoreResponseEvent::Completed(response(Some("最终完整回复"))),
+            ]),
+        };
+        let sender = Arc::new(FakeSender::default());
+        let (dispatcher, _) = dispatcher(
+            vec![Ok(OneBotCoreTransport::Stream(Box::new(stream)))],
+            sender.clone(),
+        );
+
+        assert_eq!(
+            dispatcher
+                .dispatch(inbound("m-stream", false))
+                .await
+                .unwrap(),
+            OneBotDispatchOutcome::Sent
+        );
+        assert_eq!(
+            sender.sent.lock().unwrap().as_slice(),
+            &[(
+                "private".to_owned(),
+                "20002".to_owned(),
+                "最终完整回复".to_owned()
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn core_error_stream_failure_and_empty_response_send_explicit_fallbacks() {
+        let cases = [
+            (
+                Err(RespondError::Core(CoreError::new(
+                    "timeout",
+                    "respond",
+                    "timed out",
+                ))),
+                "LLM 服务处理超时，请稍后再试",
+            ),
+            (
+                Ok(OneBotCoreTransport::Stream(Box::new(FakeStream {
+                    events: VecDeque::from([CoreResponseEvent::Failed(CoreRespondFailure {
+                        kind: CoreFailureKind::Cancelled,
+                        message: "cancelled".to_owned(),
+                        retryable: false,
+                        agent: None,
+                    })]),
+                }))),
+                STREAM_CANCELLED_TEXT,
+            ),
+            (
+                Ok(OneBotCoreTransport::Complete(response(None))),
+                EMPTY_REPLY_TEXT,
+            ),
+        ];
+
+        for (index, (output, expected_text)) in cases.into_iter().enumerate() {
+            let sender = Arc::new(FakeSender::default());
+            let (dispatcher, _) = dispatcher(vec![output], sender.clone());
+            assert!(
+                dispatcher
+                    .dispatch(inbound(&format!("m-{index}"), false))
+                    .await
+                    .is_err()
+            );
+            assert_eq!(sender.sent.lock().unwrap()[0].2, expected_text);
+        }
+    }
+
+    #[tokio::test]
+    async fn duplicate_does_not_call_core_or_send_twice() {
+        let sender = Arc::new(FakeSender::default());
+        let (dispatcher, core) = dispatcher(
+            vec![Ok(OneBotCoreTransport::Complete(response(Some(
+                "只发一次",
+            ))))],
+            sender.clone(),
+        );
+        let message = inbound("same", false);
+
+        assert_eq!(
+            dispatcher.dispatch(message.clone()).await.unwrap(),
+            OneBotDispatchOutcome::Sent
+        );
+        assert_eq!(
+            dispatcher.dispatch(message).await.unwrap(),
+            OneBotDispatchOutcome::Duplicate
+        );
+        assert_eq!(core.calls.lock().unwrap().len(), 1);
+        assert_eq!(sender.sent.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn sender_failure_is_returned_instead_of_core_success() {
+        let sender = Arc::new(FakeSender {
+            fail: true,
+            ..FakeSender::default()
+        });
+        let (dispatcher, _) = dispatcher(
+            vec![Ok(OneBotCoreTransport::Complete(response(Some(
+                "不会伪装成功",
+            ))))],
+            sender,
+        );
+
+        assert!(matches!(
+            dispatcher.dispatch(inbound("send-fail", false)).await,
+            Err(OneBotDispatchError::Send(OneBotSendError::Transport(
+                OneBotCallError::NotConnected
+            )))
+        ));
+    }
+}

--- a/qq-maid-gateway-rs/src/gateway/onebot11/dispatch.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/dispatch.rs
@@ -3,7 +3,7 @@
 //! 本模块只编排统一入站模型、CoreService、结构化输出渲染和 OneBot sender；命令、
 //! Todo、Memory、Pending 与 Tool Loop 仍完全由 Core 的既有场景策略决定。
 
-use std::{future::Future, pin::Pin, sync::Arc, time::Instant};
+use std::{future::Future, pin::Pin, sync::Arc};
 
 use async_trait::async_trait;
 use qq_maid_core::service::{
@@ -13,10 +13,7 @@ use thiserror::Error;
 use tracing::{debug, warn};
 
 use crate::{
-    gateway::{
-        dedupe::MessageDedupe,
-        platform::{self, ConversationTarget, InboundMessage},
-    },
+    gateway::platform::{self, ConversationTarget, InboundMessage},
     render::render_respond_response_for_profile,
     respond::{RespondClient, RespondError, RespondTransport, respond_error_to_qq_text},
 };
@@ -106,7 +103,6 @@ impl OneBotReplySender for OneBotSender {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum OneBotDispatchOutcome {
     Sent,
-    Duplicate,
 }
 
 #[derive(Debug, Error)]
@@ -127,19 +123,13 @@ pub(super) enum OneBotDispatchError {
 pub(super) struct OneBotInboundDispatcher {
     core: Arc<dyn OneBotCoreResponder>,
     sender: Arc<dyn OneBotReplySender>,
-    dedupe: Arc<MessageDedupe>,
 }
 
 impl OneBotInboundDispatcher {
-    pub(super) fn new(
-        respond: RespondClient,
-        sender: OneBotSender,
-        dedupe: Arc<MessageDedupe>,
-    ) -> Self {
+    pub(super) fn new(respond: RespondClient, sender: OneBotSender) -> Self {
         Self {
             core: Arc::new(respond),
             sender: Arc::new(sender),
-            dedupe,
         }
     }
 
@@ -147,15 +137,6 @@ impl OneBotInboundDispatcher {
         &self,
         inbound: InboundMessage,
     ) -> Result<OneBotDispatchOutcome, OneBotDispatchError> {
-        let Some(dedupe_key) = inbound.dedupe_message_key() else {
-            return self.dispatch_reserved(inbound).await;
-        };
-        let reservation = match self.dedupe.reserve_many([dedupe_key], Instant::now()) {
-            Ok(reservation) => reservation,
-            Err(_) => return Ok(OneBotDispatchOutcome::Duplicate),
-        };
-        // OneBot 重投不能重复触发 Core 内的持久化副作用；消息一旦进入 Core 就固定提交去重。
-        reservation.commit();
         self.dispatch_reserved(inbound).await
     }
 
@@ -223,9 +204,6 @@ impl OneBotInboundDispatcher {
     pub(super) fn log_result(result: Result<OneBotDispatchOutcome, OneBotDispatchError>) {
         match result {
             Ok(OneBotDispatchOutcome::Sent) => debug!("OneBot 11 reply dispatch completed"),
-            Ok(OneBotDispatchOutcome::Duplicate) => {
-                debug!("ignored duplicate OneBot 11 message before Core dispatch")
-            }
             Err(error) => warn!(error = %error, "OneBot 11 reply dispatch failed"),
         }
     }
@@ -414,7 +392,6 @@ mod tests {
             OneBotInboundDispatcher {
                 core: core.clone(),
                 sender,
-                dedupe: Arc::new(MessageDedupe::new(std::time::Duration::from_secs(60))),
             },
             core,
         )
@@ -515,29 +492,6 @@ mod tests {
             );
             assert_eq!(sender.sent.lock().unwrap()[0].2, expected_text);
         }
-    }
-
-    #[tokio::test]
-    async fn duplicate_does_not_call_core_or_send_twice() {
-        let sender = Arc::new(FakeSender::default());
-        let (dispatcher, core) = dispatcher(
-            vec![Ok(OneBotCoreTransport::Complete(response(Some(
-                "只发一次",
-            ))))],
-            sender.clone(),
-        );
-        let message = inbound("same", false);
-
-        assert_eq!(
-            dispatcher.dispatch(message.clone()).await.unwrap(),
-            OneBotDispatchOutcome::Sent
-        );
-        assert_eq!(
-            dispatcher.dispatch(message).await.unwrap(),
-            OneBotDispatchOutcome::Duplicate
-        );
-        assert_eq!(core.calls.lock().unwrap().len(), 1);
-        assert_eq!(sender.sent.lock().unwrap().len(), 1);
     }
 
     #[tokio::test]

--- a/qq-maid-gateway-rs/src/gateway/onebot11/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/mod.rs
@@ -6,6 +6,7 @@
 mod connection;
 mod dispatch;
 pub mod protocol;
+mod scope_dispatcher;
 mod sender;
 mod server;
 

--- a/qq-maid-gateway-rs/src/gateway/onebot11/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/mod.rs
@@ -1,9 +1,10 @@
-//! OneBot 11 反向 WebSocket 单账号连接底座。
+//! OneBot 11 反向 WebSocket 单账号 text-only 聊天入口。
 //!
-//! 当前模块管理协议、鉴权、连接、API request/response 关联和一期文本 sender，
-//! 暂不把业务事件送入 Core。后续 adapter 必须复用这里的连接与 sender 边界。
+//! 当前模块管理协议、鉴权、连接、API request/response 关联、Core 最小闭环和一期文本
+//! sender。引用、媒体和平台流式输出仍由后续任务补齐。
 
 mod connection;
+mod dispatch;
 pub mod protocol;
 mod sender;
 mod server;

--- a/qq-maid-gateway-rs/src/gateway/onebot11/scope_dispatcher.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/scope_dispatcher.rs
@@ -454,6 +454,20 @@ mod tests {
         Arc<BlockingHandler>,
         Arc<MessageDedupe>,
     ) {
+        dispatcher_with_idle_timeout(queue_capacity, max_active_scopes, Duration::from_secs(60))
+    }
+
+    fn dispatcher_with_idle_timeout(
+        queue_capacity: usize,
+        max_active_scopes: usize,
+        idle_timeout: Duration,
+    ) -> (
+        OneBotScopeDispatcher,
+        mpsc::UnboundedReceiver<String>,
+        Arc<Notify>,
+        Arc<BlockingHandler>,
+        Arc<MessageDedupe>,
+    ) {
         let (started_tx, started_rx) = mpsc::unbounded_channel();
         let release = Arc::new(Notify::new());
         let handler = Arc::new(BlockingHandler {
@@ -466,7 +480,7 @@ mod tests {
         let dispatcher = OneBotScopeDispatcher::with_handler(
             queue_capacity,
             max_active_scopes,
-            Duration::from_secs(60),
+            idle_timeout,
             handler.clone(),
             dedupe.clone(),
             CancellationToken::new(),
@@ -510,7 +524,8 @@ mod tests {
 
     #[tokio::test]
     async fn queue_and_active_scope_limits_reject_without_committing_dedupe() {
-        let (dispatcher, mut started, release, _, dedupe) = dispatcher(1, 1);
+        let (dispatcher, mut started, release, _, _) =
+            dispatcher_with_idle_timeout(1, 1, Duration::from_millis(20));
         dispatcher.enqueue(inbound("m1", "user-a", false)).unwrap();
         assert_eq!(started.recv().await.as_deref(), Some("m1"));
         dispatcher.enqueue(inbound("m2", "user-a", false)).unwrap();
@@ -519,14 +534,41 @@ mod tests {
             dispatcher.enqueue(inbound("m3", "user-a", false)),
             Err(OneBotEnqueueError::ScopeQueueFull)
         );
-        assert!(!dedupe.contains_recent_message("m3", Instant::now()));
         assert_eq!(
             dispatcher.enqueue(inbound("m4", "user-b", false)),
             Err(OneBotEnqueueError::ActiveScopeLimit)
         );
-        assert!(!dedupe.contains_recent_message("m4", Instant::now()));
 
-        release.notify_waiters();
+        release.notify_one();
+        assert_eq!(started.recv().await.as_deref(), Some("m2"));
+        release.notify_one();
+
+        let m3 = inbound("m3", "user-a", false);
+        assert_eq!(
+            dispatcher.enqueue(m3.clone()),
+            Ok(OneBotEnqueueOutcome::Accepted)
+        );
+        assert_eq!(dispatcher.enqueue(m3), Ok(OneBotEnqueueOutcome::Duplicate));
+        assert_eq!(started.recv().await.as_deref(), Some("m3"));
+        release.notify_one();
+
+        let m4 = inbound("m4", "user-b", false);
+        let retried_m4_outcome = timeout(Duration::from_secs(1), async {
+            loop {
+                match dispatcher.enqueue(m4.clone()) {
+                    Err(OneBotEnqueueError::ActiveScopeLimit) => {
+                        tokio::time::sleep(Duration::from_millis(5)).await;
+                    }
+                    outcome => break outcome,
+                }
+            }
+        })
+        .await
+        .expect("original active scope should be reclaimed after becoming idle");
+        assert_eq!(retried_m4_outcome, Ok(OneBotEnqueueOutcome::Accepted));
+        assert_eq!(dispatcher.enqueue(m4), Ok(OneBotEnqueueOutcome::Duplicate));
+        assert_eq!(started.recv().await.as_deref(), Some("m4"));
+        release.notify_one();
         dispatcher.shutdown().await;
     }
 

--- a/qq-maid-gateway-rs/src/gateway/onebot11/scope_dispatcher.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/scope_dispatcher.rs
@@ -1,0 +1,598 @@
+//! OneBot 11 入站的有界会话级调度边界。
+//!
+//! WebSocket 读循环只调用 [`OneBotScopeDispatcher::enqueue`] 做同步、快速入队；
+//! Core 与 sender 都在受追踪的 scope worker 中执行。同一 Core scope 只有一个 FIFO
+//! worker，不同 scope 可并发，worker 空闲后会回收。
+
+use std::{
+    collections::HashMap,
+    panic::AssertUnwindSafe,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+use async_trait::async_trait;
+use futures_util::FutureExt;
+use thiserror::Error;
+use tokio::{sync::mpsc, task::AbortHandle, time::timeout};
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
+use tracing::{debug, info, warn};
+
+use crate::{
+    config::AppConfig,
+    gateway::{
+        dedupe::MessageDedupe,
+        logging::mask_scope_key,
+        platform::{self, InboundMessage},
+    },
+};
+
+use super::dispatch::OneBotInboundDispatcher;
+
+const SHUTDOWN_CANCEL_TIMEOUT: Duration = Duration::from_secs(1);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum OneBotEnqueueOutcome {
+    Accepted,
+    Duplicate,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub(super) enum OneBotEnqueueError {
+    #[error("OneBot inbound dispatcher is shutting down")]
+    Shutdown,
+    #[error("OneBot inbound scope queue is full")]
+    ScopeQueueFull,
+    #[error("OneBot inbound active scope limit is reached")]
+    ActiveScopeLimit,
+    #[error("OneBot inbound message does not have a supported Core scope")]
+    InvalidScope,
+    #[error("OneBot inbound scope worker is unavailable")]
+    WorkerUnavailable,
+}
+
+#[async_trait]
+trait OneBotInboundHandler: Send + Sync {
+    async fn handle(&self, inbound: InboundMessage);
+}
+
+#[async_trait]
+impl OneBotInboundHandler for OneBotInboundDispatcher {
+    async fn handle(&self, inbound: InboundMessage) {
+        OneBotInboundDispatcher::log_result(self.dispatch(inbound).await);
+    }
+}
+
+struct ScopeEntry {
+    generation: u64,
+    sender: mpsc::Sender<InboundMessage>,
+    abort_handle: AbortHandle,
+}
+
+struct DispatcherState {
+    accepting: bool,
+    next_generation: u64,
+    scopes: HashMap<String, ScopeEntry>,
+}
+
+struct DispatcherInner {
+    state: Mutex<DispatcherState>,
+    handler: Arc<dyn OneBotInboundHandler>,
+    dedupe: Arc<MessageDedupe>,
+    queue_capacity: usize,
+    max_active_scopes: usize,
+    idle_timeout: Duration,
+    shutdown: CancellationToken,
+    tasks: TaskTracker,
+}
+
+#[derive(Clone)]
+pub(super) struct OneBotScopeDispatcher {
+    inner: Arc<DispatcherInner>,
+}
+
+impl OneBotScopeDispatcher {
+    pub(super) fn new(
+        config: &AppConfig,
+        handler: OneBotInboundDispatcher,
+        dedupe: Arc<MessageDedupe>,
+        parent_shutdown: &CancellationToken,
+    ) -> Self {
+        Self::with_handler(
+            config.conversation_queue_capacity,
+            config.max_active_conversation_workers,
+            config.conversation_worker_idle_timeout,
+            Arc::new(handler),
+            dedupe,
+            parent_shutdown.child_token(),
+        )
+    }
+
+    fn with_handler(
+        queue_capacity: usize,
+        max_active_scopes: usize,
+        idle_timeout: Duration,
+        handler: Arc<dyn OneBotInboundHandler>,
+        dedupe: Arc<MessageDedupe>,
+        shutdown: CancellationToken,
+    ) -> Self {
+        Self {
+            inner: Arc::new(DispatcherInner {
+                state: Mutex::new(DispatcherState {
+                    accepting: true,
+                    next_generation: 1,
+                    scopes: HashMap::new(),
+                }),
+                handler,
+                dedupe,
+                queue_capacity,
+                max_active_scopes,
+                idle_timeout,
+                shutdown,
+                tasks: TaskTracker::new(),
+            }),
+        }
+    }
+
+    /// 只做 scope 计算、去重 reservation 和 `try_send`，不会等待 Core、sender 或 echo。
+    pub(super) fn enqueue(
+        &self,
+        inbound: InboundMessage,
+    ) -> Result<OneBotEnqueueOutcome, OneBotEnqueueError> {
+        if self.inner.shutdown.is_cancelled() {
+            return Err(OneBotEnqueueError::Shutdown);
+        }
+        let scope_key =
+            platform::core_scope_key(&inbound).map_err(|_| OneBotEnqueueError::InvalidScope)?;
+        let reservation = match inbound.dedupe_message_key() {
+            Some(key) => match self.inner.dedupe.reserve_many([key], Instant::now()) {
+                Ok(reservation) => Some(reservation),
+                Err(_) => {
+                    debug!(
+                        scope_key = %mask_scope_key(&scope_key),
+                        "ignored duplicate OneBot 11 message before Core dispatch"
+                    );
+                    return Ok(OneBotEnqueueOutcome::Duplicate);
+                }
+            },
+            None => None,
+        };
+
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .expect("OneBot scope dispatcher lock should not be poisoned");
+        if !state.accepting || self.inner.shutdown.is_cancelled() {
+            return Err(OneBotEnqueueError::Shutdown);
+        }
+
+        if let Some(entry) = state.scopes.get(&scope_key) {
+            match entry.sender.try_send(inbound) {
+                Ok(()) => {
+                    if let Some(reservation) = reservation {
+                        reservation.commit();
+                    }
+                    return Ok(OneBotEnqueueOutcome::Accepted);
+                }
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    warn!(
+                        scope_key = %mask_scope_key(&scope_key),
+                        queue_capacity = self.inner.queue_capacity,
+                        "rejected OneBot 11 inbound message because scope queue is full"
+                    );
+                    return Err(OneBotEnqueueError::ScopeQueueFull);
+                }
+                Err(mpsc::error::TrySendError::Closed(inbound)) => {
+                    // worker 正在退出但尚未清理 map 时，由下方在同一把锁内移除旧 generation
+                    // 并尝试创建继任 worker；消息仍只会入队一次。
+                    state.scopes.remove(&scope_key);
+                    return self.enqueue_new_scope_locked(
+                        &mut state,
+                        scope_key,
+                        inbound,
+                        reservation,
+                    );
+                }
+            }
+        }
+
+        self.enqueue_new_scope_locked(&mut state, scope_key, inbound, reservation)
+    }
+
+    fn enqueue_new_scope_locked(
+        &self,
+        state: &mut DispatcherState,
+        scope_key: String,
+        inbound: InboundMessage,
+        reservation: Option<crate::gateway::dedupe::MessageReservation>,
+    ) -> Result<OneBotEnqueueOutcome, OneBotEnqueueError> {
+        if state.scopes.len() >= self.inner.max_active_scopes {
+            warn!(
+                scope_key = %mask_scope_key(&scope_key),
+                active_scopes = state.scopes.len(),
+                max_active_scopes = self.inner.max_active_scopes,
+                "rejected OneBot 11 inbound message because active scope limit is reached"
+            );
+            return Err(OneBotEnqueueError::ActiveScopeLimit);
+        }
+
+        let generation = state.next_generation;
+        state.next_generation = state.next_generation.wrapping_add(1).max(1);
+        let (sender, receiver) = mpsc::channel(self.inner.queue_capacity);
+        sender
+            .try_send(inbound)
+            .map_err(|_| OneBotEnqueueError::WorkerUnavailable)?;
+        let inner = Arc::clone(&self.inner);
+        let worker_scope = scope_key.clone();
+        let task = self.inner.tasks.spawn(async move {
+            run_scope_worker(inner, worker_scope, generation, receiver).await;
+        });
+        let abort_handle = task.abort_handle();
+        drop(task);
+        state.scopes.insert(
+            scope_key.clone(),
+            ScopeEntry {
+                generation,
+                sender,
+                abort_handle,
+            },
+        );
+        if let Some(reservation) = reservation {
+            reservation.commit();
+        }
+        info!(
+            scope_key = %mask_scope_key(&scope_key),
+            generation,
+            active_scopes = state.scopes.len(),
+            max_active_scopes = self.inner.max_active_scopes,
+            "OneBot 11 scope dispatcher created worker"
+        );
+        Ok(OneBotEnqueueOutcome::Accepted)
+    }
+
+    /// shutdown 采用 cancel 策略：停止新入站，取消当前 dispatch，丢弃排队消息，并等待
+    /// TaskTracker 确认全部 scope worker 退出；超时后显式 abort 再收口。
+    pub(super) async fn shutdown(&self) {
+        {
+            let mut state = self
+                .inner
+                .state
+                .lock()
+                .expect("OneBot scope dispatcher lock should not be poisoned");
+            state.accepting = false;
+        }
+        self.inner.shutdown.cancel();
+        self.inner.tasks.close();
+
+        if timeout(SHUTDOWN_CANCEL_TIMEOUT, self.inner.tasks.wait())
+            .await
+            .is_err()
+        {
+            let abort_handles = self
+                .inner
+                .state
+                .lock()
+                .expect("OneBot scope dispatcher lock should not be poisoned")
+                .scopes
+                .values()
+                .map(|entry| entry.abort_handle.clone())
+                .collect::<Vec<_>>();
+            warn!(
+                remaining_workers = abort_handles.len(),
+                "OneBot 11 scope dispatcher cancellation timed out; aborting workers"
+            );
+            for abort_handle in abort_handles {
+                abort_handle.abort();
+            }
+            self.inner.tasks.wait().await;
+        }
+
+        let remaining_scopes = {
+            let mut state = self
+                .inner
+                .state
+                .lock()
+                .expect("OneBot scope dispatcher lock should not be poisoned");
+            let remaining_scopes = state.scopes.len();
+            // abort 不会继续执行 worker 尾部的 generation 清理；TaskTracker 已确认任务
+            // 全部结束后可安全清空残留 sender/AbortHandle，不保留永久 scope 映射。
+            state.scopes.clear();
+            remaining_scopes
+        };
+        if remaining_scopes == 0 {
+            info!("OneBot 11 scope dispatcher shutdown completed");
+        } else {
+            warn!(
+                remaining_scopes,
+                "OneBot 11 scope dispatcher stopped with stale scope entries"
+            );
+        }
+    }
+}
+
+async fn run_scope_worker(
+    inner: Arc<DispatcherInner>,
+    scope_key: String,
+    generation: u64,
+    mut receiver: mpsc::Receiver<InboundMessage>,
+) {
+    loop {
+        let next = tokio::select! {
+            biased;
+            _ = inner.shutdown.cancelled() => break,
+            result = timeout(inner.idle_timeout, receiver.recv()) => result,
+        };
+        let inbound = match next {
+            Ok(Some(inbound)) => inbound,
+            Ok(None) => break,
+            Err(_) => {
+                // idle timeout 与新入站可能同时发生。必须在 state 锁内复查 receiver：
+                // enqueue 若先拿锁，消息已可见；worker 若先拿锁，则先移除旧 scope，
+                // 后续入站会创建继任 worker，不会把已接收消息遗落在关闭队列中。
+                let mut state = inner
+                    .state
+                    .lock()
+                    .expect("OneBot scope dispatcher lock should not be poisoned");
+                match receiver.try_recv() {
+                    Ok(inbound) => inbound,
+                    Err(mpsc::error::TryRecvError::Empty) => {
+                        remove_scope_generation(&mut state, &scope_key, generation);
+                        debug!(
+                            scope_key = %mask_scope_key(&scope_key),
+                            generation,
+                            "OneBot 11 scope dispatcher reclaimed idle worker"
+                        );
+                        return;
+                    }
+                    Err(mpsc::error::TryRecvError::Disconnected) => break,
+                }
+            }
+        };
+
+        let result = tokio::select! {
+            biased;
+            _ = inner.shutdown.cancelled() => break,
+            result = AssertUnwindSafe(inner.handler.handle(inbound)).catch_unwind() => result,
+        };
+        if result.is_err() {
+            warn!(
+                scope_key = %mask_scope_key(&scope_key),
+                generation,
+                "OneBot 11 scope worker panicked"
+            );
+            break;
+        }
+    }
+
+    let mut state = inner
+        .state
+        .lock()
+        .expect("OneBot scope dispatcher lock should not be poisoned");
+    remove_scope_generation(&mut state, &scope_key, generation);
+}
+
+fn remove_scope_generation(state: &mut DispatcherState, scope_key: &str, generation: u64) {
+    if state
+        .scopes
+        .get(scope_key)
+        .is_some_and(|entry| entry.generation == generation)
+    {
+        state.scopes.remove(scope_key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use qq_maid_common::{identity_context::IdentitySource, input_part::MessageInputPart};
+    use tokio::sync::{Notify, mpsc};
+
+    use super::*;
+    use crate::gateway::platform::{Actor, ConversationTarget, Platform};
+
+    struct BlockingHandler {
+        started: mpsc::UnboundedSender<String>,
+        release: Arc<Notify>,
+        active: AtomicUsize,
+        max_active: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl OneBotInboundHandler for BlockingHandler {
+        async fn handle(&self, inbound: InboundMessage) {
+            let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_active.fetch_max(active, Ordering::SeqCst);
+            self.started.send(inbound.message_id).unwrap();
+            self.release.notified().await;
+            self.active.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    fn inbound(message_id: &str, target_id: &str, group: bool) -> InboundMessage {
+        InboundMessage {
+            platform: Platform::OneBot11,
+            account_id: Some("10001".to_owned()),
+            conversation: if group {
+                ConversationTarget::Group {
+                    target_id: target_id.to_owned(),
+                }
+            } else {
+                ConversationTarget::Private {
+                    target_id: target_id.to_owned(),
+                }
+            },
+            actor: Actor {
+                sender_id: Some(target_id.to_owned()),
+                union_id: None,
+                display_name: None,
+                group_member_role: None,
+                is_bot: false,
+                source: IdentitySource::Event,
+            },
+            message_id: message_id.to_owned(),
+            current_msg_idx: None,
+            timestamp: None,
+            text: message_id.to_owned(),
+            input_parts: vec![MessageInputPart::text(message_id)],
+            attachments: Vec::new(),
+            quoted: None,
+            visible_entity_snapshot: None,
+            mentions: Vec::new(),
+            mentioned_bot: group,
+        }
+    }
+
+    fn dispatcher(
+        queue_capacity: usize,
+        max_active_scopes: usize,
+    ) -> (
+        OneBotScopeDispatcher,
+        mpsc::UnboundedReceiver<String>,
+        Arc<Notify>,
+        Arc<BlockingHandler>,
+        Arc<MessageDedupe>,
+    ) {
+        let (started_tx, started_rx) = mpsc::unbounded_channel();
+        let release = Arc::new(Notify::new());
+        let handler = Arc::new(BlockingHandler {
+            started: started_tx,
+            release: release.clone(),
+            active: AtomicUsize::new(0),
+            max_active: AtomicUsize::new(0),
+        });
+        let dedupe = Arc::new(MessageDedupe::new(Duration::from_secs(60)));
+        let dispatcher = OneBotScopeDispatcher::with_handler(
+            queue_capacity,
+            max_active_scopes,
+            Duration::from_secs(60),
+            handler.clone(),
+            dedupe.clone(),
+            CancellationToken::new(),
+        );
+        (dispatcher, started_rx, release, handler, dedupe)
+    }
+
+    #[tokio::test]
+    async fn same_private_and_group_scope_execute_in_fifo_order() {
+        for group in [false, true] {
+            let (dispatcher, mut started, release, _, _) = dispatcher(2, 2);
+            dispatcher.enqueue(inbound("m1", "scope-a", group)).unwrap();
+            dispatcher.enqueue(inbound("m2", "scope-a", group)).unwrap();
+
+            assert_eq!(started.recv().await.as_deref(), Some("m1"));
+            assert!(
+                timeout(Duration::from_millis(30), started.recv())
+                    .await
+                    .is_err()
+            );
+            release.notify_one();
+            assert_eq!(started.recv().await.as_deref(), Some("m2"));
+            release.notify_one();
+            dispatcher.shutdown().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn different_scopes_execute_concurrently() {
+        let (dispatcher, mut started, release, handler, _) = dispatcher(1, 2);
+        dispatcher.enqueue(inbound("m1", "user-a", false)).unwrap();
+        dispatcher.enqueue(inbound("m2", "user-b", false)).unwrap();
+
+        let mut messages = [started.recv().await.unwrap(), started.recv().await.unwrap()];
+        messages.sort();
+        assert_eq!(messages, ["m1", "m2"]);
+        assert_eq!(handler.max_active.load(Ordering::SeqCst), 2);
+        release.notify_waiters();
+        dispatcher.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn queue_and_active_scope_limits_reject_without_committing_dedupe() {
+        let (dispatcher, mut started, release, _, dedupe) = dispatcher(1, 1);
+        dispatcher.enqueue(inbound("m1", "user-a", false)).unwrap();
+        assert_eq!(started.recv().await.as_deref(), Some("m1"));
+        dispatcher.enqueue(inbound("m2", "user-a", false)).unwrap();
+
+        assert_eq!(
+            dispatcher.enqueue(inbound("m3", "user-a", false)),
+            Err(OneBotEnqueueError::ScopeQueueFull)
+        );
+        assert!(!dedupe.contains_recent_message("m3", Instant::now()));
+        assert_eq!(
+            dispatcher.enqueue(inbound("m4", "user-b", false)),
+            Err(OneBotEnqueueError::ActiveScopeLimit)
+        );
+        assert!(!dedupe.contains_recent_message("m4", Instant::now()));
+
+        release.notify_waiters();
+        dispatcher.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn duplicate_is_accepted_only_once() {
+        let (dispatcher, mut started, release, _, _) = dispatcher(1, 1);
+        let message = inbound("same", "user-a", false);
+        assert_eq!(
+            dispatcher.enqueue(message.clone()),
+            Ok(OneBotEnqueueOutcome::Accepted)
+        );
+        assert_eq!(
+            dispatcher.enqueue(message),
+            Ok(OneBotEnqueueOutcome::Duplicate)
+        );
+        assert_eq!(started.recv().await.as_deref(), Some("same"));
+        assert!(
+            timeout(Duration::from_millis(30), started.recv())
+                .await
+                .is_err()
+        );
+        release.notify_one();
+        dispatcher.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn shutdown_cancels_active_and_queued_messages_and_rejects_new_input() {
+        let (dispatcher, mut started, _release, _, _) = dispatcher(2, 1);
+        dispatcher.enqueue(inbound("m1", "user-a", false)).unwrap();
+        dispatcher.enqueue(inbound("m2", "user-a", false)).unwrap();
+        assert_eq!(started.recv().await.as_deref(), Some("m1"));
+
+        timeout(Duration::from_secs(1), dispatcher.shutdown())
+            .await
+            .expect("shutdown should cancel tracked workers promptly");
+        assert!(started.try_recv().is_err());
+        assert_eq!(
+            dispatcher.enqueue(inbound("m3", "user-a", false)),
+            Err(OneBotEnqueueError::Shutdown)
+        );
+    }
+
+    #[tokio::test]
+    async fn idle_worker_is_reclaimed_and_releases_active_scope_slot() {
+        let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+        struct ImmediateHandler(mpsc::UnboundedSender<String>);
+        #[async_trait]
+        impl OneBotInboundHandler for ImmediateHandler {
+            async fn handle(&self, inbound: InboundMessage) {
+                self.0.send(inbound.message_id).unwrap();
+            }
+        }
+        let dispatcher = OneBotScopeDispatcher::with_handler(
+            1,
+            1,
+            Duration::from_millis(20),
+            Arc::new(ImmediateHandler(started_tx)),
+            Arc::new(MessageDedupe::new(Duration::from_secs(60))),
+            CancellationToken::new(),
+        );
+
+        dispatcher.enqueue(inbound("m1", "user-a", false)).unwrap();
+        assert_eq!(started_rx.recv().await.as_deref(), Some("m1"));
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        dispatcher.enqueue(inbound("m2", "user-b", false)).unwrap();
+        assert_eq!(started_rx.recv().await.as_deref(), Some("m2"));
+        dispatcher.shutdown().await;
+    }
+}

--- a/qq-maid-gateway-rs/src/gateway/onebot11/server.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/server.rs
@@ -1,6 +1,6 @@
 //! 反向 WebSocket 监听器、鉴权和单连接事件循环。
 
-use std::{net::SocketAddr, time::Duration};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use anyhow::{Context, bail};
 use axum::{
@@ -21,15 +21,19 @@ use tracing::{debug, info, warn};
 use crate::{
     config::OneBot11Config,
     gateway::{
+        dedupe::MessageDedupe,
         logging::mask_identifier,
         ping::GatewayRuntimeStatus,
         platform::onebot11::{OneBotInboundOutcome, inbound_from_event},
     },
+    respond::RespondClient,
 };
 
 use super::{
     connection::{OneBotConnectionContext, Registration, RegistrationError},
+    dispatch::OneBotInboundDispatcher,
     protocol::{ActionResponse, OneBotEvent, OneBotId},
+    sender::OneBotSender,
 };
 
 const AUTHORIZATION: &str = "authorization";
@@ -48,12 +52,15 @@ struct ServerState {
     connection: OneBotConnectionContext,
     runtime: GatewayRuntimeStatus,
     shutdown: CancellationToken,
+    dispatcher: OneBotInboundDispatcher,
 }
 
 /// 先完成 bind 再返回，调用方可把 task 纳入 Gateway 顶层监督；客户端连接错误由 Axum
 /// 独立 handler 隔离，不会让监听器或其它平台渠道退出。
 pub async fn spawn_reverse_websocket_server(
     config: OneBot11Config,
+    respond: RespondClient,
+    dedupe: Arc<MessageDedupe>,
     runtime: GatewayRuntimeStatus,
     shutdown: CancellationToken,
 ) -> anyhow::Result<OneBotServerHandle> {
@@ -74,11 +81,14 @@ pub async fn spawn_reverse_websocket_server(
         .context("read OneBot 11 listener address")?;
     let path = config.websocket_path.clone();
     let connection = OneBotConnectionContext::new(config.request_timeout);
+    let dispatcher =
+        OneBotInboundDispatcher::new(respond, OneBotSender::new(connection.clone()), dedupe);
     let state = ServerState {
         config,
         connection: connection.clone(),
         runtime: runtime.clone(),
         shutdown: shutdown.clone(),
+        dispatcher,
     };
     let app = Router::new()
         .route(&path, get(upgrade_websocket))
@@ -346,12 +356,28 @@ async fn handle_message(
         debug!(sub_type = ?event.sub_type, "received OneBot 11 lifecycle event");
     } else {
         match inbound_from_event(&event) {
-            OneBotInboundOutcome::Message(inbound) => debug!(
-                conversation = inbound.conversation.kind(),
-                text_parts = inbound.input_parts.len(),
-                mentions = inbound.mentions.len(),
-                "adapted OneBot 11 inbound message"
-            ),
+            OneBotInboundOutcome::Message(inbound) => {
+                debug!(
+                    conversation = inbound.conversation.kind(),
+                    text_parts = inbound.input_parts.len(),
+                    mentions = inbound.mentions.len(),
+                    "adapted OneBot 11 inbound message"
+                );
+                // Core 和 sender 不能阻塞当前 WebSocket 读循环：sender 的 API response 也从
+                // 本连接读入；若在这里 await，send action 会等待一个永远无法分派的 echo。
+                let dispatcher = state.dispatcher.clone();
+                let shutdown = state.shutdown.clone();
+                tokio::spawn(async move {
+                    tokio::select! {
+                        result = dispatcher.dispatch(*inbound) => {
+                            OneBotInboundDispatcher::log_result(result);
+                        }
+                        _ = shutdown.cancelled() => {
+                            debug!("cancelled OneBot 11 reply dispatch during gateway shutdown");
+                        }
+                    }
+                });
+            }
             OneBotInboundOutcome::Ignored(reason) => debug!(
                 reason = reason.as_str(),
                 "ignored OneBot 11 event before core dispatch"

--- a/qq-maid-gateway-rs/src/gateway/onebot11/server.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/server.rs
@@ -19,7 +19,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::{
-    config::OneBot11Config,
+    config::{AppConfig, OneBot11Config},
     gateway::{
         dedupe::MessageDedupe,
         logging::mask_identifier,
@@ -33,6 +33,7 @@ use super::{
     connection::{OneBotConnectionContext, Registration, RegistrationError},
     dispatch::OneBotInboundDispatcher,
     protocol::{ActionResponse, OneBotEvent, OneBotId},
+    scope_dispatcher::{OneBotEnqueueError, OneBotEnqueueOutcome, OneBotScopeDispatcher},
     sender::OneBotSender,
 };
 
@@ -52,18 +53,19 @@ struct ServerState {
     connection: OneBotConnectionContext,
     runtime: GatewayRuntimeStatus,
     shutdown: CancellationToken,
-    dispatcher: OneBotInboundDispatcher,
+    dispatcher: OneBotScopeDispatcher,
 }
 
 /// 先完成 bind 再返回，调用方可把 task 纳入 Gateway 顶层监督；客户端连接错误由 Axum
 /// 独立 handler 隔离，不会让监听器或其它平台渠道退出。
 pub async fn spawn_reverse_websocket_server(
-    config: OneBot11Config,
+    app_config: AppConfig,
     respond: RespondClient,
     dedupe: Arc<MessageDedupe>,
     runtime: GatewayRuntimeStatus,
     shutdown: CancellationToken,
 ) -> anyhow::Result<OneBotServerHandle> {
+    let config = app_config.onebot11.clone();
     if !config.enabled {
         bail!("OneBot 11 reverse WebSocket server is disabled");
     }
@@ -81,8 +83,13 @@ pub async fn spawn_reverse_websocket_server(
         .context("read OneBot 11 listener address")?;
     let path = config.websocket_path.clone();
     let connection = OneBotConnectionContext::new(config.request_timeout);
-    let dispatcher =
-        OneBotInboundDispatcher::new(respond, OneBotSender::new(connection.clone()), dedupe);
+    let dispatcher = OneBotScopeDispatcher::new(
+        &app_config,
+        OneBotInboundDispatcher::new(respond, OneBotSender::new(connection.clone())),
+        dedupe,
+        &shutdown,
+    );
+    let dispatcher_shutdown = dispatcher.clone();
     let state = ServerState {
         config,
         connection: connection.clone(),
@@ -103,6 +110,7 @@ pub async fn spawn_reverse_websocket_server(
             })
             .await
             .context("serve OneBot 11 reverse WebSocket");
+        dispatcher_shutdown.shutdown().await;
         runtime.record_onebot_stopped();
         result
     });
@@ -363,20 +371,20 @@ async fn handle_message(
                     mentions = inbound.mentions.len(),
                     "adapted OneBot 11 inbound message"
                 );
-                // Core 和 sender 不能阻塞当前 WebSocket 读循环：sender 的 API response 也从
-                // 本连接读入；若在这里 await，send action 会等待一个永远无法分派的 echo。
-                let dispatcher = state.dispatcher.clone();
-                let shutdown = state.shutdown.clone();
-                tokio::spawn(async move {
-                    tokio::select! {
-                        result = dispatcher.dispatch(*inbound) => {
-                            OneBotInboundDispatcher::log_result(result);
-                        }
-                        _ = shutdown.cancelled() => {
-                            debug!("cancelled OneBot 11 reply dispatch during gateway shutdown");
-                        }
+                // 这里只做去重和有界 `try_send`。Core / sender 在 scope worker 中执行，
+                // 因而 action echo 仍可由当前读循环继续接收和分派，不会形成自锁。
+                match state.dispatcher.enqueue(*inbound) {
+                    Ok(OneBotEnqueueOutcome::Accepted) => {}
+                    Ok(OneBotEnqueueOutcome::Duplicate) => {}
+                    Err(OneBotEnqueueError::Shutdown) => {
+                        debug!("ignored OneBot 11 inbound message during gateway shutdown");
                     }
-                });
+                    Err(error) => {
+                        // scope dispatcher 已记录脱敏的容量原因；这里保留协议入口级结果，
+                        // 不打印消息正文、message_id 或原始平台标识。
+                        warn!(error = %error, "OneBot 11 inbound enqueue failed");
+                    }
+                }
             }
             OneBotInboundOutcome::Ignored(reason) => debug!(
                 reason = reason.as_str(),

--- a/qq-maid-gateway-rs/src/gateway/onebot11/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/tests.rs
@@ -1,6 +1,10 @@
 use std::{
+    collections::HashMap,
     net::SocketAddr,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
     time::Duration,
 };
 
@@ -11,7 +15,11 @@ use qq_maid_core::service::{
     CoreRespondOutput, CoreResponse, CoreService, UpstreamStatusSnapshot,
 };
 use serde_json::{Value, json};
-use tokio::{net::TcpStream, sync::mpsc, time::Instant};
+use tokio::{
+    net::TcpStream,
+    sync::{Barrier, Notify, mpsc},
+    time::Instant,
+};
 use tokio_tungstenite::{
     MaybeTlsStream, WebSocketStream, connect_async,
     tungstenite::{
@@ -23,7 +31,7 @@ use tokio_tungstenite::{
 use tokio_util::sync::CancellationToken;
 
 use crate::{
-    config::OneBot11Config,
+    config::AppConfig,
     gateway::{
         dedupe::MessageDedupe,
         onebot11::protocol::{ActionRequest, ActionResponse, OneBotId},
@@ -46,6 +54,50 @@ struct NoopCore;
 struct RecordingCore {
     requests: Mutex<Vec<CoreRequest>>,
     reply: String,
+}
+
+struct CoordinatedCore {
+    requests: Mutex<Vec<CoreRequest>>,
+    first_release: Option<Arc<Notify>>,
+    concurrent_barrier: Option<Arc<Barrier>>,
+    active: AtomicUsize,
+    max_active: AtomicUsize,
+    new_completed: AtomicBool,
+    followup_observed_new: AtomicBool,
+}
+
+impl CoordinatedCore {
+    fn first_blocked() -> Self {
+        Self {
+            requests: Mutex::new(Vec::new()),
+            first_release: Some(Arc::new(Notify::new())),
+            concurrent_barrier: None,
+            active: AtomicUsize::new(0),
+            max_active: AtomicUsize::new(0),
+            new_completed: AtomicBool::new(false),
+            followup_observed_new: AtomicBool::new(false),
+        }
+    }
+
+    fn concurrent(barrier: Arc<Barrier>) -> Self {
+        Self {
+            requests: Mutex::new(Vec::new()),
+            first_release: None,
+            concurrent_barrier: Some(barrier),
+            active: AtomicUsize::new(0),
+            max_active: AtomicUsize::new(0),
+            new_completed: AtomicBool::new(false),
+            followup_observed_new: AtomicBool::new(false),
+        }
+    }
+
+    fn requests(&self) -> Vec<CoreRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+
+    fn release_first(&self) {
+        self.first_release.as_ref().unwrap().notify_one();
+    }
 }
 
 impl RecordingCore {
@@ -138,16 +190,81 @@ impl CoreService for RecordingCore {
     }
 }
 
-fn test_config() -> OneBot11Config {
-    OneBot11Config {
-        enabled: true,
-        bind_host: "127.0.0.1".to_owned(),
-        bind_port: 0,
-        websocket_path: PATH.to_owned(),
-        access_token: Some(TOKEN.to_owned()),
-        request_timeout: Duration::from_millis(500),
-        max_message_bytes: 1024,
+#[async_trait]
+impl CoreService for CoordinatedCore {
+    async fn respond(&self, request: CoreRequest) -> Result<CoreRespondOutput, CoreError> {
+        let call_index = {
+            let mut requests = self.requests.lock().unwrap();
+            let call_index = requests.len();
+            requests.push(request.clone());
+            call_index
+        };
+        let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+        self.max_active.fetch_max(active, Ordering::SeqCst);
+
+        if let Some(barrier) = self.concurrent_barrier.as_ref() {
+            barrier.wait().await;
+        }
+        if call_index == 0
+            && let Some(release) = self.first_release.as_ref()
+        {
+            release.notified().await;
+        }
+        if request.text.starts_with("/new") {
+            self.new_completed.store(true, Ordering::SeqCst);
+        } else if request.text == "新会话里的消息" {
+            self.followup_observed_new
+                .store(self.new_completed.load(Ordering::SeqCst), Ordering::SeqCst);
+        }
+        self.active.fetch_sub(1, Ordering::SeqCst);
+
+        Ok(CoreRespondOutput::Complete(Box::new(CoreResponse {
+            output: Some(qq_maid_core::service::AssistantOutput::text(format!(
+                "完成:{}",
+                request.text
+            ))),
+            handled: Some(true),
+            session_id: Some(format!("session-{call_index}")),
+            command: request.text.starts_with("/new").then(|| "new".to_owned()),
+            diagnostics: None,
+            visible_entity_snapshot: None,
+        })))
     }
+
+    async fn classify_inbound(
+        &self,
+        _request: CoreRequest,
+    ) -> Result<CoreInboundClassification, CoreError> {
+        Ok(CoreInboundClassification {
+            kind: CoreInboundKind::Immediate,
+        })
+    }
+
+    async fn upstream_check(&self) -> Result<(), CoreError> {
+        Ok(())
+    }
+
+    fn health_snapshot(&self) -> CoreHealthSnapshot {
+        CoreHealthSnapshot {
+            ok: true,
+            provider: "coordinated".to_owned(),
+            model: "coordinated".to_owned(),
+            stream: false,
+            upstream: UpstreamStatusSnapshot::default(),
+        }
+    }
+}
+
+fn test_config() -> AppConfig {
+    let mut config = AppConfig::from_map(&HashMap::new()).unwrap();
+    config.onebot11.enabled = true;
+    config.onebot11.bind_host = "127.0.0.1".to_owned();
+    config.onebot11.bind_port = 0;
+    config.onebot11.websocket_path = PATH.to_owned();
+    config.onebot11.access_token = Some(TOKEN.to_owned());
+    config.onebot11.request_timeout = Duration::from_millis(500);
+    config.onebot11.max_message_bytes = 1024;
+    config
 }
 
 async fn spawn_server() -> (OneBotServerHandle, GatewayRuntimeStatus, CancellationToken) {
@@ -155,13 +272,13 @@ async fn spawn_server() -> (OneBotServerHandle, GatewayRuntimeStatus, Cancellati
 }
 
 async fn spawn_server_with_config(
-    config: OneBot11Config,
+    config: AppConfig,
 ) -> (OneBotServerHandle, GatewayRuntimeStatus, CancellationToken) {
     spawn_server_with_core(config, Arc::new(NoopCore)).await
 }
 
 async fn spawn_server_with_core(
-    config: OneBot11Config,
+    config: AppConfig,
     core: Arc<dyn CoreService>,
 ) -> (OneBotServerHandle, GatewayRuntimeStatus, CancellationToken) {
     let runtime = GatewayRuntimeStatus::new();
@@ -243,17 +360,25 @@ fn action_response(request: &ActionRequest, data: Value) -> ActionResponse {
 }
 
 fn private_message_event(message_id: &str, text: &str) -> String {
+    private_message_event_for(message_id, "20002", text)
+}
+
+fn private_message_event_for(message_id: &str, user_id: &str, text: &str) -> String {
     json!({
         "time": 1720000000,
         "self_id": "10001",
         "post_type": "message",
         "message_type": "private",
-        "user_id": "20002",
+        "user_id": user_id,
         "message_id": message_id,
         "sender": {"nickname": "测试用户"},
         "message": [{"type": "text", "data": {"text": text}}]
     })
     .to_string()
+}
+
+async fn send_text_event(socket: &mut ClientSocket, event: String) {
+    socket.send(Message::Text(event.into())).await.unwrap();
 }
 
 fn group_message_event(message_id: &str, segments: Value) -> String {
@@ -320,6 +445,119 @@ async fn private_command_reaches_core_and_sends_one_final_action() {
             .is_err()
     );
     assert_eq!(core.requests().len(), 1);
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn same_scope_waits_for_first_core_and_sender_before_starting_second_core() {
+    let core = Arc::new(CoordinatedCore::first_blocked());
+    let (handle, _runtime, shutdown) = spawn_server_with_core(test_config(), core.clone()).await;
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+
+    send_text_event(&mut client, private_message_event("serial-1", "第一条")).await;
+    send_text_event(&mut client, private_message_event("serial-2", "第二条")).await;
+    wait_until(|| core.requests().len() == 1).await;
+    assert_eq!(core.requests()[0].text, "第一条");
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), async {
+            while core.requests().len() == 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .is_err(),
+        "第一条 Core 未释放前，第二条不得进入 Core"
+    );
+
+    core.release_first();
+    let first_action = next_action_request(&mut client).await;
+    assert_eq!(
+        first_action.params["message"][0]["data"]["text"],
+        "完成:第一条"
+    );
+    assert_eq!(
+        core.requests().len(),
+        1,
+        "第一条 sender echo 前仍需保持串行"
+    );
+    complete_action(&mut client, &first_action, "serial-reply-1").await;
+
+    wait_until(|| core.requests().len() == 2).await;
+    assert_eq!(core.requests()[1].text, "第二条");
+    let second_action = next_action_request(&mut client).await;
+    complete_action(&mut client, &second_action, "serial-reply-2").await;
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn different_private_scopes_reach_core_concurrently() {
+    let barrier = Arc::new(Barrier::new(3));
+    let core = Arc::new(CoordinatedCore::concurrent(barrier.clone()));
+    let (handle, _runtime, shutdown) = spawn_server_with_core(test_config(), core.clone()).await;
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+
+    send_text_event(
+        &mut client,
+        private_message_event_for("parallel-1", "20002", "会话一"),
+    )
+    .await;
+    send_text_event(
+        &mut client,
+        private_message_event_for("parallel-2", "20003", "会话二"),
+    )
+    .await;
+    tokio::time::timeout(Duration::from_secs(1), barrier.wait())
+        .await
+        .expect("两个不同 scope 的 Core 请求应同时到达 barrier");
+    assert_eq!(core.max_active.load(Ordering::SeqCst), 2);
+
+    let first_action = next_action_request(&mut client).await;
+    let second_action = next_action_request(&mut client).await;
+    complete_action(&mut client, &first_action, "parallel-reply-1").await;
+    complete_action(&mut client, &second_action, "parallel-reply-2").await;
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn new_command_finishes_before_followup_in_same_onebot_scope() {
+    let core = Arc::new(CoordinatedCore::first_blocked());
+    let (handle, _runtime, shutdown) = spawn_server_with_core(test_config(), core.clone()).await;
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+
+    send_text_event(
+        &mut client,
+        private_message_event("new-order-1", "/new 新话题"),
+    )
+    .await;
+    send_text_event(
+        &mut client,
+        private_message_event("new-order-2", "新会话里的消息"),
+    )
+    .await;
+    wait_until(|| core.requests().len() == 1).await;
+    core.release_first();
+
+    let new_action = next_action_request(&mut client).await;
+    complete_action(&mut client, &new_action, "new-order-reply-1").await;
+    wait_until(|| core.requests().len() == 2).await;
+    assert!(
+        core.followup_observed_new.load(Ordering::SeqCst),
+        "后续消息必须在 /new 完成状态更新后进入 Core"
+    );
+    let followup_action = next_action_request(&mut client).await;
+    complete_action(&mut client, &followup_action, "new-order-reply-2").await;
 
     shutdown.cancel();
     handle.task.await.unwrap().unwrap();
@@ -693,7 +931,7 @@ async fn sender_returns_explicit_offline_and_disconnect_errors() {
 #[tokio::test]
 async fn sender_propagates_action_timeout() {
     let mut config = test_config();
-    config.request_timeout = Duration::from_millis(50);
+    config.onebot11.request_timeout = Duration::from_millis(50);
     let (handle, _runtime, shutdown) = spawn_server_with_config(config).await;
     let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
         .await
@@ -827,7 +1065,7 @@ async fn outbound_queue_wait_is_included_in_request_timeout() {
 #[tokio::test]
 async fn heartbeat_is_optional_until_client_sends_first_heartbeat() {
     let mut config = test_config();
-    config.request_timeout = Duration::from_millis(50);
+    config.onebot11.request_timeout = Duration::from_millis(50);
     let (handle, runtime, shutdown) = spawn_server_with_config(config).await;
     let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
         .await
@@ -922,7 +1160,7 @@ async fn invalid_json_is_isolated_and_client_can_reconnect() {
 #[tokio::test]
 async fn heartbeat_timeout_closes_only_the_client() {
     let mut config = test_config();
-    config.request_timeout = Duration::from_millis(100);
+    config.onebot11.request_timeout = Duration::from_millis(100);
     let (handle, runtime, shutdown) = spawn_server_with_config(config).await;
     let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
         .await
@@ -954,7 +1192,7 @@ async fn heartbeat_timeout_closes_only_the_client() {
 #[tokio::test]
 async fn api_request_timeout_does_not_drop_healthy_connection() {
     let mut config = test_config();
-    config.request_timeout = Duration::from_millis(100);
+    config.onebot11.request_timeout = Duration::from_millis(100);
     let (handle, runtime, shutdown) = spawn_server_with_config(config).await;
     let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
         .await

--- a/qq-maid-gateway-rs/src/gateway/onebot11/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/tests.rs
@@ -1,6 +1,15 @@
-use std::{net::SocketAddr, time::Duration};
+use std::{
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
+use async_trait::async_trait;
 use futures_util::{SinkExt, StreamExt};
+use qq_maid_core::service::{
+    CoreError, CoreHealthSnapshot, CoreInboundClassification, CoreInboundKind, CoreRequest,
+    CoreRespondOutput, CoreResponse, CoreService, UpstreamStatusSnapshot,
+};
 use serde_json::{Value, json};
 use tokio::{net::TcpStream, sync::mpsc, time::Instant};
 use tokio_tungstenite::{
@@ -16,9 +25,11 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     config::OneBot11Config,
     gateway::{
+        dedupe::MessageDedupe,
         onebot11::protocol::{ActionRequest, ActionResponse, OneBotId},
         ping::GatewayRuntimeStatus,
     },
+    respond::RespondClient,
 };
 
 use super::{
@@ -29,6 +40,103 @@ use super::{
 const TOKEN: &str = "test-onebot-access-token";
 const PATH: &str = "/onebot/v11/ws";
 type ClientSocket = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+struct NoopCore;
+
+struct RecordingCore {
+    requests: Mutex<Vec<CoreRequest>>,
+    reply: String,
+}
+
+impl RecordingCore {
+    fn new(reply: &str) -> Self {
+        Self {
+            requests: Mutex::new(Vec::new()),
+            reply: reply.to_owned(),
+        }
+    }
+
+    fn requests(&self) -> Vec<CoreRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl CoreService for NoopCore {
+    async fn respond(&self, _request: CoreRequest) -> Result<CoreRespondOutput, CoreError> {
+        Ok(CoreRespondOutput::Complete(Box::new(CoreResponse {
+            output: None,
+            handled: Some(true),
+            session_id: None,
+            command: None,
+            diagnostics: None,
+            visible_entity_snapshot: None,
+        })))
+    }
+
+    async fn classify_inbound(
+        &self,
+        _request: CoreRequest,
+    ) -> Result<CoreInboundClassification, CoreError> {
+        Ok(CoreInboundClassification {
+            kind: CoreInboundKind::Immediate,
+        })
+    }
+
+    async fn upstream_check(&self) -> Result<(), CoreError> {
+        Ok(())
+    }
+
+    fn health_snapshot(&self) -> CoreHealthSnapshot {
+        CoreHealthSnapshot {
+            ok: true,
+            provider: "noop".to_owned(),
+            model: "noop".to_owned(),
+            stream: false,
+            upstream: UpstreamStatusSnapshot::default(),
+        }
+    }
+}
+
+#[async_trait]
+impl CoreService for RecordingCore {
+    async fn respond(&self, request: CoreRequest) -> Result<CoreRespondOutput, CoreError> {
+        self.requests.lock().unwrap().push(request);
+        Ok(CoreRespondOutput::Complete(Box::new(CoreResponse {
+            output: Some(qq_maid_core::service::AssistantOutput::text(
+                self.reply.clone(),
+            )),
+            handled: Some(true),
+            session_id: Some("session-1".to_owned()),
+            command: None,
+            diagnostics: None,
+            visible_entity_snapshot: None,
+        })))
+    }
+
+    async fn classify_inbound(
+        &self,
+        _request: CoreRequest,
+    ) -> Result<CoreInboundClassification, CoreError> {
+        Ok(CoreInboundClassification {
+            kind: CoreInboundKind::Immediate,
+        })
+    }
+
+    async fn upstream_check(&self) -> Result<(), CoreError> {
+        Ok(())
+    }
+
+    fn health_snapshot(&self) -> CoreHealthSnapshot {
+        CoreHealthSnapshot {
+            ok: true,
+            provider: "recording".to_owned(),
+            model: "recording".to_owned(),
+            stream: false,
+            upstream: UpstreamStatusSnapshot::default(),
+        }
+    }
+}
 
 fn test_config() -> OneBot11Config {
     OneBot11Config {
@@ -43,11 +151,30 @@ fn test_config() -> OneBot11Config {
 }
 
 async fn spawn_server() -> (OneBotServerHandle, GatewayRuntimeStatus, CancellationToken) {
+    spawn_server_with_config(test_config()).await
+}
+
+async fn spawn_server_with_config(
+    config: OneBot11Config,
+) -> (OneBotServerHandle, GatewayRuntimeStatus, CancellationToken) {
+    spawn_server_with_core(config, Arc::new(NoopCore)).await
+}
+
+async fn spawn_server_with_core(
+    config: OneBot11Config,
+    core: Arc<dyn CoreService>,
+) -> (OneBotServerHandle, GatewayRuntimeStatus, CancellationToken) {
     let runtime = GatewayRuntimeStatus::new();
     let shutdown = CancellationToken::new();
-    let handle = spawn_reverse_websocket_server(test_config(), runtime.clone(), shutdown.clone())
-        .await
-        .unwrap();
+    let handle = spawn_reverse_websocket_server(
+        config,
+        RespondClient::new(core),
+        Arc::new(MessageDedupe::new(Duration::from_secs(10 * 60))),
+        runtime.clone(),
+        shutdown.clone(),
+    )
+    .await
+    .unwrap();
     (handle, runtime, shutdown)
 }
 
@@ -113,6 +240,143 @@ fn action_response(request: &ActionRequest, data: Value) -> ActionResponse {
         wording: None,
         echo: Some(request.echo.clone()),
     }
+}
+
+fn private_message_event(message_id: &str, text: &str) -> String {
+    json!({
+        "time": 1720000000,
+        "self_id": "10001",
+        "post_type": "message",
+        "message_type": "private",
+        "user_id": "20002",
+        "message_id": message_id,
+        "sender": {"nickname": "测试用户"},
+        "message": [{"type": "text", "data": {"text": text}}]
+    })
+    .to_string()
+}
+
+fn group_message_event(message_id: &str, segments: Value) -> String {
+    json!({
+        "time": 1720000001,
+        "self_id": "10001",
+        "post_type": "message",
+        "message_type": "group",
+        "user_id": "20002",
+        "group_id": "30003",
+        "message_id": message_id,
+        "sender": {"card": "群成员", "role": "member"},
+        "message": segments
+    })
+    .to_string()
+}
+
+async fn complete_action(socket: &mut ClientSocket, request: &ActionRequest, message_id: &str) {
+    socket
+        .send(Message::Text(
+            serde_json::to_string(&action_response(request, json!({"message_id": message_id})))
+                .unwrap()
+                .into(),
+        ))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn private_command_reaches_core_and_sends_one_final_action() {
+    let core = Arc::new(RecordingCore::new("Core 命令结果"));
+    let (handle, _runtime, shutdown) = spawn_server_with_core(test_config(), core.clone()).await;
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+    let event = private_message_event("private-help-1", "/help");
+
+    client
+        .send(Message::Text(event.clone().into()))
+        .await
+        .unwrap();
+    let action = next_action_request(&mut client).await;
+    assert_eq!(action.action, "send_private_msg");
+    assert_eq!(action.params["user_id"], json!(20002_u64));
+    assert_eq!(
+        action.params["message"],
+        json!([{"type": "text", "data": {"text": "Core 命令结果"}}])
+    );
+    complete_action(&mut client, &action, "reply-private-1").await;
+    wait_until(|| core.requests().len() == 1).await;
+    let request = core.requests().remove(0);
+    assert_eq!(request.text, "/help");
+    assert_eq!(request.account_id.as_deref(), Some("10001"));
+    assert_eq!(
+        request.scope_key(),
+        "platform:onebot:account:10001:private:20002"
+    );
+
+    // 同一平台消息重投不能再次调用 Core，也不能发送第二条回复。
+    client.send(Message::Text(event.into())).await.unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), client.next())
+            .await
+            .is_err()
+    );
+    assert_eq!(core.requests().len(), 1);
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn group_message_only_reaches_core_after_at_current_bot() {
+    let core = Arc::new(RecordingCore::new("群聊结果"));
+    let (handle, _runtime, shutdown) = spawn_server_with_core(test_config(), core.clone()).await;
+    let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
+        .await
+        .unwrap();
+
+    client
+        .send(Message::Text(
+            group_message_event(
+                "group-untriggered",
+                json!([{"type": "text", "data": {"text": "路过"}}]),
+            )
+            .into(),
+        ))
+        .await
+        .unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), client.next())
+            .await
+            .is_err()
+    );
+    assert!(core.requests().is_empty());
+
+    client
+        .send(Message::Text(
+            group_message_event(
+                "group-at-1",
+                json!([
+                    {"type": "at", "data": {"qq": "10001"}},
+                    {"type": "text", "data": {"text": " 请帮忙"}}
+                ]),
+            )
+            .into(),
+        ))
+        .await
+        .unwrap();
+    let action = next_action_request(&mut client).await;
+    assert_eq!(action.action, "send_group_msg");
+    assert_eq!(action.params["group_id"], json!(30003_u64));
+    complete_action(&mut client, &action, "reply-group-1").await;
+    wait_until(|| core.requests().len() == 1).await;
+    let request = core.requests().remove(0);
+    assert_eq!(request.text, " 请帮忙");
+    assert_eq!(
+        request.scope_key(),
+        "platform:onebot:account:10001:group:30003"
+    );
+
+    shutdown.cancel();
+    handle.task.await.unwrap().unwrap();
 }
 
 #[tokio::test]
@@ -430,11 +694,7 @@ async fn sender_returns_explicit_offline_and_disconnect_errors() {
 async fn sender_propagates_action_timeout() {
     let mut config = test_config();
     config.request_timeout = Duration::from_millis(50);
-    let runtime = GatewayRuntimeStatus::new();
-    let shutdown = CancellationToken::new();
-    let handle = spawn_reverse_websocket_server(config, runtime, shutdown.clone())
-        .await
-        .unwrap();
+    let (handle, _runtime, shutdown) = spawn_server_with_config(config).await;
     let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
         .await
         .unwrap();
@@ -568,11 +828,7 @@ async fn outbound_queue_wait_is_included_in_request_timeout() {
 async fn heartbeat_is_optional_until_client_sends_first_heartbeat() {
     let mut config = test_config();
     config.request_timeout = Duration::from_millis(50);
-    let runtime = GatewayRuntimeStatus::new();
-    let shutdown = CancellationToken::new();
-    let handle = spawn_reverse_websocket_server(config, runtime.clone(), shutdown.clone())
-        .await
-        .unwrap();
+    let (handle, runtime, shutdown) = spawn_server_with_config(config).await;
     let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
         .await
         .unwrap();
@@ -667,11 +923,7 @@ async fn invalid_json_is_isolated_and_client_can_reconnect() {
 async fn heartbeat_timeout_closes_only_the_client() {
     let mut config = test_config();
     config.request_timeout = Duration::from_millis(100);
-    let runtime = GatewayRuntimeStatus::new();
-    let shutdown = CancellationToken::new();
-    let handle = spawn_reverse_websocket_server(config, runtime.clone(), shutdown.clone())
-        .await
-        .unwrap();
+    let (handle, runtime, shutdown) = spawn_server_with_config(config).await;
     let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
         .await
         .unwrap();
@@ -703,11 +955,7 @@ async fn heartbeat_timeout_closes_only_the_client() {
 async fn api_request_timeout_does_not_drop_healthy_connection() {
     let mut config = test_config();
     config.request_timeout = Duration::from_millis(100);
-    let runtime = GatewayRuntimeStatus::new();
-    let shutdown = CancellationToken::new();
-    let handle = spawn_reverse_websocket_server(config, runtime.clone(), shutdown.clone())
-        .await
-        .unwrap();
+    let (handle, runtime, shutdown) = spawn_server_with_config(config).await;
     let mut client = connect(handle.local_addr, PATH, TOKEN, Some("10001"))
         .await
         .unwrap();

--- a/runtime/config/.env.example
+++ b/runtime/config/.env.example
@@ -60,7 +60,9 @@ QQ_MAID_BOT_MENTION_IDS=
 # =============================================================================
 # OneBot 11 反向 WebSocket（可选，默认关闭）
 # =============================================================================
-# 一期只建立单账号连接与协议底座，不会把消息送入 Core，也不会发送消息。
+# OneBot 入站复用上方统一会话调度配置：同一 Core scope 串行、不同 scope 并发，
+# 队列容量、活动 scope 上限和 idle 回收分别由 CONVERSATION_QUEUE_CAPACITY、
+# MAX_ACTIVE_CONVERSATION_WORKERS、CONVERSATION_WORKER_IDLE_TIMEOUT_SECS 控制。
 # OneBot 实现作为客户端连接 ws://ONEBOT11_BIND_HOST:ONEBOT11_BIND_PORT/ONEBOT11_WEBSOCKET_PATH，
 # Authorization 必须使用 Bearer ONEBOT11_ACCESS_TOKEN；不要提交真实 token。
 ONEBOT11_ENABLED=false


### PR DESCRIPTION
## 变更内容

- 将通过 OneBot 触发过滤与去重的统一 `InboundMessage` 异步送入现有 `RespondClient::respond_inbound` / CoreService。
- 复用 OneBot text-only 渲染能力和现有 sender；Core stream 只消费可信 `Completed`，忽略 status/delta，确保只发送一次最终回复。
- 为 Core 初始错误、流失败/取消/超时、流无终态、空正文和真实发送失败补充明确结果与安全 fallback。
- 让 OneBot-only、QQ/微信并存装配共享同一个 Core 和去重实例，并避免同 WebSocket 上等待 sender echo 导致事件循环自锁。
- 更新 OneBot 当前能力文档。

## 测试

- fake Core + fake sender：私聊/群聊 complete、stream completed、状态与 delta 忽略、Core 错误、取消、空正文、重复消息、发送失败。
- fake OneBot WebSocket：私聊 `/help` 完整闭环、群聊 @ 触发、未触发群聊不调用 Core、真实 send action/echo 响应。
- 真实 Core 测试装配：OneBot `/new` 会话命令、`/help`、账号/会话 scope 隔离。

已执行：

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p qq-maid-gateway-rs --all-features`
- `cargo test -p qq-maid-core --all-features`
- `cargo check --workspace --all-features`
- `cargo build --workspace --release --all-features`
- `git diff --cached --check`

Closes #441