### PR TITLE
feat: 统一 Pending 动作生命周期

### DIFF
--- a/qq-maid-core/src/runtime/pending/mod.rs
+++ b/qq-maid-core/src/runtime/pending/mod.rs
@@ -1,249 +1,152 @@
-//! 跨工具可复用的 pending 基础设施。
-//!
-//! 本模块只保存通用 envelope、生命周期判断所需元数据和确认/取消意图分类。
-//! 具体业务 pending payload 由各工具域维护。
+//! 跨工具可复用的 PreparedAction 与 pending 回复分类基础设施。
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as DeError};
-use serde_json::Value;
+mod model;
+mod reply;
 
-/// 持久化 pending 的通用 envelope。
-///
-/// 数据库中仍保存各业务原有的 JSON payload；本结构只从 payload 中抽取通用字段，
-/// 便于 respond 层做过期、发起人和 owner 隔离判断。业务执行前必须回到对应工具域
-/// 反序列化 payload，不能在这里解释业务字段。
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PendingOperation {
-    domain: String,
-    kind: String,
-    created_at: String,
-    initiator_user_id: Option<String>,
-    owner_key: Option<String>,
-    payload: Value,
-}
-
-const SUPPORTED_PENDING_DOMAINS: &[&str] = &["todo"];
-
-impl PendingOperation {
-    /// 从业务 payload 构造通用 envelope。
-    pub fn from_payload(domain: impl Into<String>, payload: Value) -> Self {
-        let domain = domain.into();
-        Self {
-            kind: string_field(&payload, "kind").unwrap_or_else(|| domain.clone()),
-            created_at: string_field(&payload, "created_at").unwrap_or_default(),
-            initiator_user_id: string_field(&payload, "initiator_user_id"),
-            owner_key: string_field(&payload, "owner_key"),
-            domain,
-            payload,
-        }
-    }
-
-    /// pending 所属业务域，例如 `todo`。
-    pub fn domain(&self) -> &str {
-        &self.domain
-    }
-
-    /// 业务 payload 的原始 kind，例如 `todo_bulk_delete`。
-    pub fn kind(&self) -> &str {
-        &self.kind
-    }
-
-    /// 获取操作的所有者键。没有 owner 概念的业务返回 `None`。
-    pub fn owner_key(&self) -> Option<&str> {
-        self.owner_key.as_deref()
-    }
-
-    /// 获取 pending 发起人。旧持久化数据没有该字段时返回 `None`，继续按历史行为处理。
-    pub fn initiator_user_id(&self) -> Option<&str> {
-        self.initiator_user_id.as_deref()
-    }
-
-    /// 获取 pending 创建时间。缺失时返回空串，调用方会按过期状态处理。
-    pub fn created_at(&self) -> &str {
-        &self.created_at
-    }
-
-    /// 业务原始 payload。只允许对应工具域继续解释。
-    pub fn payload(&self) -> &Value {
-        &self.payload
-    }
-}
-
-impl Serialize for PendingOperation {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.payload.serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for PendingOperation {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let payload = Value::deserialize(deserializer)?;
-        let kind = string_field(&payload, "kind").unwrap_or_else(|| "unknown".to_owned());
-        let domain = domain_from_kind(&kind);
-        if !SUPPORTED_PENDING_DOMAINS.contains(&domain.as_str()) {
-            return Err(D::Error::custom(format!(
-                "unsupported pending operation kind `{kind}`"
-            )));
-        }
-        Ok(Self::from_payload(domain, payload))
-    }
-}
-
-/// 用户对挂起操作的回复类型。
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PendingReplyKind {
-    /// 确认执行
-    Confirm,
-    /// 取消操作
-    Cancel,
-    /// 修改草稿内容
-    Revise,
-    /// 暂不确定，保持等待
-    Wait,
-}
-
-/// 用于识别用户确认/取消意图的词汇配置。
-#[derive(Debug, Clone, Copy)]
-pub struct PendingLexicon {
-    /// 表示确认的关键词列表
-    confirm_words: &'static [&'static str],
-    /// 表示取消的关键词列表
-    cancel_words: &'static [&'static str],
-}
-
-impl PendingLexicon {
-    /// 构造某个业务域自己的确认/取消词表。
-    pub const fn new(
-        confirm_words: &'static [&'static str],
-        cancel_words: &'static [&'static str],
-    ) -> Self {
-        Self {
-            confirm_words,
-            cancel_words,
-        }
-    }
-}
-
-/// 根据用户回复文本和词汇表，分类用户的确认/取消/修改意图。
-///
-/// 优先匹配取消词，其次匹配确认词，如果有非空非命令文本则视为修订，
-/// 否则保持等待状态。
-pub fn classify_reply(text: &str, lexicon: PendingLexicon) -> PendingReplyKind {
-    let text = text.trim();
-    let compact = compact_pending_reply(text);
-    if lexicon.cancel_words.contains(&text)
-        || lexicon
-            .cancel_words
-            .iter()
-            .any(|word| compact == *word || compact.starts_with(word))
-    {
-        return PendingReplyKind::Cancel;
-    }
-
-    if lexicon
-        .confirm_words
-        .iter()
-        .any(|word| is_confirm_match(&compact, word))
-    {
-        return PendingReplyKind::Confirm;
-    }
-    if should_parse_pending_revision(text) {
-        return PendingReplyKind::Revise;
-    }
-    PendingReplyKind::Wait
-}
-
-/// 判断用户回复是否应被解析为对挂起草稿的修订。
-///
-/// 非空且不以 `/` 开头的文本视为修订意图。
-pub fn should_parse_pending_revision(text: &str) -> bool {
-    let text = text.trim();
-    !text.is_empty() && !text.starts_with('/')
-}
-
-/// 压缩回复文本：移除空白字符和常见标点，去掉尾部的语气助词，
-/// 得到紧凑的文本用于关键词匹配。
-fn compact_pending_reply(text: &str) -> String {
-    text.chars()
-        .filter(|ch| {
-            !ch.is_whitespace()
-                && !matches!(
-                    ch,
-                    '，' | ','
-                        | '。'
-                        | '.'
-                        | '！'
-                        | '!'
-                        | '？'
-                        | '?'
-                        | '、'
-                        | ';'
-                        | '；'
-                        | ':'
-                        | '：'
-                )
-        })
-        .collect::<String>()
-        .trim_end_matches(['了', '吧', '啊', '呀', '呢'])
-        .to_owned()
-}
-
-/// 判断紧凑文本是否匹配确认词，支持关键词后接补充指示（如"确认执行"）。
-fn is_confirm_match(compact: &str, word: &str) -> bool {
-    if compact == word {
-        return true;
-    }
-    let Some(rest) = compact.strip_prefix(word) else {
-        return false;
-    };
-    matches!(
-        rest,
-        "就这个" | "就这样" | "执行" | "保存" | "写入" | "删除" | "新增" | "修改"
-    )
-}
-
-fn string_field(value: &Value, key: &str) -> Option<String> {
-    value
-        .get(key)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_owned)
-}
-
-fn domain_from_kind(kind: &str) -> String {
-    kind.split_once('_')
-        .map(|(domain, _)| domain)
-        .filter(|domain| !domain.is_empty())
-        .unwrap_or("unknown")
-        .to_owned()
-}
+pub use model::*;
+pub use reply::*;
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
 
+    fn prepared_action() -> PreparedAction {
+        PreparedAction::new(
+            PreparedActionMetadata {
+                domain: "todo".to_owned(),
+                action_kind: "todo_bulk_delete".to_owned(),
+                initiator_user_id: Some("u1".to_owned()),
+                owner_key: Some("owner:u1".to_owned()),
+                scope_key: "group:g1:actor:u1".to_owned(),
+                created_at: "2026-07-15T10:00:00+08:00".to_owned(),
+                expires_at: "2026-07-15T10:10:00+08:00".to_owned(),
+            },
+            json!({"summary": "删除 2 条"}),
+            json!({"kind": "todo_bulk_delete", "item_ids": ["a", "b"]}),
+        )
+    }
+
     #[test]
