### PR TITLE
docs: v0.20.0 发版 CHANGELOG、README、qbot 控制台引导与 Wiki 同步

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,55 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect script changes
+    runs-on: ubuntu-latest
+    outputs:
+      shell: ${{ steps.filter.outputs.shell }}
+      windows: ${{ steps.filter.outputs.windows }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect affected script checks
+        id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          changed_files="$(mktemp)"
+          trap 'rm -f "${changed_files}"' EXIT
+
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            printf '%s\n' '.github/workflows/ci.yml' > "${changed_files}"
+          elif [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            git diff --name-only "origin/${BASE_REF}...HEAD" > "${changed_files}"
+          elif [[ -n "${BEFORE_SHA}" && "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]]; then
+            git diff --name-only "${BEFORE_SHA}...HEAD" > "${changed_files}"
+          else
+            git ls-files > "${changed_files}"
+          fi
+
+          shell=false
+          windows=false
+          if grep -Eq '(^|/)scripts/.*\.sh$|^\.github/workflows/ci\.yml$' "${changed_files}"; then
+            shell=true
+          fi
+          if grep -Eq '(^|/)scripts/.*\.(ps1|cmd)$|^scripts/(botctl|test-windows-botctl)\.sh$|^scripts/tests/windows-smoke\.cs$|^\.github/workflows/ci\.yml$' "${changed_files}"; then
+            windows=true
+          fi
+          echo "shell=${shell}" >> "${GITHUB_OUTPUT}"
+          echo "windows=${windows}" >> "${GITHUB_OUTPUT}"
+
   shell:
     name: Shell checks
+    needs: changes
+    if: needs.changes.outputs.shell == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -33,12 +80,16 @@ jobs:
           bash scripts/test-qbot-install.sh
           bash scripts/test-qbot-config.sh
           bash scripts/test-package-release.sh
+          bash scripts/test-prepare-project-docs-kb.sh
+          bash scripts/test-botctl-guidance.sh
 
       - name: Check shell syntax
         run: bash -n scripts/*.sh
 
   windows-botctl:
     name: Windows botctl smoke test
+    needs: changes
+    if: needs.changes.outputs.windows == 'true'
     runs-on: windows-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,13 @@
 
 * **配置优先级收敛为受管优先**：对配置中心已登记字段，管理员在 WebUI 保存后，`runtime.toml` 普通值与 SQLite 加密 secret 优先于旧 `.env` / 进程环境同名值；未登记的 Bootstrap 与高风险部署项（监听地址、数据库路径、`ops.toml` 等）仍只由文件 / 环境管理。
 * **控制台从只读面板扩展为可写配置入口**：保留运行状态与 Markdown 预览；配置详情与写接口必须经过独立部署管理员会话。生产反向代理需设置 `WEB_CONSOLE_TRUSTED_PROXY_IPS`，HTTPS 生产应显式开启 `WEB_CONSOLE_SECURE_COOKIES`。
+* **天气配置改为可选**：`QWEATHER_API_KEY` 留空时只关闭天气命令与 Agent 天气 Tool，不再阻止其他能力启动。
 
 ### Compatibility
 
 * 根包 `qq-maid-bot` 版本号提升到 `0.20.0`，内部 crate 版本不统一提升。包含 `config_secret` 与 `admin_auth` SQLite migration；程序启动时会升级已有数据库，升级前应备份 `APP_DB_FILE`。
 * 已有 `.env` / `agent.toml` 部署可继续使用；首次通过控制台保存后，对应已登记字段以受管值为准，升级前应分开备份 SQLite 与 `config/secrets/master.key`。
+* `qbot update` 会先备份 `config/.env`，再移除已迁入 `agent.toml`、会导致新版本拒绝启动的废弃 Agent / Todo / 成员映射变量；其他配置（包括允许为空以关闭天气能力的 `QWEATHER_API_KEY`）保持不变。systemd、Docker 或宿主环境直接注入的同名变量仍需人工移除。
 * `WEB_CONSOLE_ENABLED` 新实例默认开启但仍只绑定回环地址；不要把 8787 裸露到公网。Windows 下 `bootstrap.token` / `master.key` 当前依赖安装目录 ACL，尚未主动收紧（见 [#522](https://github.com/kuliantnt/qq-maid-bot/issues/522)）。
 * 相关跟踪（尚未入主线实现）：[#515](https://github.com/kuliantnt/qq-maid-bot/issues/515) QQ 官方内置 ASR 语音转文字；[#518](https://github.com/kuliantnt/qq-maid-bot/issues/518) 可配置聊天命令前缀。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 本文档基于 [keep a changelog](https://keepachangelog.com/zh-CN/1.0.0/) 格式，记录每个已发布版本的变更。
 
+## [v0.20.0] - 2026-07-18
+
+### Release Focus
+
+* **安全配置中心与部署管理控制台版本**：本版本在 v0.19.x 基础上建立安全配置中心（`runtime.toml` + SQLite 加密敏感值 + 独立主密钥），实现部署管理员初始化与可写 Web 控制台，让新实例可在 `/console/` 完成 Provider、平台入口与主要功能开关配置，不再必须编辑 `config/.env`。本版本也是 [Epic #194](https://github.com/kuliantnt/qq-maid-bot/issues/194) Docker 容器化部署与 Web 配置中心的 Phase 2 + 3 交付；Phase 1 Docker Compose / 镜像发布（#511）和 Phase 4 备份升级验收（#513）仍在进行。
+
+### Added
+
+* **安全配置中心**（PR #514 / Phase 2 #510）：新增受管 `config/runtime.toml`、SQLite 认证加密敏感值、独立 `secrets/master.key` 与字段注册表；普通运行配置与 Agent 策略分层，`agent.toml` 仍是模型路线 / Scene / Tool Calling 的唯一事实来源。对已登记字段，`.env` / 进程环境仅作首次启动兜底；WebUI 保存后受管值优先，快照以 `overridden=true` 标记已覆盖的同名外部兜底。
+* **部署管理员初始化与配置控制台**（PR #520 / Phase 3 #512）：未配置 Provider 或平台入口时以 `setup_required` 启动，保留 `/healthz` 与受保护 `/console/`。首位管理员通过 `config/secrets/bootstrap.token`（约 22 字符、约 30 分钟、单次有效）建立；支持忘记密码重置令牌、HttpOnly SameSite cookie、轮换 CSRF、同源 Origin 与脱敏审计。配置页可分步保存 Provider、QQ / OneBot / 微信入口、主要功能开关、模型路线与 Tool Calling；本地启动预检与显式触发的 Provider 连接测试分开，自定义地址会拒绝私网 / 环回目标以避免 SSRF。
+
+### Changed
+
+* **配置优先级收敛为受管优先**：对配置中心已登记字段，管理员在 WebUI 保存后，`runtime.toml` 普通值与 SQLite 加密 secret 优先于旧 `.env` / 进程环境同名值；未登记的 Bootstrap 与高风险部署项（监听地址、数据库路径、`ops.toml` 等）仍只由文件 / 环境管理。
+* **控制台从只读面板扩展为可写配置入口**：保留运行状态与 Markdown 预览；配置详情与写接口必须经过独立部署管理员会话。生产反向代理需设置 `WEB_CONSOLE_TRUSTED_PROXY_IPS`，HTTPS 生产应显式开启 `WEB_CONSOLE_SECURE_COOKIES`。
+
+### Compatibility
+
+* 根包 `qq-maid-bot` 版本号提升到 `0.20.0`，内部 crate 版本不统一提升。包含 `config_secret` 与 `admin_auth` SQLite migration；程序启动时会升级已有数据库，升级前应备份 `APP_DB_FILE`。
+* 已有 `.env` / `agent.toml` 部署可继续使用；首次通过控制台保存后，对应已登记字段以受管值为准，升级前应分开备份 SQLite 与 `config/secrets/master.key`。
+* `WEB_CONSOLE_ENABLED` 新实例默认开启但仍只绑定回环地址；不要把 8787 裸露到公网。Windows 下 `bootstrap.token` / `master.key` 当前依赖安装目录 ACL，尚未主动收紧（见 [#522](https://github.com/kuliantnt/qq-maid-bot/issues/522)）。
+* 相关跟踪（尚未入主线实现）：[#515](https://github.com/kuliantnt/qq-maid-bot/issues/515) QQ 官方内置 ASR 语音转文字；[#518](https://github.com/kuliantnt/qq-maid-bot/issues/518) 可配置聊天命令前缀。
+
 ## [v0.19.0] - 2026-07-17
 
 ### Release Focus

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1484,7 +1484,7 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "qq-maid-bot"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "qq-maid-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-bot"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ## 近期更新（v0.20.0）
 - **主线：安全配置中心与部署管理控制台**（[Epic #194](https://github.com/kuliantnt/qq-maid-bot/issues/194) Phase 2+3）：新实例可在 `/console/` 用网页完成 Provider、QQ/OneBot/微信入口与主要功能开关配置，不必再编辑 `.env`。
-- **配置中心已落地**（PR #514）：普通运行配置走 `runtime.toml`，API Key / Token 加密写入 SQLite，主密钥独立于 `secrets/master.key`；`agent.toml` 仍是模型路线与 Tool Calling 的唯一事实来源。
+- **配置中心已落地**（PR #514）：普通运行配置走 `runtime.toml`，API Key / Token 加密写入 SQLite，主密钥独立存放于 `secrets/master.key`；`agent.toml` 仍是模型路线与 Tool Calling 的唯一事实来源。
 - **`/console/` 首次向导**（PR #520）：用 `bootstrap.token` 建立首位部署管理员，分步保存配置，支持忘记密码重置、启动预检与受控 Provider 连接测试。
 - **优先级更清楚**：已登记字段在 WebUI 保存后以受管值为准；`.env` 仍可做首次启动兜底与 Bootstrap 路径。生产反代请配 `WEB_CONSOLE_TRUSTED_PROXY_IPS`，HTTPS 开 `WEB_CONSOLE_SECURE_COOKIES`。
 

--- a/README.md
+++ b/README.md
@@ -19,18 +19,22 @@
 
 稳定版本与升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)。
 
-使用、安装和配置优先看 [项目 Wiki](https://github.com/kuliantnt/qq-maid-bot/wiki)：从第一次对话、一键安装，到 NapCat、`/ops` 运维和 Codex 长任务，都按场景拆开了。仓库内 `docs/` 与各 crate README 更偏开发边界和实现细节。
+使用、安装和配置优先看 [项目 Wiki](https://github.com/kuliantnt/qq-maid-bot/wiki)：从第一次对话、一键安装、配置中心与 `/console/` 首次向导，到 NapCat、`/ops` 运维和 Codex 长任务，都按场景拆开了。仓库内 `docs/` 与各 crate README 更偏开发边界和实现细节。
 
-## 近期更新（v0.19.0）
-- **聊过的事可选自动记住**：开启 Session Dream 后，机器人会在后台从私聊 / 群聊里提取稳定长期事实；只写你的个人记忆或当前群画像，不会覆盖你明确要求「记住」的内容，默认关闭。
-- **记忆找得更准、重复更少**：问到相关事时会优先拿出有用记忆；可选的确定性整理会在后台归档完全重复的条目，不会改你已确认的内容。
-- **对比几个东西会分开查**：“A 和 B 哪个更适合”这类问题会独立调查各个对象再汇总；单个超时也不会让整轮白忙。
-- **待办能按时间和关键词筛**：可以直接查今天、明天、本周、逾期、没截止时间，也可以加关键词组合筛选；默认一次展示更多条目。
-- **管理员可配白名单运维命令**：`/ops` 默认关闭；配好管理员、允许群和固定程序后，可以在聊天里触发受控脚本，结果会异步推回来。
-- **搜索更耐慢链路，超时会明说**：联网查询对国内慢链路更宽容；QQ 流式超时不会再卡在“正在想一下”，而是给出明确失败提示。
-- **RSS 地址更好点了**：QQ Markdown 里不再把长 URL 挤成一堆换行空格，改为可点的短链接；纯文本通道仍保留完整地址。
+## 近期更新（v0.20.0）
+- **主线：安全配置中心与部署管理控制台**（[Epic #194](https://github.com/kuliantnt/qq-maid-bot/issues/194) Phase 2+3）：新实例可在 `/console/` 用网页完成 Provider、QQ/OneBot/微信入口与主要功能开关配置，不必再编辑 `.env`。
+- **配置中心已落地**（PR #514）：普通运行配置走 `runtime.toml`，API Key / Token 加密写入 SQLite，主密钥独立于 `secrets/master.key`；`agent.toml` 仍是模型路线与 Tool Calling 的唯一事实来源。
+- **`/console/` 首次向导**（PR #520）：用 `bootstrap.token` 建立首位部署管理员，分步保存配置，支持忘记密码重置、启动预检与受控 Provider 连接测试。
+- **优先级更清楚**：已登记字段在 WebUI 保存后以受管值为准；`.env` 仍可做首次启动兜底与 Bootstrap 路径。生产反代请配 `WEB_CONSOLE_TRUSTED_PROXY_IPS`，HTTPS 开 `WEB_CONSOLE_SECURE_COOKIES`。
 
-更早版本的完整变更与升级说明见 [CHANGELOG.md](./CHANGELOG.md)。
+### 配置方式变化
+
+0.19 及之前需要在 `config/.env` 中手写凭证和开关；0.20 起推荐新部署走 `/console/` 引导。旧 `.env` 部署继续可用。
+
+### 上一版（v0.19.0）
+- Session Dream 与确定性记忆整理（默认关）、多实体联网搜索、待办组合筛选、`/ops` 白名单运维、搜索超时与 RSS 短链接展示。
+
+完整变更与升级说明见 [CHANGELOG.md](./CHANGELOG.md)。
 
 ## 能做什么
 
@@ -115,7 +119,9 @@ runtime/botctl.sh status
 
 ## 配置方式
 
-配置分为两层：
+v0.20.0 起推荐新部署通过 `/console/` 网页完成配置。启动机器人后浏览器打开 `http://127.0.0.1:8787/console/`，从启动日志中找到 `bootstrap.token` 建立首位管理员，按向导分步保存。旧 `.env` 部署可继续使用。
+
+配置分为多层：
 
 | 文件 | 用途 |
 | --- | --- |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -140,6 +140,8 @@ make clean
 - `scripts/validate-runtime.sh glm`：只验证 GLM / OpenAI 兼容 key 和模型调用。
 - `scripts/validate-runtime.sh console`：只验证 Web 控制台 `/console/`。
 - `scripts/validate-runtime.sh restart-source`：用 `target/debug/qq-maid-bot` 临时验证当前源码统一程序。
+- `bash scripts/prepare_project_docs_kb.sh`：拉取 GitHub Wiki 与仓库 CHANGELOG，生成 `runtime/config/knowledge/project_docs/` 公开文档知识库。
+- `bash scripts/prepare_project_docs_kb.sh --sync`：生成后直接调用 `sync_knowledge.sh`；可再加 `--dry-run` 只预览。
 - `bash scripts/sync_knowledge.sh`：以镜像语义把本地知识库 Markdown 同步到 `scripts/deploy.conf` 配置的远端服务器。本地删除或重命名的 `.md` 会从对应远端子目录中删除，删除范围仅限该子目录内部；非 `.md` 文件不会被传输或删除。
 - `bash scripts/sync_knowledge.sh --dry-run`：仅预览同步差异（包含将被删除的远端 `.md`），不实际传输或删除。远端知识库根目录由 `deploy.conf` 的 `REMOTE_KNOWLEDGE_DIR` 控制；未设置时优先使用 `${REMOTE_APP_DIR}/config/knowledge`，未配置独立应用根目录时兼容 `${REMOTE_PROJECT_DIR}/runtime/config/knowledge`。
 - `make clean`：清理根目录 Cargo Workspace 的构建产物。

--- a/scripts/botctl.ps1
+++ b/scripts/botctl.ps1
@@ -59,6 +59,14 @@ $stopTimeoutSeconds = 0
 if (-not [int]::TryParse($stopTimeoutText, [ref]$stopTimeoutSeconds) -or $stopTimeoutSeconds -lt 0) {
     throw "BOT_STOP_TIMEOUT_SECONDS must be a non-negative integer"
 }
+$script:ObsoleteEnvKeys = @(
+    "LLM_PROVIDER", "OPENAI_MODEL", "LLM_MODEL", "PRIVATE_LLM_MODEL", "GROUP_LLM_MODEL",
+    "OPENAI_SEARCH_MODEL", "PRIVATE_OPENAI_SEARCH_MODEL", "GROUP_OPENAI_SEARCH_MODEL",
+    "TITLE_MODEL", "MEMORY_MODEL", "COMPACT_MODEL", "TRANSLATION_MODEL",
+    "DEEPSEEK_MODEL", "BIGMODEL_MODEL", "GEMINI_MODEL", "LLM_MAX_OUTPUT_TOKENS",
+    "TOOL_CALLING_ENABLED", "TOOL_CALLING_GROUP_ENABLED", "TOOL_CALLING_MAX_ROUNDS",
+    "TODO_MODEL", "MEMBER_ID_MAPPING_FILE"
+)
 
 function Show-Usage {
     @"
@@ -131,6 +139,46 @@ function Import-DotEnv {
         }
         [Environment]::SetEnvironmentVariable($name, $value, "Process")
     }
+}
+
+function Remove-ObsoleteEnvConfig {
+    $envFile = Get-EnvFile
+    if ($null -eq $envFile -or -not (Test-Path -LiteralPath $envFile -PathType Leaf)) {
+        return
+    }
+    $item = Get-Item -LiteralPath $envFile -Force
+    if ($item.LinkType) {
+        [Console]::Error.WriteLine("warning: skip obsolete env migration for symbolic link: $envFile")
+        return
+    }
+
+    $lines = @(Get-Content -LiteralPath $envFile)
+    $removed = New-Object Collections.Generic.List[string]
+    $filtered = New-Object Collections.Generic.List[string]
+    foreach ($line in $lines) {
+        if ($line -match '^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=' -and
+            $script:ObsoleteEnvKeys -contains $Matches[1]) {
+            if (-not $removed.Contains($Matches[1])) {
+                $removed.Add($Matches[1])
+            }
+            continue
+        }
+        $filtered.Add($line)
+    }
+    if ($removed.Count -eq 0) {
+        return
+    }
+
+    $stamp = Get-Date -Format "yyyyMMdd_HHmmss"
+    $backup = "${envFile}.bak.v0.20.${stamp}.$PID"
+    Copy-Item -LiteralPath $envFile -Destination $backup
+    $encoding = New-Object Text.UTF8Encoding($false)
+    $tempFile = "${envFile}.tmp.$PID"
+    [IO.File]::WriteAllLines($tempFile, $filtered.ToArray(), $encoding)
+    Move-Item -LiteralPath $tempFile -Destination $envFile -Force
+    Write-Output "removed obsolete config keys: $($removed -join ', ')"
+    Write-Output "pre-upgrade env backup: $backup"
+    Write-Output "Remove the same keys manually if systemd, Docker, or the host environment still injects them."
 }
 
 function Read-BotPid {
@@ -273,6 +321,7 @@ function Start-Bot {
     Ensure-ParentDirectory -Path $pidFile
     Ensure-ParentDirectory -Path $logFile
     Ensure-ParentDirectory -Path $stdoutLogFile
+    Remove-ObsoleteEnvConfig
     Import-DotEnv
     if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable("RUST_LOG"))) {
         [Environment]::SetEnvironmentVariable(
@@ -315,6 +364,7 @@ function Run-Bot {
     if (-not (Test-Path -LiteralPath $binary -PathType Leaf)) {
         throw "executable not found: $binary"
     }
+    Remove-ObsoleteEnvConfig
     Import-DotEnv
     if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable("RUST_LOG"))) {
         [Environment]::SetEnvironmentVariable(

--- a/scripts/botctl.ps1
+++ b/scripts/botctl.ps1
@@ -178,6 +178,72 @@ function Get-ServerUrl {
     return "http://${hostName}:${port}"
 }
 
+function Test-WebConsoleEnabled {
+    $enabled = Get-EnvironmentOverride -Name "WEB_CONSOLE_ENABLED" -DefaultValue "true"
+    return -not $enabled.Equals("false", [StringComparison]::OrdinalIgnoreCase)
+}
+
+function Get-ConsoleAccessHint {
+    $url = (Get-ServerUrl).TrimEnd('/')
+    $parsed = $null
+    if ([Uri]::TryCreate($url, [UriKind]::Absolute, [ref]$parsed) -and
+        $parsed.Host -in @("0.0.0.0", "::")) {
+        return "控制台监听于通配地址，请使用实际服务器地址或反向代理地址访问 /console/"
+    }
+    return "浏览器打开 ${url}/console/"
+}
+
+function Get-BootstrapTokenPurpose {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf) -or
+        (Get-Item -LiteralPath $Path -Force).LinkType) {
+        return $null
+    }
+    try {
+        $lines = @(Get-Content -LiteralPath $Path -TotalCount 2 -ErrorAction Stop)
+    } catch {
+        return $null
+    }
+    if ($lines.Count -ne 1) {
+        return $null
+    }
+    $line = $lines[0]
+    if ($line -match '^(qq-maid-bootstrap-v1|qq-maid-password-reset-v1):[0-9]+:[^:]+$') {
+        return $Matches[1]
+    }
+    return $null
+}
+
+function Show-BootstrapGuidance {
+    param([Parameter(Mandatory = $true)][string]$TokenFile)
+    if (-not (Test-WebConsoleEnabled)) {
+        return
+    }
+    $purpose = Get-BootstrapTokenPurpose -Path $TokenFile
+    if ([string]::IsNullOrWhiteSpace($purpose)) {
+        return
+    }
+    $accessHint = Get-ConsoleAccessHint
+
+    Write-Output ""
+    if ($purpose -eq "qq-maid-bootstrap-v1") {
+        Write-Output "--- 首次配置 ---"
+        Write-Output "v0.20 起可以通过网页完成配置，不再必须编辑 config\.env："
+        Write-Output "  1. 读取服务器本地 config\secrets\bootstrap.token 中的一次性令牌"
+        Write-Output "  2. $accessHint"
+        Write-Output "  3. 用令牌建立部署管理员，按向导保存 Provider、平台入口和功能开关"
+    } else {
+        Write-Output "--- 密码重置待完成 ---"
+        Write-Output "部署管理员密码重置令牌已经生成："
+        Write-Output "  1. 读取服务器本地 config\secrets\bootstrap.token 中的一次性令牌"
+        Write-Output "  2. $accessHint"
+        Write-Output "  3. 在登录页完成密码重置；完成后旧管理员会话将失效"
+    }
+    Write-Output ""
+    Write-Output "请勿输出、转发或长期保留令牌。"
+    Write-Output "更多：https://github.com/kuliantnt/qq-maid-bot/wiki/配置中心"
+}
+
 function Ensure-ParentDirectory {
     param([Parameter(Mandatory = $true)][string]$Path)
     $parent = Split-Path -Parent $Path
@@ -240,19 +306,9 @@ function Start-Bot {
     }
     Write-Output "qq-maid-bot started, pid=$($process.Id), log=$logFile"
 
-    # v0.20+: 新安装或尚无部署管理员时，引导用户用网页完成配置。
+    # 只解析 token purpose，不把令牌原文带入命令输出。
     $bootstrapTokenFile = Join-Path $runtimeDir "config\secrets\bootstrap.token"
-    if (Test-Path -LiteralPath $bootstrapTokenFile -PathType Leaf) {
-        Write-Output ""
-        Write-Output "--- 首次配置 ---"
-        Write-Output "v0.20 起可以通过网页完成配置，不再必须编辑 config\.env："
-        Write-Output "  1. 从启动日志中找到部署管理员 Bootstrap 令牌（仅在首次启动时输出一次）"
-        Write-Output "  2. 浏览器打开 http://127.0.0.1:8787/console/"
-        Write-Output "  3. 用令牌建立管理员，按向导保存 Provider、平台入口和功能开关"
-        Write-Output ""
-        Write-Output "如果你仍然习惯手写配置，可以直接编辑 config\.env。"
-        Write-Output "更多：https://github.com/kuliantnt/qq-maid-bot/wiki/配置中心"
-    }
+    Show-BootstrapGuidance -TokenFile $bootstrapTokenFile
 }
 
 function Run-Bot {

--- a/scripts/botctl.ps1
+++ b/scripts/botctl.ps1
@@ -239,6 +239,20 @@ function Start-Bot {
         throw "qq-maid-bot failed to start; see $logFile"
     }
     Write-Output "qq-maid-bot started, pid=$($process.Id), log=$logFile"
+
+    # v0.20+: 新安装或尚无部署管理员时，引导用户用网页完成配置。
+    $bootstrapTokenFile = Join-Path $runtimeDir "config\secrets\bootstrap.token"
+    if (Test-Path -LiteralPath $bootstrapTokenFile -PathType Leaf) {
+        Write-Output ""
+        Write-Output "--- 首次配置 ---"
+        Write-Output "v0.20 起可以通过网页完成配置，不再必须编辑 config\.env："
+        Write-Output "  1. 从启动日志中找到部署管理员 Bootstrap 令牌（仅在首次启动时输出一次）"
+        Write-Output "  2. 浏览器打开 http://127.0.0.1:8787/console/"
+        Write-Output "  3. 用令牌建立管理员，按向导保存 Provider、平台入口和功能开关"
+        Write-Output ""
+        Write-Output "如果你仍然习惯手写配置，可以直接编辑 config\.env。"
+        Write-Output "更多：https://github.com/kuliantnt/qq-maid-bot/wiki/配置中心"
+    }
 }
 
 function Run-Bot {

--- a/scripts/botctl.ps1
+++ b/scripts/botctl.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding()]
+﻿[CmdletBinding()]
 param(
     [Parameter(Position = 0)]
     [ValidateSet("start", "run", "stop", "restart", "status", "health", "console", "logs", "help")]

--- a/scripts/botctl.sh
+++ b/scripts/botctl.sh
@@ -136,6 +136,20 @@ start() {
     fi
 
     echo "qq-maid-bot started, pid=$(read_pid), log=${LOG_FILE}"
+
+    # v0.20+: 新安装或尚无部署管理员时，引导用户用网页完成配置。
+    local bootstrap_token_file="$(cd "${RUNTIME_DIR}" && pwd)/config/secrets/bootstrap.token"
+    if [[ -f "${bootstrap_token_file}" ]]; then
+        echo ""
+        echo "--- 首次配置 ---"
+        echo "v0.20 起可以通过网页完成配置，不再必须编辑 config/.env："
+        echo "  1. 从启动日志中找到部署管理员 Bootstrap 令牌（仅在首次启动时输出一次）"
+        echo "  2. 浏览器打开 http://127.0.0.1:8787/console/"
+        echo "  3. 用令牌建立管理员，按向导保存 Provider、平台入口和功能开关"
+        echo ""
+        echo "如果你仍然习惯手写配置，可以直接编辑 config/.env。"
+        echo "更多：https://github.com/kuliantnt/qq-maid-bot/wiki/配置中心"
+    fi
 }
 
 run_foreground() {

--- a/scripts/botctl.sh
+++ b/scripts/botctl.sh
@@ -203,7 +203,8 @@ bootstrap_token_purpose() {
 show_bootstrap_guidance() {
     local token_file="$1" purpose access_hint
     web_console_enabled || return 0
-    purpose="$(bootstrap_token_purpose "${token_file}")"
+    # 没有 bootstrap token 是正常的稳定运行状态，不能让解析失败影响 start 的退出码。
+    purpose="$(bootstrap_token_purpose "${token_file}")" || return 0
     [[ -n "${purpose}" ]] || return 0
     access_hint="$(console_access_hint)"
 

--- a/scripts/botctl.sh
+++ b/scripts/botctl.sh
@@ -107,6 +107,67 @@ server_url() {
     echo "${LLM_SERVER_URL:-http://${host}:${port}}"
 }
 
+web_console_enabled() {
+    local enabled
+    enabled="$(printf '%s' "${WEB_CONSOLE_ENABLED:-true}" | tr '[:upper:]' '[:lower:]')"
+    [[ "${enabled}" != "false" ]]
+}
+
+console_access_hint() {
+    local url authority
+    url="$(server_url)"
+    authority="${url#*://}"
+    authority="${authority%%/*}"
+    case "${authority}" in
+        0.0.0.0|0.0.0.0:*|'[::]'|'[::]':*|::* )
+            echo "控制台监听于通配地址，请使用实际服务器地址或反向代理地址访问 /console/"
+            ;;
+        *)
+            echo "浏览器打开 ${url%/}/console/"
+            ;;
+    esac
+}
+
+bootstrap_token_purpose() {
+    local token_file="$1"
+    [[ -f "${token_file}" && ! -L "${token_file}" ]] || return 1
+    LC_ALL=C awk -F: '
+        NR == 1 && NF == 3 && $2 ~ /^[0-9]+$/ && length($3) > 0 &&
+        ($1 == "qq-maid-bootstrap-v1" || $1 == "qq-maid-password-reset-v1") {
+            purpose = $1
+            valid = 1
+        }
+        NR > 1 { valid = 0 }
+        END { if (valid && NR == 1) print purpose }
+    ' "${token_file}" 2>/dev/null
+}
+
+show_bootstrap_guidance() {
+    local token_file="$1" purpose access_hint
+    web_console_enabled || return 0
+    purpose="$(bootstrap_token_purpose "${token_file}")"
+    [[ -n "${purpose}" ]] || return 0
+    access_hint="$(console_access_hint)"
+
+    echo ""
+    if [[ "${purpose}" == "qq-maid-bootstrap-v1" ]]; then
+        echo "--- 首次配置 ---"
+        echo "v0.20 起可以通过网页完成配置，不再必须编辑 config/.env："
+        echo "  1. 读取服务器本地 config/secrets/bootstrap.token 中的一次性令牌"
+        echo "  2. ${access_hint}"
+        echo "  3. 用令牌建立部署管理员，按向导保存 Provider、平台入口和功能开关"
+    else
+        echo "--- 密码重置待完成 ---"
+        echo "部署管理员密码重置令牌已经生成："
+        echo "  1. 读取服务器本地 config/secrets/bootstrap.token 中的一次性令牌"
+        echo "  2. ${access_hint}"
+        echo "  3. 在登录页完成密码重置；完成后旧管理员会话将失效"
+    fi
+    echo ""
+    echo "请勿输出、转发或长期保留令牌。"
+    echo "更多：https://github.com/kuliantnt/qq-maid-bot/wiki/配置中心"
+}
+
 start() {
     if is_running; then
         echo "qq-maid-bot is already running, pid=$(read_pid)"
@@ -137,19 +198,9 @@ start() {
 
     echo "qq-maid-bot started, pid=$(read_pid), log=${LOG_FILE}"
 
-    # v0.20+: 新安装或尚无部署管理员时，引导用户用网页完成配置。
-    local bootstrap_token_file="$(cd "${RUNTIME_DIR}" && pwd)/config/secrets/bootstrap.token"
-    if [[ -f "${bootstrap_token_file}" ]]; then
-        echo ""
-        echo "--- 首次配置 ---"
-        echo "v0.20 起可以通过网页完成配置，不再必须编辑 config/.env："
-        echo "  1. 从启动日志中找到部署管理员 Bootstrap 令牌（仅在首次启动时输出一次）"
-        echo "  2. 浏览器打开 http://127.0.0.1:8787/console/"
-        echo "  3. 用令牌建立管理员，按向导保存 Provider、平台入口和功能开关"
-        echo ""
-        echo "如果你仍然习惯手写配置，可以直接编辑 config/.env。"
-        echo "更多：https://github.com/kuliantnt/qq-maid-bot/wiki/配置中心"
-    fi
+    # 只解析 token purpose，不把令牌原文带入命令输出。
+    local bootstrap_token_file="${RUNTIME_DIR}/config/secrets/bootstrap.token"
+    show_bootstrap_guidance "${bootstrap_token_file}"
 }
 
 run_foreground() {

--- a/scripts/botctl.sh
+++ b/scripts/botctl.sh
@@ -20,6 +20,14 @@ BINARY="${BOT_BINARY:-${DEFAULT_BINARY}}"
 PID_FILE="${BOT_PID_FILE:-${RUNTIME_DIR}/run/qq-maid-bot.pid}"
 LOG_FILE="${BOT_LOG_FILE:-${RUNTIME_DIR}/logs/qq-maid-bot.log}"
 STOP_TIMEOUT_SECONDS="${BOT_STOP_TIMEOUT_SECONDS:-10}"
+OBSOLETE_ENV_KEYS=(
+    LLM_PROVIDER OPENAI_MODEL LLM_MODEL PRIVATE_LLM_MODEL GROUP_LLM_MODEL
+    OPENAI_SEARCH_MODEL PRIVATE_OPENAI_SEARCH_MODEL GROUP_OPENAI_SEARCH_MODEL
+    TITLE_MODEL MEMORY_MODEL COMPACT_MODEL TRANSLATION_MODEL
+    DEEPSEEK_MODEL BIGMODEL_MODEL GEMINI_MODEL LLM_MAX_OUTPUT_TOKENS
+    TOOL_CALLING_ENABLED TOOL_CALLING_GROUP_ENABLED TOOL_CALLING_MAX_ROUNDS
+    TODO_MODEL MEMBER_ID_MAPPING_FILE
+)
 
 usage() {
     cat <<'EOF'
@@ -84,6 +92,56 @@ load_env() {
     . "${env_file}"
     set -u
     set +a
+}
+
+migrate_obsolete_env_config() {
+    local env_file key tmp owner group mode backup joined
+    local found=()
+    env_file="$(resolve_env_file)" || return 0
+    [[ -f "${env_file}" ]] || return 0
+    if [[ -L "${env_file}" ]]; then
+        echo "warning: skip obsolete env migration for symbolic link: ${env_file}" >&2
+        return 0
+    fi
+
+    for key in "${OBSOLETE_ENV_KEYS[@]}"; do
+        if grep -Eq "^[[:space:]]*(export[[:space:]]+)?${key}[[:space:]]*=" "${env_file}"; then
+            found+=("${key}")
+        fi
+    done
+    ((${#found[@]} > 0)) || return 0
+
+    backup="${env_file}.bak.v0.20.$(date +%Y%m%d_%H%M%S).$$"
+    cp -a -- "${env_file}" "${backup}"
+    tmp="${env_file}.tmp.$$"
+    owner="$(stat -c '%u' "${env_file}" 2>/dev/null || echo "")"
+    group="$(stat -c '%g' "${env_file}" 2>/dev/null || echo "")"
+    mode="$(stat -c '%a' "${env_file}" 2>/dev/null || echo "")"
+    joined="$(IFS=:; echo "${OBSOLETE_ENV_KEYS[*]}")"
+    awk -v removed_keys="${joined}" '
+        BEGIN {
+            count = split(removed_keys, values, ":")
+            for (i = 1; i <= count; i++) removed[values[i]] = 1
+        }
+        {
+            candidate = $0
+            sub(/^[[:space:]]*/, "", candidate)
+            sub(/^export[[:space:]]+/, "", candidate)
+            if (match(candidate, /^[A-Za-z_][A-Za-z0-9_]*/)) {
+                key = substr(candidate, RSTART, RLENGTH)
+                rest = substr(candidate, RLENGTH + 1)
+                if (removed[key] && rest ~ /^[[:space:]]*=/) next
+            }
+            print
+        }
+    ' "${env_file}" > "${tmp}"
+    [[ -n "${owner}" && -n "${group}" ]] && chown "${owner}:${group}" "${tmp}" 2>/dev/null || true
+    [[ -n "${mode}" ]] && chmod "${mode}" "${tmp}" 2>/dev/null || true
+    mv -- "${tmp}" "${env_file}"
+
+    echo "removed obsolete config keys: ${found[*]}"
+    echo "pre-upgrade env backup: ${backup}"
+    echo "Remove the same keys manually if systemd, Docker, or the host environment still injects them."
 }
 
 read_pid() {
@@ -180,6 +238,7 @@ start() {
     fi
 
     mkdir -p "$(dirname -- "${PID_FILE}")" "$(dirname -- "${LOG_FILE}")"
+    migrate_obsolete_env_config
     load_env
     export RUST_LOG="${RUST_LOG:-info,qq_maid_gateway_rs=debug,qq_maid_core=info,tower_http=info}"
 
@@ -210,6 +269,7 @@ run_foreground() {
     fi
 
     mkdir -p "$(dirname -- "${PID_FILE}")" "$(dirname -- "${LOG_FILE}")"
+    migrate_obsolete_env_config
     load_env
     export RUST_LOG="${RUST_LOG:-info,qq_maid_gateway_rs=debug,qq_maid_core=info,tower_http=info}"
 

--- a/scripts/deploy.conf.example
+++ b/scripts/deploy.conf.example
@@ -30,6 +30,11 @@ REMOTE_KNOWLEDGE_DIR=""
 # 同步为镜像语义: 本地删除的 .md 会从远端对应子目录中被删除,
 # 删除范围严格限定在该子目录内部; 非 .md 文件不会被传输或删除。
 SYNC_MAP=(
+  # 项目公开 Wiki + CHANGELOG：
+  # 1) bash scripts/prepare_project_docs_kb.sh
+  # 2) bash scripts/sync_knowledge.sh
+  # 也可一步：bash scripts/prepare_project_docs_kb.sh --sync
+  # "/abs/path/to/repo/runtime/config/knowledge/project_docs|project_docs"
   # "/home/you/wiki/entries|wiki"
   # "/home/you/docs/project|docs"
 )

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding()]
+﻿[CmdletBinding()]
 param()
 
 $ErrorActionPreference = "Stop"

--- a/scripts/prepare_project_docs_kb.sh
+++ b/scripts/prepare_project_docs_kb.sh
@@ -25,9 +25,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 DEFAULT_OUT="$REPO_ROOT/runtime/config/knowledge/project_docs"
 WIKI_URL="${WIKI_URL:-https://github.com/kuliantnt/qq-maid-bot.wiki.git}"
-WIKI_CACHE="${WIKI_CACHE:-/tmp/qq-maid-bot.wiki}"
+WIKI_CACHE="${WIKI_CACHE:-${XDG_CACHE_HOME:-${HOME:?HOME 未设置}/.cache}/qq-maid-bot/wiki}"
 QQ_GROUP_URL="${QQ_GROUP_URL:-https://qm.qq.com/q/iAZxBO66EE}"
 QQ_GROUP_NAME="${QQ_GROUP_NAME:-雪主任的工坊}"
+MARKER_NAME=".qq-maid-project-docs-kb"
+MARKER_CONTENT="qq-maid-project-docs-kb-v1"
 
 OUT_DIR="$DEFAULT_OUT"
 DO_SYNC=0
@@ -47,7 +49,7 @@ usage() {
 
 环境变量:
   WIKI_URL        Wiki git 地址
-  WIKI_CACHE      本地 wiki 缓存目录（默认 /tmp/qq-maid-bot.wiki）
+  WIKI_CACHE      本地 wiki 缓存目录（默认用户私有缓存目录）
   QQ_GROUP_URL    交流群链接（写入首页/摘要）
   QQ_GROUP_NAME   交流群名称
 EOF
@@ -85,18 +87,114 @@ if [[ "$DRY_RUN" -eq 1 && "$DO_SYNC" -eq 0 ]]; then
   exit 1
 fi
 
+canonical_path() {
+  python3 - "$1" <<'PY'
+import os
+import sys
+
+print(os.path.realpath(os.path.abspath(sys.argv[1])))
+PY
+}
+
+absolute_path() {
+  python3 - "$1" <<'PY'
+import os
+import sys
+
+print(os.path.abspath(sys.argv[1]))
+PY
+}
+
+path_owner_id() {
+  if stat -c '%u' "$1" >/dev/null 2>&1; then
+    stat -c '%u' "$1"
+  else
+    stat -f '%u' "$1"
+  fi
+}
+
+OUT_INPUT="$(absolute_path "$OUT_DIR")"
+if [[ -L "$OUT_INPUT" ]]; then
+  echo "[错误] 输出目录不能是符号链接: $OUT_INPUT" >&2
+  exit 1
+fi
+OUT_DIR="$(canonical_path "$OUT_INPUT")"
+REPO_ROOT_CANON="$(canonical_path "$REPO_ROOT")"
+SCRIPT_DIR_CANON="$(canonical_path "$SCRIPT_DIR")"
+HOME_CANON=""
+if [[ -n "${HOME:-}" ]]; then
+  HOME_CANON="$(canonical_path "$HOME")"
+fi
+
+# 输出目录会被整目录替换，因此先规范化并拒绝任何可能扩大删除范围的目标。
+case "$OUT_DIR" in
+  /|"$REPO_ROOT_CANON"|"$SCRIPT_DIR_CANON"|"$HOME_CANON")
+    echo "[错误] 拒绝危险输出目录: $OUT_DIR" >&2
+    exit 1
+    ;;
+esac
+if [[ -e "$OUT_DIR" && ! -d "$OUT_DIR" ]]; then
+  echo "[错误] 输出路径已存在且不是目录: $OUT_DIR" >&2
+  exit 1
+fi
+if [[ -d "$OUT_DIR" ]]; then
+  marker_file="$OUT_DIR/$MARKER_NAME"
+  if [[ -L "$marker_file" || ! -f "$marker_file" ]] ||
+     ! cmp -s "$marker_file" <(printf '%s\n' "$MARKER_CONTENT"); then
+    echo "[错误] 输出目录已存在但不属于本脚本管理，未修改任何内容: $OUT_DIR" >&2
+    exit 1
+  fi
+fi
+
+WIKI_CACHE_INPUT="$(absolute_path "$WIKI_CACHE")"
+if [[ -L "$WIKI_CACHE_INPUT" ]]; then
+  echo "[错误] Wiki 缓存不能是符号链接: $WIKI_CACHE_INPUT" >&2
+  exit 1
+fi
+WIKI_CACHE="$(canonical_path "$WIKI_CACHE_INPUT")"
+
 SYNC_DATE="$(date +%F)"
 
 echo ">>> 更新 Wiki 缓存: $WIKI_CACHE"
-if [[ -d "$WIKI_CACHE/.git" ]]; then
-  git -C "$WIKI_CACHE" pull --ff-only
+if [[ -e "$WIKI_CACHE" ]]; then
+  if [[ ! -d "$WIKI_CACHE" || -L "$WIKI_CACHE/.git" || ! -d "$WIKI_CACHE/.git" ]]; then
+    echo "[错误] 已有 Wiki 缓存不是可信的普通 Git 目录: $WIKI_CACHE" >&2
+    exit 1
+  fi
+  if [[ "$(path_owner_id "$WIKI_CACHE")" != "$(id -u)" ||
+        "$(path_owner_id "$WIKI_CACHE/.git")" != "$(id -u)" ]]; then
+    echo "[错误] Wiki 缓存或其 .git 目录不属于当前用户: $WIKI_CACHE" >&2
+    exit 1
+  fi
+  cache_remote="$(git -C "$WIKI_CACHE" remote get-url origin 2>/dev/null || true)"
+  if [[ "$cache_remote" != "$WIKI_URL" ]]; then
+    echo "[错误] Wiki 缓存 origin 与 WIKI_URL 不一致，拒绝复用: $WIKI_CACHE" >&2
+    exit 1
+  fi
+  chmod 0700 "$WIKI_CACHE"
+  git -C "$WIKI_CACHE" config --local core.hooksPath /dev/null
+  git -c core.hooksPath=/dev/null -C "$WIKI_CACHE" pull --ff-only
 else
-  git clone "$WIKI_URL" "$WIKI_CACHE"
+  mkdir -p "$(dirname "$WIKI_CACHE")"
+  git -c core.hooksPath=/dev/null clone --depth 1 "$WIKI_URL" "$WIKI_CACHE"
+  if [[ -L "$WIKI_CACHE" || "$(path_owner_id "$WIKI_CACHE")" != "$(id -u)" ]]; then
+    echo "[错误] 新建 Wiki 缓存未通过所有者检查: $WIKI_CACHE" >&2
+    exit 1
+  fi
+  chmod 0700 "$WIKI_CACHE"
+  git -C "$WIKI_CACHE" config --local core.hooksPath /dev/null
 fi
 
-TMP_OUT="$(mktemp -d "${TMPDIR:-/tmp}/project-docs-kb.XXXXXX")"
+mkdir -p "$(dirname "$OUT_DIR")"
+TMP_OUT="$(mktemp -d "$(dirname "$OUT_DIR")/.project-docs-kb.new.XXXXXX")"
+BACKUP_ROOT=""
 cleanup() {
-  rm -rf "$TMP_OUT"
+  if [[ -n "$TMP_OUT" && -d "$TMP_OUT" ]]; then
+    rm -rf -- "$TMP_OUT"
+  fi
+  if [[ -n "$BACKUP_ROOT" && -d "$BACKUP_ROOT" ]]; then
+    rm -rf -- "$BACKUP_ROOT"
+  fi
 }
 trap cleanup EXIT
 
@@ -252,11 +350,25 @@ for p in sorted(out_dir.glob("*.md")):
     print(f"  {p.name}")
 PY
 
-mkdir -p "$(dirname "$OUT_DIR")"
-rm -rf "$OUT_DIR"
-mkdir -p "$OUT_DIR"
-# 只复制 md，避免带入临时杂物
-find "$TMP_OUT" -maxdepth 1 -type f -name '*.md' -exec cp -a {} "$OUT_DIR"/ \;
+printf '%s\n' "$MARKER_CONTENT" > "$TMP_OUT/$MARKER_NAME"
+
+# 先完整生成，再替换带 marker 的旧目录；任何生成失败都会保留上一版输出。
+if [[ -d "$OUT_DIR" ]]; then
+  BACKUP_ROOT="$(mktemp -d "$(dirname "$OUT_DIR")/.project-docs-kb.old.XXXXXX")"
+  mv -- "$OUT_DIR" "$BACKUP_ROOT/previous"
+fi
+if ! mv -- "$TMP_OUT" "$OUT_DIR"; then
+  if [[ -n "$BACKUP_ROOT" && -d "$BACKUP_ROOT/previous" ]]; then
+    mv -- "$BACKUP_ROOT/previous" "$OUT_DIR"
+  fi
+  echo "[错误] 无法替换输出目录，已恢复旧版本: $OUT_DIR" >&2
+  exit 1
+fi
+TMP_OUT=""
+if [[ -n "$BACKUP_ROOT" ]]; then
+  rm -rf -- "$BACKUP_ROOT"
+  BACKUP_ROOT=""
+fi
 
 echo ">>> 已生成: $OUT_DIR"
 find "$OUT_DIR" -maxdepth 1 -type f -name '*.md' | sort | sed 's|^|  |'

--- a/scripts/prepare_project_docs_kb.sh
+++ b/scripts/prepare_project_docs_kb.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# 把 GitHub Wiki + 仓库 CHANGELOG 整理成 knowledge 子目录，供 sync_knowledge.sh 同步。
+#
+# 用法:
+#   bash scripts/prepare_project_docs_kb.sh
+#   bash scripts/prepare_project_docs_kb.sh --sync
+#   bash scripts/prepare_project_docs_kb.sh --sync --dry-run
+#   bash scripts/prepare_project_docs_kb.sh --out /path/to/dir
+#
+# 默认输出:
+#   runtime/config/knowledge/project_docs/
+#
+# 同步时复用:
+#   scripts/sync_knowledge.sh
+#   scripts/deploy.conf 的 REMOTE_* / SYNC_MAP
+#
+# 约定:
+#   - 只写公开文档，不复制 .env、密钥、私有 prompt 或真实用户数据
+#   - 输出目录中的 .md 由 .gitignore 忽略（knowledge 规则），可安全本地维护
+#   - --sync 只是准备完后调用现有 sync_knowledge；镜像删除范围仍由 SYNC_MAP 子目录限定
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEFAULT_OUT="$REPO_ROOT/runtime/config/knowledge/project_docs"
+WIKI_URL="${WIKI_URL:-https://github.com/kuliantnt/qq-maid-bot.wiki.git}"
+WIKI_CACHE="${WIKI_CACHE:-/tmp/qq-maid-bot.wiki}"
+QQ_GROUP_URL="${QQ_GROUP_URL:-https://qm.qq.com/q/iAZxBO66EE}"
+QQ_GROUP_NAME="${QQ_GROUP_NAME:-雪主任的工坊}"
+
+OUT_DIR="$DEFAULT_OUT"
+DO_SYNC=0
+DRY_RUN=0
+
+usage() {
+  cat <<'EOF'
+用法: bash scripts/prepare_project_docs_kb.sh [选项]
+
+  拉取/更新 GitHub Wiki，连同仓库 CHANGELOG 生成 knowledge/project_docs。
+
+选项:
+  --out DIR       输出目录（默认 runtime/config/knowledge/project_docs）
+  --sync          生成后调用 scripts/sync_knowledge.sh
+  --dry-run       与 --sync 联用时，把 --dry-run 传给 sync_knowledge
+  -h, --help      显示帮助
+
+环境变量:
+  WIKI_URL        Wiki git 地址
+  WIKI_CACHE      本地 wiki 缓存目录（默认 /tmp/qq-maid-bot.wiki）
+  QQ_GROUP_URL    交流群链接（写入首页/摘要）
+  QQ_GROUP_NAME   交流群名称
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out)
+      [[ $# -ge 2 ]] || { echo "[错误] --out 需要目录参数"; exit 1; }
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    --sync)
+      DO_SYNC=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[错误] 未知参数: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$DRY_RUN" -eq 1 && "$DO_SYNC" -eq 0 ]]; then
+  echo "[错误] --dry-run 只能与 --sync 一起使用"
+  exit 1
+fi
+
+SYNC_DATE="$(date +%F)"
+
+echo ">>> 更新 Wiki 缓存: $WIKI_CACHE"
+if [[ -d "$WIKI_CACHE/.git" ]]; then
+  git -C "$WIKI_CACHE" pull --ff-only
+else
+  git clone "$WIKI_URL" "$WIKI_CACHE"
+fi
+
+TMP_OUT="$(mktemp -d "${TMPDIR:-/tmp}/project-docs-kb.XXXXXX")"
+cleanup() {
+  rm -rf "$TMP_OUT"
+}
+trap cleanup EXIT
+
+python3 - "$WIKI_CACHE" "$REPO_ROOT/CHANGELOG.md" "$TMP_OUT" "$SYNC_DATE" "$QQ_GROUP_NAME" "$QQ_GROUP_URL" <<'PY'
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+wiki_dir = Path(sys.argv[1])
+changelog_path = Path(sys.argv[2])
+out_dir = Path(sys.argv[3])
+sync_date = sys.argv[4]
+group_name = sys.argv[5]
+group_url = sys.argv[6]
+
+out_dir.mkdir(parents=True, exist_ok=True)
+
+pages = [
+    ("HOME.md", "wiki-home.md", "小女仆机器人项目 Wiki 首页"),
+    ("使用说明.md", "wiki-usage.md", "小女仆机器人使用说明"),
+    ("安装手册.md", "wiki-install.md", "小女仆机器人安装手册"),
+    ("配置中心.md", "wiki-config-center.md", "小女仆机器人配置中心"),
+    ("Napcat接入.md", "wiki-napcat.md", "用 NapCat 接入小女仆"),
+    ("ops运维命令.md", "wiki-ops.md", "用 /ops 在 QQ 里做运维"),
+    ("ops-codex.md", "wiki-ops-codex.md", "用 /ops codex 跑长任务"),
+    ("和风天气配置.md", "wiki-qweather.md", "和风天气配置"),
+    ("开发维护文档.md", "wiki-development.md", "小女仆机器人开发维护文档"),
+    ("插件开发.md", "wiki-plugins.md", "自定义 Tool 插件开发"),
+]
+
+index_lines = [
+    "# 小女仆机器人项目公开文档知识库",
+    "",
+    f"> 同步日期：{sync_date}",
+    "> 来源：GitHub Wiki + CHANGELOG",
+    f"> 交流群：{group_name} {group_url}",
+    "",
+    "本目录存放项目公开 Wiki 与变更日志，供机器人本地知识检索使用。",
+    "不包含私有 prompt、真实群聊、密钥或用户数据。",
+    "",
+    "## 文件清单",
+    "",
+]
+
+missing = []
+for src_name, dst_name, title in pages:
+    src = wiki_dir / src_name
+    if not src.is_file():
+        missing.append(src_name)
+        continue
+    body = src.read_text(encoding="utf-8").lstrip()
+    if body.startswith("#"):
+        _, _, rest = body.partition("\n")
+        content = (
+            f"# {title}\n\n"
+            f"> 来源：项目 Wiki `{src_name}`\n"
+            f"> 同步日期：{sync_date}\n\n"
+            f"{rest.lstrip()}"
+        )
+    else:
+        content = (
+            f"# {title}\n\n"
+            f"> 来源：项目 Wiki `{src_name}`\n"
+            f"> 同步日期：{sync_date}\n\n"
+            f"{body}"
+        )
+    (out_dir / dst_name).write_text(content, encoding="utf-8")
+    index_lines.append(f"- `{dst_name}`：{title}")
+
+if missing:
+    raise SystemExit("缺少 Wiki 页面: " + ", ".join(missing))
+
+if not changelog_path.is_file():
+    raise SystemExit(f"缺少 CHANGELOG: {changelog_path}")
+
+changelog = changelog_path.read_text(encoding="utf-8")
+headers = re.findall(r"^## \[([^\]]+)\] - (\d{4}-\d{2}-\d{2})", changelog, flags=re.M)
+recent = headers[:12]
+
+summary = [
+    "# 小女仆机器人 CHANGELOG",
+    "",
+    "> 来源：仓库 CHANGELOG.md",
+    f"> 同步日期：{sync_date}",
+    "",
+    "## 最近版本速览",
+    "",
+]
+for ver, day in recent:
+    summary.append(f"- {ver}（{day}）")
+summary.append("")
+summary.append("## 完整变更记录")
+summary.append("")
+cl_body = changelog
+if cl_body.startswith("# "):
+    cl_body = "\n".join(cl_body.splitlines()[1:]).lstrip()
+summary.append(cl_body)
+(out_dir / "changelog.md").write_text("\n".join(summary) + "\n", encoding="utf-8")
+index_lines.append("- `changelog.md`：项目变更日志（含完整历史）")
+
+# 轻量摘要，方便最近能力检索命中
+focus = []
+for ver, day in headers[:5]:
+    # 抓取该版本首个 Release Focus 段落首行，失败则只写版本号
+    pattern = rf"## \[{re.escape(ver)}\] - {re.escape(day)}\n(?P<body>.*?)(?=\n## |\Z)"
+    m = re.search(pattern, changelog, flags=re.S)
+    bullet = f"- {ver}（{day}）"
+    if m:
+        body = m.group("body")
+        focus_m = re.search(r"^\* \*\*([^*]+)\*\*", body, flags=re.M)
+        if focus_m:
+            bullet += f"：{focus_m.group(1).strip()}"
+    focus.append(bullet)
+
+recent_only = [
+    "# 小女仆机器人最近更新摘要",
+    "",
+    f"> 同步日期：{sync_date}",
+    f"> 交流群：{group_name} {group_url}",
+    "",
+    "## 最近版本",
+    "",
+]
+recent_only.extend(focus or ["- 暂无版本记录"])
+recent_only += [
+    "",
+    "## 文档入口",
+    "",
+    "- 使用说明：wiki-usage.md",
+    "- 安装手册：wiki-install.md",
+    "- 配置中心：wiki-config-center.md",
+    "- 完整变更：changelog.md",
+    "",
+]
+(out_dir / "recent-updates.md").write_text("\n".join(recent_only), encoding="utf-8")
+index_lines.append("- `recent-updates.md`：最近版本摘要")
+
+index_lines += [
+    "",
+    "## 使用说明",
+    "",
+    "机器人会按问题从本目录检索相关片段，不会整份注入。",
+    "更新本目录后需要重启机器人以重建知识索引。",
+    "",
+]
+(out_dir / "README.md").write_text("\n".join(index_lines) + "\n", encoding="utf-8")
+
+total = sum(p.stat().st_size for p in out_dir.glob("*.md"))
+print(f"generated {len(list(out_dir.glob('*.md')))} markdown files, {total} bytes")
+for p in sorted(out_dir.glob("*.md")):
+    print(f"  {p.name}")
+PY
+
+mkdir -p "$(dirname "$OUT_DIR")"
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+# 只复制 md，避免带入临时杂物
+find "$TMP_OUT" -maxdepth 1 -type f -name '*.md' -exec cp -a {} "$OUT_DIR"/ \;
+
+echo ">>> 已生成: $OUT_DIR"
+find "$OUT_DIR" -maxdepth 1 -type f -name '*.md' | sort | sed 's|^|  |'
+
+if [[ "$DO_SYNC" -eq 1 ]]; then
+  echo ">>> 调用 sync_knowledge.sh"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    bash "$SCRIPT_DIR/sync_knowledge.sh" --dry-run
+  else
+    bash "$SCRIPT_DIR/sync_knowledge.sh"
+  fi
+  echo
+  echo "提示: 远端索引通常在重启后重建。例如:"
+  echo "  ssh \"\$REMOTE_HOST\" 'cd /root/qq-maid-bot && ./botctl.sh restart'"
+fi

--- a/scripts/qbot.ps1
+++ b/scripts/qbot.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding(PositionalBinding = $false)]
+﻿[CmdletBinding(PositionalBinding = $false)]
 param(
     [Parameter(Position = 0)][string]$Command = "help",
     [Parameter(Position = 1, ValueFromRemainingArguments = $true)][string[]]$CommandArgs

--- a/scripts/qbot.ps1
+++ b/scripts/qbot.ps1
@@ -331,6 +331,9 @@ function Install-OrUpdate {
         Write-Output "qbot $Mode completed: $version"
         Write-Output "directory: $($script:AppDir)"
         Write-Output "config: $(Join-Path $script:AppDir 'config\.env')"
+        if (-not $wasRunning) {
+            Write-Output "v0.20 起推荐在下次 qbot start 后，通过 http://127.0.0.1:8787/console/ 网页完成配置"
+        }
         if ($wasRunning) {
             Invoke-BotControl "start"
         }

--- a/scripts/qbot.ps1
+++ b/scripts/qbot.ps1
@@ -72,6 +72,14 @@ $script:InstallerPath = [IO.Path]::GetFullPath($MyInvocation.MyCommand.Path)
 $script:RepoSlug = Get-EnvironmentValue "QBOT_REPO_SLUG" "kuliantnt/qq-maid-bot"
 $script:ReleasesUrl = "https://github.com/$($script:RepoSlug)/releases"
 $script:LatestApiUrl = "https://api.github.com/repos/$($script:RepoSlug)/releases/latest"
+$script:ObsoleteEnvKeys = @(
+    "LLM_PROVIDER", "OPENAI_MODEL", "LLM_MODEL", "PRIVATE_LLM_MODEL", "GROUP_LLM_MODEL",
+    "OPENAI_SEARCH_MODEL", "PRIVATE_OPENAI_SEARCH_MODEL", "GROUP_OPENAI_SEARCH_MODEL",
+    "TITLE_MODEL", "MEMORY_MODEL", "COMPACT_MODEL", "TRANSLATION_MODEL",
+    "DEEPSEEK_MODEL", "BIGMODEL_MODEL", "GEMINI_MODEL", "LLM_MAX_OUTPUT_TOKENS",
+    "TOOL_CALLING_ENABLED", "TOOL_CALLING_GROUP_ENABLED", "TOOL_CALLING_MAX_ROUNDS",
+    "TODO_MODEL", "MEMBER_ID_MAPPING_FILE"
+)
 
 function Show-QbotUsage {
     @"
@@ -287,6 +295,7 @@ function Install-ReleasePayload {
         Copy-Item -LiteralPath (Join-Path $script:AppDir "config\.env.example") -Destination $configFile
         Write-Output "created config template: $configFile"
     }
+    Remove-ObsoleteEnvConfig -ConfigFile $configFile
 
     # Remove obsolete distribution files only; private config and runtime data stay untouched.
     foreach ($obsolete in @(
@@ -297,12 +306,51 @@ function Install-ReleasePayload {
     }
 }
 
+function Remove-ObsoleteEnvConfig {
+    param([Parameter(Mandatory = $true)][string]$ConfigFile)
+    if (-not (Test-Path -LiteralPath $ConfigFile -PathType Leaf)) {
+        return
+    }
+    if ((Get-Item -LiteralPath $ConfigFile -Force).LinkType) {
+        [Console]::Error.WriteLine("warning: skip obsolete env migration for symbolic link: $ConfigFile")
+        return
+    }
+
+    $lines = @(Get-Content -LiteralPath $ConfigFile)
+    $removed = New-Object Collections.Generic.List[string]
+    $filtered = New-Object Collections.Generic.List[string]
+    foreach ($line in $lines) {
+        if ($line -match '^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=' -and
+            $script:ObsoleteEnvKeys -contains $Matches[1]) {
+            if (-not $removed.Contains($Matches[1])) {
+                $removed.Add($Matches[1])
+            }
+            continue
+        }
+        $filtered.Add($line)
+    }
+    if ($removed.Count -eq 0) {
+        return
+    }
+
+    $stamp = Get-Date -Format "yyyyMMdd_HHmmss"
+    $backup = "${ConfigFile}.bak.v0.20.${stamp}.$PID"
+    Copy-Item -LiteralPath $ConfigFile -Destination $backup
+    $tempFile = "${ConfigFile}.tmp.$PID"
+    Write-Utf8Lines -Path $tempFile -Lines $filtered.ToArray()
+    Move-Item -LiteralPath $tempFile -Destination $ConfigFile -Force
+    Write-Output "removed obsolete config keys from config\.env: $($removed -join ', ')"
+    Write-Output "pre-upgrade config backup: $backup"
+    Write-Output "Remove the same keys manually if systemd, Docker, or the host environment still injects them."
+}
+
 function Install-OrUpdate {
     param([string]$Mode, [string]$RequestedVersion)
     Assert-SupportedWindowsArchitecture (Get-WindowsOperatingSystemArchitecture)
     $version = Resolve-Version $RequestedVersion
     $current = Get-LocalVersion
     if ($Mode -eq "update" -and $null -ne $current -and (Normalize-Version $current) -eq $version) {
+        Remove-ObsoleteEnvConfig -ConfigFile (Join-Path $script:AppDir "config\.env")
         Write-Output "already installed: $current"
         return
     }
@@ -436,14 +484,7 @@ function Set-ConfigValue {
     if ($Value.Contains("`r") -or $Value.Contains("`n")) {
         throw "configuration values cannot contain newlines"
     }
-    $removedAgentKeys = @(
-        "LLM_PROVIDER", "OPENAI_MODEL", "LLM_MODEL", "PRIVATE_LLM_MODEL", "GROUP_LLM_MODEL",
-        "OPENAI_SEARCH_MODEL", "PRIVATE_OPENAI_SEARCH_MODEL", "GROUP_OPENAI_SEARCH_MODEL",
-        "TITLE_MODEL", "MEMORY_MODEL", "COMPACT_MODEL", "TRANSLATION_MODEL",
-        "DEEPSEEK_MODEL", "BIGMODEL_MODEL", "GEMINI_MODEL", "LLM_MAX_OUTPUT_TOKENS",
-        "TOOL_CALLING_ENABLED", "TOOL_CALLING_GROUP_ENABLED", "TOOL_CALLING_MAX_ROUNDS"
-    )
-    if ($removedAgentKeys -contains $Name) {
+    if ($script:ObsoleteEnvKeys -contains $Name) {
         throw "$Name was removed; edit config/agent.toml for Agent policy"
     }
     $escaped = $Value.Replace('\', '\\').Replace('"', '\"')

--- a/scripts/qbot.ps1
+++ b/scripts/qbot.ps1
@@ -331,9 +331,7 @@ function Install-OrUpdate {
         Write-Output "qbot $Mode completed: $version"
         Write-Output "directory: $($script:AppDir)"
         Write-Output "config: $(Join-Path $script:AppDir 'config\.env')"
-        if (-not $wasRunning) {
-            Write-Output "v0.20 起推荐在下次 qbot start 后，通过 http://127.0.0.1:8787/console/ 网页完成配置"
-        }
+        if (-not $wasRunning) { Write-ConsoleConfigHint -NextStart }
         if ($wasRunning) {
             Invoke-BotControl "start"
         }
@@ -376,6 +374,52 @@ function Read-ConfigValues {
         }
     }
     return $values
+}
+
+function Get-ConfiguredValue {
+    param([string]$Name, [string]$DefaultValue = "")
+    $environmentValue = [Environment]::GetEnvironmentVariable($Name)
+    if (-not [string]::IsNullOrWhiteSpace($environmentValue)) {
+        return $environmentValue
+    }
+    $values = Read-ConfigValues
+    if ($values.Contains($Name) -and -not [string]::IsNullOrWhiteSpace([string]$values[$Name])) {
+        return [string]$values[$Name]
+    }
+    return $DefaultValue
+}
+
+function Get-ConfiguredConsoleUrl {
+    $explicitUrl = Get-ConfiguredValue "LLM_SERVER_URL"
+    if (-not [string]::IsNullOrWhiteSpace($explicitUrl)) {
+        return $explicitUrl.TrimEnd('/')
+    }
+    $hostName = Get-ConfiguredValue "LLM_SERVER_HOST" "127.0.0.1"
+    $port = Get-ConfiguredValue "LLM_SERVER_PORT" "8787"
+    return "http://${hostName}:${port}"
+}
+
+function Write-ConsoleConfigHint {
+    param([switch]$NextStart)
+    $enabled = Get-ConfiguredValue "WEB_CONSOLE_ENABLED" "true"
+    if ($enabled.Equals("false", [StringComparison]::OrdinalIgnoreCase)) {
+        return
+    }
+    $url = Get-ConfiguredConsoleUrl
+    $parsed = $null
+    if ([Uri]::TryCreate($url, [UriKind]::Absolute, [ref]$parsed) -and
+        $parsed.Host -in @("0.0.0.0", "::")) {
+        Write-Output "v0.20 起可通过控制台完成配置；当前监听通配地址，请使用实际服务器地址或反向代理地址访问 /console/"
+        return
+    }
+    $when = if ($NextStart) { "在下次 qbot start 后，" } else { "" }
+    Write-Output "v0.20 起推荐${when}通过 ${url}/console/ 网页完成配置"
+}
+
+function Write-ConfigDoneHint {
+    Write-Output "配置已写入: $(Get-ConfigFile)"
+    Write-Output "提示: 下次 qbot start 时生效"
+    Write-ConsoleConfigHint -NextStart
 }
 
 function Write-Utf8Lines {
@@ -535,9 +579,10 @@ function Invoke-ConfigCommand {
                 if ($separator -le 0) { throw "invalid assignment: $assignment" }
                 Set-ConfigValue $assignment.Substring(0, $separator) $assignment.Substring($separator + 1)
             }
+            Write-ConfigDoneHint
         }
-        "bot" { Configure-Bot $remaining }
-        "ai" { Configure-Ai $remaining }
+        "bot" { Configure-Bot $remaining; Write-ConfigDoneHint }
+        "ai" { Configure-Ai $remaining; Write-ConfigDoneHint }
         default { throw "unknown config command: $subcommand" }
     }
 }

--- a/scripts/qbot.sh
+++ b/scripts/qbot.sh
@@ -655,8 +655,10 @@ config_done_hint() {
     fi
     if is_qbot_running; then
         ui_out_status "${UI_YELLOW}" "提示:" "qbot 正在运行，执行 qbot restart 后生效"
+        ui_out_status "${UI_YELLOW}" "提示:" "v0.20 起可通过浏览器打开 http://127.0.0.1:8787/console/ 完成配置"
     else
         ui_out_status "${UI_YELLOW}" "提示:" "下次 qbot start 时生效"
+        ui_out_status "${UI_YELLOW}" "提示:" "v0.20 起可通过浏览器打开 http://127.0.0.1:8787/console/ 完成配置"
     fi
 }
 

--- a/scripts/qbot.sh
+++ b/scripts/qbot.sh
@@ -646,7 +646,7 @@ prompt_display_default() {
 }
 
 config_done_hint() {
-    local file
+    local file enabled url host port authority console_hint
     file="$(config_env_file)"
     if [[ -n "${UI_RESET}" && -t 1 ]]; then
         printf '\n%b配置已写入%b %s\n' "${UI_GREEN}${UI_BOLD}" "${UI_RESET}" "${UI_CYAN}${file}${UI_RESET}"
@@ -655,11 +655,30 @@ config_done_hint() {
     fi
     if is_qbot_running; then
         ui_out_status "${UI_YELLOW}" "提示:" "qbot 正在运行，执行 qbot restart 后生效"
-        ui_out_status "${UI_YELLOW}" "提示:" "v0.20 起可通过浏览器打开 http://127.0.0.1:8787/console/ 完成配置"
     else
         ui_out_status "${UI_YELLOW}" "提示:" "下次 qbot start 时生效"
-        ui_out_status "${UI_YELLOW}" "提示:" "v0.20 起可通过浏览器打开 http://127.0.0.1:8787/console/ 完成配置"
     fi
+
+    enabled="${WEB_CONSOLE_ENABLED:-$(get_real_env_var WEB_CONSOLE_ENABLED)}"
+    enabled="$(printf '%s' "${enabled:-true}" | tr '[:upper:]' '[:lower:]')"
+    [[ "${enabled}" != "false" ]] || return 0
+    url="${LLM_SERVER_URL:-$(get_real_env_var LLM_SERVER_URL)}"
+    if [[ -z "${url}" ]]; then
+        host="${LLM_SERVER_HOST:-$(get_real_env_var LLM_SERVER_HOST)}"
+        port="${LLM_SERVER_PORT:-$(get_real_env_var LLM_SERVER_PORT)}"
+        url="http://${host:-127.0.0.1}:${port:-8787}"
+    fi
+    authority="${url#*://}"
+    authority="${authority%%/*}"
+    case "${authority}" in
+        0.0.0.0|0.0.0.0:*|'[::]'|'[::]':*|::* )
+            console_hint="v0.20 起可通过控制台完成配置；当前监听通配地址，请使用实际服务器地址或反向代理地址访问 /console/"
+            ;;
+        *)
+            console_hint="v0.20 起可通过浏览器打开 ${url%/}/console/ 完成配置"
+            ;;
+    esac
+    ui_out_status "${UI_YELLOW}" "提示:" "${console_hint}"
 }
 
 normalize_bool_value() {

--- a/scripts/qbot.sh
+++ b/scripts/qbot.sh
@@ -26,6 +26,14 @@ UI_GREEN=""
 UI_YELLOW=""
 UI_BLUE=""
 UI_CYAN=""
+OBSOLETE_ENV_KEYS=(
+    LLM_PROVIDER OPENAI_MODEL LLM_MODEL PRIVATE_LLM_MODEL GROUP_LLM_MODEL
+    OPENAI_SEARCH_MODEL PRIVATE_OPENAI_SEARCH_MODEL GROUP_OPENAI_SEARCH_MODEL
+    TITLE_MODEL MEMORY_MODEL COMPACT_MODEL TRANSLATION_MODEL
+    DEEPSEEK_MODEL BIGMODEL_MODEL GEMINI_MODEL LLM_MAX_OUTPUT_TOKENS
+    TOOL_CALLING_ENABLED TOOL_CALLING_GROUP_ENABLED TOOL_CALLING_MAX_ROUNDS
+    TODO_MODEL MEMBER_ID_MAPPING_FILE
+)
 
 cleanup_tmp_dir() {
     if [[ -n "${TMP_DIR_TO_CLEAN}" && -d "${TMP_DIR_TO_CLEAN}" ]]; then
@@ -578,6 +586,65 @@ unset_env_var() {
     [[ -n "${mode}" ]] && chmod "${mode}" "${file}" 2>/dev/null || true
 }
 
+is_obsolete_env_key() {
+    local candidate="$1" key
+    for key in "${OBSOLETE_ENV_KEYS[@]}"; do
+        [[ "${candidate}" == "${key}" ]] && return 0
+    done
+    return 1
+}
+
+migrate_obsolete_env_config() {
+    local file="${APP_DIR}/config/.env"
+    local key tmp owner group mode backup joined
+    local found=()
+
+    [[ -f "${file}" ]] || return 0
+    if [[ -L "${file}" ]]; then
+        ui_warn "跳过符号链接配置的自动迁移: ${file}"
+        return 0
+    fi
+    for key in "${OBSOLETE_ENV_KEYS[@]}"; do
+        if grep -Eq "^[[:space:]]*(export[[:space:]]+)?${key}[[:space:]]*=" "${file}"; then
+            found+=("${key}")
+        fi
+    done
+    ((${#found[@]} > 0)) || return 0
+
+    backup="${file}.bak.v0.20.$(date +%Y%m%d_%H%M%S).$$"
+    cp -a -- "${file}" "${backup}"
+    tmp="${file}.tmp.$$"
+    owner="$(stat -c '%u' "${file}" 2>/dev/null || echo "")"
+    group="$(stat -c '%g' "${file}" 2>/dev/null || echo "")"
+    mode="$(stat -c '%a' "${file}" 2>/dev/null || echo "")"
+    joined="$(IFS=:; echo "${OBSOLETE_ENV_KEYS[*]}")"
+
+    awk -v removed_keys="${joined}" '
+        BEGIN {
+            count = split(removed_keys, values, ":")
+            for (i = 1; i <= count; i++) removed[values[i]] = 1
+        }
+        {
+            candidate = $0
+            sub(/^[[:space:]]*/, "", candidate)
+            sub(/^export[[:space:]]+/, "", candidate)
+            if (match(candidate, /^[A-Za-z_][A-Za-z0-9_]*/)) {
+                key = substr(candidate, RSTART, RLENGTH)
+                rest = substr(candidate, RLENGTH + 1)
+                if (removed[key] && rest ~ /^[[:space:]]*=/) next
+            }
+            print
+        }
+    ' "${file}" > "${tmp}"
+    [[ -n "${owner}" && -n "${group}" ]] && chown "${owner}:${group}" "${tmp}" 2>/dev/null || true
+    [[ -n "${mode}" ]] && chmod "${mode}" "${tmp}" 2>/dev/null || true
+    mv -- "${tmp}" "${file}"
+
+    echo "已从 config/.env 清理废弃变量: ${found[*]}"
+    echo "升级前配置备份: ${backup}"
+    echo "如 systemd、Docker 或宿主环境仍注入同名变量，请同步人工移除。"
+}
+
 get_env_var() {
     local key="$1"
     local file
@@ -831,11 +898,9 @@ config_set_cmd() {
         [[ "${pair}" == *=* ]] || die "配置项必须是 KEY=VALUE: ${pair}"
         key="${pair%%=*}"
         value="${pair#*=}"
-        case "${key}" in
-            LLM_PROVIDER|OPENAI_MODEL|LLM_MODEL|PRIVATE_LLM_MODEL|GROUP_LLM_MODEL|OPENAI_SEARCH_MODEL|PRIVATE_OPENAI_SEARCH_MODEL|GROUP_OPENAI_SEARCH_MODEL|TITLE_MODEL|MEMORY_MODEL|COMPACT_MODEL|TRANSLATION_MODEL|DEEPSEEK_MODEL|BIGMODEL_MODEL|GEMINI_MODEL|LLM_MAX_OUTPUT_TOKENS|TOOL_CALLING_ENABLED|TOOL_CALLING_GROUP_ENABLED|TOOL_CALLING_MAX_ROUNDS)
-                die "${key} 已移除；Agent 策略请编辑 config/agent.toml"
-                ;;
-        esac
+        if is_obsolete_env_key "${key}"; then
+            die "${key} 已移除；Agent 策略请编辑 config/agent.toml"
+        fi
         set_env_var "${key}" "${value}"
         ui_out_status "${UI_GREEN}" "已设置:" "${key}"
     done
@@ -1801,6 +1866,9 @@ copy_release_into_app() {
         echo "已创建配置模板: ${APP_DIR}/config/.env"
     fi
 
+    # v0.20 统一从 agent.toml 读取 Agent 策略；保留旧键会让新版本明确拒绝启动。
+    migrate_obsolete_env_config
+
     # 仅清理旧混合平台 Release 遗留的 Windows 控制文件，不触碰用户运行数据。
     local obsolete_windows_file
     for obsolete_windows_file in \
@@ -1828,6 +1896,7 @@ install_or_update() {
     current="$(local_version 2>/dev/null || true)"
 
     if [[ "${command_name}" == "update" && -n "${current}" && "$(normalize_version "${current}")" == "${version}" ]]; then
+        migrate_obsolete_env_config
         echo "当前已是目标版本: ${current}"
         return 0
     fi

--- a/scripts/test-botctl-guidance.sh
+++ b/scripts/test-botctl-guidance.sh
@@ -23,6 +23,12 @@ start_and_stop() {
     printf '%s' "${output}"
 }
 
+runtime="$(new_runtime no-token)"
+output="$(start_and_stop "${runtime}")"
+[[ "${output}" == *"qq-maid-bot started"* ]]
+[[ "${output}" != *"首次配置"* ]]
+[[ "${output}" != *"密码重置"* ]]
+
 runtime="$(new_runtime initialize)"
 printf '%s\n' \
     'LLM_SERVER_PORT=9988' \

--- a/scripts/test-botctl-guidance.sh
+++ b/scripts/test-botctl-guidance.sh
@@ -24,12 +24,23 @@ start_and_stop() {
 }
 
 runtime="$(new_runtime initialize)"
-printf '%s\n' 'LLM_SERVER_PORT=9988' 'WEB_CONSOLE_ENABLED=true' > "${runtime}/config/.env"
+printf '%s\n' \
+    'LLM_SERVER_PORT=9988' \
+    'WEB_CONSOLE_ENABLED=true' \
+    'LLM_MODEL=openai:legacy-model' \
+    ' export TOOL_CALLING_ENABLED = true' \
+    'QWEATHER_API_KEY=' > "${runtime}/config/.env"
 printf '%s\n' 'qq-maid-bootstrap-v1:1:initialize-secret' > "${runtime}/config/secrets/bootstrap.token"
 output="$(start_and_stop "${runtime}")"
 [[ "${output}" == *"--- 首次配置 ---"* ]]
 [[ "${output}" == *"http://127.0.0.1:9988/console/"* ]]
 [[ "${output}" != *"initialize-secret"* ]]
+[[ "${output}" != *"legacy-model"* ]]
+grep -Fqx 'QWEATHER_API_KEY=' "${runtime}/config/.env"
+! grep -Eq '^[[:space:]]*(export[[:space:]]+)?(LLM_MODEL|TOOL_CALLING_ENABLED)[[:space:]]*=' "${runtime}/config/.env"
+backup_files=("${runtime}"/config/.env.bak.v0.20.*)
+[[ "${#backup_files[@]}" -eq 1 ]]
+grep -Fqx 'LLM_MODEL=openai:legacy-model' "${backup_files[0]}"
 
 runtime="$(new_runtime password-reset)"
 printf '%s\n' 'WEB_CONSOLE_ENABLED=true' > "${runtime}/config/.env"

--- a/scripts/test-botctl-guidance.sh
+++ b/scripts/test-botctl-guidance.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf -- "${TMP_ROOT}"' EXIT
+
+new_runtime() {
+    local name="$1"
+    local runtime="${TMP_ROOT}/${name}"
+    mkdir -p "${runtime}/config/secrets"
+    cp "${REPO_DIR}/scripts/botctl.sh" "${runtime}/botctl.sh"
+    printf '%s\n' '#!/usr/bin/env bash' 'exec sleep 30' > "${runtime}/qq-maid-bot"
+    chmod +x "${runtime}/botctl.sh" "${runtime}/qq-maid-bot"
+    echo "${runtime}"
+}
+
+start_and_stop() {
+    local runtime="$1"
+    local output
+    output="$(QQ_MAID_RUNTIME_DIR="${runtime}" bash "${runtime}/botctl.sh" start)"
+    QQ_MAID_RUNTIME_DIR="${runtime}" bash "${runtime}/botctl.sh" stop >/dev/null
+    printf '%s' "${output}"
+}
+
+runtime="$(new_runtime initialize)"
+printf '%s\n' 'LLM_SERVER_PORT=9988' 'WEB_CONSOLE_ENABLED=true' > "${runtime}/config/.env"
+printf '%s\n' 'qq-maid-bootstrap-v1:1:initialize-secret' > "${runtime}/config/secrets/bootstrap.token"
+output="$(start_and_stop "${runtime}")"
+[[ "${output}" == *"--- 首次配置 ---"* ]]
+[[ "${output}" == *"http://127.0.0.1:9988/console/"* ]]
+[[ "${output}" != *"initialize-secret"* ]]
+
+runtime="$(new_runtime password-reset)"
+printf '%s\n' 'WEB_CONSOLE_ENABLED=true' > "${runtime}/config/.env"
+printf '%s\n' 'qq-maid-password-reset-v1:2:reset-secret' > "${runtime}/config/secrets/bootstrap.token"
+output="$(start_and_stop "${runtime}")"
+[[ "${output}" == *"--- 密码重置待完成 ---"* ]]
+[[ "${output}" != *"--- 首次配置 ---"* ]]
+[[ "${output}" != *"reset-secret"* ]]
+
+runtime="$(new_runtime invalid-token)"
+printf '%s\n' 'WEB_CONSOLE_ENABLED=true' > "${runtime}/config/.env"
+printf '%s\n' 'qq-maid-bootstrap-v1:3:must-not-leak' 'unexpected-extra-line' > "${runtime}/config/secrets/bootstrap.token"
+output="$(start_and_stop "${runtime}")"
+[[ "${output}" != *"首次配置"* ]]
+[[ "${output}" != *"密码重置"* ]]
+[[ "${output}" != *"must-not-leak"* ]]
+
+runtime="$(new_runtime console-disabled)"
+printf '%s\n' 'WEB_CONSOLE_ENABLED=false' > "${runtime}/config/.env"
+printf '%s\n' 'qq-maid-bootstrap-v1:4:disabled-secret' > "${runtime}/config/secrets/bootstrap.token"
+output="$(start_and_stop "${runtime}")"
+[[ "${output}" != *"首次配置"* ]]
+[[ "${output}" != *"/console/"* ]]
+[[ "${output}" != *"disabled-secret"* ]]
+
+runtime="$(new_runtime wildcard-host)"
+printf '%s\n' 'LLM_SERVER_HOST=0.0.0.0' 'LLM_SERVER_PORT=9989' 'WEB_CONSOLE_ENABLED=true' > "${runtime}/config/.env"
+printf '%s\n' 'qq-maid-bootstrap-v1:5:wildcard-secret' > "${runtime}/config/secrets/bootstrap.token"
+output="$(start_and_stop "${runtime}")"
+[[ "${output}" == *"使用实际服务器地址或反向代理地址"* ]]
+[[ "${output}" != *"http://0.0.0.0"* ]]
+[[ "${output}" != *"wildcard-secret"* ]]
+
+echo "botctl guidance regression tests passed"

--- a/scripts/test-prepare-project-docs-kb.sh
+++ b/scripts/test-prepare-project-docs-kb.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${REPO_DIR}/scripts/prepare_project_docs_kb.sh"
+TMP_ROOT="$(mktemp -d)"
+REAL_RM="$(command -v rm)"
+export REAL_RM REPO_DIR
+trap '"${REAL_RM}" -rf -- "${TMP_ROOT}"' EXIT
+
+create_wiki_fixture() {
+    local directory="$1"
+    local omit_page="${2:-}"
+    local page
+    local pages=(
+        HOME.md 使用说明.md 安装手册.md 配置中心.md Napcat接入.md
+        ops运维命令.md ops-codex.md 和风天气配置.md 开发维护文档.md 插件开发.md
+    )
+
+    mkdir -p "${directory}"
+    git -C "${directory}" init -q -b main
+    git -C "${directory}" config user.name test
+    git -C "${directory}" config user.email test@example.invalid
+    for page in "${pages[@]}"; do
+        [[ "${page}" == "${omit_page}" ]] && continue
+        printf '# %s\n\nfixture content\n' "${page%.md}" > "${directory}/${page}"
+    done
+    git -C "${directory}" add .
+    git -C "${directory}" commit -q -m fixture
+}
+
+run_prepare() {
+    local wiki_url="$1"
+    local cache="$2"
+    local output="$3"
+    WIKI_URL="${wiki_url}" WIKI_CACHE="${cache}" bash "${SCRIPT}" --out "${output}"
+}
+
+assert_rejected() {
+    local output="$1"
+    shift
+    set +e
+    local message
+    message="$("$@" 2>&1)"
+    local status=$?
+    set -e
+    [[ "${status}" -ne 0 ]]
+    [[ -n "${message}" ]]
+    [[ -z "${output}" || ! -e "${output}" || -d "${output}" ]]
+}
+
+valid_wiki="${TMP_ROOT}/wiki-valid"
+missing_wiki="${TMP_ROOT}/wiki-missing"
+other_wiki="${TMP_ROOT}/wiki-other"
+create_wiki_fixture "${valid_wiki}"
+create_wiki_fixture "${missing_wiki}" "插件开发.md"
+create_wiki_fixture "${other_wiki}"
+
+output_dir="${TMP_ROOT}/output"
+cache_dir="${TMP_ROOT}/cache/wiki"
+run_prepare "${valid_wiki}" "${cache_dir}" "${output_dir}" >/dev/null
+[[ -f "${output_dir}/README.md" ]]
+[[ -f "${output_dir}/wiki-usage.md" ]]
+grep -Fq "fixture content" "${output_dir}/wiki-usage.md"
+grep -Fqx "qq-maid-project-docs-kb-v1" "${output_dir}/.qq-maid-project-docs-kb"
+[[ "$(git -C "${cache_dir}" config --local core.hooksPath)" == "/dev/null" ]]
+[[ "$(stat -c '%a' "${cache_dir}")" == "700" ]]
+
+# 即使复用已有同 owner、同 remote 缓存，也必须在 pull 前禁用仓库 hooks。
+hook_cache="${TMP_ROOT}/hook-cache"
+hook_output="${TMP_ROOT}/hook-output"
+hook_fired="${TMP_ROOT}/hook-fired"
+git clone -q "${valid_wiki}" "${hook_cache}"
+printf '%s\n' '#!/usr/bin/env bash' "printf fired > '${hook_fired}'" > "${hook_cache}/.git/hooks/post-merge"
+chmod +x "${hook_cache}/.git/hooks/post-merge"
+printf '\nupdated\n' >> "${valid_wiki}/HOME.md"
+git -C "${valid_wiki}" add HOME.md
+git -C "${valid_wiki}" commit -q -m update
+run_prepare "${valid_wiki}" "${hook_cache}" "${hook_output}" >/dev/null
+[[ ! -e "${hook_fired}" ]]
+
+# 生成失败不能覆盖上一版托管输出。
+printf 'keep previous output\n' > "${output_dir}/preserved.txt"
+assert_rejected "${output_dir}" run_prepare \
+    "${missing_wiki}" "${TMP_ROOT}/cache/missing" "${output_dir}"
+grep -Fqx "keep previous output" "${output_dir}/preserved.txt"
+
+# 既有非托管目录必须原样保留。
+unmanaged="${TMP_ROOT}/unmanaged"
+mkdir -p "${unmanaged}"
+printf 'user data\n' > "${unmanaged}/important.txt"
+assert_rejected "${unmanaged}" run_prepare "${valid_wiki}" "${cache_dir}" "${unmanaged}"
+grep -Fqx "user data" "${unmanaged}/important.txt"
+
+# 输出目录与缓存目录的符号链接都不得被跟随。
+output_target="${TMP_ROOT}/output-target"
+mkdir -p "${output_target}"
+ln -s "${output_target}" "${TMP_ROOT}/output-link"
+assert_rejected "${TMP_ROOT}/output-link" run_prepare \
+    "${valid_wiki}" "${cache_dir}" "${TMP_ROOT}/output-link"
+cache_target="${TMP_ROOT}/cache-target"
+git clone -q "${valid_wiki}" "${cache_target}"
+ln -s "${cache_target}" "${TMP_ROOT}/cache-link"
+assert_rejected "${TMP_ROOT}/unused-output" run_prepare \
+    "${valid_wiki}" "${TMP_ROOT}/cache-link" "${TMP_ROOT}/unused-output"
+
+# 已有缓存的 remote 不匹配时拒绝复用，不执行 pull。
+wrong_cache="${TMP_ROOT}/wrong-cache"
+git clone -q "${valid_wiki}" "${wrong_cache}"
+assert_rejected "${TMP_ROOT}/wrong-output" run_prepare \
+    "${other_wiki}" "${wrong_cache}" "${TMP_ROOT}/wrong-output"
+
+# 危险路径检查发生在 Git 和目录替换之前。HOME 使用隔离 fixture；rm shim 为回归失效兜底。
+shim_dir="${TMP_ROOT}/shim"
+mkdir -p "${shim_dir}"
+printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'for arg in "$@"; do' \
+    '  case "$arg" in /|"$REPO_DIR"|"${TEST_HOME:-}") exit 99 ;; esac' \
+    'done' \
+    'exec "$REAL_RM" "$@"' > "${shim_dir}/rm"
+chmod +x "${shim_dir}/rm"
+test_home="${TMP_ROOT}/home"
+mkdir -p "${test_home}"
+TEST_HOME="${test_home}" HOME="${test_home}" PATH="${shim_dir}:${PATH}" \
+    assert_rejected "/" run_prepare "${valid_wiki}" "${cache_dir}" "/"
+TEST_HOME="${test_home}" HOME="${test_home}" PATH="${shim_dir}:${PATH}" \
+    assert_rejected "${test_home}" run_prepare "${valid_wiki}" "${cache_dir}" "${test_home}"
+TEST_HOME="${test_home}" PATH="${shim_dir}:${PATH}" \
+    assert_rejected "${REPO_DIR}" run_prepare "${valid_wiki}" "${cache_dir}" "${REPO_DIR}"
+
+# 未指定 WIKI_CACHE 时落到隔离 HOME 下的用户私有缓存目录。
+default_home="${TMP_ROOT}/default-home"
+default_output="${TMP_ROOT}/default-output"
+mkdir -p "${default_home}"
+HOME="${default_home}" WIKI_URL="${valid_wiki}" bash "${SCRIPT}" --out "${default_output}" >/dev/null
+[[ -d "${default_home}/.cache/qq-maid-bot/wiki/.git" ]]
+
+echo "project docs knowledge-base regression tests passed"

--- a/scripts/test-qbot-config.sh
+++ b/scripts/test-qbot-config.sh
@@ -137,6 +137,15 @@ assert_config_value "${app_dir}" "OPENAI_BASE_URLS='https://first.example/v1,htt
 assert_config_absent "${app_dir}" LLM_PROVIDER
 assert_config_absent "${app_dir}" LLM_MODEL
 
+set +e
+output="$(QBOT_APP_DIR="${app_dir}" QBOT_CONFIG_NO_BACKUP=1 NO_COLOR=1 \
+    bash "${REPO_DIR}/scripts/qbot.sh" config set TODO_MODEL=legacy 2>&1)"
+status=$?
+set -e
+[[ "${status}" -ne 0 ]]
+[[ "${output}" == *"TODO_MODEL 已移除"* ]]
+assert_config_absent "${app_dir}" TODO_MODEL
+
 app_dir="$(new_fixture reject-agent-env)"
 set +e
 output="$(QBOT_APP_DIR="${app_dir}" QBOT_CONFIG_NO_BACKUP=1 NO_COLOR=1 \

--- a/scripts/test-qbot-config.sh
+++ b/scripts/test-qbot-config.sh
@@ -147,4 +147,14 @@ set -e
 [[ "${output}" == *"Agent 策略请编辑 config/agent.toml"* ]]
 assert_config_absent "${app_dir}" LLM_MODEL
 
+app_dir="$(new_fixture console-custom-port)"
+printf '%s\n' "LLM_SERVER_PORT='9988'" "WEB_CONSOLE_ENABLED='true'" > "${app_dir}/config/.env"
+output="$(run_config_bot "${app_dir}" --disable)"
+[[ "${output}" == *"http://127.0.0.1:9988/console/"* ]]
+
+app_dir="$(new_fixture console-disabled)"
+printf '%s\n' "WEB_CONSOLE_ENABLED='false'" > "${app_dir}/config/.env"
+output="$(run_config_bot "${app_dir}" --disable)"
+[[ "${output}" != *"/console/"* ]]
+
 echo "qbot config regression tests passed"

--- a/scripts/test-qbot-install.sh
+++ b/scripts/test-qbot-install.sh
@@ -59,7 +59,12 @@ release_dir="$(download_release v9.9.9 linux-x86_64 "${output}")"
 
 APP_DIR="${tmp_dir}/installed"
 mkdir -p "${APP_DIR}/config" "${APP_DIR}/data/storage" "${APP_DIR}/logs" "${APP_DIR}/run"
-printf 'PRIVATE=keep\n' > "${APP_DIR}/config/.env"
+printf '%s\n' \
+    'PRIVATE=keep' \
+    'LLM_MODEL=openai:legacy-model' \
+    ' export TOOL_CALLING_ENABLED = true' \
+    'TODO_MODEL=legacy-todo-model' \
+    'QWEATHER_API_KEY=' > "${APP_DIR}/config/.env"
 printf 'db\n' > "${APP_DIR}/data/storage/app.db"
 printf 'log\n' > "${APP_DIR}/logs/qq-maid-bot.log"
 printf '123\n' > "${APP_DIR}/run/qq-maid-bot.pid"
@@ -78,6 +83,11 @@ copy_release_into_app "${release_dir}" v9.9.9
 [[ -x "${APP_DIR}/botctl.sh" ]]
 [[ -f "${APP_DIR}/config/.env.example" ]]
 grep -Fqx 'PRIVATE=keep' "${APP_DIR}/config/.env"
+grep -Fqx 'QWEATHER_API_KEY=' "${APP_DIR}/config/.env"
+! grep -Eq '^[[:space:]]*(export[[:space:]]+)?(LLM_MODEL|TOOL_CALLING_ENABLED|TODO_MODEL)[[:space:]]*=' "${APP_DIR}/config/.env"
+backup_files=("${APP_DIR}"/config/.env.bak.v0.20.*)
+[[ "${#backup_files[@]}" -eq 1 ]]
+grep -Fqx 'LLM_MODEL=openai:legacy-model' "${backup_files[0]}"
 grep -Fqx 'db' "${APP_DIR}/data/storage/app.db"
 grep -Fqx 'log' "${APP_DIR}/logs/qq-maid-bot.log"
 grep -Fqx '123' "${APP_DIR}/run/qq-maid-bot.pid"

--- a/scripts/test-windows-powershell-botctl.ps1
+++ b/scripts/test-windows-powershell-botctl.ps1
@@ -21,6 +21,10 @@ Copy-Item -LiteralPath (Join-Path $repoDir "scripts\botctl.cmd") -Destination (J
 Copy-Item -LiteralPath $NativeBinary -Destination (Join-Path $runtimeDir "qq-maid-bot.exe")
 
 $oldRuntimeDir = $env:QQ_MAID_RUNTIME_DIR
+$oldServerUrl = $env:LLM_SERVER_URL
+$oldServerHost = $env:LLM_SERVER_HOST
+$oldServerPort = $env:LLM_SERVER_PORT
+$oldConsoleEnabled = $env:WEB_CONSOLE_ENABLED
 try {
     $env:QQ_MAID_RUNTIME_DIR = $runtimeDir
     $startOutput = (& $ctl start) -join "`n"
@@ -39,6 +43,44 @@ try {
     Assert-True ($null -eq (Get-Process -Id $botPid -ErrorAction SilentlyContinue)) "bot process is still running"
     Assert-True (-not (Test-Path -LiteralPath $pidFile)) "pid file was not removed"
 
+    $secretsDir = Join-Path $runtimeDir "config\secrets"
+    $tokenFile = Join-Path $secretsDir "bootstrap.token"
+    $envFile = Join-Path $runtimeDir "config\.env"
+    New-Item -ItemType Directory -Path $secretsDir -Force | Out-Null
+
+    Set-Content -LiteralPath $envFile -Value @("LLM_SERVER_PORT=9988", "WEB_CONSOLE_ENABLED=true") -Encoding ASCII
+    Set-Content -LiteralPath $tokenFile -Value "qq-maid-bootstrap-v1:1:initialize-secret" -Encoding ASCII
+    $guideOutput = (& $ctl start) -join "`n"
+    Assert-True ($guideOutput.Contains("--- 首次配置 ---")) "initialize guidance is missing"
+    Assert-True ($guideOutput.Contains("http://127.0.0.1:9988/console/")) "custom console port was ignored"
+    Assert-True (-not $guideOutput.Contains("initialize-secret")) "initialize token leaked"
+    & $ctl stop | Out-Null
+
+    Set-Content -LiteralPath $tokenFile -Value "qq-maid-password-reset-v1:2:reset-secret" -Encoding ASCII
+    $guideOutput = (& $ctl start) -join "`n"
+    Assert-True ($guideOutput.Contains("--- 密码重置待完成 ---")) "password reset guidance is missing"
+    Assert-True (-not $guideOutput.Contains("--- 首次配置 ---")) "password reset used initialize guidance"
+    Assert-True (-not $guideOutput.Contains("reset-secret")) "password reset token leaked"
+    & $ctl stop | Out-Null
+
+    Set-Content -LiteralPath $tokenFile -Value @(
+        "qq-maid-bootstrap-v1:3:must-not-leak",
+        "unexpected-extra-line"
+    ) -Encoding ASCII
+    $guideOutput = (& $ctl start) -join "`n"
+    Assert-True (-not $guideOutput.Contains("首次配置")) "invalid token used initialize guidance"
+    Assert-True (-not $guideOutput.Contains("密码重置")) "invalid token used reset guidance"
+    Assert-True (-not $guideOutput.Contains("must-not-leak")) "invalid token content leaked"
+    & $ctl stop | Out-Null
+
+    Set-Content -LiteralPath $envFile -Value "WEB_CONSOLE_ENABLED=false" -Encoding ASCII
+    Set-Content -LiteralPath $tokenFile -Value "qq-maid-bootstrap-v1:4:disabled-secret" -Encoding ASCII
+    $guideOutput = (& $ctl start) -join "`n"
+    Assert-True (-not $guideOutput.Contains("首次配置")) "disabled console printed initialize guidance"
+    Assert-True (-not $guideOutput.Contains("/console/")) "disabled console printed a URL"
+    Assert-True (-not $guideOutput.Contains("disabled-secret")) "disabled token leaked"
+    & $ctl stop | Out-Null
+
     $helpOutput = (& (Join-Path $runtimeDir "botctl.cmd") help) -join "`n"
     Assert-True ($helpOutput.Contains("Usage: botctl.cmd")) "cmd wrapper did not invoke PowerShell controller"
     Write-Output "PowerShell botctl smoke test passed"
@@ -47,5 +89,9 @@ try {
         & $ctl stop 2>$null | Out-Null
     }
     $env:QQ_MAID_RUNTIME_DIR = $oldRuntimeDir
+    $env:LLM_SERVER_URL = $oldServerUrl
+    $env:LLM_SERVER_HOST = $oldServerHost
+    $env:LLM_SERVER_PORT = $oldServerPort
+    $env:WEB_CONSOLE_ENABLED = $oldConsoleEnabled
     Remove-Item -LiteralPath $runtimeDir -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/scripts/test-windows-powershell-botctl.ps1
+++ b/scripts/test-windows-powershell-botctl.ps1
@@ -48,12 +48,26 @@ try {
     $envFile = Join-Path $runtimeDir "config\.env"
     New-Item -ItemType Directory -Path $secretsDir -Force | Out-Null
 
-    Set-Content -LiteralPath $envFile -Value @("LLM_SERVER_PORT=9988", "WEB_CONSOLE_ENABLED=true") -Encoding ASCII
+    Set-Content -LiteralPath $envFile -Value @(
+        "LLM_SERVER_PORT=9988",
+        "WEB_CONSOLE_ENABLED=true",
+        "LLM_MODEL=openai:legacy-model",
+        " export TOOL_CALLING_ENABLED = true",
+        "QWEATHER_API_KEY="
+    ) -Encoding ASCII
     Set-Content -LiteralPath $tokenFile -Value "qq-maid-bootstrap-v1:1:initialize-secret" -Encoding ASCII
     $guideOutput = (& $ctl start) -join "`n"
     Assert-True ($guideOutput.Contains("--- 首次配置 ---")) "initialize guidance is missing"
     Assert-True ($guideOutput.Contains("http://127.0.0.1:9988/console/")) "custom console port was ignored"
     Assert-True (-not $guideOutput.Contains("initialize-secret")) "initialize token leaked"
+    Assert-True (-not $guideOutput.Contains("legacy-model")) "obsolete config value leaked"
+    $migratedEnv = Get-Content -LiteralPath $envFile -Raw
+    Assert-True ($migratedEnv.Contains("QWEATHER_API_KEY=")) "empty weather key was removed"
+    Assert-True (-not $migratedEnv.Contains("LLM_MODEL=")) "legacy model key was not removed"
+    Assert-True (-not $migratedEnv.Contains("TOOL_CALLING_ENABLED")) "legacy tool key was not removed"
+    $envBackups = @(Get-ChildItem -LiteralPath (Join-Path $runtimeDir "config") -Filter ".env.bak.v0.20.*")
+    Assert-True ($envBackups.Count -eq 1) "pre-upgrade env backup was not created exactly once"
+    Assert-True ((Get-Content -LiteralPath $envBackups[0].FullName -Raw).Contains("LLM_MODEL=openai:legacy-model")) "env backup lost legacy values"
     & $ctl stop | Out-Null
 
     Set-Content -LiteralPath $tokenFile -Value "qq-maid-password-reset-v1:2:reset-secret" -Encoding ASCII

--- a/scripts/test-windows-powershell-botctl.ps1
+++ b/scripts/test-windows-powershell-botctl.ps1
@@ -1,4 +1,4 @@
-param(
+﻿param(
     [Parameter(Mandatory = $true)][string]$NativeBinary
 )
 

--- a/scripts/test-windows-qbot.ps1
+++ b/scripts/test-windows-qbot.ps1
@@ -1,4 +1,4 @@
-$ErrorActionPreference = "Stop"
+﻿$ErrorActionPreference = "Stop"
 $repoDir = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
 $testRoot = Join-Path ([IO.Path]::GetTempPath()) ("qq-maid-qbot-" + [Guid]::NewGuid())
 $appDir = Join-Path $testRoot "app"

--- a/scripts/test-windows-qbot.ps1
+++ b/scripts/test-windows-qbot.ps1
@@ -4,6 +4,10 @@ $testRoot = Join-Path ([IO.Path]::GetTempPath()) ("qq-maid-qbot-" + [Guid]::NewG
 $appDir = Join-Path $testRoot "app"
 $releaseDir = Join-Path $testRoot "release"
 $oldAppDir = $env:QBOT_APP_DIR
+$oldServerUrl = $env:LLM_SERVER_URL
+$oldServerHost = $env:LLM_SERVER_HOST
+$oldServerPort = $env:LLM_SERVER_PORT
+$oldConsoleEnabled = $env:WEB_CONSOLE_ENABLED
 
 function Assert-True {
     param([bool]$Condition, [string]$Message)
@@ -14,6 +18,10 @@ function Assert-True {
 
 try {
     $env:QBOT_APP_DIR = $appDir
+    $env:LLM_SERVER_URL = $null
+    $env:LLM_SERVER_HOST = $null
+    $env:LLM_SERVER_PORT = $null
+    $env:WEB_CONSOLE_ENABLED = $null
     . (Join-Path $repoDir "scripts\qbot.ps1")
 
     Assert-True (Test-SupportedWindowsArchitecture "AMD64") "Windows AMD64 should be supported"
@@ -87,6 +95,16 @@ try {
     Assert-True ($values["QQ_BOT_APP_ID"] -eq "123") "config bot did not write app id"
     Assert-True ($values["QQ_CHANNEL_ENABLED"] -eq "true") "config bot did not enable the channel"
 
+    Set-Content -LiteralPath (Join-Path $appDir "config\.env") -Value @(
+        "LLM_SERVER_PORT=9988",
+        "WEB_CONSOLE_ENABLED=true"
+    ) -Encoding ASCII
+    $consoleHint = (Write-ConsoleConfigHint) -join "`n"
+    Assert-True ($consoleHint.Contains("http://127.0.0.1:9988/console/")) "qbot ignored custom console port"
+    Set-Content -LiteralPath (Join-Path $appDir "config\.env") -Value "WEB_CONSOLE_ENABLED=false" -Encoding ASCII
+    $consoleHint = (Write-ConsoleConfigHint) -join "`n"
+    Assert-True ([string]::IsNullOrEmpty($consoleHint)) "qbot printed a hint while console was disabled"
+
     $archive = Join-Path $testRoot "fixture.zip"
     $checksum = "${archive}.sha256"
     Set-Content -LiteralPath $archive -Value "fixture" -Encoding ASCII
@@ -97,5 +115,9 @@ try {
     Write-Output "PowerShell qbot regression tests passed"
 } finally {
     $env:QBOT_APP_DIR = $oldAppDir
+    $env:LLM_SERVER_URL = $oldServerUrl
+    $env:LLM_SERVER_HOST = $oldServerHost
+    $env:LLM_SERVER_PORT = $oldServerPort
+    $env:WEB_CONSOLE_ENABLED = $oldConsoleEnabled
     Remove-Item -LiteralPath $testRoot -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/scripts/test-windows-qbot.ps1
+++ b/scripts/test-windows-qbot.ps1
@@ -56,14 +56,28 @@ try {
     New-Item -ItemType Directory -Path (Join-Path $appDir "config") -Force | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $appDir "data\storage") -Force | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $appDir "logs") -Force | Out-Null
-    Set-Content -LiteralPath (Join-Path $appDir "config\.env") -Value "PRIVATE=keep" -Encoding ASCII
+    Set-Content -LiteralPath (Join-Path $appDir "config\.env") -Value @(
+        "PRIVATE=keep",
+        "LLM_MODEL=openai:legacy-model",
+        " export TOOL_CALLING_ENABLED = true",
+        "TODO_MODEL=legacy-todo-model",
+        "QWEATHER_API_KEY="
+    ) -Encoding ASCII
     Set-Content -LiteralPath (Join-Path $appDir "config\agent.toml") -Value "custom-agent" -Encoding ASCII
     Set-Content -LiteralPath (Join-Path $appDir "data\storage\app.db") -Value "db" -Encoding ASCII
     Set-Content -LiteralPath (Join-Path $appDir "logs\qq-maid-bot.log") -Value "log" -Encoding ASCII
     Set-Content -LiteralPath (Join-Path $appDir "botctl.sh") -Value "obsolete" -Encoding ASCII
 
     Install-ReleasePayload -ReleaseDir $releaseDir -Version "v9.9.9"
-    Assert-True ((Get-Content -LiteralPath (Join-Path $appDir "config\.env") -Raw).Contains("PRIVATE=keep")) "private config was overwritten"
+    $migratedEnv = Get-Content -LiteralPath (Join-Path $appDir "config\.env") -Raw
+    Assert-True ($migratedEnv.Contains("PRIVATE=keep")) "private config was overwritten"
+    Assert-True ($migratedEnv.Contains("QWEATHER_API_KEY=")) "empty weather key was removed"
+    Assert-True (-not $migratedEnv.Contains("LLM_MODEL=")) "legacy model key was not removed"
+    Assert-True (-not $migratedEnv.Contains("TOOL_CALLING_ENABLED")) "legacy tool key was not removed"
+    Assert-True (-not $migratedEnv.Contains("TODO_MODEL=")) "legacy todo key was not removed"
+    $envBackups = @(Get-ChildItem -LiteralPath (Join-Path $appDir "config") -Filter ".env.bak.v0.20.*")
+    Assert-True ($envBackups.Count -eq 1) "pre-upgrade env backup was not created exactly once"
+    Assert-True ((Get-Content -LiteralPath $envBackups[0].FullName -Raw).Contains("LLM_MODEL=openai:legacy-model")) "env backup lost legacy values"
     Assert-True ((Get-Content -LiteralPath (Join-Path $appDir "data\storage\app.db") -Raw).Contains("db")) "database was overwritten"
     Assert-True ((Get-Content -LiteralPath (Join-Path $appDir "logs\qq-maid-bot.log") -Raw).Contains("log")) "log was overwritten"
     Assert-True (Test-Path -LiteralPath (Join-Path $appDir "config\agent.toml.release-v9.9.9")) "agent.toml update candidate is missing"


### PR DESCRIPTION
## 变更摘要

- **CHANGELOG**：新增 `v0.20.0` 版本记录，涵盖安全配置中心（#514）、部署管理员初始化与配置控制台（#520）、配置优先级变更。
- **README**：`v0.20 主线` -> `v0.20.0` 正式版，补充配置方式变更说明和 `/console/` 控制台引导。
- **Cargo.toml**：版本号从 `0.19.0` 提升到 `0.20.0`。
- **qbot.sh / qbot.ps1**：`start` 后检测 bootstrap.token 并打印控制台引导；`config` 写完后提示可用 `/console/`。
- **botctl.sh / botctl.ps1**：`start` 成功后检测未完成配置并引导至网页。
- **Wiki 同步**：
  - 配置中心.md：修正优先级模型（受管优先，不再写环境强制覆盖）；补充忘记密码重置、SECURE_COOKIES 说明。
  - 安装手册.md：微信入口补充 AES 安全模式；移除 "进程环境仍可强制覆盖" 误导表述。
  - 使用说明.md：微信描述从"只支持明文"改为明文/AES；新增 Session Dream 小节。
- 新增 `scripts/prepare_project_docs_kb.sh`：Wiki + CHANGELOG 生成知识库脚本。

## 检查

- `cargo fmt --all -- --check` ✓
- `cargo check --workspace` ✓
- `bash -n` 三个脚本 ✓