### PR TITLE
[codex] 拆分 Gateway 大文件模块

### DIFF
--- a/qq-maid-gateway-rs/README.md
+++ b/qq-maid-gateway-rs/README.md
@@ -104,7 +104,7 @@ flowchart LR
 - `src/gateway/push.rs`：进程内主动推送实现。
 - `src/gateway/wechat_service.rs`：微信服务号文本回调 HTTP 入口，负责签名校验、明文 XML 解析、Core 调用、同步 XML 回复、慢请求去重和客服文本补发。
 - `src/gateway/platform/wechat_service.rs`：微信服务号平台字段到统一 `InboundMessage` / `CoreRequest` 的映射，以及 XML 解析和渲染 helper。
-- `src/gateway/platform/onebot11.rs`：OneBot 11 私聊、群聊、结构化 at/reply 以及有序文本/图片/文件 segment 到统一 `InboundMessage` 的安全映射和触发过滤。
+- `src/gateway/platform/onebot11/mod.rs`：OneBot 11 私聊、群聊、结构化 at/reply 以及有序文本/图片/文件 segment 到统一 `InboundMessage` 的安全映射和触发过滤。
 - `src/gateway/onebot11/dispatch.rs`：去重后的 OneBot 入站引用索引、Core 调用、非流式最终回复收口、结构化 output 文本降级、sender 调用和出站 message_id/可见实体快照回填。
 - `src/gateway/onebot11/protocol.rs`：OneBot 11 事件、消息段、action / response、`echo`、生命周期、心跳和无精度损失 ID 类型。
 - `src/gateway/onebot11/connection.rs`：单账号活动连接、同账号替换策略和 API `echo` 关联上下文。

--- a/qq-maid-gateway-rs/src/api/mod.rs
+++ b/qq-maid-gateway-rs/src/api/mod.rs
@@ -8,10 +8,16 @@ use std::{
 };
 
 use reqwest::StatusCode;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_json::Value;
 use thiserror::Error;
 use tracing::{info, trace, warn};
+
+mod response;
+
+#[cfg(test)]
+use response::extract_sent_message_id;
+use response::{extract_c2c_text_stream_id, extract_sent_message_ids, qq_api_error_fields};
 
 use crate::{
     auth::{AccessTokenManager, AuthError},
@@ -182,22 +188,6 @@ struct StreamInfo<'a> {
     id: Option<&'a str>,
     index: u32,
     reset: bool,
-}
-
-/// C2C 流式首帧响应 DTO。
-///
-/// 目前只接受顶层 `id` 作为 stream id；真实 QQ 联调确认字段前，不能把原始
-/// `msg_id` 或其它普通消息 id 路径猜作流式续接 id。
-#[derive(Debug, Deserialize)]
-struct C2cStreamSendResponse {
-    #[serde(default)]
-    id: Option<String>,
-    #[serde(default)]
-    code: Option<Value>,
-    #[serde(default)]
-    message: Option<String>,
-    #[serde(default)]
-    msg: Option<String>,
 }
 
 /// C2C 流式发送的结果：成功时返回 API 返回的消息 id。
@@ -745,26 +735,6 @@ pub fn build_group_text_payload(text: &str, msg_id: Option<&str>, msg_seq: u32) 
     .expect("group text payload should serialize")
 }
 
-fn extract_c2c_text_stream_id(body: &str) -> Option<String> {
-    let response = serde_json::from_str::<C2cStreamSendResponse>(body).ok()?;
-    response
-        .id
-        .map(|id| id.trim().to_owned())
-        .filter(|id| !id.is_empty())
-}
-
-fn qq_api_error_fields(body: &str) -> (Option<String>, Option<String>) {
-    let Ok(response) = serde_json::from_str::<C2cStreamSendResponse>(body) else {
-        return (None, None);
-    };
-    let code = response.code.map(|value| match value {
-        Value::String(value) => value,
-        other => other.to_string(),
-    });
-    let message = response.message.or(response.msg);
-    (code, message)
-}
-
 fn stream_log_phase(stream_state_value: u8, index: u32) -> &'static str {
     match (stream_state_value, index) {
         (10, _) => "final_chunk",
@@ -826,61 +796,6 @@ fn stream_request_log_fields(
         previous_success_msg_seq: msg_seq_attempt.previous_success_msg_seq,
         index_committed,
         msg_seq_committed: request_succeeded,
-    }
-}
-
-pub(crate) fn extract_sent_message_id(body: &str) -> Option<String> {
-    let value = serde_json::from_str::<Value>(body).ok()?;
-    let candidates = [
-        value.get("id"),
-        value.get("message_id"),
-        value.get("msg_id"),
-        value.get("d").and_then(|item| item.get("id")),
-        value.get("d").and_then(|item| item.get("message_id")),
-        value.get("d").and_then(|item| item.get("msg_id")),
-        value.get("data").and_then(|item| item.get("id")),
-        value.get("data").and_then(|item| item.get("message_id")),
-        value.get("data").and_then(|item| item.get("msg_id")),
-        value.get("message").and_then(|item| item.get("id")),
-        value.get("message").and_then(|item| item.get("message_id")),
-        value.get("message").and_then(|item| item.get("msg_id")),
-    ];
-    candidates
-        .into_iter()
-        .flatten()
-        .filter_map(Value::as_str)
-        .map(str::trim)
-        .find(|value| !value.is_empty())
-        .map(str::to_owned)
-}
-
-pub(crate) fn extract_sent_ref_index_id(body: &str) -> Option<String> {
-    let value = serde_json::from_str::<Value>(body).ok()?;
-    let candidates = [
-        value.get("msg_idx"),
-        value.get("ref_msg_idx"),
-        value.get("d").and_then(|item| item.get("msg_idx")),
-        value.get("d").and_then(|item| item.get("ref_msg_idx")),
-        value.get("data").and_then(|item| item.get("msg_idx")),
-        value.get("data").and_then(|item| item.get("ref_msg_idx")),
-        value.get("message").and_then(|item| item.get("msg_idx")),
-        value
-            .get("message")
-            .and_then(|item| item.get("ref_msg_idx")),
-    ];
-    candidates
-        .into_iter()
-        .flatten()
-        .filter_map(Value::as_str)
-        .map(str::trim)
-        .find(|value| !value.is_empty())
-        .map(str::to_owned)
-}
-
-pub(crate) fn extract_sent_message_ids(body: &str) -> SendMessageIds {
-    SendMessageIds {
-        message_id: extract_sent_message_id(body),
-        ref_index_id: extract_sent_ref_index_id(body),
     }
 }
 

