### PR TITLE
test: 收敛测试 fixture 并清理临时产物

### DIFF
--- a/qq-maid-core/src/runtime/respond/tests/support/mod.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support/mod.rs
@@ -20,7 +20,6 @@ use qq_maid_llm::{
 
 use serde_json::{Value, json};
 use tokio::sync::mpsc;
-use uuid::Uuid;
 
 use super::super::{
     RespondExecutors, RespondRequest, RespondServiceOptions, RespondStores, RustRespondService,

--- a/qq-maid-core/src/runtime/respond/tests/support/service.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support/service.rs
@@ -225,10 +225,10 @@ pub(crate) fn test_service_with_provider_base_title_query_weather_train_models_a
     models: TestModelOptions,
     tool_calling: TestToolCallingOptions,
 ) -> (RustRespondService, PathBuf) {
-    let base = std::env::temp_dir().join(format!("qq-maid-respond-{}", Uuid::new_v4()));
+    let (database, base) =
+        SqliteDatabase::open_temp_directory("qq-maid-respond", APP_MIGRATIONS).unwrap();
     let prompt_dir = base.join("prompts");
     write_prompt_set(&prompt_dir);
-    let database = SqliteDatabase::open(base.join("app.db"), APP_MIGRATIONS).unwrap();
     let knowledge_dir = base.join("knowledge");
     let knowledge_index = KnowledgeIndex::new(KnowledgeStore::new(database.clone()), knowledge_dir);
     knowledge_index.sync().unwrap();

--- a/qq-maid-core/src/runtime/respond/tests/todo_tool_loop.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo_tool_loop.rs
@@ -583,7 +583,7 @@ async fn deterministic_pending_query_then_tool_loop_complete_first_uses_latest_s
     assert!(inspector.tool_call_count() >= 1);
     let tool_request = newest_tool_request(&inspector, "after completing first visible todo");
     let completed = complete_first_visible_todo(&tool_request).await;
-    assert_eq!(completed["ok"], true);
+    assert_eq!(completed["ok"], true, "unexpected tool output: {completed}");
     assert_eq!(completed["completed"][0]["visible_number"], 1);
     assert_eq!(completed["completed"][0]["title"], "测试代办");
 
@@ -795,7 +795,7 @@ async fn deterministic_query_then_status_changes_returns_precise_missing_error()
         .unwrap();
     let tool_request = newest_tool_request(&inspector, "after state change");
     let completed = complete_first_visible_todo(&tool_request).await;
-    assert_eq!(completed["ok"], true);
+    assert_eq!(completed["ok"], true, "unexpected tool output: {completed}");
     assert_eq!(completed["completed"], serde_json::json!([]));
     assert_eq!(completed["missing_numbers"], serde_json::json!([1]));
 }

--- a/qq-maid-core/src/service/tests/support.rs
+++ b/qq-maid-core/src/service/tests/support.rs
@@ -647,17 +647,14 @@ fn test_state_with_group_tool_calling_and_query_executor(
     tool_calling_group_enabled: bool,
     query_executor: Arc<dyn WebSearchExecutor>,
 ) -> CoreRuntimeState {
-    let base_dir = std::env::temp_dir().join(format!(
-        "qq-maid-core-service-test-{}",
-        uuid::Uuid::new_v4()
-    ));
+    let (database, base_dir) =
+        SqliteDatabase::open_temp_directory("qq-maid-core-service-test", APP_MIGRATIONS).unwrap();
+    let app_db_file = database.path().to_path_buf();
     let prompt_dir = base_dir.join("prompts");
     fs::create_dir_all(&prompt_dir).unwrap();
     for file_name in crate::runtime::prompt::PROMPT_FILES {
         fs::write(prompt_dir.join(file_name), format!("{file_name} content")).unwrap();
     }
-    let app_db_file = base_dir.join("app.db");
-    let database = SqliteDatabase::open(&app_db_file, APP_MIGRATIONS).unwrap();
     let knowledge_dir = base_dir.join("knowledge");
     let knowledge_index =
         KnowledgeIndex::new(KnowledgeStore::new(database.clone()), &knowledge_dir);

--- a/qq-maid-core/src/storage/database.rs
+++ b/qq-maid-core/src/storage/database.rs
@@ -26,6 +26,9 @@ use thiserror::Error;
 pub const DEFAULT_SQLITE_POOL_SIZE: usize = 8;
 pub const MIN_SQLITE_POOL_SIZE: usize = 1;
 pub const MAX_SQLITE_POOL_SIZE: usize = 32;
+/// 测试库不会承载生产并发；缩小连接池可避免全量并行测试同时占用数百个 SQLite 连接。
+#[cfg(test)]
+const TEST_SQLITE_POOL_SIZE: usize = 2;
 
 /// 单个 SQLite migration。
 ///
@@ -48,6 +51,15 @@ struct SqliteDatabaseInner {
     pool_size: usize,
     connections: Mutex<Vec<Connection>>,
     available: Condvar,
+    #[cfg(test)]
+    cleanup: Option<TestDatabaseCleanup>,
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+enum TestDatabaseCleanup {
+    SqliteFiles,
+    Directory(PathBuf),
 }
 
 pub struct PooledSqliteConnection {
@@ -101,6 +113,8 @@ impl SqliteDatabase {
                 pool_size,
                 connections: Mutex::new(connections),
                 available: Condvar::new(),
+                #[cfg(test)]
+                cleanup: None,
             }),
         })
     }
