### PR TITLE
feat(web): 增加工具白名单与重启入口

### DIFF
--- a/qq-maid-core/src/app/mod.rs
+++ b/qq-maid-core/src/app/mod.rs
@@ -9,7 +9,7 @@ use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 use crate::{
     config::{AppConfig, ManagementBootstrapConfig, center::ConfigCenter},
     http::console::ConsoleCoreSummary,
-    http::console::{DynConsoleStatusSource, EmptyConsoleStatusSource},
+    http::console::{ConsoleToolMetadata, DynConsoleStatusSource, EmptyConsoleStatusSource},
     http::routes::{OpsHttpState, build_router},
     management::AdminAuth,
     runtime::push::PushSink,
@@ -146,6 +146,14 @@ impl LlmRuntime {
     ) -> anyhow::Result<Self> {
         let addr: SocketAddr = format!("{}:{}", config.server_host, config.server_port).parse()?;
         let core_state = CoreRuntimeState::from_config_with_database(config, database)?;
+        let registered_tools = crate::service::CoreHandle::new(core_state.clone())
+            .registered_tool_metadata()
+            .into_iter()
+            .map(|tool| ConsoleToolMetadata {
+                name: tool.name,
+                description: tool.description,
+            })
+            .collect();
         let http_state = OpsHttpState::from_config_with_center(
             &core_state.config,
             core_state.provider.clone(),
@@ -154,7 +162,8 @@ impl LlmRuntime {
             application_version,
             config_center,
             admin_auth,
-        );
+        )
+        .with_registered_tools(registered_tools);
         let workers = CoreWorkers::from_runtime_state(&core_state, push_sink)?;
 
         Ok(Self {

--- a/qq-maid-core/src/config/center/tests.rs
+++ b/qq-maid-core/src/config/center/tests.rs
@@ -1007,8 +1007,10 @@ fn agent_scene_tool_calling_save_reloads_private_and_group_policy() {
     let (file, running, _database, path) = test_agent_file();
     let mut private = running.document().unwrap().scenes.private.clone();
     private.tool_calling_enabled = false;
+    private.enabled_tools = vec!["web_search".to_owned(), "save_memory".to_owned()];
     let mut group = running.document().unwrap().scenes.group.clone();
     group.tool_calling_enabled = true;
+    group.enabled_tools = vec!["knowledge_search".to_owned()];
     let initial = file.snapshot().unwrap();
 
     file.update(
@@ -1037,9 +1039,14 @@ fn agent_scene_tool_calling_save_reloads_private_and_group_policy() {
             .unwrap()
             .tool_calling_enabled
     );
+    assert_eq!(
+        reloaded.resolve(ChatScene::Private).unwrap().enabled_tools,
+        vec!["web_search", "save_memory"]
+    );
     let group = reloaded.resolve(ChatScene::Group).unwrap();
     assert!(group.tool_calling_enabled);
     assert!(group.group_tool_calling_enabled);
+    assert_eq!(group.enabled_tools, vec!["knowledge_search"]);
 }
 
 #[test]

--- a/qq-maid-core/src/http/console.rs
+++ b/qq-maid-core/src/http/console.rs
@@ -132,10 +132,12 @@ struct RestartCommand {
     program: PathBuf,
     args: Vec<String>,
     working_dir: PathBuf,
+    script_path: PathBuf,
+    pid_file: PathBuf,
 }
 
 impl ConsoleRestartController {
-    /// 仅在部署目录存在受控进程脚本时启用，避免裸运行二进制时误报“已重启”。
+    /// 保存受控部署路径；可用性必须动态检查，以兼容 botctl 启动后才写 PID 文件。
     pub fn from_current_dir() -> Self {
         let Ok(working_dir) = std::env::current_dir() else {
             return Self::default();
@@ -143,37 +145,36 @@ impl ConsoleRestartController {
         let pid_file = std::env::var_os("BOT_PID_FILE")
             .map(PathBuf::from)
             .unwrap_or_else(|| working_dir.join("run/qq-maid-bot.pid"));
-        let managed_pid = fs::read_to_string(pid_file)
-            .ok()
-            .and_then(|value| value.trim().parse::<u32>().ok());
-        if managed_pid != Some(std::process::id()) {
-            return Self::default();
-        }
+        let pid_file = if pid_file.is_absolute() {
+            pid_file
+        } else {
+            working_dir.join(pid_file)
+        };
         #[cfg(windows)]
-        let command = working_dir
-            .join("botctl.cmd")
-            .is_file()
-            .then(|| RestartCommand {
-                program: working_dir.join("botctl.cmd"),
-                args: vec!["restart".to_owned()],
-                working_dir,
-            });
+        let command = RestartCommand {
+            program: working_dir.join("botctl.cmd"),
+            args: vec!["restart".to_owned()],
+            script_path: working_dir.join("botctl.cmd"),
+            working_dir,
+            pid_file,
+        };
         #[cfg(not(windows))]
-        let command = working_dir
-            .join("botctl.sh")
-            .is_file()
-            .then(|| RestartCommand {
-                program: PathBuf::from("bash"),
-                args: vec!["botctl.sh".to_owned(), "restart".to_owned()],
-                working_dir,
-            });
+        let command = RestartCommand {
+            program: PathBuf::from("bash"),
+            args: vec!["botctl.sh".to_owned(), "restart".to_owned()],
+            script_path: working_dir.join("botctl.sh"),
+            working_dir,
+            pid_file,
+        };
         Self {
-            command: command.map(Arc::new),
+            command: Some(Arc::new(command)),
         }
     }
 
     pub fn available(&self) -> bool {
-        self.command.is_some()
+        self.command
+            .as_deref()
+            .is_some_and(RestartCommand::available)
     }
 
     /// 先让当前请求完成，再交给部署脚本执行优雅停止和拉起。
@@ -181,6 +182,10 @@ impl ConsoleRestartController {
         let Some(command) = self.command.clone() else {
             return Err("当前运行目录没有可用的 botctl 重启脚本");
         };
+        // available() 之后 PID 文件仍可能被替换，提交异步任务前必须再次验证。
+        if !command.available() {
+            return Err("当前进程不满足受控 botctl 重启条件");
+        }
         tokio::spawn(async move {
             sleep(Duration::from_millis(500)).await;
             let result = Command::new(&command.program)
@@ -195,6 +200,18 @@ impl ConsoleRestartController {
             }
         });
         Ok(())
+    }
+}
+
+impl RestartCommand {
+    fn available(&self) -> bool {
+        if !self.script_path.is_file() {
+            return false;
+        }
+        fs::read_to_string(&self.pid_file)
+            .ok()
+            .and_then(|value| value.trim().parse::<u32>().ok())
+            == Some(std::process::id())
     }
 }
 
@@ -400,6 +417,27 @@ mod tests {
         std::env::temp_dir().join(format!("qq-maid-console-{name}-{nonce}"))
     }
 
+    fn test_restart_controller(directory: &Path) -> ConsoleRestartController {
+        ConsoleRestartController {
+            command: Some(Arc::new(RestartCommand {
+                program: PathBuf::from("unused-in-test"),
+                args: Vec::new(),
+                working_dir: directory.to_owned(),
+                script_path: directory.join("botctl.test"),
+                pid_file: directory.join("qq-maid-bot.pid"),
+            })),
+        }
+    }
+
+    fn different_pid() -> u32 {
+        let current = std::process::id();
+        if current == u32::MAX {
+            current - 1
+        } else {
+            current + 1
+        }
+    }
+
     #[test]
     fn absolute_storage_path_only_exposes_filename() {
         assert_eq!(
@@ -490,5 +528,63 @@ mod tests {
                 .contains(file.to_string_lossy().as_ref())
         );
         fs::remove_file(file).unwrap();
+    }
+
+    #[test]
+    fn restart_availability_recovers_after_pid_file_is_written() {
+        let directory = test_path("restart-late-pid");
+        fs::create_dir(&directory).unwrap();
+        fs::write(directory.join("botctl.test"), b"test").unwrap();
+        let controller = test_restart_controller(&directory);
+
+        assert!(!controller.available());
+        fs::write(
+            directory.join("qq-maid-bot.pid"),
+            std::process::id().to_string(),
+        )
+        .unwrap();
+        assert!(controller.available());
+
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn restart_rejects_mismatched_invalid_pid_and_missing_script() {
+        let directory = test_path("restart-invalid-state");
+        fs::create_dir(&directory).unwrap();
+        let script = directory.join("botctl.test");
+        let pid_file = directory.join("qq-maid-bot.pid");
+        fs::write(&script, b"test").unwrap();
+        let controller = test_restart_controller(&directory);
+
+        fs::write(&pid_file, different_pid().to_string()).unwrap();
+        assert!(!controller.available());
+        fs::write(&pid_file, "not-a-pid").unwrap();
+        assert!(!controller.available());
+        fs::write(&pid_file, std::process::id().to_string()).unwrap();
+        assert!(controller.available());
+        fs::remove_file(script).unwrap();
+        assert!(!controller.available());
+
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[tokio::test]
+    async fn restart_schedule_rechecks_pid_after_available_result() {
+        let directory = test_path("restart-schedule-recheck");
+        fs::create_dir(&directory).unwrap();
+        fs::write(directory.join("botctl.test"), b"test").unwrap();
+        let pid_file = directory.join("qq-maid-bot.pid");
+        fs::write(&pid_file, std::process::id().to_string()).unwrap();
+        let controller = test_restart_controller(&directory);
+
+        assert!(controller.available());
+        fs::write(pid_file, different_pid().to_string()).unwrap();
+        assert_eq!(
+            controller.schedule(),
+            Err("当前进程不满足受控 botctl 重启条件")
+        );
+
+        fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/qq-maid-core/src/http/console.rs
+++ b/qq-maid-core/src/http/console.rs
@@ -6,13 +6,17 @@
 use std::{
     fs::{self, File},
     io::ErrorKind,
-    path::Path,
+    path::{Path, PathBuf},
     sync::Arc,
     time::Instant,
 };
 
 use qq_maid_common::time_context::now_unix_seconds_marker;
 use serde::Serialize;
+use tokio::{
+    process::Command,
+    time::{Duration, sleep},
+};
 
 use crate::{config::AppConfig, storage::APP_MIGRATIONS};
 
@@ -110,6 +114,89 @@ impl ConsoleStatusSource for EmptyConsoleStatusSource {
 }
 
 pub type DynConsoleStatusSource = Arc<dyn ConsoleStatusSource>;
+
+/// Web 控制台展示的实际 Core Tool 注册信息；不包含参数 schema 或运行时上下文。
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ConsoleToolMetadata {
+    pub name: String,
+    pub description: String,
+}
+
+#[derive(Clone, Default)]
+pub struct ConsoleRestartController {
+    command: Option<Arc<RestartCommand>>,
+}
+
+#[derive(Clone)]
+struct RestartCommand {
+    program: PathBuf,
+    args: Vec<String>,
+    working_dir: PathBuf,
+}
+
+impl ConsoleRestartController {
+    /// 仅在部署目录存在受控进程脚本时启用，避免裸运行二进制时误报“已重启”。
+    pub fn from_current_dir() -> Self {
+        let Ok(working_dir) = std::env::current_dir() else {
+            return Self::default();
+        };
+        let pid_file = std::env::var_os("BOT_PID_FILE")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| working_dir.join("run/qq-maid-bot.pid"));
+        let managed_pid = fs::read_to_string(pid_file)
+            .ok()
+            .and_then(|value| value.trim().parse::<u32>().ok());
+        if managed_pid != Some(std::process::id()) {
+            return Self::default();
+        }
+        #[cfg(windows)]
+        let command = working_dir
+            .join("botctl.cmd")
+            .is_file()
+            .then(|| RestartCommand {
+                program: working_dir.join("botctl.cmd"),
+                args: vec!["restart".to_owned()],
+                working_dir,
+            });
+        #[cfg(not(windows))]
+        let command = working_dir
+            .join("botctl.sh")
+            .is_file()
+            .then(|| RestartCommand {
+                program: PathBuf::from("bash"),
+                args: vec!["botctl.sh".to_owned(), "restart".to_owned()],
+                working_dir,
+            });
+        Self {
+            command: command.map(Arc::new),
+        }
+    }
+
+    pub fn available(&self) -> bool {
+        self.command.is_some()
+    }
+
+    /// 先让当前请求完成，再交给部署脚本执行优雅停止和拉起。
+    pub fn schedule(&self) -> Result<(), &'static str> {
+        let Some(command) = self.command.clone() else {
+            return Err("当前运行目录没有可用的 botctl 重启脚本");
+        };
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(500)).await;
+            let result = Command::new(&command.program)
+                .args(&command.args)
+                .current_dir(&command.working_dir)
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn();
+            if let Err(error) = result {
+                tracing::error!(error = %error, "failed to schedule bot restart");
+            }
+        });
+        Ok(())
+    }
+}
 
 #[derive(Clone)]
 pub struct ConsoleCoreSummary {

--- a/qq-maid-core/src/http/console_routes.rs
+++ b/qq-maid-core/src/http/console_routes.rs
@@ -64,54 +64,74 @@ pub(super) async fn console_index(
     ))
 }
 
+// dist 新增前端模块时必须同步登记；下方测试会校验构建产物与静态 import 均已覆盖。
+const CONSOLE_ASSETS: &[(&str, &str, &str)] = &[
+    (
+        "styles.css",
+        include_str!("../../../web-console/dist/styles.css"),
+        "text/css; charset=utf-8",
+    ),
+    (
+        "app.js",
+        include_str!("../../../web-console/dist/app.js"),
+        "text/javascript; charset=utf-8",
+    ),
+    (
+        "agent-tools.js",
+        include_str!("../../../web-console/dist/agent-tools.js"),
+        "text/javascript; charset=utf-8",
+    ),
+    (
+        "api.js",
+        include_str!("../../../web-console/dist/api.js"),
+        "text/javascript; charset=utf-8",
+    ),
+    (
+        "dom.js",
+        include_str!("../../../web-console/dist/dom.js"),
+        "text/javascript; charset=utf-8",
+    ),
+    (
+        "types.js",
+        include_str!("../../../web-console/dist/types.js"),
+        "text/javascript; charset=utf-8",
+    ),
+    (
+        "views/dashboard.js",
+        include_str!("../../../web-console/dist/views/dashboard.js"),
+        "text/javascript; charset=utf-8",
+    ),
+    (
+        "views/markdown.js",
+        include_str!("../../../web-console/dist/views/markdown.js"),
+        "text/javascript; charset=utf-8",
+    ),
+    (
+        "views/platforms.js",
+        include_str!("../../../web-console/dist/views/platforms.js"),
+        "text/javascript; charset=utf-8",
+    ),
+    (
+        "views/storage.js",
+        include_str!("../../../web-console/dist/views/storage.js"),
+        "text/javascript; charset=utf-8",
+    ),
+    (
+        "views/configuration.js",
+        include_str!("../../../web-console/dist/views/configuration.js"),
+        "text/javascript; charset=utf-8",
+    ),
+];
+
 pub(super) async fn console_asset(
     State(state): State<OpsHttpState>,
     Path(asset): Path<String>,
     headers: HeaderMap,
 ) -> Response {
-    let found = match asset.as_str() {
-        "styles.css" => Some((
-            include_str!("../../../web-console/dist/styles.css"),
-            "text/css; charset=utf-8",
-        )),
-        "app.js" => Some((
-            include_str!("../../../web-console/dist/app.js"),
-            "text/javascript; charset=utf-8",
-        )),
-        "api.js" => Some((
-            include_str!("../../../web-console/dist/api.js"),
-            "text/javascript; charset=utf-8",
-        )),
-        "dom.js" => Some((
-            include_str!("../../../web-console/dist/dom.js"),
-            "text/javascript; charset=utf-8",
-        )),
-        "types.js" => Some((
-            include_str!("../../../web-console/dist/types.js"),
-            "text/javascript; charset=utf-8",
-        )),
-        "views/dashboard.js" => Some((
-            include_str!("../../../web-console/dist/views/dashboard.js"),
-            "text/javascript; charset=utf-8",
-        )),
-        "views/markdown.js" => Some((
-            include_str!("../../../web-console/dist/views/markdown.js"),
-            "text/javascript; charset=utf-8",
-        )),
-        "views/platforms.js" => Some((
-            include_str!("../../../web-console/dist/views/platforms.js"),
-            "text/javascript; charset=utf-8",
-        )),
-        "views/storage.js" => Some((
-            include_str!("../../../web-console/dist/views/storage.js"),
-            "text/javascript; charset=utf-8",
-        )),
-        "views/configuration.js" => Some((
-            include_str!("../../../web-console/dist/views/configuration.js"),
-            "text/javascript; charset=utf-8",
-        )),
-        _ => None,
-    };
+    let found = CONSOLE_ASSETS
+        .iter()
+        .find(|(path, _, _)| *path == asset)
+        .map(|(_, body, content_type)| (*body, *content_type));
     match found {
         Some((body, content_type)) => static_console_asset(body, content_type, &state, &headers),
         None => with_console_cors(StatusCode::NOT_FOUND.into_response(), &state, &headers),
@@ -346,4 +366,106 @@ pub(super) fn allowed_console_origin<'a>(
         .iter()
         .map(String::as_str)
         .find(|allowed| *allowed == origin)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CONSOLE_ASSETS;
+    use regex::Regex;
+    use std::path::{Path, PathBuf};
+
+    fn dist_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../web-console/dist")
+    }
+
+    fn collect_dist_files(root: &Path, directory: &Path, files: &mut Vec<String>) {
+        for entry in std::fs::read_dir(directory).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                collect_dist_files(root, &path, files);
+            } else {
+                files.push(
+                    path.strip_prefix(root)
+                        .unwrap()
+                        .to_str()
+                        .unwrap()
+                        .replace('\\', "/"),
+                );
+            }
+        }
+    }
+
+    fn resolve_import(source: &str, specifier: &str) -> String {
+        let mut components = source
+            .rsplit_once('/')
+            .map(|(parent, _)| parent.split('/').collect::<Vec<_>>())
+            .unwrap_or_default();
+        for component in specifier.split('/') {
+            match component {
+                "." | "" => {}
+                ".." => {
+                    components.pop();
+                }
+                value => components.push(value),
+            }
+        }
+        components.join("/")
+    }
+
+    #[test]
+    fn embedded_console_assets_match_dist_output() {
+        let root = dist_root();
+        let mut dist_files = Vec::new();
+        collect_dist_files(&root, &root, &mut dist_files);
+        dist_files.retain(|path| path != "index.html");
+        dist_files.sort();
+
+        let mut embedded = CONSOLE_ASSETS
+            .iter()
+            .map(|(path, body, _)| {
+                assert!(!body.is_empty(), "控制台资源内容不能为空: {path}");
+                (*path).to_owned()
+            })
+            .collect::<Vec<_>>();
+        embedded.sort();
+
+        assert_eq!(
+            embedded, dist_files,
+            "dist 构建产物必须全部注册到控制台资源表"
+        );
+    }
+
+    #[test]
+    fn html_and_javascript_static_imports_are_embedded() {
+        let registered = CONSOLE_ASSETS
+            .iter()
+            .map(|(path, _, _)| *path)
+            .collect::<std::collections::HashSet<_>>();
+        let html = std::fs::read_to_string(dist_root().join("index.html")).unwrap();
+        let html_asset = Regex::new(r#"(?:src|href)=["'](/console/[^"'?#]+)["']"#).unwrap();
+        for captures in html_asset.captures_iter(&html) {
+            let path = captures[1].trim_start_matches("/console/");
+            assert!(registered.contains(path), "HTML 静态资源未注册: {path}");
+        }
+
+        let static_import =
+            Regex::new(r#"(?m)^\s*(?:import|export)\s+(?:.*?\s+from\s+)?["']([^"']+)["'];?\s*$"#)
+                .unwrap();
+        for (source, body, content_type) in CONSOLE_ASSETS {
+            if *content_type != "text/javascript; charset=utf-8" {
+                continue;
+            }
+            for captures in static_import.captures_iter(body) {
+                let specifier = &captures[1];
+                if !specifier.starts_with('.') {
+                    continue;
+                }
+                let imported = resolve_import(source, specifier);
+                assert!(
+                    registered.contains(imported.as_str()),
+                    "JavaScript 静态 import 未注册: {source} -> {specifier} ({imported})"
+                );
+            }
+        }
+    }
 }

--- a/qq-maid-core/src/http/console_routes.rs
+++ b/qq-maid-core/src/http/console_routes.rs
@@ -1,0 +1,349 @@
+//! Web 控制台静态资源、状态摘要、Markdown 预览和安全响应头。
+
+use axum::{
+    Json,
+    body::Bytes,
+    extract::{Path, State},
+    http::{HeaderMap, HeaderValue, StatusCode, header},
+    response::{Html, IntoResponse, Response},
+};
+use pulldown_cmark::{Options, Parser, html};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use super::routes::OpsHttpState;
+
+pub(super) async fn console_configuration(
+    State(state): State<OpsHttpState>,
+    headers: HeaderMap,
+) -> Response {
+    if let Err(response) = super::management::require_admin(&state, &headers, false) {
+        return with_console_cors(*response, &state, &headers);
+    }
+    let Some(config_center) = state.config_center.as_ref() else {
+        return with_console_cors(StatusCode::NOT_FOUND.into_response(), &state, &headers);
+    };
+    let response = match config_center.current_snapshot() {
+        Ok(snapshot) => Json(json!({
+            "ok": true,
+            "configuration": snapshot,
+            "registered_tools": state.registered_tools.as_ref(),
+            "restart": {"available": state.restart_controller.available()},
+        }))
+        .into_response(),
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"ok": false, "error": {"code": err.code(), "message": err.message()}})),
+        )
+            .into_response(),
+    };
+    with_console_cors(response, &state, &headers)
+}
+
+pub(super) async fn healthz(State(state): State<OpsHttpState>) -> Json<serde_json::Value> {
+    let provider = state.provider.as_ref();
+    Json(json!({
+        "ok": true,
+        "ready": !state.setup_required,
+        "state": if state.setup_required { "setup_required" } else { "ready" },
+        "provider": provider.map(|value| value.name()).unwrap_or("not_configured"),
+        "model": provider.map(|value| value.model()).unwrap_or("not_configured"),
+        "stream": provider.map(|value| value.stream_enabled()).unwrap_or(false),
+        "upstream": state.upstream_status.snapshot(),
+    }))
+}
+
+pub(super) async fn console_index(
+    State(state): State<OpsHttpState>,
+    headers: HeaderMap,
+) -> Response {
+    with_console_csp(with_console_cors(
+        Html(include_str!("../../../web-console/dist/index.html")).into_response(),
+        &state,
+        &headers,
+    ))
+}
+
+pub(super) async fn console_asset(
+    State(state): State<OpsHttpState>,
+    Path(asset): Path<String>,
+    headers: HeaderMap,
+) -> Response {
+    let found = match asset.as_str() {
+        "styles.css" => Some((
+            include_str!("../../../web-console/dist/styles.css"),
+            "text/css; charset=utf-8",
+        )),
+        "app.js" => Some((
+            include_str!("../../../web-console/dist/app.js"),
+            "text/javascript; charset=utf-8",
+        )),
+        "api.js" => Some((
+            include_str!("../../../web-console/dist/api.js"),
+            "text/javascript; charset=utf-8",
+        )),
+        "dom.js" => Some((
+            include_str!("../../../web-console/dist/dom.js"),
+            "text/javascript; charset=utf-8",
+        )),
+        "types.js" => Some((
+            include_str!("../../../web-console/dist/types.js"),
+            "text/javascript; charset=utf-8",
+        )),
+        "views/dashboard.js" => Some((
+            include_str!("../../../web-console/dist/views/dashboard.js"),
+            "text/javascript; charset=utf-8",
+        )),
+        "views/markdown.js" => Some((
+            include_str!("../../../web-console/dist/views/markdown.js"),
+            "text/javascript; charset=utf-8",
+        )),
+        "views/platforms.js" => Some((
+            include_str!("../../../web-console/dist/views/platforms.js"),
+            "text/javascript; charset=utf-8",
+        )),
+        "views/storage.js" => Some((
+            include_str!("../../../web-console/dist/views/storage.js"),
+            "text/javascript; charset=utf-8",
+        )),
+        "views/configuration.js" => Some((
+            include_str!("../../../web-console/dist/views/configuration.js"),
+            "text/javascript; charset=utf-8",
+        )),
+        _ => None,
+    };
+    match found {
+        Some((body, content_type)) => static_console_asset(body, content_type, &state, &headers),
+        None => with_console_cors(StatusCode::NOT_FOUND.into_response(), &state, &headers),
+    }
+}
+
+fn static_console_asset(
+    body: &'static str,
+    content_type: &'static str,
+    state: &OpsHttpState,
+    headers: &HeaderMap,
+) -> Response {
+    let mut response = with_console_cors(body.into_response(), state, headers);
+    response
+        .headers_mut()
+        .insert(header::CONTENT_TYPE, HeaderValue::from_static(content_type));
+    response
+}
+
+#[derive(Serialize)]
+struct ConsoleCapabilityRow {
+    platform: String,
+    scope: String,
+    label: String,
+    enabled: bool,
+    inbound: crate::http::console::ConsoleCapabilities,
+    outbound: crate::http::console::ConsoleCapabilities,
+}
+
+pub(super) async fn console_status(
+    State(state): State<OpsHttpState>,
+    headers: HeaderMap,
+) -> Response {
+    let external = state.console_status_source.snapshot();
+    let capabilities = external
+        .platforms
+        .iter()
+        .flat_map(|platform| {
+            platform
+                .capability_scopes
+                .iter()
+                .map(|scope| ConsoleCapabilityRow {
+                    platform: platform.id.clone(),
+                    scope: scope.id.clone(),
+                    label: scope.label.clone(),
+                    enabled: scope.enabled,
+                    inbound: scope.capabilities.inbound.clone(),
+                    outbound: scope.capabilities.outbound.clone(),
+                })
+        })
+        .collect::<Vec<_>>();
+    let mut storage = state.core_summary.core_storage();
+    storage.extend(external.storage);
+    let upstream = state.upstream_status.snapshot();
+    let provider = state.provider.as_ref();
+    let response = Json(json!({
+        "runtime": {
+            "ok": true,
+            "ready": !state.setup_required,
+            "state": if state.setup_required { "setup_required" } else { "ready" },
+            "version": state.core_summary.application_version,
+            "started_at": state.core_summary.started_at,
+            "uptime_seconds": state.core_summary.started_instant.elapsed().as_secs(),
+        },
+        "provider": {
+            "name": provider.map(|value| value.name()).unwrap_or("not_configured"),
+            "model": provider.map(|value| value.model()).unwrap_or("not_configured"),
+            "streaming": provider.map(|value| value.stream_enabled()).unwrap_or(false),
+            "configured": provider.is_some() && state.core_summary.provider_configured,
+            "upstream": upstream,
+        },
+        "platforms": external.platforms,
+        "capabilities": capabilities,
+        "storage": storage,
+        "configuration": {
+            "web_console_enabled": state.config.web_console_enabled,
+            "cors_allowlist_configured": !state.config.web_console_allowed_origins.is_empty(),
+            "listen": state.core_summary.listen_summary,
+            "rss_enabled": state.core_summary.rss_enabled,
+            "tool_calling_enabled": state.core_summary.tool_calling_enabled,
+        }
+    }))
+    .into_response();
+    with_console_cors(response, &state, &headers)
+}
+
+#[derive(Debug, Deserialize)]
+struct MarkdownRenderRequest {
+    markdown: String,
+}
+
+pub(super) async fn markdown_render(
+    State(state): State<OpsHttpState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    if body.len() > 64 * 1024 {
+        return with_console_cors(
+            (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                Json(json!({"ok": false, "error": "markdown payload too large"})),
+            )
+                .into_response(),
+            &state,
+            &headers,
+        );
+    }
+
+    let payload = match serde_json::from_slice::<MarkdownRenderRequest>(&body) {
+        Ok(payload) => payload,
+        Err(_) => {
+            return with_console_cors(
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"ok": false, "error": "invalid markdown render payload"})),
+                )
+                    .into_response(),
+                &state,
+                &headers,
+            );
+        }
+    };
+    let html = render_markdown_html(&payload.markdown);
+    with_console_cors(
+        Json(json!({"ok": true, "html": html})).into_response(),
+        &state,
+        &headers,
+    )
+}
+
+pub(super) async fn markdown_render_preflight(
+    State(state): State<OpsHttpState>,
+    headers: HeaderMap,
+) -> Response {
+    with_console_preflight_cors(StatusCode::NO_CONTENT.into_response(), &state, &headers)
+}
+
+fn render_markdown_html(markdown: &str) -> String {
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_TABLES);
+    options.insert(Options::ENABLE_TASKLISTS);
+    options.insert(Options::ENABLE_STRIKETHROUGH);
+    let parser = Parser::new_ext(markdown, options);
+    let mut html = String::new();
+    html::push_html(&mut html, parser);
+    let mut cleaner = ammonia::Builder::default();
+    cleaner.add_tags(["input"]);
+    cleaner.add_tag_attributes("input", ["type", "checked", "disabled"]);
+    cleaner.clean(&html).to_string()
+}
+
+fn with_console_security(mut response: Response) -> Response {
+    response.headers_mut().insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    response
+        .headers_mut()
+        .insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
+    response
+}
+
+fn with_console_csp(mut response: Response) -> Response {
+    response.headers_mut().insert(
+        header::CONTENT_SECURITY_POLICY,
+        HeaderValue::from_static(
+            "default-src 'self'; style-src 'self'; script-src 'self'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'",
+        ),
+    );
+    response
+}
+
+pub(super) fn with_console_cors(
+    mut response: Response,
+    state: &OpsHttpState,
+    headers: &HeaderMap,
+) -> Response {
+    let Some(origin) = allowed_console_origin(state, headers) else {
+        return with_console_security(response);
+    };
+    let Ok(value) = HeaderValue::from_str(origin) else {
+        return with_console_security(response);
+    };
+    response
+        .headers_mut()
+        .insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, value);
+    response
+        .headers_mut()
+        .insert(header::VARY, HeaderValue::from_static("origin"));
+    with_console_security(response)
+}
+
+fn with_console_preflight_cors(
+    mut response: Response,
+    state: &OpsHttpState,
+    headers: &HeaderMap,
+) -> Response {
+    let Some(origin) = allowed_console_origin(state, headers) else {
+        return with_console_security(response);
+    };
+    let Ok(value) = HeaderValue::from_str(origin) else {
+        return with_console_security(response);
+    };
+    response
+        .headers_mut()
+        .insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, value);
+    response.headers_mut().insert(
+        header::ACCESS_CONTROL_ALLOW_METHODS,
+        HeaderValue::from_static("POST, OPTIONS"),
+    );
+    response.headers_mut().insert(
+        header::ACCESS_CONTROL_ALLOW_HEADERS,
+        HeaderValue::from_static("content-type"),
+    );
+    response.headers_mut().insert(
+        header::VARY,
+        HeaderValue::from_static(
+            "origin, access-control-request-method, access-control-request-headers",
+        ),
+    );
+    with_console_security(response)
+}
+
+pub(super) fn allowed_console_origin<'a>(
+    state: &'a OpsHttpState,
+    headers: &'a HeaderMap,
+) -> Option<&'a str> {
+    let origin = headers.get(header::ORIGIN)?.to_str().ok()?;
+    state
+        .config
+        .web_console_allowed_origins
+        .iter()
+        .map(String::as_str)
+        .find(|allowed| *allowed == origin)
+}