--- a/qq-maid-gateway-rs/src/api/response.rs
+++ b/qq-maid-gateway-rs/src/api/response.rs
@@ -1,0 +1,100 @@
+//! QQ OpenAPI 响应体解析。
+//!
+//! 这里仅负责从兼容的响应结构中提取发送结果和流式错误字段，不参与请求发送、
+//! 重试或 fallback 决策，避免协议兼容路径继续堆积在 API 客户端主模块中。
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::SendMessageIds;
+
+/// C2C 流式首帧响应 DTO。
+///
+/// 目前只接受顶层 `id` 作为 stream id；真实 QQ 联调确认字段前，不能把原始
+/// `msg_id` 或其它普通消息 id 路径猜作流式续接 id。
+#[derive(Debug, Deserialize)]
+struct C2cStreamSendResponse {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    code: Option<Value>,
+    #[serde(default)]
+    message: Option<String>,
+    #[serde(default)]
+    msg: Option<String>,
+}
+
+pub(super) fn extract_c2c_text_stream_id(body: &str) -> Option<String> {
+    let response = serde_json::from_str::<C2cStreamSendResponse>(body).ok()?;
+    response
+        .id
+        .map(|id| id.trim().to_owned())
+        .filter(|id| !id.is_empty())
+}
+
+pub(super) fn qq_api_error_fields(body: &str) -> (Option<String>, Option<String>) {
+    let Ok(response) = serde_json::from_str::<C2cStreamSendResponse>(body) else {
+        return (None, None);
+    };
+    let code = response.code.map(|value| match value {
+        Value::String(value) => value,
+        other => other.to_string(),
+    });
+    let message = response.message.or(response.msg);
+    (code, message)
+}
+
+pub(crate) fn extract_sent_message_id(body: &str) -> Option<String> {
+    let value = serde_json::from_str::<Value>(body).ok()?;
+    let candidates = [
+        value.get("id"),
+        value.get("message_id"),
+        value.get("msg_id"),
+        value.get("d").and_then(|item| item.get("id")),
+        value.get("d").and_then(|item| item.get("message_id")),
+        value.get("d").and_then(|item| item.get("msg_id")),
+        value.get("data").and_then(|item| item.get("id")),
+        value.get("data").and_then(|item| item.get("message_id")),
+        value.get("data").and_then(|item| item.get("msg_id")),
+        value.get("message").and_then(|item| item.get("id")),
+        value.get("message").and_then(|item| item.get("message_id")),
+        value.get("message").and_then(|item| item.get("msg_id")),
+    ];
+    candidates
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .find(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+pub(crate) fn extract_sent_ref_index_id(body: &str) -> Option<String> {
+    let value = serde_json::from_str::<Value>(body).ok()?;
+    let candidates = [
+        value.get("msg_idx"),
+        value.get("ref_msg_idx"),
+        value.get("d").and_then(|item| item.get("msg_idx")),
+        value.get("d").and_then(|item| item.get("ref_msg_idx")),
+        value.get("data").and_then(|item| item.get("msg_idx")),
+        value.get("data").and_then(|item| item.get("ref_msg_idx")),
+        value.get("message").and_then(|item| item.get("msg_idx")),
+        value
+            .get("message")
+            .and_then(|item| item.get("ref_msg_idx")),
+    ];
+    candidates
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .find(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+pub(crate) fn extract_sent_message_ids(body: &str) -> SendMessageIds {
+    SendMessageIds {
+        message_id: extract_sent_message_id(body),
+        ref_index_id: extract_sent_ref_index_id(body),
+    }
+}

--- a/qq-maid-gateway-rs/src/gateway/media_fetch/local_cache.rs
+++ b/qq-maid-gateway-rs/src/gateway/media_fetch/local_cache.rs
@@ -1,0 +1,244 @@
+//! QQ 官方媒体的本地缓存路径、文件名、MIME 与清理策略。
+//!
+//! 网络下载仍由父模块负责；本模块只处理本地文件布局和缓存上限，避免文件系统
+//! 细节与附件下载状态机混在同一文件中。
+
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+    sync::atomic::Ordering,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use tracing::warn;
+
+use super::{
+    Attachment, MEDIA_CACHE_MAX_BYTES, MEDIA_CACHE_TTL, MEDIA_FILE_COUNTER, MediaFetchContext,
+};
+
+pub(super) fn cleanup_media_cache_best_effort(root: &Path) {
+    if let Err(error) = cleanup_media_cache_with_limits(
+        root,
+        SystemTime::now(),
+        MEDIA_CACHE_TTL,
+        MEDIA_CACHE_MAX_BYTES,
+    ) {
+        warn!(
+            error = %error,
+            "QQ official media cache cleanup failed"
+        );
+    }
+}
+
+pub(super) fn cleanup_media_cache_with_limits(
+    root: &Path,
+    now: SystemTime,
+    ttl: Duration,
+    max_bytes: u64,
+) -> io::Result<()> {
+    if !root.exists() {
+        return Ok(());
+    }
+    let mut files = Vec::new();
+    collect_media_cache_files(root, &mut files)?;
+
+    let mut retained = Vec::new();
+    let mut total_bytes = 0_u64;
+    for file in files {
+        let expired = now.duration_since(file.modified).is_ok_and(|age| age > ttl);
+        if expired {
+            let _ = fs::remove_file(&file.path);
+            continue;
+        }
+        total_bytes = total_bytes.saturating_add(file.len);
+        retained.push(file);
+    }
+
+    retained.sort_by(|left, right| {
+        left.modified
+            .cmp(&right.modified)
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    for file in retained {
+        if total_bytes <= max_bytes {
+            break;
+        }
+        if fs::remove_file(&file.path).is_ok() {
+            total_bytes = total_bytes.saturating_sub(file.len);
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct MediaCacheFile {
+    path: PathBuf,
+    modified: SystemTime,
+    len: u64,
+}
+
+fn collect_media_cache_files(root: &Path, output: &mut Vec<MediaCacheFile>) -> io::Result<()> {
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        let path = entry.path();
+        let metadata = entry.metadata()?;
+        if metadata.is_dir() {
+            collect_media_cache_files(&path, output)?;
+        } else if metadata.is_file() {
+            output.push(MediaCacheFile {
+                path,
+                modified: metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+                len: metadata.len(),
+            });
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn media_dir(context: &MediaFetchContext) -> PathBuf {
+    context
+        .root_dir
+        .join(safe_path_segment(context.platform))
+        .join(safe_path_segment(&context.app_id))
+        .join(safe_path_segment(&context.peer_id))
+}
+
+pub(super) fn unique_filename(attachment: &Attachment, response_mime: Option<&str>) -> String {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default();
+    let counter = MEDIA_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let fallback = filename_for_mime(response_mime, attachment.filename.as_deref());
+    format!("{timestamp}-{counter}-{}", safe_filename(&fallback))
+}
+
+pub(super) fn partial_download_path(local_path: &Path) -> PathBuf {
+    let filename = local_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("image.bin");
+    local_path.with_file_name(format!(".{filename}.part"))
+}
+
+fn filename_for_mime(content_type: Option<&str>, filename: Option<&str>) -> String {
+    let filename = filename
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("image");
+    if Path::new(filename).extension().is_some() {
+        return filename.to_owned();
+    }
+    let extension = match content_type
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "image/jpeg" | "image/jpg" => "jpg",
+        "image/png" => "png",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        "image/bmp" => "bmp",
+        _ => "bin",
+    };
+    format!("{filename}.{extension}")
+}
+
+fn safe_filename(value: &str) -> String {
+    let candidate = value
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or("image")
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    let candidate = candidate.trim_matches(['.', '_', '-']);
+    if candidate.is_empty() {
+        "image.bin".to_owned()
+    } else {
+        candidate.to_owned()
+    }
+}
+
+fn safe_path_segment(value: &str) -> String {
+    let candidate = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if candidate.trim_matches('_').is_empty() {
+        "-".to_owned()
+    } else {
+        candidate
+    }
+}
+
+pub(super) fn clean_mime_type(value: &str) -> Option<String> {
+    canonical_image_mime(value.split(';').next().map(str::trim).unwrap_or_default())
+        .map(str::to_owned)
+}
+
+pub(super) fn preferred_image_mime(
+    attachment_content_type: Option<&str>,
+    response_mime: Option<&str>,
+    filename: Option<&str>,
+) -> Option<String> {
+    let attachment_mime = attachment_content_type.and_then(canonical_image_mime);
+    if attachment_mime.is_some() {
+        return attachment_mime.map(str::to_owned);
+    }
+    response_mime
+        .and_then(canonical_image_mime)
+        .or_else(|| filename.and_then(infer_image_mime_type_from_filename))
+        .map(str::to_owned)
+}
+
+fn canonical_image_mime(value: &str) -> Option<&'static str> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "image/jpeg" | "image/jpg" => Some("image/jpeg"),
+        "image/png" => Some("image/png"),
+        "image/gif" => Some("image/gif"),
+        "image/webp" => Some("image/webp"),
+        "image/bmp" => Some("image/bmp"),
+        _ => None,
+    }
+}
+
+fn infer_image_mime_type_from_filename(filename: &str) -> Option<&'static str> {
+    match filename
+        .trim()
+        .rsplit('.')
+        .next()
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("jpg" | "jpeg") => Some("image/jpeg"),
+        Some("png") => Some("image/png"),
+        Some("gif") => Some("image/gif"),
+        Some("webp") => Some("image/webp"),
+        Some("bmp") => Some("image/bmp"),
+        _ => None,
+    }
+}
+
+pub(super) fn normalized_url_scheme(url: &str) -> &'static str {
+    if url.starts_with("https://") {
+        "https"
+    } else if url.starts_with("http://") {
+        "http"
+    } else {
+        "other"
+    }
+}

--- a/qq-maid-gateway-rs/src/gateway/media_fetch/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/media_fetch/mod.rs
@@ -3,19 +3,25 @@
 //! 这里只处理平台事件中明确给出的远端附件 URL，不访问 `file://` 或用户本机路径。
 //! 下载结果写入本地媒体缓存后，通过 `MessageMedia.local_path` 交给 LLM provider 读取。
 
-use std::{
-    fs,
-    io::{self, Write},
-    path::{Path, PathBuf},
-    sync::atomic::{AtomicU64, Ordering},
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::{io::Write, path::PathBuf, sync::atomic::AtomicU64, time::Duration};
+
+#[cfg(test)]
+use std::time::SystemTime;
 
 use futures_util::future::join_all;
 use qq_maid_common::input_part::{MediaStatus, MessageInputPart, MessageMedia};
 use tracing::{debug, warn};
 
 use super::event::Attachment;
+
+mod local_cache;
+
+#[cfg(test)]
+use local_cache::cleanup_media_cache_with_limits;
+use local_cache::{
+    clean_mime_type, cleanup_media_cache_best_effort, media_dir, normalized_url_scheme,
+    partial_download_path, preferred_image_mime, unique_filename,
+};
 
 static MEDIA_FILE_COUNTER: AtomicU64 = AtomicU64::new(1);
 
@@ -266,233 +272,6 @@ async fn download_attachment(
         local_path,
         mime_type: preferred_mime,
     })
-}
-
-fn cleanup_media_cache_best_effort(root: &Path) {
-    if let Err(error) = cleanup_media_cache_with_limits(
-        root,
-        SystemTime::now(),
-        MEDIA_CACHE_TTL,
-        MEDIA_CACHE_MAX_BYTES,
-    ) {
-        warn!(
-            error = %error,
-            "QQ official media cache cleanup failed"
-        );
-    }
-}
-
-fn cleanup_media_cache_with_limits(
-    root: &Path,
-    now: SystemTime,
-    ttl: Duration,
-    max_bytes: u64,
-) -> io::Result<()> {
-    if !root.exists() {
-        return Ok(());
-    }
-    let mut files = Vec::new();
-    collect_media_cache_files(root, &mut files)?;
-
-    let mut retained = Vec::new();
-    let mut total_bytes = 0_u64;
-    for file in files {
-        let expired = now.duration_since(file.modified).is_ok_and(|age| age > ttl);
-        if expired {
-            let _ = fs::remove_file(&file.path);
-            continue;
-        }
-        total_bytes = total_bytes.saturating_add(file.len);
-        retained.push(file);
-    }
-
-    retained.sort_by(|left, right| {
-        left.modified
-            .cmp(&right.modified)
-            .then_with(|| left.path.cmp(&right.path))
-    });
-    for file in retained {
-        if total_bytes <= max_bytes {
-            break;
-        }
-        if fs::remove_file(&file.path).is_ok() {
-            total_bytes = total_bytes.saturating_sub(file.len);
-        }
-    }
-    Ok(())
-}
-
-#[derive(Debug)]
-struct MediaCacheFile {
-    path: PathBuf,
-    modified: SystemTime,
-    len: u64,
-}
-
-fn collect_media_cache_files(root: &Path, output: &mut Vec<MediaCacheFile>) -> io::Result<()> {
-    for entry in fs::read_dir(root)? {
-        let entry = entry?;
-        let path = entry.path();
-        let metadata = entry.metadata()?;
-        if metadata.is_dir() {
-            collect_media_cache_files(&path, output)?;
-        } else if metadata.is_file() {
-            output.push(MediaCacheFile {
-                path,
-                modified: metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
-                len: metadata.len(),
-            });
-        }
-    }
-    Ok(())
-}
-
-fn media_dir(context: &MediaFetchContext) -> PathBuf {
-    context
-        .root_dir
-        .join(safe_path_segment(context.platform))
-        .join(safe_path_segment(&context.app_id))
-        .join(safe_path_segment(&context.peer_id))
-}
-
-fn unique_filename(attachment: &Attachment, response_mime: Option<&str>) -> String {
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_millis())
-        .unwrap_or_default();
-    let counter = MEDIA_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let fallback = filename_for_mime(response_mime, attachment.filename.as_deref());
-    format!("{timestamp}-{counter}-{}", safe_filename(&fallback))
-}
-
-fn partial_download_path(local_path: &Path) -> PathBuf {
-    let filename = local_path
-        .file_name()
-        .and_then(|value| value.to_str())
-        .unwrap_or("image.bin");
-    local_path.with_file_name(format!(".{filename}.part"))
-}
-
-fn filename_for_mime(content_type: Option<&str>, filename: Option<&str>) -> String {
-    let filename = filename
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or("image");
-    if Path::new(filename).extension().is_some() {
-        return filename.to_owned();
-    }
-    let extension = match content_type
-        .unwrap_or("")
-        .trim()
-        .to_ascii_lowercase()
-        .as_str()
-    {
-        "image/jpeg" | "image/jpg" => "jpg",
-        "image/png" => "png",
-        "image/gif" => "gif",
-        "image/webp" => "webp",
-        "image/bmp" => "bmp",
-        _ => "bin",
-    };
-    format!("{filename}.{extension}")
-}
-
-fn safe_filename(value: &str) -> String {
-    let candidate = value
-        .rsplit(['/', '\\'])
-        .next()
-        .unwrap_or("image")
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_') {
-                ch
-            } else {
-                '_'
-            }
-        })
-        .collect::<String>();
-    let candidate = candidate.trim_matches(['.', '_', '-']);
-    if candidate.is_empty() {
-        "image.bin".to_owned()
-    } else {
-        candidate.to_owned()
-    }
-}
-
-fn safe_path_segment(value: &str) -> String {
-    let candidate = value
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
-                ch
-            } else {
-                '_'
-            }
-        })
-        .collect::<String>();
-    if candidate.trim_matches('_').is_empty() {
-        "-".to_owned()
-    } else {
-        candidate
-    }
-}
-
-fn clean_mime_type(value: &str) -> Option<String> {
-    canonical_image_mime(value.split(';').next().map(str::trim).unwrap_or_default())
-        .map(str::to_owned)
-}
-
-fn preferred_image_mime(
-    attachment_content_type: Option<&str>,
-    response_mime: Option<&str>,
-    filename: Option<&str>,
-) -> Option<String> {
-    let attachment_mime = attachment_content_type.and_then(canonical_image_mime);
-    if attachment_mime.is_some() {
-        return attachment_mime.map(str::to_owned);
-    }
-    response_mime
-        .and_then(canonical_image_mime)
-        .or_else(|| filename.and_then(infer_image_mime_type_from_filename))
-        .map(str::to_owned)
-}
-
-fn canonical_image_mime(value: &str) -> Option<&'static str> {
-    match value.trim().to_ascii_lowercase().as_str() {
-        "image/jpeg" | "image/jpg" => Some("image/jpeg"),
-        "image/png" => Some("image/png"),
-        "image/gif" => Some("image/gif"),
-        "image/webp" => Some("image/webp"),
-        "image/bmp" => Some("image/bmp"),
-        _ => None,
-    }
-}
-
-fn infer_image_mime_type_from_filename(filename: &str) -> Option<&'static str> {
-    match filename
-        .trim()
-        .rsplit('.')
-        .next()
-        .map(str::to_ascii_lowercase)
-        .as_deref()
-    {
-        Some("jpg" | "jpeg") => Some("image/jpeg"),
-        Some("png") => Some("image/png"),
-        Some("gif") => Some("image/gif"),
-        Some("webp") => Some("image/webp"),
-        Some("bmp") => Some("image/bmp"),
-        _ => None,
-    }
-}
-
-fn normalized_url_scheme(url: &str) -> &'static str {
-    if url.starts_with("https://") {
-        "https"
-    } else if url.starts_with("http://") {
-        "http"
-    } else {
-        "other"
-    }
 }
 
 fn looks_like_image_attachment(attachment: &Attachment) -> bool {

--- a/qq-maid-gateway-rs/src/gateway/platform/onebot11/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/onebot11/mod.rs
@@ -13,6 +13,13 @@ use crate::gateway::onebot11::protocol::{MessageSegment, OneBotEvent, OneBotMess
 
 use super::model::{Actor, ConversationTarget, GroupMemberRoleKind, InboundMessage, Platform};
 
+mod sanitize;
+
+use sanitize::{
+    clean_data_id, clean_data_string, clean_data_u64, explicit_media_status, infer_image_mime,
+    safe_filename, safe_mime_type, safe_opaque_reference, safe_remote_url,
+};
+
 /// OneBot 事件的 adapter 结果。被忽略的事件保留稳定分类，便于调用方做限量结构化观测，
 /// 但不得记录消息正文或完整 ID。
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -330,97 +337,6 @@ fn media_part(
         OneBotMediaKind::Image => MessageInputPart::image(media),
         OneBotMediaKind::File => MessageInputPart::file(media),
     }
-}
-
-fn clean_data_string(
-    data: &std::collections::BTreeMap<String, Value>,
-    fields: &[&str],
-) -> Option<String> {
-    fields
-        .iter()
-        .filter_map(|field| data.get(*field).and_then(Value::as_str))
-        .map(str::trim)
-        .find(|value| !value.is_empty())
-        .map(str::to_owned)
-}
-
-fn clean_data_id(
-    data: &std::collections::BTreeMap<String, Value>,
-    fields: &[&str],
-) -> Option<String> {
-    fields
-        .iter()
-        .find_map(|field| data.get(*field).and_then(id_from_value))
-}
-
-fn clean_data_u64(
-    data: &std::collections::BTreeMap<String, Value>,
-    fields: &[&str],
-) -> Option<u64> {
-    fields.iter().find_map(|field| match data.get(*field) {
-        Some(Value::Number(value)) => value.as_u64(),
-        Some(Value::String(value)) => value.trim().parse::<u64>().ok(),
-        _ => None,
-    })
-}
-
-fn explicit_media_status(data: &std::collections::BTreeMap<String, Value>) -> Option<MediaStatus> {
-    let status = clean_data_string(data, &["download_status", "status"])?.to_ascii_lowercase();
-    match status.as_str() {
-        "missing" | "missing_readable_url" => Some(MediaStatus::MissingReadableUrl),
-        "size_exceeded" | "too_large" => Some(MediaStatus::SizeExceeded),
-        "unsupported" | "unsupported_type" => Some(MediaStatus::UnsupportedType),
-        "download_failed" | "failed" => Some(MediaStatus::DownloadFailed),
-        "expired" | "url_expired" => Some(MediaStatus::Expired),
-        // `ok`/`available` 仍需通过 URL 安全判定，不能让客户端状态绕过 scheme 校验。
-        _ => None,
-    }
-}
-
-fn safe_remote_url(value: &str) -> Option<String> {
-    let value = value.trim();
-    let parsed = reqwest::Url::parse(value).ok()?;
-    (matches!(parsed.scheme(), "http" | "https") && parsed.host_str().is_some())
-        .then(|| value.to_owned())
-}
-
-fn safe_filename(value: &str) -> Option<String> {
-    let value = value.trim();
-    (!value.is_empty()
-        && value.len() <= 255
-        && !value.contains(['/', '\\', ':'])
-        && !value.to_ascii_lowercase().starts_with("base64"))
-    .then(|| value.to_owned())
-}
-
-fn safe_opaque_reference(value: &str) -> Option<String> {
-    safe_filename(value)
-}
-
-fn safe_mime_type(value: &str) -> Option<String> {
-    let value = value.trim().to_ascii_lowercase();
-    (!value.is_empty()
-        && value.len() <= 127
-        && value.is_ascii()
-        && value.contains('/')
-        && !value.contains(char::is_whitespace))
-    .then_some(value)
-}
-
-fn infer_image_mime(filename: Option<&str>, kind: OneBotMediaKind) -> Option<String> {
-    if !matches!(kind, OneBotMediaKind::Image) {
-        return None;
-    }
-    let extension = filename?.rsplit('.').next()?.to_ascii_lowercase();
-    let mime = match extension.as_str() {
-        "jpg" | "jpeg" => "image/jpeg",
-        "png" => "image/png",
-        "gif" => "image/gif",
-        "webp" => "image/webp",
-        "bmp" => "image/bmp",
-        _ => return None,
-    };
-    Some(mime.to_owned())
 }
 
 fn mention_identity(target_id: String, is_self: bool) -> MentionIdentity {

--- a/qq-maid-gateway-rs/src/gateway/platform/onebot11/sanitize.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/onebot11/sanitize.rs
@@ -1,0 +1,93 @@
+//! OneBot 消息段字段清洗与媒体元数据校验。
+//!
+//! 客户端上报值只在这里转换为可进入统一入站模型的安全字段；本机路径、data URL
+//! 和不可信 MIME 等内容不得绕过该边界进入 Core。
+
+use std::collections::BTreeMap;
+
+use qq_maid_common::input_part::MediaStatus;
+use serde_json::Value;
+
+use super::{OneBotMediaKind, id_from_value};
+
+pub(super) fn clean_data_string(data: &BTreeMap<String, Value>, fields: &[&str]) -> Option<String> {
+    fields
+        .iter()
+        .filter_map(|field| data.get(*field).and_then(Value::as_str))
+        .map(str::trim)
+        .find(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+pub(super) fn clean_data_id(data: &BTreeMap<String, Value>, fields: &[&str]) -> Option<String> {
+    fields
+        .iter()
+        .find_map(|field| data.get(*field).and_then(id_from_value))
+}
+
+pub(super) fn clean_data_u64(data: &BTreeMap<String, Value>, fields: &[&str]) -> Option<u64> {
+    fields.iter().find_map(|field| match data.get(*field) {
+        Some(Value::Number(value)) => value.as_u64(),
+        Some(Value::String(value)) => value.trim().parse::<u64>().ok(),
+        _ => None,
+    })
+}
+
+pub(super) fn explicit_media_status(data: &BTreeMap<String, Value>) -> Option<MediaStatus> {
+    let status = clean_data_string(data, &["download_status", "status"])?.to_ascii_lowercase();
+    match status.as_str() {
+        "missing" | "missing_readable_url" => Some(MediaStatus::MissingReadableUrl),
+        "size_exceeded" | "too_large" => Some(MediaStatus::SizeExceeded),
+        "unsupported" | "unsupported_type" => Some(MediaStatus::UnsupportedType),
+        "download_failed" | "failed" => Some(MediaStatus::DownloadFailed),
+        "expired" | "url_expired" => Some(MediaStatus::Expired),
+        // `ok`/`available` 仍需通过 URL 安全判定，不能让客户端状态绕过 scheme 校验。
+        _ => None,
+    }
+}
+
+pub(super) fn safe_remote_url(value: &str) -> Option<String> {
+    let value = value.trim();
+    let parsed = reqwest::Url::parse(value).ok()?;
+    (matches!(parsed.scheme(), "http" | "https") && parsed.host_str().is_some())
+        .then(|| value.to_owned())
+}
+
+pub(super) fn safe_filename(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()
+        && value.len() <= 255
+        && !value.contains(['/', '\\', ':'])
+        && !value.to_ascii_lowercase().starts_with("base64"))
+    .then(|| value.to_owned())
+}
+
+pub(super) fn safe_opaque_reference(value: &str) -> Option<String> {
+    safe_filename(value)
+}
+
+pub(super) fn safe_mime_type(value: &str) -> Option<String> {
+    let value = value.trim().to_ascii_lowercase();
+    (!value.is_empty()
+        && value.len() <= 127
+        && value.is_ascii()
+        && value.contains('/')
+        && !value.contains(char::is_whitespace))
+    .then_some(value)
+}
+
+pub(super) fn infer_image_mime(filename: Option<&str>, kind: OneBotMediaKind) -> Option<String> {
+    if !matches!(kind, OneBotMediaKind::Image) {
+        return None;
+    }
+    let extension = filename?.rsplit('.').next()?.to_ascii_lowercase();
+    let mime = match extension.as_str() {
+        "jpg" | "jpeg" => "image/jpeg",
+        "png" => "image/png",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "bmp" => "image/bmp",
+        _ => return None,
+    };
+    Some(mime.to_owned())
+}

--- a/qq-maid-gateway-rs/src/message_chunk/error.rs
+++ b/qq-maid-gateway-rs/src/message_chunk/error.rs
@@ -1,0 +1,81 @@
+//! 普通消息分段发送的错误与诊断分类。
+//!
+//! 本模块只描述发送进度和日志分类，不参与分段边界计算或实际发送，避免错误模型
+//! 与较长的 Markdown 分段算法继续混在同一文件中。
+
+use thiserror::Error;
+
+use crate::{api::ApiError, render::OutboundMessage};
+
+use super::OutboundChunk;
+
+/// 出站多段发送编排错误。
+///
+/// 底层 `ApiError` 继续只表示单次 QQ API / 鉴权 / HTTP / 状态码 / unsupported 错误；
+/// 多段发送的进度语义由本类型承载，避免在 `ApiError` 里重复 `SingleApi` 分支。
+#[derive(Debug, Error)]
+pub enum OutboundSendError {
+    /// 一个分段都没成功发出（首段即失败）。
+    #[error("qq outbound send failed before any chunk was sent")]
+    NotSent {
+        #[source]
+        source: ApiError,
+    },
+    /// 已成功发送部分分段，后续分段失败；已成功前段不重发。
+    #[error(
+        "qq outbound send partially failed: {sent_chunks}/{total_chunks} chunks sent, \
+         failed at chunk {failed_chunk_index}, {remaining_chars} chars remaining"
+    )]
+    PartiallySent {
+        #[source]
+        source: ApiError,
+        sent_chunks: usize,
+        total_chunks: usize,
+        failed_chunk_index: usize,
+        remaining_chars: usize,
+    },
+}
+
+impl OutboundSendError {
+    /// 是否已有分段成功发送，调用方可据此决定是否记录部分送达。
+    pub fn has_partial_progress(&self) -> bool {
+        matches!(self, Self::PartiallySent { .. })
+    }
+}
+
+pub(super) fn make_send_error(
+    source: ApiError,
+    index: usize,
+    total: usize,
+    remaining: usize,
+) -> OutboundSendError {
+    if index == 0 {
+        OutboundSendError::NotSent { source }
+    } else {
+        OutboundSendError::PartiallySent {
+            source,
+            sent_chunks: index,
+            total_chunks: total,
+            failed_chunk_index: index,
+            remaining_chars: remaining,
+        }
+    }
+}
+
+pub(super) fn outbound_kind(message: &OutboundMessage) -> &'static str {
+    match message {
+        OutboundMessage::Text { .. } => "text",
+        OutboundMessage::Markdown { .. } => "markdown",
+        OutboundMessage::Image { .. } => "image",
+        OutboundMessage::ImagePlaceholder { .. } => "image_placeholder",
+        OutboundMessage::AttachmentPlaceholder { .. } => "attachment_placeholder",
+    }
+}
+
+pub(super) fn message_type_name(chunk: &OutboundChunk) -> &'static str {
+    if chunk.markdown.is_some() {
+        "markdown"
+    } else {
+        "text"
+    }
+}

