### PR TITLE
[codex] 扩展待办列表组合筛选

### DIFF
--- a/qq-maid-common/src/time_context/date_range.rs
+++ b/qq-maid-common/src/time_context/date_range.rs
@@ -60,6 +60,8 @@ pub fn parse_date_range_expression(
         ("昨天", today - Duration::days(1), today - Duration::days(1))
     } else if compact.contains("今天") {
         ("今天", today, today)
+    } else if compact.contains("明天") {
+        ("明天", today + Duration::days(1), today + Duration::days(1))
     } else if compact.contains("本周") || compact.contains("这周") {
         ("本周", this_week_start, this_week_start + Duration::days(6))
     } else if compact.contains("上周") {

--- a/qq-maid-common/src/time_context/tests.rs
+++ b/qq-maid-common/src/time_context/tests.rs
@@ -45,6 +45,18 @@ fn resolves_relative_dates_and_ranges() {
 }
 
 #[test]
+fn parses_tomorrow_and_week_ranges_with_fixed_context() {
+    let ctx = fixed_context();
+    let tomorrow = parse_date_range_expression("明天", &ctx).unwrap();
+    assert_eq!(tomorrow.start, ymd(2026, 6, 10));
+    assert_eq!(tomorrow.end, ymd(2026, 6, 10));
+
+    let week = parse_date_range_expression("本周", &ctx).unwrap();
+    assert_eq!(week.start, ymd(2026, 6, 8));
+    assert_eq!(week.end, ymd(2026, 6, 14));
+}
+
+#[test]
 fn resolves_month_ranges_across_year_boundary() {
     let offset = shanghai_offset();
     let ctx =

--- a/qq-maid-core/src/runtime/respond/help.rs
+++ b/qq-maid-core/src/runtime/respond/help.rs
@@ -44,6 +44,7 @@ const HELP_MODULES: &[HelpModule] = &[
         summary: "管理当前用户和当前聊天范围内的待办。中文别名：`/待办`、`/任务`。",
         commands: &[
             "- `/todo`：查看未完成待办",
+            "- `/todo list [今天|明天|本周|逾期|无截止时间] [未完成|已完成|全部] [关键词 文本]`：组合筛选待办",
             "- `/todo all`：查看全部待办",
             "- `/todo search 关键词`：搜索未完成待办",
             "- `/todo done`、`/todo undo`：查看已完成待办",

--- a/qq-maid-core/src/runtime/respond/tests/todo/query.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo/query.rs
@@ -9,7 +9,7 @@ async fn todo_query_writes_visible_snapshot_for_tool_followup() {
 
     let response = service.respond(message("看一下待办")).await.unwrap();
     assert_eq!(response.command.as_deref(), Some("todo_list"));
-    let text = response.text.unwrap();
+    let text = response.text.as_deref().unwrap();
     assert!(text.contains("1. 第一条"));
     assert!(text.contains("2. 第二条"));
 
@@ -22,11 +22,11 @@ async fn todo_query_writes_visible_snapshot_for_tool_followup() {
 }
 
 #[tokio::test]
-async fn todo_pending_list_collapses_after_five_items_and_full_query_restores_all() {
+async fn todo_pending_list_shows_ten_and_reports_truncation_total() {
     let service = test_service();
     let owner = TodoStore::owner(Some("u1"), "group:g1");
     let mut created_ids = Vec::new();
-    for index in 1..=6 {
+    for index in 1..=11 {
         let item = service
             .task_store
             .create(&owner, draft(&format!("第{index}条待办")))
@@ -36,34 +36,109 @@ async fn todo_pending_list_collapses_after_five_items_and_full_query_restores_al
 
     let response = service.respond(message("/todo")).await.unwrap();
     assert_eq!(response.command.as_deref(), Some("todo_list"));
-    let text = response.text.unwrap();
-    assert!(text.contains("🚧 进行中 · 共 6 项"));
+    let text = response.text.as_deref().unwrap();
+    assert!(text.contains("🚧 进行中 · 共 11 项"));
     assert!(text.contains("1. 第1条待办"));
-    assert!(text.contains("5. 第5条待办"));
-    assert!(!text.contains("第6条待办"));
-    assert!(text.contains("还有 1 项进行中待办，可说“查看全部进行中待办”。"));
+    assert!(text.contains("10. 第10条待办"));
+    assert!(!text.contains("第11条待办"));
+    assert!(text.contains("共找到 11 条待办，当前展示前 10 条"));
+    assert!(
+        response
+            .markdown
+            .as_deref()
+            .unwrap()
+            .contains("共找到 11 条待办，当前展示前 10 条")
+    );
     let session = service
         .session_store
         .get_or_create_active(&test_meta())
         .unwrap();
     let snapshot = session.last_todo_query.expect("missing todo snapshot");
-    assert_eq!(snapshot.result_ids, created_ids[..5].to_vec());
+    assert_eq!(snapshot.result_ids, created_ids[..10].to_vec());
+}
 
-    let full = service
-        .respond(message("查看全部进行中待办"))
+#[tokio::test]
+async fn todo_list_command_rejects_conflicting_time_filters_with_help() {
+    let service = test_service();
+
+    let response = service
+        .respond(message("/todo list 今天 明天"))
         .await
         .unwrap();
-    assert_eq!(full.command.as_deref(), Some("todo_list"));
-    let full_text = full.text.unwrap();
-    assert!(full_text.contains("🚧 进行中 · 共 6 项"));
-    assert!(full_text.contains("6. 第6条待办"));
-    assert!(!full_text.contains("还有 1 项进行中待办"));
-    let session = service
-        .session_store
-        .get_or_create_active(&test_meta())
+
+    assert_eq!(response.command.as_deref(), Some("todo_list_invalid"));
+    let text = response.text.unwrap();
+    assert!(text.contains("筛选条件无效"));
+    assert!(text.contains("一次查询只能指定一个时间条件"));
+    assert!(text.contains("/todo list"));
+}
+
+#[tokio::test]
+async fn todo_list_command_combines_time_status_and_fuzzy_keyword() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    let today = qq_maid_common::time_context::request_time_context().local_date();
+    let tomorrow = (today + Duration::days(1)).format("%Y-%m-%d").to_string();
+    let day_after = (today + Duration::days(2)).format("%Y-%m-%d").to_string();
+    service
+        .task_store
+        .create(&owner, draft_due_date("项目 A 报告", &tomorrow))
         .unwrap();
-    let snapshot = session.last_todo_query.expect("missing full todo snapshot");
-    assert_eq!(snapshot.result_ids, created_ids);
+    service
+        .task_store
+        .create(&owner, draft_due_date("项目 B 报告", &tomorrow))
+        .unwrap();
+    service
+        .task_store
+        .create(&owner, draft_due_date("项目 A 后续", &day_after))
+        .unwrap();
+
+    let response = service
+        .respond(message("/todo list 明天 未完成 项目 A"))
+        .await
+        .unwrap();
+    let text = response.text.unwrap();
+    assert!(text.contains("项目 A 报告"));
+    assert!(!text.contains("项目 B 报告"));
+    assert!(!text.contains("项目 A 后续"));
+}
+
+#[tokio::test]
+async fn todo_list_command_supports_completed_no_due_and_keyword_filters() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    let pending = service
+        .task_store
+        .create(&owner, draft("报销材料"))
+        .unwrap();
+    let completed = service
+        .task_store
+        .create(&owner, draft("报销报告"))
+        .unwrap();
+    service.task_store.complete(&owner, &completed.id).unwrap();
+
+    let completed_response = service
+        .respond(message("/todo list 已完成 关键词 报销"))
+        .await
+        .unwrap();
+    let completed_text = completed_response.text.unwrap();
+    assert!(completed_text.contains("报销报告"));
+    assert!(!completed_text.contains("报销材料"));
+
+    let no_due_response = service
+        .respond(message("/todo list 无截止时间 报销"))
+        .await
+        .unwrap();
+    let no_due_text = no_due_response.text.unwrap();
+    assert!(no_due_text.contains("报销材料"));
+    assert!(!no_due_text.contains("报销报告"));
+    assert!(
+        service
+            .task_store
+            .get_by_id(&owner, &pending.id)
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[tokio::test]
@@ -122,6 +197,16 @@ async fn natural_todo_date_query_filters_pending_by_local_due_date() {
     let tomorrow_text_reply = tomorrow_response.text.unwrap();
     assert!(tomorrow_text_reply.contains("明天事项"));
     assert!(!tomorrow_text_reply.contains("今天日期型"));
+
+    let natural_tomorrow = service
+        .respond(message("帮我看看明天的待办"))
+        .await
+        .unwrap();
+    assert_eq!(natural_tomorrow.command.as_deref(), Some("todo_due_date"));
+    let natural_tomorrow_text = natural_tomorrow.text.unwrap();
+    assert!(natural_tomorrow_text.contains("明天事项"));
+    assert!(!natural_tomorrow_text.contains("今天日期型"));
+    assert!(!natural_tomorrow_text.contains("无时间事项"));
 
     let standard_chat_response = service.respond(message("明天要做什么")).await.unwrap();
     assert_ne!(

--- a/qq-maid-core/src/runtime/respond/tests/todo/query.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo/query.rs
@@ -74,6 +74,129 @@ async fn todo_list_command_rejects_conflicting_time_filters_with_help() {
 }
 
 #[tokio::test]
+async fn todo_list_overdue_pending_is_order_independent() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    let today = qq_maid_common::time_context::request_time_context().local_date();
+    let yesterday = (today - Duration::days(1)).format("%Y-%m-%d").to_string();
+    let tomorrow = (today + Duration::days(1)).format("%Y-%m-%d").to_string();
+    let overdue = service
+        .task_store
+        .create(&owner, draft_due_date("逾期未完成", &yesterday))
+        .unwrap();
+    service
+        .task_store
+        .create(&owner, draft_due_date("未来未完成", &tomorrow))
+        .unwrap();
+    let completed = service
+        .task_store
+        .create(&owner, draft_due_date("逾期已完成", &yesterday))
+        .unwrap();
+    service.task_store.complete(&owner, &completed.id).unwrap();
+
+    let mut replies = Vec::new();
+    for arguments in ["未完成 逾期", "逾期 未完成"] {
+        let response = service
+            .respond(message(&format!("/todo list {arguments}")))
+            .await
+            .unwrap();
+        assert_eq!(response.command.as_deref(), Some("todo_list"));
+        let text = response.text.unwrap();
+        assert!(text.contains("🚧 进行中 · 共 1 项"));
+        assert!(text.contains("逾期未完成"));
+        assert!(!text.contains("未来未完成"));
+        assert!(!text.contains("逾期已完成"));
+
+        let snapshot = service
+            .session_store
+            .get_or_create_active(&test_meta())
+            .unwrap()
+            .last_todo_query
+            .expect("missing overdue snapshot");
+        assert_eq!(snapshot.query_type, "search");
+        assert_eq!(snapshot.condition, "未完成、逾期");
+        assert_eq!(snapshot.result_ids, vec![overdue.id.clone()]);
+        replies.push(text);
+    }
+    assert_eq!(replies[0], replies[1]);
+}
+
+#[tokio::test]
+async fn todo_list_status_conflicts_are_order_independent() {
+    let service = test_service();
+    let cases = [
+        ("已完成 逾期", "逾期 已完成", "逾期筛选只适用于未完成待办"),
+        ("全部 逾期", "逾期 全部", "逾期筛选只适用于未完成待办"),
+        (
+            "未完成 已完成",
+            "已完成 未完成",
+            "一次查询只能指定一个状态条件",
+        ),
+        ("全部 已完成", "已完成 全部", "一次查询只能指定一个状态条件"),
+        (
+            "pending completed",
+            "completed pending",
+            "一次查询只能指定一个状态条件",
+        ),
+    ];
+
+    for (forward, reverse, expected_error) in cases {
+        let forward_response = service
+            .respond(message(&format!("/todo list {forward}")))
+            .await
+            .unwrap();
+        let reverse_response = service
+            .respond(message(&format!("/todo list {reverse}")))
+            .await
+            .unwrap();
+        assert_eq!(
+            forward_response.command.as_deref(),
+            Some("todo_list_invalid")
+        );
+        assert_eq!(
+            reverse_response.command.as_deref(),
+            Some("todo_list_invalid")
+        );
+        let forward_text = forward_response.text.unwrap();
+        let reverse_text = reverse_response.text.unwrap();
+        assert!(forward_text.contains(expected_error));
+        assert_eq!(forward_text, reverse_text);
+    }
+}
+
+#[tokio::test]
+async fn todo_list_duplicate_status_is_deduplicated_in_condition() {
+    let service = test_service();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    let tomorrow = (qq_maid_common::time_context::request_time_context().local_date()
+        + Duration::days(1))
+    .format("%Y-%m-%d")
+    .to_string();
+    let item = service
+        .task_store
+        .create(&owner, draft_due_date("明天待办", &tomorrow))
+        .unwrap();
+
+    let response = service
+        .respond(message("/todo list 未完成 未完成 明天"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("todo_list"));
+    assert!(response.text.unwrap().contains("明天待办"));
+    let snapshot = service
+        .session_store
+        .get_or_create_active(&test_meta())
+        .unwrap()
+        .last_todo_query
+        .expect("missing duplicate status snapshot");
+    assert_eq!(snapshot.query_type, "due-date");
+    assert_eq!(snapshot.condition, "未完成、明天");
+    assert_eq!(snapshot.condition.matches("未完成").count(), 1);
+    assert_eq!(snapshot.result_ids, vec![item.id]);
+}
+
+#[tokio::test]
 async fn todo_list_command_combines_time_status_and_fuzzy_keyword() {
     let service = test_service();
     let owner = TodoStore::owner(Some("u1"), "group:g1");

--- a/qq-maid-core/src/runtime/respond/tests/todo_agent/query.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo_agent/query.rs
@@ -32,6 +32,128 @@ async fn ordinary_chat_response_does_not_inherit_old_todo_visible_snapshot() {
 }
 
 #[tokio::test]
+async fn natural_language_tool_query_combines_tomorrow_status_and_keyword() {
+    let today = qq_maid_common::time_context::request_time_context().local_date();
+    let tomorrow = (today + chrono::Duration::days(1))
+        .format("%Y-%m-%d")
+        .to_string();
+    let day_after = (today + chrono::Duration::days(2))
+        .format("%Y-%m-%d")
+        .to_string();
+    let arguments = serde_json::json!({
+        "status": "pending",
+        "due_date": null,
+        "date_range_text": "明天",
+        "time_filter": null,
+        "keyword": "项目 A"
+    })
+    .to_string();
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json("list_todos", arguments, "查询完成");
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    for (title, date) in [
+        ("项目 A 报告", tomorrow.as_str()),
+        ("项目 B 报告", tomorrow.as_str()),
+        ("项目 A 后续", day_after.as_str()),
+    ] {
+        service
+            .task_store
+            .create(
+                &owner,
+                TodoItemDraft {
+                    title: title.to_owned(),
+                    detail: None,
+                    raw_text: None,
+                    due_date: Some(date.to_owned()),
+                    due_at: None,
+                    reminder_at: None,
+                    time_precision: TodoTimePrecision::Date,
+                    recurrence_kind: crate::runtime::tools::todo::TodoRecurrenceKind::None,
+                    recurrence_interval_days: 0,
+                    recurrence_interval: 0,
+                    recurrence_unit: crate::runtime::tools::todo::TodoRecurrenceUnit::Day,
+                },
+            )
+            .unwrap();
+    }
+
+    let response = service
+        .respond(private_message("明天项目 A 的未完成事项"))
+        .await
+        .unwrap();
+    let text = response.text.unwrap();
+    assert!(text.contains("项目 A 报告"));
+    assert!(!text.contains("项目 B 报告"));
+    assert!(!text.contains("项目 A 后续"));
+    assert_eq!(inspector.tool_call_count(), 1);
+
+    let session = service
+        .session_store
+        .get_or_create_active(&private_test_meta())
+        .unwrap();
+    let snapshot = session.last_todo_query.expect("missing combined snapshot");
+    assert_eq!(snapshot.query_type, "due-date");
+    assert_eq!(snapshot.result_ids.len(), 1);
+}
+
+#[tokio::test]
+async fn natural_language_tool_query_supports_fuzzy_keyword_search() {
+    let arguments = serde_json::json!({
+        "status": "pending",
+        "due_date": null,
+        "date_range_text": null,
+        "time_filter": null,
+        "keyword": "报销"
+    })
+    .to_string();
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json("list_todos", arguments, "查询完成");
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let matched = service
+        .task_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "提交报销报告".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: None,
+                due_at: None,
+                reminder_at: None,
+                time_precision: TodoTimePrecision::None,
+                recurrence_kind: crate::runtime::tools::todo::TodoRecurrenceKind::None,
+                recurrence_interval_days: 0,
+                recurrence_interval: 0,
+                recurrence_unit: crate::runtime::tools::todo::TodoRecurrenceUnit::Day,
+            },
+        )
+        .unwrap();
+    create_private_todo(&service, "检查服务器日志");
+
+    let response = service
+        .respond(private_message("找标题里有报销的待办"))
+        .await
+        .unwrap();
+    let text = response.text.unwrap();
+    assert!(text.contains("提交报销报告"));
+    assert!(!text.contains("检查服务器日志"));
+    assert_eq!(inspector.tool_call_count(), 1);
+
+    let session = service
+        .session_store
+        .get_or_create_active(&private_test_meta())
+        .unwrap();
+    let snapshot = session.last_todo_query.expect("missing keyword snapshot");
+    assert_eq!(snapshot.query_type, "search");
+    assert_eq!(snapshot.condition, "关键词“报销”");
+    assert_eq!(snapshot.result_ids, vec![matched.id]);
+}
+
+#[tokio::test]
 async fn list_todos_due_date_receipt_preserves_filtered_visible_snapshot() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
@@ -397,7 +519,7 @@ async fn natural_language_todo_query_aliases_and_filters_stay_deterministic() {
 }
 
 #[tokio::test]
-async fn todo_completed_lists_use_dynamic_collapse_hints() {
+async fn todo_completed_lists_show_up_to_ten_without_old_five_item_collapse() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), false);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
@@ -415,34 +537,18 @@ async fn todo_completed_lists_use_dynamic_collapse_hints() {
         .unwrap();
     let completed_text = completed.text.unwrap();
     assert!(completed_text.contains("✅ 已完成 · 共 9 项"));
-    assert!(completed_text.contains("还有 4 项已完成待办，可说“查看全部已完成待办”。"));
+    assert!(!completed_text.contains("还有"));
     let session = service
         .session_store
         .get_or_create_active(&private_test_meta())
         .unwrap();
     let snapshot = session.last_todo_query.expect("missing completed snapshot");
     assert_eq!(snapshot.query_type, "completed-list");
-    assert_eq!(snapshot.result_ids.len(), 5);
-
-    let completed_full = service
-        .respond(private_message("查看全部已完成待办"))
-        .await
-        .unwrap();
-    let completed_full_text = completed_full.text.unwrap();
-    assert!(!completed_full_text.contains("还有 4 项已完成待办"));
-    let session = service
-        .session_store
-        .get_or_create_active(&private_test_meta())
-        .unwrap();
-    let snapshot = session
-        .last_todo_query
-        .expect("missing full completed snapshot");
-    assert_eq!(snapshot.query_type, "completed-list");
     assert_eq!(snapshot.result_ids.len(), 9);
 }
 
 #[tokio::test]
-async fn todo_date_filter_collapse_hint_restores_full_result_scope() {
+async fn todo_date_filter_shows_nine_without_old_five_item_collapse() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), false);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
@@ -460,7 +566,7 @@ async fn todo_date_filter_collapse_hint_restores_full_result_scope() {
         .unwrap();
     let text = response.text.unwrap();
     assert!(text.contains("已完成待办：截至今天完成"));
-    assert!(text.contains("还有 4 项截至今天完成的已完成待办，可说“查看完整结果”。"));
+    assert!(!text.contains("还有"));
     let session = service
         .session_store
         .get_or_create_active(&private_test_meta())
@@ -468,31 +574,15 @@ async fn todo_date_filter_collapse_hint_restores_full_result_scope() {
     let snapshot = session.last_todo_query.expect("missing date snapshot");
     assert_eq!(snapshot.query_type, "completed-time");
     assert_eq!(snapshot.condition, "截至今天完成");
-    assert_eq!(snapshot.result_ids.len(), 5);
-
-    let full = service
-        .respond(private_message("查看完整结果"))
-        .await
-        .unwrap();
-    let full_text = full.text.unwrap();
-    assert!(full_text.contains("已完成待办：截至今天完成"));
-    assert!(!full_text.contains("还有 4 项截至今天完成的已完成待办"));
-    let session = service
-        .session_store
-        .get_or_create_active(&private_test_meta())
-        .unwrap();
-    let snapshot = session.last_todo_query.expect("missing full date snapshot");
-    assert_eq!(snapshot.query_type, "completed-time");
-    assert_eq!(snapshot.condition, "截至今天完成");
     assert_eq!(snapshot.result_ids.len(), 9);
 }
 
 #[tokio::test]
-async fn todo_all_collapse_hint_restores_full_result_with_tool_loop_enabled() {
+async fn todo_all_caps_at_ten_and_reports_real_total() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
-    for index in 1..=10 {
+    for index in 1..=11 {
         service
             .task_store
             .create(&owner, todo_draft(format!("全部待办 {index}")))
@@ -502,19 +592,10 @@ async fn todo_all_collapse_hint_restores_full_result_with_tool_loop_enabled() {
     let collapsed = service.respond(private_message("全部待办")).await.unwrap();
     let collapsed_text = collapsed.text.unwrap();
     assert_eq!(collapsed.command.as_deref(), Some("todo_all"));
-    assert!(collapsed_text.contains("📋 全部待办 · 共 10 项"));
-    assert!(collapsed_text.contains("还有 5 项待办，可说“查看完整结果”。"));
-
-    let full = service
-        .respond(private_message("查看完整结果"))
-        .await
-        .unwrap();
-    let full_text = full.text.unwrap();
-
-    assert_eq!(full.command.as_deref(), Some("todo_all"));
-    assert!(full_text.contains("📋 全部待办 · 共 10 项"));
-    assert!(full_text.contains("全部待办 10"));
-    assert!(!full_text.contains("还有 5 项待办"));
+    assert!(collapsed_text.contains("📋 全部待办 · 共 11 项"));
+    assert!(collapsed_text.contains("全部待办 10"));
+    assert!(!collapsed_text.contains("全部待办 11"));
+    assert!(collapsed_text.contains("共找到 11 条待办，当前展示前 10 条"));
     assert_eq!(inspector.tool_call_count(), 0);
 }
 

--- a/qq-maid-core/src/runtime/respond/tests/todo_receipt.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo_receipt.rs
@@ -28,11 +28,11 @@ async fn todo_complete_receipt_is_lightweight_and_refreshes_pending_snapshot() {
     assert!(text.contains("✅ 已完成待办 · 1条"));
     assert!(!text.contains("🚧 当前进行中 · 共 6 项"));
     assert!(!text.contains("还有 1 项进行中待办"));
-    assert_refreshed_pending_snapshot(&service, &owner, 5);
+    assert_refreshed_pending_snapshot(&service, &owner, 6);
 }
 
 #[tokio::test]
-async fn todo_complete_receipt_refreshes_pending_snapshot_with_two_hidden_items() {
+async fn todo_complete_receipt_refreshes_pending_snapshot_at_ten_item_limit() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
         .with_tool_call_json(
@@ -42,7 +42,7 @@ async fn todo_complete_receipt_refreshes_pending_snapshot_with_two_hidden_items(
         );
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
     let owner = private_todo_owner();
-    create_numbered_private_todos(&service, "待办", 1..=8);
+    create_numbered_private_todos(&service, "待办", 1..=12);
 
     service
         .respond(private_message("看一下待办"))
@@ -55,36 +55,6 @@ async fn todo_complete_receipt_refreshes_pending_snapshot_with_two_hidden_items(
 
     let text = response.text.unwrap();
     assert!(text.contains("✅ 已完成待办 · 1条"));
-    assert!(!text.contains("🚧 当前进行中 · 共 7 项"));
-    assert!(!text.contains("还有 2 项进行中待办"));
-    assert_refreshed_pending_snapshot(&service, &owner, 5);
-}
-
-#[tokio::test]
-async fn todo_complete_receipt_refreshes_pending_snapshot_with_dynamic_hidden_count() {
-    let inspector = MockProvider::new()
-        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
-        .with_tool_call_json(
-            "complete_todos",
-            r#"{"numbers":[1],"reference":null}"#,
-            "已完成第一条",
-        );
-    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
-    let owner = private_todo_owner();
-    create_numbered_private_todos(&service, "待办", 1..=9);
-
-    service
-        .respond(private_message("看一下待办"))
-        .await
-        .unwrap();
-    let response = service
-        .respond(private_message("完成第一条"))
-        .await
-        .unwrap();
-
-    let text = response.text.unwrap();
-    assert!(text.contains("✅ 已完成待办 · 1条"));
-    assert!(!text.contains("🚧 当前进行中 · 共 8 项"));
-    assert!(!text.contains("还有 3 项进行中待办"));
-    assert_refreshed_pending_snapshot(&service, &owner, 5);
+    assert!(!text.contains("🚧 当前进行中 · 共 11 项"));
+    assert_refreshed_pending_snapshot(&service, &owner, 10);
 }

--- a/qq-maid-core/src/runtime/tools/todo/common.rs
+++ b/qq-maid-core/src/runtime/tools/todo/common.rs
@@ -123,14 +123,6 @@ impl TodoToolListStatus {
         }
     }
 
-    pub(super) fn query_type(self) -> &'static str {
-        match self {
-            Self::Pending => "list",
-            Self::Completed => "completed-list",
-            Self::All => "all",
-        }
-    }
-
     pub(super) fn condition(self) -> &'static str {
         match self {
             Self::Pending => "",

--- a/qq-maid-core/src/runtime/tools/todo/flow/mod.rs
+++ b/qq-maid-core/src/runtime/tools/todo/flow/mod.rs
@@ -15,7 +15,8 @@ use crate::{
         },
         session::{SessionMeta, SessionRecord},
         tools::todo::{
-            TodoItem, TodoOwner, TodoStatus, TodoStore, todo_visible_entity_snapshot,
+            TodoItem, TodoOwner, TodoQueryStatus, TodoStatus, TodoStore,
+            query_filter::parse_todo_list_query, todo_visible_entity_snapshot,
             valid_last_visible_todo_query,
         },
     },
@@ -202,32 +203,69 @@ impl RustRespondService {
 
         let (reply, command_name, visible_query_shown) = match command.action.as_str() {
             "todo_list" => {
-                if let Some(date_query) = parse_todo_due_date_query(&command.argument) {
-                    let items = self
-                        .task_store
-                        .list_by_due_date(&owner, TodoStatus::Pending, date_query.date)
-                        .map_err(todo_error)?;
-                    remember_todo_query(
-                        session,
-                        &owner,
-                        "due-date",
-                        date_query.condition.clone(),
-                        &items,
+                match parse_todo_list_query(&command.argument, &request_time_context()) {
+                    Ok(parsed) => {
+                        let page = self
+                            .task_store
+                            .query_todos(&owner, &parsed.query)
+                            .map_err(todo_error)?;
+                        let query_type = match parsed.query.status {
+                            TodoQueryStatus::All => "all",
+                            TodoQueryStatus::Completed => "completed-list",
+                            TodoQueryStatus::Pending
+                                if parsed.query.keyword.is_some()
+                                    || matches!(
+                                        parsed.query.time,
+                                        Some(
+                                            crate::runtime::tools::todo::TodoQueryTimeFilter::Overdue { .. }
+                                                | crate::runtime::tools::todo::TodoQueryTimeFilter::NoDueDate
+                                        )
+                                    ) =>
+                            {
+                                "search"
+                            }
+                            TodoQueryStatus::Pending if parsed.query.time.is_some() => "due-date",
+                            TodoQueryStatus::Pending => "list",
+                        };
+                        session.remember_last_todo_query(
+                            &owner.key,
+                            query_type,
+                            parsed.condition.clone(),
+                            page.items.iter().map(|item| item.id.clone()).collect(),
+                        );
+                        let title = match parsed.query.status {
+                            TodoQueryStatus::Pending => "🚧 进行中",
+                            TodoQueryStatus::Completed => "✅ 已完成",
+                            TodoQueryStatus::All => "📋 全部待办",
+                        };
+                        let empty_text = if parsed.condition.is_empty() {
+                            match parsed.query.status {
+                                TodoQueryStatus::Pending => "暂无未完成待办",
+                                TodoQueryStatus::Completed => "暂无已完成待办",
+                                TodoQueryStatus::All => "当前没有待办。",
+                            }
+                        } else {
+                            "没有找到匹配的待办。"
+                        };
+                        (
+                            format_todo_query_page_reply(
+                                &page,
+                                title,
+                                empty_text,
+                                &parsed.condition,
+                            ),
+                            "todo_list".to_owned(),
+                            true,
+                        )
+                    }
+                    Err(err) => (
+                        simple_todo_notice(&format!(
+                            "筛选条件无效：{}\n用法：/todo list [今天|明天|本周|逾期|无截止时间] [未完成|已完成|全部] [关键词 文本]",
+                            err.message()
+                        )),
+                        "todo_list_invalid".to_owned(),
                         false,
-                    );
-                    (
-                        format_todo_due_date_reply(&items, &date_query.label, false),
-                        "todo_due_date".to_owned(),
-                        true,
-                    )
-                } else {
-                    let items = self.task_store.list_pending(&owner).map_err(todo_error)?;
-                    remember_todo_query(session, &owner, "list", "", &items, false);
-                    (
-                        format_todo_list_reply(&items, false),
-                        "todo_list".to_owned(),
-                        true,
-                    )
+                    ),
                 }
             }
             "todo_all" => {
@@ -818,9 +856,13 @@ fn pure_todo_due_date_query_patterns(date_query: &TodoDueDateQuery) -> Vec<Strin
             format!("{date}待办"),
             format!("我的{date}待办"),
             format!("查看{date}待办"),
+            format!("看看{date}待办"),
+            format!("帮我看看{date}待办"),
             format!("查询{date}待办"),
             format!("列出{date}待办"),
             format!("查看{date}的待办"),
+            format!("看看{date}的待办"),
+            format!("帮我看看{date}的待办"),
             format!("查询{date}的待办"),
             format!("列出{date}的待办"),
             format!("{date}未完成待办"),

--- a/qq-maid-core/src/runtime/tools/todo/format.rs
+++ b/qq-maid-core/src/runtime/tools/todo/format.rs
@@ -15,8 +15,7 @@ use crate::runtime::{
     tools::todo::{TodoItem, TodoStatus, preview_next_reminder_at, recurrence_label},
 };
 
-pub(crate) const TODO_LIST_VISIBLE_LIMIT: usize = 5;
-pub(crate) const TODO_ALL_BOARD_COLLAPSE_REMAINDER_THRESHOLD: usize = 2;
+pub(crate) const TODO_LIST_VISIBLE_LIMIT: usize = 10;
 
 pub(crate) fn visible_todo_items(items: &[TodoItem], force_full: bool) -> &[TodoItem] {
     if force_full || items.len() <= TODO_LIST_VISIBLE_LIMIT {
@@ -29,12 +28,7 @@ pub(crate) fn visible_todo_all_board_items(items: &[TodoItem], force_full: bool)
     if force_full || items.len() <= TODO_LIST_VISIBLE_LIMIT {
         return items;
     }
-    let hidden_count = items.len().saturating_sub(TODO_LIST_VISIBLE_LIMIT);
-    if hidden_count <= TODO_ALL_BOARD_COLLAPSE_REMAINDER_THRESHOLD {
-        items
-    } else {
-        &items[..TODO_LIST_VISIBLE_LIMIT]
-    }
+    &items[..TODO_LIST_VISIBLE_LIMIT]
 }
 
 pub(crate) fn format_todo_detail_line(detail: &str, markdown: bool) -> String {
@@ -408,18 +402,51 @@ fn format_todo_status_list_reply(
 pub(crate) fn append_todo_collapse_hint(
     rows: &mut Vec<String>,
     hidden_count: usize,
-    range_label: Option<&str>,
-    command: &str,
+    _range_label: Option<&str>,
+    _command: &str,
 ) {
     if hidden_count == 0 {
         return;
     }
     rows.push(String::new());
-    let range_label = range_label.map(str::trim).filter(|value| !value.is_empty());
-    match range_label {
-        Some(label) => rows.push(format!("还有 {hidden_count} 项{label}，可说“{command}”。")),
-        None => rows.push(format!("还有 {hidden_count} 项未展示，可说“{command}”。")),
+    rows.push(format!(
+        "共找到 {} 条待办，当前展示前 {} 条。可以增加时间、状态或关键词条件缩小范围。",
+        TODO_LIST_VISIBLE_LIMIT + hidden_count,
+        TODO_LIST_VISIBLE_LIMIT
+    ));
+}
+
+/// 共享查询页的确定性展示。查询层已经应用 limit，这里只根据真实总数提示截断。
+pub(crate) fn format_todo_query_page_reply(
+    page: &crate::runtime::tools::todo::TodoQueryPage,
+    title: &str,
+    empty_text: &str,
+    condition: &str,
+) -> CommandBody {
+    if page.total_count == 0 {
+        let suffix = if condition.trim().is_empty() {
+            String::new()
+        } else {
+            format!("（筛选条件：{}）", condition.trim())
+        };
+        return simple_todo_notice(&format!("{empty_text}{suffix}"));
     }
+    let mut rows = vec![format!("{title} · 共 {} 项", page.total_count)];
+    rows.extend(format_todo_rows(&page.items));
+    let mut markdown_rows = vec![format!("# {title} · 共 {} 项", page.total_count)];
+    markdown_rows.extend(format_todo_rows_markdown(&page.items, false));
+    if page.offset + page.items.len() < page.total_count {
+        let hint = format!(
+            "共找到 {} 条待办，当前展示前 {} 条。可以增加时间、状态或关键词条件缩小范围。",
+            page.total_count,
+            page.items.len()
+        );
+        rows.push(String::new());
+        rows.push(hint.clone());
+        markdown_rows.push(String::new());
+        markdown_rows.push(escape_text(&hint));
+    }
+    CommandBody::dual(rows.join("\n"), markdown_rows.join("\n"))
 }
 
 fn format_todo_all_board_rows(items: &[TodoItem], markdown: bool) -> Vec<String> {

--- a/qq-maid-core/src/runtime/tools/todo/list.rs
+++ b/qq-maid-core/src/runtime/tools/todo/list.rs
@@ -8,7 +8,9 @@ use qq_maid_llm::tool::{Tool, ToolContext, ToolEffect, ToolMetadata, ToolOutput}
 use chrono::NaiveDate;
 
 use crate::error::LlmError;
-use crate::runtime::tools::todo::{TodoStatus, resolve_todo_list_date_filter};
+use crate::runtime::tools::todo::{
+    TodoQuery, TodoQueryStatus, TodoQueryTimeFilter, resolve_todo_list_date_filter,
+};
 
 use super::common::{
     LIST_TODOS_TOOL_NAME, bad_tool_arguments, optional_text, todo_status_argument, todo_tool_error,
@@ -54,9 +56,18 @@ impl Tool for ListTodoTool {
                     "date_range_text": {
                         "type": ["string", "null"],
                         "description": "用户原始中文时间范围，例如“今天”“昨天”“前天”“本周”“上周”“下周”“本月”“上月”“最近 7 天”“这几天”“这两天”“明后天”。无范围筛选时传 null。"
+                    },
+                    "time_filter": {
+                        "type": ["string", "null"],
+                        "enum": ["overdue", "no_due_date", null],
+                        "description": "特殊时间条件：overdue 查询已逾期且未完成，no_due_date 查询无截止时间；与 due_date/date_range_text 互斥。"
+                    },
+                    "keyword": {
+                        "type": ["string", "null"],
+                        "description": "在待办标题、详情和原文中模糊搜索；多个空格分隔词使用 AND 匹配。项目名称当前也按关键词搜索。"
                     }
                 },
-                "required": ["status", "due_date", "date_range_text"],
+                "required": ["status", "due_date", "date_range_text", "time_filter", "keyword"],
                 "additionalProperties": false
             }),
         }
@@ -84,7 +95,7 @@ impl Tool for ListTodoTool {
                     .map(|range| (range.start, range.end, range.raw))
                     .ok_or_else(|| {
                         bad_tool_arguments(
-                            "date_range_text must be one of 今天/昨天/前天/本周/上周/下周/本月/上月/最近N天/这几天/这两天/明后天",
+                            "date_range_text must be one of 今天/明天/昨天/前天/本周/上周/下周/本月/上月/最近N天/这几天/这两天/明后天",
                         )
                     })
             })
@@ -99,31 +110,52 @@ impl Tool for ListTodoTool {
                     .ok_or_else(|| bad_tool_arguments("due_date must be a valid YYYY-MM-DD date"))
             })
             .transpose()?;
+        let special_time_filter = optional_text(&arguments, "time_filter")?;
+        if special_time_filter.is_some() && (due_date.is_some() || date_range.is_some()) {
+            return Err(bad_tool_arguments(
+                "time_filter 与 due_date/date_range_text 不能同时传入",
+            ));
+        }
         let date_filter = resolve_todo_list_date_filter(
             status.storage_status(),
             due_date,
             date_range.as_ref().map(|(start, end, _)| (*start, *end)),
         )
         .map_err(todo_tool_error)?;
-        let items = match (status, date_filter) {
-            (TodoToolListStatus::Pending, Some(filter)) => {
-                self.todo_store
-                    .list_by_date_filter(&scope.owner, TodoStatus::Pending, filter)
+        let ctx = qq_maid_common::time_context::request_time_context();
+        let time = match special_time_filter.as_deref() {
+            Some("overdue") => Some(TodoQueryTimeFilter::Overdue {
+                now: qq_maid_common::time_context::parse_local_datetime_for_comparison(
+                    ctx.current_time(),
+                )
+                .expect("request time context must contain a valid local datetime"),
+            }),
+            Some("no_due_date") => Some(TodoQueryTimeFilter::NoDueDate),
+            Some(_) => {
+                return Err(bad_tool_arguments(
+                    "time_filter must be overdue/no_due_date/null",
+                ));
             }
-            (TodoToolListStatus::Completed, Some(filter)) => {
-                self.todo_store
-                    .list_by_date_filter(&scope.owner, TodoStatus::Completed, filter)
-            }
-            (TodoToolListStatus::All, Some(filter)) => self
-                .todo_store
-                .list_all_by_date_filter_for_board(&scope.owner, filter),
-            (TodoToolListStatus::Pending, None) => self.todo_store.list_pending(&scope.owner),
-            (TodoToolListStatus::Completed, None) => self.todo_store.list_completed(&scope.owner),
-            // Tool 可见编号也必须和 `/todo all` 看板一致，否则模型随后按“第 N 个”
-            // 调用 complete/restore/delete 时会绑定到用户没有按该顺序看到的条目。
-            (TodoToolListStatus::All, None) => self.todo_store.list_all_for_board(&scope.owner),
-        }
-        .map_err(todo_tool_error)?;
+            None => date_filter.map(|filter| TodoQueryTimeFilter::DateRange {
+                start: filter.start,
+                end: filter.end,
+                field: filter.field,
+            }),
+        };
+        let query = TodoQuery {
+            status: match status {
+                TodoToolListStatus::Pending => TodoQueryStatus::Pending,
+                TodoToolListStatus::Completed => TodoQueryStatus::Completed,
+                TodoToolListStatus::All => TodoQueryStatus::All,
+            },
+            time,
+            keyword: optional_text(&arguments, "keyword")?,
+            ..TodoQuery::default()
+        };
+        let page = self
+            .todo_store
+            .query_todos(&scope.owner, &query)
+            .map_err(todo_tool_error)?;
         let due_date_text = date_filter.and_then(|filter| {
             (filter.start == filter.end).then(|| filter.start.format("%Y-%m-%d").to_string())
         });
@@ -131,16 +163,26 @@ impl Tool for ListTodoTool {
         let due_end = date_filter.map(|filter| format_date(filter.end));
         let date_range_field = date_filter.map(|filter| filter.field.as_str());
         let date_range_label = date_range.as_ref().map(|(_, _, raw)| raw.clone());
-        let query_type = if date_filter.is_some() && matches!(status, TodoToolListStatus::Pending) {
-            "due-date"
+        let mut conditions = Vec::new();
+        if let Some(value) = date_range_label.as_deref().or(due_date_text.as_deref()) {
+            conditions.push(value.to_owned());
+        }
+        if let Some(value) = special_time_filter.as_deref() {
+            conditions.push(match value {
+                "overdue" => "逾期".to_owned(),
+                "no_due_date" => "无截止时间".to_owned(),
+                _ => value.to_owned(),
+            });
+        }
+        if let Some(value) = query.keyword.as_deref() {
+            conditions.push(format!("关键词“{value}”"));
+        }
+        let condition = if conditions.is_empty() {
+            status.condition().to_owned()
         } else {
-            status.query_type()
+            conditions.join("、")
         };
-        let condition = date_range_label
-            .as_deref()
-            .or(due_date_text.as_deref())
-            .unwrap_or_else(|| status.condition());
-        scope.remember_internal_query(query_type, condition, &items)?;
+        scope.remember_internal_query("list-query", &condition, &page.items)?;
 
         Ok(ToolOutput::json(json!({
             "status": status.as_str(),
@@ -151,8 +193,14 @@ impl Tool for ListTodoTool {
             "date_range_end": due_end,
             "date_range_text": date_range_label,
             "date_range_field": date_range_field,
-            "items": todo_items_json(&items),
-            "count": items.len(),
+            "time_filter": special_time_filter,
+            "condition": condition,
+            "items": todo_items_json(&page.items),
+            "count": page.items.len(),
+            "total_count": page.total_count,
+            "displayed_count": page.items.len(),
+            "truncated": page.offset + page.items.len() < page.total_count,
+            "keyword": query.keyword,
             "numbering": "visible_number 是本轮工具查询编号，仅在当前 Tool Loop 内有效；用户跨轮次的第 N 条仍以最近实际展示给用户的 /todo 列表为准；未暴露数据库内部 ID。"
         })))
     }
@@ -163,10 +211,10 @@ fn format_date(date: NaiveDate) -> String {
 }
 
 impl super::common::TodoToolListStatus {
-    fn storage_status(self) -> Option<TodoStatus> {
+    fn storage_status(self) -> Option<crate::runtime::tools::todo::TodoStatus> {
         match self {
-            Self::Pending => Some(TodoStatus::Pending),
-            Self::Completed => Some(TodoStatus::Completed),
+            Self::Pending => Some(crate::runtime::tools::todo::TodoStatus::Pending),
+            Self::Completed => Some(crate::runtime::tools::todo::TodoStatus::Completed),
             Self::All => None,
         }
     }

--- a/qq-maid-core/src/runtime/tools/todo/list.rs
+++ b/qq-maid-core/src/runtime/tools/todo/list.rs
@@ -10,6 +10,7 @@ use chrono::NaiveDate;
 use crate::error::LlmError;
 use crate::runtime::tools::todo::{
     TodoQuery, TodoQueryStatus, TodoQueryTimeFilter, resolve_todo_list_date_filter,
+    storage::validate_todo_query,
 };
 
 use super::common::{
@@ -152,6 +153,7 @@ impl Tool for ListTodoTool {
             keyword: optional_text(&arguments, "keyword")?,
             ..TodoQuery::default()
         };
+        validate_todo_query(&query).map_err(todo_tool_error)?;
         let page = self
             .todo_store
             .query_todos(&scope.owner, &query)

--- a/qq-maid-core/src/runtime/tools/todo/mod.rs
+++ b/qq-maid-core/src/runtime/tools/todo/mod.rs
@@ -22,6 +22,7 @@ pub(crate) mod interaction_state;
 mod json;
 pub(crate) mod ops;
 pub(crate) mod pending;
+pub(crate) mod query_filter;
 pub(crate) mod receipt;
 pub(crate) mod recurrence;
 pub(crate) mod reminder;

--- a/qq-maid-core/src/runtime/tools/todo/query_filter.rs
+++ b/qq-maid-core/src/runtime/tools/todo/query_filter.rs
@@ -1,0 +1,106 @@
+//! Todo 主动查询参数归一化。
+
+use qq_maid_common::time_context::{
+    RequestTimeContext, parse_date_range_expression, parse_local_datetime_for_comparison,
+};
+
+use super::{TodoError, TodoListDateField, TodoQuery, TodoQueryStatus, TodoQueryTimeFilter};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParsedTodoQuery {
+    pub query: TodoQuery,
+    pub condition: String,
+}
+
+/// 解析 `/todo list ...` 的组合筛选。未识别的剩余文本作为关键词参与 AND 查询，
+/// 因此 `/todo list 项目 A` 会在标题、详情和原文中做模糊匹配。
+pub(crate) fn parse_todo_list_query(
+    argument: &str,
+    ctx: &RequestTimeContext,
+) -> Result<ParsedTodoQuery, TodoError> {
+    let mut query = TodoQuery::default();
+    let mut keyword_parts = Vec::new();
+    let mut conditions = Vec::new();
+    let tokens = argument.split_whitespace().collect::<Vec<_>>();
+    let mut index = 0;
+    while index < tokens.len() {
+        let token = tokens[index];
+        match token {
+            "未完成" | "进行中" | "pending" => {
+                query.status = TodoQueryStatus::Pending;
+                conditions.push("未完成".to_owned());
+            }
+            "已完成" | "completed" => {
+                query.status = TodoQueryStatus::Completed;
+                conditions.push("已完成".to_owned());
+            }
+            "全部" | "all" => {
+                query.status = TodoQueryStatus::All;
+                conditions.push("全部状态".to_owned());
+            }
+            "逾期" | "overdue" => {
+                set_time_filter(
+                    &mut query,
+                    TodoQueryTimeFilter::Overdue {
+                        now: parse_local_datetime_for_comparison(ctx.current_time())
+                            .expect("request time context must contain a valid local datetime"),
+                    },
+                )?;
+                query.status = TodoQueryStatus::Pending;
+                conditions.push("逾期".to_owned());
+            }
+            "无截止时间" | "无日期" | "no-due" => {
+                set_time_filter(&mut query, TodoQueryTimeFilter::NoDueDate)?;
+                conditions.push("无截止时间".to_owned());
+            }
+            "关键词" | "keyword" => {
+                let keyword = tokens[index + 1..].join(" ");
+                if keyword.trim().is_empty() {
+                    return Err(TodoError::bad_request(
+                        "关键词不能为空。用法：/todo list 关键词 报告",
+                    ));
+                }
+                keyword_parts.push(keyword);
+                break;
+            }
+            _ => {
+                if let Some(range) = parse_date_range_expression(token, ctx) {
+                    set_time_filter(
+                        &mut query,
+                        TodoQueryTimeFilter::DateRange {
+                            start: range.start,
+                            end: range.end,
+                            field: TodoListDateField::Planned,
+                        },
+                    )?;
+                    conditions.push(range.raw);
+                } else {
+                    keyword_parts.push(token.to_owned());
+                }
+            }
+        }
+        index += 1;
+    }
+    if !keyword_parts.is_empty() {
+        let keyword = keyword_parts.join(" ");
+        conditions.push(format!("关键词“{keyword}”"));
+        query.keyword = Some(keyword);
+    }
+    if matches!(query.status, TodoQueryStatus::Completed)
+        && let Some(TodoQueryTimeFilter::DateRange { field, .. }) = query.time.as_mut()
+    {
+        *field = TodoListDateField::CompletedAt;
+    }
+    Ok(ParsedTodoQuery {
+        query,
+        condition: conditions.join("、"),
+    })
+}
+
+fn set_time_filter(query: &mut TodoQuery, filter: TodoQueryTimeFilter) -> Result<(), TodoError> {
+    if query.time.is_some() {
+        return Err(TodoError::bad_request("一次查询只能指定一个时间条件。"));
+    }
+    query.time = Some(filter);
+    Ok(())
+}

--- a/qq-maid-core/src/runtime/tools/todo/query_filter.rs
+++ b/qq-maid-core/src/runtime/tools/todo/query_filter.rs
@@ -4,7 +4,10 @@ use qq_maid_common::time_context::{
     RequestTimeContext, parse_date_range_expression, parse_local_datetime_for_comparison,
 };
 
-use super::{TodoError, TodoListDateField, TodoQuery, TodoQueryStatus, TodoQueryTimeFilter};
+use super::{
+    TodoError, TodoListDateField, TodoQuery, TodoQueryStatus, TodoQueryTimeFilter,
+    storage::validate_todo_query,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ParsedTodoQuery {
@@ -19,24 +22,22 @@ pub(crate) fn parse_todo_list_query(
     ctx: &RequestTimeContext,
 ) -> Result<ParsedTodoQuery, TodoError> {
     let mut query = TodoQuery::default();
+    let mut explicit_status = None;
     let mut keyword_parts = Vec::new();
-    let mut conditions = Vec::new();
+    let mut time_condition = None;
     let tokens = argument.split_whitespace().collect::<Vec<_>>();
     let mut index = 0;
     while index < tokens.len() {
         let token = tokens[index];
         match token {
             "未完成" | "进行中" | "pending" => {
-                query.status = TodoQueryStatus::Pending;
-                conditions.push("未完成".to_owned());
+                set_explicit_status(&mut explicit_status, TodoQueryStatus::Pending)?;
             }
             "已完成" | "completed" => {
-                query.status = TodoQueryStatus::Completed;
-                conditions.push("已完成".to_owned());
+                set_explicit_status(&mut explicit_status, TodoQueryStatus::Completed)?;
             }
             "全部" | "all" => {
-                query.status = TodoQueryStatus::All;
-                conditions.push("全部状态".to_owned());
+                set_explicit_status(&mut explicit_status, TodoQueryStatus::All)?;
             }
             "逾期" | "overdue" => {
                 set_time_filter(
@@ -46,12 +47,11 @@ pub(crate) fn parse_todo_list_query(
                             .expect("request time context must contain a valid local datetime"),
                     },
                 )?;
-                query.status = TodoQueryStatus::Pending;
-                conditions.push("逾期".to_owned());
+                time_condition = Some("逾期".to_owned());
             }
             "无截止时间" | "无日期" | "no-due" => {
                 set_time_filter(&mut query, TodoQueryTimeFilter::NoDueDate)?;
-                conditions.push("无截止时间".to_owned());
+                time_condition = Some("无截止时间".to_owned());
             }
             "关键词" | "keyword" => {
                 let keyword = tokens[index + 1..].join(" ");
@@ -73,7 +73,7 @@ pub(crate) fn parse_todo_list_query(
                             field: TodoListDateField::Planned,
                         },
                     )?;
-                    conditions.push(range.raw);
+                    time_condition = Some(range.raw);
                 } else {
                     keyword_parts.push(token.to_owned());
                 }
@@ -81,20 +81,56 @@ pub(crate) fn parse_todo_list_query(
         }
         index += 1;
     }
+    query.status = explicit_status.unwrap_or_default();
     if !keyword_parts.is_empty() {
         let keyword = keyword_parts.join(" ");
-        conditions.push(format!("关键词“{keyword}”"));
         query.keyword = Some(keyword);
     }
+    validate_todo_query(&query)?;
     if matches!(query.status, TodoQueryStatus::Completed)
         && let Some(TodoQueryTimeFilter::DateRange { field, .. }) = query.time.as_mut()
     {
         *field = TodoListDateField::CompletedAt;
     }
+    // 展示条件按固定类别排序，避免用户调整 token 顺序后标题或快照发生变化。
+    let mut conditions = Vec::new();
+    if let Some(status) = explicit_status {
+        conditions.push(status_condition(status).to_owned());
+    }
+    if let Some(condition) = time_condition {
+        conditions.push(condition);
+    }
+    if let Some(keyword) = query.keyword.as_deref() {
+        conditions.push(format!("关键词“{keyword}”"));
+    }
     Ok(ParsedTodoQuery {
         query,
         condition: conditions.join("、"),
     })
+}
+
+fn set_explicit_status(
+    explicit_status: &mut Option<TodoQueryStatus>,
+    status: TodoQueryStatus,
+) -> Result<(), TodoError> {
+    match explicit_status {
+        Some(current) if *current != status => {
+            Err(TodoError::bad_request("一次查询只能指定一个状态条件。"))
+        }
+        Some(_) => Ok(()),
+        None => {
+            *explicit_status = Some(status);
+            Ok(())
+        }
+    }
+}
+
+fn status_condition(status: TodoQueryStatus) -> &'static str {
+    match status {
+        TodoQueryStatus::Pending => "未完成",
+        TodoQueryStatus::Completed => "已完成",
+        TodoQueryStatus::All => "全部状态",
+    }
 }
 
 fn set_time_filter(query: &mut TodoQuery, filter: TodoQueryTimeFilter) -> Result<(), TodoError> {

--- a/qq-maid-core/src/runtime/tools/todo/receipt.rs
+++ b/qq-maid-core/src/runtime/tools/todo/receipt.rs
@@ -23,9 +23,9 @@ use crate::{
         session::{SessionMeta, SessionRecord},
         tools::todo::{
             ReminderFieldMode, TodoCardOptions, TodoItem, TodoListDateField, TodoListDateFilter,
-            TodoOwner, TodoRecurrenceKind, TodoRecurrenceUnit, TodoRenderItem, TodoStatus,
-            TodoStore, format_todo_cards, todo_last_action_visible_entity_snapshot,
-            todo_visible_entity_snapshot,
+            TodoOwner, TodoQuery, TodoQueryStatus, TodoQueryTimeFilter, TodoRecurrenceKind,
+            TodoRecurrenceUnit, TodoRenderItem, TodoStatus, TodoStore, format_todo_cards,
+            todo_last_action_visible_entity_snapshot, todo_visible_entity_snapshot,
         },
     },
     service::VisibleEntitySnapshot,
@@ -61,11 +61,15 @@ enum TodoWriteOperation {
 #[derive(Debug, Clone)]
 struct RelatedListSpec {
     status: TodoStatus,
+    query_status: TodoQueryStatus,
     query_type: &'static str,
     condition: String,
     due_date: Option<NaiveDate>,
     due_range: Option<(NaiveDate, NaiveDate)>,
     date_field: TodoListDateField,
+    keyword: Option<String>,
+    special_time_filter: Option<String>,
+    shared_query: bool,
     title: &'static str,
     empty_text: &'static str,
     time_value: fn(&TodoItem) -> Option<String>,
@@ -613,6 +617,45 @@ fn remember_related_list_snapshot(
     owner: &TodoOwner,
     spec: &RelatedListSpec,
 ) -> Result<(Vec<TodoItem>, usize, bool), LlmError> {
+    if spec.shared_query {
+        let mut query = TodoQuery {
+            status: spec.query_status,
+            keyword: spec.keyword.clone(),
+            ..TodoQuery::default()
+        };
+        query.time = match spec.special_time_filter.as_deref() {
+            Some("overdue") => Some(TodoQueryTimeFilter::Overdue {
+                now: qq_maid_common::time_context::parse_local_datetime_for_comparison(
+                    qq_maid_common::time_context::request_time_context().current_time(),
+                )
+                .expect("request time context must contain a valid local datetime"),
+            }),
+            Some("no_due_date") => Some(TodoQueryTimeFilter::NoDueDate),
+            _ => spec
+                .due_range
+                .map(|(start, end)| TodoQueryTimeFilter::DateRange {
+                    start,
+                    end,
+                    field: spec.date_field,
+                })
+                .or_else(|| {
+                    spec.due_date.map(|date| TodoQueryTimeFilter::DateRange {
+                        start: date,
+                        end: date,
+                        field: spec.date_field,
+                    })
+                }),
+        };
+        let page = todo_store.query_todos(owner, &query).map_err(todo_error)?;
+        session.remember_last_todo_query(
+            &owner.key,
+            spec.query_type,
+            spec.condition.clone(),
+            page.items.iter().map(|item| item.id.clone()).collect(),
+        );
+        let truncated = page.offset + page.items.len() < page.total_count;
+        return Ok((page.items, page.total_count, truncated));
+    }
     let items = list_for_related_spec(todo_store, owner, spec).map_err(todo_error)?;
     let total_count = items.len();
     let shown = visible_related_items(&items, spec).to_vec();
@@ -749,6 +792,14 @@ fn append_related_list(
         ));
     }
     if truncated {
+        if spec.shared_query {
+            rows.push(String::new());
+            rows.push(format!(
+                "共找到 {total_count} 条待办，当前展示前 {} 条。可以增加时间、状态或关键词条件缩小范围。",
+                items.len()
+            ));
+            return;
+        }
         let (range_label, command) = collapse_prompt_for_related_spec(spec);
         append_todo_collapse_hint(
             rows,
@@ -834,11 +885,15 @@ fn todo_write_operation(name: &str) -> Option<TodoWriteOperation> {
 fn pending_list_spec() -> RelatedListSpec {
     RelatedListSpec {
         status: TodoStatus::Pending,
+        query_status: TodoQueryStatus::Pending,
         query_type: "list",
         condition: String::new(),
         due_date: None,
         due_range: None,
         date_field: TodoListDateField::Planned,
+        keyword: None,
+        special_time_filter: None,
+        shared_query: false,
         title: "🚧 当前进行中",
         empty_text: "当前没有进行中的待办。",
         time_value: todo_due_chip,
@@ -848,11 +903,15 @@ fn pending_list_spec() -> RelatedListSpec {
 fn completed_list_spec() -> RelatedListSpec {
     RelatedListSpec {
         status: TodoStatus::Completed,
+        query_status: TodoQueryStatus::Completed,
         query_type: "completed-list",
         condition: "已完成列表".to_owned(),
         due_date: None,
         due_range: None,
         date_field: TodoListDateField::Planned,
+        keyword: None,
+        special_time_filter: None,
+        shared_query: false,
         title: "✅ 当前已完成",
         empty_text: "当前没有已完成待办。",
         time_value: display_todo_completed_at,
@@ -866,14 +925,20 @@ fn list_spec_from_output(output: &Value) -> RelatedListSpec {
         Some("all") => RelatedListSpec { ..all_list_spec() },
         _ => pending_list_spec(),
     };
+    spec.query_status = match status.as_deref() {
+        Some("completed") => TodoQueryStatus::Completed,
+        Some("all") => TodoQueryStatus::All,
+        _ => TodoQueryStatus::Pending,
+    };
+    spec.shared_query = true;
+    spec.condition = string_field(output, "condition").unwrap_or_default();
+    spec.keyword = string_field(output, "keyword");
+    spec.special_time_filter = string_field(output, "time_filter");
     if let Some(due_date) = string_field(output, "due_date")
         .and_then(|value| NaiveDate::parse_from_str(&value, "%Y-%m-%d").ok())
     {
         spec.condition = due_date.format("%Y-%m-%d").to_string();
         spec.due_date = Some(due_date);
-        if matches!(status.as_deref(), None | Some("pending")) {
-            spec.query_type = "due-date";
-        }
     } else if let (Some(start), Some(end)) = (
         string_field(output, "due_start")
             .and_then(|value| NaiveDate::parse_from_str(&value, "%Y-%m-%d").ok()),
@@ -885,21 +950,29 @@ fn list_spec_from_output(output: &Value) -> RelatedListSpec {
         });
         spec.due_range = Some((start, end));
         spec.date_field = date_field_from_output(output, status.as_deref());
-        if matches!(status.as_deref(), None | Some("pending")) {
-            spec.query_type = "due-date";
-        }
     }
+    spec.query_type = match status.as_deref() {
+        Some("all") => "all",
+        Some("completed") => "completed-list",
+        _ if spec.due_date.is_some() || spec.due_range.is_some() => "due-date",
+        _ if spec.keyword.is_some() => "search",
+        _ => "list",
+    };
     spec
 }
 
 fn all_list_spec() -> RelatedListSpec {
     RelatedListSpec {
         status: TodoStatus::Pending,
+        query_status: TodoQueryStatus::All,
         query_type: "all",
         condition: "全部待办".to_owned(),
         due_date: None,
         due_range: None,
         date_field: TodoListDateField::Planned,
+        keyword: None,
+        special_time_filter: None,
+        shared_query: false,
         title: "📋 全部待办",
         empty_text: "当前没有待办。",
         time_value: todo_due_chip,

--- a/qq-maid-core/src/runtime/tools/todo/storage/mod.rs
+++ b/qq-maid-core/src/runtime/tools/todo/storage/mod.rs
@@ -20,6 +20,7 @@ use crate::{
 mod id;
 mod normalize;
 mod query;
+mod query_model;
 mod recurrence;
 mod schema;
 mod search;

--- a/qq-maid-core/src/runtime/tools/todo/storage/mod.rs
+++ b/qq-maid-core/src/runtime/tools/todo/storage/mod.rs
@@ -29,6 +29,8 @@ mod time;
 mod types;
 mod write;
 
+pub(crate) use query_model::validate_todo_query;
+
 // 时间相关 helper 是 Todo 存储 API 的一部分，经由 runtime::tools::todo 统一导出。
 pub(crate) use recurrence::{
     TodoRecurrenceRule, recurrence_kind_for_rule, recurrence_rule_from_interval_unit,

--- a/qq-maid-core/src/runtime/tools/todo/storage/query.rs
+++ b/qq-maid-core/src/runtime/tools/todo/storage/query.rs
@@ -219,7 +219,7 @@ pub(super) fn get_by_id_status_unlocked(
 
 /// rusqlite 行到 `TodoItem` 的映射；`time_precision` / `status` 反向解析失败
 /// 时封装成列级错误，便于上层按数据异常归类。
-fn todo_item_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TodoItem> {
+pub(super) fn todo_item_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TodoItem> {
     let time_precision = row.get::<_, String>(9)?;
     let time_precision = TodoTimePrecision::from_db(&time_precision)
         .map_err(|message| from_sql_text_error(9, message))?;

--- a/qq-maid-core/src/runtime/tools/todo/storage/query_model.rs
+++ b/qq-maid-core/src/runtime/tools/todo/storage/query_model.rs
@@ -22,7 +22,7 @@ impl TodoStore {
         owner: &super::TodoOwner,
         query: &TodoQuery,
     ) -> Result<TodoQueryPage, TodoError> {
-        validate_query(query)?;
+        validate_todo_query(query)?;
         let conn = self.connection()?;
         let (where_sql, params) = build_where(owner, query);
         let count_sql = format!("SELECT COUNT(*) FROM todos WHERE {where_sql}");
@@ -56,7 +56,8 @@ impl TodoStore {
     }
 }
 
-fn validate_query(query: &TodoQuery) -> Result<(), TodoError> {
+/// 校验 Slash、自然语言与 Tool 共用的 Todo 查询组合语义。
+pub(crate) fn validate_todo_query(query: &TodoQuery) -> Result<(), TodoError> {
     if query.limit == 0 {
         return Err(TodoError::bad_request("limit 必须大于 0。"));
     }
@@ -68,7 +69,7 @@ fn validate_query(query: &TodoQuery) -> Result<(), TodoError> {
         ));
     }
     if matches!(query.time, Some(TodoQueryTimeFilter::Overdue { .. }))
-        && matches!(query.status, TodoQueryStatus::Completed)
+        && !matches!(query.status, TodoQueryStatus::Pending)
     {
         return Err(TodoError::bad_request("逾期筛选只适用于未完成待办。"));
     }

--- a/qq-maid-core/src/runtime/tools/todo/storage/query_model.rs
+++ b/qq-maid-core/src/runtime/tools/todo/storage/query_model.rs
@@ -1,0 +1,192 @@
+//! 用户主动 Todo 查询的共享 SQL 模型。
+//!
+//! Slash、确定性自然语言和 Tool 都必须走这里。总数和当前页分别通过 COUNT 与
+//! LIMIT/OFFSET 获取，不把 owner 下的全部 Todo 加载到内存后再截断。
+
+use rusqlite::{params_from_iter, types::Value as SqlValue};
+
+use super::{
+    TODO_QUERY_MAX_LIMIT, TodoError, TodoListDateField, TodoQuery, TodoQueryPage, TodoQueryStatus,
+    TodoQueryTimeFilter, TodoStatus, TodoStore, query::todo_item_from_row,
+};
+
+const SELECT_COLUMNS: &str = "id, user_id, scope_key, title, detail, raw_text,
+    due_date, due_at, reminder_at, time_precision, recurrence_kind,
+    recurrence_interval_days, recurrence_interval, recurrence_unit, status,
+    created_at, updated_at, completed_at";
+
+impl TodoStore {
+    /// 执行共享 Todo 查询并返回真实总数与当前页。
+    pub fn query_todos(
+        &self,
+        owner: &super::TodoOwner,
+        query: &TodoQuery,
+    ) -> Result<TodoQueryPage, TodoError> {
+        validate_query(query)?;
+        let conn = self.connection()?;
+        let (where_sql, params) = build_where(owner, query);
+        let count_sql = format!("SELECT COUNT(*) FROM todos WHERE {where_sql}");
+        let total_count = conn
+            .query_row(&count_sql, params_from_iter(params.iter()), |row| {
+                row.get::<_, i64>(0)
+            })
+            .map_err(TodoError::from_sql)?
+            .try_into()
+            .map_err(|_| TodoError::data("todo count overflow"))?;
+
+        let limit = query.limit.min(TODO_QUERY_MAX_LIMIT);
+        let order_sql = order_by_sql(query.status);
+        let page_sql = format!(
+            "SELECT {SELECT_COLUMNS} FROM todos WHERE {where_sql} {order_sql} LIMIT {limit} OFFSET {}",
+            query.offset
+        );
+        let mut stmt = conn.prepare(&page_sql).map_err(TodoError::from_sql)?;
+        let items = stmt
+            .query_map(params_from_iter(params.iter()), todo_item_from_row)
+            .map_err(TodoError::from_sql)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(TodoError::from_sql)?;
+
+        Ok(TodoQueryPage {
+            items,
+            total_count,
+            limit,
+            offset: query.offset,
+        })
+    }
+}
+
+fn validate_query(query: &TodoQuery) -> Result<(), TodoError> {
+    if query.limit == 0 {
+        return Err(TodoError::bad_request("limit 必须大于 0。"));
+    }
+    if let Some(TodoQueryTimeFilter::DateRange { start, end, .. }) = query.time
+        && start > end
+    {
+        return Err(TodoError::bad_request(
+            "日期范围无效，开始日期不能晚于结束日期。",
+        ));
+    }
+    if matches!(query.time, Some(TodoQueryTimeFilter::Overdue { .. }))
+        && matches!(query.status, TodoQueryStatus::Completed)
+    {
+        return Err(TodoError::bad_request("逾期筛选只适用于未完成待办。"));
+    }
+    Ok(())
+}
+
+fn build_where(owner: &super::TodoOwner, query: &TodoQuery) -> (String, Vec<SqlValue>) {
+    let mut clauses = vec!["owner_key = ?".to_owned(), "scope_key = ?".to_owned()];
+    let mut params = vec![
+        SqlValue::Text(owner.key.clone()),
+        SqlValue::Text(owner.scope_key.clone()),
+    ];
+    match query.status {
+        TodoQueryStatus::Pending => {
+            clauses.push("status = ?".to_owned());
+            params.push(SqlValue::Text(TodoStatus::Pending.as_str().to_owned()));
+        }
+        TodoQueryStatus::Completed => {
+            clauses.push("status = ?".to_owned());
+            params.push(SqlValue::Text(TodoStatus::Completed.as_str().to_owned()));
+        }
+        TodoQueryStatus::All => {}
+    }
+    if let Some(time) = &query.time {
+        append_time_filter(&mut clauses, &mut params, time);
+    }
+    if let Some(keyword) = query
+        .keyword
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        for token in keyword.split_whitespace() {
+            clauses.push(
+                "LOWER(COALESCE(title, '') || CHAR(10) || COALESCE(detail, '') || CHAR(10) || COALESCE(raw_text, '')) LIKE ? ESCAPE '\\'"
+                    .to_owned(),
+            );
+            params.push(SqlValue::Text(format!(
+                "%{}%",
+                escape_like(token).to_lowercase()
+            )));
+        }
+    }
+    (clauses.join(" AND "), params)
+}
+
+fn append_time_filter(
+    clauses: &mut Vec<String>,
+    params: &mut Vec<SqlValue>,
+    filter: &TodoQueryTimeFilter,
+) {
+    match filter {
+        TodoQueryTimeFilter::DateRange { start, end, field } => {
+            let expression = match field {
+                TodoListDateField::Planned => planned_local_date_sql(),
+                TodoListDateField::CompletedAt => local_date_sql("completed_at"),
+            };
+            clauses.push(format!("{expression} BETWEEN ? AND ?"));
+            params.push(SqlValue::Text(start.format("%Y-%m-%d").to_string()));
+            params.push(SqlValue::Text(end.format("%Y-%m-%d").to_string()));
+        }
+        TodoQueryTimeFilter::NoDueDate => clauses.push(
+            "NULLIF(TRIM(COALESCE(due_at, '')), '') IS NULL AND NULLIF(TRIM(COALESCE(due_date, '')), '') IS NULL"
+                .to_owned(),
+        ),
+        TodoQueryTimeFilter::Overdue { now } => {
+            clauses.push("status = 'pending'".to_owned());
+            clauses.push(format!(
+                "((NULLIF(TRIM(COALESCE(due_at, '')), '') IS NOT NULL AND {} < ?) OR (NULLIF(TRIM(COALESCE(due_at, '')), '') IS NULL AND NULLIF(TRIM(COALESCE(due_date, '')), '') IS NOT NULL AND due_date < ?))",
+                local_datetime_sql("due_at")
+            ));
+            params.push(SqlValue::Text(now.format("%Y-%m-%d %H:%M:%S").to_string()));
+            params.push(SqlValue::Text(now.format("%Y-%m-%d").to_string()));
+        }
+    }
+}
+
+fn order_by_sql(status: TodoQueryStatus) -> String {
+    let due = planned_local_datetime_sql();
+    let completed = local_datetime_sql("completed_at");
+    match status {
+        TodoQueryStatus::Pending => format!(
+            "ORDER BY CASE WHEN {due} IS NULL THEN 1 ELSE 0 END ASC, {due} ASC, CAST(id AS INTEGER) ASC"
+        ),
+        TodoQueryStatus::Completed => format!("ORDER BY {completed} DESC, CAST(id AS INTEGER) ASC"),
+        TodoQueryStatus::All => format!(
+            "ORDER BY CASE status WHEN 'pending' THEN 0 ELSE 1 END ASC, CASE WHEN status = 'pending' AND {due} IS NULL THEN 1 ELSE 0 END ASC, CASE WHEN status = 'pending' THEN {due} END ASC, CASE WHEN status = 'completed' THEN {completed} END DESC, CAST(id AS INTEGER) ASC"
+        ),
+    }
+}
+
+fn planned_local_date_sql() -> String {
+    format!(
+        "CASE WHEN NULLIF(TRIM(COALESCE(due_at, '')), '') IS NOT NULL THEN {} ELSE NULLIF(TRIM(COALESCE(due_date, '')), '') END",
+        local_date_sql("due_at")
+    )
+}
+
+fn planned_local_datetime_sql() -> String {
+    format!(
+        "CASE WHEN NULLIF(TRIM(COALESCE(due_at, '')), '') IS NOT NULL THEN {} WHEN NULLIF(TRIM(COALESCE(due_date, '')), '') IS NOT NULL THEN due_date || ' 00:00:00' ELSE NULL END",
+        local_datetime_sql("due_at")
+    )
+}
+
+fn local_date_sql(column: &str) -> String {
+    format!("SUBSTR({}, 1, 10)", local_datetime_sql(column))
+}
+
+fn local_datetime_sql(column: &str) -> String {
+    format!(
+        "CASE WHEN {column} IS NULL OR TRIM({column}) = '' THEN NULL WHEN {column} GLOB '*[+-][0-9][0-9]:[0-9][0-9]' OR UPPER({column}) GLOB '*Z' THEN STRFTIME('%Y-%m-%d %H:%M:%S', {column}, '+8 hours') ELSE REPLACE(SUBSTR({column}, 1, 19), 'T', ' ') END"
+    )
+}
+
+fn escape_like(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}

--- a/qq-maid-core/src/runtime/tools/todo/storage/tests.rs
+++ b/qq-maid-core/src/runtime/tools/todo/storage/tests.rs
@@ -1321,3 +1321,169 @@ fn delete_completed_by_ids_filters_owner_scope_and_status_in_transaction() {
 
     assert_delete_by_status_keeps_filters(&store, &fixture, TodoStatus::Completed);
 }
+
+#[test]
+fn shared_query_defaults_to_ten_and_reports_total_count() {
+    let store = test_store();
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    for index in 1..=12 {
+        store
+            .create(&owner, draft_with_title(&format!("第 {index} 条")))
+            .unwrap();
+    }
+
+    let page = store.query_todos(&owner, &TodoQuery::default()).unwrap();
+
+    assert_eq!(page.total_count, 12);
+    assert_eq!(page.items.len(), TODO_QUERY_DEFAULT_LIMIT);
+    assert_eq!(page.limit, TODO_QUERY_DEFAULT_LIMIT);
+}
+
+#[test]
+fn shared_query_combines_time_status_keyword_and_keeps_scope_isolation() {
+    let store = test_store();
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let other = TodoStore::owner(Some("u2"), "private:u2");
+    let ctx = fixed_context();
+    let now = qq_maid_common::time_context::parse_local_datetime_for_comparison(ctx.current_time())
+        .unwrap();
+
+    let create = |owner: &TodoOwner,
+                  title: &str,
+                  detail: Option<&str>,
+                  due_date: Option<&str>,
+                  due_at: Option<&str>| {
+        store
+            .create(
+                owner,
+                TodoItemDraft {
+                    title: title.to_owned(),
+                    detail: detail.map(str::to_owned),
+                    due_date: due_date.map(str::to_owned),
+                    due_at: due_at.map(str::to_owned),
+                    time_precision: if due_at.is_some() {
+                        TodoTimePrecision::DateTime
+                    } else if due_date.is_some() {
+                        TodoTimePrecision::Date
+                    } else {
+                        TodoTimePrecision::None
+                    },
+                    ..draft_with_title(title)
+                },
+            )
+            .unwrap()
+    };
+
+    let overdue = create(&owner, "逾期报告", None, Some("2026-06-09"), None);
+    let today = create(&owner, "今天事项", None, Some("2026-06-10"), None);
+    let utc_today = create(
+        &owner,
+        "UTC 跨日事项",
+        None,
+        None,
+        Some("2026-06-09T16:30:00+00:00"),
+    );
+    let tomorrow = create(
+        &owner,
+        "项目 A 报告",
+        Some("提交报销报告"),
+        Some("2026-06-11"),
+        None,
+    );
+    let completed = create(&owner, "项目 A 已完成", None, Some("2026-06-12"), None);
+    let no_due = create(&owner, "无日期事项", None, None, None);
+    create(&other, "项目 A 报告", None, Some("2026-06-11"), None);
+    store.complete(&owner, &completed.id).unwrap();
+
+    let today_page = store
+        .query_todos(
+            &owner,
+            &TodoQuery {
+                time: Some(TodoQueryTimeFilter::DateRange {
+                    start: ctx.local_date(),
+                    end: ctx.local_date(),
+                    field: TodoListDateField::Planned,
+                }),
+                ..TodoQuery::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(
+        today_page
+            .items
+            .iter()
+            .map(|item| item.id.as_str())
+            .collect::<Vec<_>>(),
+        vec![today.id.as_str(), utc_today.id.as_str()]
+    );
+
+    let combined = store
+        .query_todos(
+            &owner,
+            &TodoQuery {
+                time: Some(TodoQueryTimeFilter::DateRange {
+                    start: ctx.local_date() + Duration::days(1),
+                    end: ctx.local_date() + Duration::days(1),
+                    field: TodoListDateField::Planned,
+                }),
+                keyword: Some("项目 A 报告".to_owned()),
+                ..TodoQuery::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(combined.total_count, 1);
+    assert_eq!(combined.items[0].id, tomorrow.id);
+
+    let week = store
+        .query_todos(
+            &owner,
+            &TodoQuery {
+                status: TodoQueryStatus::All,
+                time: Some(TodoQueryTimeFilter::DateRange {
+                    start: ctx.local_date() - Duration::days(2),
+                    end: ctx.local_date() + Duration::days(4),
+                    field: TodoListDateField::Planned,
+                }),
+                ..TodoQuery::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(week.total_count, 5);
+
+    let overdue_page = store
+        .query_todos(
+            &owner,
+            &TodoQuery {
+                time: Some(TodoQueryTimeFilter::Overdue { now }),
+                ..TodoQuery::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(overdue_page.items[0].id, overdue.id);
+    assert_eq!(overdue_page.items[1].id, utc_today.id);
+    assert_eq!(overdue_page.total_count, 2);
+
+    let no_due_page = store
+        .query_todos(
+            &owner,
+            &TodoQuery {
+                time: Some(TodoQueryTimeFilter::NoDueDate),
+                ..TodoQuery::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(no_due_page.items[0].id, no_due.id);
+
+    let completed_page = store
+        .query_todos(
+            &owner,
+            &TodoQuery {
+                status: TodoQueryStatus::Completed,
+                keyword: Some("项目 A".to_owned()),
+                ..TodoQuery::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(completed_page.total_count, 1);
+    assert_eq!(completed_page.items[0].id, completed.id);
+}

--- a/qq-maid-core/src/runtime/tools/todo/storage/tests.rs
+++ b/qq-maid-core/src/runtime/tools/todo/storage/tests.rs
@@ -1340,6 +1340,31 @@ fn shared_query_defaults_to_ten_and_reports_total_count() {
 }
 
 #[test]
+fn shared_query_rejects_non_pending_overdue_statuses() {
+    let store = test_store();
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let now = qq_maid_common::time_context::parse_local_datetime_for_comparison(
+        fixed_context().current_time(),
+    )
+    .unwrap();
+
+    for status in [TodoQueryStatus::Completed, TodoQueryStatus::All] {
+        let err = store
+            .query_todos(
+                &owner,
+                &TodoQuery {
+                    status,
+                    time: Some(TodoQueryTimeFilter::Overdue { now }),
+                    ..TodoQuery::default()
+                },
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), "bad_request");
+        assert_eq!(err.message(), "逾期筛选只适用于未完成待办。");
+    }
+}
+
+#[test]
 fn shared_query_combines_time_status_keyword_and_keeps_scope_isolation() {
     let store = test_store();
     let owner = TodoStore::owner(Some("u1"), "private:u1");

--- a/qq-maid-core/src/runtime/tools/todo/storage/types.rs
+++ b/qq-maid-core/src/runtime/tools/todo/storage/types.rs
@@ -1,6 +1,6 @@
 //! Todo storage public data types and storage-local conversions.
 
-use chrono::NaiveDate;
+use chrono::{DateTime, FixedOffset, NaiveDate};
 use serde::{Deserialize, Serialize};
 
 use crate::storage::database::{DatabaseError, SqliteDatabase};
@@ -160,6 +160,65 @@ pub struct TodoListDateFilter {
     pub start: NaiveDate,
     pub end: NaiveDate,
     pub field: TodoListDateField,
+}
+
+/// 用户主动查询 Todo 时使用的默认展示数量。
+pub const TODO_QUERY_DEFAULT_LIMIT: usize = 10;
+/// 服务端允许的单次查询上限，为后续分页保留显式边界。
+pub const TODO_QUERY_MAX_LIMIT: usize = 20;
+
+/// Todo 列表查询状态范围。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TodoQueryStatus {
+    #[default]
+    Pending,
+    Completed,
+    All,
+}
+
+/// Todo 列表时间筛选。日期范围按请求时区下的本地自然日解释。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TodoQueryTimeFilter {
+    DateRange {
+        start: NaiveDate,
+        end: NaiveDate,
+        field: TodoListDateField,
+    },
+    Overdue {
+        now: DateTime<FixedOffset>,
+    },
+    NoDueDate,
+}
+
+/// 命令、自然语言和 Tool 共用的 Todo 查询模型。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TodoQuery {
+    pub status: TodoQueryStatus,
+    pub time: Option<TodoQueryTimeFilter>,
+    pub keyword: Option<String>,
+    pub limit: usize,
+    pub offset: usize,
+}
+
+impl Default for TodoQuery {
+    fn default() -> Self {
+        Self {
+            status: TodoQueryStatus::Pending,
+            time: None,
+            keyword: None,
+            limit: TODO_QUERY_DEFAULT_LIMIT,
+            offset: 0,
+        }
+    }
+}
+
+/// Todo 查询结果同时携带真实匹配总数，避免展示层静默截断。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TodoQueryPage {
+    pub items: Vec<TodoItem>,
+    pub total_count: usize,
+    pub limit: usize,
+    pub offset: usize,
 }
 
 /// 根据查询状态和参数决定时间范围筛哪个业务字段。

--- a/qq-maid-core/src/runtime/tools/todo/tests/list.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests/list.rs
@@ -1,6 +1,82 @@
 use super::support::*;
 use super::*;
 
+fn list_arguments(
+    status: &str,
+    date_range_text: Option<&str>,
+    time_filter: Option<&str>,
+    keyword: Option<&str>,
+) -> Value {
+    json!({
+        "status": status,
+        "due_date": null,
+        "date_range_text": date_range_text,
+        "time_filter": time_filter,
+        "keyword": keyword,
+    })
+}
+
+#[tokio::test]
+async fn list_tool_returns_ten_items_with_real_total_and_truncation_flag() {
+    let (todo_store, session_store, _notification_store, owner) = test_stores();
+    for index in 1..=11 {
+        todo_store
+            .create(&owner, tool_test_draft(&format!("第 {index} 条")))
+            .unwrap();
+    }
+
+    let output = ListTodoTool::new(todo_store, session_store)
+        .execute(test_context(), list_arguments("pending", None, None, None))
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(output["count"], 10);
+    assert_eq!(output["total_count"], 11);
+    assert_eq!(output["displayed_count"], 10);
+    assert_eq!(output["truncated"], true);
+}
+
+#[tokio::test]
+async fn list_tool_combines_tomorrow_status_and_keyword_filters() {
+    let (todo_store, session_store, _notification_store, owner) = test_stores();
+    let today = qq_maid_common::time_context::request_time_context().local_date();
+    let tomorrow = (today + chrono::Duration::days(1))
+        .format("%Y-%m-%d")
+        .to_string();
+    let day_after = (today + chrono::Duration::days(2))
+        .format("%Y-%m-%d")
+        .to_string();
+    for (title, date) in [
+        ("项目 A 报告", tomorrow.as_str()),
+        ("项目 B 报告", tomorrow.as_str()),
+        ("项目 A 后续", day_after.as_str()),
+    ] {
+        todo_store
+            .create(
+                &owner,
+                TodoItemDraft {
+                    due_date: Some(date.to_owned()),
+                    time_precision: TodoTimePrecision::Date,
+                    ..tool_test_draft(title)
+                },
+            )
+            .unwrap();
+    }
+
+    let output = ListTodoTool::new(todo_store, session_store)
+        .execute(
+            test_context(),
+            list_arguments("pending", Some("明天"), None, Some("项目 A")),
+        )
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(output["total_count"], 1);
+    assert_eq!(output["items"][0]["title"], "项目 A 报告");
+}
+
 #[tokio::test]
 async fn list_tool_all_uses_board_order_for_task_local_numbers_without_user_snapshot_pollution() {
     let (todo_store, session_store, notification_store, owner) = test_stores();

--- a/qq-maid-core/src/runtime/tools/todo/tests/list.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests/list.rs
@@ -78,6 +78,23 @@ async fn list_tool_combines_tomorrow_status_and_keyword_filters() {
 }
 
 #[tokio::test]
+async fn list_tool_rejects_completed_or_all_with_overdue_before_querying() {
+    for status in ["completed", "all"] {
+        let (todo_store, session_store, _notification_store, _owner) = test_stores();
+        let err = ListTodoTool::new(todo_store, session_store)
+            .execute(
+                test_context(),
+                list_arguments(status, None, Some("overdue"), None),
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, "bad_request");
+        assert_eq!(err.message, "逾期筛选只适用于未完成待办。");
+    }
+}
+
+#[tokio::test]
 async fn list_tool_all_uses_board_order_for_task_local_numbers_without_user_snapshot_pollution() {
     let (todo_store, session_store, notification_store, owner) = test_stores();
     todo_store

--- a/qq-maid-core/src/runtime/tools/todo/tests/schema.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests/schema.rs
@@ -70,7 +70,7 @@ fn todo_selector_schemas_allow_null_for_unused_strict_fields() {
 }
 
 #[test]
-fn list_todos_schema_requires_nullable_due_date_for_strict_tools() {
+fn list_todos_schema_exposes_structured_combination_filters() {
     let (todo_store, session_store, _, _) = test_stores();
     let schema = ListTodoTool::new(todo_store, session_store)
         .metadata()
@@ -80,6 +80,8 @@ fn list_todos_schema_requires_nullable_due_date_for_strict_tools() {
     assert!(required.contains(&json!("status")));
     assert!(required.contains(&json!("due_date")));
     assert!(required.contains(&json!("date_range_text")));
+    assert!(required.contains(&json!("time_filter")));
+    assert!(required.contains(&json!("keyword")));
     assert!(json_type_contains(
         &schema["properties"]["due_date"],
         "string"
@@ -95,6 +97,14 @@ fn list_todos_schema_requires_nullable_due_date_for_strict_tools() {
     assert!(json_type_contains(
         &schema["properties"]["date_range_text"],
         "null"
+    ));
+    assert!(json_type_contains(
+        &schema["properties"]["time_filter"],
+        "string"
+    ));
+    assert!(json_type_contains(
+        &schema["properties"]["keyword"],
+        "string"
     ));
 }
 


### PR DESCRIPTION
## 变更

- 将用户主动 Todo 列表默认展示上限从 5 调整为 10，超量时返回真实总数和当前展示数量
- 新增共享 `TodoQuery` SQL 查询模型，支持时间、状态、关键词组合筛选以及稳定排序
- `/todo list`、确定性日期查询和自然语言 `list_todos` Tool 复用同一查询实现
- 时间条件支持今天、明天、本周、逾期和无截止时间，并基于现有 Asia/Shanghai 请求时间上下文归一化
- 关键词在标题、详情和原文中模糊匹配，多个词默认使用 AND
- 查询结果通过 `COUNT` 与 `LIMIT/OFFSET` 获取，为后续分页保留接口空间
- 清理旧的 5 条折叠测试并补充截断、组合筛选、时区、scope 隔离、Markdown/纯文本和自然语言查询测试

## 范围说明

- 按讨论结果，不新增项目实体、数据库表或 migration
- “项目 A”等项目描述当前作为关键词，在现有 Todo 文本字段中模糊搜索
- Todo 创建数量没有新增限制
- 本次未实现分页交互，查询参数已保留 `limit` 和 `offset`

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo build --workspace --release --all-features`
- `git diff --check`

以上检查均通过。