--- a/qq-maid-core/src/http/management/mod.rs
+++ b/qq-maid-core/src/http/management/mod.rs
@@ -21,7 +21,7 @@ use crate::config::{
     center::{AgentConfigChange, ConfigCenterError, ManagedConfigChange, SecretConfigChange},
 };
 
-use super::routes::{OpsHttpState, with_console_cors};
+use super::{console_routes::with_console_cors, routes::OpsHttpState};
 
 mod auth_routes;
 
@@ -52,7 +52,59 @@ pub(super) fn management_router() -> Router<OpsHttpState> {
             "/api/v1/console/configuration/test-connection",
             post(test_provider_connection),
         )
+        .route("/api/v1/console/restart", post(restart_process))
         .layer(DefaultBodyLimit::max(256 * 1024))
+}
+
+async fn restart_process(State(state): State<OpsHttpState>, headers: HeaderMap) -> Response {
+    let (auth, _, _, actor_id) = match admin_context(&state, &headers, true) {
+        Ok(value) => value,
+        Err(response) => return respond(&state, &headers, *response),
+    };
+    if !state.restart_controller.available() {
+        let _ = auth.audit(Some(actor_id), "process.restart", "unavailable");
+        return respond(
+            &state,
+            &headers,
+            api_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "restart_unavailable",
+                "当前运行目录没有可用的受控重启脚本",
+            ),
+        );
+    }
+    if let Err(error) = auth.audit(Some(actor_id), "process.restart", "success") {
+        return respond(
+            &state,
+            &headers,
+            api_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                error.code(),
+                error.message(),
+            ),
+        );
+    }
+    match state.restart_controller.schedule() {
+        Ok(()) => respond(
+            &state,
+            &headers,
+            Json(json!({
+                "ok": true,
+                "restart_scheduled": true,
+                "message": "重启命令已提交，服务会短暂离线",
+            }))
+            .into_response(),
+        ),
+        Err(message) => respond(
+            &state,
+            &headers,
+            api_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "restart_unavailable",
+                message,
+            ),
+        ),
+    }
 }
 
 #[derive(Deserialize)]
