### PR TITLE
feat: 统一群聊斜杠命令处理并优化命令反馈

### DIFF
--- a/qq-maid-core/README.md
+++ b/qq-maid-core/README.md
@@ -53,6 +53,8 @@ qq-maid-core/src/
 
 Gateway 调用 Core 的唯一业务入口是 `CoreService::respond(CoreRequest)`。Gateway 只传入最终拼接后的文本、平台、成员身份和私聊 / 群聊目标；`scope_key` 由 Core 根据目标派生。私聊普通聊天在 `TOOL_CALLING_ENABLED=true` 时可进入完整 Tool Loop；群聊普通聊天还需要 `TOOL_CALLING_GROUP_ENABLED=true` 或 `agent.toml` 场景开关，并按 `enabled_tools` 白名单裁剪模型可见工具。明确定义的 slash 前缀命令和 pending 确认流程继续走既有分支。`/ping check` 调用 `CoreService::upstream_check()`，该分支不进入 respond 业务 flow，不创建 session，也不触发标题、记忆、Todo、查询或 Tool Calling。
 
+群聊入口可在不唤醒机器人的情况下把斜杠候选交给 Core。Core 依次使用现有确定性命令解析器执行已注册命令并保留原参数、角色和 scope 权限校验；所有解析器均未命中的未知群命令返回明确的静默结果，不进入聊天模型。私聊未知斜杠文本维持原有普通聊天兼容行为。
+
 `scope_key` 表示 conversation scope，只描述消息发生的对话空间；`actor.user_id` 表示发言人；Todo / Memory 等业务 owner 由 `qq-maid-core/src/identity.rs` helper 在 conversation scope 上叠加 actor 推导。详细术语见 [Scope 与 Identity 边界](../docs/design/scope-identity-boundary.md)。
 
 ### 统一通知接入

--- a/qq-maid-core/src/runtime/command/mod.rs
+++ b/qq-maid-core/src/runtime/command/mod.rs
@@ -11,6 +11,14 @@ pub struct ParsedCommand {
     pub raw_command: String,
 }
 
+/// 判断文本是否为需要由 Core 继续解析的斜杠命令候选。
+///
+/// 这里只识别前缀，不判断命令是否注册；未知群命令会在确定性分派末尾静默收口。
+pub fn is_slash_command_candidate(text: &str) -> bool {
+    let text = text.trim_start();
+    text.starts_with('/') || text.starts_with('／')
+}
+
 /// 解析 slash 命令文本。
 ///
 /// 如果输入不以 `/` 开头则返回 `None`，否则提取动作和参数，

--- a/qq-maid-core/src/runtime/respond/command_dispatcher.rs
+++ b/qq-maid-core/src/runtime/respond/command_dispatcher.rs
@@ -3,12 +3,12 @@
 //! 本模块只处理 pending、session command、slash/确定性命令和进入聊天前的状态准备。
 //! 若没有命中确定性路径，则返回 `PreparedChat` 交给 Chat flow 继续处理。
 
