### PR TITLE
[codex] 固定日期查询用例时间

### DIFF
--- a/qq-maid-core/src/runtime/respond/tests/todo_tool_loop.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo_tool_loop.rs
@@ -612,26 +612,23 @@ async fn deterministic_date_query_then_tool_loop_complete_first_uses_date_snapsh
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
     let owner = private_todo_owner();
-    let today = qq_maid_common::time_context::request_time_context()
-        .local_date()
-        .format("%Y-%m-%d")
-        .to_string();
-    let today_item = create_private_todo_due_date(&service, "今天要完成", today.clone());
+    let query_date = "2099-07-15";
+    let dated_item = create_private_todo_due_date(&service, "指定日期要完成", query_date);
     let no_time = create_private_todo(&service, "无时间待办");
 
     let listed = service
-        .respond(private_message("查看今天待办"))
+        .respond(private_message("查看2099-07-15待办"))
         .await
         .unwrap();
     assert_eq!(listed.command.as_deref(), Some("todo_due_date"));
     let listed_text = listed.text.unwrap();
-    assert!(listed_text.contains("1. 今天要完成"));
+    assert!(listed_text.contains("1. 指定日期要完成"));
     assert!(!listed_text.contains("无时间待办"));
 
     let snapshot = last_todo_snapshot(&service, "date");
     assert_eq!(snapshot.query_type, "due-date");
-    assert_eq!(snapshot.condition, today);
-    assert_eq!(snapshot.result_ids, vec![today_item.id.clone()]);
+    assert_eq!(snapshot.condition, query_date);
+    assert_eq!(snapshot.result_ids, vec![dated_item.id.clone()]);
 
     let _ = service
         .respond(private_message("完成第一条"))
@@ -640,12 +637,12 @@ async fn deterministic_date_query_then_tool_loop_complete_first_uses_date_snapsh
     let tool_request = newest_tool_request(&inspector, "after completing first dated todo");
     let completed = complete_first_visible_todo(&tool_request).await;
     assert_eq!(completed["ok"], true);
-    assert_eq!(completed["completed"][0]["title"], "今天要完成");
+    assert_eq!(completed["completed"][0]["title"], "指定日期要完成");
 
     assert_eq!(
         service
             .task_store
-            .get_by_id(&owner, &today_item.id)
+            .get_by_id(&owner, &dated_item.id)
             .unwrap()
             .unwrap()
             .status,


### PR DESCRIPTION
## 修改内容

- 将日期查询与 Tool Loop 联动测试中的真实“今天”替换为固定日期 `2099-07-15`
- 同步调整测试数据命名和断言，保留日期快照及“完成第一条”的覆盖目标

## 根因

测试造数据和业务解析“今天”分别获取时间上下文。如果两次调用跨越北京时间零点，或测试线程在高负载下被长时间挂起，待办日期与查询日期可能不一致，导致整套测试出现潜在 flake。

## 影响

仅修改测试，不改变生产代码和用户可见行为。测试不再依赖真实日期，日期快照与后续 Tool Loop 的联动验证保持不变。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p qq-maid-core deterministic_date_query_then_tool_loop_complete_first_uses_date_snapshot`
- `make test-core`
- `cargo check -p qq-maid-core`
- `git diff --check`