@@ -756,6 +808,8 @@ fn configuration_success(
             "ok": true,
             "persisted": true,
             "configuration": snapshot,
+            "registered_tools": state.registered_tools.as_ref(),
+            "restart": {"available": state.restart_controller.available()},
         }))
         .into_response(),
     )

--- a/qq-maid-core/src/http/management/mod.rs
+++ b/qq-maid-core/src/http/management/mod.rs
@@ -73,7 +73,8 @@ async fn restart_process(State(state): State<OpsHttpState>, headers: HeaderMap) 
             ),
         );
     }
-    if let Err(error) = auth.audit(Some(actor_id), "process.restart", "success") {
+    // 这里只记录管理员请求已被接受，不能把异步命令提交等同于进程重启成功。
+    if let Err(error) = auth.audit(Some(actor_id), "process.restart", "accepted") {
         return respond(
             &state,
             &headers,
@@ -95,15 +96,18 @@ async fn restart_process(State(state): State<OpsHttpState>, headers: HeaderMap) 
             }))
             .into_response(),
         ),
-        Err(message) => respond(
-            &state,
-            &headers,
-            api_error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "restart_unavailable",
-                message,
-            ),
-        ),
+        Err(message) => {
+            let _ = auth.audit(Some(actor_id), "process.restart", "unavailable");
+            respond(
+                &state,
+                &headers,
+                api_error(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "restart_unavailable",
+                    message,
+                ),
+            )
+        }
     }
 }
 

--- a/qq-maid-core/src/http/mod.rs
+++ b/qq-maid-core/src/http/mod.rs
@@ -4,5 +4,7 @@
 
 pub mod api;
 pub mod console;
+mod console_routes;
 mod management;
+mod router_builder;
 pub mod routes;

--- a/qq-maid-core/src/http/router_builder.rs
+++ b/qq-maid-core/src/http/router_builder.rs
@@ -1,0 +1,36 @@
+//! 控制台路由树组装。
+
+use axum::{
+    Router,
+    routing::{get, post},
+};
+
+use super::{
+    console_routes::{
+        console_asset, console_configuration, console_index, console_status, healthz,
+        markdown_render, markdown_render_preflight,
+    },
+    management::management_router,
+    routes::OpsHttpState,
+};
+
+/// 构建 Axum 路由树，注册所有 HTTP 端点。
+pub fn build_router(state: OpsHttpState) -> Router {
+    let console_enabled = state.config.web_console_enabled;
+    let router = Router::new().route("/healthz", get(healthz));
+    let router = if console_enabled {
+        router
+            .route("/console/", get(console_index))
+            .route("/console/{*asset}", get(console_asset))
+            .route("/api/v1/console/status", get(console_status))
+            .route("/api/v1/console/configuration", get(console_configuration))
+            .route(
+                "/api/v1/markdown/render",
+                post(markdown_render).options(markdown_render_preflight),
+            )
+            .merge(management_router())
+    } else {
+        router
+    };
+    router.with_state(state)
+}