--- a/qq-maid-gateway-rs/src/message_chunk/mod.rs
+++ b/qq-maid-gateway-rs/src/message_chunk/mod.rs
@@ -11,12 +11,18 @@
 //! - 各段消费的原文连续拼接应等于原始回复，不丢字、不重字、不乱序；
 //! - 中文、Emoji、组合字符不会被切坏，按 Unicode scalar 安全切分。
 
-use thiserror::Error;
 use tracing::{debug, info, trace, warn};
 
+mod error;
+
+pub use error::OutboundSendError;
+use error::{make_send_error, message_type_name, outbound_kind};
+
+#[cfg(test)]
+use crate::api::ApiError;
 use crate::api::{
-    ApiError, C2cReplyTarget, GroupOutboundSender, GroupReplyTarget, OutboundSender,
-    SendMessageIds, SendResult,
+    C2cReplyTarget, GroupOutboundSender, GroupReplyTarget, OutboundSender, SendMessageIds,
+    SendResult,
 };
 use crate::logging::mask_openid;
 use crate::markdown::MarkdownPayload;
@@ -91,40 +97,6 @@ pub struct OutboundChunk {
     pub rendered_chars: usize,
     pub chunk_index: usize,
     pub chunk_count: usize,
-}
-
-/// 出站多段发送编排错误。
-///
-/// 底层 `ApiError` 继续只表示单次 QQ API / 鉴权 / HTTP / 状态码 / unsupported 错误；
-/// 多段发送的进度语义由本类型承载，避免在 `ApiError` 里重复 `SingleApi` 分支。
-#[derive(Debug, Error)]
-pub enum OutboundSendError {
-    /// 一个分段都没成功发出（首段即失败）。
-    #[error("qq outbound send failed before any chunk was sent")]
-    NotSent {
-        #[source]
-        source: ApiError,
-    },
-    /// 已成功发送部分分段，后续分段失败；已成功前段不重发。
-    #[error(
-        "qq outbound send partially failed: {sent_chunks}/{total_chunks} chunks sent, \
-         failed at chunk {failed_chunk_index}, {remaining_chars} chars remaining"
-    )]
-    PartiallySent {
-        #[source]
-        source: ApiError,
-        sent_chunks: usize,
-        total_chunks: usize,
-        failed_chunk_index: usize,
-        remaining_chars: usize,
-    },
-}
-
-impl OutboundSendError {
-    /// 是否已有分段成功发送，调用方可据此决定是否记录部分送达。
-    pub fn has_partial_progress(&self) -> bool {
-        matches!(self, Self::PartiallySent { .. })
-    }
 }
 
 // ===========================================================================