@@ -145,10 +159,67 @@ impl SqliteDatabase {
 
     #[cfg(test)]
     pub fn open_temp(prefix: &str, migrations: &[SqliteMigration]) -> Result<Self, DatabaseError> {
-        Self::open(
+        let mut database = Self::open_with_pool_size(
             std::env::temp_dir().join(format!("{prefix}-{}.db", uuid::Uuid::new_v4())),
             migrations,
-        )
+            TEST_SQLITE_POOL_SIZE,
+        )?;
+        Arc::get_mut(&mut database.inner)
+            .expect("new temporary database must have a unique inner owner")
+            .cleanup = Some(TestDatabaseCleanup::SqliteFiles);
+        Ok(database)
+    }
+
+    /// 创建由数据库生命周期托管的测试工作目录。
+    ///
+    /// prompt、knowledge 等同库测试产物都应放进返回目录；最后一个数据库 clone 释放后，
+    /// 整个目录会被清理，避免全量测试长期堆积数 GB 临时文件。
+    #[cfg(test)]
+    pub fn open_temp_directory(
+        prefix: &str,
+        migrations: &[SqliteMigration],
+    ) -> Result<(Self, PathBuf), DatabaseError> {
+        let directory = std::env::temp_dir().join(format!("{prefix}-{}", uuid::Uuid::new_v4()));
+        let mut database =
+            Self::open_with_pool_size(directory.join("app.db"), migrations, TEST_SQLITE_POOL_SIZE)?;
+        Arc::get_mut(&mut database.inner)
+            .expect("new temporary database must have a unique inner owner")
+            .cleanup = Some(TestDatabaseCleanup::Directory(directory.clone()));
+        Ok((database, directory))
+    }
+}
+
+#[cfg(test)]
+impl Drop for SqliteDatabaseInner {
+    fn drop(&mut self) {
+        let Some(cleanup) = self.cleanup.take() else {
+            return;
+        };
+        // 最后一个 database / pooled connection 释放后，先关闭池中连接再删除 WAL 产物。
+        // 清理失败不应掩盖原测试结果；回归测试会验证正常路径确实不会留下文件。
+        match self.connections.get_mut() {
+            Ok(connections) => connections.clear(),
+            Err(poisoned) => poisoned.into_inner().clear(),
+        }
+        match cleanup {
+            TestDatabaseCleanup::SqliteFiles => remove_sqlite_test_artifacts(&self.path),
+            TestDatabaseCleanup::Directory(path) => {
+                let _ = fs::remove_dir_all(path);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+fn remove_sqlite_test_artifacts(path: &Path) {
+    let path_text = path.as_os_str().to_string_lossy();
+    for artifact in [
+        path.to_path_buf(),
+        PathBuf::from(format!("{path_text}-wal")),
+        PathBuf::from(format!("{path_text}-shm")),
+    ] {
+        // Drop 期间不能 panic；残留会由专门回归测试暴露，而不是覆盖业务测试失败。
+        let _ = fs::remove_file(artifact);
     }
 }
 
@@ -376,6 +447,41 @@ mod tests {
         drop(first);
         drop(second);
         assert_eq!(db.idle_connection_count(), 2);
+    }
+
+    #[test]
+    fn temporary_database_is_removed_after_last_owner_drops() {
+        let database = SqliteDatabase::open_temp("qq-maid-cleanup-test", TEST_MIGRATIONS).unwrap();
+        let path = database.path().to_path_buf();
+        let cloned = database.clone();
+
+        assert_eq!(database.pool_size(), TEST_SQLITE_POOL_SIZE);
+        assert!(path.exists());
+        drop(database);
+        assert!(
+            path.exists(),
+            "a live clone must keep the database available"
+        );
+        drop(cloned);
+
+        assert!(!path.exists());
+        assert!(!PathBuf::from(format!("{}-wal", path.display())).exists());
+        assert!(!PathBuf::from(format!("{}-shm", path.display())).exists());
+    }
+
+    #[test]
+    fn temporary_database_directory_is_removed_with_related_files() {
+        let (database, directory) =
+            SqliteDatabase::open_temp_directory("qq-maid-cleanup-dir-test", TEST_MIGRATIONS)
+                .unwrap();
+        let related = directory.join("prompts/system_prompt.txt");
+        fs::create_dir_all(related.parent().unwrap()).unwrap();
+        fs::write(&related, "test prompt").unwrap();
+
+        assert!(related.exists());
+        drop(database);
+
+        assert!(!directory.exists());
     }
 
     #[test]

--- a/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
@@ -1,10 +1,11 @@
 use super::{AggregationDispatcher, MessageAggregator, MessageAggregatorHandle};
 use crate::{
-    config::{AgentTypingConfig, AppConfig, GroupMessageMode, MessageAggregationConfig},
+    config::AppConfig,
     gateway::{
         dedupe::MessageDedupe,
         dispatcher::DispatcherEnqueueError,
         event::{C2cMessage, GroupMessage},
+        test_support::qq_official_test_config,
     },
     respond::{RespondClient, scope_key_from_c2c_message},
 };
@@ -281,48 +282,21 @@ struct Harness {
 }
 
 fn test_config() -> AppConfig {
-    AppConfig {
-        qq_official_enabled: true,
-        app_id: Some("appid".to_owned()),
-        app_secret: Some("secret".to_owned()),
-        bot_mention_ids: Vec::new(),
-        sandbox: false,
-        api_base: "https://example.test".to_owned(),
-        token_refresh_margin: Duration::from_secs(60),
-        enable_markdown: false,
-        enable_image: false,
-        enable_group_messages: true,
-        verbose_log: false,
-        member_detail_enrich_enabled: false,
-        group_message_mode: GroupMessageMode::Mention,
-        bot_display_name: "小女仆".to_owned(),
-        group_active_keywords: vec!["小女仆".to_owned()],
-        conversation_queue_capacity: 8,
-        max_active_conversation_workers: 4,
-        conversation_worker_idle_timeout: Duration::from_secs(60),
-        message_aggregation: MessageAggregationConfig {
-            private_enabled: true,
-            group_enabled: false,
-            quiet: Duration::from_millis(100),
-            max_wait: Duration::from_millis(300),
-            max_messages: 3,
-            max_chars: 12,
-            max_active_keys: 4,
-        },
-        c2c_final_reply_stream_enabled: false,
-        c2c_visible_progress_status_enabled: true,
-        agent_typing: AgentTypingConfig {
-            enabled: false,
-            delay: Duration::from_secs(1),
-        },
-        markdown_chunk_soft_limit: 1800,
-        text_chunk_soft_limit: 1800,
-        media_dir: std::path::PathBuf::from("media/inbound"),
-        media_download_timeout: Duration::from_secs(10),
-        media_max_bytes: crate::config::DEFAULT_MEDIA_MAX_BYTES,
-        wechat_service: crate::config::WechatServiceConfig::default(),
-        onebot11: crate::config::OneBot11Config::default(),
-    }
+    let mut config = qq_official_test_config();
+    config.app_id = Some("appid".to_owned());
+    config.enable_markdown = false;
+    config.enable_group_messages = true;
+    config.conversation_queue_capacity = 8;
+    config.max_active_conversation_workers = 4;
+    config.conversation_worker_idle_timeout = Duration::from_secs(60);
+    config.message_aggregation.quiet = Duration::from_millis(100);
+    config.message_aggregation.max_wait = Duration::from_millis(300);
+    config.message_aggregation.max_messages = 3;
+    config.message_aggregation.max_chars = 12;
+    config.message_aggregation.max_active_keys = 4;
+    config.markdown_chunk_soft_limit = 1800;
+    config.text_chunk_soft_limit = 1800;
+    config
 }
 
 fn harness_with_config(config: AppConfig) -> Harness {

--- a/qq-maid-gateway-rs/src/gateway/dispatcher/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/dispatcher/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::config::{AgentTypingConfig, GroupMessageMode};
+use crate::gateway::test_support::qq_official_test_config;
 use crate::respond::{RespondClient, scope_key_from_c2c_message, scope_key_from_group_message};
 use qq_maid_core::service::{
     CoreError, CoreHealthSnapshot, CoreInboundClassification, CoreRequest, CoreRespondOutput,
@@ -128,48 +128,22 @@ impl MessageHandler for RecordingHandler {
 }
 
 fn test_config() -> AppConfig {
-    AppConfig {
-        qq_official_enabled: true,
-        app_id: Some("appid".to_owned()),
-        app_secret: Some("secret".to_owned()),
-        bot_mention_ids: Vec::new(),
-        sandbox: false,
-        api_base: "http://127.0.0.1:1".to_owned(),
-        token_refresh_margin: Duration::from_secs(60),
-        enable_markdown: false,
-        enable_image: false,
-        enable_group_messages: true,
-        verbose_log: false,
-        member_detail_enrich_enabled: false,
-        group_message_mode: GroupMessageMode::Mention,
-        bot_display_name: "小女仆".to_owned(),
-        group_active_keywords: vec!["小女仆".to_owned()],
-        conversation_queue_capacity: 8,
-        max_active_conversation_workers: 4,
-        conversation_worker_idle_timeout: Duration::from_secs(60),
-        message_aggregation: crate::config::MessageAggregationConfig {
-            private_enabled: true,
-            group_enabled: false,
-            quiet: Duration::from_millis(1200),
-            max_wait: Duration::from_millis(3000),
-            max_messages: 10,
-            max_chars: 12000,
-            max_active_keys: 1024,
-        },
-        c2c_final_reply_stream_enabled: false,
-        c2c_visible_progress_status_enabled: true,
-        agent_typing: AgentTypingConfig {
-            enabled: false,
-            delay: Duration::from_secs(1),
-        },
-        markdown_chunk_soft_limit: 1800,
-        text_chunk_soft_limit: 1800,
-        media_dir: std::path::PathBuf::from("media/inbound"),
-        media_download_timeout: Duration::from_secs(10),
-        media_max_bytes: crate::config::DEFAULT_MEDIA_MAX_BYTES,
-        wechat_service: crate::config::WechatServiceConfig::default(),
-        onebot11: crate::config::OneBot11Config::default(),
-    }
+    let mut config = qq_official_test_config();
+    config.app_id = Some("appid".to_owned());
+    config.api_base = "http://127.0.0.1:1".to_owned();
+    config.enable_markdown = false;
+    config.enable_group_messages = true;
+    config.conversation_queue_capacity = 8;
+    config.max_active_conversation_workers = 4;
+    config.conversation_worker_idle_timeout = Duration::from_secs(60);
+    config.message_aggregation.quiet = Duration::from_millis(1200);
+    config.message_aggregation.max_wait = Duration::from_millis(3000);
+    config.message_aggregation.max_messages = 10;
+    config.message_aggregation.max_chars = 12000;
+    config.message_aggregation.max_active_keys = 1024;
+    config.markdown_chunk_soft_limit = 1800;
+    config.text_chunk_soft_limit = 1800;
+    config
 }
 
 fn c2c(id: &str, user: &str) -> C2cMessage {

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -21,6 +21,8 @@ mod qq_official;
 mod ref_index;
 mod retry;
 mod stream;
+#[cfg(test)]
+mod test_support;
 mod typing;
 mod wechat_service;
 

--- a/qq-maid-gateway-rs/src/gateway/outbound.rs
+++ b/qq-maid-gateway-rs/src/gateway/outbound.rs
@@ -406,57 +406,13 @@ impl GroupOutboundSender for RuntimeRecordingGroupSender<'_> {
 mod tests {
     use super::*;
     use crate::api::ApiError;
-    use crate::config::{
-        AgentTypingConfig, DEFAULT_CONVERSATION_QUEUE_CAPACITY, DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT,
-        DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS, DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS,
-        DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS, DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES,
-        DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS, DEFAULT_MESSAGE_AGGREGATION_QUIET_MS,
-        DEFAULT_TEXT_CHUNK_SOFT_LIMIT, GroupMessageMode, MessageAggregationConfig,
-    };
+    use crate::gateway::test_support::qq_official_test_config;
 
     fn test_config() -> AppConfig {
-        AppConfig {
-            qq_official_enabled: true,
-            app_id: Some("app".to_owned()),
-            app_secret: Some("secret".to_owned()),
-            bot_mention_ids: Vec::new(),
-            sandbox: false,
-            api_base: "https://example.test".to_owned(),
-            token_refresh_margin: Duration::from_secs(60),
-            enable_markdown: true,
-            enable_image: false,
-            enable_group_messages: true,
-            verbose_log: false,
-            member_detail_enrich_enabled: false,
-            group_message_mode: GroupMessageMode::Mention,
-            bot_display_name: "小女仆".to_owned(),
-            group_active_keywords: vec!["小女仆".to_owned()],
-            conversation_queue_capacity: DEFAULT_CONVERSATION_QUEUE_CAPACITY,
-            max_active_conversation_workers: DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS,
-            conversation_worker_idle_timeout: Duration::from_secs(300),
-            message_aggregation: MessageAggregationConfig {
-                private_enabled: true,
-                group_enabled: false,
-                quiet: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_QUIET_MS),
-                max_wait: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS),
-                max_messages: DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES,
-                max_chars: DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS,
-                max_active_keys: DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS,
-            },
-            c2c_final_reply_stream_enabled: true,
-            c2c_visible_progress_status_enabled: true,
-            agent_typing: AgentTypingConfig {
-                enabled: false,
-                delay: Duration::from_secs(1),
-            },
-            markdown_chunk_soft_limit: DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT,
-            text_chunk_soft_limit: DEFAULT_TEXT_CHUNK_SOFT_LIMIT,
-            media_dir: std::path::PathBuf::from("media/inbound"),
-            media_download_timeout: Duration::from_secs(10),
-            media_max_bytes: crate::config::DEFAULT_MEDIA_MAX_BYTES,
-            wechat_service: crate::config::WechatServiceConfig::default(),
-            onebot11: crate::config::OneBot11Config::default(),
-        }
+        let mut config = qq_official_test_config();
+        config.enable_group_messages = true;
+        config.c2c_final_reply_stream_enabled = true;
+        config
     }
 
     #[test]

--- a/qq-maid-gateway-rs/src/gateway/qq_official/c2c/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/qq_official/c2c/tests.rs
@@ -10,18 +10,15 @@ fn empty_reply_fallback_uses_configured_bot_display_name() {
 }
 use crate::{
     api::{ApiError, C2cReplyTarget, SendFuture},
-    config::{
-        AgentTypingConfig, DEFAULT_CONVERSATION_QUEUE_CAPACITY, DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT,
-        DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS, DEFAULT_MEDIA_MAX_BYTES,
-        DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS, DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS,
-        DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES, DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS,
-        DEFAULT_MESSAGE_AGGREGATION_QUIET_MS, DEFAULT_TEXT_CHUNK_SOFT_LIMIT, GroupMessageMode,
-        MessageAggregationConfig,
+    config::AppConfig,
+    gateway::test_support::{
+        c2c_message_fixture as c2c_message, qq_official_test_config as test_config,
+        respond_response_fixture as respond_response,
     },
     media::ImagePayload,
 };
 use qq_maid_core::service::{CoreRespondFailure, CoreResponseStatus, CoreResponseStatusKind};
-use std::{collections::VecDeque, sync::Mutex, time::Duration};
+use std::{collections::VecDeque, sync::Mutex};
 
 #[derive(Debug)]
 struct FakeEventStream {
@@ -120,35 +117,6 @@ impl OutboundSender for FakeOutboundSender {
     }
 }
 
-fn c2c_message() -> C2cMessage {
-    C2cMessage {
-        message_id: "msg-1".to_owned(),
-        current_msg_idx: None,
-        event_id: Some("event-1".to_owned()),
-        source_message_ids: vec!["msg-1".to_owned()],
-        source_event_ids: vec!["event-1".to_owned()],
-        user_openid: "user-1".to_owned(),
-        content: "晚上好".to_owned(),
-        reply: None,
-        timestamp: None,
-        first_message_timestamp: None,
-        last_message_timestamp: None,
-        input_parts: vec![qq_maid_common::input_part::MessageInputPart::text("晚上好")],
-        attachments: Vec::new(),
-    }
-}
-
-fn respond_response(text: &str) -> RespondResponse {
-    RespondResponse {
-        output: Some(qq_maid_core::service::AssistantOutput::markdown(text, text)),
-        handled: Some(true),
-        session_id: None,
-        command: None,
-        diagnostics: None,
-        visible_entity_snapshot: None,
-    }
-}
-
 fn quoted_lookup_found(
     ref_index: &SharedRefIndex,
     config: &AppConfig,
@@ -171,51 +139,6 @@ fn quoted_lookup_found(
         .as_ref()
         .filter(|quoted| quoted.lookup_found)
         .and_then(|quoted| quoted.text_summary.clone())
-}
-
-fn test_config() -> AppConfig {
-    AppConfig {
-        qq_official_enabled: true,
-        app_id: Some("app".to_owned()),
-        app_secret: Some("secret".to_owned()),
-        bot_mention_ids: Vec::new(),
-        sandbox: false,
-        api_base: "https://example.test".to_owned(),
-        token_refresh_margin: Duration::from_secs(60),
-        enable_markdown: true,
-        enable_image: false,
-        enable_group_messages: false,
-        verbose_log: false,
-        member_detail_enrich_enabled: false,
-        group_message_mode: GroupMessageMode::Mention,
-        bot_display_name: "小女仆".to_owned(),
-        group_active_keywords: vec!["小女仆".to_owned()],
-        conversation_queue_capacity: DEFAULT_CONVERSATION_QUEUE_CAPACITY,
-        max_active_conversation_workers: DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS,
-        conversation_worker_idle_timeout: Duration::from_secs(300),
-        message_aggregation: MessageAggregationConfig {
-            private_enabled: true,
-            group_enabled: false,
-            quiet: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_QUIET_MS),
-            max_wait: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS),
-            max_messages: DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES,
-            max_chars: DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS,
-            max_active_keys: DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS,
-        },
-        c2c_final_reply_stream_enabled: false,
-        c2c_visible_progress_status_enabled: true,
-        agent_typing: AgentTypingConfig {
-            enabled: false,
-            delay: Duration::from_secs(1),
-        },
-        markdown_chunk_soft_limit: DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT,
-        text_chunk_soft_limit: DEFAULT_TEXT_CHUNK_SOFT_LIMIT,
-        media_dir: std::path::PathBuf::from("media/inbound"),
-        media_download_timeout: Duration::from_secs(10),
-        media_max_bytes: DEFAULT_MEDIA_MAX_BYTES,
-        wechat_service: crate::config::WechatServiceConfig::default(),
-        onebot11: crate::config::OneBot11Config::default(),
-    }
 }
 
 #[test]

--- a/qq-maid-gateway-rs/src/gateway/qq_official/group/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/qq_official/group/tests.rs
@@ -50,17 +50,11 @@ async fn group_stream_timeout_sends_core_safe_failure_text() {
             .contains_ref_index_id("REFIDX_failure")
     );
 }
-use crate::config::{
-    AgentTypingConfig, DEFAULT_CONVERSATION_QUEUE_CAPACITY, DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT,
-    DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS, DEFAULT_MEDIA_MAX_BYTES,
-    DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS, DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS,
-    DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES, DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS,
-    DEFAULT_MESSAGE_AGGREGATION_QUIET_MS, DEFAULT_TEXT_CHUNK_SOFT_LIMIT, GroupMessageMode,
-    MessageAggregationConfig,
-};
 use crate::{
     api::{ApiError, GroupReplyTarget, QqApiClient, SendFuture},
     auth::AccessTokenManager,
+    config::GroupMessageMode,
+    gateway::test_support::qq_official_test_config,
     markdown::MarkdownPayload,
 };
 use axum::{Router, body::Bytes, routing::get};
@@ -152,48 +146,10 @@ fn group_message(content: &str, event_type: GroupEventType) -> GroupMessage {
 }
 
 fn test_config() -> AppConfig {
-    AppConfig {
-        qq_official_enabled: true,
-        app_id: Some("app".to_owned()),
-        app_secret: Some("secret".to_owned()),
-        bot_mention_ids: Vec::new(),
-        sandbox: false,
-        api_base: "http://127.0.0.1:1".to_owned(),
-        token_refresh_margin: Duration::from_secs(60),
-        enable_markdown: true,
-        enable_image: false,
-        enable_group_messages: true,
-        verbose_log: false,
-        member_detail_enrich_enabled: false,
-        group_message_mode: GroupMessageMode::Mention,
-        bot_display_name: "小女仆".to_owned(),
-        group_active_keywords: vec!["小女仆".to_owned()],
-        conversation_queue_capacity: DEFAULT_CONVERSATION_QUEUE_CAPACITY,
-        max_active_conversation_workers: DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS,
-        conversation_worker_idle_timeout: Duration::from_secs(300),
-        message_aggregation: MessageAggregationConfig {
-            private_enabled: true,
-            group_enabled: false,
-            quiet: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_QUIET_MS),
-            max_wait: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS),
-            max_messages: DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES,
-            max_chars: DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS,
-            max_active_keys: DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS,
-        },
-        c2c_final_reply_stream_enabled: false,
-        c2c_visible_progress_status_enabled: true,
-        agent_typing: AgentTypingConfig {
-            enabled: false,
-            delay: Duration::from_secs(1),
-        },
-        markdown_chunk_soft_limit: DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT,
-        text_chunk_soft_limit: DEFAULT_TEXT_CHUNK_SOFT_LIMIT,
-        media_dir: std::path::PathBuf::from("media/inbound"),
-        media_download_timeout: Duration::from_secs(10),
-        media_max_bytes: DEFAULT_MEDIA_MAX_BYTES,
-        wechat_service: crate::config::WechatServiceConfig::default(),
-        onebot11: crate::config::OneBot11Config::default(),
-    }
+    let mut config = qq_official_test_config();
+    config.api_base = "http://127.0.0.1:1".to_owned();
+    config.enable_group_messages = true;
+    config
 }
 
 fn qq_group_capability() -> ReplyCapability {

--- a/qq-maid-gateway-rs/src/gateway/stream/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests.rs
@@ -7,24 +7,27 @@ use crate::{
         ApiError, C2cReplyTarget, C2cStreamState, OutboundSender, SendFuture, SendMessageIds,
         StreamSendResult,
     },
-    config::{
-        AgentTypingConfig, AppConfig, DEFAULT_CONVERSATION_QUEUE_CAPACITY,
-        DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT, DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS,
-        DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS, DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS,
-        DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES, DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS,
-        DEFAULT_MESSAGE_AGGREGATION_QUIET_MS, DEFAULT_TEXT_CHUNK_SOFT_LIMIT, GroupMessageMode,
-        MessageAggregationConfig,
+    config::{AgentTypingConfig, AppConfig},
+    event::MessageReply,
+    gateway::test_support::{
+        c2c_message_fixture as c2c_message, qq_official_test_config,
+        respond_response_fixture as respond_response,
     },
-    event::{C2cMessage, MessageReply},
     markdown::MarkdownPayload,
     media::ImagePayload,
-    respond::{RespondEvent, RespondResponse},
+    respond::RespondEvent,
 };
 use qq_maid_core::service::{
     CoreFailureKind, CoreOutputPolicy, CoreRespondFailure, CoreResponseStatus,
     CoreResponseStatusKind,
 };
 use std::{collections::VecDeque, sync::Arc, time::Duration};
+
+fn test_config() -> AppConfig {
+    let mut config = qq_official_test_config();
+    config.c2c_final_reply_stream_enabled = true;
+    config
+}
 
 #[derive(Debug)]
 struct FakeEventStream {
@@ -196,35 +199,6 @@ impl C2cStreamSender for FakeStreamSender {
     }
 }
 
-fn c2c_message() -> C2cMessage {
-    C2cMessage {
-        message_id: "msg-1".to_owned(),
-        current_msg_idx: None,
-        event_id: Some("event-1".to_owned()),
-        source_message_ids: vec!["msg-1".to_owned()],
-        source_event_ids: vec!["event-1".to_owned()],
-        user_openid: "user-1".to_owned(),
-        content: "晚上好".to_owned(),
-        reply: None,
-        timestamp: None,
-        first_message_timestamp: None,
-        last_message_timestamp: None,
-        input_parts: vec![qq_maid_common::input_part::MessageInputPart::text("晚上好")],
-        attachments: Vec::new(),
-    }
-}
-
-fn respond_response(text: &str) -> RespondResponse {
-    RespondResponse {
-        output: Some(qq_maid_core::service::AssistantOutput::markdown(text, text)),
-        handled: Some(true),
-        session_id: None,
-        command: None,
-        diagnostics: None,
-        visible_entity_snapshot: None,
-    }
-}
-
 fn quoted_lookup_found(
     ref_index: &crate::gateway::ref_index::SharedRefIndex,
     config: &AppConfig,
@@ -247,51 +221,6 @@ fn quoted_lookup_found(
         .as_ref()
         .filter(|quoted| quoted.lookup_found)
         .and_then(|quoted| quoted.text_summary.clone())
-}
-
-fn test_config() -> AppConfig {
-    AppConfig {
-        qq_official_enabled: true,
-        app_id: Some("app".to_owned()),
-        app_secret: Some("secret".to_owned()),
-        bot_mention_ids: Vec::new(),
-        sandbox: false,
-        api_base: "https://example.test".to_owned(),
-        token_refresh_margin: Duration::from_secs(60),
-        enable_markdown: true,
-        enable_image: false,
-        enable_group_messages: false,
-        verbose_log: false,
-        member_detail_enrich_enabled: false,
-        group_message_mode: GroupMessageMode::Mention,
-        bot_display_name: "小女仆".to_owned(),
-        group_active_keywords: vec!["小女仆".to_owned()],
-        conversation_queue_capacity: DEFAULT_CONVERSATION_QUEUE_CAPACITY,
-        max_active_conversation_workers: DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS,
-        conversation_worker_idle_timeout: Duration::from_secs(300),
-        message_aggregation: MessageAggregationConfig {
-            private_enabled: true,
-            group_enabled: false,
-            quiet: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_QUIET_MS),
-            max_wait: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS),
-            max_messages: DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES,
-            max_chars: DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS,
-            max_active_keys: DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS,
-        },
-        c2c_final_reply_stream_enabled: true,
-        c2c_visible_progress_status_enabled: true,
-        agent_typing: AgentTypingConfig {
-            enabled: false,
-            delay: Duration::from_secs(1),
-        },
-        markdown_chunk_soft_limit: DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT,
-        text_chunk_soft_limit: DEFAULT_TEXT_CHUNK_SOFT_LIMIT,
-        media_dir: std::path::PathBuf::from("media/inbound"),
-        media_download_timeout: Duration::from_secs(10),
-        media_max_bytes: crate::config::DEFAULT_MEDIA_MAX_BYTES,
-        wechat_service: crate::config::WechatServiceConfig::default(),
-        onebot11: crate::config::OneBot11Config::default(),
-    }
 }
 
 #[tokio::test]

--- a/qq-maid-gateway-rs/src/gateway/test_support.rs
+++ b/qq-maid-gateway-rs/src/gateway/test_support.rs
@@ -1,0 +1,100 @@
+//! Gateway 单测共享 fixture。
+//!
+//! 这里只收敛跨多个 Gateway 领域都稳定复用的完整配置与基础消息样本；具体发送器、
+//! 聚合器和平台 fake 仍留在各自测试模块，避免隐藏被测协议和关键断言。
+
+use std::time::Duration;
+
+use qq_maid_core::service::AssistantOutput;
+
+use super::event::C2cMessage;
+use crate::{
+    config::{
+        AgentTypingConfig, AppConfig, DEFAULT_CONVERSATION_QUEUE_CAPACITY,
+        DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT, DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS,
+        DEFAULT_MEDIA_MAX_BYTES, DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS,
+        DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS, DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES,
+        DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS, DEFAULT_MESSAGE_AGGREGATION_QUIET_MS,
+        DEFAULT_TEXT_CHUNK_SOFT_LIMIT, GroupMessageMode, MessageAggregationConfig, OneBot11Config,
+        WechatServiceConfig,
+    },
+    respond::RespondResponse,
+};
+
+/// 返回已绑定 QQ 官方渠道的稳定测试基线。
+///
+/// 测试若关心流式、群聊、聚合窗口或分段限制，应在调用处显式修改对应字段，确保关键输入
+/// 仍然可见；此处只统一与被测行为无关的配置样板。
+pub(crate) fn qq_official_test_config() -> AppConfig {
+    AppConfig {
+        qq_official_enabled: true,
+        app_id: Some("app".to_owned()),
+        app_secret: Some("secret".to_owned()),
+        bot_mention_ids: Vec::new(),
+        sandbox: false,
+        api_base: "https://example.test".to_owned(),
+        token_refresh_margin: Duration::from_secs(60),
+        enable_markdown: true,
+        enable_image: false,
+        enable_group_messages: false,
+        verbose_log: false,
+        member_detail_enrich_enabled: false,
+        group_message_mode: GroupMessageMode::Mention,
+        bot_display_name: "小女仆".to_owned(),
+        group_active_keywords: vec!["小女仆".to_owned()],
+        conversation_queue_capacity: DEFAULT_CONVERSATION_QUEUE_CAPACITY,
+        max_active_conversation_workers: DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS,
+        conversation_worker_idle_timeout: Duration::from_secs(300),
+        message_aggregation: MessageAggregationConfig {
+            private_enabled: true,
+            group_enabled: false,
+            quiet: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_QUIET_MS),
+            max_wait: Duration::from_millis(DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS),
+            max_messages: DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES,
+            max_chars: DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS,
+            max_active_keys: DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS,
+        },
+        c2c_final_reply_stream_enabled: false,
+        c2c_visible_progress_status_enabled: true,
+        agent_typing: AgentTypingConfig {
+            enabled: false,
+            delay: Duration::from_secs(1),
+        },
+        markdown_chunk_soft_limit: DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT,
+        text_chunk_soft_limit: DEFAULT_TEXT_CHUNK_SOFT_LIMIT,
+        media_dir: std::path::PathBuf::from("media/inbound"),
+        media_download_timeout: Duration::from_secs(10),
+        media_max_bytes: DEFAULT_MEDIA_MAX_BYTES,
+        wechat_service: WechatServiceConfig::default(),
+        onebot11: OneBot11Config::default(),
+    }
+}
+
+pub(crate) fn c2c_message_fixture() -> C2cMessage {
+    C2cMessage {
+        message_id: "msg-1".to_owned(),
+        current_msg_idx: None,
+        event_id: Some("event-1".to_owned()),
+        source_message_ids: vec!["msg-1".to_owned()],
+        source_event_ids: vec!["event-1".to_owned()],
+        user_openid: "user-1".to_owned(),
+        content: "晚上好".to_owned(),
+        reply: None,
+        timestamp: None,
+        first_message_timestamp: None,
+        last_message_timestamp: None,
+        input_parts: vec![qq_maid_common::input_part::MessageInputPart::text("晚上好")],
+        attachments: Vec::new(),
+    }
+}
+
+pub(crate) fn respond_response_fixture(text: &str) -> RespondResponse {
+    RespondResponse {
+        output: Some(AssistantOutput::markdown(text, text)),
+        handled: Some(true),
+        session_id: None,
+        command: None,
+        diagnostics: None,
+        visible_entity_snapshot: None,
+    }
+}

--- a/qq-maid-llm/src/provider/bigmodel.rs
+++ b/qq-maid-llm/src/provider/bigmodel.rs
@@ -208,58 +208,10 @@ mod tests {
     use super::*;
     use crate::provider::ToolChatRequest;
     use crate::{
-        provider::test_support::{WeatherToolStub, test_tool_context},
+        provider::test_support::{WeatherToolStub, spawn_chat_completions_mock, test_tool_context},
         tool::ToolRegistry,
     };
-    use axum::{
-        Router,
-        body::Body,
-        extract::State,
-        http::{StatusCode, header},
-        response::IntoResponse,
-        routing::post,
-    };
-    use serde_json::{Value, json};
-    use std::sync::Arc;
-    use tokio::{net::TcpListener, sync::Mutex};
-
-    #[derive(Debug)]
-    struct MockChatState {
-        bodies: Vec<String>,
-        requests: Vec<Value>,
-    }
-
-    async fn mock_chat_handler(
-        State(state): State<Arc<Mutex<MockChatState>>>,
-        body: Body,
-    ) -> impl IntoResponse {
-        let bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
-        let request: Value = serde_json::from_slice(&bytes).unwrap();
-        let mut state = state.lock().await;
-        state.requests.push(request);
-        let body = state.bodies.remove(0);
-        (
-            StatusCode::OK,
-            [(header::CONTENT_TYPE, "text/event-stream")],
-            body,
-        )
-    }
-
-    async fn spawn_mock_chat(bodies: Vec<String>) -> (String, Arc<Mutex<MockChatState>>) {
-        let state = Arc::new(Mutex::new(MockChatState {
-            bodies,
-            requests: Vec::new(),
-        }));
-        let app = Router::new()
-            .route("/chat/completions", post(mock_chat_handler))
-            .with_state(state.clone());
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            axum::serve(listener, app).await.unwrap();
-        });
-        (format!("http://{addr}"), state)
-    }
+    use serde_json::json;
 
     #[test]
     fn effective_bigmodel_model_strips_bigmodel_prefix() {
@@ -309,7 +261,7 @@ mod tests {
 
     #[tokio::test]
     async fn chat_retries_non_stream_after_empty_sse_when_stream_enabled() {
-        let (base_url, state) = spawn_mock_chat(vec![
+        let (base_url, state) = spawn_chat_completions_mock(vec![
             "data: [DONE]\n\n".to_owned(),
             json!({"choices": [{"message": {"content": "bigmodel non-stream"}}]}).to_string(),
         ])
@@ -344,7 +296,7 @@ mod tests {
 
     #[tokio::test]
     async fn chat_with_tools_runs_chat_completions_tool_loop() {
-        let (base_url, state) = spawn_mock_chat(vec![
+        let (base_url, state) = spawn_chat_completions_mock(vec![
             json!({
                 "choices": [{
                     "message": {

--- a/qq-maid-llm/src/provider/deepseek.rs
+++ b/qq-maid-llm/src/provider/deepseek.rs
@@ -207,59 +207,11 @@ mod tests {
     use super::*;
     use crate::provider::ToolChatRequest;
     use crate::{
-        provider::test_support::{WeatherToolStub, test_tool_context},
+        provider::test_support::{WeatherToolStub, spawn_chat_completions_mock, test_tool_context},
         tool::ToolRegistry,
     };
-    use axum::{
-        Router,
-        body::Body,
-        extract::State,
-        http::{StatusCode, header},
-        response::IntoResponse,
-        routing::post,
-    };
     use futures::StreamExt;
-    use serde_json::{Value, json};
-    use std::sync::Arc;
-    use tokio::{net::TcpListener, sync::Mutex};
-
-    #[derive(Debug)]
-    struct MockChatState {
-        bodies: Vec<String>,
-        requests: Vec<Value>,
-    }
-
-    async fn mock_chat_handler(
-        State(state): State<Arc<Mutex<MockChatState>>>,
-        body: Body,
-    ) -> impl IntoResponse {
-        let bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
-        let request: Value = serde_json::from_slice(&bytes).unwrap();
-        let mut state = state.lock().await;
-        state.requests.push(request);
-        let body = state.bodies.remove(0);
-        (
-            StatusCode::OK,
-            [(header::CONTENT_TYPE, "text/event-stream")],
-            body,
-        )
-    }
-
-    async fn spawn_mock_chat(bodies: Vec<String>) -> (String, Arc<Mutex<MockChatState>>) {
-        let state = Arc::new(Mutex::new(MockChatState {
-            bodies,
-            requests: Vec::new(),
-        }));
-        let app = Router::new()
-            .route("/chat/completions", post(mock_chat_handler))
-            .with_state(state.clone());
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            axum::serve(listener, app).await.unwrap();
-        });
-        (format!("http://{addr}"), state)
-    }
+    use serde_json::json;
 
     #[test]
     fn effective_deepseek_model_strips_deepseek_prefix() {
@@ -302,7 +254,7 @@ mod tests {
 
     #[tokio::test]
     async fn chat_retries_non_stream_after_empty_sse_when_stream_enabled() {
-        let (base_url, state) = spawn_mock_chat(vec![
+        let (base_url, state) = spawn_chat_completions_mock(vec![
             "data: [DONE]\n\n".to_owned(),
             json!({"choices": [{"message": {"content": "deepseek non-stream"}}]}).to_string(),
         ])
@@ -337,7 +289,7 @@ mod tests {
 
     #[tokio::test]
     async fn stream_chat_after_delta_error_does_not_retry_non_stream() {
-        let (base_url, state) = spawn_mock_chat(vec![
+        let (base_url, state) = spawn_chat_completions_mock(vec![
             "data: {\"choices\":[{\"delta\":{\"content\":\"半截\"}}]}\n\ndata: {not-json}\n\n"
                 .to_owned(),
         ])
@@ -372,7 +324,7 @@ mod tests {
 
     #[tokio::test]
     async fn chat_with_tools_runs_chat_completions_tool_loop() {
-        let (base_url, state) = spawn_mock_chat(vec![
+        let (base_url, state) = spawn_chat_completions_mock(vec![
             json!({
                 "choices": [{
                     "message": {

--- a/qq-maid-llm/src/provider/test_support.rs
+++ b/qq-maid-llm/src/provider/test_support.rs
@@ -3,11 +3,22 @@
 //! 这里只放多个 provider 测试都会复用的轻量 stub，避免把同一组测试工具在
 //! DeepSeek / BigModel / OpenAI 之间各复制一份。
 
+use std::{collections::VecDeque, sync::Arc};
+
 use async_trait::async_trait;
+use axum::{
+    Router,
+    body::Body,
+    extract::State,
+    http::{StatusCode, header},
+    response::IntoResponse,
+    routing::post,
+};
 use qq_maid_common::identity_context::{
     ConversationKind, ExecutionActorContext, ExecutionConversationContext,
 };
 use serde_json::{Value, json};
+use tokio::{net::TcpListener, sync::Mutex};
 
 use crate::{
     error::LlmError,
@@ -72,4 +83,48 @@ pub(crate) fn test_tool_context() -> ToolContext {
         tool_call_id: None,
         execution_deadline: None,
     }
+}
+
+#[derive(Debug)]
+pub(crate) struct MockChatCompletionsState {
+    bodies: VecDeque<String>,
+    pub(crate) requests: Vec<Value>,
+}
+
+async fn mock_chat_completions_handler(
+    State(state): State<Arc<Mutex<MockChatCompletionsState>>>,
+    body: Body,
+) -> impl IntoResponse {
+    let bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+    let request: Value = serde_json::from_slice(&bytes).unwrap();
+    let mut state = state.lock().await;
+    state.requests.push(request);
+    let body = state
+        .bodies
+        .pop_front()
+        .expect("mock chat response queue should not be empty");
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "text/event-stream")],
+        body,
+    )
+}
+
+/// 启动 Chat Completions provider 共用的顺序响应 fake，并保留完整请求供各协议测试断言。
+pub(crate) async fn spawn_chat_completions_mock(
+    bodies: Vec<String>,
+) -> (String, Arc<Mutex<MockChatCompletionsState>>) {
+    let state = Arc::new(Mutex::new(MockChatCompletionsState {
+        bodies: bodies.into(),
+        requests: Vec::new(),
+    }));
+    let app = Router::new()
+        .route("/chat/completions", post(mock_chat_completions_handler))
+        .with_state(state.clone());
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}"), state)
 }


### PR DESCRIPTION
## 概要

- 收敛 Gateway 跨模块重复的 QQ 官方配置、C2C 消息与响应 fixture。
- 收敛 DeepSeek / BigModel 重复的 Chat Completions mock server。
- 为 Core 临时 SQLite fixture 增加生命周期清理，并把测试连接池从生产默认 8 缩到 2。
- 让 Respond / CoreService 测试工作目录跟随最后一个数据库持有者自动回收。
- 为全量测试中曾偶发失败的两条 Todo 工具测试补充完整结构化输出诊断。

Closes #189

## 盘点与边界

### 已提取

| 区域 | 提取前 | 提取后 |
| --- | --- | --- |
| Gateway | 6 个测试模块各自维护完整 `AppConfig`；C2C 消息和响应样本重复 2 份 | 统一到 `gateway/test_support.rs`，各测试只覆盖与被测行为有关的字段 |
| LLM | DeepSeek、BigModel 各自维护同构 Axum mock server | 统一到 `provider/test_support.rs`，provider 测试保留协议断言 |
| Core | 临时数据库与 prompt/knowledge 工作目录各自生成且不回收；每库默认 8 连接 | `open_temp` / `open_temp_directory` 统一托管清理，测试池固定 2 连接 |

### 刻意保留在本地

- OneBot 专用配置、Gateway 发送器 fake、聚合器 harness：协议与被测行为不同，抽出会隐藏关键输入。
- Provider 专属 SSE payload 与断言：仅共享传输 fake，不合并协议语义。
- 显式验证 reopen / migration / 错误路径的临时文件：这些测试需要主动关闭后再次按路径打开，不套用“最后持有者释放即删除”的 helper。

## 根因与影响

全量并行测试会同时创建大量 SQLite fixture。旧 fixture 每个按生产值打开 8 个连接，同时 Respond / CoreService 的完整工作目录不会回收，长期累计后会放大文件、连接和调度压力，Todo / Memory 这类依赖短期会话快照的测试更容易在高负载下暴露偶发失败。

现在测试 fixture 使用独立 UUID 路径、较小连接池，并在最后一个数据库 clone / pooled connection 释放后关闭连接并删除数据库、WAL/SHM 或整个工作目录。正常运行时的 `SqliteDatabase::open` 行为不变，不涉及生产 schema 或 migration。

本地清理同时移除了历史测试数据库、Respond/CoreService 工作目录及 Ops 测试 UUID 临时文件；未删除真实运行数据库或未知临时目录。

## 规模

- 16 个文件
- 新增 343 行，删除 468 行，净减少 125 行
- 新增 2 条临时数据库生命周期回归测试
- Todo 并行专项 273 条通过

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features -- --quiet`
  - Common 63
  - Core 1046
  - Gateway 504
  - LLM 249
- `cargo test -p qq-maid-core todo --all-features -- --test-threads=32`（273 通过）
- `cargo test -p qq-maid-core temporary_database_ --all-features`（2 通过）
- `cargo build --workspace --release --all-features`
- `git diff --check`