--- a/qq-maid-core/src/http/routes.rs
+++ b/qq-maid-core/src/http/routes.rs
@@ -455,6 +455,8 @@ mod tests {
         let (css_status, _) =
             request_response(test_state(), "GET", "/console/styles.css", None).await;
         let (js_status, _) = request_response(test_state(), "GET", "/console/app.js", None).await;
+        let (agent_tools_status, _) =
+            request_response(test_state(), "GET", "/console/agent-tools.js", None).await;
         let (status_api, _) =
             request_response(test_state(), "GET", "/api/v1/console/status", None).await;
 
@@ -462,6 +464,7 @@ mod tests {
         assert_eq!(render_status, axum::http::StatusCode::NOT_FOUND);
         assert_eq!(css_status, axum::http::StatusCode::NOT_FOUND);
         assert_eq!(js_status, axum::http::StatusCode::NOT_FOUND);
+        assert_eq!(agent_tools_status, axum::http::StatusCode::NOT_FOUND);
         assert_eq!(status_api, axum::http::StatusCode::NOT_FOUND);
         Ok(())
     }
@@ -506,6 +509,7 @@ mod tests {
         for (path, expected_content_type) in [
             ("/console/styles.css", "text/css; charset=utf-8"),
             ("/console/app.js", "text/javascript; charset=utf-8"),
+            ("/console/agent-tools.js", "text/javascript; charset=utf-8"),
         ] {
             let (status, headers, body) =
                 request_text_response(state.clone(), "GET", path, None, None).await;

--- a/qq-maid-core/src/http/routes.rs
+++ b/qq-maid-core/src/http/routes.rs
@@ -5,30 +5,21 @@
 //! Gateway 与 Core 之间的业务调用已经改为进程内 `CoreService`，这里不再公开
 //! 内部 respond 或 SSE 传入口，避免同进程组件保留长期双轨。
 
-use axum::{
-    Json, Router,
-    body::Bytes,
-    extract::{Path, State},
-    http::{HeaderMap, HeaderValue, StatusCode, header},
-    response::{Html, IntoResponse, Response},
-    routing::{get, post},
-};
-use pulldown_cmark::{Options, Parser, html};
 use qq_maid_llm::provider::{DynLlmProvider, status::UpstreamStatus};
-use serde::{Deserialize, Serialize};
+#[cfg(test)]
 use serde_json::json;
 use std::{sync::Arc, time::Instant};
 
 use crate::{
     config::{AppConfig, center::ConfigCenter},
     http::console::{
-        ConsoleCoreSummary, ConsoleStatusSource, DynConsoleStatusSource, EmptyConsoleStatusSource,
+        ConsoleCoreSummary, ConsoleRestartController, ConsoleStatusSource, ConsoleToolMetadata,
+        DynConsoleStatusSource, EmptyConsoleStatusSource,
     },
     management::AdminAuth,
 };
 
-use super::management::management_router;
-
+pub use super::router_builder::build_router;
 /// 运维 HTTP 接口需要的最小配置。
 #[derive(Clone)]
 pub struct OpsHttpConfig {
@@ -65,11 +56,20 @@ pub struct OpsHttpState {
     pub config_center: Option<ConfigCenter>,
     /// 配置 WebUI 与后续 Memory WebUI 统一复用的部署管理员安全边界。
     pub admin_auth: Option<AdminAuth>,
+    /// 当前进程真实注册的 Tool 元数据，供 WebUI 动态展示白名单选项。
+    pub registered_tools: Arc<Vec<ConsoleToolMetadata>>,
+    /// 仅复用部署目录中的受控 botctl 脚本，不直接操作 systemd 或 Docker。
+    pub restart_controller: ConsoleRestartController,
     /// 缺少 Provider 或平台入口时仍开放管理恢复入口，但不能伪报机器人已经就绪。
     pub setup_required: bool,
 }
 
 impl OpsHttpState {
+    pub fn with_registered_tools(mut self, tools: Vec<ConsoleToolMetadata>) -> Self {
+        self.registered_tools = Arc::new(tools);
+        self
+    }
+
     pub fn from_parts(
         config: OpsHttpConfig,
         provider: DynLlmProvider,
@@ -92,6 +92,8 @@ impl OpsHttpState {
             console_status_source: Arc::new(EmptyConsoleStatusSource),
             config_center: None,
             admin_auth: None,
+            registered_tools: Arc::new(Vec::new()),
+            restart_controller: ConsoleRestartController::default(),
             setup_required: false,
         }
     }
@@ -131,6 +133,8 @@ impl OpsHttpState {
             console_status_source,
             config_center,
             admin_auth,
+            registered_tools: Arc::new(Vec::new()),
+            restart_controller: ConsoleRestartController::from_current_dir(),
             setup_required: false,
         }
     }
@@ -149,354 +153,14 @@ impl OpsHttpState {
             console_status_source: Arc::new(EmptyConsoleStatusSource),
             config_center: Some(config_center),
             admin_auth,
+            registered_tools: Arc::new(Vec::new()),
+            restart_controller: ConsoleRestartController::from_current_dir(),
             setup_required: true,
         }
     }
 }
 
-/// 构建 Axum 路由树，注册所有 HTTP 端点。
-pub fn build_router(state: OpsHttpState) -> Router {
-    let console_enabled = state.config.web_console_enabled;
-    let router = Router::new().route("/healthz", get(healthz));
-    let router = if console_enabled {
-        router
-            .route("/console/", get(console_index))
-            .route("/console/{*asset}", get(console_asset))
-            .route("/api/v1/console/status", get(console_status))
-            .route("/api/v1/console/configuration", get(console_configuration))
-            .route(
-                "/api/v1/markdown/render",
-                post(markdown_render).options(markdown_render_preflight),
-            )
-            .merge(management_router())
-    } else {
-        router
-    };
-    router.with_state(state)
-}
-
-async fn console_configuration(State(state): State<OpsHttpState>, headers: HeaderMap) -> Response {
-    if let Err(response) = super::management::require_admin(&state, &headers, false) {
-        return with_console_cors(*response, &state, &headers);
-    }
-    let Some(config_center) = state.config_center.as_ref() else {
-        return with_console_cors(StatusCode::NOT_FOUND.into_response(), &state, &headers);
-    };
-    let response = match config_center.current_snapshot() {
-        Ok(snapshot) => Json(json!({"ok": true, "configuration": snapshot})).into_response(),
-        Err(err) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"ok": false, "error": {"code": err.code(), "message": err.message()}})),
-        )
-            .into_response(),
-    };
-    with_console_cors(response, &state, &headers)
-}
-
-/// 健康检查端点，返回当前提供商和模型信息。
-async fn healthz(State(state): State<OpsHttpState>) -> Json<serde_json::Value> {
-    let provider = state.provider.as_ref();
-    Json(json!({
-        "ok": true,
-        "ready": !state.setup_required,
-        "state": if state.setup_required { "setup_required" } else { "ready" },
-        "provider": provider.map(|value| value.name()).unwrap_or("not_configured"),
-        "model": provider.map(|value| value.model()).unwrap_or("not_configured"),
-        "stream": provider.map(|value| value.stream_enabled()).unwrap_or(false),
-        "upstream": state.upstream_status.snapshot(),
-    }))
-}
-
-async fn console_index(State(state): State<OpsHttpState>, headers: HeaderMap) -> Response {
-    with_console_csp(with_console_cors(
-        Html(include_str!("../../../web-console/dist/index.html")).into_response(),
-        &state,
-        &headers,
-    ))
-}
-
-async fn console_asset(
-    State(state): State<OpsHttpState>,
-    Path(asset): Path<String>,
-    headers: HeaderMap,
-) -> Response {
-    let found = match asset.as_str() {
-        "styles.css" => Some((
-            include_str!("../../../web-console/dist/styles.css"),
-            "text/css; charset=utf-8",
-        )),
-        "app.js" => Some((
-            include_str!("../../../web-console/dist/app.js"),
-            "text/javascript; charset=utf-8",
-        )),
-        "api.js" => Some((
-            include_str!("../../../web-console/dist/api.js"),
-            "text/javascript; charset=utf-8",
-        )),
-        "dom.js" => Some((
-            include_str!("../../../web-console/dist/dom.js"),
-            "text/javascript; charset=utf-8",
-        )),
-        "types.js" => Some((
-            include_str!("../../../web-console/dist/types.js"),
-            "text/javascript; charset=utf-8",
-        )),
-        "views/dashboard.js" => Some((
-            include_str!("../../../web-console/dist/views/dashboard.js"),
-            "text/javascript; charset=utf-8",
-        )),
-        "views/markdown.js" => Some((
-            include_str!("../../../web-console/dist/views/markdown.js"),
-            "text/javascript; charset=utf-8",
-        )),
-        "views/platforms.js" => Some((
-            include_str!("../../../web-console/dist/views/platforms.js"),
-            "text/javascript; charset=utf-8",
-        )),
-        "views/storage.js" => Some((
-            include_str!("../../../web-console/dist/views/storage.js"),
-            "text/javascript; charset=utf-8",
-        )),
-        "views/configuration.js" => Some((
-            include_str!("../../../web-console/dist/views/configuration.js"),
-            "text/javascript; charset=utf-8",
-        )),
-        _ => None,
-    };
-    match found {
-        Some((body, content_type)) => static_console_asset(body, content_type, &state, &headers),
-        None => with_console_cors(StatusCode::NOT_FOUND.into_response(), &state, &headers),
-    }
-}
-
-fn static_console_asset(
-    body: &'static str,
-    content_type: &'static str,
-    state: &OpsHttpState,
-    headers: &HeaderMap,
-) -> Response {
-    let mut response = with_console_cors(body.into_response(), state, headers);
-    response
-        .headers_mut()
-        .insert(header::CONTENT_TYPE, HeaderValue::from_static(content_type));
-    response
-}
-
-#[derive(Serialize)]
-struct ConsoleCapabilityRow {
-    platform: String,
-    scope: String,
-    label: String,
-    enabled: bool,
-    inbound: crate::http::console::ConsoleCapabilities,
-    outbound: crate::http::console::ConsoleCapabilities,
-}
-
-async fn console_status(State(state): State<OpsHttpState>, headers: HeaderMap) -> Response {
-    let external = state.console_status_source.snapshot();
-    let capabilities = external
-        .platforms
-        .iter()
-        .flat_map(|platform| {
-            platform
-                .capability_scopes
-                .iter()
-                .map(|scope| ConsoleCapabilityRow {
-                    platform: platform.id.clone(),
-                    scope: scope.id.clone(),
-                    label: scope.label.clone(),
-                    enabled: scope.enabled,
-                    inbound: scope.capabilities.inbound.clone(),
-                    outbound: scope.capabilities.outbound.clone(),
-                })
-        })
-        .collect::<Vec<_>>();
-    let mut storage = state.core_summary.core_storage();
-    storage.extend(external.storage);
-    let upstream = state.upstream_status.snapshot();
-    let provider = state.provider.as_ref();
-    let response = Json(json!({
-        "runtime": {
-            "ok": true,
-            "ready": !state.setup_required,
-            "state": if state.setup_required { "setup_required" } else { "ready" },
-            "version": state.core_summary.application_version,
-            "started_at": state.core_summary.started_at,
-            "uptime_seconds": state.core_summary.started_instant.elapsed().as_secs(),
-        },
-        "provider": {
-            "name": provider.map(|value| value.name()).unwrap_or("not_configured"),
-            "model": provider.map(|value| value.model()).unwrap_or("not_configured"),
-            "streaming": provider.map(|value| value.stream_enabled()).unwrap_or(false),
-            "configured": provider.is_some() && state.core_summary.provider_configured,
-            "upstream": upstream,
-        },
-        "platforms": external.platforms,
-        "capabilities": capabilities,
-        "storage": storage,
-        "configuration": {
-            "web_console_enabled": state.config.web_console_enabled,
-            "cors_allowlist_configured": !state.config.web_console_allowed_origins.is_empty(),
-            "listen": state.core_summary.listen_summary,
-            "rss_enabled": state.core_summary.rss_enabled,
-            "tool_calling_enabled": state.core_summary.tool_calling_enabled,
-        }
-    }))
-    .into_response();
-    with_console_cors(response, &state, &headers)
-}
-
-#[derive(Debug, Deserialize)]
-struct MarkdownRenderRequest {
-    markdown: String,
-}
-
-async fn markdown_render(
-    State(state): State<OpsHttpState>,
-    headers: HeaderMap,
-    body: Bytes,
-) -> Response {
-    if body.len() > 64 * 1024 {
-        return with_console_cors(
-            (
-                StatusCode::PAYLOAD_TOO_LARGE,
-                Json(json!({"ok": false, "error": "markdown payload too large"})),
-            )
-                .into_response(),
-            &state,
-            &headers,
-        );
-    }
-
-    let payload = match serde_json::from_slice::<MarkdownRenderRequest>(&body) {
-        Ok(payload) => payload,
-        Err(_) => {
-            return with_console_cors(
-                (
-                    StatusCode::BAD_REQUEST,
-                    Json(json!({"ok": false, "error": "invalid markdown render payload"})),
-                )
-                    .into_response(),
-                &state,
-                &headers,
-            );
-        }
-    };
-    let html = render_markdown_html(&payload.markdown);
-    with_console_cors(
-        Json(json!({"ok": true, "html": html})).into_response(),
-        &state,
-        &headers,
-    )
-}
-
-async fn markdown_render_preflight(
-    State(state): State<OpsHttpState>,
-    headers: HeaderMap,
-) -> Response {
-    // 跨站 `application/json` 请求会先发 OPTIONS 预检；这里必须显式返回允许的方法
-    // 和请求头，否则 allowlist origin 仍会被浏览器拦下。
-    with_console_preflight_cors(StatusCode::NO_CONTENT.into_response(), &state, &headers)
-}
-
-fn render_markdown_html(markdown: &str) -> String {
-    let mut options = Options::empty();
-    options.insert(Options::ENABLE_TABLES);
-    options.insert(Options::ENABLE_TASKLISTS);
-    options.insert(Options::ENABLE_STRIKETHROUGH);
-    let parser = Parser::new_ext(markdown, options);
-    let mut html = String::new();
-    html::push_html(&mut html, parser);
-    let mut cleaner = ammonia::Builder::default();
-    cleaner.add_tags(["input"]);
-    cleaner.add_tag_attributes("input", ["type", "checked", "disabled"]);
-    cleaner.clean(&html).to_string()
-}
-
-fn with_console_security(mut response: Response) -> Response {
-    response.headers_mut().insert(
-        header::X_CONTENT_TYPE_OPTIONS,
-        HeaderValue::from_static("nosniff"),
-    );
-    response
-        .headers_mut()
-        .insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
-    response
-}
-
-fn with_console_csp(mut response: Response) -> Response {
-    response.headers_mut().insert(
-        header::CONTENT_SECURITY_POLICY,
-        HeaderValue::from_static(
-            "default-src 'self'; style-src 'self'; script-src 'self'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'",
-        ),
-    );
-    response
-}
-
-pub(super) fn with_console_cors(
-    mut response: Response,
-    state: &OpsHttpState,
-    headers: &HeaderMap,
-) -> Response {
-    let Some(origin) = allowed_console_origin(state, headers) else {
-        return with_console_security(response);
-    };
-    let Ok(value) = HeaderValue::from_str(origin) else {
-        return with_console_security(response);
-    };
-    response
-        .headers_mut()
-        .insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, value);
-    response
-        .headers_mut()
-        .insert(header::VARY, HeaderValue::from_static("origin"));
-    with_console_security(response)
-}
-
-fn with_console_preflight_cors(
-    mut response: Response,
-    state: &OpsHttpState,
-    headers: &HeaderMap,
-) -> Response {
-    let Some(origin) = allowed_console_origin(state, headers) else {
-        return with_console_security(response);
-    };
-    let Ok(value) = HeaderValue::from_str(origin) else {
-        return with_console_security(response);
-    };
-    response
-        .headers_mut()
-        .insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, value);
-    response.headers_mut().insert(
-        header::ACCESS_CONTROL_ALLOW_METHODS,
-        HeaderValue::from_static("POST, OPTIONS"),
-    );
-    response.headers_mut().insert(
-        header::ACCESS_CONTROL_ALLOW_HEADERS,
-        HeaderValue::from_static("content-type"),
-    );
-    response.headers_mut().insert(
-        header::VARY,
-        HeaderValue::from_static(
-            "origin, access-control-request-method, access-control-request-headers",
-        ),
-    );
-    with_console_security(response)
-}
-
-pub(super) fn allowed_console_origin<'a>(
-    state: &'a OpsHttpState,
-    headers: &'a HeaderMap,
-) -> Option<&'a str> {
-    let origin = headers.get(header::ORIGIN)?.to_str().ok()?;
-    state
-        .config
-        .web_console_allowed_origins
-        .iter()
-        .map(String::as_str)
-        .find(|allowed| *allowed == origin)
-}
+// 控制台静态资源、状态和安全响应头由 console_routes 模块负责。
 
 #[cfg(test)]
 mod tests {
@@ -509,7 +173,7 @@ mod tests {
         util::metrics::LlmMetrics,
     };
     use async_trait::async_trait;
-    use axum::body::Body;
+    use axum::{body::Body, http::StatusCode};
     use http_body_util::BodyExt;
     use qq_maid_llm::provider::{
         ChatOutcome, LlmProvider,
@@ -979,6 +643,10 @@ mod tests {
             agent_path.to_string_lossy().into_owned(),
         )]);
         let running_agent = AgentRuntimeConfig::load_from_environment(&agent_environment).unwrap();
