### PR TITLE
fix: 补充 QQ 流式超时失败提示

### DIFF
--- a/qq-maid-gateway-rs/src/gateway/c2c.rs
+++ b/qq-maid-gateway-rs/src/gateway/c2c.rs
@@ -602,19 +602,18 @@ async fn send_disabled_progress_status<S: OutboundSender + ?Sized>(
     }
 }
 
-async fn send_local_c2c_failure_text<S: OutboundSender + ?Sized>(
+pub(super) async fn send_local_c2c_failure_text<S: OutboundSender + ?Sized>(
     sender: &S,
     message: &C2cMessage,
     text: &str,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<SendMessageIds> {
     let target = ReplyTarget::qq_c2c(
         message.user_openid.clone(),
         Some(message.message_id.clone()),
     )
     .to_qq_c2c_target()
     .expect("QQ C2C reply target should adapt to QQ API target");
-    sender.send_text(&target, text).await?;
-    Ok(())
+    Ok(sender.send_text(&target, text).await?)
 }
 
 fn failure_stop_reason(failure: &CoreRespondFailure) -> TypingStopReason {

--- a/qq-maid-gateway-rs/src/gateway/group.rs
+++ b/qq-maid-gateway-rs/src/gateway/group.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use anyhow::Context;
-use qq_maid_core::service::CoreInboundKind;
+use qq_maid_core::service::{CoreInboundKind, CoreRespondFailure};
 use tracing::{debug, info, warn};
 
 fn empty_group_reply_fallback_text(bot_display_name: &str) -> String {
@@ -41,9 +41,10 @@ use super::{
     ping::GatewayRuntimeStatus,
     platform,
     ref_index::SharedRefIndex,
+    stream::RespondEventStream,
 };
 use crate::{
-    api::{QqApiClient, SendMessageIds},
+    api::{GroupOutboundSender, QqApiClient, SendMessageIds},
     config::AppConfig,
     message_chunk::{ChunkLimits, OutboundSendError, send_group_outbound_chunked},
     render::{OutboundMessage, render_respond_response_for_profile},
@@ -330,8 +331,8 @@ pub(super) async fn handle_group_message(
             )
             .await?;
         }
-        RespondTransport::Stream(stream) => {
-            if let Some(response) = consume_respond_stream(stream).await {
+        RespondTransport::Stream(stream) => match consume_respond_stream(stream).await {
+            GroupStreamOutcome::Completed(response) => {
                 send_group_respond_response(
                     api,
                     runtime,
@@ -343,7 +344,16 @@ pub(super) async fn handle_group_message(
                 )
                 .await?;
             }
-        }
+            GroupStreamOutcome::Failed(failure) => {
+                let sender = RuntimeRecordingGroupSender {
+                    inner: api,
+                    runtime,
+                };
+                send_group_stream_failure(&sender, group_outbound_cache, &message, &failure)
+                    .await?;
+            }
+            GroupStreamOutcome::ClosedBeforeCompleted => {}
+        },
     }
     Ok(())
 }
@@ -463,13 +473,21 @@ fn record_group_bot_outbound_send(
     );
 }
 
-async fn consume_respond_stream(
-    mut stream: qq_maid_core::service::CoreResponseStream,
-) -> Option<RespondResponse> {
+#[derive(Debug)]
+enum GroupStreamOutcome {
+    Completed(RespondResponse),
+    Failed(CoreRespondFailure),
+    ClosedBeforeCompleted,
+}
+
+async fn consume_respond_stream<E>(mut stream: E) -> GroupStreamOutcome
+where
+    E: RespondEventStream,
+{
     let output_policy = stream.output_policy();
     let mut status_event_count = 0_usize;
     let mut text_delta_count = 0_usize;
-    while let Some(event) = stream.recv().await {
+    while let Some(event) = stream.recv_event().await {
         match event {
             RespondEvent::Status(status) => {
                 status_event_count += 1;
@@ -493,7 +511,7 @@ async fn consume_respond_stream(
                     status_event_count,
                     "group stream collapsed into single Completed response"
                 );
-                return Some(*response);
+                return GroupStreamOutcome::Completed(*response);
             }
             RespondEvent::Failed(failure) => {
                 warn!(
@@ -504,11 +522,35 @@ async fn consume_respond_stream(
                     status_event_count,
                     "core respond stream failed"
                 );
-                return None;
+                return GroupStreamOutcome::Failed(failure);
             }
         }
     }
-    None
+    GroupStreamOutcome::ClosedBeforeCompleted
+}
+
+async fn send_group_stream_failure<S>(
+    sender: &S,
+    group_outbound_cache: &Arc<Mutex<BotOutboundCache>>,
+    message: &GroupMessage,
+    failure: &CoreRespondFailure,
+) -> anyhow::Result<()>
+where
+    S: GroupOutboundSender + ?Sized,
+{
+    let target = ReplyTarget::qq_group(
+        message.group_openid.clone(),
+        Some(message.message_id.clone()),
+    )
+    .to_qq_group_target()
+    .expect("QQ group reply target should adapt to QQ API target");
+    // failure.message 由 Core 按失败类型映射为安全用户文案；Gateway 只负责真实发送，
+    // 不把上游原始错误、工具结果或模型中间内容暴露到群聊。
+    let sent_ids = sender.send_text(&target, &failure.message).await?;
+    let mut cache = group_outbound_cache.lock().unwrap();
+    cache.insert(sent_ids.message_id);
+    cache.insert_ref_index_id(sent_ids.ref_index_id);
+    Ok(())
 }
 
 fn log_group_message_received(message: &GroupMessage, verbose_log: bool) {
@@ -556,6 +598,45 @@ mod tests {
             "哦哦，刚刚在处理上一条消息，稍后再说一声小助手就能继续了呢。"
         );
     }
+
+    #[tokio::test]
+    async fn group_stream_timeout_sends_core_safe_failure_text() {
+        let stream = FakeGroupEventStream::new([RespondEvent::Failed(CoreRespondFailure {
+            kind: CoreFailureKind::LlmTimeout,
+            message: "LLM 服务处理超时，请稍后再试。".to_owned(),
+            retryable: true,
+            agent: None,
+        })]);
+        let failure = match consume_respond_stream(stream).await {
+            GroupStreamOutcome::Failed(failure) => failure,
+            other => panic!("expected failed group stream, got {other:?}"),
+        };
+        let sender = RecordingGroupFailureSender::default();
+        let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        let message = group_message("联网对比", GroupEventType::GroupAtMessage);
+
+        send_group_stream_failure(&sender, &cache, &message, &failure)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            sender.calls.lock().unwrap().as_slice(),
+            [(
+                GroupReplyTarget {
+                    group_openid: "group-1".to_owned(),
+                    msg_id: Some("group-msg-1".to_owned()),
+                },
+                "LLM 服务处理超时，请稍后再试。".to_owned(),
+            )]
+        );
+        assert!(cache.lock().unwrap().contains("failure-message-id"));
+        assert!(
+            cache
+                .lock()
+                .unwrap()
+                .contains_ref_index_id("REFIDX_failure")
+        );
+    }
     use crate::config::{
         AgentTypingConfig, DEFAULT_CONVERSATION_QUEUE_CAPACITY, DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT,
         DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS, DEFAULT_MEDIA_MAX_BYTES,
@@ -565,21 +646,74 @@ mod tests {
         MessageAggregationConfig,
     };
     use crate::{
-        api::{ApiError, QqApiClient},
+        api::{ApiError, GroupReplyTarget, QqApiClient, SendFuture},
         auth::AccessTokenManager,
+        markdown::MarkdownPayload,
     };
     use axum::{Router, body::Bytes, routing::get};
     use qq_maid_common::input_part::{MessageInputPart, MessageMedia};
     use qq_maid_core::service::{
-        CoreError, CoreHealthSnapshot, CoreInboundClassification, CoreRequest, CoreRespondOutput,
-        CoreService, UpstreamStatusSnapshot,
+        CoreError, CoreFailureKind, CoreHealthSnapshot, CoreInboundClassification,
+        CoreOutputPolicy, CoreRequest, CoreRespondOutput, CoreService, UpstreamStatusSnapshot,
     };
+    use std::collections::VecDeque;
     use std::sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     };
     use std::time::Duration;
     use tokio::net::TcpListener;
+
+    #[derive(Debug)]
+    struct FakeGroupEventStream {
+        events: VecDeque<RespondEvent>,
+    }
+
+    impl FakeGroupEventStream {
+        fn new(events: impl IntoIterator<Item = RespondEvent>) -> Self {
+            Self {
+                events: events.into_iter().collect(),
+            }
+        }
+    }
+
+    impl RespondEventStream for FakeGroupEventStream {
+        fn recv_event<'a>(&'a mut self) -> crate::gateway::stream::RespondEventFuture<'a> {
+            Box::pin(async move { self.events.pop_front() })
+        }
+
+        fn output_policy(&self) -> CoreOutputPolicy {
+            CoreOutputPolicy::ProgressThenStream
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingGroupFailureSender {
+        calls: Mutex<Vec<(GroupReplyTarget, String)>>,
+    }
+
+    impl GroupOutboundSender for RecordingGroupFailureSender {
+        fn send_text<'a>(&'a self, target: &'a GroupReplyTarget, text: &'a str) -> SendFuture<'a> {
+            Box::pin(async move {
+                self.calls
+                    .lock()
+                    .unwrap()
+                    .push((target.clone(), text.to_owned()));
+                Ok(SendMessageIds {
+                    message_id: Some("failure-message-id".to_owned()),
+                    ref_index_id: Some("REFIDX_failure".to_owned()),
+                })
+            })
+        }
+
+        fn send_markdown<'a>(
+            &'a self,
+            _target: &'a GroupReplyTarget,
+            _markdown: &'a MarkdownPayload,
+        ) -> SendFuture<'a> {
+            Box::pin(async { Err(ApiError::Unsupported("markdown")) })
+        }
+    }
 
     fn group_message(content: &str, event_type: GroupEventType) -> GroupMessage {
         GroupMessage {

--- a/qq-maid-gateway-rs/src/gateway/stream/delivery.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/delivery.rs
@@ -14,7 +14,10 @@ use crate::{
     api::{C2cReplyTarget, C2cStreamState, QqApiClient},
     config::AppConfig,
     gateway::{
-        c2c::{record_c2c_bot_outbound_refs, send_c2c_respond_response_with_sender},
+        c2c::{
+            record_c2c_bot_outbound_refs, send_c2c_respond_response_with_sender,
+            send_local_c2c_failure_text,
+        },
         event::C2cMessage,
         logging::{mask_identifier, mask_openid},
         outbound::{ReplyCapability, RuntimeRecordingSender},
@@ -709,32 +712,65 @@ where
                     accumulated_chars = accumulated.chars().count(),
                     "core respond stream failed"
                 );
-                if let C2cStreamingPhase::Active(mut stream_state)
-                | C2cStreamingPhase::BrokenActive(mut stream_state) = phase
-                {
-                    send_stream_end(
-                        sender,
-                        user_openid,
-                        Some(reply_msg_id),
-                        stream_final_packet_content(&pending_delta),
-                        &mut stream_state,
-                    )
-                    .await
-                    .inspect_err(|err| {
-                        warn!(
+                match phase {
+                    C2cStreamingPhase::Pending(_) => {
+                        // 进度提示是独立普通消息，不代表 QQ stream 已取得本轮回复所有权。
+                        // Core 在首帧前失败时必须把安全失败文案回给用户，避免会话永久停在
+                        // “正在处理”；若首帧已成功则继续由 Active 分支独占收尾。
+                        let sent_ids =
+                            send_local_c2c_failure_text(sender, message, &failure.message).await?;
+                        if let Some(ref_index) = ref_index {
+                            record_c2c_bot_outbound_refs(
+                                ref_index,
+                                message,
+                                config,
+                                [sent_ids],
+                                &failure.message,
+                                None,
+                            );
+                        }
+                        info!(
                             user = %masked_user,
                             reply_msg_id = %masked_reply_msg_id,
-                            phase = "failed_final_chunk",
-                            stream_state_value = 10_u8,
-                            reset = false,
-                            index = stream_state.index,
-                            has_stream_id = stream_state.stream_id.is_some(),
-                            content_chars = accumulated.chars().count(),
-                            error = %err.log_summary(),
+                            kind = ?failure.kind,
+                            retryable = failure.retryable,
+                            response_delivery_mode = "ordinary_failure_reply",
+                            stream_state = "pending",
+                            text_delta_count,
+                            status_event_count,
                             accumulated_chars = accumulated.chars().count(),
-                            "QQ stream finalization after core failure failed"
+                            elapsed_ms = started_at.elapsed().as_millis(),
+                            "QQ C2C pending stream failure sent to user"
                         );
-                    })?;
+                        return Ok(C2cStreamingPhase::Completed);
+                    }
+                    C2cStreamingPhase::Active(mut stream_state)
+                    | C2cStreamingPhase::BrokenActive(mut stream_state) => {
+                        send_stream_end(
+                            sender,
+                            user_openid,
+                            Some(reply_msg_id),
+                            stream_final_packet_content(&pending_delta),
+                            &mut stream_state,
+                        )
+                        .await
+                        .inspect_err(|err| {
+                            warn!(
+                                user = %masked_user,
+                                reply_msg_id = %masked_reply_msg_id,
+                                phase = "failed_final_chunk",
+                                stream_state_value = 10_u8,
+                                reset = false,
+                                index = stream_state.index,
+                                has_stream_id = stream_state.stream_id.is_some(),
+                                content_chars = accumulated.chars().count(),
+                                error = %err.log_summary(),
+                                accumulated_chars = accumulated.chars().count(),
+                                "QQ stream finalization after core failure failed"
+                            );
+                        })?;
+                    }
+                    C2cStreamingPhase::Completed => return Ok(C2cStreamingPhase::Completed),
                 }
                 return Err(anyhow::anyhow!(
                     "core respond stream failed before Completed: kind={:?}, retryable={}",

--- a/qq-maid-gateway-rs/src/gateway/stream/event_stream.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/event_stream.rs
@@ -12,7 +12,7 @@ pub(crate) type RespondEventFuture<'a> =
     Pin<Box<dyn Future<Output = Option<RespondEvent>> + Send + 'a>>;
 pub(crate) type StreamSendFuture<'a> = Pin<Box<dyn Future<Output = StreamSendResult> + Send + 'a>>;
 
-/// Core 流事件来源抽象，仅用于把 C2C 流式状态机与真实 Core channel 解耦，便于覆盖异常分支。
+/// Core 流事件来源抽象，用于把 QQ 流事件消费者与真实 Core channel 解耦，便于覆盖异常分支。
 pub(crate) trait RespondEventStream: Send {
     fn recv_event<'a>(&'a mut self) -> RespondEventFuture<'a>;
 

--- a/qq-maid-gateway-rs/src/gateway/stream/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/mod.rs
@@ -9,6 +9,7 @@ mod send;
 mod types;
 
 pub(super) use delivery::stream_respond_c2c;
+pub(crate) use event_stream::RespondEventStream;
 
 #[cfg(test)]
 pub(super) use delivery::{
@@ -16,9 +17,7 @@ pub(super) use delivery::{
     stream_respond_c2c_with_sender_and_ref_index, stream_respond_c2c_with_sender_and_typing,
 };
 #[cfg(test)]
-pub(super) use event_stream::{
-    C2cStreamSender, RespondEventFuture, RespondEventStream, StreamSendFuture,
-};
+pub(super) use event_stream::{C2cStreamSender, RespondEventFuture, StreamSendFuture};
 #[cfg(test)]
 pub(super) use send::{STREAM_FINAL_MARKER, send_stream_chunk, send_stream_end};
 #[cfg(test)]

--- a/qq-maid-gateway-rs/src/gateway/stream/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests.rs
@@ -1108,10 +1108,10 @@ async fn stream_middle_failure_does_not_send_ordinary_fallback_on_completed() {
 }
 
 #[tokio::test]
-async fn core_failed_event_is_returned_as_observable_error() {
+async fn pending_core_failure_sends_safe_ordinary_failure_reply() {
     let events = FakeEventStream::new([RespondEvent::Failed(CoreRespondFailure {
         kind: CoreFailureKind::Internal,
-        message: "boom".to_owned(),
+        message: "处理失败，请稍后再试。".to_owned(),
         retryable: false,
         agent: None,
     })]);
@@ -1120,8 +1120,14 @@ async fn core_failed_event_is_returned_as_observable_error() {
     let result =
         stream_respond_c2c_with_sender(events, &sender, &c2c_message(), &test_config()).await;
 
-    assert!(result.is_err());
-    assert!(sender.calls().is_empty());
+    assert!(matches!(result.unwrap(), C2cStreamingPhase::Completed));
+    assert_eq!(
+        sender.calls(),
+        vec![FakeCall::Text {
+            content: "处理失败，请稍后再试。".to_owned(),
+            msg_id: Some("msg-1".to_owned()),
+        }]
+    );
 }
 
 #[tokio::test]
@@ -1154,9 +1160,42 @@ async fn stream_timeout_failure_stops_typing_with_timeout_reason() {
     )
     .await;
 
-    assert!(result.is_err());
+    assert!(matches!(result.unwrap(), C2cStreamingPhase::Completed));
     assert_eq!(
         *stop_reason.lock().unwrap(),
         Some(TypingStopReason::Timeout)
+    );
+    assert_eq!(
+        sender.calls(),
+        vec![FakeCall::Text {
+            content: "LLM 服务处理超时，请稍后再试。".to_owned(),
+            msg_id: Some("msg-1".to_owned()),
+        }]
+    );
+}
+
+#[tokio::test]
+async fn active_core_failure_finalizes_stream_without_ordinary_failure_reply() {
+    let events = FakeEventStream::new([
+        RespondEvent::TextDelta("已发送".to_owned()),
+        RespondEvent::Failed(CoreRespondFailure {
+            kind: CoreFailureKind::LlmTimeout,
+            message: "LLM 服务处理超时，请稍后再试。".to_owned(),
+            retryable: true,
+            agent: None,
+        }),
+    ]);
+    let sender = FakeStreamSender::new([Ok(Some("stream-1".to_owned())), Ok(None)]);
+
+    let result =
+        stream_respond_c2c_with_sender(events, &sender, &c2c_message(), &test_config()).await;
+
+    assert!(result.is_err());
+    let calls = sender.calls();
+    assert_eq!(calls.len(), 2);
+    assert!(
+        calls
+            .iter()
+            .all(|call| matches!(call, FakeCall::Stream { .. }))
     );
 }


### PR DESCRIPTION
## 变更

- QQ C2C 在 Core 首帧前失败时发送 Core 提供的安全失败文案，并回填 ref index
- QQ 群聊保留 stream `Failed` 事件并回复安全失败文案，同时记录 outbound message/ref index id
- 保持 C2C 首帧成功后的 stream 所有权约束，失败时只结束原 stream，不补发第二条普通消息
- 增加私聊 Pending 超时、群聊超时及 Active stream 失败回归测试

## 根因

Core 已生成“LLM 服务处理超时，请稍后再试。”等安全用户文案，但 QQ C2C 流式 Pending 分支直接返回错误、群聊 stream consumer 将 `Failed` 折叠为 `None`，导致用户只能看到先前的进度提示。

## 用户影响

上游或联网查询超时后，私聊和群聊都会收到明确失败提示，不再永久停留在“正在想一下”；已开始的 C2C 流仍不会产生重复普通回复。

## 验证

- `make test-gateway`
- `cargo clippy -p qq-maid-gateway-rs --all-targets --all-features -- -D warnings`
- `make test`
- `git diff --check`