-use crate::error::LlmError;
+use crate::{error::LlmError, runtime::command::is_slash_command_candidate};
 
 use super::{
     PlannedRespond, RespondRequest, RespondResponse, RustRespondService,
     chat_flow::PreparedChat,
-    common::session_error,
+    common::{session_error, suppressed_response},
     interaction_state::{
         command_bypasses_pending, prepare_message_context_for_model, respond_interaction_meta,
         respond_meta, session_pending_visible_to_user, shared_session_turn_actor,
@@ -233,6 +233,19 @@ impl<'a> CommandDispatcher<'a> {
             {
                 return Ok(DispatchOutcome::Respond(Box::new(response)));
             }
+        }
+
+        // 所有已注册命令解析器都已尝试；群聊中的剩余斜杠候选属于未知命令。
+        // Core 在这里明确静默收口，避免把命令文本当普通聊天交给模型。
+        if req
+            .group_id
+            .as_deref()
+            .is_some_and(|id| !id.trim().is_empty())
+            && is_slash_command_candidate(&user_text)
+        {
+            return Ok(DispatchOutcome::Respond(Box::new(suppressed_response(
+                "unknown_group_slash_command",
+            ))));
         }
 
         // 兜底：进入普通 LLM 聊天流程。共享历史 actor 快照已在上方准备；这里把

--- a/qq-maid-core/src/runtime/respond/common.rs
+++ b/qq-maid-core/src/runtime/respond/common.rs
@@ -177,7 +177,7 @@ pub(crate) fn suppressed_response(reason: &'static str) -> RespondResponse {
         ok: true,
         text: None,
         markdown: None,
-        handled: Some(false),
+        handled: Some(true),
         session_id: None,
         command: None,
         diagnostics: Some(json!({

--- a/qq-maid-core/src/runtime/respond/common.rs
+++ b/qq-maid-core/src/runtime/respond/common.rs
@@ -171,6 +171,34 @@ pub(crate) fn command_response_with_stream(
     }
 }
 
+/// 构造 Core 已完成路由判定、但明确不应向群聊发送回复的结果。
+pub(crate) fn suppressed_response(reason: &'static str) -> RespondResponse {
+    RespondResponse {
+        ok: true,
+        text: None,
+        markdown: None,
+        handled: Some(false),
+        session_id: None,
+        command: None,
+        diagnostics: Some(json!({
+            "backend": "rust",
+            "suppressed": true,
+            "reason": reason,
+        })),
+        metrics: LlmMetrics {
+            provider: "rust".to_owned(),
+            model: "command-router".to_owned(),
+            stream: false,
+            ttfe_ms: None,
+            ttft_ms: None,
+            total_latency_ms: 0,
+        },
+        usage: None,
+        error: None,
+        visible_entity_snapshot: None,
+    }
+}
+
 /// 将 `SessionError` 转换为统一的 `LlmError`。
 pub(crate) fn session_error(err: crate::runtime::session::SessionError) -> LlmError {
     LlmError::new(

--- a/qq-maid-core/src/runtime/respond/memory_flow/format.rs
+++ b/qq-maid-core/src/runtime/respond/memory_flow/format.rs
@@ -6,7 +6,10 @@
 //! 普通聊天不会经由此处自动写长期记忆。
 
 use crate::runtime::{
-    respond::{common::truncate_chars, session_flow::datetime_for_display},
+    respond::{
+        command_render::escape_markdown_inline, common::truncate_chars,
+        session_flow::datetime_for_display,
+    },
     tools::memory::{MemoryKind, MemoryRecord},
 };
 
@@ -27,35 +30,79 @@ pub(super) fn format_memory_list_reply(
     command_scope: &MemoryCommandScope,
 ) -> String {
     let scope_title = memory_kind_label(command_scope.kind());
+    let command_prefix = localized_memory_command_prefix(command_scope.kind());
     if records.is_empty() {
         if query.trim().is_empty() {
-            return format!(
-                "🧠 {scope_title}\n\n当前还没有内容。\n\n可直接发送：{} 要记住的内容",
-                command_scope.command_prefix
-            );
+            let add_command = localized_memory_add_command(command_scope.kind());
+            let add_hint = match command_scope.kind() {
+                MemoryKind::Group => {
+                    format!("群主或管理员添加：`{add_command}`")
+                }
+                _ => format!("添加内容：`{add_command}`"),
+            };
+            return [
+                format!("# 🧠 {scope_title}"),
+                String::new(),
+                "当前还没有保存内容。".to_owned(),
+                String::new(),
+                "## 快速操作".to_owned(),
+                String::new(),
+                format!("- {add_hint}"),
+                format!("- 查看列表：`{command_prefix}`"),
+            ]
+            .join("\n");
         }
-        return format!("🧠 {scope_title}\n\n没有找到匹配“{}”的内容。", query);
+        return [
+            format!("# 🧠 {scope_title}"),
+            String::new(),
+            format!("没有找到匹配“{}”的内容。", escape_markdown_inline(query)),
+            String::new(),
+            "## 可以试试".to_owned(),
+            String::new(),
+            format!("- 查看全部：`{command_prefix}`"),
+            format!("- 更换关键词：`{command_prefix} 列表 关键词`"),
+        ]
+        .join("\n");
     }
     let mut rows = vec![
-        format!("🧠 {scope_title}（共 {} 条）", records.len()),
+        format!("# 🧠 {scope_title}"),
+        String::new(),
+        format!("共 {} 条", records.len()),
         String::new(),
     ];
     for (index, record) in records.iter().enumerate() {
         rows.push(format!(
             "{}. {}",
             index + 1,
-            truncate_chars(&record.content, 100)
+            escape_markdown_inline(&truncate_chars(&record.content, 100))
         ));
     }
-    let prefix = command_scope.command_prefix;
     rows.extend([
         String::new(),
-        "可回复：".to_owned(),
-        format!("- `{prefix} show 1`"),
-        format!("- `{prefix} edit 1 新内容`"),
-        format!("- `{prefix} delete 1`"),
+        "## 可用操作".to_owned(),
+        String::new(),
+        format!("- 查看详情：`{command_prefix} 查看 1`"),
+        format!("- 修改内容：`{command_prefix} 修改 1 新内容`"),
+        format!("- 删除内容：`{command_prefix} 删除 1`"),
+        format!("- 搜索内容：`{command_prefix} 列表 关键词`"),
     ]);
     rows.join("\n")
+}
+
+fn localized_memory_command_prefix(kind: MemoryKind) -> &'static str {
+    match kind {
+        MemoryKind::Personal | MemoryKind::LegacyUnassigned => "/记忆",
+        MemoryKind::GroupProfile => "/记忆 画像",
+        MemoryKind::Group => "/记忆 群",
+    }
+}
+
+fn localized_memory_add_command(kind: MemoryKind) -> &'static str {
+    match kind {
+        MemoryKind::Personal | MemoryKind::LegacyUnassigned => "/记忆 要记住的内容",
+        MemoryKind::GroupProfile => "/记忆 画像 添加 要记住的内容",
+        MemoryKind::Group => "/记忆 群 添加 要记住的内容",
+    }
 }
 
 pub(super) fn format_memory_detail_reply(record: &MemoryRecord) -> String {

--- a/qq-maid-core/src/runtime/respond/router.rs
+++ b/qq-maid-core/src/runtime/respond/router.rs
@@ -6,6 +6,7 @@
 use crate::{
     config::{ChatScene, ResolvedAgentPolicy},
     error::LlmError,
+    runtime::command::is_slash_command_candidate,
     runtime::tools::classify_status_hint,
     service::{CoreInboundClassification, CoreInboundKind},
 };
@@ -71,7 +72,7 @@ impl<'a> RespondRouter<'a> {
         if is_event_wrapped_command(trimmed) {
             return Ok(PlannedRespond::command_event());
         }
-        if trimmed.starts_with('/') || trimmed.starts_with('／') {
+        if is_slash_command_candidate(trimmed) {
             return Ok(PlannedRespond::immediate_chat(
                 "deterministic_slash_fallback",
             ));
@@ -144,6 +145,14 @@ impl<'a> RespondRouter<'a> {
             .session_store
             .get_active(&meta)
             .map_err(session_error)?;
+
+        // Gateway 只提交候选，Core 负责后续注册表与权限判断；所有斜杠候选都应绕过
+        // Gateway 普通聊天冷却，确保未知命令也能在 Core 静默收口。
+        if is_slash_command_candidate(&user_text) {
+            return Ok(CoreInboundClassification {
+                kind: CoreInboundKind::Immediate,
+            });
+        }
 
         if pending_blocks_immediate(
             &user_text,

--- a/qq-maid-core/src/runtime/respond/rss_flow.rs
+++ b/qq-maid-core/src/runtime/respond/rss_flow.rs
@@ -467,30 +467,61 @@ fn resolve_subscription_target<'a>(
 
 fn format_rss_list_reply(subscriptions: &[RssSubscription]) -> String {
     if subscriptions.is_empty() {
-        return "当前目标没有 RSS 订阅。\n添加订阅：/rss add RSS地址 [名称]".to_owned();
+        return [
+            "# 📰 RSS 订阅",
+            "",
+            "当前会话还没有订阅。",
+            "",
+            "## 快速操作",
+            "",
+            "- 添加订阅：`/rss add RSS地址 [名称]`",
+            "- 测试订阅源：`/rss test RSS地址`",
+            "- 查看最近更新：`/rss recent [数量]`",
+        ]
+        .join("\n");
     }
-    let mut rows = vec!["RSS 订阅：".to_owned()];
+    let mut rows = vec![
+        "# 📰 RSS 订阅".to_owned(),
+        String::new(),
+        format!("共 {} 个订阅", subscriptions.len()),
+        String::new(),
+    ];
     for (index, subscription) in subscriptions.iter().enumerate() {
         rows.push(format!(
-            "{}. {} [{}] {}",
+            "{}. **{}** · {}",
             index + 1,
-            truncate_chars(&subscription.title, 40),
+            escape_markdown_inline(&truncate_chars(&subscription.title, 40)),
             if subscription.enabled {
-                "启用"
+                "✅ 已启用"
             } else {
-                "停用"
-            },
-            subscription.url
+                "⏸️ 已停用"
+            }
         ));
-        if subscription.last_checked_at.is_some() || subscription.last_error.is_some() {
-            rows.push(format!(
-                "   最近检查：{}；错误：{}",
-                format_rss_check_time(subscription.last_checked_at.as_deref()),
-                subscription.last_error.as_deref().unwrap_or("无")
-            ));
+        rows.push(format!(
+            "   地址：{}",
+            escape_markdown_inline(&subscription.url)
+        ));
+        rows.push(format!(
+            "   最近检查：{}",
+            format_rss_check_time(subscription.last_checked_at.as_deref())
+        ));
+        if let Some(error) = subscription
+            .last_error
+            .as_deref()
+            .filter(|error| !error.trim().is_empty())
+        {
+            rows.push(format!("   ⚠️ 最近错误：{}", escape_markdown_inline(error)));
         }
+        rows.push(String::new());
     }
-    rows.push("操作：/rss recent [数量]；/rss add 地址 [名称]；/rss delete 1".to_owned());
+    rows.extend([
+        "## 快速操作".to_owned(),
+        String::new(),
+        "- 查看更新：`/rss recent [数量]`".to_owned(),
+        "- 添加订阅：`/rss add RSS地址 [名称]`".to_owned(),
+        "- 删除订阅：`/rss delete 1`".to_owned(),
+        "- 测试订阅源：`/rss test RSS地址`".to_owned(),
+    ]);
     rows.join("\n")
 }
 
@@ -779,10 +810,11 @@ mod tests {
     fn empty_rss_list_guides_user_to_add_subscription() {
         let reply = format_rss_list_reply(&[]);
 
-        assert_eq!(
-            reply,
-            "当前目标没有 RSS 订阅。\n添加订阅：/rss add RSS地址 [名称]"
-        );
+        assert!(reply.starts_with("# 📰 RSS 订阅"));
+        assert!(reply.contains("当前会话还没有订阅"));
+        assert!(reply.contains("## 快速操作"));
+        assert!(reply.contains("`/rss add RSS地址 [名称]`"));
+        assert!(reply.contains("`/rss test RSS地址`"));
     }
 
     #[test]
@@ -822,9 +854,12 @@ mod tests {
 
         let reply = format_rss_list_reply(&subscriptions);
 
-        assert!(reply.contains("最近检查：2026-06-18 03:51；错误：无"));
-        assert!(reply.contains("最近检查：2026-06-18 03:51；错误：timeout"));
-        assert!(reply.contains("操作：/rss recent [数量]"));
+        assert!(reply.starts_with("# 📰 RSS 订阅"));
+        assert!(reply.contains("共 2 个订阅"));
+        assert!(reply.contains("1. **Feed** · ✅ 已启用"));
+        assert!(reply.contains("最近检查：2026-06-18 03:51"));
+        assert!(reply.contains("⚠️ 最近错误：timeout"));
+        assert!(reply.contains("查看更新：`/rss recent [数量]`"));
         assert!(!reply.contains("T03:51:44+08:00"));
         assert!(!reply.contains("T19:51:44+00:00"));
     }

--- a/qq-maid-core/src/runtime/respond/tests/memory.rs
+++ b/qq-maid-core/src/runtime/respond/tests/memory.rs
@@ -199,6 +199,25 @@ async fn group_memory_is_visible_to_group_but_only_admin_or_owner_can_manage() {
 }
 
 #[tokio::test]
+async fn empty_group_memory_list_shows_scoped_quick_actions() {
+    let service = test_service();
+
+    let response = service
+        .respond(group_member_message("/记忆 群", Some("member")))
+        .await
+        .unwrap();
+    let text = response.text.unwrap();
+    let markdown = response.markdown.unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("memory_list"));
+    assert!(text.contains("当前群公共记忆"));
+    assert!(text.contains("当前还没有保存内容"));
+    assert!(text.contains("群主或管理员添加：/记忆 群 添加 要记住的内容"));
+    assert!(markdown.starts_with("# 🧠 当前群公共记忆"));
+    assert!(markdown.contains("`/记忆 群 添加 要记住的内容`"));
+}
+
+#[tokio::test]
 async fn group_memory_delete_accepts_normalized_mention_body_and_quoted_context_once() {
     let provider_calls = Arc::new(AtomicUsize::new(0));
     let service = test_service_with_provider(MockProvider::with_counter(provider_calls.clone()));
@@ -695,7 +714,10 @@ async fn memory_root_aliases_list_records_without_llm() {
     for command in ["/memory", "/记忆", "/记"] {
         let response = service.respond(private_message(command)).await.unwrap();
         assert_eq!(response.command.as_deref(), Some("memory_list"));
-        assert!(response.text.unwrap().contains("当前还没有内容"));
+        let text = response.text.unwrap();
+        assert!(text.contains("当前还没有保存内容"));
+        assert!(text.contains("快速操作"));
+        assert!(text.contains("/记忆 要记住的内容"));
     }
     assert_eq!(calls.load(Ordering::SeqCst), 0);
 
@@ -718,9 +740,10 @@ async fn memory_root_aliases_list_records_without_llm() {
         .text
         .unwrap();
     let populated = service.respond(private_message("/记忆")).await.unwrap();
-    assert!(text.contains("🧠 个人记忆（共 1 条）"));
+    assert!(text.contains("🧠 个人记忆"));
+    assert!(text.contains("共 1 条"));
     assert!(text.contains("日常聊天中不要只用编号称呼成员"));
-    assert!(text.contains("/memory show 1"));
+    assert!(text.contains("/记忆 查看 1"));
     assert!(populated.markdown.as_deref().unwrap().contains("1. "));
     assert_eq!(calls.load(Ordering::SeqCst), 0);
 }

--- a/qq-maid-core/src/runtime/respond/tests/memory_phase_b.rs
+++ b/qq-maid-core/src/runtime/respond/tests/memory_phase_b.rs
@@ -201,7 +201,7 @@ async fn list_and_detail_are_friendly_without_internal_fields_or_id() {
         .unwrap()
         .text
         .unwrap();
-    for expected in ["🧠 个人记忆（共 1 条）", "1 ", "可回复：", "/memory show 1"] {
+    for expected in ["🧠 个人记忆", "共 1 条", "1 ", "可用操作", "/记忆 查看 1"] {
         assert!(list.contains(expected), "列表缺少字段：{expected}");
     }
     for internal in ["preference", "private", "active", "owner_key", "scope_key"] {

--- a/qq-maid-core/src/runtime/respond/tests/rss.rs
+++ b/qq-maid-core/src/runtime/respond/tests/rss.rs
@@ -165,7 +165,7 @@ async fn rss_list_and_delete_use_current_scope_only() {
             .markdown
             .as_deref()
             .unwrap()
-            .contains("1. 群订阅")
+            .contains("1. **群订阅** · ✅ 已启用")
     );
     let private_list = service
         .respond(private_message("/订阅", "u2"))
@@ -177,7 +177,7 @@ async fn rss_list_and_delete_use_current_scope_only() {
             .markdown
             .as_deref()
             .unwrap()
-            .contains("1. 私聊订阅")
+            .contains("1. **私聊订阅** · ✅ 已启用")
     );
 
     let deleted = service.respond(message("/rss delete 1")).await.unwrap();

--- a/qq-maid-core/src/service/tests/commands.rs
+++ b/qq-maid-core/src/service/tests/commands.rs
@@ -57,6 +57,96 @@ async fn core_help_command_is_wrapped_as_response_events() {
 }
 
 #[tokio::test]
+async fn core_group_registered_command_executes_without_model() {
+    let provider =
+        TestProvider::replying("unused").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let state = test_state_with_tool_calling(provider.clone(), 5, true);
+    let service = CoreHandle::new(state);
+    let mut stream = expect_stream(service.respond(group_request("/help")).await.unwrap());
+    let response = collect_completed_without_text_delta(&mut stream).await;
+
+    assert_eq!(response.command.as_deref(), Some("help"));
+    assert!(
+        response
+            .text_content()
+            .is_some_and(|text| text.contains("帮助"))
+    );
+    assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn core_unknown_group_slash_is_silent_without_model_call() {
+    let provider =
+        TestProvider::replying("不应调用").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let state = test_state_with_tool_calling(provider.clone(), 5, true);
+    let service = CoreHandle::new(state);
+
+    let classification = service
+        .classify_inbound(group_request("/unknown"))
+        .await
+        .unwrap();
+    assert_eq!(classification.kind, CoreInboundKind::Immediate);
+
+    let CoreRespondOutput::Complete(response) =
+        service.respond(group_request("/unknown")).await.unwrap()
+    else {
+        panic!("unknown group slash should complete synchronously");
+    };
+    assert!(response.suppresses_reply());
+    assert_eq!(
+        response.diagnostics.as_ref().unwrap()["reason"],
+        "unknown_group_slash_command"
+    );
+    assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn core_unknown_private_slash_keeps_existing_chat_behavior() {
+    let provider = TestProvider::replying("私聊仍按普通聊天处理");
+    let state = test_state(provider.clone(), 5);
+    let service = CoreHandle::new(state);
+    let CoreRespondOutput::Complete(response) =
+        service.respond(private_request("/unknown")).await.unwrap()
+    else {
+        panic!("immediate private fallback should complete synchronously");
+    };
+
+    assert_eq!(response.text_content(), Some("私聊仍按普通聊天处理"));
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn group_command_validation_and_role_checks_stay_in_core() {
+    let provider =
+        TestProvider::replying("不应调用").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let state = test_state_with_tool_calling(provider.clone(), 5, true);
+    let service = CoreHandle::new(state);
+
+    let CoreRespondOutput::Complete(invalid) =
+        service.respond(group_request("/翻译")).await.unwrap()
+    else {
+        panic!("invalid command arguments should complete synchronously");
+    };
+    assert_eq!(invalid.command.as_deref(), Some("translation"));
+    assert!(
+        invalid
+            .text_content()
+            .is_some_and(|text| text.contains("用法：/翻译"))
+    );
+
+    let mut denied_request = group_request("/memory group add 群规则");
+    denied_request.actor.group_member_role = Some(crate::service::CoreGroupMemberRole::Member);
+    let CoreRespondOutput::Complete(denied) = service.respond(denied_request).await.unwrap() else {
+        panic!("permission rejection should complete synchronously");
+    };
+    assert_eq!(denied.command.as_deref(), Some("group_admin_required"));
+    assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
 async fn onebot_commands_use_real_core_and_account_scoped_conversation() {
     let provider =
         TestProvider::replying("unused").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);

--- a/qq-maid-core/src/service/tests/commands.rs
+++ b/qq-maid-core/src/service/tests/commands.rs
@@ -47,6 +47,7 @@ async fn core_help_command_is_wrapped_as_response_events() {
         panic!("expected completed help response");
     };
     assert_eq!(response.command.as_deref(), Some("help"));
+    assert!(!response.suppresses_reply());
     assert!(
         response
             .text_content()
@@ -66,6 +67,7 @@ async fn core_group_registered_command_executes_without_model() {
     let response = collect_completed_without_text_delta(&mut stream).await;
 
     assert_eq!(response.command.as_deref(), Some("help"));
+    assert!(!response.suppresses_reply());
     assert!(
         response
             .text_content()
@@ -93,7 +95,10 @@ async fn core_unknown_group_slash_is_silent_without_model_call() {
     else {
         panic!("unknown group slash should complete synchronously");
     };
+    assert_eq!(response.handled, Some(true));
+    assert_eq!(response.output, None);
     assert!(response.suppresses_reply());
+    assert_eq!(response.diagnostics.as_ref().unwrap()["suppressed"], true);
     assert_eq!(
         response.diagnostics.as_ref().unwrap()["reason"],
         "unknown_group_slash_command"
@@ -130,6 +135,7 @@ async fn group_command_validation_and_role_checks_stay_in_core() {
         panic!("invalid command arguments should complete synchronously");
     };
     assert_eq!(invalid.command.as_deref(), Some("translation"));
+    assert!(!invalid.suppresses_reply());
     assert!(
         invalid
             .text_content()
@@ -142,6 +148,8 @@ async fn group_command_validation_and_role_checks_stay_in_core() {
         panic!("permission rejection should complete synchronously");
     };
     assert_eq!(denied.command.as_deref(), Some("group_admin_required"));
+    assert!(!denied.suppresses_reply());
+    assert!(denied.text_content().is_some());
     assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
     assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
 }

--- a/qq-maid-core/src/service/tests/response.rs
+++ b/qq-maid-core/src/service/tests/response.rs
@@ -125,4 +125,5 @@ fn text_content_returns_none_when_output_absent() {
 
     assert_eq!(response.text_content(), None);
     assert_eq!(response.markdown_content(), None);
+    assert!(response.suppresses_reply());
 }

--- a/qq-maid-core/src/service/tests/response.rs
+++ b/qq-maid-core/src/service/tests/response.rs
@@ -113,7 +113,7 @@ fn markdown_content_is_none_when_output_only_has_text() {
 }
 
 #[test]
-fn text_content_returns_none_when_output_absent() {
+fn output_absence_without_suppressed_marker_does_not_suppress_reply() {
     let response = CoreResponse {
         output: None,
         handled: Some(false),
@@ -125,5 +125,22 @@ fn text_content_returns_none_when_output_absent() {
 
     assert_eq!(response.text_content(), None);
     assert_eq!(response.markdown_content(), None);
+    assert!(!response.suppresses_reply());
+}
+
+#[test]
+fn explicit_suppressed_marker_suppresses_reply() {
+    let response = CoreResponse {
+        output: None,
+        handled: Some(true),
+        session_id: None,
+        command: None,
+        diagnostics: Some(serde_json::json!({
+            "suppressed": true,
+            "reason": "test_suppressed_response",
+        })),
+        visible_entity_snapshot: None,
+    };
+
     assert!(response.suppresses_reply());
 }

--- a/qq-maid-core/src/service/types.rs
+++ b/qq-maid-core/src/service/types.rs
@@ -299,6 +299,11 @@ impl CoreResponse {
             .as_ref()
             .and_then(|output| output.markdown.as_deref())
     }
+
+    /// Core 明确判定本轮无需回复时，Gateway 必须静默结束，不能补发空响应兜底文案。
+    pub fn suppresses_reply(&self) -> bool {
+        self.handled == Some(false) && self.output.is_none()
+    }
 }
 
 impl CoreRequest {

--- a/qq-maid-core/src/service/types.rs
+++ b/qq-maid-core/src/service/types.rs
@@ -301,8 +301,15 @@ impl CoreResponse {
     }
 
     /// Core 明确判定本轮无需回复时，Gateway 必须静默结束，不能补发空响应兜底文案。
+    ///
+    /// 静默属于显式跨层契约，只认 `diagnostics.suppressed=true`；`handled` 或正文为空
+    /// 都可能来自其他响应状态，不能据此推断静默。
     pub fn suppresses_reply(&self) -> bool {
-        self.handled == Some(false) && self.output.is_none()
+        self.diagnostics
+            .as_ref()
+            .and_then(|diagnostics| diagnostics.get("suppressed"))
+            .and_then(serde_json::Value::as_bool)
+            == Some(true)
     }
 }
 

--- a/qq-maid-gateway-rs/README.md
+++ b/qq-maid-gateway-rs/README.md
@@ -61,7 +61,7 @@ flowchart LR
 
 - `InboundMessage` 是 Gateway 内部的平台无关入站模型，包含 `Actor` 与 `Conversation`。QQ、OneBot、微信等协议字段只能在各自 adapter 内解析。
 - `CoreRequest` 是 Gateway 调用 Core 的稳定契约。Core 可以看到平台枚举、Actor 和 Conversation，但不理解 QQ `msg_seq`、stream id、微信 XML 字段或 OneBot CQ 片段。
-- OneBot 11 已实现默认关闭的单账号反向 WebSocket server、鉴权、生命周期/心跳、连接替换、API request/response 共用连接上下文、文本/结构化 at/reply/图片/文件入站 adapter、Core/Command 编排、文本 sender、主动推送精确路由和脱敏状态。reply 以平台 `message_id` 写入独立 scope 的进程内 ref_index，安全 http/https 图片可进入既有多模态链路；客户端本机路径、`file://` 和 base64 只保留不可读摘要。Core stream 只在可信 `Completed` 后发送一条最终文本，不向 OneBot 平台发送 status/delta，也不实现富媒体发送。
+- OneBot 11 已实现默认关闭的单账号反向 WebSocket server、鉴权、生命周期/心跳、连接替换、API request/response 共用连接上下文、文本/结构化 at/reply/图片/文件入站 adapter、群聊斜杠候选透传、Core/Command 编排、文本 sender、主动推送精确路由和脱敏状态。reply 以平台 `message_id` 写入独立 scope 的进程内 ref_index，安全 http/https 图片可进入既有多模态链路；客户端本机路径、`file://` 和 base64 只保留不可读摘要。Core stream 只在可信 `Completed` 后发送一条最终文本，不向 OneBot 平台发送 status/delta，也不实现富媒体发送。
 - `scope_key` / `owner_key` 是业务隔离键，用于 Session、Pending、Memory、Todo 等状态归属，不是发送地址。
 - `ReplyTarget` / `DeliveryTarget` 保存真实投递目标，必须保留平台和 `raw_target_id`。发送逻辑只能使用投递目标调用 sender，不能从 `scope_key` 或 `owner_key` 反解析平台 ID。
 - RSS、Notification、Todo 提醒和 Push 这类主动投递也必须携带原始 delivery target；后续多平台收敛时不要把目标统一替换成 namespaced 字符串。
@@ -151,7 +151,7 @@ QQ_APPID=你的QQ机器人AppID
 QQ_SECRET=你的QQ机器人AppSecret
 ```
 
-普通群消息由 `QQ_MAID_GROUP_MESSAGE_MODE` 控制，默认 `mention` 保持有限触发；`off` 完全关闭普通群消息，`command` 只处理 `/` 或全角 `／` 开头的命令，`mention` 额外处理平台 @ 标记和回复机器人消息，`active` 只处理包含 `QQ_MAID_GROUP_ACTIVE_KEYWORDS` 指定提示词的普通群消息，提示词默认 `小女仆`，多个用英文逗号分隔。第一个有效关键词同时作为程序生成状态提示和兜底文案中的机器人主称呼，其余关键词仍作为 active 模式别名；仅当新变量完全未设置时，旧变量 `QQ_MAID_STATUS_DISPLAY_NAME` 才作为主称呼回退，且不会加入 active 关键词。旧变量 `QQ_MAID_ENABLE_GROUP_MESSAGES` 仅在未设置新变量时兼容，`false` 映射为 `off`，`true` 映射为 `active`，未设置时默认 `mention`。这些策略只对 QQ 官方已经推送到 Gateway 的群事件生效；如果平台没有推送普通非 @ 群消息，Gateway 无法通过关键词提前收到或登记该消息。群聊不会开放通用 Harness、文件处理或代码执行；Tool Calling 由 Core 的 `TOOL_CALLING_GROUP_ENABLED` 控制且默认关闭。gateway 只负责把群聊目标传给 Core，由 Core 按既有命令和普通聊天边界处理。
+普通群消息由 `QQ_MAID_GROUP_MESSAGE_MODE` 控制，默认 `mention` 保持有限触发；`off` 完全关闭普通群消息，其余模式都会先把 `/` 或全角 `／` 开头的候选原样交给 Core 判定，Gateway 不维护业务命令白名单。`command` 除斜杠候选外不处理普通文本，`mention` 额外处理平台 @ 标记和回复机器人消息，`active` 额外处理包含 `QQ_MAID_GROUP_ACTIVE_KEYWORDS` 指定提示词的普通群消息。提示词默认 `小女仆`，多个用英文逗号分隔。第一个有效关键词同时作为程序生成状态提示和兜底文案中的机器人主称呼，其余关键词仍作为 active 模式别名；仅当新变量完全未设置时，旧变量 `QQ_MAID_STATUS_DISPLAY_NAME` 才作为主称呼回退，且不会加入 active 关键词。旧变量 `QQ_MAID_ENABLE_GROUP_MESSAGES` 仅在未设置新变量时兼容，`false` 映射为 `off`，`true` 映射为 `active`，未设置时默认 `mention`。这些策略只对 QQ 官方已经推送到 Gateway 的群事件生效；如果平台没有推送普通非 @ 群消息，Gateway 无法通过关键词提前收到或登记该消息。群聊不会开放通用 Harness、文件处理或代码执行；Tool Calling 由 Core 的 `TOOL_CALLING_GROUP_ENABLED` 控制且默认关闭。gateway 只负责把群聊目标传给 Core，由 Core 按既有命令和普通聊天边界处理；未知群聊斜杠候选由 Core 静默拦截。
 
 普通群事件是否 @ 当前机器人只信任官方结构化 `mentions[].is_you == true`；旧的 AppID、openid、member_openid、CQ 文本和 `<@...>` 文本不再作为触发依据。`QQ_MAID_BOT_MENTION_IDS` 仅保留为旧配置兼容，不应再用于修正普通群 @ 判定。不要把真实 ID 写入公开文档或提交到仓库。
 
@@ -159,7 +159,7 @@ QQ_SECRET=你的QQ机器人AppSecret
 
 `QQ_MAID_C2C_VISIBLE_PROGRESS_STATUS_ENABLED` 控制私聊 Tool Loop 的可见进度文本，默认开启，只在 Core 输出策略为 `progress_then_complete` / `progress_then_stream` 时发送一次受控短提示。它不是 QQ 原生 typing 状态；原生 typing 由 `QQ_MAID_AGENT_TYPING_ENABLED` / `QQ_MAID_AGENT_TYPING_DELAY_MS` 单独控制。
 
-OneBot 11 入口最小配置：
+OneBot 11 群聊默认只放行明确 at 当前机器人、引用机器人出站消息或斜杠命令候选；候选是否合法及是否有权限仍由 Core 判定。入口最小配置：
 
 ```env
 ONEBOT11_ENABLED=false

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -1108,7 +1108,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn slash_candidates_bypass_wake_filter_and_each_reach_core_once() {
+    async fn slash_candidates_reach_core_and_explicit_suppression_sends_nothing() {
         let mut config = test_config();
         config.group_message_mode = GroupMessageMode::Active;
         let outbound_cache = Arc::new(Mutex::new(BotOutboundCache::default()));
@@ -1122,10 +1122,13 @@ mod tests {
             vec!["/help"],
             RespondResponse {
                 output: None,
-                handled: Some(false),
+                handled: Some(true),
                 session_id: None,
                 command: None,
-                diagnostics: None,
+                diagnostics: Some(serde_json::json!({
+                    "suppressed": true,
+                    "reason": "test_gateway_suppressed_response",
+                })),
                 visible_entity_snapshot: None,
             },
         );
@@ -1173,6 +1176,7 @@ mod tests {
         .await
         .unwrap();
 
+        // 测试 API 地址不可达；两次调用均成功返回，证明显式 suppressed 响应未进入发送链路。
         let mut ordinary = group_message("路过", GroupEventType::GroupMessage);
         ordinary.message_id = "group-unwoken-ordinary".to_owned();
         handle_group_message(

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -376,6 +376,14 @@ async fn send_group_respond_response(
     response: &RespondResponse,
     ref_index: &SharedRefIndex,
 ) -> anyhow::Result<()> {
+    if response.suppresses_reply() {
+        debug!(
+            message_id = %message.message_id,
+            group = %mask_openid(&message.group_openid),
+            "group reply suppressed by Core"
+        );
+        return Ok(());
+    }
     let capability = ReplyCapability::qq_official_group(config);
     let outbound = match render_respond_response_for_profile(response, &capability.render) {
         Some(outbound) => outbound,
@@ -705,8 +713,11 @@ mod tests {
         classify_calls: Arc<AtomicUsize>,
         immediate_inputs: Vec<&str>,
     ) -> RespondClient {
-        RespondClient::new(Arc::new(MockCore {
-            response: RespondResponse {
+        respond_client_with_response(
+            respond_calls,
+            classify_calls,
+            immediate_inputs,
+            RespondResponse {
                 output: None,
                 handled: Some(true),
                 session_id: None,
@@ -714,6 +725,17 @@ mod tests {
                 diagnostics: None,
                 visible_entity_snapshot: None,
             },
+        )
+    }
+
+    fn respond_client_with_response(
+        respond_calls: Arc<AtomicUsize>,
+        classify_calls: Arc<AtomicUsize>,
+        immediate_inputs: Vec<&str>,
+        response: RespondResponse,
+    ) -> RespondClient {
+        RespondClient::new(Arc::new(MockCore {
+            response,
             respond_calls,
             classify_calls,
             immediate_inputs: immediate_inputs.into_iter().map(str::to_owned).collect(),
@@ -1083,6 +1105,93 @@ mod tests {
         .unwrap();
 
         assert_eq!(hits_third.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn slash_candidates_bypass_wake_filter_and_each_reach_core_once() {
+        let mut config = test_config();
+        config.group_message_mode = GroupMessageMode::Active;
+        let outbound_cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        let cooldowns = Arc::new(Mutex::new(GroupCooldowns::default()));
+        let dedupe = crate::gateway::dedupe::MessageDedupe::new(Duration::from_secs(60));
+        let respond_calls = Arc::new(AtomicUsize::new(0));
+        let classify_calls = Arc::new(AtomicUsize::new(0));
+        let respond = respond_client_with_response(
+            respond_calls.clone(),
+            classify_calls.clone(),
+            vec!["/help"],
+            RespondResponse {
+                output: None,
+                handled: Some(false),
+                session_id: None,
+                command: None,
+                diagnostics: None,
+                visible_entity_snapshot: None,
+            },
+        );
+        let api = api_client();
+        let runtime = GatewayRuntimeStatus::new();
+        let identity = bot_identity();
+        let ref_index = crate::gateway::ref_index::ref_index();
+
+        let mut direct = group_message("/help", GroupEventType::GroupMessage);
+        direct.message_id = "group-direct-command".to_owned();
+        handle_group_message(
+            direct,
+            &config,
+            &respond,
+            &api,
+            &dedupe,
+            &outbound_cache,
+            &cooldowns,
+            &identity,
+            &runtime,
+            &ref_index,
+        )
+        .await
+        .unwrap();
+
+        let mut mentioned = group_message("@小女仆 /help", GroupEventType::GroupMessage);
+        mentioned.message_id = "group-mentioned-command".to_owned();
+        mentioned.mentions = vec![crate::gateway::event::GroupMention {
+            is_you: true,
+            member_role: None,
+            target_id: None,
+        }];
+        handle_group_message(
+            mentioned,
+            &config,
+            &respond,
+            &api,
+            &dedupe,
+            &outbound_cache,
+            &cooldowns,
+            &identity,
+            &runtime,
+            &ref_index,
+        )
+        .await
+        .unwrap();
+
+        let mut ordinary = group_message("路过", GroupEventType::GroupMessage);
+        ordinary.message_id = "group-unwoken-ordinary".to_owned();
+        handle_group_message(
+            ordinary,
+            &config,
+            &respond,
+            &api,
+            &dedupe,
+            &outbound_cache,
+            &cooldowns,
+            &identity,
+            &runtime,
+            &ref_index,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(classify_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(respond_calls.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]

--- a/qq-maid-gateway-rs/src/gateway/group_filter.rs
+++ b/qq-maid-gateway-rs/src/gateway/group_filter.rs
@@ -20,6 +20,7 @@ use super::{
     BotOutboundCache,
     bot_identity::SharedBotIdentity,
     event::{GroupEventType, GroupMessage},
+    platform::is_slash_command_candidate,
 };
 use crate::config::GroupMessageMode;
 
@@ -109,8 +110,9 @@ pub(crate) fn should_ignore_group_message(
 /// QQ 官方 at 事件和普通群消息中的结构化 `is_you` 都归一为“提到当前机器人”。
 /// 后续只按群消息模式决定是否进入 Core：
 /// - Off：不处理；
-/// - Command：仅斜杠命令；
-/// - Mention：命令、提到机器人、回复机器人；
+/// - 其他模式：先放行斜杠命令候选，再应用各自的唤醒规则；
+/// - Command：除直接斜杠候选外，仅接受归一化后的 @ 命令；
+/// - Mention：提到机器人或回复机器人；
 /// - Active：提到机器人或命中配置提示词。
 ///
 /// 这些本地策略只对 QQ 官方已经推送到 Gateway 的群事件生效，关键词不能让平台额外推送
@@ -127,17 +129,17 @@ pub(crate) fn should_process_group_message(
 
     // QQ 有时把 `@机器人 /help` 作为普通群消息下发；
     // 此时原始 content 不是斜杠开头，需要使用 gateway 已归一化的 Core 文本判断命令。
-    let is_normalized_command = is_group_command(respond_content);
+    let is_direct_command_candidate = is_slash_command_candidate(&message.content);
+    let is_normalized_command = is_slash_command_candidate(respond_content);
     let is_structured_mention_command = mentions_current_bot && is_normalized_command;
 
     match mode {
         GroupMessageMode::Off => false,
-        GroupMessageMode::Command => {
-            is_group_command(&message.content) || is_structured_mention_command
-        }
+        // 斜杠候选必须先于唤醒判断进入 Core；是否合法、是否有权限均由 Core 决定。
+        _ if is_direct_command_candidate => true,
+        GroupMessageMode::Command => is_structured_mention_command,
         GroupMessageMode::Mention => {
-            is_group_command(&message.content)
-                || is_structured_mention_command
+            is_structured_mention_command
                 || mentions_current_bot
                 || is_reply_to_bot(message, bot_outbound_cache)
         }
@@ -152,12 +154,6 @@ pub(crate) fn should_process_group_message(
 pub(crate) fn mentions_current_bot(message: &GroupMessage) -> bool {
     message.event_type == GroupEventType::GroupAtMessage
         || message.mentions.iter().any(|mention| mention.is_you)
-}
-
-/// 判断内容是否以 `/` 或全角 `／` 开头（群命令）。
-fn is_group_command(content: &str) -> bool {
-    let trimmed = content.trim_start();
-    trimmed.starts_with('/') || trimmed.starts_with('／')
 }
 
 /// `active` 模式只按显式提示词触发，避免普通群聊闲谈被机器人自动插话。
@@ -274,6 +270,27 @@ mod tests {
         ));
         assert!(should_process_group_message(
             GroupMessageMode::Command,
+            &active_keywords,
+            &command,
+            &command.content,
+            &bot_identity(),
+            &cache
+        ));
+        for mode in [GroupMessageMode::Mention, GroupMessageMode::Active] {
+            assert!(
+                should_process_group_message(
+                    mode,
+                    &active_keywords,
+                    &command,
+                    &command.content,
+                    &bot_identity(),
+                    &cache
+                ),
+                "{mode:?} should forward slash candidates before wake filtering"
+            );
+        }
+        assert!(!should_process_group_message(
+            GroupMessageMode::Off,
             &active_keywords,
             &command,
             &command.content,

--- a/qq-maid-gateway-rs/src/gateway/onebot11/dispatch.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/dispatch.rs
@@ -15,7 +15,7 @@ use tracing::{debug, warn};
 
 use crate::{
     gateway::{
-        platform::{self, ConversationTarget, InboundMessage},
+        platform::{self, ConversationTarget, InboundMessage, is_slash_command_candidate},
         ref_index::SharedRefIndex,
     },
     render::render_respond_response_for_profile,
@@ -107,6 +107,7 @@ impl OneBotReplySender for OneBotSender {
 pub(super) enum OneBotDispatchOutcome {
     Sent,
     IgnoredNonBotReply,
+    SuppressedByCore,
 }
 
 #[derive(Debug, Error)]
@@ -166,6 +167,7 @@ impl OneBotInboundDispatcher {
         }
         if matches!(inbound.conversation, ConversationTarget::Group { .. })
             && !inbound.mentioned_bot
+            && !is_slash_command_candidate(&inbound.text)
             && inbound.quoted.as_ref().and_then(|quoted| quoted.from_bot) != Some(true)
         {
             // 群聊 reply 候选只有在索引确认引用机器人出站消息后才触发；重启后的 miss
@@ -206,6 +208,9 @@ impl OneBotInboundDispatcher {
                 return Err(OneBotDispatchError::StreamEnded);
             }
         };
+        if response.suppresses_reply() {
+            return Ok(OneBotDispatchOutcome::SuppressedByCore);
+        }
         let capability = crate::gateway::outbound::ReplyCapability::onebot11_text();
         let Some(outbound) = render_respond_response_for_profile(&response, &capability.render)
         else {
@@ -263,6 +268,9 @@ impl OneBotInboundDispatcher {
             Ok(OneBotDispatchOutcome::Sent) => debug!("OneBot 11 reply dispatch completed"),
             Ok(OneBotDispatchOutcome::IgnoredNonBotReply) => {
                 debug!("ignored OneBot 11 group reply not addressed to current bot")
+            }
+            Ok(OneBotDispatchOutcome::SuppressedByCore) => {
+                debug!("OneBot 11 reply suppressed by Core")
             }
             Err(error) => warn!(error = %error, "OneBot 11 reply dispatch failed"),
         }
@@ -409,6 +417,17 @@ mod tests {
         })
     }
 
+    fn suppressed_response() -> Box<CoreResponse> {
+        Box::new(CoreResponse {
+            output: None,
+            handled: Some(false),
+            session_id: None,
+            command: None,
+            diagnostics: None,
+            visible_entity_snapshot: None,
+        })
+    }
+
     fn snapshot(entity_id: &str) -> VisibleEntitySnapshot {
         VisibleEntitySnapshot {
             platform: "onebot11".to_owned(),
@@ -502,6 +521,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn direct_group_slash_candidate_without_at_reaches_core_once() {
+        let sender = Arc::new(FakeSender::default());
+        let (dispatcher, core) = dispatcher(
+            vec![Ok(OneBotCoreTransport::Complete(response(Some(
+                "命令结果",
+            ))))],
+            sender.clone(),
+        );
+        let mut command = inbound("direct-command", true);
+        command.mentioned_bot = false;
+
+        assert_eq!(
+            dispatcher.dispatch(command).await.unwrap(),
+            OneBotDispatchOutcome::Sent
+        );
+        assert_eq!(core.calls.lock().unwrap().len(), 1);
+        assert_eq!(sender.sent.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn group_slash_suppressed_by_core_sends_nothing() {
+        let sender = Arc::new(FakeSender::default());
+        let (dispatcher, core) = dispatcher(
+            vec![Ok(OneBotCoreTransport::Complete(suppressed_response()))],
+            sender.clone(),
+        );
+        let mut command = inbound("unknown-command", true);
+        command.mentioned_bot = false;
+        command.text = "/unknown".to_owned();
+        command.input_parts = vec![MessageInputPart::text("/unknown")];
+
+        assert_eq!(
+            dispatcher.dispatch(command).await.unwrap(),
+            OneBotDispatchOutcome::SuppressedByCore
+        );
+        assert_eq!(core.calls.lock().unwrap().len(), 1);
+        assert!(sender.sent.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
     async fn stream_ignores_status_and_delta_then_sends_only_completed_body() {
         let stream = FakeStream {
             events: VecDeque::from([
@@ -581,6 +640,8 @@ mod tests {
 
         let mut bot_reply = inbound("reply-to-bot", true);
         bot_reply.mentioned_bot = false;
+        bot_reply.text = "继续".to_owned();
+        bot_reply.input_parts = vec![MessageInputPart::text("继续")];
         bot_reply.quoted = Some(QuotedMessageContext {
             reference_id: Some("sent-1".to_owned()),
             ..Default::default()
@@ -592,6 +653,8 @@ mod tests {
 
         let mut user_reply = inbound("reply-to-user", true);
         user_reply.mentioned_bot = false;
+        user_reply.text = "继续".to_owned();
+        user_reply.input_parts = vec![MessageInputPart::text("继续")];
         user_reply.quoted = Some(QuotedMessageContext {
             reference_id: Some("user-message".to_owned()),
             ..Default::default()

--- a/qq-maid-gateway-rs/src/gateway/onebot11/dispatch.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/dispatch.rs
@@ -420,6 +420,20 @@ mod tests {
     fn suppressed_response() -> Box<CoreResponse> {
         Box::new(CoreResponse {
             output: None,
+            handled: Some(true),
+            session_id: None,
+            command: None,
+            diagnostics: Some(serde_json::json!({
+                "suppressed": true,
+                "reason": "unknown_group_slash_command",
+            })),
+            visible_entity_snapshot: None,
+        })
+    }
+
+    fn unhandled_empty_response() -> Box<CoreResponse> {
+        Box::new(CoreResponse {
+            output: None,
             handled: Some(false),
             session_id: None,
             command: None,
@@ -558,6 +572,23 @@ mod tests {
         );
         assert_eq!(core.calls.lock().unwrap().len(), 1);
         assert!(sender.sent.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn unhandled_empty_response_without_marker_is_not_suppressed() {
+        let sender = Arc::new(FakeSender::default());
+        let (dispatcher, core) = dispatcher(
+            vec![Ok(
+                OneBotCoreTransport::Complete(unhandled_empty_response()),
+            )],
+            sender.clone(),
+        );
+
+        let error = dispatcher.dispatch(inbound("empty-response", true)).await;
+
+        assert!(matches!(error, Err(OneBotDispatchError::EmptyResponse)));
+        assert_eq!(core.calls.lock().unwrap().len(), 1);
+        assert_eq!(sender.sent.lock().unwrap().len(), 1);
     }
 
     #[tokio::test]

--- a/qq-maid-gateway-rs/src/gateway/platform/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/mod.rs
@@ -14,3 +14,9 @@ pub(crate) use core::{core_scope_key, render_text_for_core, to_core_request};
 #[cfg(test)]
 pub(crate) use model::Actor;
 pub(crate) use model::{ConversationTarget, InboundMessage, Platform};
+
+/// 只识别需要交给 Core 判定的斜杠命令候选，不在 Gateway 维护命令白名单。
+pub(crate) fn is_slash_command_candidate(text: &str) -> bool {
+    let text = text.trim_start();
+    text.starts_with('/') || text.starts_with('／')
+}

--- a/qq-maid-gateway-rs/src/gateway/platform/onebot11/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/onebot11/mod.rs
@@ -11,7 +11,10 @@ use serde_json::{Map, Value};
 
 use crate::gateway::onebot11::protocol::{MessageSegment, OneBotEvent, OneBotMessage};
 
-use super::model::{Actor, ConversationTarget, GroupMemberRoleKind, InboundMessage, Platform};
+use super::{
+    is_slash_command_candidate,
+    model::{Actor, ConversationTarget, GroupMemberRoleKind, InboundMessage, Platform},
+};
 
 mod sanitize;
 
@@ -117,7 +120,10 @@ pub(crate) fn inbound_from_event_with_media_limit(
         MessageType::Group => {
             // reply 当前机器人时是否触发，需要在 scope worker 内通过 ref_index 判定；
             // adapter 只允许含结构化 reply 的候选继续，不能把任意群消息都送入 Core。
-            if !parsed.mentioned_bot && parsed.quoted.is_none() {
+            if !parsed.mentioned_bot
+                && parsed.quoted.is_none()
+                && !is_slash_command_candidate(&parsed.text)
+            {
                 return OneBotInboundOutcome::Ignored(OneBotIgnoreReason::GroupNotTriggered);
             }
             let Some(group_id) = event_id(event, "group_id") else {
@@ -570,6 +576,28 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn direct_group_slash_candidate_without_at_preserves_core_context() {
+        let inbound = message(inbound_from_event(&group_event(json!([
+            {"type": "text", "data": {"text": " /memory list"}}
+        ]))));
+
+        assert_eq!(inbound.text, " /memory list");
+        assert!(!inbound.mentioned_bot);
+        assert_eq!(inbound.message_id, "40004");
+        assert_eq!(inbound.actor.sender_id.as_deref(), Some("20002"));
+        assert_eq!(
+            inbound.actor.group_member_role,
+            Some(GroupMemberRoleKind::Admin)
+        );
+        assert_eq!(
+            inbound.conversation,
+            ConversationTarget::Group {
+                target_id: "30003".to_owned()
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 背景

群聊中的斜杠命令此前可能在 Gateway 唤醒过滤阶段被拦截，用户需要额外 @、回复机器人或输入唤醒词；同时，Memory 与 RSS 命令列表的操作提示较简略。

本 PR 将斜杠候选统一交给 Core 做权威解析，并完善常用命令的反馈展示。

## 修改内容

### 统一群聊斜杠命令处理

- QQ 官方群聊在显式 `off` 以外的模式中，先放行 `/` 或 `／` 开头的斜杠候选，再应用普通文本唤醒规则。
- OneBot 11 群聊允许无 at / reply 的斜杠候选进入 Core，并完整保留 actor、群角色、消息与会话上下文。
- Gateway 只识别斜杠候选，不维护业务命令白名单。
- Core 复用现有确定性命令解析链：
  - 已注册命令进入原有命令执行与权限校验；
  - 未注册的群聊斜杠命令静默收口，不进入聊天模型。
- Gateway 识别 Core 的静默结果，不再为空输出补发兜底文案。
- 排查后保留 Gateway 本地运维 `/ping` 与私聊聚合取消控制；未发现重复的 Todo、Memory、RSS、Help 等业务命令实现。

### 优化命令反馈

- 优化个人记忆、群画像和群公共记忆列表的标题、空状态、搜索提示及快捷操作。
- Memory 操作提示改为当前已支持的中文命令形式，并按作用域展示正确前缀。
- 优化 RSS 列表的订阅数量、启停状态、地址、最近检查时间、错误信息及快捷操作。
- 对动态内容进行 Markdown 转义，继续保留 Markdown 与纯文本双通道输出。

## 行为边界

- 普通未唤醒群文本行为不变。
- 命令参数错误、群角色、管理员权限和 Memory scope 权限仍由 Core 原流程校验。
- 私聊未知斜杠文本保持原有普通聊天兼容行为。
- `QQ_MAID_GROUP_MESSAGE_MODE=off` 仍完全关闭 QQ 普通群消息。
- 同一命令消息不会同时进入命令链和普通聊天链。

## 根因

QQ 的 `active` 模式及 OneBot 群 adapter / dispatch 在进入 Core 前要求唤醒条件；同时 Core 对未注册斜杠文本会落回普通聊天路径，导致未知命令调用模型。

此外，Memory 与 RSS 列表原有反馈偏简略，缺少明确的作用域提示和可直接复制的后续操作。

## 验证

斜杠命令路由相关：

- `make test-gateway`
- `make test-core`
- `make test`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo build --workspace --release --all-features`

命令反馈相关：

- Memory 相关测试：72 项
- RSS flow 测试：7 项
- RSS respond 测试：11 项
- `cargo fmt --all -- --check`
- `cargo check -p qq-maid-core --all-features`
- `git diff --check`

未使用真实 QQ / OneBot 凭证进行真机视觉与交互验收。