+        state.registered_tools = Arc::new(vec![ConsoleToolMetadata {
+            name: "web_search".to_owned(),
+            description: "受控搜索".to_owned(),
+        }]);
         state.config_center = Some(
             ConfigCenter::open(
                 managed_config_fields(),
@@ -1024,6 +692,9 @@ mod tests {
         assert!(secret["effective_value"].is_null());
         assert_eq!(json["configuration"]["agent"]["source"], "agent_toml");
         assert_eq!(json["configuration"]["agent"]["pending_restart"], false);
+        assert_eq!(json["registered_tools"][0]["name"], "web_search");
+        assert_eq!(json["registered_tools"][0]["description"], "受控搜索");
+        assert_eq!(json["restart"]["available"], false);
 
         let revision = json["configuration"]["revision"].as_str().unwrap();
         let mutation = json!({
@@ -1044,6 +715,27 @@ mod tests {
         )
         .await;
         assert_eq!(missing_csrf, StatusCode::FORBIDDEN);
+        let (restart_missing_csrf, _) = request_response_with_cookie(
+            state.clone(),
+            "POST",
+            "/api/v1/console/restart",
+            Some(json!({})),
+            &cookie,
+            None,
+        )
+        .await;
+        assert_eq!(restart_missing_csrf, StatusCode::FORBIDDEN);
+        let (restart_unavailable, restart_json) = request_response_with_cookie(
+            state.clone(),
+            "POST",
+            "/api/v1/console/restart",
+            Some(json!({})),
+            &cookie,
+            Some(&csrf),
+        )
+        .await;
+        assert_eq!(restart_unavailable, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(restart_json["error"]["code"], "restart_unavailable");
         let (saved, saved_json) = request_response_with_cookie(
             state.clone(),
             "PATCH",
@@ -1289,6 +981,7 @@ mod tests {
             let (status, _json) = request_response(test_state(), method, path, body).await;
             assert_eq!(status, axum::http::StatusCode::NOT_FOUND, "{method} {path}");
         }
+
         Ok(())
     }
 }

--- a/qq-maid-core/src/management/auth.rs
+++ b/qq-maid-core/src/management/auth.rs
@@ -1254,6 +1254,7 @@ fn admin_capabilities() -> Vec<String> {
         "console.config.read",
         "console.config.write",
         "console.audit.write",
+        "console.process.restart",
         "memory.admin",
     ]
     .into_iter()

--- a/qq-maid-core/src/runtime/respond/mod.rs
+++ b/qq-maid-core/src/runtime/respond/mod.rs
@@ -375,6 +375,11 @@ impl RustRespondService {
         self.command_prefix
     }
 
+    /// 返回当前 Core 实际注册的模型 Tool；控制台只消费其中的名称和说明。
+    pub fn registered_tool_metadata(&self) -> Vec<qq_maid_llm::tool::ToolMetadata> {
+        self.tool_runtime.metadata()
+    }
+
     /// 识别旧 `/` 或重复配置前缀，确保它们不会落回 canonical slash 解析器。
     pub(crate) fn is_foreign_or_repeated_command_text(&self, text: &str) -> bool {
         let text = text.trim_start();

--- a/qq-maid-core/src/runtime/respond/tool_runtime.rs
+++ b/qq-maid-core/src/runtime/respond/tool_runtime.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     storage::notification::NotificationOutboxStore,
 };
-use qq_maid_llm::tool::{DEFAULT_TOOL_TIMEOUT, ToolRegistry};
+use qq_maid_llm::tool::{DEFAULT_TOOL_TIMEOUT, ToolMetadata, ToolRegistry};
 
 use super::{
     RespondExecutors, RespondRequest, RespondStores, agent_route::AgentToolMode,
@@ -193,6 +193,10 @@ impl ToolRuntime {
 
     pub(crate) fn registry_for_tool_name(&self, tool_name: &str) -> Result<ToolRegistry, LlmError> {
         self.registry.subset(&[tool_name])
+    }
+
+    pub(crate) fn metadata(&self) -> Vec<ToolMetadata> {
+        self.registry.metadata()
     }
 
     pub(crate) fn postprocess_tool_turn(

--- a/qq-maid-core/src/service/handle.rs
+++ b/qq-maid-core/src/service/handle.rs
@@ -63,6 +63,10 @@ impl CoreHandle {
             respond_options(&state.config),
         )
     }
+
+    pub fn registered_tool_metadata(&self) -> Vec<qq_maid_llm::tool::ToolMetadata> {
+        self.respond_service().registered_tool_metadata()
+    }
 }
 
 #[async_trait]

--- a/web-console/dist/agent-tools.js
+++ b/web-console/dist/agent-tools.js
@@ -1,0 +1,25 @@
+/** 未注册项只能来自已保存白名单，避免通过普通工具列表构造任意名称。 */
+export function agentToolOptions(registeredTools, savedNames, editable) {
+    const selected = new Set(savedNames);
+    const registeredNames = new Set(registeredTools.map((tool) => tool.name));
+    return [
+        ...registeredTools.map((tool) => ({
+            ...tool,
+            registered: true,
+            checked: selected.has(tool.name),
+            disabled: !editable,
+        })),
+        ...savedNames
+            .filter((name) => !registeredNames.has(name))
+            .map((name) => ({
+            name,
+            description: "已写入 agent.toml，但当前进程未注册此工具",
+            registered: false,
+            checked: true,
+            disabled: !editable,
+        })),
+    ];
+}
+export function selectedAgentToolNames(inputs) {
+    return [...inputs].filter((input) => input.checked).map((input) => input.value);
+}

--- a/web-console/dist/api.js
+++ b/web-console/dist/api.js
@@ -71,25 +71,29 @@ export async function fetchConfiguration() {
     const payload = record(await fetchJson("/api/v1/console/configuration", {
         headers: { Accept: "application/json" },
     }));
-    return parseConfigurationSnapshot(payload.configuration);
+    return parseConfigurationPayload(payload);
 }
 export async function updateRuntimeConfiguration(expectedRevision, changes) {
     const payload = record(await mutatingJson("/api/v1/console/configuration/runtime", "PATCH", {
         expected_revision: expectedRevision,
         changes,
     }));
-    return parseConfigurationSnapshot(payload.configuration);
+    return parseConfigurationPayload(payload);
 }
 export async function updateSecretConfiguration(changes) {
     const payload = record(await mutatingJson("/api/v1/console/configuration/secrets", "PATCH", { changes }));
-    return parseConfigurationSnapshot(payload.configuration);
+    return parseConfigurationPayload(payload);
 }
 export async function updateAgentConfiguration(expectedRevision, changes) {
     const payload = record(await mutatingJson("/api/v1/console/configuration/agent", "PATCH", {
         expected_revision: expectedRevision,
         changes,
     }));
-    return parseConfigurationSnapshot(payload.configuration);
+    return parseConfigurationPayload(payload);
+}
+export async function requestRestart() {
+    const payload = record(await mutatingJson("/api/v1/console/restart", "POST", {}));
+    return string(payload.message, "重启命令已提交");
 }
 export async function validateConfiguration() {
     const payload = record(await mutatingJson("/api/v1/console/configuration/validate", "POST", {}));
@@ -215,13 +219,19 @@ function parseSession(value) {
         expiresAt: finiteNumber(item.expires_at) ?? 0,
     };
 }
-function parseConfigurationSnapshot(value) {
+function parseConfigurationPayload(value) {
+    const payload = record(value);
+    return parseConfigurationSnapshot(payload.configuration, payload.registered_tools, payload.restart);
+}
+function parseConfigurationSnapshot(value, toolsValue = [], restartValue = {}) {
     const item = record(value);
     const agent = record(item.agent);
     return {
         revision: string(item.revision, "missing"),
         fileExists: item.file_exists === true,
         fields: array(item.fields).map(parseConfigField),
+        registeredTools: array(toolsValue).map(parseRegisteredTool),
+        restartAvailable: record(restartValue).available === true,
         agent: Object.keys(agent).length === 0 ? null : {
             revision: string(agent.revision, "missing"),
             fileExists: agent.file_exists === true,
@@ -231,6 +241,13 @@ function parseConfigurationSnapshot(value) {
             savedValue: agent.saved_value,
             runningValue: agent.running_value,
         },
+    };
+}
+function parseRegisteredTool(value) {
+    const item = record(value);
+    return {
+        name: string(item.name, "unknown"),
+        description: string(item.description, ""),
     };
 }
 function parseConfigField(value) {

--- a/web-console/dist/index.html
+++ b/web-console/dist/index.html
@@ -43,6 +43,7 @@
         <p class="security-note">默认同源并受部署管理员会话与 CSRF 保护；公网访问仍必须使用受信 TLS 反向代理。</p>
       </div>
       <div class="refresh-box">
+        <button id="restart-service" class="danger" type="button" disabled>重启服务</button>
         <button id="refresh-status" type="button">手动刷新</button>
         <label class="auto-refresh" for="auto-refresh"><input id="auto-refresh" type="checkbox"> 自动刷新</label>
         <span>管理员：<strong id="admin-username">—</strong></span>
@@ -160,7 +161,7 @@
       </section>
     </main>
 
-    <footer data-authenticated hidden>配置变更不会控制 Docker socket 或 systemd；需要重启时请使用当前部署方式的受控命令。</footer>
+    <footer data-authenticated hidden>重启操作复用当前运行目录的受控 botctl 脚本，不直接控制 Docker socket 或 systemd。</footer>
     <script type="module" src="/console/app.js"></script>
   </body>
 </html>

--- a/web-console/dist/styles.css
+++ b/web-console/dist/styles.css
@@ -125,6 +125,8 @@ button:active:not(.reveal-button) { transform: translateY(1px); }
 button:disabled { cursor: progress; opacity: .6; }
 button.secondary { background: #fff; border-color: #c6d4cc; color: var(--accent-strong); }
 button.secondary:hover { background: var(--accent-soft); }
+button.danger { background: #a92828; }
+button.danger:hover { background: #861f1f; }
 .topbar button.secondary { background: rgba(255, 255, 255, .08); border-color: rgba(255, 255, 255, .35); color: #eaf6f0; }
 .topbar button.secondary:hover { background: rgba(255, 255, 255, .16); }
 
@@ -379,6 +381,12 @@ textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(13, 138
 .field-meta { display: block; margin-top: .3rem; color: var(--muted); font-size: .68rem; font-weight: 500; }
 .clear-secret { display: flex; align-items: center; gap: .3rem; margin: 0; white-space: nowrap; font-weight: 500; }
 .compact-row { grid-template-columns: 1fr auto; }
+.tool-whitelist { grid-column: 1 / -1; margin: 0; padding: .8rem; border: 1px solid var(--line); border-radius: 8px; }
+.tool-whitelist legend { padding: 0 .35rem; color: var(--muted); font-size: .8rem; font-weight: 700; }
+.tool-whitelist-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr)); gap: .45rem .8rem; }
+.tool-checkbox { display: flex; align-items: flex-start; gap: .45rem; margin: 0; font-size: .85rem; font-weight: 550; cursor: pointer; }
+.tool-checkbox input { margin-top: .2rem; }
+.tool-whitelist-save { margin-top: .8rem; }
 .status-message { min-height: 1.4rem; }
 
 footer { padding: 1.4rem 1rem; color: var(--muted); border-top: 1px solid var(--line); text-align: center; font-size: .76rem; }

--- a/web-console/dist/styles.css
+++ b/web-console/dist/styles.css
@@ -386,6 +386,7 @@ textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(13, 138
 .tool-whitelist-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr)); gap: .45rem .8rem; }
 .tool-checkbox { display: flex; align-items: flex-start; gap: .45rem; margin: 0; font-size: .85rem; font-weight: 550; cursor: pointer; }
 .tool-checkbox input { margin-top: .2rem; }
+.tool-registration-state { color: var(--warn); font-size: .72rem; font-weight: 650; }
 .tool-whitelist-save { margin-top: .8rem; }
 .status-message { min-height: 1.4rem; }
 

--- a/web-console/dist/views/configuration.js
+++ b/web-console/dist/views/configuration.js
@@ -1,4 +1,5 @@
 import { ConsoleApiError, fetchConfiguration, requestRestart, testProviderConnection, updateAgentConfiguration, updateRuntimeConfiguration, updateSecretConfiguration, validateConfiguration, } from "../api.js";
+import { agentToolOptions, selectedAgentToolNames } from "../agent-tools.js";
 import { togglePasswordReveal } from "../dom.js";
 const FIELD_LABELS = {
     "command.prefix": "聊天命令前缀",
@@ -196,14 +197,8 @@ function renderAgent(snapshot) {
         const legend = document.createElement("legend");
         legend.textContent = `${sceneName === "private" ? "私聊" : "群聊"}工具白名单`;
         tools.append(legend);
-        const selected = new Set(array(scene.enabled_tools).filter((value) => typeof value === "string"));
-        const registeredNames = new Set(snapshot.registeredTools.map((tool) => tool.name));
-        const visibleTools = [
-            ...snapshot.registeredTools,
-            ...[...selected]
-                .filter((name) => !registeredNames.has(name))
-                .map((name) => ({ name, description: "已写入 agent.toml，但当前进程未注册此工具" })),
-        ];
+        const savedNames = array(scene.enabled_tools).filter((value) => typeof value === "string");
+        const visibleTools = agentToolOptions(snapshot.registeredTools, savedNames, agent.editable);
         if (visibleTools.length === 0) {
             const hint = document.createElement("p");
             hint.className = "hint";
@@ -214,7 +209,7 @@ function renderAgent(snapshot) {
             const grid = document.createElement("div");
             grid.className = "tool-whitelist-grid";
             for (const tool of visibleTools) {
-                grid.append(toolCheckbox(tool, sceneName, selected.has(tool.name), !agent.editable || !registeredNames.has(tool.name)));
+                grid.append(toolCheckbox(tool, sceneName));
             }
             tools.append(grid);
         }
@@ -326,25 +321,32 @@ async function saveAgentScene(sceneName) {
         }]));
 }
 function agentSceneConfig(sceneName, scenes) {
+    const toolInputs = document.querySelectorAll(`input[data-agent-tool="${sceneName}"]`);
     return {
         ...record(scenes[sceneName]),
         tool_calling_enabled: element(`agent-tool-${sceneName}`, HTMLInputElement).checked,
-        enabled_tools: [...document.querySelectorAll(`input[data-agent-tool="${sceneName}"]:checked`)].map((input) => input.value),
+        enabled_tools: selectedAgentToolNames(toolInputs),
     };
 }
-function toolCheckbox(tool, sceneName, checked, disabled) {
+function toolCheckbox(tool, sceneName) {
     const label = document.createElement("label");
     label.className = "tool-checkbox";
     label.title = tool.description;
     const input = document.createElement("input");
     input.type = "checkbox";
     input.value = tool.name;
-    input.checked = checked;
-    input.disabled = disabled;
+    input.checked = tool.checked;
+    input.disabled = tool.disabled;
     input.dataset.agentTool = sceneName;
     const name = document.createElement("span");
     name.textContent = tool.name;
     label.append(input, name);
+    if (!tool.registered) {
+        const state = document.createElement("span");
+        state.className = "tool-registration-state";
+        state.textContent = "当前进程未注册";
+        label.append(state);
+    }
     return label;
 }
 function bindRestart(snapshot) {

--- a/web-console/dist/views/configuration.js
+++ b/web-console/dist/views/configuration.js
@@ -1,4 +1,4 @@
-import { ConsoleApiError, fetchConfiguration, testProviderConnection, updateAgentConfiguration, updateRuntimeConfiguration, updateSecretConfiguration, validateConfiguration, } from "../api.js";
+import { ConsoleApiError, fetchConfiguration, requestRestart, testProviderConnection, updateAgentConfiguration, updateRuntimeConfiguration, updateSecretConfiguration, validateConfiguration, } from "../api.js";
 import { togglePasswordReveal } from "../dom.js";
 const FIELD_LABELS = {
     "command.prefix": "聊天命令前缀",
@@ -81,6 +81,7 @@ function render(snapshot) {
     renderPublicFields(snapshot);
     renderSecretFields(snapshot);
     renderAgent(snapshot);
+    bindRestart(snapshot);
     bindValidation();
     bindConnectionTest();
 }
@@ -190,6 +191,41 @@ function renderAgent(snapshot) {
         input.disabled = !agent.editable;
         row.append(label, input);
         target.append(row);
+        const tools = document.createElement("fieldset");
+        tools.className = "tool-whitelist";
+        const legend = document.createElement("legend");
+        legend.textContent = `${sceneName === "private" ? "私聊" : "群聊"}工具白名单`;
+        tools.append(legend);
+        const selected = new Set(array(scene.enabled_tools).filter((value) => typeof value === "string"));
+        const registeredNames = new Set(snapshot.registeredTools.map((tool) => tool.name));
+        const visibleTools = [
+            ...snapshot.registeredTools,
+            ...[...selected]
+                .filter((name) => !registeredNames.has(name))
+                .map((name) => ({ name, description: "已写入 agent.toml，但当前进程未注册此工具" })),
+        ];
+        if (visibleTools.length === 0) {
+            const hint = document.createElement("p");
+            hint.className = "hint";
+            hint.textContent = "当前没有可用的已注册工具。";
+            tools.append(hint);
+        }
+        else {
+            const grid = document.createElement("div");
+            grid.className = "tool-whitelist-grid";
+            for (const tool of visibleTools) {
+                grid.append(toolCheckbox(tool, sceneName, selected.has(tool.name), !agent.editable || !registeredNames.has(tool.name)));
+            }
+            tools.append(grid);
+        }
+        const saveScene = document.createElement("button");
+        saveScene.type = "button";
+        saveScene.className = "secondary tool-whitelist-save";
+        saveScene.textContent = `保存${sceneName === "private" ? "私聊" : "群聊"}配置`;
+        saveScene.disabled = !agent.editable;
+        saveScene.onclick = () => void saveAgentScene(sceneName);
+        tools.append(saveScene);
+        target.append(tools);
     }
     const save = element("save-agent-config", HTMLButtonElement);
     save.disabled = !agent.editable;
@@ -275,10 +311,58 @@ async function saveAgent() {
         changes.push({ action: "set_search_route", name: routeName, model: element(`agent-search-${routeName}`, HTMLInputElement).value.trim() });
     }
     for (const sceneName of ["private", "group"]) {
-        const config = { ...record(scenes[sceneName]), tool_calling_enabled: element(`agent-tool-${sceneName}`, HTMLInputElement).checked };
-        changes.push({ action: "set_scene", scene: sceneName, config });
+        changes.push({ action: "set_scene", scene: sceneName, config: agentSceneConfig(sceneName, scenes) });
     }
     await runSave(async () => updateAgentConfiguration(current.agent.revision, changes));
+}
+async function saveAgentScene(sceneName) {
+    if (!current?.agent)
+        return;
+    const scenes = record(record(current.agent.savedValue).scenes);
+    await runSave(async () => updateAgentConfiguration(current.agent.revision, [{
+            action: "set_scene",
+            scene: sceneName,
+            config: agentSceneConfig(sceneName, scenes),
+        }]));
+}
+function agentSceneConfig(sceneName, scenes) {
+    return {
+        ...record(scenes[sceneName]),
+        tool_calling_enabled: element(`agent-tool-${sceneName}`, HTMLInputElement).checked,
+        enabled_tools: [...document.querySelectorAll(`input[data-agent-tool="${sceneName}"]:checked`)].map((input) => input.value),
+    };
+}
+function toolCheckbox(tool, sceneName, checked, disabled) {
+    const label = document.createElement("label");
+    label.className = "tool-checkbox";
+    label.title = tool.description;
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.value = tool.name;
+    input.checked = checked;
+    input.disabled = disabled;
+    input.dataset.agentTool = sceneName;
+    const name = document.createElement("span");
+    name.textContent = tool.name;
+    label.append(input, name);
+    return label;
+}
+function bindRestart(snapshot) {
+    const restart = element("restart-service", HTMLButtonElement);
+    restart.disabled = !snapshot.restartAvailable;
+    restart.title = snapshot.restartAvailable ? "通过当前运行目录的 botctl 重启" : "当前运行目录没有可用的 botctl 重启脚本";
+    restart.onclick = async () => {
+        if (!window.confirm("确定要重启服务吗？控制台会短暂离线。"))
+            return;
+        restart.disabled = true;
+        try {
+            showResult(await requestRestart(), false);
+        }
+        catch (cause) {
+            showResult(errorMessage(cause), true);
+            restart.disabled = !snapshot.restartAvailable;
+        }
+    };
 }
 function bindValidation() {
     element("validate-config", HTMLButtonElement).onclick = async () => {
@@ -464,6 +548,9 @@ function errorMessage(cause) { return cause instanceof Error ? cause.message : "
 function setButtonsDisabled(disabled) {
     for (const id of ["save-public-config", "save-secret-config", "save-agent-config", "validate-config", "test-provider-connection"]) {
         element(id, HTMLButtonElement).disabled = disabled;
+    }
+    for (const button of document.querySelectorAll(".tool-whitelist-save")) {
+        button.disabled = disabled || current?.agent?.editable !== true;
     }
 }
 function element(id, constructor) {

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "check": "tsc --noEmit",
-    "build": "node scripts/build.mjs"
+    "build": "node scripts/build.mjs",
+    "test": "npm run build && node --test tests/*.test.mjs"
   },
   "devDependencies": {
     "typescript": "5.9.3"

--- a/web-console/src/agent-tools.ts
+++ b/web-console/src/agent-tools.ts
@@ -1,0 +1,40 @@
+import type { RegisteredTool } from "./types.js";
+
+export interface AgentToolOption extends RegisteredTool {
+  registered: boolean;
+  checked: boolean;
+  disabled: boolean;
+}
+
+/** 未注册项只能来自已保存白名单，避免通过普通工具列表构造任意名称。 */
+export function agentToolOptions(
+  registeredTools: RegisteredTool[],
+  savedNames: string[],
+  editable: boolean,
+): AgentToolOption[] {
+  const selected = new Set(savedNames);
+  const registeredNames = new Set(registeredTools.map((tool) => tool.name));
+  return [
+    ...registeredTools.map((tool) => ({
+      ...tool,
+      registered: true,
+      checked: selected.has(tool.name),
+      disabled: !editable,
+    })),
+    ...savedNames
+      .filter((name) => !registeredNames.has(name))
+      .map((name) => ({
+        name,
+        description: "已写入 agent.toml，但当前进程未注册此工具",
+        registered: false,
+        checked: true,
+        disabled: !editable,
+      })),
+  ];
+}
+
+export function selectedAgentToolNames(
+  inputs: Iterable<Pick<HTMLInputElement, "checked" | "value">>,
+): string[] {
+  return [...inputs].filter((input) => input.checked).map((input) => input.value);
+}

--- a/web-console/src/api.ts
+++ b/web-console/src/api.ts
@@ -14,6 +14,7 @@ import type {
   BootstrapStatus,
   ConfigurationSnapshot,
   ConfigFieldSnapshot,
+  RegisteredTool,
 } from "./types.js";
 
 export class ConsoleApiError extends Error {
@@ -95,7 +96,7 @@ export async function fetchConfiguration(): Promise<ConfigurationSnapshot> {
   const payload = record(await fetchJson("/api/v1/console/configuration", {
     headers: { Accept: "application/json" },
   }));
-  return parseConfigurationSnapshot(payload.configuration);
+  return parseConfigurationPayload(payload);
 }
 
 export async function updateRuntimeConfiguration(expectedRevision: string, changes: unknown[]): Promise<ConfigurationSnapshot> {
@@ -103,12 +104,12 @@ export async function updateRuntimeConfiguration(expectedRevision: string, chang
     expected_revision: expectedRevision,
     changes,
   }));
-  return parseConfigurationSnapshot(payload.configuration);
+  return parseConfigurationPayload(payload);
 }
 
 export async function updateSecretConfiguration(changes: unknown[]): Promise<ConfigurationSnapshot> {
   const payload = record(await mutatingJson("/api/v1/console/configuration/secrets", "PATCH", { changes }));
-  return parseConfigurationSnapshot(payload.configuration);
+  return parseConfigurationPayload(payload);
 }
 
 export async function updateAgentConfiguration(expectedRevision: string, changes: unknown[]): Promise<ConfigurationSnapshot> {
@@ -116,7 +117,12 @@ export async function updateAgentConfiguration(expectedRevision: string, changes
     expected_revision: expectedRevision,
     changes,
   }));
-  return parseConfigurationSnapshot(payload.configuration);
+  return parseConfigurationPayload(payload);
+}
+
+export async function requestRestart(): Promise<string> {
+  const payload = record(await mutatingJson("/api/v1/console/restart", "POST", {}));
+  return string(payload.message, "重启命令已提交");
 }
 
 export async function validateConfiguration(): Promise<{ valid: boolean; message: string }> {
@@ -246,13 +252,20 @@ function parseSession(value: unknown): AdminSession {
   };
 }
 
-function parseConfigurationSnapshot(value: unknown): ConfigurationSnapshot {
+function parseConfigurationPayload(value: unknown): ConfigurationSnapshot {
+  const payload = record(value);
+  return parseConfigurationSnapshot(payload.configuration, payload.registered_tools, payload.restart);
+}
+
+function parseConfigurationSnapshot(value: unknown, toolsValue: unknown = [], restartValue: unknown = {}): ConfigurationSnapshot {
   const item = record(value);
   const agent = record(item.agent);
   return {
     revision: string(item.revision, "missing"),
     fileExists: item.file_exists === true,
     fields: array(item.fields).map(parseConfigField),
+    registeredTools: array(toolsValue).map(parseRegisteredTool),
+    restartAvailable: record(restartValue).available === true,
     agent: Object.keys(agent).length === 0 ? null : {
       revision: string(agent.revision, "missing"),
       fileExists: agent.file_exists === true,
@@ -262,6 +275,14 @@ function parseConfigurationSnapshot(value: unknown): ConfigurationSnapshot {
       savedValue: agent.saved_value,
       runningValue: agent.running_value,
     },
+  };
+}
+
+function parseRegisteredTool(value: unknown): RegisteredTool {
+  const item = record(value);
+  return {
+    name: string(item.name, "unknown"),
+    description: string(item.description, ""),
   };
 }
 

--- a/web-console/src/index.html
+++ b/web-console/src/index.html
@@ -43,6 +43,7 @@
         <p class="security-note">默认同源并受部署管理员会话与 CSRF 保护；公网访问仍必须使用受信 TLS 反向代理。</p>
       </div>
       <div class="refresh-box">
+        <button id="restart-service" class="danger" type="button" disabled>重启服务</button>
         <button id="refresh-status" type="button">手动刷新</button>
         <label class="auto-refresh" for="auto-refresh"><input id="auto-refresh" type="checkbox"> 自动刷新</label>
         <span>管理员：<strong id="admin-username">—</strong></span>
@@ -160,7 +161,7 @@
       </section>
     </main>
 
-    <footer data-authenticated hidden>配置变更不会控制 Docker socket 或 systemd；需要重启时请使用当前部署方式的受控命令。</footer>
+    <footer data-authenticated hidden>重启操作复用当前运行目录的受控 botctl 脚本，不直接控制 Docker socket 或 systemd。</footer>
     <script type="module" src="/console/app.js"></script>
   </body>
 </html>

--- a/web-console/src/styles.css
+++ b/web-console/src/styles.css
@@ -125,6 +125,8 @@ button:active:not(.reveal-button) { transform: translateY(1px); }
 button:disabled { cursor: progress; opacity: .6; }
 button.secondary { background: #fff; border-color: #c6d4cc; color: var(--accent-strong); }
 button.secondary:hover { background: var(--accent-soft); }
+button.danger { background: #a92828; }
+button.danger:hover { background: #861f1f; }
 .topbar button.secondary { background: rgba(255, 255, 255, .08); border-color: rgba(255, 255, 255, .35); color: #eaf6f0; }
 .topbar button.secondary:hover { background: rgba(255, 255, 255, .16); }
 
@@ -379,6 +381,12 @@ textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(13, 138
 .field-meta { display: block; margin-top: .3rem; color: var(--muted); font-size: .68rem; font-weight: 500; }
 .clear-secret { display: flex; align-items: center; gap: .3rem; margin: 0; white-space: nowrap; font-weight: 500; }
 .compact-row { grid-template-columns: 1fr auto; }
+.tool-whitelist { grid-column: 1 / -1; margin: 0; padding: .8rem; border: 1px solid var(--line); border-radius: 8px; }
+.tool-whitelist legend { padding: 0 .35rem; color: var(--muted); font-size: .8rem; font-weight: 700; }
+.tool-whitelist-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr)); gap: .45rem .8rem; }
+.tool-checkbox { display: flex; align-items: flex-start; gap: .45rem; margin: 0; font-size: .85rem; font-weight: 550; cursor: pointer; }
+.tool-checkbox input { margin-top: .2rem; }
+.tool-whitelist-save { margin-top: .8rem; }
 .status-message { min-height: 1.4rem; }
 
 footer { padding: 1.4rem 1rem; color: var(--muted); border-top: 1px solid var(--line); text-align: center; font-size: .76rem; }

--- a/web-console/src/styles.css
+++ b/web-console/src/styles.css
@@ -386,6 +386,7 @@ textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(13, 138
 .tool-whitelist-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr)); gap: .45rem .8rem; }
 .tool-checkbox { display: flex; align-items: flex-start; gap: .45rem; margin: 0; font-size: .85rem; font-weight: 550; cursor: pointer; }
 .tool-checkbox input { margin-top: .2rem; }
+.tool-registration-state { color: var(--warn); font-size: .72rem; font-weight: 650; }
 .tool-whitelist-save { margin-top: .8rem; }
 .status-message { min-height: 1.4rem; }
 

--- a/web-console/src/types.ts
+++ b/web-console/src/types.ts
@@ -76,11 +76,18 @@ export interface AgentConfigSnapshot {
   runningValue: unknown;
 }
 
+export interface RegisteredTool {
+  name: string;
+  description: string;
+}
+
 export interface ConfigurationSnapshot {
   revision: string;
   fileExists: boolean;
   agent: AgentConfigSnapshot | null;
   fields: ConfigFieldSnapshot[];
+  registeredTools: RegisteredTool[];
+  restartAvailable: boolean;
 }
 
 export interface ProviderStatus {

--- a/web-console/src/views/configuration.ts
+++ b/web-console/src/views/configuration.ts
@@ -8,8 +8,9 @@ import {
   updateSecretConfiguration,
   validateConfiguration,
 } from "../api.js";
+import { agentToolOptions, selectedAgentToolNames, type AgentToolOption } from "../agent-tools.js";
 import { togglePasswordReveal } from "../dom.js";
-import type { ConfigFieldSnapshot, ConfigurationSnapshot, RegisteredTool } from "../types.js";
+import type { ConfigFieldSnapshot, ConfigurationSnapshot } from "../types.js";
 
 const FIELD_LABELS: Record<string, string> = {
   "command.prefix": "聊天命令前缀",
@@ -229,14 +230,8 @@ function renderAgent(snapshot: ConfigurationSnapshot): void {
     const legend = document.createElement("legend");
     legend.textContent = `${sceneName === "private" ? "私聊" : "群聊"}工具白名单`;
     tools.append(legend);
-    const selected = new Set(array(scene.enabled_tools).filter((value): value is string => typeof value === "string"));
-    const registeredNames = new Set(snapshot.registeredTools.map((tool) => tool.name));
-    const visibleTools = [
-      ...snapshot.registeredTools,
-      ...[...selected]
-        .filter((name) => !registeredNames.has(name))
-        .map((name) => ({ name, description: "已写入 agent.toml，但当前进程未注册此工具" })),
-    ];
+    const savedNames = array(scene.enabled_tools).filter((value): value is string => typeof value === "string");
+    const visibleTools = agentToolOptions(snapshot.registeredTools, savedNames, agent.editable);
     if (visibleTools.length === 0) {
       const hint = document.createElement("p");
       hint.className = "hint";
@@ -246,7 +241,7 @@ function renderAgent(snapshot: ConfigurationSnapshot): void {
       const grid = document.createElement("div");
       grid.className = "tool-whitelist-grid";
       for (const tool of visibleTools) {
-        grid.append(toolCheckbox(tool, sceneName, selected.has(tool.name), !agent.editable || !registeredNames.has(tool.name)));
+        grid.append(toolCheckbox(tool, sceneName));
       }
       tools.append(grid);
     }
@@ -359,26 +354,33 @@ async function saveAgentScene(sceneName: string): Promise<void> {
 }
 
 function agentSceneConfig(sceneName: string, scenes: Record<string, unknown>): Record<string, unknown> {
+  const toolInputs = document.querySelectorAll<HTMLInputElement>(`input[data-agent-tool="${sceneName}"]`);
   return {
     ...record(scenes[sceneName]),
     tool_calling_enabled: element(`agent-tool-${sceneName}`, HTMLInputElement).checked,
-    enabled_tools: [...document.querySelectorAll<HTMLInputElement>(`input[data-agent-tool="${sceneName}"]:checked`)].map((input) => input.value),
+    enabled_tools: selectedAgentToolNames(toolInputs),
   };
 }
 
-function toolCheckbox(tool: RegisteredTool, sceneName: string, checked: boolean, disabled: boolean): HTMLElement {
+function toolCheckbox(tool: AgentToolOption, sceneName: string): HTMLElement {
   const label = document.createElement("label");
   label.className = "tool-checkbox";
   label.title = tool.description;
   const input = document.createElement("input");
   input.type = "checkbox";
   input.value = tool.name;
-  input.checked = checked;
-  input.disabled = disabled;
+  input.checked = tool.checked;
+  input.disabled = tool.disabled;
   input.dataset.agentTool = sceneName;
   const name = document.createElement("span");
   name.textContent = tool.name;
   label.append(input, name);
+  if (!tool.registered) {
+    const state = document.createElement("span");
+    state.className = "tool-registration-state";
+    state.textContent = "当前进程未注册";
+    label.append(state);
+  }
   return label;
 }
 

--- a/web-console/src/views/configuration.ts
+++ b/web-console/src/views/configuration.ts
@@ -1,6 +1,7 @@
 import {
   ConsoleApiError,
   fetchConfiguration,
+  requestRestart,
   testProviderConnection,
   updateAgentConfiguration,
   updateRuntimeConfiguration,
@@ -8,7 +9,7 @@ import {
   validateConfiguration,
 } from "../api.js";
 import { togglePasswordReveal } from "../dom.js";
-import type { ConfigFieldSnapshot, ConfigurationSnapshot } from "../types.js";
+import type { ConfigFieldSnapshot, ConfigurationSnapshot, RegisteredTool } from "../types.js";
 
 const FIELD_LABELS: Record<string, string> = {
   "command.prefix": "聊天命令前缀",
@@ -96,6 +97,7 @@ function render(snapshot: ConfigurationSnapshot): void {
   renderPublicFields(snapshot);
   renderSecretFields(snapshot);
   renderAgent(snapshot);
+  bindRestart(snapshot);
   bindValidation();
   bindConnectionTest();
 }
@@ -221,6 +223,41 @@ function renderAgent(snapshot: ConfigurationSnapshot): void {
     input.disabled = !agent.editable;
     row.append(label, input);
     target.append(row);
+
+    const tools = document.createElement("fieldset");
+    tools.className = "tool-whitelist";
+    const legend = document.createElement("legend");
+    legend.textContent = `${sceneName === "private" ? "私聊" : "群聊"}工具白名单`;
+    tools.append(legend);
+    const selected = new Set(array(scene.enabled_tools).filter((value): value is string => typeof value === "string"));
+    const registeredNames = new Set(snapshot.registeredTools.map((tool) => tool.name));
+    const visibleTools = [
+      ...snapshot.registeredTools,
+      ...[...selected]
+        .filter((name) => !registeredNames.has(name))
+        .map((name) => ({ name, description: "已写入 agent.toml，但当前进程未注册此工具" })),
+    ];
+    if (visibleTools.length === 0) {
+      const hint = document.createElement("p");
+      hint.className = "hint";
+      hint.textContent = "当前没有可用的已注册工具。";
+      tools.append(hint);
+    } else {
+      const grid = document.createElement("div");
+      grid.className = "tool-whitelist-grid";
+      for (const tool of visibleTools) {
+        grid.append(toolCheckbox(tool, sceneName, selected.has(tool.name), !agent.editable || !registeredNames.has(tool.name)));
+      }
+      tools.append(grid);
+    }
+    const saveScene = document.createElement("button");
+    saveScene.type = "button";
+    saveScene.className = "secondary tool-whitelist-save";
+    saveScene.textContent = `保存${sceneName === "private" ? "私聊" : "群聊"}配置`;
+    saveScene.disabled = !agent.editable;
+    saveScene.onclick = () => void saveAgentScene(sceneName);
+    tools.append(saveScene);
+    target.append(tools);
   }
   const save = element("save-agent-config", HTMLButtonElement);
   save.disabled = !agent.editable;
@@ -306,10 +343,59 @@ async function saveAgent(): Promise<void> {
     changes.push({ action: "set_search_route", name: routeName, model: element(`agent-search-${routeName}`, HTMLInputElement).value.trim() });
   }
   for (const sceneName of ["private", "group"]) {
-    const config = { ...record(scenes[sceneName]), tool_calling_enabled: element(`agent-tool-${sceneName}`, HTMLInputElement).checked };
-    changes.push({ action: "set_scene", scene: sceneName, config });
+    changes.push({ action: "set_scene", scene: sceneName, config: agentSceneConfig(sceneName, scenes) });
   }
   await runSave(async () => updateAgentConfiguration(current!.agent!.revision, changes));
+}
+
+async function saveAgentScene(sceneName: string): Promise<void> {
+  if (!current?.agent) return;
+  const scenes = record(record(current.agent.savedValue).scenes);
+  await runSave(async () => updateAgentConfiguration(current!.agent!.revision, [{
+    action: "set_scene",
+    scene: sceneName,
+    config: agentSceneConfig(sceneName, scenes),
+  }]));
+}
+
+function agentSceneConfig(sceneName: string, scenes: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...record(scenes[sceneName]),
+    tool_calling_enabled: element(`agent-tool-${sceneName}`, HTMLInputElement).checked,
+    enabled_tools: [...document.querySelectorAll<HTMLInputElement>(`input[data-agent-tool="${sceneName}"]:checked`)].map((input) => input.value),
+  };
+}
+
+function toolCheckbox(tool: RegisteredTool, sceneName: string, checked: boolean, disabled: boolean): HTMLElement {
+  const label = document.createElement("label");
+  label.className = "tool-checkbox";
+  label.title = tool.description;
+  const input = document.createElement("input");
+  input.type = "checkbox";
+  input.value = tool.name;
+  input.checked = checked;
+  input.disabled = disabled;
+  input.dataset.agentTool = sceneName;
+  const name = document.createElement("span");
+  name.textContent = tool.name;
+  label.append(input, name);
+  return label;
+}
+
+function bindRestart(snapshot: ConfigurationSnapshot): void {
+  const restart = element("restart-service", HTMLButtonElement);
+  restart.disabled = !snapshot.restartAvailable;
+  restart.title = snapshot.restartAvailable ? "通过当前运行目录的 botctl 重启" : "当前运行目录没有可用的 botctl 重启脚本";
+  restart.onclick = async () => {
+    if (!window.confirm("确定要重启服务吗？控制台会短暂离线。")) return;
+    restart.disabled = true;
+    try {
+      showResult(await requestRestart(), false);
+    } catch (cause) {
+      showResult(errorMessage(cause), true);
+      restart.disabled = !snapshot.restartAvailable;
+    }
+  };
 }
 
 function bindValidation(): void {
@@ -499,6 +585,9 @@ function errorMessage(cause: unknown): string { return cause instanceof Error ? 
 function setButtonsDisabled(disabled: boolean): void {
   for (const id of ["save-public-config", "save-secret-config", "save-agent-config", "validate-config", "test-provider-connection"]) {
     element(id, HTMLButtonElement).disabled = disabled;
+  }
+  for (const button of document.querySelectorAll<HTMLButtonElement>(".tool-whitelist-save")) {
+    button.disabled = disabled || current?.agent?.editable !== true;
   }
 }
 

--- a/web-console/tests/agent-tools.test.mjs
+++ b/web-console/tests/agent-tools.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { agentToolOptions, selectedAgentToolNames } from "../dist/agent-tools.js";
+
+const registeredTools = [{ name: "web_search", description: "受控搜索" }];
+
+function checkboxInputs(options) {
+  return options.map((option) => ({ checked: option.checked, value: option.name }));
+}
+
+test("未注册工具可取消并从保存值删除", () => {
+  const options = agentToolOptions(registeredTools, ["web_search", "legacy_tool"], true);
+  const legacy = options.find((tool) => tool.name === "legacy_tool");
+
+  assert.deepEqual(legacy, {
+    name: "legacy_tool",
+    description: "已写入 agent.toml，但当前进程未注册此工具",
+    registered: false,
+    checked: true,
+    disabled: false,
+  });
+  legacy.checked = false;
+  assert.deepEqual(selectedAgentToolNames(checkboxInputs(options)), ["web_search"]);
+});
+
+test("未操作未注册工具时保存其他配置仍保留它", () => {
+  const options = agentToolOptions(registeredTools, ["legacy_tool"], true);
+
+  assert.deepEqual(selectedAgentToolNames(checkboxInputs(options)), ["legacy_tool"]);
+  assert.deepEqual(options.map((tool) => tool.name), ["web_search", "legacy_tool"]);
+  assert.deepEqual(agentToolOptions(registeredTools, [], true).map((tool) => tool.name), ["web_search"]);
+});


### PR DESCRIPTION
## 变更
- 在 Agent / Tool Calling 中动态展示当前注册工具，分别保存私聊和群聊白名单到 agent.toml
- 复用现有 ConfigCenter 的 revision、校验、原子写入和热加载机制
- 顶部增加受管理员会话与 CSRF 保护的 botctl 重启按钮
- 拆分 HTTP 路由模块，并将 management 迁移为 management/mod.rs

## 验证
- npm run check
- npm run build
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features
- cargo build --workspace --release --all-features
- git diff --check