@@ -966,43 +938,6 @@ where
         "chunked group outbound completed"
     );
     Ok(sent_ids)
-}
-
-fn make_send_error(
-    source: ApiError,
-    index: usize,
-    total: usize,
-    remaining: usize,
-) -> OutboundSendError {
-    if index == 0 {
-        OutboundSendError::NotSent { source }
-    } else {
-        OutboundSendError::PartiallySent {
-            source,
-            sent_chunks: index,
-            total_chunks: total,
-            failed_chunk_index: index,
-            remaining_chars: remaining,
-        }
-    }
-}
-
-fn outbound_kind(message: &OutboundMessage) -> &'static str {
-    match message {
-        OutboundMessage::Text { .. } => "text",
-        OutboundMessage::Markdown { .. } => "markdown",
-        OutboundMessage::Image { .. } => "image",
-        OutboundMessage::ImagePlaceholder { .. } => "image_placeholder",
-        OutboundMessage::AttachmentPlaceholder { .. } => "attachment_placeholder",
-    }
-}
-
-fn message_type_name(chunk: &OutboundChunk) -> &'static str {
-    if chunk.markdown.is_some() {
-        "markdown"
-    } else {
-        "text"
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 变更内容

- 将 QQ OpenAPI 响应 DTO 与消息 ID / 错误字段解析拆到 `api/response.rs`。
- 将普通消息分段发送错误与诊断分类拆到 `message_chunk/error.rs`。
- 将 OneBot 消息段字段清洗和媒体元数据校验拆到 `gateway/platform/onebot11/sanitize.rs`。
- 将 QQ 官方媒体本地缓存、路径、文件名和 MIME helper 拆到 `gateway/media_fetch/local_cache.rs`。
- 将已有同名 `foo.rs + foo/` 模块统一为目录入口 `foo/mod.rs`，并更新 Gateway README 路径。

四个原始大文件均降到 1000 行以下，仓库内 1000 行以上 Rust 文件由 30 个降到 26 个。

## 兼容性

- 不改变公开模块路径和调用接口。
- 不改变 QQ 发送顺序、fallback、流式 ID 解析、OneBot 入站过滤或媒体缓存语义。
- 不涉及配置格式、数据库 schema、migration 或用户可见文案调整。

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo build --workspace --release --all-features`
- `make test-gateway`
- `git diff --check`

Refs #327
