### PR TITLE
[codex] 修复 Workspace 快照时钟回拨随机失效

### DIFF
--- a/qq-maid-core/src/runtime/freshness.rs
+++ b/qq-maid-core/src/runtime/freshness.rs
@@ -6,14 +6,71 @@
 use chrono::{DateTime, Duration};
 use qq_maid_common::time_context;
 
+/// 持久化快照使用墙上时钟；允许系统校时造成的小幅回拨，但不接受明显的未来时间。
+const MAX_SNAPSHOT_CLOCK_SKEW_SECONDS: i64 = 5;
+
 /// 判断一条快照记录是否仍在有效期内（created_at 为 RFC3339，TTL 单位为秒）。
 pub fn query_is_fresh(created_at: &str, ttl_seconds: i64) -> bool {
+    query_is_fresh_at(created_at, ttl_seconds, &time_context::now_iso_cn())
+}
+
+fn query_is_fresh_at(created_at: &str, ttl_seconds: i64, now: &str) -> bool {
+    if ttl_seconds < 0 {
+        return false;
+    }
     let Ok(created_at) = DateTime::parse_from_rfc3339(created_at.trim()) else {
         return false;
     };
-    let Ok(now) = DateTime::parse_from_rfc3339(&time_context::now_iso_cn()) else {
+    let Ok(now) = DateTime::parse_from_rfc3339(now.trim()) else {
         return false;
     };
     let age = now.signed_duration_since(created_at.with_timezone(&time_context::shanghai_offset()));
-    age >= Duration::zero() && age.num_seconds() <= ttl_seconds
+    age >= Duration::seconds(-MAX_SNAPSHOT_CLOCK_SKEW_SECONDS)
+        && age <= Duration::seconds(ttl_seconds)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_snapshot_tolerates_small_wall_clock_rollback() {
+        assert!(query_is_fresh_at(
+            "2026-07-19T14:00:02+08:00",
+            600,
+            "2026-07-19T14:00:00+08:00",
+        ));
+    }
+
+    #[test]
+    fn fresh_snapshot_rejects_future_time_beyond_clock_skew_budget() {
+        assert!(!query_is_fresh_at(
+            "2026-07-19T14:00:06+08:00",
+            600,
+            "2026-07-19T14:00:00+08:00",
+        ));
+    }
+
+    #[test]
+    fn fresh_snapshot_still_enforces_ttl_boundary() {
+        assert!(query_is_fresh_at(
+            "2026-07-19T14:00:00+08:00",
+            600,
+            "2026-07-19T14:10:00+08:00",
+        ));
+        assert!(!query_is_fresh_at(
+            "2026-07-19T14:00:00+08:00",
+            600,
+            "2026-07-19T14:10:01+08:00",
+        ));
+    }
+
+    #[test]
+    fn fresh_snapshot_rejects_negative_ttl_even_during_clock_rollback() {
+        assert!(!query_is_fresh_at(
+            "2026-07-19T14:00:02+08:00",
+            -1,
+            "2026-07-19T14:00:00+08:00",
+        ));
+    }
 }

--- a/qq-maid-core/src/runtime/respond/tests/memory_regressions.rs
+++ b/qq-maid-core/src/runtime/respond/tests/memory_regressions.rs
@@ -315,7 +315,10 @@ async fn replace_confirmation_rejects_record_drift_without_overwrite() {
         .unwrap()
         .text
         .unwrap();
-    assert!(text.contains("执行失败"));
+    assert!(
+        text.contains("执行失败"),
+        "unexpected replace confirmation reply: {text}"
+    );
     assert!(!text.contains("已纠正记忆"));
     assert_eq!(
         service.memory_store.get(&record.id).unwrap().content,
@@ -328,10 +331,16 @@ async fn delete_confirmation_rejects_record_drift_without_deletion() {
     let service = test_service();
     let record = create_personal_memory(&service, "准备删除的旧内容");
     service.respond(private_message("/memory")).await.unwrap();
-    service
+    let prepared = service
         .respond(private_message("/memory delete 1"))
         .await
+        .unwrap()
+        .text
         .unwrap();
+    assert!(
+        prepared.contains("待删除"),
+        "delete pending was not prepared: {prepared}"
+    );
 
     service
         .memory_store
@@ -350,7 +359,10 @@ async fn delete_confirmation_rejects_record_drift_without_deletion() {
         .unwrap()
         .text
         .unwrap();
-    assert!(text.contains("执行失败"));
+    assert!(
+        text.contains("执行失败"),
+        "unexpected delete confirmation reply: {text}"
+    );
     assert!(!text.contains("已删除这条记忆"));
     assert_eq!(
         service.memory_store.get(&record.id).unwrap().content,

--- a/qq-maid-core/src/runtime/tools/ops/execute.rs
+++ b/qq-maid-core/src/runtime/tools/ops/execute.rs
@@ -97,7 +97,9 @@ pub(super) async fn execute_codex(
 ) -> OpsExecutionResult {
     let program_directory = match config.canonical_program_directory() {
         Ok(directory) => directory,
-        Err(_) => return spawn_failed("codex", Duration::ZERO),
+        Err(_) => {
+            return spawn_failed("codex", Duration::ZERO, "spawn_program_directory_failed");
+        }
     };
     execute_spec(
         "codex",
@@ -153,7 +155,7 @@ async fn execute_spec(
     if let Some(directory) = &spec.prepend_path_directory
         && prepend_program_directory_to_path(&mut command, directory).is_err()
     {
-        return spawn_failed(name, started_at.elapsed());
+        return spawn_failed(name, started_at.elapsed(), "spawn_path_failed");
     }
     if let Some(directory) = &spec.working_directory {
         command.current_dir(directory);
@@ -166,7 +168,9 @@ async fn execute_spec(
     }
     let mut child = match command.spawn() {
         Ok(child) => child,
-        Err(_) => return spawn_failed(name, started_at.elapsed()),
+        Err(error) => {
+            return spawn_failed(name, started_at.elapsed(), spawn_error_type(&error));
+        }
     };
     *process_id.lock().unwrap() = child.id();
 
@@ -353,7 +357,7 @@ async fn terminate_task(child: &mut Child) -> TerminationOutcome {
     }
 }
 
-fn spawn_failed(name: &str, elapsed: Duration) -> OpsExecutionResult {
+fn spawn_failed(name: &str, elapsed: Duration, error_type: &'static str) -> OpsExecutionResult {
     OpsExecutionResult {
         command: name.to_owned(),
         status: OpsExecutionStatus::SpawnFailed,
@@ -363,8 +367,19 @@ fn spawn_failed(name: &str, elapsed: Duration) -> OpsExecutionResult {
         stderr: String::new(),
         stdout_truncated: false,
         stderr_truncated: false,
-        error_type: Some("spawn_failed".to_owned()),
+        error_type: Some(error_type.to_owned()),
         tree_termination_limited: false,
+    }
+}
+
+fn spawn_error_type(error: &std::io::Error) -> &'static str {
+    // 只保留可诊断类别，不把程序路径、参数或操作系统原始错误文本带入结果。
+    match error.kind() {
+        std::io::ErrorKind::NotFound => "spawn_not_found",
+        std::io::ErrorKind::PermissionDenied => "spawn_permission_denied",
+        std::io::ErrorKind::WouldBlock => "spawn_resource_exhausted",
+        std::io::ErrorKind::InvalidInput => "spawn_invalid_input",
+        _ => "spawn_failed",
     }
 }
 

--- a/qq-maid-core/src/runtime/tools/ops/tests.rs
+++ b/qq-maid-core/src/runtime/tools/ops/tests.rs
@@ -529,6 +529,7 @@ async fn executor_distinguishes_success_timeout_spawn_failure_and_truncation() {
     let missing_config = command_config(&missing, 2, 4096, 4096);
     let spawn_failed = execute("test", &missing_config, &[]).await;
     assert_eq!(spawn_failed.status, OpsExecutionStatus::SpawnFailed);
+    assert_eq!(spawn_failed.error_type.as_deref(), Some("spawn_not_found"));
 }
 
 #[cfg(unix)]
@@ -561,7 +562,11 @@ async fn executor_timeout_kills_process_group_and_finishes_output_collection() {
     ));
     let result = execute("test", &command_config(&script, 1, 4096, 4096), &[]).await;
 
-    assert_eq!(result.status, OpsExecutionStatus::TimedOut);
+    assert_eq!(
+        result.status,
+        OpsExecutionStatus::TimedOut,
+        "unexpected execution result: {result:?}"
+    );
     assert!(result.elapsed < Duration::from_millis(1800));
     let child_pid: i32 = fs::read_to_string(&child_pid_file)
         .unwrap()


### PR DESCRIPTION
Closes #524

## 根因

Memory 与 Todo 的最近可见列表都依赖 `runtime::freshness::query_is_fresh`。快照时间使用持久化的 RFC3339 墙上时钟；原实现要求 `age >= 0`，系统校时造成短暂回拨时，刚写入的快照会被立即判定过期。

重复运行 Core 默认并行测试时，`delete_confirmation_rejects_record_drift_without_deletion` 曾进入这一分支：`/memory delete 1` 没有建立 pending，后续“确认”因此落入普通聊天并返回“回复：确认”。该机制也会影响 Issue 中列出的 Memory/Todo 最近列表与编号测试。

## 修改

- 给持久化快照增加 5 秒墙上时钟回拨容差，同时继续严格执行 TTL，拒绝超过容差的未来时间和负 TTL。
- 为回拨容差、未来时间、TTL 边界和负 TTL 增加确定性单元测试。
- 强化 Memory 漂移回归测试，先验证 pending 已建立，并在失败时输出实际回复。
- 排查期间还捕获过一次 Ops 超时测试返回 `SpawnFailed`；将被吞掉的启动错误收敛为脱敏类别，并增强断言诊断。最终全量回归未再复现该异常。

未增加固定等待、全局串行、ignored 测试，也未放宽原有业务断言。

## 验证

- 修复前：Core 默认并行全量重复运行可复现随机失败；Memory 删除漂移用例在 200 次内复现 pending 丢失。
- 修复后：Memory 删除漂移用例连续 200 次通过。
- Issue 列出的 3 个已知受害用例：默认模式各连续 100 次通过，`--test-threads=1` 对照各通过 1 次。
- 最终代码状态：`cargo test --workspace` 默认并行连续 3 轮通过。
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo build --workspace --release --all-features`

## 残余风险

排查期间出现的单次 Ops `SpawnFailed` 在补充脱敏错误分类后未再次出现，当前没有足够证据归入同一根因。若 CI 后续再次出现，新的 `error_type` 和断言会直接区分路径、权限、资源耗尽或通用启动失败，便于单独跟进。
