### PR TITLE
[codex] 更新时提示替换 Agent 配置

### DIFF
--- a/scripts/qbot.ps1
+++ b/scripts/qbot.ps1
@@ -344,17 +344,113 @@ function Remove-ObsoleteEnvConfig {
     Write-Output "Remove the same keys manually if systemd, Docker, or the host environment still injects them."
 }
 
+function Get-NextAgentConfigBackupPath {
+    param([Parameter(Mandatory = $true)][string]$ConfigFile)
+    $candidate = "${ConfigFile}.old"
+    $suffix = 0
+    while (Test-Path -LiteralPath $candidate) {
+        $suffix++
+        $candidate = "${ConfigFile}.old.${suffix}"
+    }
+    return $candidate
+}
+
+function Replace-AgentConfigFromRelease {
+    param(
+        [Parameter(Mandatory = $true)][string]$ConfigFile,
+        [Parameter(Mandatory = $true)][string]$TemplateFile
+    )
+    if (-not (Test-Path -LiteralPath $ConfigFile -PathType Leaf)) {
+        throw "Agent config replacement failed: existing file not found: $ConfigFile"
+    }
+    if ((Get-Item -LiteralPath $ConfigFile -Force).LinkType) {
+        throw "Agent config replacement failed: symbolic links are not replaced automatically: $ConfigFile"
+    }
+    if (-not (Test-Path -LiteralPath $TemplateFile -PathType Leaf)) {
+        throw "Agent config replacement failed: Release template not found: $TemplateFile"
+    }
+
+    $directory = Split-Path -Parent $ConfigFile
+    $tempFile = Join-Path $directory (".agent.toml.new." + [Guid]::NewGuid().ToString("N"))
+    $backup = Get-NextAgentConfigBackupPath -ConfigFile $ConfigFile
+    $backupCreated = $false
+    try {
+        Copy-Item -LiteralPath $TemplateFile -Destination $tempFile
+        $templateHash = (Get-FileHash -LiteralPath $TemplateFile -Algorithm SHA256).Hash
+        $tempHash = (Get-FileHash -LiteralPath $tempFile -Algorithm SHA256).Hash
+        if ($templateHash -ne $tempHash) {
+            throw "the new template could not be written completely"
+        }
+
+        Move-Item -LiteralPath $ConfigFile -Destination $backup
+        $backupCreated = $true
+        Move-Item -LiteralPath $tempFile -Destination $ConfigFile
+    } catch {
+        $reason = $_.Exception.Message
+        if ($backupCreated -and -not (Test-Path -LiteralPath $ConfigFile)) {
+            try {
+                Move-Item -LiteralPath $backup -Destination $ConfigFile
+                $backupCreated = $false
+                throw "Agent config replacement failed: $reason; the original file was restored"
+            } catch {
+                if ($backupCreated) {
+                    throw "Agent config replacement failed: $reason; automatic restore failed and the original file remains at $backup"
+                }
+                throw
+            }
+        }
+        throw "Agent config replacement failed: $reason; the original file was not modified"
+    } finally {
+        Remove-Item -LiteralPath $tempFile -Force -ErrorAction SilentlyContinue
+    }
+
+    Write-Output "已使用当前 Release 的新版默认配置替换 agent.toml"
+    Write-Output "旧配置备份: $backup"
+    Write-Output "请参考备份重新填写 Provider、模型路线、Scene 和工具白名单等自定义配置。"
+}
+
+function Request-AgentConfigReplacement {
+    param(
+        [Parameter(Mandatory = $true)][string]$ConfigFile,
+        [Parameter(Mandatory = $true)][string]$TemplateFile,
+        [AllowEmptyString()][string]$Response,
+        [switch]$NonInteractive
+    )
+    if (-not (Test-Path -LiteralPath $ConfigFile)) {
+        return
+    }
+
+    Write-Output "检测到现有 agent.toml，当前版本的配置结构可能已更新。"
+    $responseProvided = $PSBoundParameters.ContainsKey("Response")
+    $inputRedirected = $false
+    try {
+        $inputRedirected = [Console]::IsInputRedirected
+    } catch {
+        $inputRedirected = $true
+    }
+
+    if (-not $responseProvided -and
+        ($NonInteractive -or -not [Environment]::UserInteractive -or $inputRedirected)) {
+        Write-Output "当前为非交互环境，默认保留现有 agent.toml。"
+        Write-Output "旧配置可能不兼容；请手工检查，或在交互终端重新运行 qbot update。"
+        return
+    }
+    if (-not $responseProvided) {
+        $Response = Read-Host "是否使用新版默认配置替换？原文件将备份为 agent.toml.old。[y/N]"
+    }
+    if ($Response -notin @("y", "Y")) {
+        Write-Output "已保留现有 agent.toml；旧配置可能不兼容，请自行检查。"
+        return
+    }
+
+    Replace-AgentConfigFromRelease -ConfigFile $ConfigFile -TemplateFile $TemplateFile
+}
+
 function Install-OrUpdate {
     param([string]$Mode, [string]$RequestedVersion)
     Assert-SupportedWindowsArchitecture (Get-WindowsOperatingSystemArchitecture)
     $version = Resolve-Version $RequestedVersion
     $current = Get-LocalVersion
-    if ($Mode -eq "update" -and $null -ne $current -and (Normalize-Version $current) -eq $version) {
-        Remove-ObsoleteEnvConfig -ConfigFile (Join-Path $script:AppDir "config\.env")
-        Write-Output "already installed: $current"
-        return
-    }
-
     $package = "qq-maid-bot-${version}-windows-x86_64"
     $archiveName = "${package}.zip"
     $tempDir = Join-Path ([IO.Path]::GetTempPath()) ("qbot-install-" + [Guid]::NewGuid())
@@ -369,6 +465,16 @@ function Install-OrUpdate {
         Test-ReleaseChecksum -Archive $archive -ChecksumFile $checksum
         Expand-Archive -LiteralPath $archive -DestinationPath $tempDir -Force
         $releaseDir = Join-Path $tempDir $package
+
+        Request-AgentConfigReplacement `
+            -ConfigFile (Join-Path $script:AppDir "config\agent.toml") `
+            -TemplateFile (Join-Path $releaseDir "config\agent.toml")
+
+        if ($Mode -eq "update" -and $null -ne $current -and (Normalize-Version $current) -eq $version) {
+            Remove-ObsoleteEnvConfig -ConfigFile (Join-Path $script:AppDir "config\.env")
+            Write-Output "already installed: $current"
+            return
+        }
 
         $wasRunning = Test-InstalledBotRunning
         if ($wasRunning) {

--- a/scripts/qbot.sh
+++ b/scripts/qbot.sh
@@ -645,6 +645,109 @@ migrate_obsolete_env_config() {
     echo "如 systemd、Docker 或宿主环境仍注入同名变量，请同步人工移除。"
 }
 
+next_agent_config_backup() {
+    local file="$1"
+    local candidate="${file}.old"
+    local suffix=0
+
+    while [[ -e "${candidate}" || -L "${candidate}" ]]; do
+        suffix=$((suffix + 1))
+        candidate="${file}.old.${suffix}"
+    done
+    echo "${candidate}"
+}
+
+replace_agent_config_from_release() {
+    local file="$1"
+    local template="$2"
+    local dir tmp backup owner group mode
+
+    [[ -f "${file}" ]] || {
+        ui_fail "Agent 配置替换失败：现有文件不存在: ${file}"
+        return 1
+    }
+    [[ ! -L "${file}" ]] || {
+        ui_fail "Agent 配置替换失败：不自动替换符号链接: ${file}"
+        return 1
+    }
+    [[ -f "${template}" ]] || {
+        ui_fail "Agent 配置替换失败：Release 模板不存在: ${template}"
+        return 1
+    }
+
+    dir="$(dirname -- "${file}")"
+    if ! tmp="$(mktemp "${dir}/.agent.toml.new.XXXXXX")"; then
+        ui_fail "Agent 配置替换失败：无法在 ${dir} 创建临时文件"
+        return 1
+    fi
+    if ! cp -- "${template}" "${tmp}" || ! cmp -s -- "${template}" "${tmp}"; then
+        rm -f -- "${tmp}"
+        ui_fail "Agent 配置替换失败：无法完整写入新版模板；原文件未修改"
+        return 1
+    fi
+
+    owner="$(stat -c '%u' "${file}" 2>/dev/null || true)"
+    group="$(stat -c '%g' "${file}" 2>/dev/null || true)"
+    mode="$(stat -c '%a' "${file}" 2>/dev/null || true)"
+    if [[ -n "${owner}" && -n "${group}" ]]; then
+        chown "${owner}:${group}" "${tmp}" 2>/dev/null || true
+    fi
+    if [[ -n "${mode}" ]]; then
+        chmod "${mode}" "${tmp}" 2>/dev/null || true
+    fi
+
+    backup="$(next_agent_config_backup "${file}")"
+    if ! mv -- "${file}" "${backup}"; then
+        rm -f -- "${tmp}"
+        ui_fail "Agent 配置替换失败：无法备份原文件；原文件未修改"
+        return 1
+    fi
+    if ! mv -- "${tmp}" "${file}"; then
+        rm -f -- "${tmp}"
+        if [[ ! -e "${file}" && ! -L "${file}" ]] && mv -- "${backup}" "${file}"; then
+            ui_fail "Agent 配置替换失败：新版模板未生效，已恢复原文件"
+        else
+            ui_fail "Agent 配置替换失败且无法自动恢复；原文件保留在: ${backup}"
+        fi
+        return 1
+    fi
+
+    echo "已使用当前 Release 的新版默认配置替换 agent.toml"
+    echo "旧配置备份: ${backup}"
+    echo "请参考备份重新填写 Provider、模型路线、Scene 和工具白名单等自定义配置。"
+}
+
+prompt_agent_config_replacement() {
+    local file="$1"
+    local template="$2"
+    local reply=""
+    local reply_provided=0
+
+    [[ -f "${file}" || -L "${file}" ]] || return 0
+    echo "检测到现有 agent.toml，当前版本的配置结构可能已更新。"
+
+    # 第三个参数只供脚本回归测试注入回答；真实更新必须来自交互终端。
+    if (($# >= 3)); then
+        reply="${3}"
+        reply_provided=1
+    elif [[ -t 0 ]]; then
+        read -r -p "是否使用新版默认配置替换？原文件将备份为 agent.toml.old。[y/N] " reply || reply=""
+        reply_provided=1
+    fi
+
+    if ((reply_provided == 0)); then
+        echo "当前为非交互环境，默认保留现有 agent.toml。"
+        echo "旧配置可能不兼容；请手工检查，或在交互终端重新运行 qbot update。"
+        return 0
+    fi
+    if [[ "${reply}" != "y" && "${reply}" != "Y" ]]; then
+        echo "已保留现有 agent.toml；旧配置可能不兼容，请自行检查。"
+        return 0
+    fi
+
+    replace_agent_config_from_release "${file}" "${template}"
+}
+
 get_env_var() {
     local key="$1"
     local file
@@ -1895,16 +1998,22 @@ install_or_update() {
     version="$(resolve_version "${requested_version}")"
     current="$(local_version 2>/dev/null || true)"
 
-    if [[ "${command_name}" == "update" && -n "${current}" && "$(normalize_version "${current}")" == "${version}" ]]; then
-        migrate_obsolete_env_config
-        echo "当前已是目标版本: ${current}"
-        return 0
-    fi
-
     tmp_dir="$(mktemp -d)"
     TMP_DIR_TO_CLEAN="${tmp_dir}"
 
     release_dir="$(download_release "${version}" "${target}" "${tmp_dir}")"
+
+    prompt_agent_config_replacement \
+        "${APP_DIR}/config/agent.toml" \
+        "${release_dir}/config/agent.toml" || die "替换 agent.toml 失败，已停止本次更新"
+
+    if [[ "${command_name}" == "update" && -n "${current}" && "$(normalize_version "${current}")" == "${version}" ]]; then
+        migrate_obsolete_env_config
+        rm -rf "${tmp_dir}"
+        TMP_DIR_TO_CLEAN=""
+        echo "当前已是目标版本: ${current}"
+        return 0
+    fi
 
     was_running=0
     if is_qbot_running; then

--- a/scripts/test-qbot-install.sh
+++ b/scripts/test-qbot-install.sh
@@ -33,6 +33,68 @@ fi
 
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "${tmp_dir}"' EXIT
+
+agent_template="${tmp_dir}/agent-template.toml"
+printf '%s\n' 'version = 1' '[scenes.private]' 'enabled_tools = ["new_tool"]' > "${agent_template}"
+
+agent_yes="${tmp_dir}/agent-yes.toml"
+printf '%s\n' 'version = 1' 'custom = "keep-before-replacement"' > "${agent_yes}"
+output="$(prompt_agent_config_replacement "${agent_yes}" "${agent_template}" y)"
+cmp -s "${agent_yes}" "${agent_template}"
+grep -Fqx 'custom = "keep-before-replacement"' "${agent_yes}.old"
+[[ "${output}" == *"旧配置备份: ${agent_yes}.old"* ]]
+[[ "${output}" == *"Provider、模型路线、Scene 和工具白名单"* ]]
+
+for response in n ""; do
+    agent_keep="${tmp_dir}/agent-keep-${response:-empty}.toml"
+    printf '%s\n' 'version = 1' "custom = \"keep-${response:-empty}\"" > "${agent_keep}"
+    original_hash="$(sha256sum "${agent_keep}")"
+    output="$(prompt_agent_config_replacement "${agent_keep}" "${agent_template}" "${response}")"
+    [[ "$(sha256sum "${agent_keep}")" == "${original_hash}" ]]
+    [[ ! -e "${agent_keep}.old" ]]
+    [[ "${output}" == *"已保留现有 agent.toml"* ]]
+done
+
+agent_collision="${tmp_dir}/agent-collision.toml"
+printf '%s\n' 'current-old-config' > "${agent_collision}"
+printf '%s\n' 'earlier-backup' > "${agent_collision}.old"
+prompt_agent_config_replacement "${agent_collision}" "${agent_template}" y >/dev/null
+grep -Fqx 'earlier-backup' "${agent_collision}.old"
+grep -Fqx 'current-old-config' "${agent_collision}.old.1"
+cmp -s "${agent_collision}" "${agent_template}"
+
+agent_failure="${tmp_dir}/agent-failure.toml"
+printf '%s\n' 'original-must-survive' > "${agent_failure}"
+mv_calls=0
+# shellcheck disable=SC2317 # 测试通过同名函数模拟第二次 mv 失败。
+mv() {
+    mv_calls=$((mv_calls + 1))
+    if ((mv_calls == 2)); then
+        return 1
+    fi
+    command mv "$@"
+}
+set +e
+failure_output="$(replace_agent_config_from_release "${agent_failure}" "${agent_template}" 2>&1)"
+failure_status=$?
+set -e
+unset -f mv
+[[ "${failure_status}" -ne 0 ]]
+grep -Fqx 'original-must-survive' "${agent_failure}"
+[[ ! -e "${agent_failure}.old" ]]
+if compgen -G "${tmp_dir}/.agent.toml.new.*" >/dev/null; then
+    echo "agent replacement left a temporary file" >&2
+    exit 1
+fi
+[[ "${failure_output}" == *"已恢复原文件"* ]]
+
+agent_noninteractive="${tmp_dir}/agent-noninteractive.toml"
+printf '%s\n' 'noninteractive-must-stay' > "${agent_noninteractive}"
+output="$(prompt_agent_config_replacement "${agent_noninteractive}" "${agent_template}" < /dev/null)"
+grep -Fqx 'noninteractive-must-stay' "${agent_noninteractive}"
+[[ ! -e "${agent_noninteractive}.old" ]]
+[[ "${output}" == *"非交互环境，默认保留"* ]]
+
 fixture="${tmp_dir}/fixture"
 output="${tmp_dir}/output"
 package="qq-maid-bot-v9.9.9-linux-x86_64"

--- a/scripts/test-windows-qbot.ps1
+++ b/scripts/test-windows-qbot.ps1
@@ -53,6 +53,67 @@ try {
     Set-Content -LiteralPath (Join-Path $releaseDir "config\.env.example") -Value "EXAMPLE=1" -Encoding ASCII
     Set-Content -LiteralPath (Join-Path $releaseDir "config\agent.toml") -Value "release-agent" -Encoding ASCII
 
+    $agentTestDir = Join-Path $testRoot "agent-migration"
+    New-Item -ItemType Directory -Path $agentTestDir -Force | Out-Null
+    $agentTemplate = Join-Path $agentTestDir "template.toml"
+    Set-Content -LiteralPath $agentTemplate -Value "new-release-template" -Encoding ASCII
+
+    $agentYes = Join-Path $agentTestDir "yes.toml"
+    Set-Content -LiteralPath $agentYes -Value "custom-before-replacement" -Encoding ASCII
+    $yesOutput = (Request-AgentConfigReplacement -ConfigFile $agentYes -TemplateFile $agentTemplate -Response "y") -join "`n"
+    Assert-True ((Get-FileHash $agentYes).Hash -eq (Get-FileHash $agentTemplate).Hash) "y did not install the Release agent template"
+    Assert-True ((Get-Content -LiteralPath "${agentYes}.old" -Raw).Contains("custom-before-replacement")) "y did not preserve the old agent config"
+    Assert-True ($yesOutput.Contains("旧配置备份: ${agentYes}.old")) "y did not report the agent backup path"
+    Assert-True ($yesOutput.Contains("Provider、模型路线、Scene 和工具白名单")) "y did not report required custom configuration work"
+
+    foreach ($case in @(@{ Name = "no"; Response = "n" }, @{ Name = "empty"; Response = "" })) {
+        $agentKeep = Join-Path $agentTestDir ("keep-" + $case.Name + ".toml")
+        Set-Content -LiteralPath $agentKeep -Value ("keep-" + $case.Name) -Encoding ASCII
+        $beforeHash = (Get-FileHash -LiteralPath $agentKeep -Algorithm SHA256).Hash
+        $keepOutput = (Request-AgentConfigReplacement -ConfigFile $agentKeep -TemplateFile $agentTemplate -Response $case.Response) -join "`n"
+        Assert-True ((Get-FileHash -LiteralPath $agentKeep -Algorithm SHA256).Hash -eq $beforeHash) "$($case.Name) changed agent.toml"
+        Assert-True (-not (Test-Path -LiteralPath "${agentKeep}.old")) "$($case.Name) created an unexpected backup"
+        Assert-True ($keepOutput.Contains("已保留现有 agent.toml")) "$($case.Name) did not report that agent.toml was preserved"
+    }
+
+    $agentCollision = Join-Path $agentTestDir "collision.toml"
+    Set-Content -LiteralPath $agentCollision -Value "current-old-config" -Encoding ASCII
+    Set-Content -LiteralPath "${agentCollision}.old" -Value "earlier-backup" -Encoding ASCII
+    Request-AgentConfigReplacement -ConfigFile $agentCollision -TemplateFile $agentTemplate -Response "Y" | Out-Null
+    Assert-True ((Get-Content -LiteralPath "${agentCollision}.old" -Raw).Contains("earlier-backup")) "existing .old backup was overwritten"
+    Assert-True ((Get-Content -LiteralPath "${agentCollision}.old.1" -Raw).Contains("current-old-config")) "replacement did not use the next backup suffix"
+
+    $agentFailure = Join-Path $agentTestDir "failure.toml"
+    Set-Content -LiteralPath $agentFailure -Value "original-must-survive" -Encoding ASCII
+    $script:AgentMoveCalls = 0
+    function Move-Item {
+        param([string]$LiteralPath, [string]$Destination)
+        $script:AgentMoveCalls++
+        if ($script:AgentMoveCalls -eq 2) {
+            throw "simulated template activation failure"
+        }
+        Microsoft.PowerShell.Management\Move-Item -LiteralPath $LiteralPath -Destination $Destination
+    }
+    $replacementError = $null
+    try {
+        Replace-AgentConfigFromRelease -ConfigFile $agentFailure -TemplateFile $agentTemplate
+    } catch {
+        $replacementError = $_.Exception.Message
+    } finally {
+        Remove-Item Function:\Move-Item -ErrorAction SilentlyContinue
+    }
+    Assert-True ($null -ne $replacementError -and $replacementError.Contains("original file was restored")) "replacement failure was not reported with rollback"
+    Assert-True ((Get-Content -LiteralPath $agentFailure -Raw).Contains("original-must-survive")) "replacement failure did not restore agent.toml"
+    Assert-True (-not (Test-Path -LiteralPath "${agentFailure}.old")) "replacement failure left a misleading backup"
+    Assert-True (@(Get-ChildItem -LiteralPath $agentTestDir -Filter ".agent.toml.new.*").Count -eq 0) "replacement failure left a temporary file"
+
+    $agentNonInteractive = Join-Path $agentTestDir "noninteractive.toml"
+    Set-Content -LiteralPath $agentNonInteractive -Value "noninteractive-must-stay" -Encoding ASCII
+    $nonInteractiveOutput = (Request-AgentConfigReplacement -ConfigFile $agentNonInteractive -TemplateFile $agentTemplate -NonInteractive) -join "`n"
+    Assert-True ((Get-Content -LiteralPath $agentNonInteractive -Raw).Contains("noninteractive-must-stay")) "non-interactive update replaced agent.toml"
+    Assert-True (-not (Test-Path -LiteralPath "${agentNonInteractive}.old")) "non-interactive update created an unexpected backup"
+    Assert-True ($nonInteractiveOutput.Contains("非交互环境，默认保留")) "non-interactive update did not explain the default"
+
     New-Item -ItemType Directory -Path (Join-Path $appDir "config") -Force | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $appDir "data\storage") -Force | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $appDir "logs") -Force | Out-Null


### PR DESCRIPTION
## 背景

v0.19 的 `agent.toml` 可能缺少当前版本要求的 Scene 工具白名单，或引用已经不存在的搜索路线，升级后会导致 Agent 策略校验失败。更新脚本此前只保留旧文件，没有给出替换当前模板的入口。

## 修改

- Linux `qbot.sh` 和 Windows `qbot.ps1` 在更新发现现有 `agent.toml` 时询问是否使用当前 Release 模板替换。
- 仅明确输入 `y`/`Y` 才替换；拒绝、回车或非交互环境均保留旧文件并提示人工检查。
- 替换前把旧文件顺延备份为 `agent.toml.old`、`.old.1` 等，避免覆盖已有备份。
- 新模板先写入同目录临时文件并校验完整性；激活失败时恢复原配置并清理临时文件。
- 不解析或修改 TOML 字段，不修改 Rust Core 和 botctl。

## 验证

- `bash scripts/test-qbot-install.sh`
- `bash scripts/test-qbot-config.sh`
- `bash scripts/test-package-release.sh`
- `bash scripts/test-prepare-project-docs-kb.sh`
- `bash scripts/test-botctl-guidance.sh`
- `bash -n scripts/*.sh`
- PowerShell Parser 检查全部 `scripts/*.ps1`
- `powershell.exe -File scripts/test-windows-qbot.ps1`
- `shellcheck` 检查本次 Shell 文件，排除仓库既存的 SC1007/SC2015/SC2086/SC2128/SC2178/SC2251/SC2295 基线告警后通过
- `git diff --check`