-    fn legacy_pending_without_initiator_deserializes_as_generic_envelope() {
-        let pending: PendingOperation = serde_json::from_value(json!({
+    fn prepared_action_round_trips_with_lifecycle_metadata() {
+        let original = prepared_action();
+        let value = serde_json::to_value(&original).unwrap();
+        assert_eq!(value["schema_version"], 1);
+        assert_eq!(value["state"], "waiting_confirmation");
+        assert_eq!(value["revision"], 1);
+        assert_eq!(value["expires_at"], "2026-07-15T10:10:00+08:00");
+        assert_eq!(value["scope_key"], "group:g1:actor:u1");
+
+        let restored: PreparedAction = serde_json::from_value(value).unwrap();
+        assert_eq!(restored, original);
+    }
+
+    #[test]
+    fn legacy_pending_without_new_fields_deserializes() {
+        let pending: PreparedAction = serde_json::from_value(json!({
             "kind": "todo_add",
             "owner_key": "u1",
-            "draft": {
-                "title": "旧事项"
-            },
+            "draft": {"title": "旧事项"},
             "created_at": "2026-06-27T12:00:00+08:00"
         }))
         .unwrap();
 
+        assert!(pending.is_legacy());
         assert_eq!(pending.domain(), "todo");
         assert_eq!(pending.kind(), "todo_add");
         assert_eq!(pending.owner_key(), Some("u1"));
         assert_eq!(pending.initiator_user_id(), None);
+        assert_eq!(pending.revision(), 1);
+    }
+
+    #[test]
+    fn execution_rejects_expired_cross_user_scope_owner_and_revision() {
+        let base = PreparedActionExecutionContext {
+            initiator_user_id: Some("u1"),
+            owner_key: Some("owner:u1"),
+            scope_key: "group:g1:actor:u1",
+            expected_revision: 1,
+            now: "2026-07-15T10:05:00+08:00",
+        };
+        let action = prepared_action();
+        assert_eq!(action.validate_for_execution(&base), Ok(()));
+
+        let mut context = base;
+        context.initiator_user_id = Some("u2");
+        assert_eq!(
+            action.validate_for_execution(&context),
+            Err(PreparedActionValidationError::InitiatorMismatch)
+        );
+        context = base;
+        context.owner_key = Some("owner:u2");
+        assert_eq!(
+            action.validate_for_execution(&context),
+            Err(PreparedActionValidationError::OwnerMismatch)
+        );
+        context = base;
+        context.scope_key = "group:g2:actor:u1";
+        assert_eq!(
+            action.validate_for_execution(&context),
+            Err(PreparedActionValidationError::ScopeMismatch)
+        );
+        context = base;
+        context.expected_revision = 0;
+        assert_eq!(
+            action.validate_for_execution(&context),
+            Err(PreparedActionValidationError::RevisionMismatch)
+        );
+        context = base;
+        context.now = "2026-07-15T10:10:00+08:00";
+        assert_eq!(
+            action.validate_for_execution(&context),
+            Err(PreparedActionValidationError::Expired)
+        );
+    }
+
+    #[test]
+    fn revised_action_invalidates_old_revision_and_supports_failed_state() {
+        let mut action = prepared_action();
+        let revision = action
+            .revise(
+                json!({"kind": "todo_bulk_delete", "item_ids": ["a"]}),
+                json!({"summary": "删除 1 条"}),
+                "2026-07-15T10:12:00+08:00",
+            )
+            .unwrap();
+        assert_eq!(revision, 2);
+
+        let old_context = PreparedActionExecutionContext {
+            initiator_user_id: Some("u1"),
+            owner_key: Some("owner:u1"),
+            scope_key: "group:g1:actor:u1",
+            expected_revision: 1,
+            now: "2026-07-15T10:05:00+08:00",
+        };
+        assert_eq!(
+            action.begin_execution(&old_context),
+            Err(PreparedActionValidationError::RevisionMismatch)
+        );
+
+        let current_context = PreparedActionExecutionContext {
+            expected_revision: 2,
+            ..old_context
+        };
+        action.begin_execution(&current_context).unwrap();
+        action.mark_failed(2).unwrap();
+        assert_eq!(action.state(), PreparedActionState::Failed);
+        assert_eq!(
+            action.begin_execution(&current_context),
+            Err(PreparedActionValidationError::InvalidState)
+        );
+    }
+
+    #[test]
+    fn expiry_helper_uses_explicit_timestamp() {
+        assert_eq!(
+            expires_at_after("2026-07-15T10:00:00+08:00", 600).as_deref(),
+            Some("2026-07-15T10:10:00+08:00")
+        );
+        assert!(expires_at_after("invalid", 600).is_none());
+        assert!(!qq_maid_common::time_context::now_iso_cn().is_empty());
     }
 }

--- a/qq-maid-core/src/runtime/pending/mod.rs
+++ b/qq-maid-core/src/runtime/pending/mod.rs
@@ -42,21 +42,15 @@ mod tests {
     }
 
     #[test]
-    fn legacy_pending_without_new_fields_deserializes() {
-        let pending: PreparedAction = serde_json::from_value(json!({
+    fn flat_pending_without_envelope_is_rejected() {
+        let result = serde_json::from_value::<PreparedAction>(json!({
             "kind": "todo_add",
             "owner_key": "u1",
             "draft": {"title": "旧事项"},
             "created_at": "2026-06-27T12:00:00+08:00"
-        }))
-        .unwrap();
+        }));
 
-        assert!(pending.is_legacy());
-        assert_eq!(pending.domain(), "todo");
-        assert_eq!(pending.kind(), "todo_add");
-        assert_eq!(pending.owner_key(), Some("u1"));
-        assert_eq!(pending.initiator_user_id(), None);
-        assert_eq!(pending.revision(), 1);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/qq-maid-core/src/runtime/pending/model.rs
+++ b/qq-maid-core/src/runtime/pending/model.rs
@@ -1,0 +1,439 @@
+//! 跨工具可复用的 pending 基础设施。
+//!
+//! 本模块只保存通用 PreparedAction envelope、生命周期校验和确认/取消意图分类。
+//! 具体业务 payload 与用户文案由各工具域维护。
+
+use chrono::{DateTime, Duration};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as DeError};
+use serde_json::Value;
+use thiserror::Error;
+
+/// 当前 PreparedAction 持久化结构版本。
+pub const PREPARED_ACTION_SCHEMA_VERSION: u32 = 1;
+/// 新动作的初始 revision。revision 只增不减，后续修订必须递增。
+pub const INITIAL_PREPARED_ACTION_REVISION: u64 = 1;
+
+const SUPPORTED_PENDING_DOMAINS: &[&str] = &["todo"];
+
+/// 需要持久化的非终态生命周期。
+///
+/// Completed、Cancelled、Expired 是处理结果，完成后继续清除 Session pending，
+/// 不在这里保存历史记录。
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PreparedActionState {
+    /// 已准备完毕，尚未执行任何副作用。
+    WaitingConfirmation,
+    /// 已通过身份、作用域、过期时间和 revision 校验，正在执行真实工具。
+    Executing,
+    /// 真实执行返回失败；是否保留以便用户取消由业务域决定。
+    Failed,
+}
+
+/// 执行前由可信运行时提供的身份与作用域上下文。
+#[derive(Debug, Clone, Copy)]
+pub struct PreparedActionExecutionContext<'a> {
+    pub initiator_user_id: Option<&'a str>,
+    pub owner_key: Option<&'a str>,
+    pub scope_key: &'a str,
+    pub expected_revision: u64,
+    pub now: &'a str,
+}
+
+/// 创建 PreparedAction 时由业务域提供的通用元数据。
+#[derive(Debug, Clone)]
+pub struct PreparedActionMetadata {
+    pub domain: String,
+    pub action_kind: String,
+    pub initiator_user_id: Option<String>,
+    pub owner_key: Option<String>,
+    pub scope_key: String,
+    pub created_at: String,
+    pub expires_at: String,
+}
+
+/// PreparedAction 在执行前校验失败的明确原因。
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum PreparedActionValidationError {
+    #[error("unsupported prepared action schema version {0}")]
+    UnsupportedSchemaVersion(u32),
+    #[error("prepared action is not waiting for confirmation")]
+    InvalidState,
+    #[error("prepared action initiator does not match current user")]
+    InitiatorMismatch,
+    #[error("prepared action owner does not match current owner")]
+    OwnerMismatch,
+    #[error("prepared action scope does not match current session")]
+    ScopeMismatch,
+    #[error("prepared action has expired or contains an invalid expiry")]
+    Expired,
+    #[error("prepared action revision does not match expected revision")]
+    RevisionMismatch,
+    #[error("prepared action is missing required execution metadata")]
+    MissingMetadata,
+}
+
+/// 持久化 pending 的通用 PreparedAction envelope。
+///
+/// 通用层只理解动作身份、生命周期和不透明 JSON；Todo ID、提醒等业务字段仍由
+/// `runtime::tools::todo` 解释。Session 只保存这一套 pending 状态。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreparedAction {
+    schema_version: u32,
+    domain: String,
+    action_kind: String,
+    state: PreparedActionState,
+    initiator_user_id: Option<String>,
+    owner_key: Option<String>,
+    scope_key: Option<String>,
+    created_at: String,
+    expires_at: Option<String>,
+    revision: u64,
+    display_snapshot: Value,
+    payload: Value,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct StoredPreparedAction {
+    schema_version: u32,
+    domain: String,
+    action_kind: String,
+    state: PreparedActionState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    initiator_user_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    owner_key: Option<String>,
+    scope_key: String,
+    created_at: String,
+    expires_at: String,
+    revision: u64,
+    #[serde(default)]
+    display_snapshot: Value,
+    payload: Value,
+}
+
+impl PreparedAction {
+    /// 构造新 PreparedAction。调用方必须传入可信的 session scope 与明确过期时间。
+    pub fn new(metadata: PreparedActionMetadata, display_snapshot: Value, payload: Value) -> Self {
+        Self {
+            schema_version: PREPARED_ACTION_SCHEMA_VERSION,
+            domain: metadata.domain,
+            action_kind: metadata.action_kind,
+            state: PreparedActionState::WaitingConfirmation,
+            initiator_user_id: metadata.initiator_user_id,
+            owner_key: metadata.owner_key,
+            scope_key: Some(metadata.scope_key),
+            created_at: metadata.created_at,
+            expires_at: Some(metadata.expires_at),
+            revision: INITIAL_PREPARED_ACTION_REVISION,
+            display_snapshot,
+            payload,
+        }
+    }
+
+    /// 从旧扁平业务 payload 构造兼容对象。
+    ///
+    /// 旧数据没有 scope/expires_at/revision，不能伪造这些字段。运行时只对明确支持的
+    /// 旧 Todo JSON 沿用原 TTL 与 owner 规则；无法安全恢复的 payload 由业务域清理。
+    fn from_legacy_payload(domain: impl Into<String>, payload: Value) -> Self {
+        let domain = domain.into();
+        Self {
+            schema_version: 0,
+            action_kind: string_field(&payload, "kind").unwrap_or_else(|| domain.clone()),
+            state: PreparedActionState::WaitingConfirmation,
+            initiator_user_id: string_field(&payload, "initiator_user_id"),
+            owner_key: string_field(&payload, "owner_key"),
+            scope_key: None,
+            created_at: string_field(&payload, "created_at").unwrap_or_default(),
+            expires_at: None,
+            revision: INITIAL_PREPARED_ACTION_REVISION,
+            display_snapshot: Value::Null,
+            domain,
+            payload,
+        }
+    }
+
+    pub fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    /// pending 所属业务域，例如 `todo`。
+    pub fn domain(&self) -> &str {
+        &self.domain
+    }
+
+    /// 业务动作类型，例如 `todo_bulk_delete`。
+    pub fn kind(&self) -> &str {
+        &self.action_kind
+    }
+
+    pub fn state(&self) -> PreparedActionState {
+        self.state
+    }
+
+    pub fn owner_key(&self) -> Option<&str> {
+        self.owner_key.as_deref()
+    }
+
+    pub fn scope_key(&self) -> Option<&str> {
+        self.scope_key.as_deref()
+    }
+
+    pub fn initiator_user_id(&self) -> Option<&str> {
+        self.initiator_user_id.as_deref()
+    }
+
+    pub fn created_at(&self) -> &str {
+        &self.created_at
+    }
+
+    pub fn expires_at(&self) -> Option<&str> {
+        self.expires_at.as_deref()
+    }
+
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    pub fn display_snapshot(&self) -> &Value {
+        &self.display_snapshot
+    }
+
+    /// 业务原始 payload。只允许对应工具域继续解释。
+    pub fn payload(&self) -> &Value {
+        &self.payload
+    }
+
+    pub fn is_legacy(&self) -> bool {
+        self.schema_version == 0
+    }
+
+    /// 新结构以 expires_at 为唯一过期依据；旧结构由业务域继续使用原 created_at TTL。
+    pub fn is_expired_at(&self, now: &str) -> bool {
+        let (Some(expires_at), Ok(now)) = (
+            self.expires_at.as_deref(),
+            DateTime::parse_from_rfc3339(now.trim()),
+        ) else {
+            return !self.is_legacy();
+        };
+        let Ok(expires_at) = DateTime::parse_from_rfc3339(expires_at.trim()) else {
+            return true;
+        };
+        now >= expires_at
+    }
+
+    /// 校验并切换到 Executing。调用方必须先持久化该状态，再执行副作用。
+    pub fn begin_execution(
+        &mut self,
+        context: &PreparedActionExecutionContext<'_>,
+    ) -> Result<(), PreparedActionValidationError> {
+        self.validate_for_execution(context)?;
+        self.state = PreparedActionState::Executing;
+        Ok(())
+    }
+
+    /// 将真实执行失败记录为 Failed，不生成成功文案。
+    pub fn mark_failed(&mut self, revision: u64) -> Result<(), PreparedActionValidationError> {
+        if self.revision != revision {
+            return Err(PreparedActionValidationError::RevisionMismatch);
+        }
+        if self.state != PreparedActionState::Executing {
+            return Err(PreparedActionValidationError::InvalidState);
+        }
+        self.state = PreparedActionState::Failed;
+        Ok(())
+    }
+
+    /// 为后续 #214 提供结构化修订能力；本任务不解析自然语言修订。
+    ///
+    /// revision 递增后，持有旧 revision 的确认会在 `begin_execution` 阶段失效。
+    pub fn revise(
+        &mut self,
+        payload: Value,
+        display_snapshot: Value,
+        expires_at: impl Into<String>,
+    ) -> Result<u64, PreparedActionValidationError> {
+        if !matches!(
+            self.state,
+            PreparedActionState::WaitingConfirmation | PreparedActionState::Failed
+        ) {
+            return Err(PreparedActionValidationError::InvalidState);
+        }
+        self.payload = payload;
+        self.display_snapshot = display_snapshot;
+        self.expires_at = Some(expires_at.into());
+        self.revision = self.revision.saturating_add(1);
+        self.state = PreparedActionState::WaitingConfirmation;
+        Ok(self.revision)
+    }
+
+    /// 工具已经取得执行权但返回“仍需补充”时，保存新的展示问题并回到等待态。
+    pub fn continue_waiting_after_execution(
+        &mut self,
+        payload: Value,
+        display_snapshot: Value,
+        expires_at: impl Into<String>,
+    ) -> Result<u64, PreparedActionValidationError> {
+        if self.state != PreparedActionState::Executing {
+            return Err(PreparedActionValidationError::InvalidState);
+        }
+        self.payload = payload;
+        self.display_snapshot = display_snapshot;
+        self.expires_at = Some(expires_at.into());
+        self.revision = self.revision.saturating_add(1);
+        self.state = PreparedActionState::WaitingConfirmation;
+        Ok(self.revision)
+    }
+
+    pub fn validate_for_execution(
+        &self,
+        context: &PreparedActionExecutionContext<'_>,
+    ) -> Result<(), PreparedActionValidationError> {
+        if self.schema_version != PREPARED_ACTION_SCHEMA_VERSION {
+            return Err(PreparedActionValidationError::UnsupportedSchemaVersion(
+                self.schema_version,
+            ));
+        }
+        if self.state != PreparedActionState::WaitingConfirmation {
+            return Err(PreparedActionValidationError::InvalidState);
+        }
+        if self.revision != context.expected_revision {
+            return Err(PreparedActionValidationError::RevisionMismatch);
+        }
+        let (Some(initiator), Some(scope_key), Some(expires_at)) = (
+            self.initiator_user_id.as_deref(),
+            self.scope_key.as_deref(),
+            self.expires_at.as_deref(),
+        ) else {
+            return Err(PreparedActionValidationError::MissingMetadata);
+        };
+        if context.initiator_user_id != Some(initiator) {
+            return Err(PreparedActionValidationError::InitiatorMismatch);
+        }
+        if self.owner_key.as_deref() != context.owner_key {
+            return Err(PreparedActionValidationError::OwnerMismatch);
+        }
+        if scope_key != context.scope_key {
+            return Err(PreparedActionValidationError::ScopeMismatch);
+        }
+        let Ok(now) = DateTime::parse_from_rfc3339(context.now.trim()) else {
+            return Err(PreparedActionValidationError::Expired);
+        };
+        let Ok(expires_at) = DateTime::parse_from_rfc3339(expires_at.trim()) else {
+            return Err(PreparedActionValidationError::Expired);
+        };
+        if now >= expires_at {
+            return Err(PreparedActionValidationError::Expired);
+        }
+        Ok(())
+    }
+}
+
+/// 按 created_at 计算明确的 RFC3339 过期时间；非法时间返回 None，由调用方拒绝创建。
+pub fn expires_at_after(created_at: &str, ttl_seconds: i64) -> Option<String> {
+    let created_at = DateTime::parse_from_rfc3339(created_at.trim()).ok()?;
+    Some((created_at + Duration::seconds(ttl_seconds)).to_rfc3339())
+}
+
+impl Serialize for PreparedAction {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // 旧对象只来自既有 Session 或兼容测试；未发生修订时保持原扁平 JSON，避免
+        // 无意把缺少可信 scope/expires_at 的数据包装成看似完整的新动作。
+        if self.is_legacy() {
+            return self.payload.serialize(serializer);
+        }
+        StoredPreparedAction {
+            schema_version: self.schema_version,
+            domain: self.domain.clone(),
+            action_kind: self.action_kind.clone(),
+            state: self.state,
+            initiator_user_id: self.initiator_user_id.clone(),
+            owner_key: self.owner_key.clone(),
+            scope_key: self.scope_key.clone().unwrap_or_default(),
+            created_at: self.created_at.clone(),
+            expires_at: self.expires_at.clone().unwrap_or_default(),
+            revision: self.revision,
+            display_snapshot: self.display_snapshot.clone(),
+            payload: self.payload.clone(),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for PreparedAction {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        if value.get("schema_version").is_none() {
+            let kind = string_field(&value, "kind").unwrap_or_else(|| "unknown".to_owned());
+            let domain = domain_from_kind(&kind);
+            if !SUPPORTED_PENDING_DOMAINS.contains(&domain.as_str()) {
+                return Err(D::Error::custom(format!(
+                    "unsupported pending operation kind `{kind}`"
+                )));
+            }
+            return Ok(Self::from_legacy_payload(domain, value));
+        }
+
+        let stored: StoredPreparedAction =
+            serde_json::from_value(value).map_err(D::Error::custom)?;
+        if !SUPPORTED_PENDING_DOMAINS.contains(&stored.domain.as_str()) {
+            return Err(D::Error::custom(format!(
+                "unsupported prepared action domain `{}`",
+                stored.domain
+            )));
+        }
+        if stored.schema_version != PREPARED_ACTION_SCHEMA_VERSION {
+            return Err(D::Error::custom(format!(
+                "unsupported prepared action schema version `{}`",
+                stored.schema_version
+            )));
+        }
+        if stored.revision == 0
+            || stored.scope_key.trim().is_empty()
+            || stored.created_at.trim().is_empty()
+            || stored.expires_at.trim().is_empty()
+            || stored.action_kind.trim().is_empty()
+        {
+            return Err(D::Error::custom(
+                "prepared action is missing required lifecycle metadata",
+            ));
+        }
+        Ok(Self {
+            schema_version: stored.schema_version,
+            domain: stored.domain,
+            action_kind: stored.action_kind,
+            state: stored.state,
+            initiator_user_id: stored.initiator_user_id,
+            owner_key: stored.owner_key,
+            scope_key: Some(stored.scope_key),
+            created_at: stored.created_at,
+            expires_at: Some(stored.expires_at),
+            revision: stored.revision,
+            display_snapshot: stored.display_snapshot,
+            payload: stored.payload,
+        })
+    }
+}
+
+fn string_field(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn domain_from_kind(kind: &str) -> String {
+    kind.split_once('_')
+        .map(|(domain, _)| domain)
+        .filter(|domain| !domain.is_empty())
+        .unwrap_or("unknown")
+        .to_owned()
+}

--- a/qq-maid-core/src/runtime/pending/model.rs
+++ b/qq-maid-core/src/runtime/pending/model.rs
@@ -4,7 +4,7 @@
 //! 具体业务 payload 与用户文案由各工具域维护。
 
 use chrono::{DateTime, Duration};
-use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as DeError};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
 
@@ -77,7 +77,7 @@ pub enum PreparedActionValidationError {
 ///
 /// 通用层只理解动作身份、生命周期和不透明 JSON；Todo ID、提醒等业务字段仍由
 /// `runtime::tools::todo` 解释。Session 只保存这一套 pending 状态。
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PreparedAction {
     schema_version: u32,
     domain: String,
@@ -85,29 +85,10 @@ pub struct PreparedAction {
     state: PreparedActionState,
     initiator_user_id: Option<String>,
     owner_key: Option<String>,
-    scope_key: Option<String>,
-    created_at: String,
-    expires_at: Option<String>,
-    revision: u64,
-    display_snapshot: Value,
-    payload: Value,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct StoredPreparedAction {
-    schema_version: u32,
-    domain: String,
-    action_kind: String,
-    state: PreparedActionState,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    initiator_user_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    owner_key: Option<String>,
     scope_key: String,
     created_at: String,
     expires_at: String,
     revision: u64,
-    #[serde(default)]
     display_snapshot: Value,
     payload: Value,
 }
@@ -122,33 +103,11 @@ impl PreparedAction {
             state: PreparedActionState::WaitingConfirmation,
             initiator_user_id: metadata.initiator_user_id,
             owner_key: metadata.owner_key,
-            scope_key: Some(metadata.scope_key),
+            scope_key: metadata.scope_key,
             created_at: metadata.created_at,
-            expires_at: Some(metadata.expires_at),
+            expires_at: metadata.expires_at,
             revision: INITIAL_PREPARED_ACTION_REVISION,
             display_snapshot,
-            payload,
-        }
-    }
-
-    /// 从旧扁平业务 payload 构造兼容对象。
-    ///
-    /// 旧数据没有 scope/expires_at/revision，不能伪造这些字段。运行时只对明确支持的
-    /// 旧 Todo JSON 沿用原 TTL 与 owner 规则；无法安全恢复的 payload 由业务域清理。
-    fn from_legacy_payload(domain: impl Into<String>, payload: Value) -> Self {
-        let domain = domain.into();
-        Self {
-            schema_version: 0,
-            action_kind: string_field(&payload, "kind").unwrap_or_else(|| domain.clone()),
-            state: PreparedActionState::WaitingConfirmation,
-            initiator_user_id: string_field(&payload, "initiator_user_id"),
-            owner_key: string_field(&payload, "owner_key"),
-            scope_key: None,
-            created_at: string_field(&payload, "created_at").unwrap_or_default(),
-            expires_at: None,
-            revision: INITIAL_PREPARED_ACTION_REVISION,
-            display_snapshot: Value::Null,
-            domain,
             payload,
         }
     }
@@ -175,8 +134,8 @@ impl PreparedAction {
         self.owner_key.as_deref()
     }
 
-    pub fn scope_key(&self) -> Option<&str> {
-        self.scope_key.as_deref()
+    pub fn scope_key(&self) -> &str {
+        &self.scope_key
     }
 
     pub fn initiator_user_id(&self) -> Option<&str> {
@@ -187,8 +146,8 @@ impl PreparedAction {
         &self.created_at
     }
 
-    pub fn expires_at(&self) -> Option<&str> {
-        self.expires_at.as_deref()
+    pub fn expires_at(&self) -> &str {
+        &self.expires_at
     }
 
     pub fn revision(&self) -> u64 {
@@ -204,19 +163,12 @@ impl PreparedAction {
         &self.payload
     }
 
-    pub fn is_legacy(&self) -> bool {
-        self.schema_version == 0
-    }
-
-    /// 新结构以 expires_at 为唯一过期依据；旧结构由业务域继续使用原 created_at TTL。
+    /// 以 envelope 中固化的 expires_at 为唯一过期依据；非法时间按过期处理。
     pub fn is_expired_at(&self, now: &str) -> bool {
-        let (Some(expires_at), Ok(now)) = (
-            self.expires_at.as_deref(),
-            DateTime::parse_from_rfc3339(now.trim()),
-        ) else {
-            return !self.is_legacy();
+        let Ok(now) = DateTime::parse_from_rfc3339(now.trim()) else {
+            return true;
         };
-        let Ok(expires_at) = DateTime::parse_from_rfc3339(expires_at.trim()) else {
+        let Ok(expires_at) = DateTime::parse_from_rfc3339(self.expires_at.trim()) else {
             return true;
         };
         now >= expires_at
@@ -261,7 +213,7 @@ impl PreparedAction {
         }
         self.payload = payload;
         self.display_snapshot = display_snapshot;
-        self.expires_at = Some(expires_at.into());
+        self.expires_at = expires_at.into();
         self.revision = self.revision.saturating_add(1);
         self.state = PreparedActionState::WaitingConfirmation;
         Ok(self.revision)
@@ -279,7 +231,7 @@ impl PreparedAction {
         }
         self.payload = payload;
         self.display_snapshot = display_snapshot;
-        self.expires_at = Some(expires_at.into());
+        self.expires_at = expires_at.into();
         self.revision = self.revision.saturating_add(1);
         self.state = PreparedActionState::WaitingConfirmation;
         Ok(self.revision)
@@ -289,22 +241,14 @@ impl PreparedAction {
         &self,
         context: &PreparedActionExecutionContext<'_>,
     ) -> Result<(), PreparedActionValidationError> {
-        if self.schema_version != PREPARED_ACTION_SCHEMA_VERSION {
-            return Err(PreparedActionValidationError::UnsupportedSchemaVersion(
-                self.schema_version,
-            ));
-        }
+        self.validate_envelope()?;
         if self.state != PreparedActionState::WaitingConfirmation {
             return Err(PreparedActionValidationError::InvalidState);
         }
         if self.revision != context.expected_revision {
             return Err(PreparedActionValidationError::RevisionMismatch);
         }
-        let (Some(initiator), Some(scope_key), Some(expires_at)) = (
-            self.initiator_user_id.as_deref(),
-            self.scope_key.as_deref(),
-            self.expires_at.as_deref(),
-        ) else {
+        let Some(initiator) = self.initiator_user_id.as_deref() else {
             return Err(PreparedActionValidationError::MissingMetadata);
         };
         if context.initiator_user_id != Some(initiator) {
@@ -313,16 +257,43 @@ impl PreparedAction {
         if self.owner_key.as_deref() != context.owner_key {
             return Err(PreparedActionValidationError::OwnerMismatch);
         }
-        if scope_key != context.scope_key {
+        if self.scope_key != context.scope_key {
             return Err(PreparedActionValidationError::ScopeMismatch);
         }
         let Ok(now) = DateTime::parse_from_rfc3339(context.now.trim()) else {
             return Err(PreparedActionValidationError::Expired);
         };
-        let Ok(expires_at) = DateTime::parse_from_rfc3339(expires_at.trim()) else {
+        let Ok(expires_at) = DateTime::parse_from_rfc3339(self.expires_at.trim()) else {
             return Err(PreparedActionValidationError::Expired);
         };
         if now >= expires_at {
+            return Err(PreparedActionValidationError::Expired);
+        }
+        Ok(())
+    }
+
+    /// 校验从 Session 读取的 envelope 是否为当前支持的完整结构。
+    ///
+    /// 升级前的扁平 Pending 会在 serde 阶段失败；版本不支持或字段不完整的 envelope
+    /// 同样由 Session 层直接清理，不进入具体业务域。
+    pub fn validate_envelope(&self) -> Result<(), PreparedActionValidationError> {
+        if self.schema_version != PREPARED_ACTION_SCHEMA_VERSION {
+            return Err(PreparedActionValidationError::UnsupportedSchemaVersion(
+                self.schema_version,
+            ));
+        }
+        if !SUPPORTED_PENDING_DOMAINS.contains(&self.domain.as_str())
+            || self.revision == 0
+            || self.scope_key.trim().is_empty()
+            || self.created_at.trim().is_empty()
+            || self.expires_at.trim().is_empty()
+            || self.action_kind.trim().is_empty()
+        {
+            return Err(PreparedActionValidationError::MissingMetadata);
+        }
+        if DateTime::parse_from_rfc3339(self.created_at.trim()).is_err()
+            || DateTime::parse_from_rfc3339(self.expires_at.trim()).is_err()
+        {
             return Err(PreparedActionValidationError::Expired);
         }
         Ok(())
@@ -333,107 +304,4 @@ impl PreparedAction {
 pub fn expires_at_after(created_at: &str, ttl_seconds: i64) -> Option<String> {
     let created_at = DateTime::parse_from_rfc3339(created_at.trim()).ok()?;
     Some((created_at + Duration::seconds(ttl_seconds)).to_rfc3339())
-}
-
-impl Serialize for PreparedAction {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        // 旧对象只来自既有 Session 或兼容测试；未发生修订时保持原扁平 JSON，避免
-        // 无意把缺少可信 scope/expires_at 的数据包装成看似完整的新动作。
-        if self.is_legacy() {
-            return self.payload.serialize(serializer);
-        }
-        StoredPreparedAction {
-            schema_version: self.schema_version,
-            domain: self.domain.clone(),
-            action_kind: self.action_kind.clone(),
-            state: self.state,
-            initiator_user_id: self.initiator_user_id.clone(),
-            owner_key: self.owner_key.clone(),
-            scope_key: self.scope_key.clone().unwrap_or_default(),
-            created_at: self.created_at.clone(),
-            expires_at: self.expires_at.clone().unwrap_or_default(),
-            revision: self.revision,
-            display_snapshot: self.display_snapshot.clone(),
-            payload: self.payload.clone(),
-        }
-        .serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for PreparedAction {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = Value::deserialize(deserializer)?;
-        if value.get("schema_version").is_none() {
-            let kind = string_field(&value, "kind").unwrap_or_else(|| "unknown".to_owned());
-            let domain = domain_from_kind(&kind);
-            if !SUPPORTED_PENDING_DOMAINS.contains(&domain.as_str()) {
-                return Err(D::Error::custom(format!(
-                    "unsupported pending operation kind `{kind}`"
-                )));
-            }
-            return Ok(Self::from_legacy_payload(domain, value));
-        }
-
-        let stored: StoredPreparedAction =
-            serde_json::from_value(value).map_err(D::Error::custom)?;
-        if !SUPPORTED_PENDING_DOMAINS.contains(&stored.domain.as_str()) {
-            return Err(D::Error::custom(format!(
-                "unsupported prepared action domain `{}`",
-                stored.domain
-            )));
-        }
-        if stored.schema_version != PREPARED_ACTION_SCHEMA_VERSION {
-            return Err(D::Error::custom(format!(
-                "unsupported prepared action schema version `{}`",
-                stored.schema_version
-            )));
-        }
-        if stored.revision == 0
-            || stored.scope_key.trim().is_empty()
-            || stored.created_at.trim().is_empty()
-            || stored.expires_at.trim().is_empty()
-            || stored.action_kind.trim().is_empty()
-        {
-            return Err(D::Error::custom(
-                "prepared action is missing required lifecycle metadata",
-            ));
-        }
-        Ok(Self {
-            schema_version: stored.schema_version,
-            domain: stored.domain,
-            action_kind: stored.action_kind,
-            state: stored.state,
-            initiator_user_id: stored.initiator_user_id,
-            owner_key: stored.owner_key,
-            scope_key: Some(stored.scope_key),
-            created_at: stored.created_at,
-            expires_at: Some(stored.expires_at),
-            revision: stored.revision,
-            display_snapshot: stored.display_snapshot,
-            payload: stored.payload,
-        })
-    }
-}
-
-fn string_field(value: &Value, key: &str) -> Option<String> {
-    value
-        .get(key)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_owned)
-}
-
-fn domain_from_kind(kind: &str) -> String {
-    kind.split_once('_')
-        .map(|(domain, _)| domain)
-        .filter(|domain| !domain.is_empty())
-        .unwrap_or("unknown")
-        .to_owned()
 }

--- a/qq-maid-core/src/runtime/pending/reply.rs
+++ b/qq-maid-core/src/runtime/pending/reply.rs
@@ -1,0 +1,98 @@
+//! Pending 确认、取消和修订意图的轻量文本分类。
+
+/// 用户对挂起操作的回复类型。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PendingReplyKind {
+    Confirm,
+    Cancel,
+    Revise,
+    Wait,
+}
+
+/// 用于识别用户确认/取消意图的词汇配置。
+#[derive(Debug, Clone, Copy)]
+pub struct PendingLexicon {
+    confirm_words: &'static [&'static str],
+    cancel_words: &'static [&'static str],
+}
+
+impl PendingLexicon {
+    pub const fn new(
+        confirm_words: &'static [&'static str],
+        cancel_words: &'static [&'static str],
+    ) -> Self {
+        Self {
+            confirm_words,
+            cancel_words,
+        }
+    }
+}
+
+/// 根据用户回复文本和词汇表，分类用户的确认/取消/修改意图。
+pub fn classify_reply(text: &str, lexicon: PendingLexicon) -> PendingReplyKind {
+    let text = text.trim();
+    let compact = compact_pending_reply(text);
+    if lexicon.cancel_words.contains(&text)
+        || lexicon
+            .cancel_words
+            .iter()
+            .any(|word| compact == *word || compact.starts_with(word))
+    {
+        return PendingReplyKind::Cancel;
+    }
+
+    if lexicon
+        .confirm_words
+        .iter()
+        .any(|word| is_confirm_match(&compact, word))
+    {
+        return PendingReplyKind::Confirm;
+    }
+    if should_parse_pending_revision(text) {
+        return PendingReplyKind::Revise;
+    }
+    PendingReplyKind::Wait
+}
+
+pub fn should_parse_pending_revision(text: &str) -> bool {
+    let text = text.trim();
+    !text.is_empty() && !text.starts_with('/')
+}
+
+fn compact_pending_reply(text: &str) -> String {
+    text.chars()
+        .filter(|ch| {
+            !ch.is_whitespace()
+                && !matches!(
+                    ch,
+                    '，' | ','
+                        | '。'
+                        | '.'
+                        | '！'
+                        | '!'
+                        | '？'
+                        | '?'
+                        | '、'
+                        | ';'
+                        | '；'
+                        | ':'
+                        | '：'
+                )
+        })
+        .collect::<String>()
+        .trim_end_matches(['了', '吧', '啊', '呀', '呢'])
+        .to_owned()
+}
+
+fn is_confirm_match(compact: &str, word: &str) -> bool {
+    if compact == word {
+        return true;
+    }
+    let Some(rest) = compact.strip_prefix(word) else {
+        return false;
+    };
+    matches!(
+        rest,
+        "就这个" | "就这样" | "执行" | "保存" | "写入" | "删除" | "新增" | "修改"
+    )
+}

--- a/qq-maid-core/src/runtime/respond/tests/chat.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat.rs
@@ -21,7 +21,7 @@ use super::{
 };
 use crate::runtime::{
     tools::rss::{RssFeedItem, RssTarget, RssTargetType},
-    tools::todo::{TodoItemDraft, TodoPendingOperation, TodoStore, TodoTimePrecision},
+    tools::todo::{TodoItemDraft, TodoPendingPayload, TodoStore, TodoTimePrecision},
 };
 
 #[tokio::test]
@@ -343,7 +343,7 @@ async fn private_strong_todo_reference_without_context_enters_tool_loop_and_clar
         .get_or_create_active(&private_test_meta())
         .unwrap();
     match todo_pending(session.pending_operation.as_ref()) {
-        Some(TodoPendingOperation::TodoClarify { request, .. }) => {
+        Some(TodoPendingPayload::TodoClarify { request, .. }) => {
             assert_eq!(request.tool_name, "complete_todos");
             assert_eq!(
                 request.error_code.as_str(),
@@ -889,7 +889,7 @@ async fn last_reference_rejects_owner_mismatch_and_missing_todo() {
         .unwrap();
     assert!(matches!(
         todo_pending(session.pending_operation.as_ref()),
-        Some(TodoPendingOperation::TodoClarify { .. })
+        Some(TodoPendingPayload::TodoClarify { .. })
     ));
 }
 

--- a/qq-maid-core/src/runtime/respond/tests/support/fixtures.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support/fixtures.rs
@@ -29,12 +29,8 @@ pub(crate) fn private_todo_owner() -> TodoOwner {
     TodoStore::owner(Some("u1"), "private:u1")
 }
 
-pub(crate) fn todo_pending(pending: Option<&PendingOperation>) -> Option<TodoPendingOperation> {
-    pending.and_then(|pending| {
-        TodoPendingOperation::try_from_pending(pending)
-            .ok()
-            .flatten()
-    })
+pub(crate) fn todo_pending(pending: Option<&PreparedAction>) -> Option<TodoPendingPayload> {
+    pending.and_then(|pending| TodoPendingPayload::try_from_pending(pending).ok().flatten())
 }
 
 pub(crate) fn raw_tool_result(

--- a/qq-maid-core/src/runtime/respond/tests/support/mod.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support/mod.rs
@@ -31,14 +31,14 @@ use crate::{
     error::LlmError,
     runtime::{
         knowledge::KnowledgeIndex,
-        pending::PendingOperation,
+        pending::PreparedAction,
         prompt::PromptConfig,
         session::{LastTodoQuery, SessionMeta, SessionStore},
         tools::{
             ClaudeModelMetric, ClaudeRadarSummary, CodexModelMetric, CodexRadarSummary,
             RadarExecutor, RadarSnapshot, RadarTarget,
             todo::{
-                TodoItem, TodoItemDraft, TodoOwner, TodoPendingOperation, TodoStatus, TodoStore,
+                TodoItem, TodoItemDraft, TodoOwner, TodoPendingPayload, TodoStatus, TodoStore,
                 TodoTimePrecision,
             },
         },

--- a/qq-maid-core/src/runtime/respond/tests/todo/clarification.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo/clarification.rs
@@ -102,7 +102,7 @@ async fn todo_clarification_control_ask_again_keeps_pending_without_mutation() {
                 .pending_operation
                 .as_ref()
         ),
-        Some(TodoPendingOperation::TodoClarify { .. })
+        Some(TodoPendingPayload::TodoClarify { .. })
     ));
 }
 
@@ -238,7 +238,7 @@ async fn todo_clarification_candidate_scope_does_not_persist_as_last_query() {
 }
 
 #[tokio::test]
-async fn todo_clarification_loop_error_keeps_original_pending_and_blocks_other_tools() {
+async fn todo_clarification_loop_error_marks_failed_and_blocks_repeat_execution() {
     let provider = MockProvider::new().with_tool_call_json("weather", r#"{}"#, "不会返回");
     let service = test_service_with_provider(provider);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
@@ -257,17 +257,24 @@ async fn todo_clarification_loop_error_keeps_original_pending_and_blocks_other_t
         .await
         .unwrap();
 
-    assert_eq!(response.command.as_deref(), Some("todo_clarify_loop_error"));
+    assert_eq!(
+        response.command.as_deref(),
+        Some("pending_execution_failed")
+    );
+    assert!(response.text.unwrap().contains("执行失败"));
+    let pending = service
+        .session_store
+        .get_or_create_active(&private_todo_meta())
+        .unwrap()
+        .pending_operation
+        .expect("failed prepared action should be retained");
+    assert_eq!(
+        pending.state(),
+        crate::runtime::pending::PreparedActionState::Failed
+    );
     assert!(matches!(
-        todo_pending(
-            service
-                .session_store
-                .get_or_create_active(&private_todo_meta())
-                .unwrap()
-                .pending_operation
-                .as_ref()
-        ),
-        Some(TodoPendingOperation::TodoClarify { .. })
+        todo_pending(Some(&pending)),
+        Some(TodoPendingPayload::TodoClarify { .. })
     ));
     assert_eq!(
         service
@@ -306,7 +313,7 @@ async fn todo_clarification_no_tool_reply_updates_question_and_keeps_pending() {
         .get_or_create_active(&private_todo_meta())
         .unwrap();
     match todo_pending(session.pending_operation.as_ref()) {
-        Some(TodoPendingOperation::TodoClarify { request, .. }) => {
+        Some(TodoPendingPayload::TodoClarify { request, .. }) => {
             assert!(request.question.contains("请再说明"));
         }
         other => panic!("expected TodoClarify pending, got {other:?}"),
@@ -353,7 +360,7 @@ async fn todo_clarification_delete_tool_replaces_with_confirmation_pending() {
                 .pending_operation
                 .as_ref()
         ),
-        Some(TodoPendingOperation::TodoDelete { .. })
+        Some(TodoPendingPayload::TodoDelete { .. })
     ));
 }
 
@@ -392,7 +399,7 @@ async fn todo_clarification_out_of_range_number_keeps_pending_without_side_effec
                 .pending_operation
                 .as_ref()
         ),
-        Some(TodoPendingOperation::TodoClarify { .. })
+        Some(TodoPendingPayload::TodoClarify { .. })
     ));
 }
 

--- a/qq-maid-core/src/runtime/respond/tests/todo/mod.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo/mod.rs
@@ -1,10 +1,10 @@
 use super::support::*;
 use crate::runtime::{
-    pending::PendingOperation,
+    pending::PreparedAction,
     session::{SessionMeta, now_iso_cn},
     tools::todo::{
         ClarificationCandidate, PendingTodoClarification, TodoItem, TodoItemDraft,
-        TodoPendingOperation, TodoStatus, TodoStore, TodoTimePrecision,
+        TodoPendingPayload, TodoStatus, TodoStore, TodoTimePrecision,
     },
 };
 use chrono::Duration;
@@ -26,12 +26,8 @@ fn draft(title: &str) -> TodoItemDraft {
     }
 }
 
-fn todo_pending(pending: Option<&PendingOperation>) -> Option<TodoPendingOperation> {
-    pending.and_then(|pending| {
-        TodoPendingOperation::try_from_pending(pending)
-            .ok()
-            .flatten()
-    })
+fn todo_pending(pending: Option<&PreparedAction>) -> Option<TodoPendingPayload> {
+    pending.and_then(|pending| TodoPendingPayload::try_from_pending(pending).ok().flatten())
 }
 
 fn draft_due_date(title: &str, due_date: &str) -> TodoItemDraft {
@@ -232,7 +228,7 @@ fn install_todo_clarification(
         .get_or_create_active(&private_todo_meta())
         .unwrap();
     session.pending_operation = Some(
-        TodoPendingOperation::TodoClarify {
+        TodoPendingPayload::TodoClarify {
             initiator_user_id: Some("u1".to_owned()),
             owner_key: "u1".to_owned(),
             request: PendingTodoClarification {
@@ -246,7 +242,7 @@ fn install_todo_clarification(
             },
             created_at,
         }
-        .into(),
+        .into_prepared_action(&session.scope_key),
     );
     service.session_store.save(&mut session).unwrap();
 }

--- a/qq-maid-core/src/runtime/respond/tests/todo_agent/guard.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo_agent/guard.rs
@@ -4,7 +4,7 @@ use qq_maid_llm::provider::ToolCallingProtocol;
 use serde_json::Value;
 
 use crate::runtime::tools::todo::{
-    TodoItemDraft, TodoPendingOperation, TodoStatus, TodoStore, TodoTimePrecision,
+    TodoItemDraft, TodoPendingPayload, TodoStatus, TodoStore, TodoTimePrecision,
 };
 
 use super::super::support::*;
@@ -457,7 +457,7 @@ async fn todo_delete_pending_item_false_deleted_text_does_not_pass_success_guard
         .get_or_create_active(&private_test_meta())
         .unwrap();
     match todo_pending(session.pending_operation.as_ref()) {
-        Some(TodoPendingOperation::TodoBulkDelete {
+        Some(TodoPendingPayload::TodoBulkDelete {
             item_ids, status, ..
         }) => {
             assert_eq!(item_ids.len(), 1);

--- a/qq-maid-core/src/runtime/respond/tests/todo_agent/pending.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo_agent/pending.rs
@@ -3,7 +3,7 @@
 use qq_maid_llm::provider::ToolCallingProtocol;
 
 use crate::runtime::tools::todo::{
-    TodoItemDraft, TodoPendingOperation, TodoStatus, TodoStore, TodoTimePrecision,
+    TodoItemDraft, TodoPendingPayload, TodoStatus, TodoStore, TodoTimePrecision,
 };
 
 use super::super::support::*;
@@ -58,7 +58,7 @@ async fn todo_delete_completed_item_accepts_delete_tool_pending_result() {
         .get_or_create_active(&private_test_meta())
         .unwrap();
     match todo_pending(session.pending_operation.as_ref()) {
-        Some(TodoPendingOperation::TodoDelete { item, .. }) => {
+        Some(TodoPendingPayload::TodoDelete { item, .. }) => {
             assert_eq!(item.title, "已完成可永久删除");
             assert_eq!(item.status, TodoStatus::Completed);
         }
@@ -124,6 +124,6 @@ async fn todo_delete_completed_pending_confirmation_is_verified_by_real_tool_res
         .unwrap();
     assert!(matches!(
         todo_pending(session.pending_operation.as_ref()),
-        Some(TodoPendingOperation::TodoDelete { .. })
+        Some(TodoPendingPayload::TodoDelete { .. })
     ));
 }

--- a/qq-maid-core/src/runtime/tools/todo/delete.rs
+++ b/qq-maid-core/src/runtime/tools/todo/delete.rs
@@ -9,7 +9,7 @@ use crate::{
     error::LlmError,
     runtime::{
         session::now_iso_cn,
-        tools::todo::{TodoItem, TodoPendingOperation, TodoStatus},
+        tools::todo::{TodoItem, TodoPendingPayload, TodoStatus},
     },
 };
 
@@ -371,13 +371,13 @@ fn create_delete_confirmation(
     // 必须使用带 status 字段的 `TodoBulkDelete`，避免升级后无法区分旧确认意图。
     if items.len() == 1 && status != TodoStatus::Pending {
         scope.session.pending_operation = Some(
-            TodoPendingOperation::TodoDelete {
+            TodoPendingPayload::TodoDelete {
                 initiator_user_id: scope.owner.user_id.clone(),
                 owner_key: scope.owner.key.clone(),
                 item: items[0].clone(),
                 created_at,
             }
-            .into(),
+            .into_prepared_action(&scope.session.scope_key),
         );
         scope.save()?;
         return Ok(ToolOutput::json(json!({
@@ -391,7 +391,7 @@ fn create_delete_confirmation(
     }
 
     scope.session.pending_operation = Some(
-        TodoPendingOperation::TodoBulkDelete {
+        TodoPendingPayload::TodoBulkDelete {
             initiator_user_id: scope.owner.user_id.clone(),
             owner_key: scope.owner.key.clone(),
             item_ids: items.iter().map(|item| item.id.clone()).collect(),
@@ -401,7 +401,7 @@ fn create_delete_confirmation(
             source_condition: source_condition.clone(),
             created_at,
         }
-        .into(),
+        .into_prepared_action(&scope.session.scope_key),
     );
     scope.save()?;
     Ok(ToolOutput::json(json!({

--- a/qq-maid-core/src/runtime/tools/todo/delete.rs
+++ b/qq-maid-core/src/runtime/tools/todo/delete.rs
@@ -367,8 +367,8 @@ fn create_delete_confirmation(
     scope.ensure_no_pending()?;
     let created_at = now_iso_cn();
     let message = delete_confirmation_message(&items, &status);
-    // `TodoDelete` 的历史 Pending 语义是确认后软取消。进行中待办的新版永久删除
-    // 必须使用带 status 字段的 `TodoBulkDelete`，避免升级后无法区分旧确认意图。
+    // 单条 `TodoDelete` 仅用于已完成待办；进行中待办的永久删除必须使用带明确
+    // status 的 `TodoBulkDelete`，避免把删除确认误解为软取消。
     if items.len() == 1 && status != TodoStatus::Pending {
         scope.session.pending_operation = Some(
             TodoPendingPayload::TodoDelete {

--- a/qq-maid-core/src/runtime/tools/todo/flow/mod.rs
+++ b/qq-maid-core/src/runtime/tools/todo/flow/mod.rs
@@ -27,6 +27,8 @@ mod command;
 mod completed_query;
 mod format;
 mod pending;
+mod pending_clarification;
+mod pending_lifecycle;
 mod receipt;
 
 pub(crate) use command::parse_todo_command;

--- a/qq-maid-core/src/runtime/tools/todo/flow/pending.rs
+++ b/qq-maid-core/src/runtime/tools/todo/flow/pending.rs
@@ -2,7 +2,7 @@
 //!
 //! Todo 写操作统一由 Tool Loop 触发；slash 写入口已移除。这里处理 Tool 仍会产生的
 //! 两类跨轮状态：
-//! - 确认类 pending：旧版 `TodoAdd`、永久删除 `TodoBulkDelete`；
+//! - 确认类 pending：单条删除和批量删除；
 //!   新建/修改/完成/取消/恢复不再进入确认；
 //! - 澄清类 pending：`TodoClarify`，保存原工具、原始参数和精简候选边界，用户补充后
 //!   通过受限 Tool Loop 重入原 Todo Tool，由 LLM 只负责选择/继续澄清，真正校验与副作用
@@ -11,10 +11,6 @@
 //! `TodoClarify` 不在 Pending 层解析自然语言、不直接调用 `ops::*`、不构造确认 pending；
 //! 当前候选编号通过请求级 TodoTool selection scope 临时生效，不污染 `last_todo_query`。
 //!
-//! 旧 slash 写流程专用的 `TodoDone` / `TodoEdit` / `TodoSelectCandidate` 变体在
-//! `PreparedAction` 中保留为空壳兼容旧 session；运行时遇到会清理并提示重新用
-//! 自然语言发起操作，避免旧 pending 长期卡住会话。
-
 use std::{collections::HashMap, sync::Arc};
 
 use qq_maid_llm::{
@@ -45,16 +41,10 @@ use crate::{
 
 use super::format::*;
 use super::pending_clarification::*;
-use super::receipt::{receipt_after_created, receipt_after_deleted};
+use super::receipt::receipt_after_deleted;
 
 use crate::runtime::respond::common::CommandBody;
 use crate::runtime::respond::{RespondResponse, RustRespondService, common::todo_error};
-
-#[derive(Debug, Clone, Copy)]
-struct PendingTodoExecution {
-    revision: u64,
-    legacy: bool,
-}
 
 impl RustRespondService {
     /// 处理 Todo 待确认与澄清恢复操作。
@@ -72,7 +62,6 @@ impl RustRespondService {
             return Ok(None);
         };
         let pending_revision = pending.revision();
-        let legacy_pending = pending.is_legacy();
         if pending.owner_key().is_some_and(|key| key != owner.key) {
             return Ok(None);
         }
@@ -82,76 +71,13 @@ impl RustRespondService {
                 return Ok(Some(self.clear_pending_response(
                     session,
                     user_text,
-                    CommandBody::plain(
-                        "这条旧版待确认操作缺少安全恢复所需的信息，已清理。请重新发起。",
-                    ),
+                    CommandBody::plain("这条待确认操作数据无效，已清理。请重新发起。"),
                     "todo_pending_invalid",
                 )?));
             }
         };
 
         match pending {
-            TodoPendingPayload::TodoAdd { draft, .. } => {
-                let reply_kind = classify_reply(user_text, todo_lexicon());
-                if matches!(reply_kind, PendingReplyKind::Cancel) {
-                    return Ok(Some(self.clear_pending_response(
-                        session,
-                        user_text,
-                        CommandBody::plain("已取消，不新增待办。"),
-                        "todo_cancel",
-                    )?));
-                }
-                if matches!(reply_kind, PendingReplyKind::Confirm) {
-                    if !self.claim_todo_pending_execution(
-                        session,
-                        owner,
-                        pending_revision,
-                        legacy_pending,
-                    )? {
-                        return Ok(Some(self.append_pending_response(
-                            session,
-                            user_text,
-                            CommandBody::plain(
-                                "这条待确认操作已变化或已被处理，没有重复执行。请重新发起。",
-                            ),
-                            "pending_claim_rejected",
-                        )?));
-                    }
-                    let created = match crate::runtime::tools::todo::ops::create_one(
-                        &self.task_store,
-                        session,
-                        owner,
-                        draft,
-                    ) {
-                        Ok(created) => created,
-                        Err(err) => {
-                            return Ok(Some(self.pending_execution_failed_response(
-                                session,
-                                user_text,
-                                pending_revision,
-                                legacy_pending,
-                                todo_error(err),
-                            )?));
-                        }
-                    };
-                    let receipt =
-                        receipt_after_created(&self.task_store, session, owner, &created)?;
-                    return Ok(Some(self.clear_pending_response(
-                        session,
-                        user_text,
-                        receipt.body,
-                        receipt.command,
-                    )?));
-                }
-                // Todo 写操作改为单入口后，不再在 pending 阶段做二次 LLM 修订。
-                // 这样可以避免“澄清/修订状态没落盘但回复成功”的旧链路问题。
-                Ok(Some(self.append_pending_response(
-                    session,
-                    user_text,
-                    format_todo_pending_add_waiting_reply(),
-                    "todo_add",
-                )?))
-            }
             TodoPendingPayload::TodoDelete { item, .. } => {
                 let reply_kind = classify_reply(user_text, todo_lexicon());
                 if matches!(reply_kind, PendingReplyKind::Cancel) {
@@ -164,23 +90,18 @@ impl RustRespondService {
                 }
                 if matches!(reply_kind, PendingReplyKind::Confirm) {
                     if item.status == TodoStatus::Pending {
-                        // legacy only：旧版 `TodoDelete + Pending` 曾表示软取消。
-                        // 新版删除/取消已严格分离，不能再把确认删除解释成取消。
+                        // 单条 TodoDelete 只允许用于已完成待办；进行中范围必须使用
+                        // 带明确 status 的 TodoBulkDelete，避免把永久删除误解为软取消。
                         return Ok(Some(self.clear_pending_response(
                             session,
                             user_text,
                             CommandBody::plain(
-                                "这条旧版待确认操作已失效。请重新发起删除或取消操作。",
+                                "这条待确认删除范围无效。请重新发起删除或取消操作。",
                             ),
-                            "todo_legacy_delete",
+                            "todo_delete_invalid_pending",
                         )?));
                     }
-                    if !self.claim_todo_pending_execution(
-                        session,
-                        owner,
-                        pending_revision,
-                        legacy_pending,
-                    )? {
+                    if !self.claim_todo_pending_execution(session, owner, pending_revision)? {
                         return Ok(Some(self.append_pending_response(
                             session,
                             user_text,
@@ -202,7 +123,6 @@ impl RustRespondService {
                                 session,
                                 user_text,
                                 pending_revision,
-                                legacy_pending,
                                 todo_error(err),
                             )?));
                         }
@@ -261,12 +181,7 @@ impl RustRespondService {
                     )?));
                 }
                 if matches!(reply_kind, PendingReplyKind::Confirm) {
-                    if !self.claim_todo_pending_execution(
-                        session,
-                        owner,
-                        pending_revision,
-                        legacy_pending,
-                    )? {
+                    if !self.claim_todo_pending_execution(session, owner, pending_revision)? {
                         return Ok(Some(self.append_pending_response(
                             session,
                             user_text,
@@ -288,7 +203,6 @@ impl RustRespondService {
                                 session,
                                 user_text,
                                 pending_revision,
-                                legacy_pending,
                                 todo_error(err),
                             )?));
                         }
@@ -348,24 +262,9 @@ impl RustRespondService {
                     session,
                     owner,
                     request,
-                    PendingTodoExecution {
-                        revision: pending_revision,
-                        legacy: legacy_pending,
-                    },
+                    pending_revision,
                 )
                 .await
-            }
-            TodoPendingPayload::TodoDone { .. }
-            | TodoPendingPayload::TodoEdit { .. }
-            | TodoPendingPayload::TodoSelectCandidate { .. } => {
-                Ok(Some(self.clear_pending_response(
-                    session,
-                    user_text,
-                    CommandBody::plain(
-                        "这条旧版待办确认流程已清理。请直接用自然语言重新发起待办操作。",
-                    ),
-                    "todo_pending_deprecated",
-                )?))
             }
         }
     }
@@ -376,7 +275,7 @@ impl RustRespondService {
         session: &mut SessionRecord,
         owner: &TodoOwner,
         request: PendingTodoClarification,
-        execution: PendingTodoExecution,
+        revision: u64,
     ) -> Result<Option<RespondResponse>, LlmError> {
         if is_clarification_abandon_text(user_text) {
             return Ok(Some(self.clear_pending_response(
@@ -406,12 +305,12 @@ impl RustRespondService {
         if let Some(number) = parse_explicit_candidate_number(user_text) {
             return self
                 .run_pending_todo_clarification_fast_path(
-                    user_text, session, owner, request, number, execution,
+                    user_text, session, owner, request, number, revision,
                 )
                 .await;
         }
 
-        self.run_pending_todo_clarification_loop(user_text, session, owner, request, execution)
+        self.run_pending_todo_clarification_loop(user_text, session, owner, request, revision)
             .await
     }
 
@@ -422,7 +321,7 @@ impl RustRespondService {
         owner: &TodoOwner,
         request: PendingTodoClarification,
         number: usize,
-        execution: PendingTodoExecution,
+        revision: u64,
     ) -> Result<Option<RespondResponse>, LlmError> {
         let Some(arguments) = clarification_tool_arguments_for_number(&request, number)? else {
             return Ok(Some(self.append_pending_response(
@@ -441,12 +340,7 @@ impl RustRespondService {
                 "todo_pending",
             )
         })?;
-        if !self.claim_todo_pending_execution(
-            session,
-            owner,
-            execution.revision,
-            execution.legacy,
-        )? {
+        if !self.claim_todo_pending_execution(session, owner, revision)? {
             return Ok(Some(self.append_pending_response(
                 session,
                 user_text,
@@ -460,24 +354,8 @@ impl RustRespondService {
         {
             Ok(output) => output,
             Err(err) => {
-                if execution.legacy {
-                    self.refresh_pending_session(session)?;
-                    return Ok(Some(self.append_pending_response(
-                        session,
-                        user_text,
-                        CommandBody::plain(format!(
-                            "这次待办恢复执行失败，没有清除原澄清状态。错误：{}",
-                            err.message
-                        )),
-                        "todo_clarify_tool_error",
-                    )?));
-                }
                 return Ok(Some(self.pending_execution_failed_response(
-                    session,
-                    user_text,
-                    execution.revision,
-                    execution.legacy,
-                    err,
+                    session, user_text, revision, err,
                 )?));
             }
         };
@@ -518,7 +396,7 @@ impl RustRespondService {
         session: &mut SessionRecord,
         owner: &TodoOwner,
         request: PendingTodoClarification,
-        execution: PendingTodoExecution,
+        revision: u64,
     ) -> Result<Option<RespondResponse>, LlmError> {
         let registry = self.restricted_todo_clarification_registry(&request)?;
         let context = clarification_tool_context(session, owner);
@@ -546,12 +424,7 @@ impl RustRespondService {
                 ("agent_profile".to_owned(), policy.profile.clone()),
             ]),
         };
-        if !self.claim_todo_pending_execution(
-            session,
-            owner,
-            execution.revision,
-            execution.legacy,
-        )? {
+        if !self.claim_todo_pending_execution(session, owner, revision)? {
             return Ok(Some(self.append_pending_response(
                 session,
                 user_text,
@@ -574,24 +447,8 @@ impl RustRespondService {
         {
             Ok(outcome) => outcome,
             Err(err) => {
-                if execution.legacy {
-                    self.refresh_pending_session(session)?;
-                    return Ok(Some(self.append_pending_response(
-                        session,
-                        user_text,
-                        CommandBody::plain(format!(
-                            "这次待办恢复没有完成，原澄清状态已保留。错误：{}",
-                            err.message
-                        )),
-                        "todo_clarify_loop_error",
-                    )?));
-                }
                 return Ok(Some(self.pending_execution_failed_response(
-                    session,
-                    user_text,
-                    execution.revision,
-                    execution.legacy,
-                    err,
+                    session, user_text, revision, err,
                 )?));
             }
         };
@@ -851,28 +708,6 @@ fn keep_todo_clarification(
         created_at: request.created_at.clone(),
         request,
     };
-    if session
-        .pending_operation
-        .as_ref()
-        .is_some_and(|pending| pending.is_legacy())
-    {
-        let legacy_json = serde_json::to_value(operation).map_err(|err| {
-            LlmError::new(
-                "pending_encode_error",
-                format!("failed to encode legacy todo clarification: {err}"),
-                "todo_pending",
-            )
-        })?;
-        session.pending_operation = Some(serde_json::from_value(legacy_json).map_err(|err| {
-            LlmError::new(
-                "pending_decode_error",
-                format!("failed to retain legacy todo clarification: {err}"),
-                "todo_pending",
-            )
-        })?);
-        return Ok(());
-    }
-
     let replacement = operation.into_prepared_action(&session.scope_key);
     let current = session.pending_operation.as_mut().ok_or_else(|| {
         LlmError::new(
@@ -885,7 +720,7 @@ fn keep_todo_clarification(
         .continue_waiting_after_execution(
             replacement.payload().clone(),
             replacement.display_snapshot().clone(),
-            replacement.expires_at().unwrap_or_default(),
+            replacement.expires_at(),
         )
         .map_err(|err| {
             LlmError::new(

--- a/qq-maid-core/src/runtime/tools/todo/flow/pending.rs
+++ b/qq-maid-core/src/runtime/tools/todo/flow/pending.rs
@@ -12,21 +12,16 @@
 //! 当前候选编号通过请求级 TodoTool selection scope 临时生效，不污染 `last_todo_query`。
 //!
 //! 旧 slash 写流程专用的 `TodoDone` / `TodoEdit` / `TodoSelectCandidate` 变体在
-//! `PendingOperation` 中保留为空壳兼容旧 session；运行时遇到会清理并提示重新用
+//! `PreparedAction` 中保留为空壳兼容旧 session；运行时遇到会清理并提示重新用
 //! 自然语言发起操作，避免旧 pending 长期卡住会话。
 
 use std::{collections::HashMap, sync::Arc};
 
-use async_trait::async_trait;
 use qq_maid_llm::{
-    provider::{
-        ChatOutcome, ToolChatRequest,
-        types::{ChatMessage, ChatRequest},
-    },
-    tool::{DynTool, Tool, ToolContext, ToolMetadata, ToolOutput, ToolRegistry},
+    provider::{ToolChatRequest, types::ChatRequest},
+    tool::{DynTool, ToolRegistry},
 };
 use serde_json::{Value, json};
-use uuid::Uuid;
 
 use crate::runtime::visible_entity::VisibleEntitySelectionScope as SelectionScope;
 use crate::{
@@ -35,11 +30,10 @@ use crate::{
     runtime::{
         freshness::query_is_fresh,
         pending::{PendingReplyKind, classify_reply},
-        session::{LAST_QUERY_TTL_SECONDS, SessionMeta, SessionRecord},
-        tools::TaskStore,
+        session::{LAST_QUERY_TTL_SECONDS, SessionRecord},
         tools::todo::{
-            PendingTodoClarification, TODO_PENDING_DOMAIN, TodoBulkDeleteOutcome, TodoOwner,
-            TodoPendingOperation, TodoStatus, todo_lexicon,
+            PendingTodoClarification, TodoBulkDeleteOutcome, TodoOwner, TodoPendingPayload,
+            TodoStatus, todo_lexicon,
         },
         tools::{
             CompleteTodoTool, DeleteTodoTool, EditTodoTool, ManageRecurringReminderTool,
@@ -50,70 +44,19 @@ use crate::{
 };
 
 use super::format::*;
+use super::pending_clarification::*;
 use super::receipt::{receipt_after_created, receipt_after_deleted};
 
 use crate::runtime::respond::common::CommandBody;
-use crate::runtime::respond::{
-    RespondRequest, RespondResponse, RustRespondService, common::todo_error,
-};
+use crate::runtime::respond::{RespondResponse, RustRespondService, common::todo_error};
+
+#[derive(Debug, Clone, Copy)]
+struct PendingTodoExecution {
+    revision: u64,
+    legacy: bool,
+}
 
 impl RustRespondService {
-    /// 处理会话中的 Todo pending。
-    ///
-    /// Respond 层只负责在发现 session 有 pending 时调用本入口；Todo 的过期文案、
-    /// 发起人/owner 隔离和具体状态机都留在 Todo 域内。
-    pub(crate) async fn handle_pending_operation(
-        &self,
-        _req: &RespondRequest,
-        user_text: &str,
-        meta: &SessionMeta,
-        session: &mut SessionRecord,
-    ) -> Result<Option<RespondResponse>, LlmError> {
-        let Some(pending) = session.pending_operation.clone() else {
-            return Ok(None);
-        };
-        if pending.domain() != TODO_PENDING_DOMAIN {
-            return Ok(None);
-        }
-
-        if !query_is_fresh(pending.created_at(), LAST_QUERY_TTL_SECONDS) {
-            return Ok(Some(self.clear_pending_response(
-                session,
-                user_text,
-                CommandBody::plain("这条待确认操作已过期，没有执行。请重新发起。"),
-                TodoPendingOperation::expired_command(&pending),
-            )?));
-        }
-
-        // 新 pending 会保存发起人；旧持久化 pending 没有该字段时继续按历史行为兼容。
-        // 一旦记录了发起人，后续确认、取消、修订和候选选择都必须来自同一个 user_id。
-        if pending
-            .initiator_user_id()
-            .is_some_and(|initiator| meta.user_id.as_deref() != Some(initiator))
-        {
-            return Ok(Some(self.append_pending_response(
-                session,
-                user_text,
-                CommandBody::plain("这个操作由其他成员发起，请由发起人继续。"),
-                "pending_initiator_mismatch",
-            )?));
-        }
-
-        let owner = TaskStore::owner(meta.user_id.as_deref(), &meta.scope_key);
-        if pending.owner_key().is_some_and(|key| key != owner.key) {
-            return Ok(Some(self.append_pending_response(
-                session,
-                user_text,
-                CommandBody::plain(
-                    "当前有一条待办操作还在等待发起人确认。请先回复“确认 / 取消”，或由发起人处理完后再继续。",
-                ),
-                "todo_pending_wait",
-            )?));
-        }
-        self.handle_pending_todo_operation(user_text, session, &owner)
-            .await
-    }
-
     /// 处理 Todo 待确认与澄清恢复操作。
     ///
     /// 确认类 pending 只接受确认/取消；`TodoClarify` 则在取消、过期和候选边界检查后，
@@ -128,27 +71,27 @@ impl RustRespondService {
         let Some(pending) = session.pending_operation.clone() else {
             return Ok(None);
         };
+        let pending_revision = pending.revision();
+        let legacy_pending = pending.is_legacy();
         if pending.owner_key().is_some_and(|key| key != owner.key) {
             return Ok(None);
         }
-        let pending = TodoPendingOperation::try_from_pending(&pending)
-            .map_err(|err| {
-                LlmError::new(
-                    "pending_decode_error",
-                    format!("failed to decode todo pending operation: {err}"),
-                    "todo_pending",
-                )
-            })?
-            .ok_or_else(|| {
-                LlmError::new(
-                    "pending_domain_mismatch",
-                    "pending operation is not a todo pending",
-                    "todo_pending",
-                )
-            })?;
+        let pending = match TodoPendingPayload::try_from_pending(&pending) {
+            Ok(Some(pending)) => pending,
+            Ok(None) | Err(_) => {
+                return Ok(Some(self.clear_pending_response(
+                    session,
+                    user_text,
+                    CommandBody::plain(
+                        "这条旧版待确认操作缺少安全恢复所需的信息，已清理。请重新发起。",
+                    ),
+                    "todo_pending_invalid",
+                )?));
+            }
+        };
 
         match pending {
-            TodoPendingOperation::TodoAdd { draft, .. } => {
+            TodoPendingPayload::TodoAdd { draft, .. } => {
                 let reply_kind = classify_reply(user_text, todo_lexicon());
                 if matches!(reply_kind, PendingReplyKind::Cancel) {
                     return Ok(Some(self.clear_pending_response(
@@ -159,13 +102,38 @@ impl RustRespondService {
                     )?));
                 }
                 if matches!(reply_kind, PendingReplyKind::Confirm) {
-                    let created = crate::runtime::tools::todo::ops::create_one(
+                    if !self.claim_todo_pending_execution(
+                        session,
+                        owner,
+                        pending_revision,
+                        legacy_pending,
+                    )? {
+                        return Ok(Some(self.append_pending_response(
+                            session,
+                            user_text,
+                            CommandBody::plain(
+                                "这条待确认操作已变化或已被处理，没有重复执行。请重新发起。",
+                            ),
+                            "pending_claim_rejected",
+                        )?));
+                    }
+                    let created = match crate::runtime::tools::todo::ops::create_one(
                         &self.task_store,
                         session,
                         owner,
                         draft,
-                    )
-                    .map_err(todo_error)?;
+                    ) {
+                        Ok(created) => created,
+                        Err(err) => {
+                            return Ok(Some(self.pending_execution_failed_response(
+                                session,
+                                user_text,
+                                pending_revision,
+                                legacy_pending,
+                                todo_error(err),
+                            )?));
+                        }
+                    };
                     let receipt =
                         receipt_after_created(&self.task_store, session, owner, &created)?;
                     return Ok(Some(self.clear_pending_response(
@@ -184,7 +152,7 @@ impl RustRespondService {
                     "todo_add",
                 )?))
             }
-            TodoPendingOperation::TodoDelete { item, .. } => {
+            TodoPendingPayload::TodoDelete { item, .. } => {
                 let reply_kind = classify_reply(user_text, todo_lexicon());
                 if matches!(reply_kind, PendingReplyKind::Cancel) {
                     return Ok(Some(self.clear_pending_response(
@@ -207,13 +175,38 @@ impl RustRespondService {
                             "todo_legacy_delete",
                         )?));
                     }
-                    let outcome = delete_by_ids_with_pending_status(
+                    if !self.claim_todo_pending_execution(
+                        session,
+                        owner,
+                        pending_revision,
+                        legacy_pending,
+                    )? {
+                        return Ok(Some(self.append_pending_response(
+                            session,
+                            user_text,
+                            CommandBody::plain(
+                                "这条待确认操作已变化或已被处理，没有重复执行。请重新发起。",
+                            ),
+                            "pending_claim_rejected",
+                        )?));
+                    }
+                    let outcome = match delete_by_ids_with_pending_status(
                         &self.task_store,
                         owner,
                         std::slice::from_ref(&item.id),
                         &item.status,
-                    )
-                    .map_err(todo_error)?;
+                    ) {
+                        Ok(outcome) => outcome,
+                        Err(err) => {
+                            return Ok(Some(self.pending_execution_failed_response(
+                                session,
+                                user_text,
+                                pending_revision,
+                                legacy_pending,
+                                todo_error(err),
+                            )?));
+                        }
+                    };
                     if outcome.deleted_count == 0 {
                         return Ok(Some(self.clear_pending_response(
                             session,
@@ -252,7 +245,7 @@ impl RustRespondService {
                     "todo_delete",
                 )?))
             }
-            TodoPendingOperation::TodoBulkDelete {
+            TodoPendingPayload::TodoBulkDelete {
                 item_ids,
                 matched_count,
                 status,
@@ -268,13 +261,38 @@ impl RustRespondService {
                     )?));
                 }
                 if matches!(reply_kind, PendingReplyKind::Confirm) {
-                    let outcome = delete_by_ids_with_pending_status(
+                    if !self.claim_todo_pending_execution(
+                        session,
+                        owner,
+                        pending_revision,
+                        legacy_pending,
+                    )? {
+                        return Ok(Some(self.append_pending_response(
+                            session,
+                            user_text,
+                            CommandBody::plain(
+                                "这条待确认操作已变化或已被处理，没有重复执行。请重新发起。",
+                            ),
+                            "pending_claim_rejected",
+                        )?));
+                    }
+                    let outcome = match delete_by_ids_with_pending_status(
                         &self.task_store,
                         owner,
                         &item_ids,
                         &status,
-                    )
-                    .map_err(todo_error)?;
+                    ) {
+                        Ok(outcome) => outcome,
+                        Err(err) => {
+                            return Ok(Some(self.pending_execution_failed_response(
+                                session,
+                                user_text,
+                                pending_revision,
+                                legacy_pending,
+                                todo_error(err),
+                            )?));
+                        }
+                    };
                     if outcome.deleted_count > 0 {
                         for item_id in &item_ids {
                             if self
@@ -324,13 +342,22 @@ impl RustRespondService {
                     "todo_delete",
                 )?))
             }
-            TodoPendingOperation::TodoClarify { request, .. } => {
-                self.handle_pending_todo_clarification(user_text, session, owner, request)
-                    .await
+            TodoPendingPayload::TodoClarify { request, .. } => {
+                self.handle_pending_todo_clarification(
+                    user_text,
+                    session,
+                    owner,
+                    request,
+                    PendingTodoExecution {
+                        revision: pending_revision,
+                        legacy: legacy_pending,
+                    },
+                )
+                .await
             }
-            TodoPendingOperation::TodoDone { .. }
-            | TodoPendingOperation::TodoEdit { .. }
-            | TodoPendingOperation::TodoSelectCandidate { .. } => {
+            TodoPendingPayload::TodoDone { .. }
+            | TodoPendingPayload::TodoEdit { .. }
+            | TodoPendingPayload::TodoSelectCandidate { .. } => {
                 Ok(Some(self.clear_pending_response(
                     session,
                     user_text,
@@ -349,6 +376,7 @@ impl RustRespondService {
         session: &mut SessionRecord,
         owner: &TodoOwner,
         request: PendingTodoClarification,
+        execution: PendingTodoExecution,
     ) -> Result<Option<RespondResponse>, LlmError> {
         if is_clarification_abandon_text(user_text) {
             return Ok(Some(self.clear_pending_response(
@@ -378,12 +406,12 @@ impl RustRespondService {
         if let Some(number) = parse_explicit_candidate_number(user_text) {
             return self
                 .run_pending_todo_clarification_fast_path(
-                    user_text, session, owner, request, number,
+                    user_text, session, owner, request, number, execution,
                 )
                 .await;
         }
 
-        self.run_pending_todo_clarification_loop(user_text, session, owner, request)
+        self.run_pending_todo_clarification_loop(user_text, session, owner, request, execution)
             .await
     }
 
@@ -394,6 +422,7 @@ impl RustRespondService {
         owner: &TodoOwner,
         request: PendingTodoClarification,
         number: usize,
+        execution: PendingTodoExecution,
     ) -> Result<Option<RespondResponse>, LlmError> {
         let Some(arguments) = clarification_tool_arguments_for_number(&request, number)? else {
             return Ok(Some(self.append_pending_response(
@@ -412,21 +441,43 @@ impl RustRespondService {
                 "todo_pending",
             )
         })?;
+        if !self.claim_todo_pending_execution(
+            session,
+            owner,
+            execution.revision,
+            execution.legacy,
+        )? {
+            return Ok(Some(self.append_pending_response(
+                session,
+                user_text,
+                CommandBody::plain("这次待办澄清已变化或已被处理，没有重复执行。请重新发起。"),
+                "pending_claim_rejected",
+            )?));
+        }
         let output = match registry
             .execute_json(&context, &request.tool_name, &arguments_text)
             .await
         {
             Ok(output) => output,
             Err(err) => {
-                self.refresh_pending_session(session)?;
-                return Ok(Some(self.append_pending_response(
+                if execution.legacy {
+                    self.refresh_pending_session(session)?;
+                    return Ok(Some(self.append_pending_response(
+                        session,
+                        user_text,
+                        CommandBody::plain(format!(
+                            "这次待办恢复执行失败，没有清除原澄清状态。错误：{}",
+                            err.message
+                        )),
+                        "todo_clarify_tool_error",
+                    )?));
+                }
+                return Ok(Some(self.pending_execution_failed_response(
                     session,
                     user_text,
-                    CommandBody::plain(format!(
-                        "这次待办恢复执行失败，没有清除原澄清状态。错误：{}",
-                        err.message
-                    )),
-                    "todo_clarify_tool_error",
+                    execution.revision,
+                    execution.legacy,
+                    err,
                 )?));
             }
         };
@@ -444,7 +495,7 @@ impl RustRespondService {
                 .or_else(|| output_value.get("message").and_then(Value::as_str))
                 .unwrap_or("目标待办状态已变化或无法唯一定位，没有执行待办操作。请重新选择候选。")
                 .to_owned();
-            keep_todo_clarification(session, owner, request, question.clone());
+            keep_todo_clarification(session, owner, request, question.clone())?;
             return Ok(Some(self.append_pending_response(
                 session,
                 user_text,
@@ -467,6 +518,7 @@ impl RustRespondService {
         session: &mut SessionRecord,
         owner: &TodoOwner,
         request: PendingTodoClarification,
+        execution: PendingTodoExecution,
     ) -> Result<Option<RespondResponse>, LlmError> {
         let registry = self.restricted_todo_clarification_registry(&request)?;
         let context = clarification_tool_context(session, owner);
@@ -494,6 +546,19 @@ impl RustRespondService {
                 ("agent_profile".to_owned(), policy.profile.clone()),
             ]),
         };
+        if !self.claim_todo_pending_execution(
+            session,
+            owner,
+            execution.revision,
+            execution.legacy,
+        )? {
+            return Ok(Some(self.append_pending_response(
+                session,
+                user_text,
+                CommandBody::plain("这次待办澄清已变化或已被处理，没有重复执行。请重新发起。"),
+                "pending_claim_rejected",
+            )?));
+        }
         let outcome = match self
             .provider
             .chat_with_tools(ToolChatRequest {
@@ -509,15 +574,24 @@ impl RustRespondService {
         {
             Ok(outcome) => outcome,
             Err(err) => {
-                self.refresh_pending_session(session)?;
-                return Ok(Some(self.append_pending_response(
+                if execution.legacy {
+                    self.refresh_pending_session(session)?;
+                    return Ok(Some(self.append_pending_response(
+                        session,
+                        user_text,
+                        CommandBody::plain(format!(
+                            "这次待办恢复没有完成，原澄清状态已保留。错误：{}",
+                            err.message
+                        )),
+                        "todo_clarify_loop_error",
+                    )?));
+                }
+                return Ok(Some(self.pending_execution_failed_response(
                     session,
                     user_text,
-                    CommandBody::plain(format!(
-                        "这次待办恢复没有完成，原澄清状态已保留。错误：{}",
-                        err.message
-                    )),
-                    "todo_clarify_loop_error",
+                    execution.revision,
+                    execution.legacy,
+                    err,
                 )?));
             }
         };
@@ -555,7 +629,7 @@ impl RustRespondService {
             }
             Some(ClarificationControlAction::AskAgain(question)) => {
                 if same_todo_clarification(session, &request) {
-                    keep_todo_clarification(session, owner, request, question.clone());
+                    keep_todo_clarification(session, owner, request, question.clone())?;
                 }
                 return Ok(Some(self.append_pending_response(
                     session,
@@ -571,7 +645,7 @@ impl RustRespondService {
         // 回复视为新的最小澄清问题，保留候选边界，不产生副作用。
         let question = non_empty_reply(&outcome.reply, &request.question);
         if same_todo_clarification(session, &request) {
-            keep_todo_clarification(session, owner, request, question.clone());
+            keep_todo_clarification(session, owner, request, question.clone())?;
         }
         Ok(Some(self.append_pending_response(
             session,
@@ -678,212 +752,6 @@ fn delete_by_ids_with_pending_status(
     }
 }
 
-const CLARIFICATION_CONTROL_TOOL_NAME: &str = "clarification_control";
-
-struct ClarificationControlTool;
-
-#[async_trait]
-impl Tool for ClarificationControlTool {
-    fn metadata(&self) -> ToolMetadata {
-        ToolMetadata {
-            name: CLARIFICATION_CONTROL_TOOL_NAME.to_owned(),
-            description: "澄清恢复控制工具。仅用于表示仍需追问或放弃当前澄清，不操作 Todo 数据。"
-                .to_owned(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "action": {
-                        "type": "string",
-                        "enum": ["ask_again", "abandon"],
-                        "description": "ask_again=信息仍不足，需要继续追问；abandon=用户放弃或明显不是在回答当前澄清。"
-                    },
-                    "question": {
-                        "type": ["string", "null"],
-                        "description": "action=ask_again 时给用户的最小澄清问题；其他情况传 null。"
-                    }
-                },
-                "required": ["action", "question"],
-                "additionalProperties": false
-            }),
-        }
-    }
-
-    async fn execute(
-        &self,
-        _context: ToolContext,
-        arguments: Value,
-    ) -> Result<ToolOutput, LlmError> {
-        let action = arguments
-            .get("action")
-            .and_then(Value::as_str)
-            .ok_or_else(|| LlmError::new("bad_tool_arguments", "action is required", "tool"))?;
-        let question = arguments
-            .get("question")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_owned);
-        match action {
-            "ask_again" => Ok(ToolOutput::json(json!({
-                "ok": true,
-                "action": "ask_again",
-                "question": question.unwrap_or_else(|| "请再具体说明要操作哪条待办。".to_owned()),
-            }))),
-            "abandon" => Ok(ToolOutput::json(json!({
-                "ok": true,
-                "action": "abandon",
-                "question": Value::Null,
-            }))),
-            _ => Err(LlmError::new(
-                "bad_tool_arguments",
-                "action must be ask_again or abandon",
-                "tool",
-            )),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum ClarificationControlAction {
-    AskAgain(String),
-    Abandon,
-}
-
-fn clarification_control_action(outcome: &ChatOutcome) -> Option<ClarificationControlAction> {
-    outcome
-        .agent
-        .tool_results
-        .iter()
-        .rev()
-        .find(|result| result.name == CLARIFICATION_CONTROL_TOOL_NAME)
-        .and_then(
-            |result| match result.output.get("action").and_then(Value::as_str) {
-                Some("ask_again") => Some(ClarificationControlAction::AskAgain(
-                    result
-                        .output
-                        .get("question")
-                        .and_then(Value::as_str)
-                        .map(str::trim)
-                        .filter(|value| !value.is_empty())
-                        .unwrap_or("请再具体说明要操作哪条待办。")
-                        .to_owned(),
-                )),
-                Some("abandon") => Some(ClarificationControlAction::Abandon),
-                _ => None,
-            },
-        )
-}
-
-fn candidate_scope(request: &PendingTodoClarification) -> Result<Arc<[String]>, LlmError> {
-    if request.candidates.is_empty() {
-        return Err(LlmError::new(
-            "todo_clarification_scope_empty",
-            "todo clarification candidates are empty",
-            "todo_pending",
-        ));
-    }
-    let ids = request
-        .candidates
-        .iter()
-        .map(|candidate| candidate.id.clone())
-        .collect::<Vec<_>>();
-    Ok(Arc::from(ids.into_boxed_slice()))
-}
-
-fn build_todo_clarification_messages(
-    user_text: &str,
-    request: &PendingTodoClarification,
-) -> Vec<ChatMessage> {
-    let candidates = request
-        .candidates
-        .iter()
-        .map(|candidate| format!("{}. {}", candidate.display_number, candidate.title))
-        .collect::<Vec<_>>()
-        .join("\n");
-    let original_arguments =
-        serde_json::to_string_pretty(&request.arguments).unwrap_or_else(|_| "{}".to_owned());
-    let system = format!(
-        "你正在恢复一个待办工具澄清任务。\n\n\
-职责边界：\n\
-- 只能恢复原工具 `{tool_name}`，不得改成其他 Todo 操作。\n\
-- 当前候选编号只在本次澄清中有效，必须从候选 1..N 里选择；不要使用数据库内部 ID。\n\
-- 候选标题里的数字（例如“6 号”“买 2 个”）不是候选编号。\n\
-- 如果能唯一确定目标，请调用原工具 `{tool_name}`，用候选展示编号作为 number/numbers，并保留或补全原始参数里的其他业务字段。\n\
-- 如果仍无法唯一确定，请调用 `{control_tool}`，action=ask_again，并给出最小澄清问题。\n\
-- 如果用户明确放弃或明显不是在回答当前澄清，请调用 `{control_tool}`，action=abandon。\n\
-- 不要编造成功结果；工具结果才是真实执行状态。\n\n\
-原工具：{tool_name}\n原始参数 JSON：\n{original_arguments}\n\n上一次澄清问题：\n{question}\n\n当前候选：\n{candidates}",
-        tool_name = request.tool_name,
-        control_tool = CLARIFICATION_CONTROL_TOOL_NAME,
-        question = request.question,
-    );
-    vec![
-        ChatMessage::system(system),
-        ChatMessage::user(user_text.trim().to_owned()),
-    ]
-}
-
-fn clarification_tool_context(session: &SessionRecord, owner: &TodoOwner) -> ToolContext {
-    let kind = if session
-        .group_id
-        .as_deref()
-        .is_some_and(|value| !value.trim().is_empty())
-    {
-        qq_maid_common::identity_context::ConversationKind::Group
-    } else {
-        qq_maid_common::identity_context::ConversationKind::Private
-    };
-    ToolContext {
-        task_id: format!("todo-clarify:{}", Uuid::new_v4()),
-        actor: qq_maid_common::identity_context::ExecutionActorContext {
-            user_id: owner.user_id.clone(),
-            group_member_role: None,
-        },
-        conversation: qq_maid_common::identity_context::ExecutionConversationContext {
-            platform: session.platform.clone(),
-            // 历史 SessionRecord 未保存 account_id；澄清恢复沿用已绑定 owner/scope，
-            // 不通过解析 scope 猜测账号。新入站 ToolContext 会携带完整 account_id。
-            account_id: None,
-            kind,
-            target_id: session.group_id.clone().or_else(|| owner.user_id.clone()),
-            scope_id: owner.scope_key.clone(),
-            interaction_scope_id: session.scope_key.clone(),
-        },
-        tool_call_id: Some(format!("clarify-{}", session.session_id)),
-    }
-}
-
-fn is_clarification_abandon_text(text: &str) -> bool {
-    let compact = text
-        .trim()
-        .chars()
-        .filter(|ch| {
-            !ch.is_whitespace()
-                && !matches!(
-                    ch,
-                    '，' | ','
-                        | '。'
-                        | '.'
-                        | '！'
-                        | '!'
-                        | '？'
-                        | '?'
-                        | '、'
-                        | ';'
-                        | '；'
-                        | ':'
-                        | '：'
-                )
-        })
-        .collect::<String>()
-        .trim_end_matches(['了', '吧', '啊', '呀', '呢'])
-        .to_owned();
-    matches!(
-        compact.as_str(),
-        "取消" | "放弃" | "算了" | "不用" | "不要" | "撤销"
-    )
-}
-
 fn parse_explicit_candidate_number(text: &str) -> Option<usize> {
     let compact = text
         .trim()
@@ -964,8 +832,8 @@ fn same_todo_clarification(session: &SessionRecord, request: &PendingTodoClarifi
         session
             .pending_operation
             .as_ref()
-            .and_then(|pending| TodoPendingOperation::try_from_pending(pending).ok().flatten()),
-        Some(TodoPendingOperation::TodoClarify { request: current, .. })
+            .and_then(|pending| TodoPendingPayload::try_from_pending(pending).ok().flatten()),
+        Some(TodoPendingPayload::TodoClarify { request: current, .. })
             if current.tool_name == request.tool_name && current.created_at == request.created_at
     )
 }
@@ -975,17 +843,58 @@ fn keep_todo_clarification(
     owner: &TodoOwner,
     mut request: PendingTodoClarification,
     question: String,
-) {
+) -> Result<(), LlmError> {
     request.question = question;
-    session.pending_operation = Some(
-        TodoPendingOperation::TodoClarify {
-            initiator_user_id: owner.user_id.clone(),
-            owner_key: owner.key.clone(),
-            created_at: request.created_at.clone(),
-            request,
-        }
-        .into(),
-    );
+    let operation = TodoPendingPayload::TodoClarify {
+        initiator_user_id: owner.user_id.clone(),
+        owner_key: owner.key.clone(),
+        created_at: request.created_at.clone(),
+        request,
+    };
+    if session
+        .pending_operation
+        .as_ref()
+        .is_some_and(|pending| pending.is_legacy())
+    {
+        let legacy_json = serde_json::to_value(operation).map_err(|err| {
+            LlmError::new(
+                "pending_encode_error",
+                format!("failed to encode legacy todo clarification: {err}"),
+                "todo_pending",
+            )
+        })?;
+        session.pending_operation = Some(serde_json::from_value(legacy_json).map_err(|err| {
+            LlmError::new(
+                "pending_decode_error",
+                format!("failed to retain legacy todo clarification: {err}"),
+                "todo_pending",
+            )
+        })?);
+        return Ok(());
+    }
+
+    let replacement = operation.into_prepared_action(&session.scope_key);
+    let current = session.pending_operation.as_mut().ok_or_else(|| {
+        LlmError::new(
+            "pending_missing",
+            "todo clarification disappeared before returning to waiting state",
+            "todo_pending",
+        )
+    })?;
+    current
+        .continue_waiting_after_execution(
+            replacement.payload().clone(),
+            replacement.display_snapshot().clone(),
+            replacement.expires_at().unwrap_or_default(),
+        )
+        .map_err(|err| {
+            LlmError::new(
+                "pending_transition_failed",
+                format!("failed to return todo clarification to waiting state: {err}"),
+                "todo_pending",
+            )
+        })?;
+    Ok(())
 }
 
 fn clarification_command_for_output(output: &Value) -> &'static str {

--- a/qq-maid-core/src/runtime/tools/todo/flow/pending_clarification.rs
+++ b/qq-maid-core/src/runtime/tools/todo/flow/pending_clarification.rs
@@ -1,0 +1,232 @@
+//! TodoClarify 的受限控制工具、提示构造与候选执行上下文。
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use qq_maid_llm::{
+    provider::{ChatOutcome, types::ChatMessage},
+    tool::{Tool, ToolContext, ToolMetadata, ToolOutput},
+};
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+use crate::{
+    error::LlmError,
+    runtime::{
+        session::SessionRecord,
+        tools::todo::{PendingTodoClarification, TodoOwner},
+    },
+};
+
+const CLARIFICATION_CONTROL_TOOL_NAME: &str = "clarification_control";
+
+pub(super) struct ClarificationControlTool;
+
+#[async_trait]
+impl Tool for ClarificationControlTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            name: CLARIFICATION_CONTROL_TOOL_NAME.to_owned(),
+            description: "澄清恢复控制工具。仅用于表示仍需追问或放弃当前澄清，不操作 Todo 数据。"
+                .to_owned(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["ask_again", "abandon"],
+                        "description": "ask_again=信息仍不足，需要继续追问；abandon=用户放弃或明显不是在回答当前澄清。"
+                    },
+                    "question": {
+                        "type": ["string", "null"],
+                        "description": "action=ask_again 时给用户的最小澄清问题；其他情况传 null。"
+                    }
+                },
+                "required": ["action", "question"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    async fn execute(
+        &self,
+        _context: ToolContext,
+        arguments: Value,
+    ) -> Result<ToolOutput, LlmError> {
+        let action = arguments
+            .get("action")
+            .and_then(Value::as_str)
+            .ok_or_else(|| LlmError::new("bad_tool_arguments", "action is required", "tool"))?;
+        let question = arguments
+            .get("question")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned);
+        match action {
+            "ask_again" => Ok(ToolOutput::json(json!({
+                "ok": true,
+                "action": "ask_again",
+                "question": question.unwrap_or_else(|| "请再具体说明要操作哪条待办。".to_owned()),
+            }))),
+            "abandon" => Ok(ToolOutput::json(json!({
+                "ok": true,
+                "action": "abandon",
+                "question": Value::Null,
+            }))),
+            _ => Err(LlmError::new(
+                "bad_tool_arguments",
+                "action must be ask_again or abandon",
+                "tool",
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ClarificationControlAction {
+    AskAgain(String),
+    Abandon,
+}
+
+pub(super) fn clarification_control_action(
+    outcome: &ChatOutcome,
+) -> Option<ClarificationControlAction> {
+    outcome
+        .agent
+        .tool_results
+        .iter()
+        .rev()
+        .find(|result| result.name == CLARIFICATION_CONTROL_TOOL_NAME)
+        .and_then(
+            |result| match result.output.get("action").and_then(Value::as_str) {
+                Some("ask_again") => Some(ClarificationControlAction::AskAgain(
+                    result
+                        .output
+                        .get("question")
+                        .and_then(Value::as_str)
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .unwrap_or("请再具体说明要操作哪条待办。")
+                        .to_owned(),
+                )),
+                Some("abandon") => Some(ClarificationControlAction::Abandon),
+                _ => None,
+            },
+        )
+}
+
+pub(super) fn candidate_scope(
+    request: &PendingTodoClarification,
+) -> Result<Arc<[String]>, LlmError> {
+    if request.candidates.is_empty() {
+        return Err(LlmError::new(
+            "todo_clarification_scope_empty",
+            "todo clarification candidates are empty",
+            "todo_pending",
+        ));
+    }
+    let ids = request
+        .candidates
+        .iter()
+        .map(|candidate| candidate.id.clone())
+        .collect::<Vec<_>>();
+    Ok(Arc::from(ids.into_boxed_slice()))
+}
+
+pub(super) fn build_todo_clarification_messages(
+    user_text: &str,
+    request: &PendingTodoClarification,
+) -> Vec<ChatMessage> {
+    let candidates = request
+        .candidates
+        .iter()
+        .map(|candidate| format!("{}. {}", candidate.display_number, candidate.title))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let original_arguments =
+        serde_json::to_string_pretty(&request.arguments).unwrap_or_else(|_| "{}".to_owned());
+    let system = format!(
+        "你正在恢复一个待办工具澄清任务。\n\n\
+职责边界：\n\
+- 只能恢复原工具 `{tool_name}`，不得改成其他 Todo 操作。\n\
+- 当前候选编号只在本次澄清中有效，必须从候选 1..N 里选择；不要使用数据库内部 ID。\n\
+- 候选标题里的数字（例如“6 号”“买 2 个”）不是候选编号。\n\
+- 如果能唯一确定目标，请调用原工具 `{tool_name}`，用候选展示编号作为 number/numbers，并保留或补全原始参数里的其他业务字段。\n\
+- 如果仍无法唯一确定，请调用 `{control_tool}`，action=ask_again，并给出最小澄清问题。\n\
+- 如果用户明确放弃或明显不是在回答当前澄清，请调用 `{control_tool}`，action=abandon。\n\
+- 不要编造成功结果；工具结果才是真实执行状态。\n\n\
+原工具：{tool_name}\n原始参数 JSON：\n{original_arguments}\n\n上一次澄清问题：\n{question}\n\n当前候选：\n{candidates}",
+        tool_name = request.tool_name,
+        control_tool = CLARIFICATION_CONTROL_TOOL_NAME,
+        question = request.question,
+    );
+    vec![
+        ChatMessage::system(system),
+        ChatMessage::user(user_text.trim().to_owned()),
+    ]
+}
+
+pub(super) fn clarification_tool_context(
+    session: &SessionRecord,
+    owner: &TodoOwner,
+) -> ToolContext {
+    let kind = if session
+        .group_id
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        qq_maid_common::identity_context::ConversationKind::Group
+    } else {
+        qq_maid_common::identity_context::ConversationKind::Private
+    };
+    ToolContext {
+        task_id: format!("todo-clarify:{}", Uuid::new_v4()),
+        actor: qq_maid_common::identity_context::ExecutionActorContext {
+            user_id: owner.user_id.clone(),
+            group_member_role: None,
+        },
+        conversation: qq_maid_common::identity_context::ExecutionConversationContext {
+            platform: session.platform.clone(),
+            // 历史 SessionRecord 未保存 account_id；澄清恢复沿用已绑定 owner/scope，
+            // 不通过解析 scope 猜测账号。新入站 ToolContext 会携带完整 account_id。
+            account_id: None,
+            kind,
+            target_id: session.group_id.clone().or_else(|| owner.user_id.clone()),
+            scope_id: owner.scope_key.clone(),
+            interaction_scope_id: session.scope_key.clone(),
+        },
+        tool_call_id: Some(format!("clarify-{}", session.session_id)),
+    }
+}
+
+pub(super) fn is_clarification_abandon_text(text: &str) -> bool {
+    let compact = text
+        .trim()
+        .chars()
+        .filter(|ch| {
+            !ch.is_whitespace()
+                && !matches!(
+                    ch,
+                    '，' | ','
+                        | '。'
+                        | '.'
+                        | '！'
+                        | '!'
+                        | '？'
+                        | '?'
+                        | '、'
+                        | ';'
+                        | '；'
+                        | ':'
+                        | '：'
+                )
+        })
+        .collect::<String>()
+        .trim_end_matches(['了', '吧', '啊', '呀', '呢'])
+        .to_owned();
+    matches!(
+        compact.as_str(),
+        "取消" | "放弃" | "算了" | "不用" | "不要" | "撤销"
+    )
+}

--- a/qq-maid-core/src/runtime/tools/todo/flow/pending_lifecycle.rs
+++ b/qq-maid-core/src/runtime/tools/todo/flow/pending_lifecycle.rs
@@ -6,7 +6,6 @@
 use crate::{
     error::LlmError,
     runtime::{
-        freshness::query_is_fresh,
         pending::{
             PendingReplyKind, PreparedActionExecutionContext, PreparedActionState, classify_reply,
         },
@@ -14,9 +13,7 @@ use crate::{
             RespondRequest, RespondResponse, RustRespondService,
             common::{CommandBody, session_error},
         },
-        session::{
-            LAST_QUERY_TTL_SECONDS, PendingExecutionClaim, SessionMeta, SessionRecord, now_iso_cn,
-        },
+        session::{PendingExecutionClaim, SessionMeta, SessionRecord, now_iso_cn},
         tools::{
             TaskStore,
             todo::{TODO_PENDING_DOMAIN, TodoOwner, TodoPendingPayload, todo_lexicon},
@@ -37,17 +34,11 @@ impl RustRespondService {
             return Ok(None);
         };
         let pending_revision = pending.revision();
-        let legacy_pending = pending.is_legacy();
         if pending.domain() != TODO_PENDING_DOMAIN {
             return Ok(None);
         }
 
-        let expired = if legacy_pending {
-            !query_is_fresh(pending.created_at(), LAST_QUERY_TTL_SECONDS)
-        } else {
-            pending.is_expired_at(&now_iso_cn())
-        };
-        if expired {
+        if pending.is_expired_at(&now_iso_cn()) {
             return Ok(Some(self.clear_pending_response(
                 session,
                 user_text,
@@ -56,8 +47,7 @@ impl RustRespondService {
             )?));
         }
 
-        // 新动作必须绑定可信 interaction session；旧 JSON 没有该字段，只走兼容分支。
-        if !legacy_pending && pending.scope_key() != Some(session.scope_key.as_str()) {
+        if pending.scope_key() != session.scope_key {
             return Ok(Some(self.clear_pending_response(
                 session,
                 user_text,
@@ -65,9 +55,7 @@ impl RustRespondService {
                 "pending_scope_mismatch",
             )?));
         }
-        if !legacy_pending
-            && (pending.initiator_user_id().is_none() || pending.owner_key().is_none())
-        {
+        if pending.initiator_user_id().is_none() || pending.owner_key().is_none() {
             return Ok(Some(self.clear_pending_response(
                 session,
                 user_text,
@@ -139,17 +127,15 @@ impl RustRespondService {
         {
             Ok(response) => Ok(response),
             Err(err)
-                if !legacy_pending
-                    && session.pending_operation.as_ref().is_some_and(|pending| {
-                        pending.state() == PreparedActionState::Executing
-                            && pending.revision() == pending_revision
-                    }) =>
+                if session.pending_operation.as_ref().is_some_and(|pending| {
+                    pending.state() == PreparedActionState::Executing
+                        && pending.revision() == pending_revision
+                }) =>
             {
                 Ok(Some(self.pending_execution_failed_response(
                     session,
                     user_text,
                     pending_revision,
-                    false,
                     err,
                 )?))
             }
@@ -157,17 +143,13 @@ impl RustRespondService {
         }
     }
 
-    /// 原子领取当前 PreparedAction 的执行权；旧 JSON 只沿用原兼容路径。
+    /// 原子领取当前 PreparedAction 的执行权。
     pub(super) fn claim_todo_pending_execution(
         &self,
         session: &mut SessionRecord,
         owner: &TodoOwner,
         revision: u64,
-        legacy_pending: bool,
     ) -> Result<bool, LlmError> {
-        if legacy_pending {
-            return Ok(true);
-        }
         let now = now_iso_cn();
         let scope_key = session.scope_key.clone();
         let context = PreparedActionExecutionContext {
@@ -203,12 +185,8 @@ impl RustRespondService {
         session: &mut SessionRecord,
         user_text: &str,
         revision: u64,
-        legacy_pending: bool,
         err: LlmError,
     ) -> Result<RespondResponse, LlmError> {
-        if legacy_pending {
-            return Err(err);
-        }
         let message = err.message.clone();
         *session = self
             .session_store

--- a/qq-maid-core/src/runtime/tools/todo/flow/pending_lifecycle.rs
+++ b/qq-maid-core/src/runtime/tools/todo/flow/pending_lifecycle.rs
@@ -1,0 +1,226 @@
+//! Todo PreparedAction 的通用生命周期入口。
+//!
+//! 本模块只处理身份、owner、interaction scope、过期时间、state 与 revision，
+//! 以及执行权的事务领取和 Failed 落盘；Todo payload 的具体执行留在 `pending.rs`。
+
+use crate::{
+    error::LlmError,
+    runtime::{
+        freshness::query_is_fresh,
+        pending::{
+            PendingReplyKind, PreparedActionExecutionContext, PreparedActionState, classify_reply,
+        },
+        respond::{
+            RespondRequest, RespondResponse, RustRespondService,
+            common::{CommandBody, session_error},
+        },
+        session::{
+            LAST_QUERY_TTL_SECONDS, PendingExecutionClaim, SessionMeta, SessionRecord, now_iso_cn,
+        },
+        tools::{
+            TaskStore,
+            todo::{TODO_PENDING_DOMAIN, TodoOwner, TodoPendingPayload, todo_lexicon},
+        },
+    },
+};
+
+impl RustRespondService {
+    /// 统一校验 Todo PreparedAction，再交给 Todo payload 状态机。
+    pub(crate) async fn handle_pending_operation(
+        &self,
+        _req: &RespondRequest,
+        user_text: &str,
+        meta: &SessionMeta,
+        session: &mut SessionRecord,
+    ) -> Result<Option<RespondResponse>, LlmError> {
+        let Some(pending) = session.pending_operation.clone() else {
+            return Ok(None);
+        };
+        let pending_revision = pending.revision();
+        let legacy_pending = pending.is_legacy();
+        if pending.domain() != TODO_PENDING_DOMAIN {
+            return Ok(None);
+        }
+
+        let expired = if legacy_pending {
+            !query_is_fresh(pending.created_at(), LAST_QUERY_TTL_SECONDS)
+        } else {
+            pending.is_expired_at(&now_iso_cn())
+        };
+        if expired {
+            return Ok(Some(self.clear_pending_response(
+                session,
+                user_text,
+                CommandBody::plain("这条待确认操作已过期，没有执行。请重新发起。"),
+                TodoPendingPayload::expired_command(&pending),
+            )?));
+        }
+
+        // 新动作必须绑定可信 interaction session；旧 JSON 没有该字段，只走兼容分支。
+        if !legacy_pending && pending.scope_key() != Some(session.scope_key.as_str()) {
+            return Ok(Some(self.clear_pending_response(
+                session,
+                user_text,
+                CommandBody::plain("这条待确认操作的会话作用域已变化，没有执行。请重新发起。"),
+                "pending_scope_mismatch",
+            )?));
+        }
+        if !legacy_pending
+            && (pending.initiator_user_id().is_none() || pending.owner_key().is_none())
+        {
+            return Ok(Some(self.clear_pending_response(
+                session,
+                user_text,
+                CommandBody::plain("这条待确认操作缺少身份或所有者信息，没有执行。请重新发起。"),
+                "pending_metadata_missing",
+            )?));
+        }
+
+        if pending
+            .initiator_user_id()
+            .is_some_and(|initiator| meta.user_id.as_deref() != Some(initiator))
+        {
+            return Ok(Some(self.append_pending_response(
+                session,
+                user_text,
+                CommandBody::plain("这个操作由其他成员发起，请由发起人继续。"),
+                "pending_initiator_mismatch",
+            )?));
+        }
+
+        let owner = TaskStore::owner(meta.user_id.as_deref(), &meta.scope_key);
+        if pending.owner_key().is_some_and(|key| key != owner.key) {
+            return Ok(Some(self.append_pending_response(
+                session,
+                user_text,
+                CommandBody::plain(
+                    "当前有一条待办操作还在等待发起人确认。请先回复“确认 / 取消”，或由发起人处理完后再继续。",
+                ),
+                "todo_pending_wait",
+            )?));
+        }
+
+        match pending.state() {
+            PreparedActionState::WaitingConfirmation => {}
+            PreparedActionState::Executing => {
+                return Ok(Some(self.append_pending_response(
+                    session,
+                    user_text,
+                    CommandBody::plain("这条操作正在执行，请勿重复确认。"),
+                    "pending_executing",
+                )?));
+            }
+            PreparedActionState::Failed => {
+                if matches!(
+                    classify_reply(user_text, todo_lexicon()),
+                    PendingReplyKind::Cancel
+                ) {
+                    return Ok(Some(self.clear_pending_response(
+                        session,
+                        user_text,
+                        CommandBody::plain("已清理执行失败的待确认操作，请重新发起。"),
+                        "pending_failed_cancel",
+                    )?));
+                }
+                return Ok(Some(self.append_pending_response(
+                    session,
+                    user_text,
+                    CommandBody::plain(
+                        "这条待确认操作上次执行失败，没有重复执行。请回复“取消”后重新发起。",
+                    ),
+                    "pending_failed",
+                )?));
+            }
+        }
+
+        match self
+            .handle_pending_todo_operation(user_text, session, &owner)
+            .await
+        {
+            Ok(response) => Ok(response),
+            Err(err)
+                if !legacy_pending
+                    && session.pending_operation.as_ref().is_some_and(|pending| {
+                        pending.state() == PreparedActionState::Executing
+                            && pending.revision() == pending_revision
+                    }) =>
+            {
+                Ok(Some(self.pending_execution_failed_response(
+                    session,
+                    user_text,
+                    pending_revision,
+                    false,
+                    err,
+                )?))
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    /// 原子领取当前 PreparedAction 的执行权；旧 JSON 只沿用原兼容路径。
+    pub(super) fn claim_todo_pending_execution(
+        &self,
+        session: &mut SessionRecord,
+        owner: &TodoOwner,
+        revision: u64,
+        legacy_pending: bool,
+    ) -> Result<bool, LlmError> {
+        if legacy_pending {
+            return Ok(true);
+        }
+        let now = now_iso_cn();
+        let scope_key = session.scope_key.clone();
+        let context = PreparedActionExecutionContext {
+            initiator_user_id: owner.user_id.as_deref(),
+            owner_key: Some(owner.key.as_str()),
+            scope_key: &scope_key,
+            expected_revision: revision,
+            now: &now,
+        };
+        match self
+            .session_store
+            .claim_pending_execution(&session.session_id, &context)
+            .map_err(session_error)?
+        {
+            PendingExecutionClaim::Claimed(latest) => {
+                *session = latest;
+                Ok(true)
+            }
+            PendingExecutionClaim::Rejected {
+                session: latest,
+                error,
+            } => {
+                tracing::warn!(error = %error, "prepared action execution claim rejected");
+                *session = latest;
+                Ok(false)
+            }
+        }
+    }
+
+    /// 真实执行失败时保留 Failed 状态与真实错误，禁止用成功文案覆盖。
+    pub(super) fn pending_execution_failed_response(
+        &self,
+        session: &mut SessionRecord,
+        user_text: &str,
+        revision: u64,
+        legacy_pending: bool,
+        err: LlmError,
+    ) -> Result<RespondResponse, LlmError> {
+        if legacy_pending {
+            return Err(err);
+        }
+        let message = err.message.clone();
+        *session = self
+            .session_store
+            .mark_pending_execution_failed(&session.session_id, revision)
+            .map_err(session_error)?;
+        self.append_pending_response(
+            session,
+            user_text,
+            CommandBody::plain(format!(
+                "这条待确认操作执行失败，没有完成。错误：{message}\n请回复“取消”后重新发起。"
+            )),
+            "pending_execution_failed",
+        )
+    }
+}

--- a/qq-maid-core/src/runtime/tools/todo/format.rs
+++ b/qq-maid-core/src/runtime/tools/todo/format.rs
@@ -478,12 +478,6 @@ pub(crate) fn format_todo_inline(item: &TodoItem) -> String {
     truncate_chars(&item.title, 80)
 }
 
-pub(crate) fn format_todo_pending_add_waiting_reply() -> CommandBody {
-    simple_todo_notice(
-        "这条旧版新增待办草稿还在等待确认。要新增请回复“确认 / 可以 / 好”；要放弃请回复“取消 / 不要 / 算了”。",
-    )
-}
-
 pub(crate) fn format_todo_pending_delete_waiting_reply(status: &TodoStatus) -> CommandBody {
     let text = match status {
         TodoStatus::Pending => {

--- a/qq-maid-core/src/runtime/tools/todo/mod.rs
+++ b/qq-maid-core/src/runtime/tools/todo/mod.rs
@@ -56,7 +56,7 @@ pub use get::GetTodoTool;
 pub use list::ListTodoTool;
 pub use merge::MergeTodoTool;
 pub(crate) use pending::{
-    ClarificationCandidate, PendingTodoClarification, TODO_PENDING_DOMAIN, TodoPendingOperation,
+    ClarificationCandidate, PendingTodoClarification, TODO_PENDING_DOMAIN, TodoPendingPayload,
     todo_lexicon,
 };
 pub use recurring::ManageRecurringReminderTool;

--- a/qq-maid-core/src/runtime/tools/todo/ops.rs
+++ b/qq-maid-core/src/runtime/tools/todo/ops.rs
@@ -11,7 +11,7 @@
 //! - 内部 ID 由调用方完成“可见编号 -> ID”解析后传入；本层不接受可见编号。
 //! - 快照清空/记忆规则与历史实现严格一致：批量操作只在成功变更非空时清空
 //!   `last_todo_query`，避免全部 skipped 时把用户仍可复用的列表快照误清掉；
-//!   单条新增或确认链路成功后无条件清空并记录最近对象。
+//!   新增或确认链路成功后无条件清空并记录最近对象。
 //! - Todo pending payload 与状态机在 `tools/todo/pending.rs` 和
 //!   `tools/todo/flow/pending.rs`；本层不构造 pending。
 
@@ -22,22 +22,6 @@ use crate::runtime::{
         TodoRecurrenceKind, TodoStatus, TodoStore,
     },
 };
-
-/// 新增单条待办，并维护 session 最近对象快照。
-///
-/// 新增待办已改为直接写入；成功后必须立即清空旧列表编号快照，
-/// 并把新条目记录为 `created` 最近对象，供后续“刚刚那个”续指使用。
-pub fn create_one(
-    store: &TodoStore,
-    session: &mut SessionRecord,
-    owner: &TodoOwner,
-    draft: TodoItemDraft,
-) -> Result<TodoItem, crate::runtime::tools::todo::TodoError> {
-    let created = store.create(owner, draft)?;
-    session.last_todo_query = None;
-    session.remember_last_todo_action(&owner.key, &created, "created");
-    Ok(created)
-}
 
 /// 批量新增待办，并维护 session 最近对象快照。
 ///

--- a/qq-maid-core/src/runtime/tools/todo/pending.rs
+++ b/qq-maid-core/src/runtime/tools/todo/pending.rs
@@ -1,12 +1,15 @@
 //! Todo 专属 pending payload 与确认词表。
 //!
-//! `runtime::pending::PendingOperation` 只负责通用 envelope；本模块维护 Todo 的
+//! `runtime::pending::PreparedAction` 只负责通用 envelope；本模块维护 Todo 的
 //! 持久化 payload、旧 session 兼容变体、澄清候选边界和 Todo 确认词表。
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::runtime::pending::{PendingLexicon, PendingOperation};
+use crate::runtime::{
+    pending::{PendingLexicon, PreparedAction, PreparedActionMetadata, expires_at_after},
+    session::LAST_QUERY_TTL_SECONDS,
+};
 
 use super::{TodoItem, TodoItemDraft, TodoStatus};
 
@@ -77,7 +80,7 @@ pub struct PendingTodoClarification {
 // `kind=todo_*` 持久化 pending 语义，避免和通用 Pending envelope 混淆。
 #[allow(clippy::enum_variant_names)]
 #[serde(tag = "kind", rename_all = "snake_case")]
-pub enum TodoPendingOperation {
+pub enum TodoPendingPayload {
     /// 旧版新增待办草稿确认。
     ///
     /// 新版本 `create_todo` 已直接写库，不再产生该 pending；保留此变体只为兼容
@@ -169,9 +172,9 @@ pub enum TodoPendingOperation {
     },
 }
 
-impl TodoPendingOperation {
+impl TodoPendingPayload {
     pub(crate) fn try_from_pending(
-        pending: &PendingOperation,
+        pending: &PreparedAction,
     ) -> Result<Option<Self>, serde_json::Error> {
         if pending.domain() != TODO_PENDING_DOMAIN {
             return Ok(None);
@@ -179,20 +182,101 @@ impl TodoPendingOperation {
         serde_json::from_value(pending.payload().clone()).map(Some)
     }
 
-    pub(crate) fn expired_command(pending: &PendingOperation) -> &'static str {
+    pub(crate) fn expired_command(pending: &PreparedAction) -> &'static str {
         if pending.kind() == "todo_clarify" {
             "todo_clarify_expired"
         } else {
             "todo_pending_expired"
         }
     }
-}
 
-impl From<TodoPendingOperation> for PendingOperation {
-    fn from(operation: TodoPendingOperation) -> Self {
-        let payload = serde_json::to_value(operation)
-            .expect("TodoPendingOperation serialization should not fail");
-        PendingOperation::from_payload(TODO_PENDING_DOMAIN, payload)
+    /// 将 Todo payload 包装为统一 PreparedAction。
+    ///
+    /// `scope_key` 必须来自当前 interaction session，不能从 payload 或模型参数推导。
+    pub(crate) fn into_prepared_action(self, scope_key: &str) -> PreparedAction {
+        let display_snapshot = self.display_snapshot();
+        let payload =
+            serde_json::to_value(&self).expect("TodoPendingPayload serialization should not fail");
+        let action_kind = payload
+            .get("kind")
+            .and_then(Value::as_str)
+            .unwrap_or("todo_unknown")
+            .to_owned();
+        let created_at = payload
+            .get("created_at")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+        let expires_at = expires_at_after(&created_at, LAST_QUERY_TTL_SECONDS)
+            .unwrap_or_else(|| created_at.clone());
+        let initiator_user_id = payload
+            .get("initiator_user_id")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        let owner_key = payload
+            .get("owner_key")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        PreparedAction::new(
+            PreparedActionMetadata {
+                domain: TODO_PENDING_DOMAIN.to_owned(),
+                action_kind,
+                initiator_user_id,
+                owner_key,
+                scope_key: scope_key.to_owned(),
+                created_at,
+                expires_at,
+            },
+            display_snapshot,
+            payload,
+        )
+    }
+
+    /// 生成只用于确认提示/后续修订展示的快照，不作为执行依据。
+    fn display_snapshot(&self) -> Value {
+        match self {
+            Self::TodoAdd { draft, .. } => serde_json::json!({
+                "title": draft.title,
+            }),
+            Self::TodoDone { item, .. } | Self::TodoDelete { item, .. } => serde_json::json!({
+                "title": item.title,
+                "status": item.status,
+            }),
+            Self::TodoEdit { before, draft, .. } => serde_json::json!({
+                "before_title": before.title,
+                "after_title": draft.title,
+            }),
+            Self::TodoBulkDelete {
+                matched_count,
+                status,
+                summary,
+                source_condition,
+                ..
+            } => serde_json::json!({
+                "matched_count": matched_count,
+                "status": status,
+                "summary": summary,
+                "source_condition": source_condition,
+            }),
+            Self::TodoSelectCandidate {
+                action, candidates, ..
+            } => serde_json::json!({
+                "action": action,
+                "candidates": candidates.iter().enumerate().map(|(index, item)| serde_json::json!({
+                    "display_number": index + 1,
+                    "title": item.title,
+                    "status": item.status,
+                })).collect::<Vec<_>>(),
+            }),
+            Self::TodoClarify { request, .. } => serde_json::json!({
+                "question": request.question,
+                "candidates": request.candidates.iter().map(|candidate| serde_json::json!({
+                    "display_number": candidate.display_number,
+                    "title": candidate.title,
+                    "status": candidate.status,
+                })).collect::<Vec<_>>(),
+            }),
+        }
     }
 }
 
@@ -229,7 +313,7 @@ mod tests {
 
     #[test]
     fn legacy_pending_without_initiator_deserializes() {
-        let pending: TodoPendingOperation = serde_json::from_value(json!({
+        let pending: TodoPendingPayload = serde_json::from_value(json!({
             "kind": "todo_add",
             "owner_key": "u1",
             "draft": {
@@ -240,10 +324,128 @@ mod tests {
         .unwrap();
 
         match pending {
-            TodoPendingOperation::TodoAdd {
+            TodoPendingPayload::TodoAdd {
                 initiator_user_id, ..
             } => assert_eq!(initiator_user_id, None),
             other => panic!("expected TodoAdd, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn all_legacy_todo_pending_json_variants_decode_through_prepared_action() {
+        let item: TodoItem = serde_json::from_value(json!({
+            "id": "todo-1",
+            "scope_key": "u1",
+            "title": "旧待办",
+            "created_at": "2026-07-15T09:00:00+08:00",
+            "updated_at": "2026-07-15T09:00:00+08:00"
+        }))
+        .unwrap();
+        let draft: TodoItemDraft = serde_json::from_value(json!({"title": "旧待办"})).unwrap();
+        let created_at = "2026-07-15T10:00:00+08:00".to_owned();
+        let operations = vec![
+            TodoPendingPayload::TodoAdd {
+                initiator_user_id: None,
+                owner_key: "u1".to_owned(),
+                draft: draft.clone(),
+                allow_revision: true,
+                created_at: created_at.clone(),
+            },
+            TodoPendingPayload::TodoDone {
+                initiator_user_id: None,
+                owner_key: "u1".to_owned(),
+                item: item.clone(),
+                created_at: created_at.clone(),
+            },
+            TodoPendingPayload::TodoEdit {
+                initiator_user_id: None,
+                owner_key: "u1".to_owned(),
+                before: item.clone(),
+                draft: draft.clone(),
+                created_at: created_at.clone(),
+            },
+            TodoPendingPayload::TodoDelete {
+                initiator_user_id: None,
+                owner_key: "u1".to_owned(),
+                item: item.clone(),
+                created_at: created_at.clone(),
+            },
+            TodoPendingPayload::TodoBulkDelete {
+                initiator_user_id: None,
+                owner_key: "u1".to_owned(),
+                item_ids: vec![item.id.clone()],
+                matched_count: 1,
+                status: TodoStatus::Completed,
+                summary: "旧待办".to_owned(),
+                source_condition: "已完成".to_owned(),
+                created_at: created_at.clone(),
+            },
+            TodoPendingPayload::TodoSelectCandidate {
+                initiator_user_id: None,
+                owner_key: "u1".to_owned(),
+                action: PendingTodoAction::Delete,
+                candidates: vec![item.clone()],
+                edit_text: None,
+                created_at: created_at.clone(),
+            },
+            TodoPendingPayload::TodoClarify {
+                initiator_user_id: None,
+                owner_key: "u1".to_owned(),
+                request: PendingTodoClarification {
+                    tool_name: "complete_todos".to_owned(),
+                    arguments: json!({"numbers": null}),
+                    allow_many: true,
+                    error_code: "todo_reference_unavailable".to_owned(),
+                    question: "哪一条？".to_owned(),
+                    candidates: vec![],
+                    created_at: created_at.clone(),
+                },
+                created_at,
+            },
+        ];
+
+        for operation in operations {
+            let legacy_json = serde_json::to_value(&operation).unwrap();
+            let action: PreparedAction = serde_json::from_value(legacy_json).unwrap();
+            assert!(action.is_legacy(), "kind={}", action.kind());
+            assert_eq!(
+                TodoPendingPayload::try_from_pending(&action).unwrap(),
+                Some(operation)
+            );
+        }
+    }
+
+    #[test]
+    fn todo_payload_builds_versioned_prepared_action() {
+        let pending = TodoPendingPayload::TodoAdd {
+            initiator_user_id: Some("u1".to_owned()),
+            owner_key: "owner:u1".to_owned(),
+            draft: TodoItemDraft {
+                title: "新待办".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                reminder_at: None,
+                time_precision: Default::default(),
+                recurrence_kind: Default::default(),
+                recurrence_interval_days: 0,
+                recurrence_interval: 0,
+                recurrence_unit: Default::default(),
+            },
+            allow_revision: false,
+            created_at: "2026-07-15T10:00:00+08:00".to_owned(),
+        }
+        .into_prepared_action("group:g1:actor:u1");
+
+        assert!(!pending.is_legacy());
+        assert_eq!(pending.kind(), "todo_add");
+        assert_eq!(pending.scope_key(), Some("group:g1:actor:u1"));
+        assert_eq!(pending.expires_at(), Some("2026-07-15T10:10:00+08:00"));
+        assert_eq!(pending.display_snapshot()["title"], "新待办");
+        assert!(matches!(
+            TodoPendingPayload::try_from_pending(&pending).unwrap(),
+            Some(TodoPendingPayload::TodoAdd { .. })
+        ));
     }
 }

--- a/qq-maid-core/src/runtime/tools/todo/pending.rs
+++ b/qq-maid-core/src/runtime/tools/todo/pending.rs
@@ -1,7 +1,7 @@
 //! Todo 专属 pending payload 与确认词表。
 //!
 //! `runtime::pending::PreparedAction` 只负责通用 envelope；本模块维护 Todo 的
-//! 持久化 payload、旧 session 兼容变体、澄清候选边界和 Todo 确认词表。
+//! 持久化 payload、澄清候选边界和 Todo 确认词表。
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -11,7 +11,7 @@ use crate::runtime::{
     session::LAST_QUERY_TTL_SECONDS,
 };
 
-use super::{TodoItem, TodoItemDraft, TodoStatus};
+use super::{TodoItem, TodoStatus};
 
 pub(crate) const TODO_PENDING_DOMAIN: &str = "todo";
 
@@ -32,18 +32,6 @@ pub struct ClarificationCandidate {
     pub status: TodoStatus,
 }
 
-/// 待确认的待办操作类型。
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum PendingTodoAction {
-    /// 标记完成
-    Done,
-    /// 编辑内容
-    Edit,
-    /// 删除
-    Delete,
-}
-
 /// Agent Loop 中等待用户补充目标的 Todo 工具调用。
 ///
 /// 这里只保存恢复原任务必需的结构化信息：原工具名、原始参数、选择基数、触发澄清的
@@ -57,16 +45,13 @@ pub struct PendingTodoClarification {
     /// 原始工具参数；不包含数据库内部 ID。
     pub arguments: Value,
     /// 原工具是否允许一次操作多条。
-    #[serde(default)]
     pub allow_many: bool,
     /// 触发澄清的结构化错误码。
     pub error_code: String,
     /// 给用户看的最小澄清问题。
     pub question: String,
     /// 本次澄清候选集及展示顺序；下一轮编号只能映射这份候选，不得使用无关的
-    /// `last_todo_query` 快照。旧 pending 缺失该字段时兼容为空，恢复路径会安全提示
-    /// 用户重新发起。
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    /// `last_todo_query` 快照。
     pub candidates: Vec<ClarificationCandidate>,
     /// 创建时间，按最近查询 TTL 过期。
     pub created_at: String,
@@ -74,53 +59,10 @@ pub struct PendingTodoClarification {
 
 /// Todo 业务 pending payload。
 ///
-/// 仍按历史 `kind=todo_*` 格式序列化，保证已持久化 session 和现有数据库字段兼容。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-// 这些变体名刻意保留 `Todo` 前缀：它们对应迁移期仍需兼容的历史
-// `kind=todo_*` 持久化 pending 语义，避免和通用 Pending envelope 混淆。
 #[allow(clippy::enum_variant_names)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum TodoPendingPayload {
-    /// 旧版新增待办草稿确认。
-    ///
-    /// 新版本 `create_todo` 已直接写库，不再产生该 pending；保留此变体只为兼容
-    /// 已持久化的旧 Session，允许用户继续确认或取消旧草稿。
-    TodoAdd {
-        /// 发起 pending 的用户标识；与 owner_key 分开保存，避免 user_id 缺失时绕过校验。
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        initiator_user_id: Option<String>,
-        /// 所有者标识键
-        owner_key: String,
-        /// 待办草稿
-        draft: TodoItemDraft,
-        /// 旧版草稿是否允许自然语言修订。
-        ///
-        /// 新版本不会再生成 `TodoAdd` pending，也不会恢复 pending 阶段二次 LLM 修订；
-        /// 字段仅为旧 Session 反序列化兼容保留。
-        #[serde(default = "default_todo_add_allow_revision")]
-        allow_revision: bool,
-        /// 创建时间
-        created_at: String,
-    },
-    /// 标记待办为完成
-    TodoDone {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        initiator_user_id: Option<String>,
-        owner_key: String,
-        item: TodoItem,
-        created_at: String,
-    },
-    /// 编辑待办事项
-    TodoEdit {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        initiator_user_id: Option<String>,
-        owner_key: String,
-        /// 编辑前的待办项
-        before: TodoItem,
-        /// 编辑后的草稿
-        draft: TodoItemDraft,
-        created_at: String,
-    },
     /// 删除单个待办
     TodoDelete {
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -137,29 +79,13 @@ pub enum TodoPendingPayload {
         /// 要删除的待办 ID 列表
         item_ids: Vec<String>,
         /// 发起时匹配到的条目数量，用于确认后按原始范围反馈。
-        #[serde(default)]
         matched_count: usize,
-        /// 批量删除限定的目标状态；旧 pending 缺失该字段时兼容为已完成清理。
-        #[serde(default = "default_todo_bulk_delete_status")]
+        /// 批量删除限定的目标状态。
         status: TodoStatus,
         /// 操作摘要
         summary: String,
         /// 删除条件的原始描述
         source_condition: String,
-        created_at: String,
-    },
-    /// 需要用户从多个候选中选择操作的待办
-    TodoSelectCandidate {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        initiator_user_id: Option<String>,
-        owner_key: String,
-        /// 待执行的操作类型
-        action: PendingTodoAction,
-        /// 候选待办项列表
-        candidates: Vec<TodoItem>,
-        /// 用户提供的编辑文本（仅在编辑操作时存在）
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        edit_text: Option<String>,
         created_at: String,
     },
     /// Agent Loop 内等待用户补充待办目标后恢复原工具动作。
@@ -235,16 +161,9 @@ impl TodoPendingPayload {
     /// 生成只用于确认提示/后续修订展示的快照，不作为执行依据。
     fn display_snapshot(&self) -> Value {
         match self {
-            Self::TodoAdd { draft, .. } => serde_json::json!({
-                "title": draft.title,
-            }),
-            Self::TodoDone { item, .. } | Self::TodoDelete { item, .. } => serde_json::json!({
+            Self::TodoDelete { item, .. } => serde_json::json!({
                 "title": item.title,
                 "status": item.status,
-            }),
-            Self::TodoEdit { before, draft, .. } => serde_json::json!({
-                "before_title": before.title,
-                "after_title": draft.title,
             }),
             Self::TodoBulkDelete {
                 matched_count,
@@ -257,16 +176,6 @@ impl TodoPendingPayload {
                 "status": status,
                 "summary": summary,
                 "source_condition": source_condition,
-            }),
-            Self::TodoSelectCandidate {
-                action, candidates, ..
-            } => serde_json::json!({
-                "action": action,
-                "candidates": candidates.iter().enumerate().map(|(index, item)| serde_json::json!({
-                    "display_number": index + 1,
-                    "title": item.title,
-                    "status": item.status,
-                })).collect::<Vec<_>>(),
             }),
             Self::TodoClarify { request, .. } => serde_json::json!({
                 "question": request.question,
@@ -298,154 +207,31 @@ pub(crate) fn todo_lexicon() -> PendingLexicon {
     )
 }
 
-fn default_todo_add_allow_revision() -> bool {
-    true
-}
-
-fn default_todo_bulk_delete_status() -> TodoStatus {
-    TodoStatus::Completed
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn legacy_pending_without_initiator_deserializes() {
-        let pending: TodoPendingPayload = serde_json::from_value(json!({
-            "kind": "todo_add",
-            "owner_key": "u1",
-            "draft": {
-                "title": "旧待办"
-            },
-            "created_at": "2026-06-27T12:00:00+08:00"
-        }))
-        .unwrap();
-
-        match pending {
-            TodoPendingPayload::TodoAdd {
-                initiator_user_id, ..
-            } => assert_eq!(initiator_user_id, None),
-            other => panic!("expected TodoAdd, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn all_legacy_todo_pending_json_variants_decode_through_prepared_action() {
-        let item: TodoItem = serde_json::from_value(json!({
-            "id": "todo-1",
-            "scope_key": "u1",
-            "title": "旧待办",
-            "created_at": "2026-07-15T09:00:00+08:00",
-            "updated_at": "2026-07-15T09:00:00+08:00"
-        }))
-        .unwrap();
-        let draft: TodoItemDraft = serde_json::from_value(json!({"title": "旧待办"})).unwrap();
-        let created_at = "2026-07-15T10:00:00+08:00".to_owned();
-        let operations = vec![
-            TodoPendingPayload::TodoAdd {
-                initiator_user_id: None,
-                owner_key: "u1".to_owned(),
-                draft: draft.clone(),
-                allow_revision: true,
-                created_at: created_at.clone(),
-            },
-            TodoPendingPayload::TodoDone {
-                initiator_user_id: None,
-                owner_key: "u1".to_owned(),
-                item: item.clone(),
-                created_at: created_at.clone(),
-            },
-            TodoPendingPayload::TodoEdit {
-                initiator_user_id: None,
-                owner_key: "u1".to_owned(),
-                before: item.clone(),
-                draft: draft.clone(),
-                created_at: created_at.clone(),
-            },
-            TodoPendingPayload::TodoDelete {
-                initiator_user_id: None,
-                owner_key: "u1".to_owned(),
-                item: item.clone(),
-                created_at: created_at.clone(),
-            },
-            TodoPendingPayload::TodoBulkDelete {
-                initiator_user_id: None,
-                owner_key: "u1".to_owned(),
-                item_ids: vec![item.id.clone()],
-                matched_count: 1,
-                status: TodoStatus::Completed,
-                summary: "旧待办".to_owned(),
-                source_condition: "已完成".to_owned(),
-                created_at: created_at.clone(),
-            },
-            TodoPendingPayload::TodoSelectCandidate {
-                initiator_user_id: None,
-                owner_key: "u1".to_owned(),
-                action: PendingTodoAction::Delete,
-                candidates: vec![item.clone()],
-                edit_text: None,
-                created_at: created_at.clone(),
-            },
-            TodoPendingPayload::TodoClarify {
-                initiator_user_id: None,
-                owner_key: "u1".to_owned(),
-                request: PendingTodoClarification {
-                    tool_name: "complete_todos".to_owned(),
-                    arguments: json!({"numbers": null}),
-                    allow_many: true,
-                    error_code: "todo_reference_unavailable".to_owned(),
-                    question: "哪一条？".to_owned(),
-                    candidates: vec![],
-                    created_at: created_at.clone(),
-                },
-                created_at,
-            },
-        ];
-
-        for operation in operations {
-            let legacy_json = serde_json::to_value(&operation).unwrap();
-            let action: PreparedAction = serde_json::from_value(legacy_json).unwrap();
-            assert!(action.is_legacy(), "kind={}", action.kind());
-            assert_eq!(
-                TodoPendingPayload::try_from_pending(&action).unwrap(),
-                Some(operation)
-            );
-        }
-    }
 
     #[test]
     fn todo_payload_builds_versioned_prepared_action() {
-        let pending = TodoPendingPayload::TodoAdd {
+        let pending = TodoPendingPayload::TodoBulkDelete {
             initiator_user_id: Some("u1".to_owned()),
             owner_key: "owner:u1".to_owned(),
-            draft: TodoItemDraft {
-                title: "新待办".to_owned(),
-                detail: None,
-                raw_text: None,
-                due_date: None,
-                due_at: None,
-                reminder_at: None,
-                time_precision: Default::default(),
-                recurrence_kind: Default::default(),
-                recurrence_interval_days: 0,
-                recurrence_interval: 0,
-                recurrence_unit: Default::default(),
-            },
-            allow_revision: false,
+            item_ids: vec!["todo-1".to_owned()],
+            matched_count: 1,
+            status: TodoStatus::Completed,
+            summary: "旧待办".to_owned(),
+            source_condition: "已完成".to_owned(),
             created_at: "2026-07-15T10:00:00+08:00".to_owned(),
         }
         .into_prepared_action("group:g1:actor:u1");
 
-        assert!(!pending.is_legacy());
-        assert_eq!(pending.kind(), "todo_add");
-        assert_eq!(pending.scope_key(), Some("group:g1:actor:u1"));
-        assert_eq!(pending.expires_at(), Some("2026-07-15T10:10:00+08:00"));
-        assert_eq!(pending.display_snapshot()["title"], "新待办");
+        assert_eq!(pending.kind(), "todo_bulk_delete");
+        assert_eq!(pending.scope_key(), "group:g1:actor:u1");
+        assert_eq!(pending.expires_at(), "2026-07-15T10:10:00+08:00");
+        assert_eq!(pending.display_snapshot()["matched_count"], 1);
         assert!(matches!(
             TodoPendingPayload::try_from_pending(&pending).unwrap(),
-            Some(TodoPendingPayload::TodoAdd { .. })
+            Some(TodoPendingPayload::TodoBulkDelete { .. })
         ));
     }
 }

--- a/qq-maid-core/src/runtime/tools/todo/pending_tests.rs
+++ b/qq-maid-core/src/runtime/tools/todo/pending_tests.rs
@@ -1,11 +1,11 @@
 use crate::runtime::respond::tests::support::{message, test_meta, test_service};
 use crate::runtime::{
-    pending::PendingOperation,
+    pending::PreparedAction,
     session::{SessionMeta, now_iso_cn},
     tools::{
         CompleteTodoTool,
         todo::{
-            ClarificationCandidate, PendingTodoClarification, TodoItemDraft, TodoPendingOperation,
+            ClarificationCandidate, PendingTodoClarification, TodoItemDraft, TodoPendingPayload,
             TodoStatus, TodoStore, TodoTimePrecision,
         },
     },
@@ -30,13 +30,28 @@ fn draft(title: &str) -> TodoItemDraft {
     }
 }
 
-fn save_pending(service: &crate::runtime::respond::RustRespondService, pending: PendingOperation) {
+fn save_pending(service: &crate::runtime::respond::RustRespondService, pending: PreparedAction) {
     let mut session = service
         .session_store
         .get_or_create_active(&test_meta())
         .unwrap();
     session.pending_operation = Some(pending);
     service.session_store.save(&mut session).unwrap();
+}
+
+fn legacy_todo_pending(payload: TodoPendingPayload) -> PreparedAction {
+    serde_json::from_value(serde_json::to_value(payload).unwrap()).unwrap()
+}
+
+fn prepared_todo_add(title: &str, scope_key: &str, created_at: &str) -> PreparedAction {
+    TodoPendingPayload::TodoAdd {
+        initiator_user_id: Some("u1".to_owned()),
+        owner_key: TodoStore::owner(Some("u1"), "group:g1").key,
+        draft: draft(title),
+        allow_revision: false,
+        created_at: created_at.to_owned(),
+    }
+    .into_prepared_action(scope_key)
 }
 
 fn stable_group_scope() -> &'static str {
@@ -96,19 +111,122 @@ async fn inbound_classification_marks_pending_input_immediate() {
     let owner = TodoStore::owner(Some("u1"), "group:g1");
     save_pending(
         &service,
-        TodoPendingOperation::TodoAdd {
+        TodoPendingPayload::TodoAdd {
             initiator_user_id: Some("u1".to_owned()),
             owner_key: owner.key,
             draft: draft("买牛奶"),
             allow_revision: false,
             created_at: now_iso_cn(),
         }
-        .into(),
+        .into_prepared_action("group:g1"),
     );
 
     let classification = service.classify_inbound(message("取消")).unwrap();
 
     assert_eq!(classification.kind, CoreInboundKind::Immediate);
+}
+
+#[tokio::test]
+async fn prepared_todo_add_confirm_executes_once_and_clears_pending() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    save_pending(
+        &service,
+        prepared_todo_add("只新增一次", "group:g1", &now_iso_cn()),
+    );
+
+    let stored = service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap()
+        .pending_operation
+        .expect("missing prepared action");
+    assert!(!stored.is_legacy());
+    assert_eq!(stored.scope_key(), Some("group:g1"));
+    assert!(stored.expires_at().is_some());
+    assert_eq!(stored.revision(), 1);
+
+    let first = service.respond(message("确认")).await.unwrap();
+    assert!(first.text.unwrap().contains("已新增待办"));
+    assert_eq!(service.task_store.list_pending(&owner).unwrap().len(), 1);
+    assert!(
+        service
+            .session_store
+            .get_or_create_active(&test_meta())
+            .unwrap()
+            .pending_operation
+            .is_none()
+    );
+
+    // Pending 已完成并清除，重复“确认”不会再次取得 PreparedAction 执行权。
+    service.respond(message("确认")).await.unwrap();
+    assert_eq!(service.task_store.list_pending(&owner).unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn prepared_todo_add_cancel_and_expiry_never_execute() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    save_pending(
+        &service,
+        prepared_todo_add("取消项", "group:g1", &now_iso_cn()),
+    );
+    let cancelled = service.respond(message("取消")).await.unwrap();
+    assert!(cancelled.text.unwrap().contains("已取消"));
+    assert!(service.task_store.list_pending(&owner).unwrap().is_empty());
+
+    save_pending(
+        &service,
+        prepared_todo_add("过期项", "group:g1", "2020-01-01T00:00:00+08:00"),
+    );
+    let expired = service.respond(message("确认")).await.unwrap();
+    assert!(expired.text.unwrap().contains("已过期"));
+    assert!(service.task_store.list_pending(&owner).unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn prepared_todo_add_cross_scope_is_cleared_without_execution() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    save_pending(
+        &service,
+        prepared_todo_add("错误作用域", "group:g2", &now_iso_cn()),
+    );
+
+    let response = service.respond(message("确认")).await.unwrap();
+    assert!(response.text.unwrap().contains("会话作用域已变化"));
+    assert!(service.task_store.list_pending(&owner).unwrap().is_empty());
+    assert!(
+        service
+            .session_store
+            .get_or_create_active(&test_meta())
+            .unwrap()
+            .pending_operation
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn incomplete_legacy_todo_pending_is_cleared_without_guessing() {
+    let service = test_service();
+    let pending: PreparedAction = serde_json::from_value(json!({
+        "kind": "todo_bulk_delete",
+        "owner_key": TodoStore::owner(Some("u1"), "group:g1").key,
+        "created_at": now_iso_cn()
+    }))
+    .unwrap();
+    save_pending(&service, pending);
+
+    let response = service.respond(message("确认")).await.unwrap();
+    assert!(response.text.unwrap().contains("缺少安全恢复所需的信息"));
+    assert!(
+        service
+            .session_store
+            .get_or_create_active(&test_meta())
+            .unwrap()
+            .pending_operation
+            .is_none()
+    );
 }
 
 #[test]
@@ -151,14 +269,14 @@ async fn todo_add_pending_confirm_and_cancel_are_supported_for_tool_path() {
     let owner = TodoStore::owner(Some("u1"), "group:g1");
     save_pending(
         &service,
-        TodoPendingOperation::TodoAdd {
+        TodoPendingPayload::TodoAdd {
             initiator_user_id: Some("u1".to_owned()),
             owner_key: owner.key.clone(),
             draft: draft("买牛奶"),
             allow_revision: false,
             created_at: now_iso_cn(),
         }
-        .into(),
+        .into_prepared_action("group:g1"),
     );
 
     let waiting = service.respond(message("改成买酸奶")).await.unwrap();
@@ -192,13 +310,12 @@ async fn legacy_todo_delete_pending_item_confirm_asks_to_restart_without_cancel(
     let item = service.task_store.create(&owner, draft("买牛奶")).unwrap();
     save_pending(
         &service,
-        TodoPendingOperation::TodoDelete {
+        legacy_todo_pending(TodoPendingPayload::TodoDelete {
             initiator_user_id: Some("u1".to_owned()),
             owner_key: owner.key.clone(),
             item: item.clone(),
             created_at: now_iso_cn(),
-        }
-        .into(),
+        }),
     );
 
     let cancel = service.respond(message("取消")).await.unwrap();
@@ -215,13 +332,12 @@ async fn legacy_todo_delete_pending_item_confirm_asks_to_restart_without_cancel(
 
     save_pending(
         &service,
-        TodoPendingOperation::TodoDelete {
+        legacy_todo_pending(TodoPendingPayload::TodoDelete {
             initiator_user_id: Some("u1".to_owned()),
             owner_key: owner.key.clone(),
             item: item.clone(),
             created_at: now_iso_cn(),
-        }
-        .into(),
+        }),
     );
     let confirmed = service.respond(message("确认")).await.unwrap();
     assert!(confirmed.text.unwrap().contains("旧版待确认操作已失效"));
@@ -243,13 +359,12 @@ async fn deprecated_slash_pending_is_cleared_without_execution() {
     let item = service.task_store.create(&owner, draft("旧待办")).unwrap();
     save_pending(
         &service,
-        TodoPendingOperation::TodoDone {
+        legacy_todo_pending(TodoPendingPayload::TodoDone {
             initiator_user_id: Some("u1".to_owned()),
             owner_key: owner.key.clone(),
             item: item.clone(),
             created_at: now_iso_cn(),
-        }
-        .into(),
+        }),
     );
 
     let response = service.respond(message("确认")).await.unwrap();
@@ -286,14 +401,14 @@ async fn todo_add_confirm_keeps_fresh_last_todo_action_over_stale_db_snapshot() 
     session.remember_last_todo_action(&owner.key, &stale_item, "created");
     session.remember_last_todo_query(&owner.key, "list", "", vec![stale_item.id.clone()]);
     session.pending_operation = Some(
-        TodoPendingOperation::TodoAdd {
+        TodoPendingPayload::TodoAdd {
             initiator_user_id: Some("u1".to_owned()),
             owner_key: owner.key.clone(),
             draft: draft("新待办"),
             allow_revision: false,
             created_at: now_iso_cn(),
         }
-        .into(),
+        .into_prepared_action("group:g1"),
     );
     service.session_store.save(&mut session).unwrap();
 
@@ -335,7 +450,7 @@ async fn todo_delete_confirm_pending_item_refreshes_snapshot_after_delete() {
         vec![item.id.clone(), other.id.clone()],
     );
     session.pending_operation = Some(
-        TodoPendingOperation::TodoBulkDelete {
+        TodoPendingPayload::TodoBulkDelete {
             initiator_user_id: Some("u1".to_owned()),
             owner_key: owner.key.clone(),
             item_ids: vec![item.id.clone()],
@@ -345,7 +460,7 @@ async fn todo_delete_confirm_pending_item_refreshes_snapshot_after_delete() {
             source_condition: "进行中待办".to_owned(),
             created_at: now_iso_cn(),
         }
-        .into(),
+        .into_prepared_action("group:g1"),
     );
     service.session_store.save(&mut session).unwrap();
 
@@ -394,13 +509,12 @@ async fn todo_delete_confirm_skips_item_when_status_changed_after_pending_create
 
     save_pending(
         &service,
-        TodoPendingOperation::TodoDelete {
+        legacy_todo_pending(TodoPendingPayload::TodoDelete {
             initiator_user_id: Some("u1".to_owned()),
             owner_key: owner.key.clone(),
             item: item.clone(),
             created_at: now_iso_cn(),
-        }
-        .into(),
+        }),
     );
 
     service.task_store.complete(&owner, &item.id).unwrap();
@@ -432,7 +546,7 @@ async fn todo_bulk_delete_confirm_keeps_items_whose_status_changed_after_pending
 
     save_pending(
         &service,
-        TodoPendingOperation::TodoBulkDelete {
+        TodoPendingPayload::TodoBulkDelete {
             initiator_user_id: Some("u1".to_owned()),
             owner_key: owner.key.clone(),
             item_ids: ids.clone(),
@@ -442,7 +556,7 @@ async fn todo_bulk_delete_confirm_keeps_items_whose_status_changed_after_pending
             source_condition: "已完成待办".to_owned(),
             created_at: now_iso_cn(),
         }
-        .into(),
+        .into_prepared_action("group:g1"),
     );
 
     service
@@ -480,7 +594,7 @@ async fn stable_group_todo_clarify_is_isolated_by_actor_interaction_session() {
         .get_or_create_active(&stable_group_interaction_meta("u1"))
         .unwrap();
     session.pending_operation = Some(
-        TodoPendingOperation::TodoClarify {
+        TodoPendingPayload::TodoClarify {
             initiator_user_id: Some("u1".to_owned()),
             owner_key: owner.key.clone(),
             request: PendingTodoClarification {
@@ -499,7 +613,7 @@ async fn stable_group_todo_clarify_is_isolated_by_actor_interaction_session() {
             },
             created_at,
         }
-        .into(),
+        .into_prepared_action(&session.scope_key),
     );
     service.session_store.save(&mut session).unwrap();
 
@@ -587,7 +701,7 @@ async fn todo_clarify_manage_recurring_reminder_number_resume_skips_next() {
         .get_or_create_active(&test_meta())
         .unwrap();
     session.pending_operation = Some(
-        TodoPendingOperation::TodoClarify {
+        TodoPendingPayload::TodoClarify {
             initiator_user_id: Some("u1".to_owned()),
             owner_key: owner.key.clone(),
             request: PendingTodoClarification {
@@ -611,7 +725,7 @@ async fn todo_clarify_manage_recurring_reminder_number_resume_skips_next() {
             },
             created_at,
         }
-        .into(),
+        .into_prepared_action(&session.scope_key),
     );
     service.session_store.save(&mut session).unwrap();
 

--- a/qq-maid-core/src/runtime/tools/todo/pending_tests.rs
+++ b/qq-maid-core/src/runtime/tools/todo/pending_tests.rs
@@ -39,16 +39,21 @@ fn save_pending(service: &crate::runtime::respond::RustRespondService, pending: 
     service.session_store.save(&mut session).unwrap();
 }
 
-fn legacy_todo_pending(payload: TodoPendingPayload) -> PreparedAction {
-    serde_json::from_value(serde_json::to_value(payload).unwrap()).unwrap()
-}
-
-fn prepared_todo_add(title: &str, scope_key: &str, created_at: &str) -> PreparedAction {
-    TodoPendingPayload::TodoAdd {
+fn prepared_bulk_delete(
+    owner_key: &str,
+    item_ids: Vec<String>,
+    status: TodoStatus,
+    scope_key: &str,
+    created_at: &str,
+) -> PreparedAction {
+    TodoPendingPayload::TodoBulkDelete {
         initiator_user_id: Some("u1".to_owned()),
-        owner_key: TodoStore::owner(Some("u1"), "group:g1").key,
-        draft: draft(title),
-        allow_revision: false,
+        owner_key: owner_key.to_owned(),
+        matched_count: item_ids.len(),
+        item_ids,
+        status,
+        summary: "待删除事项".to_owned(),
+        source_condition: "测试范围".to_owned(),
         created_at: created_at.to_owned(),
     }
     .into_prepared_action(scope_key)
@@ -111,14 +116,13 @@ async fn inbound_classification_marks_pending_input_immediate() {
     let owner = TodoStore::owner(Some("u1"), "group:g1");
     save_pending(
         &service,
-        TodoPendingPayload::TodoAdd {
-            initiator_user_id: Some("u1".to_owned()),
-            owner_key: owner.key,
-            draft: draft("买牛奶"),
-            allow_revision: false,
-            created_at: now_iso_cn(),
-        }
-        .into_prepared_action("group:g1"),
+        prepared_bulk_delete(
+            &owner.key,
+            vec!["todo-1".to_owned()],
+            TodoStatus::Pending,
+            "group:g1",
+            &now_iso_cn(),
+        ),
     );
 
     let classification = service.classify_inbound(message("取消")).unwrap();
@@ -127,12 +131,22 @@ async fn inbound_classification_marks_pending_input_immediate() {
 }
 
 #[tokio::test]
-async fn prepared_todo_add_confirm_executes_once_and_clears_pending() {
+async fn prepared_bulk_delete_confirm_executes_once_and_clears_pending() {
     let service = test_service();
     let owner = TodoStore::owner(Some("u1"), "group:g1");
+    let item = service
+        .task_store
+        .create(&owner, draft("只删除一次"))
+        .unwrap();
     save_pending(
         &service,
-        prepared_todo_add("只新增一次", "group:g1", &now_iso_cn()),
+        prepared_bulk_delete(
+            &owner.key,
+            vec![item.id.clone()],
+            TodoStatus::Pending,
+            "group:g1",
+            &now_iso_cn(),
+        ),
     );
 
     let stored = service
@@ -141,14 +155,19 @@ async fn prepared_todo_add_confirm_executes_once_and_clears_pending() {
         .unwrap()
         .pending_operation
         .expect("missing prepared action");
-    assert!(!stored.is_legacy());
-    assert_eq!(stored.scope_key(), Some("group:g1"));
-    assert!(stored.expires_at().is_some());
+    assert_eq!(stored.scope_key(), "group:g1");
+    assert!(!stored.expires_at().is_empty());
     assert_eq!(stored.revision(), 1);
 
     let first = service.respond(message("确认")).await.unwrap();
-    assert!(first.text.unwrap().contains("已新增待办"));
-    assert_eq!(service.task_store.list_pending(&owner).unwrap().len(), 1);
+    assert!(first.text.unwrap().contains("已永久删除 1 条进行中待办"));
+    assert!(
+        service
+            .task_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .is_none()
+    );
     assert!(
         service
             .session_store
@@ -160,65 +179,90 @@ async fn prepared_todo_add_confirm_executes_once_and_clears_pending() {
 
     // Pending 已完成并清除，重复“确认”不会再次取得 PreparedAction 执行权。
     service.respond(message("确认")).await.unwrap();
-    assert_eq!(service.task_store.list_pending(&owner).unwrap().len(), 1);
-}
-
-#[tokio::test]
-async fn prepared_todo_add_cancel_and_expiry_never_execute() {
-    let service = test_service();
-    let owner = TodoStore::owner(Some("u1"), "group:g1");
-    save_pending(
-        &service,
-        prepared_todo_add("取消项", "group:g1", &now_iso_cn()),
-    );
-    let cancelled = service.respond(message("取消")).await.unwrap();
-    assert!(cancelled.text.unwrap().contains("已取消"));
-    assert!(service.task_store.list_pending(&owner).unwrap().is_empty());
-
-    save_pending(
-        &service,
-        prepared_todo_add("过期项", "group:g1", "2020-01-01T00:00:00+08:00"),
-    );
-    let expired = service.respond(message("确认")).await.unwrap();
-    assert!(expired.text.unwrap().contains("已过期"));
-    assert!(service.task_store.list_pending(&owner).unwrap().is_empty());
-}
-
-#[tokio::test]
-async fn prepared_todo_add_cross_scope_is_cleared_without_execution() {
-    let service = test_service();
-    let owner = TodoStore::owner(Some("u1"), "group:g1");
-    save_pending(
-        &service,
-        prepared_todo_add("错误作用域", "group:g2", &now_iso_cn()),
-    );
-
-    let response = service.respond(message("确认")).await.unwrap();
-    assert!(response.text.unwrap().contains("会话作用域已变化"));
-    assert!(service.task_store.list_pending(&owner).unwrap().is_empty());
     assert!(
         service
-            .session_store
-            .get_or_create_active(&test_meta())
+            .task_store
+            .get_by_id(&owner, &item.id)
             .unwrap()
-            .pending_operation
             .is_none()
     );
 }
 
 #[tokio::test]
-async fn incomplete_legacy_todo_pending_is_cleared_without_guessing() {
+async fn prepared_bulk_delete_cancel_and_expiry_never_execute() {
     let service = test_service();
-    let pending: PreparedAction = serde_json::from_value(json!({
-        "kind": "todo_bulk_delete",
-        "owner_key": TodoStore::owner(Some("u1"), "group:g1").key,
-        "created_at": now_iso_cn()
-    }))
-    .unwrap();
-    save_pending(&service, pending);
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    let cancelled_item = service.task_store.create(&owner, draft("取消项")).unwrap();
+    save_pending(
+        &service,
+        prepared_bulk_delete(
+            &owner.key,
+            vec![cancelled_item.id.clone()],
+            TodoStatus::Pending,
+            "group:g1",
+            &now_iso_cn(),
+        ),
+    );
+    let cancelled = service.respond(message("取消")).await.unwrap();
+    assert!(cancelled.text.unwrap().contains("已取消"));
+    assert!(
+        service
+            .task_store
+            .get_by_id(&owner, &cancelled_item.id)
+            .unwrap()
+            .is_some()
+    );
+
+    let expired_item = service.task_store.create(&owner, draft("过期项")).unwrap();
+    save_pending(
+        &service,
+        prepared_bulk_delete(
+            &owner.key,
+            vec![expired_item.id.clone()],
+            TodoStatus::Pending,
+            "group:g1",
+            "2020-01-01T00:00:00+08:00",
+        ),
+    );
+    let expired = service.respond(message("确认")).await.unwrap();
+    assert!(expired.text.unwrap().contains("已过期"));
+    assert!(
+        service
+            .task_store
+            .get_by_id(&owner, &expired_item.id)
+            .unwrap()
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn prepared_bulk_delete_cross_scope_is_cleared_without_execution() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    let item = service
+        .task_store
+        .create(&owner, draft("错误作用域"))
+        .unwrap();
+    save_pending(
+        &service,
+        prepared_bulk_delete(
+            &owner.key,
+            vec![item.id.clone()],
+            TodoStatus::Pending,
+            "group:g2",
+            &now_iso_cn(),
+        ),
+    );
 
     let response = service.respond(message("确认")).await.unwrap();
-    assert!(response.text.unwrap().contains("缺少安全恢复所需的信息"));
+    assert!(response.text.unwrap().contains("会话作用域已变化"));
+    assert!(
+        service
+            .task_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .is_some()
+    );
     assert!(
         service
             .session_store
@@ -264,58 +308,19 @@ fn inbound_classification_marks_natural_todo_queries_immediate() {
 }
 
 #[tokio::test]
-async fn todo_add_pending_confirm_and_cancel_are_supported_for_tool_path() {
-    let service = test_service();
-    let owner = TodoStore::owner(Some("u1"), "group:g1");
-    save_pending(
-        &service,
-        TodoPendingPayload::TodoAdd {
-            initiator_user_id: Some("u1".to_owned()),
-            owner_key: owner.key.clone(),
-            draft: draft("买牛奶"),
-            allow_revision: false,
-            created_at: now_iso_cn(),
-        }
-        .into_prepared_action("group:g1"),
-    );
-
-    let waiting = service.respond(message("改成买酸奶")).await.unwrap();
-    assert!(waiting.text.unwrap().contains("还在等待确认"));
-    assert!(service.task_store.list_pending(&owner).unwrap().is_empty());
-
-    let confirmed = service.respond(message("确认")).await.unwrap();
-    let text = confirmed.text.unwrap();
-    assert!(text.contains("✅ 已新增待办"));
-    assert!(text.contains("买牛奶"));
-    assert!(!text.contains("🚧 当前进行中 · 共 1 项"));
-    let todos = service.task_store.list_pending(&owner).unwrap();
-    assert_eq!(todos.len(), 1);
-    let session = service
-        .session_store
-        .get_or_create_active(&test_meta())
-        .unwrap();
-    assert_eq!(
-        session
-            .last_todo_query
-            .expect("missing refreshed todo query")
-            .result_ids,
-        vec![todos[0].id.clone()]
-    );
-}
-
-#[tokio::test]
-async fn legacy_todo_delete_pending_item_confirm_asks_to_restart_without_cancel() {
+async fn invalid_single_delete_pending_scope_can_cancel_or_restart() {
     let service = test_service();
     let owner = TodoStore::owner(Some("u1"), "group:g1");
     let item = service.task_store.create(&owner, draft("买牛奶")).unwrap();
     save_pending(
         &service,
-        legacy_todo_pending(TodoPendingPayload::TodoDelete {
+        TodoPendingPayload::TodoDelete {
             initiator_user_id: Some("u1".to_owned()),
             owner_key: owner.key.clone(),
             item: item.clone(),
             created_at: now_iso_cn(),
-        }),
+        }
+        .into_prepared_action("group:g1"),
     );
 
     let cancel = service.respond(message("取消")).await.unwrap();
@@ -332,101 +337,25 @@ async fn legacy_todo_delete_pending_item_confirm_asks_to_restart_without_cancel(
 
     save_pending(
         &service,
-        legacy_todo_pending(TodoPendingPayload::TodoDelete {
+        TodoPendingPayload::TodoDelete {
             initiator_user_id: Some("u1".to_owned()),
             owner_key: owner.key.clone(),
             item: item.clone(),
-            created_at: now_iso_cn(),
-        }),
-    );
-    let confirmed = service.respond(message("确认")).await.unwrap();
-    assert!(confirmed.text.unwrap().contains("旧版待确认操作已失效"));
-    assert_eq!(
-        service
-            .task_store
-            .get_by_id(&owner, &item.id)
-            .unwrap()
-            .unwrap()
-            .status,
-        TodoStatus::Pending
-    );
-}
-
-#[tokio::test]
-async fn deprecated_slash_pending_is_cleared_without_execution() {
-    let service = test_service();
-    let owner = TodoStore::owner(Some("u1"), "group:g1");
-    let item = service.task_store.create(&owner, draft("旧待办")).unwrap();
-    save_pending(
-        &service,
-        legacy_todo_pending(TodoPendingPayload::TodoDone {
-            initiator_user_id: Some("u1".to_owned()),
-            owner_key: owner.key.clone(),
-            item: item.clone(),
-            created_at: now_iso_cn(),
-        }),
-    );
-
-    let response = service.respond(message("确认")).await.unwrap();
-    assert!(response.text.unwrap().contains("旧版待办确认流程已清理"));
-    assert_eq!(
-        service
-            .task_store
-            .get_by_id(&owner, &item.id)
-            .unwrap()
-            .unwrap()
-            .status,
-        TodoStatus::Pending
-    );
-    let session = service
-        .session_store
-        .get_or_create_active(&test_meta())
-        .unwrap();
-    assert!(session.pending_operation.is_none());
-}
-
-#[tokio::test]
-async fn todo_add_confirm_keeps_fresh_last_todo_action_over_stale_db_snapshot() {
-    let service = test_service();
-    let owner = TodoStore::owner(Some("u1"), "group:g1");
-
-    // 数据库 session 里先写入旧快照：模拟用户之前查询过待办、并新增过一条待办。
-    // 确认流程会重新从数据库读取 latest，当前轮次的新值必须覆盖这些旧值，
-    // 不能反过来被旧值覆盖，否则“刚才那个”会指向已被取代的旧待办。
-    let stale_item = service.task_store.create(&owner, draft("旧待办")).unwrap();
-    let mut session = service
-        .session_store
-        .get_or_create_active(&test_meta())
-        .unwrap();
-    session.remember_last_todo_action(&owner.key, &stale_item, "created");
-    session.remember_last_todo_query(&owner.key, "list", "", vec![stale_item.id.clone()]);
-    session.pending_operation = Some(
-        TodoPendingPayload::TodoAdd {
-            initiator_user_id: Some("u1".to_owned()),
-            owner_key: owner.key.clone(),
-            draft: draft("新待办"),
-            allow_revision: false,
             created_at: now_iso_cn(),
         }
         .into_prepared_action("group:g1"),
     );
-    service.session_store.save(&mut session).unwrap();
-
     let confirmed = service.respond(message("确认")).await.unwrap();
-    let text = confirmed.text.unwrap();
-    assert!(text.contains("✅ 已新增待办"));
-    assert!(text.contains("新待办"));
-    assert!(!text.contains("🚧 当前进行中"));
-
-    // 确认后 last_todo_action 必须指向刚新增的“新待办”；
-    // 若 append_pending_response 未合并该字段，latest 里的旧值会反向覆盖。
-    let session = service
-        .session_store
-        .get_or_create_active(&test_meta())
-        .unwrap();
-    let last_action = session.last_todo_action.expect("missing last_todo_action");
-    assert_eq!(last_action.title, "新待办");
-    assert_eq!(last_action.action, "created");
+    assert!(confirmed.text.unwrap().contains("待确认删除范围无效"));
+    assert_eq!(
+        service
+            .task_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Pending
+    );
 }
 
 #[tokio::test]
@@ -496,37 +425,6 @@ async fn todo_delete_confirm_pending_item_refreshes_snapshot_after_delete() {
             .status,
         TodoStatus::Pending
     );
-}
-
-#[tokio::test]
-async fn todo_delete_confirm_skips_item_when_status_changed_after_pending_created() {
-    let service = test_service();
-    let owner = TodoStore::owner(Some("u1"), "group:g1");
-    let item = service
-        .task_store
-        .create(&owner, draft("临时删除"))
-        .unwrap();
-
-    save_pending(
-        &service,
-        legacy_todo_pending(TodoPendingPayload::TodoDelete {
-            initiator_user_id: Some("u1".to_owned()),
-            owner_key: owner.key.clone(),
-            item: item.clone(),
-            created_at: now_iso_cn(),
-        }),
-    );
-
-    service.task_store.complete(&owner, &item.id).unwrap();
-    let confirmed = service.respond(message("确认")).await.unwrap();
-    assert!(confirmed.text.unwrap().contains("旧版待确认操作已失效"));
-
-    let current = service
-        .task_store
-        .get_by_id(&owner, &item.id)
-        .unwrap()
-        .unwrap();
-    assert_eq!(current.status, TodoStatus::Completed);
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/tools/todo/receipt.rs
+++ b/qq-maid-core/src/runtime/tools/todo/receipt.rs
@@ -24,8 +24,8 @@ use crate::{
         tools::todo::{
             ReminderFieldMode, TodoCardOptions, TodoItem, TodoListDateField, TodoListDateFilter,
             TodoOwner, TodoRecurrenceKind, TodoRecurrenceUnit, TodoRenderItem, TodoStatus,
-            TodoStore, format_todo_cards, preview_next_reminder_at,
-            todo_last_action_visible_entity_snapshot, todo_visible_entity_snapshot,
+            TodoStore, format_todo_cards, todo_last_action_visible_entity_snapshot,
+            todo_visible_entity_snapshot,
         },
     },
     service::VisibleEntitySnapshot,
@@ -334,23 +334,6 @@ fn todo_detail_body(output: &Value) -> CommandBody {
         .unwrap_or_else(|| CommandBody::plain("没有找到待办详情。"))
 }
 
-pub(crate) fn receipt_after_created(
-    todo_store: &TodoStore,
-    session: &mut SessionRecord,
-    owner: &TodoOwner,
-    item: &TodoItem,
-) -> Result<TodoWriteReceipt, LlmError> {
-    receipt_with_related_list_body(
-        todo_store,
-        session,
-        owner,
-        todo_detail_card_body("✅ 已新增待办", &todo_detail_card_item_from_todo(item)),
-        pending_list_spec(),
-        "todo_confirm",
-        None,
-    )
-}
-
 pub(crate) fn receipt_after_deleted(
     todo_store: &TodoStore,
     session: &mut SessionRecord,
@@ -622,31 +605,6 @@ fn receipt_with_related_list(
         command,
         error_code: None,
     })
-}
-
-fn receipt_with_related_list_body(
-    todo_store: &TodoStore,
-    session: &mut SessionRecord,
-    owner: &TodoOwner,
-    body: CommandBody,
-    spec: RelatedListSpec,
-    command: &'static str,
-    trailing_hint: Option<&'static str>,
-) -> Result<TodoWriteReceipt, LlmError> {
-    let text = body.text;
-    let markdown = body.markdown.unwrap_or_else(|| text.clone());
-    receipt_with_related_list(
-        todo_store,
-        session,
-        owner,
-        RelatedReceiptDraft {
-            lines: vec![text],
-            markdown_lines: vec![markdown],
-            spec,
-            command,
-            trailing_hint,
-        },
-    )
 }
 
 fn remember_related_list_snapshot(
@@ -1205,29 +1163,6 @@ fn todo_render_item_from_detail_card(item: TodoDetailCardItem) -> TodoRenderItem
         status: item.status,
         next_reminder_at: item.next_reminder_at,
         completed_at: item.completed_at,
-    }
-}
-
-fn todo_detail_card_item_from_todo(item: &TodoItem) -> TodoDetailCardItem {
-    TodoDetailCardItem {
-        title: item.title.clone(),
-        detail: item.detail.clone(),
-        due_date: item.due_date.clone(),
-        due_at: item.due_at.clone(),
-        reminder_at: item.reminder_at.clone(),
-        recurrence_kind: item.recurrence_kind.clone(),
-        recurrence_interval_days: item.recurrence_interval_days,
-        recurrence_interval: item.recurrence_interval,
-        recurrence_unit: item.recurrence_unit,
-        status: Some(
-            match item.status {
-                TodoStatus::Pending => "pending",
-                TodoStatus::Completed => "completed",
-            }
-            .to_owned(),
-        ),
-        next_reminder_at: preview_next_reminder_at(item).ok().flatten(),
-        completed_at: item.completed_at.clone(),
     }
 }
 

--- a/qq-maid-core/src/runtime/tools/todo/scope.rs
+++ b/qq-maid-core/src/runtime/tools/todo/scope.rs
@@ -17,7 +17,7 @@ use crate::{
         session::{LAST_QUERY_TTL_SECONDS, LastTodoQuery, SessionMeta, SessionStore, now_iso_cn},
         tools::todo::{
             ClarificationCandidate, PendingTodoClarification, TodoItem, TodoOwner,
-            TodoPendingOperation, TodoStatus, TodoStore, valid_last_visible_todo_query,
+            TodoPendingPayload, TodoStatus, TodoStore, valid_last_visible_todo_query,
         },
     },
 };
@@ -508,7 +508,7 @@ impl TodoToolScope {
         }
         if matches!(
             todo_pending_operation(self.session.pending_operation.as_ref()),
-            Some(TodoPendingOperation::TodoClarify { owner_key, .. }) if owner_key == self.owner.key
+            Some(TodoPendingPayload::TodoClarify { owner_key, .. }) if owner_key == self.owner.key
         ) {
             self.session.pending_operation = None;
         }
@@ -601,7 +601,7 @@ impl TodoToolScope {
         if self.selection_scope.is_some()
             && matches!(
                 todo_pending_operation(self.session.pending_operation.as_ref()),
-                Some(TodoPendingOperation::TodoClarify { owner_key, .. }) if owner_key == self.owner.key
+                Some(TodoPendingPayload::TodoClarify { owner_key, .. }) if owner_key == self.owner.key
             )
         {
             return Ok(());
@@ -698,7 +698,7 @@ impl TodoToolScope {
         let question = clarification_question(error_code, message, &candidates);
         let created_at = now_iso_cn();
         self.session.pending_operation = Some(
-            TodoPendingOperation::TodoClarify {
+            TodoPendingPayload::TodoClarify {
                 initiator_user_id: self.owner.user_id.clone(),
                 owner_key: self.owner.key.clone(),
                 request: PendingTodoClarification {
@@ -712,7 +712,7 @@ impl TodoToolScope {
                 },
                 created_at,
             }
-            .into(),
+            .into_prepared_action(&self.session.scope_key),
         );
         self.save()?;
         Ok(ToolOutput::json(serde_json::json!({
@@ -838,13 +838,9 @@ pub(in crate::runtime::tools::todo) fn clarification_candidates_for_items(
 }
 
 fn todo_pending_operation(
-    pending: Option<&crate::runtime::pending::PendingOperation>,
-) -> Option<TodoPendingOperation> {
-    pending.and_then(|pending| {
-        TodoPendingOperation::try_from_pending(pending)
-            .ok()
-            .flatten()
-    })
+    pending: Option<&crate::runtime::pending::PreparedAction>,
+) -> Option<TodoPendingPayload> {
+    pending.and_then(|pending| TodoPendingPayload::try_from_pending(pending).ok().flatten())
 }
 
 fn sanitize_clarification_arguments(arguments: &Value) -> Value {

--- a/qq-maid-core/src/runtime/tools/todo/tests/delete.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests/delete.rs
@@ -50,7 +50,7 @@ async fn delete_tool_number_clarification_includes_pending_candidates_without_vi
         ))
         .unwrap();
     match todo_pending(session.pending_operation.as_ref()) {
-        Some(TodoPendingOperation::TodoClarify { request, .. }) => {
+        Some(TodoPendingPayload::TodoClarify { request, .. }) => {
             assert_eq!(request.tool_name, "delete_todos");
             assert_eq!(request.candidates.len(), 1);
             assert_eq!(request.candidates[0].id, item.id);
@@ -141,7 +141,7 @@ async fn delete_tool_query_unique_creates_single_delete_pending() {
         ))
         .unwrap();
     match todo_pending(session.pending_operation.as_ref()) {
-        Some(TodoPendingOperation::TodoBulkDelete {
+        Some(TodoPendingPayload::TodoBulkDelete {
             item_ids, status, ..
         }) => {
             assert_eq!(item_ids.len(), 1);
@@ -253,7 +253,7 @@ async fn delete_tool_query_multiple_creates_clarification_without_snapshot_pollu
         vec![visible.id]
     );
     match todo_pending(session.pending_operation.as_ref()) {
-        Some(TodoPendingOperation::TodoClarify { request, .. }) => {
+        Some(TodoPendingPayload::TodoClarify { request, .. }) => {
             assert_eq!(request.tool_name, "delete_todos");
             assert_eq!(request.candidates.len(), 2);
         }
@@ -311,7 +311,7 @@ async fn delete_tool_query_pending_match_creates_confirmation() {
         ))
         .unwrap();
     match todo_pending(session.pending_operation.as_ref()) {
-        Some(TodoPendingOperation::TodoBulkDelete {
+        Some(TodoPendingPayload::TodoBulkDelete {
             item_ids, status, ..
         }) => {
             assert_eq!(item_ids.len(), 1);
@@ -433,7 +433,7 @@ async fn delete_numbers_prefer_current_task_query_over_stale_visible_snapshot() 
         ))
         .unwrap();
     match todo_pending(session.pending_operation.as_ref()) {
-        Some(TodoPendingOperation::TodoDelete { item, .. }) => {
+        Some(TodoPendingPayload::TodoDelete { item, .. }) => {
             assert_eq!(item.status, TodoStatus::Completed)
         }
         other => panic!("expected single delete pending, got {other:?}"),
@@ -493,7 +493,7 @@ async fn delete_numbers_prefer_quoted_snapshot_over_latest_last_todo_query() {
         ))
         .unwrap();
     match todo_pending(session.pending_operation.as_ref()) {
-        Some(TodoPendingOperation::TodoBulkDelete { item_ids, .. }) => {
+        Some(TodoPendingPayload::TodoBulkDelete { item_ids, .. }) => {
             assert_eq!(item_ids, vec![list_a_ids[6].clone()]);
             assert_ne!(item_ids, vec![list_b_ids[6].clone()]);
         }

--- a/qq-maid-core/src/runtime/tools/todo/tests/edit.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests/edit.rs
@@ -406,7 +406,7 @@ async fn unresolved_last_reference_creates_todo_clarification_pending() {
         ))
         .unwrap();
     match todo_pending(session.pending_operation.as_ref()) {
-        Some(TodoPendingOperation::TodoClarify { request, .. }) => {
+        Some(TodoPendingPayload::TodoClarify { request, .. }) => {
             assert_eq!(request.tool_name, "complete_todos");
             assert_eq!(
                 request.arguments,

--- a/qq-maid-core/src/runtime/tools/todo/tests/mod.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests/mod.rs
@@ -13,7 +13,7 @@ use qq_maid_llm::{
 
 use crate::runtime::session::{SessionMeta, SessionStore};
 use crate::runtime::tools::todo::{
-    TodoItem, TodoItemDraft, TodoOwner, TodoPendingOperation, TodoStatus, TodoStore,
+    TodoItem, TodoItemDraft, TodoOwner, TodoPendingPayload, TodoStatus, TodoStore,
     TodoTimePrecision,
 };
 

--- a/qq-maid-core/src/runtime/tools/todo/tests/support.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests/support.rs
@@ -20,13 +20,9 @@ pub(super) fn test_context() -> ToolContext {
 }
 
 pub(super) fn todo_pending(
-    pending: Option<&crate::runtime::pending::PendingOperation>,
-) -> Option<TodoPendingOperation> {
-    pending.and_then(|pending| {
-        TodoPendingOperation::try_from_pending(pending)
-            .ok()
-            .flatten()
-    })
+    pending: Option<&crate::runtime::pending::PreparedAction>,
+) -> Option<TodoPendingPayload> {
+    pending.and_then(|pending| TodoPendingPayload::try_from_pending(pending).ok().flatten())
 }
 
 pub(super) fn test_stores() -> (

--- a/qq-maid-core/src/service/tests/mod.rs
+++ b/qq-maid-core/src/service/tests/mod.rs
@@ -19,7 +19,7 @@ use crate::{
             StatusHint,
         },
         session::SessionMeta,
-        tools::todo::{TodoItemDraft, TodoPendingOperation, TodoStore, TodoTimePrecision},
+        tools::todo::{TodoItemDraft, TodoPendingPayload, TodoStore, TodoTimePrecision},
     },
     util::metrics::LlmMetrics,
 };

--- a/qq-maid-core/src/service/tests/planning.rs
+++ b/qq-maid-core/src/service/tests/planning.rs
@@ -168,7 +168,7 @@ fn core_plan_keeps_pending_confirmation_immediate() {
     let mut session = session_store.get_or_create_active(&meta).unwrap();
     let owner = TodoStore::owner(Some("u1"), private_scope());
     session.pending_operation = Some(
-        TodoPendingOperation::TodoAdd {
+        TodoPendingPayload::TodoAdd {
             initiator_user_id: Some("u1".to_owned()),
             owner_key: owner.key,
             draft: TodoItemDraft {
@@ -187,7 +187,7 @@ fn core_plan_keeps_pending_confirmation_immediate() {
             allow_revision: true,
             created_at: "2026-06-30T00:00:00+08:00".to_owned(),
         }
-        .into(),
+        .into_prepared_action(&session.scope_key),
     );
     session_store.save(&mut session).unwrap();
 

--- a/qq-maid-core/src/service/tests/planning.rs
+++ b/qq-maid-core/src/service/tests/planning.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::runtime::tools::todo::TodoStatus;
 
 #[test]
 fn core_plan_routes_general_private_chat_to_agent_when_tools_available() {
@@ -168,23 +169,14 @@ fn core_plan_keeps_pending_confirmation_immediate() {
     let mut session = session_store.get_or_create_active(&meta).unwrap();
     let owner = TodoStore::owner(Some("u1"), private_scope());
     session.pending_operation = Some(
-        TodoPendingPayload::TodoAdd {
+        TodoPendingPayload::TodoBulkDelete {
             initiator_user_id: Some("u1".to_owned()),
             owner_key: owner.key,
-            draft: TodoItemDraft {
-                title: "检查日志".to_owned(),
-                detail: None,
-                raw_text: Some("检查日志".to_owned()),
-                due_date: None,
-                due_at: None,
-                reminder_at: None,
-                time_precision: TodoTimePrecision::None,
-                recurrence_kind: crate::runtime::tools::todo::TodoRecurrenceKind::None,
-                recurrence_interval_days: 0,
-                recurrence_interval: 0,
-                recurrence_unit: crate::runtime::tools::todo::TodoRecurrenceUnit::Day,
-            },
-            allow_revision: true,
+            item_ids: vec!["todo-1".to_owned()],
+            matched_count: 1,
+            status: TodoStatus::Pending,
+            summary: "检查日志".to_owned(),
+            source_condition: "测试范围".to_owned(),
             created_at: "2026-06-30T00:00:00+08:00".to_owned(),
         }
         .into_prepared_action(&session.scope_key),

--- a/qq-maid-core/src/storage/session/mod.rs
+++ b/qq-maid-core/src/storage/session/mod.rs
@@ -6,9 +6,10 @@
 
 pub use qq_maid_common::redaction::redact_sensitive_text;
 use qq_maid_common::time_context;
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
 use serde_json::{Map, Value};
 
+use crate::runtime::pending::{PreparedActionExecutionContext, PreparedActionValidationError};
 use crate::storage::database::{SqliteDatabase, SqliteMigration};
 
 mod error;
@@ -121,6 +122,18 @@ pub const DEFAULT_SESSION_TITLE: &str = "未命名会话";
 /// 最近列表/查询快照的统一有效期（秒）。
 pub const LAST_QUERY_TTL_SECONDS: i64 = 10 * 60;
 
+/// 原子领取 PreparedAction 执行权的结果。
+#[derive(Debug)]
+pub enum PendingExecutionClaim {
+    /// 已将数据库中的最新 pending 切换为 Executing；只有该分支允许执行副作用。
+    Claimed(SessionRecord),
+    /// 最新 pending 已变化、失效或被其他请求领取，不得执行副作用。
+    Rejected {
+        session: SessionRecord,
+        error: PreparedActionValidationError,
+    },
+}
+
 /// 会话存储器，基于项目通用 SQLite 连接实现。
 ///
 /// 数据库连接由应用启动时统一打开并执行 migration；SessionStore 不再读取
@@ -175,6 +188,73 @@ impl SessionStore {
     pub fn save(&self, session: &mut SessionRecord) -> Result<(), SessionError> {
         let mut conn = self.connection()?;
         self.save_unlocked(&mut conn, session, true)
+    }
+
+    /// 在 SQLite IMMEDIATE 事务内校验最新 PreparedAction 并原子切换到 Executing。
+    ///
+    /// 这一步必须发生在真实工具调用之前；并发或重复确认只会有一个请求取得执行权。
+    pub fn claim_pending_execution(
+        &self,
+        session_id: &str,
+        context: &PreparedActionExecutionContext<'_>,
+    ) -> Result<PendingExecutionClaim, SessionError> {
+        let mut conn = self.connection()?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(SessionError::from_sql)?;
+        let mut latest = load_session_unlocked(&tx, session_id)?.ok_or_else(|| {
+            SessionError::data(format!(
+                "session `{session_id}` disappeared before pending execution"
+            ))
+        })?;
+        let Some(pending) = latest.pending_operation.as_mut() else {
+            tx.commit().map_err(SessionError::from_sql)?;
+            return Ok(PendingExecutionClaim::Rejected {
+                session: latest,
+                error: PreparedActionValidationError::InvalidState,
+            });
+        };
+        if let Err(err) = pending.begin_execution(context) {
+            tx.commit().map_err(SessionError::from_sql)?;
+            return Ok(PendingExecutionClaim::Rejected {
+                session: latest,
+                error: err,
+            });
+        }
+        latest.updated_at = now_iso_cn();
+        upsert_session_tx(&tx, &latest)?;
+        replace_messages_tx(&tx, &latest)?;
+        tx.commit().map_err(SessionError::from_sql)?;
+        Ok(PendingExecutionClaim::Claimed(latest))
+    }
+
+    /// 将已领取但真实执行失败的动作标记为 Failed，并返回数据库最新 Session。
+    pub fn mark_pending_execution_failed(
+        &self,
+        session_id: &str,
+        revision: u64,
+    ) -> Result<SessionRecord, SessionError> {
+        let mut conn = self.connection()?;
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(SessionError::from_sql)?;
+        let mut latest = load_session_unlocked(&tx, session_id)?.ok_or_else(|| {
+            SessionError::data(format!(
+                "session `{session_id}` disappeared after pending execution failed"
+            ))
+        })?;
+        let pending = latest
+            .pending_operation
+            .as_mut()
+            .ok_or_else(|| SessionError::data("pending disappeared after execution failed"))?;
+        pending
+            .mark_failed(revision)
+            .map_err(|err| SessionError::data(format!("failed to mark pending failed: {err}")))?;
+        latest.updated_at = now_iso_cn();
+        upsert_session_tx(&tx, &latest)?;
+        replace_messages_tx(&tx, &latest)?;
+        tx.commit().map_err(SessionError::from_sql)?;
+        Ok(latest)
     }
 
     /// 仅当当前标题仍为预期旧标题时更新标题，不回写会话历史或其他状态。

--- a/qq-maid-core/src/storage/session/model.rs
+++ b/qq-maid-core/src/storage/session/model.rs
@@ -5,7 +5,7 @@ use serde_json::{Map, Value};
 
 use crate::{
     identity::{parse_stable_scope_key, stable_scope_key},
-    runtime::pending::PendingOperation,
+    runtime::pending::PreparedAction,
     runtime::tools::todo::{TodoItem, TodoStatus},
 };
 
@@ -43,7 +43,7 @@ pub struct SessionRecord {
     #[serde(default)]
     pub history: Vec<SessionMessage>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pending_operation: Option<PendingOperation>,
+    pub pending_operation: Option<PreparedAction>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_todo_query: Option<LastTodoQuery>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/qq-maid-core/src/storage/session/row.rs
+++ b/qq-maid-core/src/storage/session/row.rs
@@ -7,7 +7,7 @@
 
 use rusqlite::{Connection, OptionalExtension, Row, params};
 
-use crate::runtime::pending::PendingOperation;
+use crate::runtime::pending::PreparedAction;
 
 use super::jsonio::{decode_json, decode_optional_json};
 use super::normalize::normalize_session;
@@ -101,7 +101,7 @@ impl StoredSessionRow {
 
 fn decode_pending_operation_json(
     text: Option<&str>,
-) -> Result<Option<PendingOperation>, SessionError> {
+) -> Result<Option<PreparedAction>, SessionError> {
     let Some(text) = text.map(str::trim).filter(|text| !text.is_empty()) else {
         return Ok(None);
     };

--- a/qq-maid-core/src/storage/session/row.rs
+++ b/qq-maid-core/src/storage/session/row.rs
@@ -81,7 +81,7 @@ impl StoredSessionRow {
             history,
             pending_operation: decode_pending_operation_json(
                 self.pending_operation_json.as_deref(),
-            )?,
+            ),
             last_todo_query: decode_optional_json(
                 self.last_todo_query_json.as_deref(),
                 "last todo query",
@@ -99,28 +99,20 @@ impl StoredSessionRow {
     }
 }
 
-fn decode_pending_operation_json(
-    text: Option<&str>,
-) -> Result<Option<PreparedAction>, SessionError> {
-    let Some(text) = text.map(str::trim).filter(|text| !text.is_empty()) else {
-        return Ok(None);
+fn decode_pending_operation_json(text: Option<&str>) -> Option<PreparedAction> {
+    let text = text.map(str::trim).filter(|text| !text.is_empty())?;
+    let pending = match serde_json::from_str::<PreparedAction>(text) {
+        Ok(pending) => pending,
+        Err(err) => {
+            tracing::warn!(error = %err, "discarding unreadable session pending operation");
+            return None;
+        }
     };
-    let value = serde_json::from_str::<serde_json::Value>(text).map_err(|err| {
-        SessionError::decode(format!("failed to decode pending operation: {err}"))
-    })?;
-    if is_legacy_memory_pending(&value) {
-        return Ok(None);
+    if let Err(err) = pending.validate_envelope() {
+        tracing::warn!(error = %err, "discarding unsupported session pending operation");
+        return None;
     }
-    serde_json::from_value(value)
-        .map(Some)
-        .map_err(|err| SessionError::decode(format!("failed to decode pending operation: {err}")))
-}
-
-fn is_legacy_memory_pending(value: &serde_json::Value) -> bool {
-    matches!(
-        value.get("kind").and_then(serde_json::Value::as_str),
-        Some("memory_create" | "memory_update" | "memory_delete")
-    )
+    Some(pending)
 }
 
 /// 按 session_id 整行读取并规范化为 `SessionRecord`，缺失返回 None。
@@ -144,8 +136,21 @@ pub(super) fn load_session_unlocked(
     let Some(row) = row else {
         return Ok(None);
     };
+    let stored_pending = row
+        .pending_operation_json
+        .as_deref()
+        .is_some_and(|text| !text.trim().is_empty());
     let messages = load_messages_unlocked(conn, &row.session_id)?;
     let mut session = row.into_record(messages)?;
+    if stored_pending && session.pending_operation.is_none() {
+        // Pending 是短期会话中间状态。升级前的扁平格式或损坏 envelope 不做恢复、
+        // 不推断缺失字段，读取时直接从 Session 清理，后续操作需由用户重新发起。
+        conn.execute(
+            "UPDATE sessions SET pending_operation_json = NULL WHERE session_id = ?1",
+            params![session.session_id.as_str()],
+        )
+        .map_err(SessionError::from_sql)?;
+    }
     normalize_session(&mut session);
     Ok(Some(session))
 }

--- a/qq-maid-core/src/storage/session/tests.rs
+++ b/qq-maid-core/src/storage/session/tests.rs
@@ -1,7 +1,10 @@
 use super::*;
 use crate::runtime::{
-    pending::PendingOperation,
-    tools::todo::{TodoItemDraft, TodoPendingOperation, TodoStatus, valid_last_visible_todo_query},
+    pending::{
+        PreparedAction, PreparedActionExecutionContext, PreparedActionMetadata,
+        PreparedActionState, PreparedActionValidationError,
+    },
+    tools::todo::{TodoItemDraft, TodoPendingPayload, TodoStatus, valid_last_visible_todo_query},
 };
 use uuid::Uuid;
 
@@ -31,8 +34,8 @@ fn write_pending_json_for_test(store: &SessionStore, session_id: &str, pending_j
     .unwrap();
 }
 
-fn pending_todo_add(title: &str) -> PendingOperation {
-    TodoPendingOperation::TodoAdd {
+fn pending_todo_add(title: &str) -> PreparedAction {
+    TodoPendingPayload::TodoAdd {
         initiator_user_id: Some("u1".to_owned()),
         owner_key: "u1".to_owned(),
         draft: TodoItemDraft {
@@ -51,7 +54,80 @@ fn pending_todo_add(title: &str) -> PendingOperation {
         allow_revision: false,
         created_at: now_iso_cn(),
     }
-    .into()
+    .into_prepared_action("group:g1")
+}
+
+fn prepared_action(scope_key: &str) -> PreparedAction {
+    PreparedAction::new(
+        PreparedActionMetadata {
+            domain: "todo".to_owned(),
+            action_kind: "todo_add".to_owned(),
+            initiator_user_id: Some("u1".to_owned()),
+            owner_key: Some("u1".to_owned()),
+            scope_key: scope_key.to_owned(),
+            created_at: "2026-07-15T10:00:00+08:00".to_owned(),
+            expires_at: "2026-07-15T10:10:00+08:00".to_owned(),
+        },
+        serde_json::json!({"title": "测试"}),
+        serde_json::json!({
+            "kind": "todo_add",
+            "initiator_user_id": "u1",
+            "owner_key": "u1",
+            "draft": {"title": "测试"},
+            "created_at": "2026-07-15T10:00:00+08:00"
+        }),
+    )
+}
+
+#[test]
+fn pending_execution_claim_is_atomic_and_revision_guarded() {
+    let store = test_store();
+    let meta = test_meta();
+    let mut session = store.create(&meta, "原子领取", true).unwrap();
+    session.pending_operation = Some(prepared_action(&meta.scope_key));
+    store.save(&mut session).unwrap();
+    let context = PreparedActionExecutionContext {
+        initiator_user_id: Some("u1"),
+        owner_key: Some("u1"),
+        scope_key: &meta.scope_key,
+        expected_revision: 1,
+        now: "2026-07-15T10:05:00+08:00",
+    };
+
+    let claimed = store
+        .claim_pending_execution(&session.session_id, &context)
+        .unwrap();
+    let PendingExecutionClaim::Claimed(claimed_session) = claimed else {
+        panic!("first claim should succeed");
+    };
+    assert_eq!(
+        claimed_session.pending_operation.as_ref().unwrap().state(),
+        PreparedActionState::Executing
+    );
+
+    let repeated = store
+        .claim_pending_execution(&session.session_id, &context)
+        .unwrap();
+    assert!(matches!(
+        repeated,
+        PendingExecutionClaim::Rejected {
+            error: PreparedActionValidationError::InvalidState,
+            ..
+        }
+    ));
+
+    let failed = store
+        .mark_pending_execution_failed(&session.session_id, 1)
+        .unwrap();
+    assert_eq!(
+        failed.pending_operation.as_ref().unwrap().state(),
+        PreparedActionState::Failed
+    );
+    assert_eq!(
+        failed.pending_operation.as_ref().unwrap().revision(),
+        1,
+        "失败状态保留原 revision，不能被当成一次修订后重试"
+    );
 }
 
 #[test]

--- a/qq-maid-core/src/storage/session/tests.rs
+++ b/qq-maid-core/src/storage/session/tests.rs
@@ -4,7 +4,7 @@ use crate::runtime::{
         PreparedAction, PreparedActionExecutionContext, PreparedActionMetadata,
         PreparedActionState, PreparedActionValidationError,
     },
-    tools::todo::{TodoItemDraft, TodoPendingPayload, TodoStatus, valid_last_visible_todo_query},
+    tools::todo::{TodoPendingPayload, TodoStatus, valid_last_visible_todo_query},
 };
 use uuid::Uuid;
 
@@ -34,24 +34,15 @@ fn write_pending_json_for_test(store: &SessionStore, session_id: &str, pending_j
     .unwrap();
 }
 
-fn pending_todo_add(title: &str) -> PreparedAction {
-    TodoPendingPayload::TodoAdd {
+fn pending_todo_delete(summary: &str) -> PreparedAction {
+    TodoPendingPayload::TodoBulkDelete {
         initiator_user_id: Some("u1".to_owned()),
         owner_key: "u1".to_owned(),
-        draft: TodoItemDraft {
-            title: title.to_owned(),
-            detail: None,
-            raw_text: Some(title.to_owned()),
-            due_date: None,
-            due_at: None,
-            reminder_at: None,
-            time_precision: Default::default(),
-            recurrence_kind: Default::default(),
-            recurrence_interval_days: 0,
-            recurrence_interval: 0,
-            recurrence_unit: Default::default(),
-        },
-        allow_revision: false,
+        item_ids: vec!["todo-1".to_owned()],
+        matched_count: 1,
+        status: TodoStatus::Pending,
+        summary: summary.to_owned(),
+        source_condition: "测试范围".to_owned(),
         created_at: now_iso_cn(),
     }
     .into_prepared_action("group:g1")
@@ -158,7 +149,7 @@ fn reset_keeps_session_but_clears_context() {
     let mut session = store.create(&meta, "话题", true).unwrap();
     session.summary = "摘要".to_owned();
     session.append_message("user", "hi");
-    session.pending_operation = Some(pending_todo_add("新待办"));
+    session.pending_operation = Some(pending_todo_delete("新待办"));
 
     session.reset();
     store.save(&mut session).unwrap();
@@ -279,7 +270,7 @@ fn sqlite_reopen_restores_pending_and_last_queries() {
     let meta = test_meta();
     let store = SessionStore::new(SqliteDatabase::open(&path, SESSION_MIGRATIONS).unwrap());
     let mut session = store.create(&meta, "跨进程状态", true).unwrap();
-    session.pending_operation = Some(pending_todo_add("需要确认的待办"));
+    session.pending_operation = Some(pending_todo_delete("需要确认的待办"));
     session.last_todo_query = Some(LastTodoQuery {
         owner_key: "u1".to_owned(),
         query_type: "pending".to_owned(),
@@ -316,8 +307,8 @@ fn sqlite_reopen_restores_pending_and_last_queries() {
 }
 
 #[test]
-fn legacy_memory_pending_json_loads_as_no_pending() {
-    for kind in ["memory_create", "memory_update", "memory_delete"] {
+fn flat_pending_json_is_cleared_on_read() {
+    for kind in ["todo_add", "todo_delete", "memory_create"] {
         let store = test_store();
         let meta = test_meta();
         let session = store.create(&meta, "旧 memory pending", true).unwrap();
@@ -336,11 +327,20 @@ fn legacy_memory_pending_json_loads_as_no_pending() {
 
         assert_eq!(reloaded.session_id, session.session_id, "kind={kind}");
         assert!(reloaded.pending_operation.is_none(), "kind={kind}");
+        let conn = store.connection().unwrap();
+        let stored: Option<String> = conn
+            .query_row(
+                "SELECT pending_operation_json FROM sessions WHERE session_id = ?1",
+                params![session.session_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(stored.is_none(), "kind={kind}");
     }
 }
 
 #[test]
-fn unknown_or_broken_pending_json_still_reports_decode_error() {
+fn unknown_pending_json_is_cleared_instead_of_blocking_session() {
     let store = test_store();
     let meta = test_meta();
     let session = store.create(&meta, "未知 pending", true).unwrap();
@@ -350,14 +350,34 @@ fn unknown_or_broken_pending_json_still_reports_decode_error() {
         r#"{"kind":"unknown_pending","created_at":"2026-07-01T00:00:00+08:00"}"#,
     );
 
-    let err = store.get_or_create_active(&meta).unwrap_err();
-    assert_eq!(err.code(), "decode_error");
-    assert!(err.message().contains("pending operation"));
+    let reloaded = store.get_or_create_active(&meta).unwrap();
+    assert!(reloaded.pending_operation.is_none());
 
     write_pending_json_for_test(&store, &session.session_id, "{");
-    let err = store.get_or_create_active(&meta).unwrap_err();
-    assert_eq!(err.code(), "decode_error");
-    assert!(err.message().contains("pending operation"));
+    let reloaded = store.get_or_create_active(&meta).unwrap();
+    assert!(reloaded.pending_operation.is_none());
+}
+
+#[test]
+fn unsupported_prepared_action_schema_is_cleared_on_read() {
+    let store = test_store();
+    let meta = test_meta();
+    let session = store.create(&meta, "旧版本 envelope", true).unwrap();
+    let mut value = serde_json::to_value(prepared_action("group:g1")).unwrap();
+    value["schema_version"] = serde_json::json!(0);
+    write_pending_json_for_test(&store, &session.session_id, &value.to_string());
+
+    let reloaded = store.get_or_create_active(&meta).unwrap();
+    assert!(reloaded.pending_operation.is_none());
+    let conn = store.connection().unwrap();
+    let stored: Option<String> = conn
+        .query_row(
+            "SELECT pending_operation_json FROM sessions WHERE session_id = ?1",
+            params![session.session_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(stored.is_none());
 }
 
 #[test]
@@ -369,7 +389,7 @@ fn append_exchange_with_latest_merges_query_snapshot_without_overwriting_newer_f
     store.save(&mut stale).unwrap();
 
     let mut latest = store.get_or_create_active(&meta).unwrap();
-    latest.pending_operation = Some(pending_todo_add("较新的 pending"));
+    latest.pending_operation = Some(pending_todo_delete("较新的 pending"));
     latest.last_todo_action = Some(LastTodoAction {
         owner_key: "group:g1".to_owned(),
         item_id: "todo-new".to_owned(),


### PR DESCRIPTION
## 背景

现有 Pending 虽然能够承载 Todo 确认，但通用层只保留了部分身份信息，缺少明确状态、`expires_at`、`revision` 和完整 scope 校验；执行前也没有统一的原子领取步骤，无法为后续修订和其他领域确认安全复用。

## 修改

- 将 Session 中的 Pending 统一为 `PreparedAction` envelope，包含 schema version、domain、action kind、state、发起用户、owner/scope、创建与过期时间、revision、展示快照和业务 payload。
- Todo 仅保留 `TodoPendingPayload` 业务载荷，不再维护第二套生命周期结构。
- 增加等待确认、执行中、失败状态，以及用户、owner、scope、过期时间和 revision 的统一校验。
- 使用 SQLite immediate transaction 原子领取待执行动作，先持久化为 Executing 再执行副作用，阻止重复或并发确认产生第二次执行。
- 执行失败保留为 Failed 并返回真实错误；完成、取消和过期仍按原行为清理 Session Pending。
- 本次不兼容升级前遗留的 Pending 数据。旧格式仅属于短期会话中间状态，读取失败时直接清理，并要求用户重新发起操作。
- `scope_key` 和 `expires_at` 是标准 envelope 的必填字段；不再存在 schema version 0、自定义双格式 serde 或两套过期逻辑。
- 不新增数据库 migration。
- 拆分 Pending model/reply、Todo 生命周期和 clarification 模块，避免相关单文件继续膨胀。

## 行为边界

- 保留 Todo 删除、批量删除、clarification、身份与作用域隔离、固化内部 ID、执行前重读、真实执行数量、reminder/outbox 和执行后快照清理行为。
- 本次只提供 revision 字段、校验与递增接口，不实现 #214 的自然语言修订流程。

## 验证

- `cargo test -p qq-maid-core --all-features`（855 passed）
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`

Refs #212
