### PR TITLE
[codex] 统一 rustls 使用 ring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,29 +133,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "pkg-config",
-]
-
-[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,8 +290,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -379,15 +354,6 @@ dependencies = [
  "block-buffer 0.12.1",
  "crypto-common 0.2.2",
  "inout",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -772,12 +738,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,12 +867,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1478,16 +1432,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
-dependencies = [
- "getrandom 0.4.3",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2044,6 +1988,9 @@ dependencies = [
  "chrono",
  "pulldown-cmark",
  "regex",
+ "reqwest 0.13.4",
+ "rustls",
+ "rustls-platform-verifier",
  "serde",
 ]
 
@@ -2172,7 +2119,6 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
@@ -2431,7 +2377,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -2510,7 +2455,6 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2575,7 +2519,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/qq-maid-common/Cargo.toml
+++ b/qq-maid-common/Cargo.toml
@@ -11,5 +11,10 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 regex = "1"
 # 通用 Markdown 到纯文本渲染，包含引用式链接和合法转义解析。
 pulldown-cmark = "0.13"
+# 各入口和业务 HTTP 客户端共用 rustls，但不让 reqwest 隐式选择 aws-lc-rs。
+reqwest = { version = "0.13", default-features = false, features = ["rustls-no-provider"] }
+# 全 workspace 统一使用 ring，并保留 reqwest 原有的系统证书校验语义。
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+rustls-platform-verifier = "0.7"
 # 跨 crate 输入块需要在 Core 请求和 LLM 请求中序列化。
 serde = { version = "1", features = ["derive"] }

--- a/qq-maid-common/src/http_client.rs
+++ b/qq-maid-common/src/http_client.rs
@@ -1,0 +1,43 @@
+//! 统一的 reqwest rustls 客户端配置。
+
+use std::sync::Arc;
+
+use rustls_platform_verifier::BuilderVerifierExt;
+
+/// 创建显式使用 ring 和系统证书校验器的 reqwest builder。
+///
+/// 这里传入预配置的 `ClientConfig`，避免 `rustls-no-provider` 要求调用全局
+/// `install_default()`，也不会让其他依赖改变本项目的 CryptoProvider 选择。
+pub fn try_builder() -> Result<reqwest::ClientBuilder, rustls::Error> {
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let mut tls = rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()?
+        .with_platform_verifier()?
+        .with_no_client_auth();
+    tls.alpn_protocols = vec![b"http/1.1".to_vec()];
+
+    Ok(reqwest::Client::builder().tls_backend_preconfigured(tls))
+}
+
+/// 与 `reqwest::Client::new()` 一致，构建失败时直接暴露错误而不伪造可用客户端。
+pub fn client() -> reqwest::Client {
+    try_builder()
+        .expect("ring-backed rustls configuration must be valid")
+        .build()
+        .expect("ring-backed reqwest client must initialize")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_ring_client_without_installing_global_provider() {
+        let had_no_default = rustls::crypto::CryptoProvider::get_default().is_none();
+        try_builder().unwrap().build().unwrap();
+
+        if had_no_default {
+            assert!(rustls::crypto::CryptoProvider::get_default().is_none());
+        }
+    }
+}

--- a/qq-maid-common/src/lib.rs
+++ b/qq-maid-common/src/lib.rs
@@ -3,6 +3,7 @@
 //! 这里只放 gateway 和 LLM 都可能复用、且不依赖业务状态的通用逻辑。
 
 pub mod command_prefix;
+pub mod http_client;
 pub mod identity_context;
 pub mod input_part;
 pub mod markdown;

--- a/qq-maid-core/Cargo.toml
+++ b/qq-maid-core/Cargo.toml
@@ -37,8 +37,8 @@ html2text = "0.17.1"
 pulldown-cmark = "0.13"
 # 正则表达式
 regex = "1"
-# HTTP 客户端（使用 rustls 而非 openssl）
-reqwest = { version = "0.13", default-features = false, features = ["gzip", "json", "rustls"] }
+# HTTP 客户端（使用 rustls 而非 openssl，CryptoProvider 由 common 统一配置）
+reqwest = { version = "0.13", default-features = false, features = ["gzip", "json", "rustls-no-provider"] }
 # gateway 与 Core 共享的无业务状态基础工具。
 qq-maid-common = { path = "../qq-maid-common" }
 # LLM Provider、路由、SSE、usage、健康状态和 Web Search 协议由独立 crate 承载。

--- a/qq-maid-core/src/http/management/mod.rs
+++ b/qq-maid-core/src/http/management/mod.rs
@@ -419,7 +419,21 @@ async fn test_provider_connection(
         Ok(value) => value,
         Err(response) => return respond(&state, &headers, *response),
     };
-    let client = match reqwest::Client::builder()
+    let client_builder = match qq_maid_common::http_client::try_builder() {
+        Ok(value) => value,
+        Err(_) => {
+            return respond(
+                &state,
+                &headers,
+                api_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "connection_test_unavailable",
+                    "connection test TLS could not be initialized",
+                ),
+            );
+        }
+    };
+    let client = match client_builder
         .redirect(reqwest::redirect::Policy::none())
         .connect_timeout(Duration::from_secs(5))
         .timeout(Duration::from_secs(8))

--- a/qq-maid-core/src/runtime/tools/radar.rs
+++ b/qq-maid-core/src/runtime/tools/radar.rs
@@ -127,7 +127,8 @@ pub struct HttpRadarExecutor {
 
 impl HttpRadarExecutor {
     pub fn new() -> Result<Self, LlmError> {
-        let client = reqwest::Client::builder()
+        let client = qq_maid_common::http_client::try_builder()
+            .map_err(|err| LlmError::provider(err.to_string(), "radar_tls"))?
             .user_agent(RADAR_USER_AGENT)
             .timeout(Duration::from_secs(10))
             .build()

--- a/qq-maid-core/src/runtime/tools/rss/feed.rs
+++ b/qq-maid-core/src/runtime/tools/rss/feed.rs
@@ -82,7 +82,8 @@ impl Default for RssFetchConfig {
 
 impl RssFetcher {
     pub fn new(config: RssFetchConfig) -> Result<Self, RssFeedError> {
-        let client = reqwest::Client::builder()
+        let client = qq_maid_common::http_client::try_builder()
+            .map_err(|err| RssFeedError::Client(err.to_string()))?
             .timeout(Duration::from_secs(config.timeout_seconds))
             .redirect(Policy::limited(5))
             .user_agent(config.user_agent.clone())

--- a/qq-maid-core/src/runtime/tools/train/mod.rs
+++ b/qq-maid-core/src/runtime/tools/train/mod.rs
@@ -110,7 +110,8 @@ pub struct Train12306Executor {
 impl Train12306Executor {
     /// 构造执行器，沿用全局请求超时配置，避免单命令长期阻塞。
     pub fn new(config: &AppConfig) -> Result<Self, LlmError> {
-        let client = reqwest::Client::builder()
+        let client = qq_maid_common::http_client::try_builder()
+            .map_err(|err| LlmError::config(format!("failed to configure 12306 train TLS: {err}")))?
             .timeout(Duration::from_secs(config.request_timeout_seconds))
             .build()
             .map_err(|err| {

--- a/qq-maid-core/src/runtime/tools/weather/qweather/mod.rs
+++ b/qq-maid-core/src/runtime/tools/weather/qweather/mod.rs
@@ -130,7 +130,8 @@ impl QWeatherExecutor {
         if api_key.trim().is_empty() {
             return Err(LlmError::config("QWEATHER_API_KEY must be configured"));
         }
-        let client = reqwest::Client::builder()
+        let client = qq_maid_common::http_client::try_builder()
+            .map_err(|err| LlmError::config(format!("failed to configure QWeather TLS: {err}")))?
             .user_agent(format!("qq-maid-core/{}", env!("CARGO_PKG_VERSION")))
             .timeout(Duration::from_secs(request_timeout_seconds))
             .build()

--- a/qq-maid-gateway-rs/Cargo.toml
+++ b/qq-maid-gateway-rs/Cargo.toml
@@ -17,7 +17,7 @@ fastrand = "2"
 getrandom = "0.4"
 qq-maid-core = { path = "../qq-maid-core" }
 qq-maid-common = { path = "../qq-maid-common" }
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-no-provider"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 quick-xml = "0.41.0"

--- a/qq-maid-gateway-rs/src/auth.rs
+++ b/qq-maid-gateway-rs/src/auth.rs
@@ -277,7 +277,7 @@ mod tests {
     /// 公共测试 helper：创建 AccessTokenManager 实例。
     fn test_manager() -> AccessTokenManager {
         AccessTokenManager::new(
-            reqwest::Client::new(),
+            qq_maid_common::http_client::client(),
             "appid",
             "app-secret",
             Duration::from_secs(60),
@@ -359,7 +359,7 @@ mod tests {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         drop(listener);
-        let request_error = reqwest::Client::new()
+        let request_error = qq_maid_common::http_client::client()
             .get(format!("http://{address}/token"))
             .send()
             .await

--- a/qq-maid-gateway-rs/src/gateway/command/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/command/mod.rs
@@ -122,7 +122,7 @@ impl GatewayCommandService {
             .enabled_qq_official_credentials()
             .map(|(app_id, app_secret)| {
                 AccessTokenManager::new(
-                    reqwest::Client::new(),
+                    qq_maid_common::http_client::client(),
                     app_id,
                     app_secret,
                     config.token_refresh_margin,

--- a/qq-maid-gateway-rs/src/gateway/dispatcher/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/dispatcher/tests.rs
@@ -222,12 +222,16 @@ fn test_actor_with_handler(
     drop(unused_command_tx);
     let (reject_tx, reject_rx) = mpsc::channel(32);
     let auth = AccessTokenManager::new(
-        reqwest::Client::new(),
+        qq_maid_common::http_client::client(),
         config.app_id.clone().expect("test QQ app id"),
         config.app_secret.clone().expect("test QQ app secret"),
         config.token_refresh_margin,
     );
-    let api = QqApiClient::new(reqwest::Client::new(), config.api_base.clone(), auth);
+    let api = QqApiClient::new(
+        qq_maid_common::http_client::client(),
+        config.api_base.clone(),
+        auth,
+    );
     let actor = DispatcherActor::new(
         config,
         api,

--- a/qq-maid-gateway-rs/src/gateway/media_fetch/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/media_fetch/mod.rs
@@ -502,7 +502,7 @@ mod tests {
         };
 
         fetch_qq_official_image_attachments(
-            &reqwest::Client::new(),
+            &qq_maid_common::http_client::client(),
             &context,
             "msg-1",
             &mut parts,
@@ -550,7 +550,7 @@ mod tests {
         };
 
         fetch_qq_official_image_attachments(
-            &reqwest::Client::new(),
+            &qq_maid_common::http_client::client(),
             &context,
             "msg-1",
             &mut parts,
@@ -645,7 +645,7 @@ mod tests {
         };
 
         fetch_qq_official_image_attachments(
-            &reqwest::Client::new(),
+            &qq_maid_common::http_client::client(),
             &context,
             "msg-1",
             &mut parts,
@@ -716,7 +716,7 @@ mod tests {
         };
 
         fetch_qq_official_image_attachments(
-            &reqwest::Client::new(),
+            &qq_maid_common::http_client::client(),
             &context,
             "msg-1",
             &mut parts,
@@ -784,7 +784,7 @@ mod tests {
         };
 
         fetch_qq_official_image_attachments(
-            &reqwest::Client::new(),
+            &qq_maid_common::http_client::client(),
             &context,
             "msg-1",
             &mut parts,
@@ -848,7 +848,7 @@ mod tests {
         };
 
         fetch_qq_official_image_attachments(
-            &reqwest::Client::new(),
+            &qq_maid_common::http_client::client(),
             &context,
             "msg-1",
             &mut parts,

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -77,7 +77,7 @@ pub async fn run(
         .enabled_qq_official_credentials()
         .map(|(app_id, app_secret)| {
             AccessTokenManager::new(
-                reqwest::Client::new(),
+                qq_maid_common::http_client::client(),
                 app_id,
                 app_secret,
                 config.token_refresh_margin,
@@ -294,7 +294,7 @@ async fn run_qq_official(
         .context("QQ official channel enabled without credentials")?;
     let app_id = app_id.to_owned();
     let respond = respond.with_qq_official_account_id(app_id.clone());
-    let http_client = reqwest::Client::new();
+    let http_client = qq_maid_common::http_client::client();
     let api = QqApiClient::new(http_client.clone(), config.api_base.clone(), auth.clone());
     let group_outbound_cache = Arc::new(Mutex::new(BotOutboundCache::default()));
     // 主动推送已经进程内化；Core 通过 PushSink 进入这里，仍由 Gateway 负责 QQ 发送。

--- a/qq-maid-gateway-rs/src/gateway/ping/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/ping/tests.rs
@@ -637,7 +637,7 @@ async fn ping_check_direct_failure_overrides_stale_healthz_status() {
     let config = config();
     let runtime = GatewayRuntimeStatus::new_for_test();
     let auth = AccessTokenManager::new(
-        reqwest::Client::new(),
+        qq_maid_common::http_client::client(),
         "appid",
         "app-secret-value",
         Duration::from_secs(60),

--- a/qq-maid-gateway-rs/src/gateway/push.rs
+++ b/qq-maid-gateway-rs/src/gateway/push.rs
@@ -1434,10 +1434,10 @@ mod tests {
 
     fn panic_api_client() -> QqApiClient {
         crate::api::QqApiClient::new(
-            reqwest::Client::new(),
+            qq_maid_common::http_client::client(),
             "http://127.0.0.1",
             crate::auth::AccessTokenManager::new(
-                reqwest::Client::new(),
+                qq_maid_common::http_client::client(),
                 "app",
                 "secret",
                 Duration::from_secs(60),

--- a/qq-maid-gateway-rs/src/gateway/qq_official/c2c/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/qq_official/c2c/mod.rs
@@ -274,7 +274,7 @@ pub(crate) async fn handle_c2c_message(
         return Ok(());
     }
     fetch_qq_official_image_attachments(
-        &reqwest::Client::new(),
+        &qq_maid_common::http_client::client(),
         &MediaFetchContext {
             platform: "qq_official",
             app_id: config

--- a/qq-maid-gateway-rs/src/gateway/qq_official/group/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/qq_official/group/mod.rs
@@ -309,7 +309,7 @@ pub(crate) async fn handle_group_message(
     }
 
     fetch_qq_official_image_attachments(
-        &reqwest::Client::new(),
+        &qq_maid_common::http_client::client(),
         &MediaFetchContext {
             platform: "qq_official",
             app_id: config

--- a/qq-maid-gateway-rs/src/gateway/qq_official/group/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/qq_official/group/tests.rs
@@ -247,10 +247,10 @@ fn respond_client_with_response(
 
 fn api_client() -> QqApiClient {
     QqApiClient::new(
-        reqwest::Client::new(),
+        qq_maid_common::http_client::client(),
         "http://127.0.0.1:1",
         AccessTokenManager::new(
-            reqwest::Client::new(),
+            qq_maid_common::http_client::client(),
             "app",
             "secret",
             Duration::from_secs(60),

--- a/qq-maid-gateway-rs/src/gateway/retry.rs
+++ b/qq-maid-gateway-rs/src/gateway/retry.rs
@@ -164,7 +164,7 @@ mod tests {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         drop(listener);
-        let request_error = reqwest::Client::new()
+        let request_error = qq_maid_common::http_client::client()
             .get(format!("http://{address}/gateway"))
             .send()
             .await

--- a/qq-maid-gateway-rs/src/gateway/wechat_service/customer.rs
+++ b/qq-maid-gateway-rs/src/gateway/wechat_service/customer.rs
@@ -25,7 +25,7 @@ pub(super) fn build_customer_messenger(
         return None;
     };
     Some(Arc::new(WechatCustomerMessageClient::new(
-        reqwest::Client::new(),
+        qq_maid_common::http_client::client(),
         config.api_base.clone(),
         app_id.clone(),
         app_secret.clone(),

--- a/qq-maid-gateway-rs/src/gateway/wechat_service/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/wechat_service/tests.rs
@@ -828,7 +828,7 @@ async fn customer_message_refreshes_token_and_retries_once_when_token_invalid() 
         axum::serve(listener, app).await.unwrap();
     });
     let client = WechatCustomerMessageClient::new(
-        reqwest::Client::new(),
+        qq_maid_common::http_client::client(),
         format!("http://{addr}"),
         "appid".to_owned(),
         "secret".to_owned(),

--- a/qq-maid-llm/Cargo.toml
+++ b/qq-maid-llm/Cargo.toml
@@ -10,7 +10,7 @@ async-trait = "0.1"
 base64 = "0.22"
 futures = "0.3"
 qq-maid-common = { path = "../qq-maid-common" }
-reqwest = { version = "0.13", default-features = false, features = ["gzip", "json", "rustls"] }
+reqwest = { version = "0.13", default-features = false, features = ["gzip", "json", "rustls-no-provider"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/qq-maid-llm/src/provider/bigmodel.rs
+++ b/qq-maid-llm/src/provider/bigmodel.rs
@@ -47,7 +47,8 @@ impl BigModelProvider {
             .bigmodel_api_key
             .clone()
             .ok_or_else(|| LlmError::config("BIGMODEL_API_KEY is required"))?;
-        let http_client = reqwest::Client::builder()
+        let http_client = qq_maid_common::http_client::try_builder()
+            .map_err(|err| LlmError::config(format!("failed to configure BigModel TLS: {err}")))?
             .timeout(Duration::from_secs(config.request_timeout_seconds))
             .build()
             .map_err(|err| {
@@ -245,7 +246,11 @@ mod tests {
     #[test]
     fn bigmodel_tool_calling_protocol_uses_chat_completions() {
         let provider = BigModelProvider {
-            client: ChatCompletionsClient::new("test-key", None, reqwest::Client::new()),
+            client: ChatCompletionsClient::new(
+                "test-key",
+                None,
+                qq_maid_common::http_client::client(),
+            ),
             model: "glm-5.2".to_owned(),
             stream: true,
             media_max_bytes: 10 * 1024 * 1024,
@@ -267,7 +272,11 @@ mod tests {
         ])
         .await;
         let provider = BigModelProvider {
-            client: ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new()),
+            client: ChatCompletionsClient::new(
+                "test-key",
+                Some(&base_url),
+                qq_maid_common::http_client::client(),
+            ),
             model: "glm-5.2".to_owned(),
             stream: true,
             media_max_bytes: 10 * 1024 * 1024,
@@ -326,7 +335,11 @@ mod tests {
         ])
         .await;
         let provider = BigModelProvider {
-            client: ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new()),
+            client: ChatCompletionsClient::new(
+                "test-key",
+                Some(&base_url),
+                qq_maid_common::http_client::client(),
+            ),
             model: "glm-5.2".to_owned(),
             stream: true,
             media_max_bytes: 10 * 1024 * 1024,

--- a/qq-maid-llm/src/provider/deepseek.rs
+++ b/qq-maid-llm/src/provider/deepseek.rs
@@ -46,7 +46,8 @@ impl DeepSeekProvider {
             .deepseek_api_key
             .clone()
             .ok_or_else(|| LlmError::config("DEEPSEEK_API_KEY is required"))?;
-        let http_client = reqwest::Client::builder()
+        let http_client = qq_maid_common::http_client::try_builder()
+            .map_err(|err| LlmError::config(format!("failed to configure DeepSeek TLS: {err}")))?
             .timeout(Duration::from_secs(config.request_timeout_seconds))
             .build()
             .map_err(|err| {
@@ -238,7 +239,11 @@ mod tests {
     #[test]
     fn deepseek_tool_calling_protocol_uses_chat_completions() {
         let provider = DeepSeekProvider {
-            client: ChatCompletionsClient::new("test-key", None, reqwest::Client::new()),
+            client: ChatCompletionsClient::new(
+                "test-key",
+                None,
+                qq_maid_common::http_client::client(),
+            ),
             model: "deepseek-chat".to_owned(),
             stream: true,
             media_max_bytes: 10 * 1024 * 1024,
@@ -260,7 +265,11 @@ mod tests {
         ])
         .await;
         let provider = DeepSeekProvider {
-            client: ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new()),
+            client: ChatCompletionsClient::new(
+                "test-key",
+                Some(&base_url),
+                qq_maid_common::http_client::client(),
+            ),
             model: "deepseek-chat".to_owned(),
             stream: true,
             media_max_bytes: 10 * 1024 * 1024,
@@ -295,7 +304,11 @@ mod tests {
         ])
         .await;
         let provider = DeepSeekProvider {
-            client: ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new()),
+            client: ChatCompletionsClient::new(
+                "test-key",
+                Some(&base_url),
+                qq_maid_common::http_client::client(),
+            ),
             model: "deepseek-chat".to_owned(),
             stream: true,
             media_max_bytes: 10 * 1024 * 1024,
@@ -354,7 +367,11 @@ mod tests {
         ])
         .await;
         let provider = DeepSeekProvider {
-            client: ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new()),
+            client: ChatCompletionsClient::new(
+                "test-key",
+                Some(&base_url),
+                qq_maid_common::http_client::client(),
+            ),
             model: "deepseek-chat".to_owned(),
             stream: true,
             media_max_bytes: 10 * 1024 * 1024,

--- a/qq-maid-llm/src/provider/openai/chat.rs
+++ b/qq-maid-llm/src/provider/openai/chat.rs
@@ -1081,8 +1081,11 @@ mod tests {
             StatusCode::OK,
         )
         .await;
-        let client =
-            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+        let client = ChatCompletionsClient::new(
+            "test-key",
+            Some(&base_url),
+            qq_maid_common::http_client::client(),
+        );
 
         let outcome = non_stream_completion(
             &client,
@@ -1112,8 +1115,11 @@ mod tests {
         )
         .to_owned();
         let (base_url, _state) = spawn_mock_chat(vec![body], StatusCode::OK).await;
-        let client =
-            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+        let client = ChatCompletionsClient::new(
+            "test-key",
+            Some(&base_url),
+            qq_maid_common::http_client::client(),
+        );
 
         let outcome = stream_completion(
             &client,
@@ -1142,8 +1148,11 @@ mod tests {
         )
         .to_owned();
         let (base_url, _state) = spawn_mock_chat(vec![body], StatusCode::OK).await;
-        let client =
-            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+        let client = ChatCompletionsClient::new(
+            "test-key",
+            Some(&base_url),
+            qq_maid_common::http_client::client(),
+        );
 
         let outcome = stream_completion(
             &client,
@@ -1165,8 +1174,11 @@ mod tests {
     async fn stream_chat_completion_requires_done_after_delta() {
         let body = "data: {\"choices\":[{\"delta\":{\"content\":\"半截\"}}]}\n\n".to_owned();
         let (base_url, _state) = spawn_mock_chat(vec![body], StatusCode::OK).await;
-        let client =
-            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+        let client = ChatCompletionsClient::new(
+            "test-key",
+            Some(&base_url),
+            qq_maid_common::http_client::client(),
+        );
 
         let err = stream_completion(
             &client,
@@ -1191,8 +1203,11 @@ mod tests {
         )
         .to_owned();
         let (base_url, _state) = spawn_mock_chat(vec![body], StatusCode::OK).await;
-        let client =
-            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+        let client = ChatCompletionsClient::new(
+            "test-key",
+            Some(&base_url),
+            qq_maid_common::http_client::client(),
+        );
 
         let outcome = stream_completion(
             &client,
@@ -1218,8 +1233,11 @@ mod tests {
             StatusCode::OK,
         )
         .await;
-        let client =
-            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+        let client = ChatCompletionsClient::new(
+            "test-key",
+            Some(&base_url),
+            qq_maid_common::http_client::client(),
+        );
 
         let outcome = chat_completions_with_stream_fallback(
             true,
@@ -1251,8 +1269,11 @@ mod tests {
             StatusCode::OK,
         )
         .await;
-        let client =
-            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+        let client = ChatCompletionsClient::new(
+            "test-key",
+            Some(&base_url),
+            qq_maid_common::http_client::client(),
+        );
 
         let outcome = chat_completions_with_stream_fallback(
             true,
@@ -1286,8 +1307,11 @@ mod tests {
             StatusCode::OK,
         )
         .await;
-        let client =
-            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+        let client = ChatCompletionsClient::new(
+            "test-key",
+            Some(&base_url),
+            qq_maid_common::http_client::client(),
+        );
 
         let err = stream_completion(
             &client,
@@ -1319,8 +1343,11 @@ mod tests {
             StatusCode::BAD_REQUEST,
         )
         .await;
-        let client =
-            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+        let client = ChatCompletionsClient::new(
+            "test-key",
+            Some(&base_url),
+            qq_maid_common::http_client::client(),
+        );
 
         let err = non_stream_completion(
             &client,
@@ -1345,8 +1372,11 @@ mod tests {
             StatusCode::OK,
         )
         .await;
-        let client =
-            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+        let client = ChatCompletionsClient::new(
+            "test-key",
+            Some(&base_url),
+            qq_maid_common::http_client::client(),
+        );
 
         let err = non_stream_completion(
             &client,
@@ -1369,8 +1399,11 @@ mod tests {
             StatusCode::TOO_MANY_REQUESTS,
         )
         .await;
-        let client =
-            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+        let client = ChatCompletionsClient::new(
+            "test-key",
+            Some(&base_url),
+            qq_maid_common::http_client::client(),
+        );
 
         let err = non_stream_completion(
             &client,

--- a/qq-maid-llm/src/provider/openai/chat_tool_loop.rs
+++ b/qq-maid-llm/src/provider/openai/chat_tool_loop.rs
@@ -916,8 +916,11 @@ mod tests {
             }),
         ])
         .await;
-        let client =
-            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+        let client = ChatCompletionsClient::new(
+            "test-key",
+            Some(&base_url),
+            qq_maid_common::http_client::client(),
+        );
         let tools = ToolRegistry::new()
             .register(WeatherToolStub::new("小雨"))
             .unwrap();
@@ -985,8 +988,11 @@ mod tests {
             }),
         ])
         .await;
-        let client =
-            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+        let client = ChatCompletionsClient::new(
+            "test-key",
+            Some(&base_url),
+            qq_maid_common::http_client::client(),
+        );
         let tools = ToolRegistry::new()
             .register(WeatherToolStub::new("小雨"))
             .unwrap();
@@ -1047,8 +1053,11 @@ mod tests {
             }),
         ])
         .await;
-        let client =
-            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+        let client = ChatCompletionsClient::new(
+            "test-key",
+            Some(&base_url),
+            qq_maid_common::http_client::client(),
+        );
         let sequence = Arc::new(StdMutex::new(Vec::new()));
         let mut tools = ToolRegistry::new();
         tools
@@ -1100,8 +1109,11 @@ mod tests {
             }]
         })])
         .await;
-        let client =
-            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+        let client = ChatCompletionsClient::new(
+            "test-key",
+            Some(&base_url),
+            qq_maid_common::http_client::client(),
+        );
         let tools = ToolRegistry::new()
             .register(WeatherToolStub::new("小雨"))
             .unwrap();
@@ -1205,8 +1217,11 @@ mod tests {
             }),
         ])
         .await;
-        let client =
-            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+        let client = ChatCompletionsClient::new(
+            "test-key",
+            Some(&base_url),
+            qq_maid_common::http_client::client(),
+        );
         let tools = ToolRegistry::new()
             .register(WeatherToolStub::new("小雨"))
             .unwrap();
@@ -1246,8 +1261,11 @@ mod tests {
             }]
         })])
         .await;
-        let client =
-            ChatCompletionsClient::new("test-key", Some(&base_url), reqwest::Client::new());
+        let client = ChatCompletionsClient::new(
+            "test-key",
+            Some(&base_url),
+            qq_maid_common::http_client::client(),
+        );
         let tools = ToolRegistry::new()
             .register(WeatherToolStub::new("小雨"))
             .unwrap();

--- a/qq-maid-llm/src/provider/openai/mod.rs
+++ b/qq-maid-llm/src/provider/openai/mod.rs
@@ -80,7 +80,8 @@ impl OpenAiProvider {
             .openai_api_key
             .clone()
             .ok_or_else(|| LlmError::config("OPENAI_API_KEY is required"))?;
-        let http_client = reqwest::Client::builder()
+        let http_client = qq_maid_common::http_client::try_builder()
+            .map_err(|err| LlmError::config(format!("failed to configure OpenAI TLS: {err}")))?
             .timeout(Duration::from_secs(config.request_timeout_seconds))
             .build()
             .map_err(|err| {
@@ -671,7 +672,7 @@ mod tests {
     }
 
     fn provider_with_api_mode(api_mode: OpenAiApiMode) -> OpenAiProvider {
-        let http_client = reqwest::Client::new();
+        let http_client = qq_maid_common::http_client::client();
         OpenAiProvider {
             responses_client: http_client.clone(),
             chat_client: ChatCompletionsClient::new("test-key".to_owned(), None, http_client),
@@ -708,7 +709,7 @@ mod tests {
             chat_requests: Vec::new(),
         })
         .await;
-        let http_client = reqwest::Client::new();
+        let http_client = qq_maid_common::http_client::client();
         let chat_client =
             ChatCompletionsClient::new("test-key", Some(&base_url), http_client.clone());
 
@@ -746,7 +747,7 @@ mod tests {
             chat_requests: Vec::new(),
         })
         .await;
-        let http_client = reqwest::Client::new();
+        let http_client = qq_maid_common::http_client::client();
         let chat_client =
             ChatCompletionsClient::new("test-key", Some(&base_url), http_client.clone());
         let messages = [
@@ -799,7 +800,7 @@ mod tests {
             chat_requests: Vec::new(),
         })
         .await;
-        let http_client = reqwest::Client::new();
+        let http_client = qq_maid_common::http_client::client();
         let chat_client =
             ChatCompletionsClient::new("test-key", Some(&base_url), http_client.clone());
 
@@ -838,7 +839,7 @@ mod tests {
             .to_owned(),
         )
         .await;
-        let http_client = reqwest::Client::new();
+        let http_client = qq_maid_common::http_client::client();
         let chat_client =
             ChatCompletionsClient::new("test-key", Some(&base_url), http_client.clone());
 
@@ -884,7 +885,7 @@ mod tests {
             .to_owned(),
         )
         .await;
-        let http_client = reqwest::Client::new();
+        let http_client = qq_maid_common::http_client::client();
         let chat_client =
             ChatCompletionsClient::new("test-key", Some(&base_url), http_client.clone());
 

--- a/qq-maid-llm/src/provider/openai/responses.rs
+++ b/qq-maid-llm/src/provider/openai/responses.rs
@@ -426,7 +426,7 @@ mod tests {
             StatusCode::OK,
         )
         .await;
-        let client = reqwest::Client::new();
+        let client = qq_maid_common::http_client::client();
         let messages = [ChatMessage::user("hi")];
         let req = stream_req(&client, &base_url, &messages);
         let outcome = openai_responses_stream_chat(&req).await.unwrap();
@@ -439,7 +439,7 @@ mod tests {
     #[tokio::test]
     async fn ordinary_responses_stream_finishes_on_completed_without_http_eof() {
         let base_url = spawn_never_closing_completed_response().await;
-        let client = reqwest::Client::new();
+        let client = qq_maid_common::http_client::client();
         let messages = [ChatMessage::user("hi")];
         let req = stream_req(&client, &base_url, &messages);
 
@@ -462,7 +462,7 @@ mod tests {
             StatusCode::OK,
         )
         .await;
-        let client = reqwest::Client::new();
+        let client = qq_maid_common::http_client::client();
         let messages = [ChatMessage::user("hi")];
         let req = stream_req(&client, &base_url, &messages);
 
@@ -484,7 +484,7 @@ mod tests {
             StatusCode::OK,
         )
         .await;
-        let client = reqwest::Client::new();
+        let client = qq_maid_common::http_client::client();
         let messages = [ChatMessage::user("hi")];
         let req = stream_req(&client, &base_url, &messages);
 
@@ -505,7 +505,7 @@ mod tests {
             StatusCode::OK,
         )
         .await;
-        let client = reqwest::Client::new();
+        let client = qq_maid_common::http_client::client();
         let messages = [ChatMessage::user("hi")];
         let req = stream_req(&client, &base_url, &messages);
 
@@ -526,7 +526,7 @@ mod tests {
             StatusCode::OK,
         )
         .await;
-        let client = reqwest::Client::new();
+        let client = qq_maid_common::http_client::client();
         let messages = [ChatMessage::user("hi")];
         let req = stream_req(&client, &base_url, &messages);
 
@@ -549,7 +549,7 @@ mod tests {
             StatusCode::OK,
         )
         .await;
-        let client = reqwest::Client::new();
+        let client = qq_maid_common::http_client::client();
         let messages = [ChatMessage::user("hi")];
         let req = stream_req(&client, &base_url, &messages);
 
@@ -575,7 +575,7 @@ mod tests {
             StatusCode::OK,
         )
         .await;
-        let client = reqwest::Client::new();
+        let client = qq_maid_common::http_client::client();
         let messages = [ChatMessage::user("hi")];
         let mut req = stream_req(&client, &base_url, &messages);
         req.stream = false;

--- a/qq-maid-llm/src/provider/openai/tool_loop/tests/integration.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/tests/integration.rs
@@ -4,7 +4,7 @@ use super::*;
 async fn tool_loop_executes_function_call_and_returns_output_to_model() {
     let (base_url, state) = spawn_tool_loop_mock().await;
     let registry = ToolRegistry::new().register(WeatherToolStub).unwrap();
-    let client = reqwest::Client::new();
+    let client = qq_maid_common::http_client::client();
 
     let outcome = run_agent_loop(
         Box::new(
@@ -51,7 +51,7 @@ async fn tool_loop_executes_function_call_and_returns_output_to_model() {
 async fn tool_loop_budget_exceeded_before_first_provider_request() {
     let (base_url, state) = spawn_tool_loop_mock().await;
     let registry = ToolRegistry::new().register(WeatherToolStub).unwrap();
-    let client = reqwest::Client::new();
+    let client = qq_maid_common::http_client::client();
 
     let err = run_agent_loop(
         Box::new(
@@ -92,7 +92,7 @@ async fn tool_loop_budget_exceeded_before_first_provider_request() {
 async fn tool_loop_budget_exceeded_after_tool_result_skips_next_provider_request() {
     let (base_url, state) = spawn_tool_loop_mock().await;
     let registry = ToolRegistry::new().register(WeatherToolStub).unwrap();
-    let client = reqwest::Client::new();
+    let client = qq_maid_common::http_client::client();
 
     let err = run_agent_loop(
         Box::new(
@@ -135,7 +135,7 @@ async fn tool_loop_budget_exceeded_after_tool_result_skips_next_provider_request
 async fn tool_loop_budget_estimate_error_skips_provider_request() {
     let (base_url, state) = spawn_tool_loop_mock().await;
     let registry = ToolRegistry::new().register(WeatherToolStub).unwrap();
-    let client = reqwest::Client::new();
+    let client = qq_maid_common::http_client::client();
 
     let err = run_agent_loop(
         Box::new(
@@ -188,7 +188,7 @@ async fn tool_loop_serializes_multiple_calls_and_skips_dependent_call_after_fail
             calls: ok_calls.clone(),
         })
         .unwrap();
-    let client = reqwest::Client::new();
+    let client = qq_maid_common::http_client::client();
 
     let outcome = run_agent_loop(
         Box::new(
@@ -255,7 +255,7 @@ async fn tool_loop_prepares_same_round_calls_before_executing_any_tool() {
             sequence: sequence.clone(),
         }))
         .unwrap();
-    let client = reqwest::Client::new();
+    let client = qq_maid_common::http_client::client();
 
     let outcome = run_agent_loop(
         Box::new(
@@ -303,7 +303,7 @@ async fn tool_loop_keeps_independent_calls_after_prepare_failure() {
         .unwrap()
         .register(WeatherToolStub)
         .unwrap();
-    let client = reqwest::Client::new();
+    let client = qq_maid_common::http_client::client();
 
     let outcome = run_agent_loop(
         Box::new(
@@ -366,7 +366,7 @@ async fn tool_loop_skips_dependent_call_after_structured_tool_failure() {
             calls: ok_calls.clone(),
         })
         .unwrap();
-    let client = reqwest::Client::new();
+    let client = qq_maid_common::http_client::client();
 
     let outcome = run_agent_loop(
         Box::new(

--- a/qq-maid-llm/src/provider/openai/tool_loop/tests/streaming.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/tests/streaming.rs
@@ -38,7 +38,7 @@ async fn agent_stream_finishes_on_completed_without_waiting_for_http_eof() {
     let base_url = spawn_never_closing_completed_stream().await;
     let registry = ToolRegistry::new().register(WeatherToolStub).unwrap();
     let mut session = ResponsesAgentSession::new(
-        reqwest::Client::new(),
+        qq_maid_common::http_client::client(),
         "test-key".to_owned(),
         Some(base_url),
         "openai",
@@ -79,7 +79,7 @@ async fn agent_stream_finishes_on_done_without_waiting_for_http_eof() {
     let base_url = spawn_never_closing_done_stream().await;
     let registry = ToolRegistry::new().register(WeatherToolStub).unwrap();
     let mut session = ResponsesAgentSession::new(
-        reqwest::Client::new(),
+        qq_maid_common::http_client::client(),
         "test-key".to_owned(),
         Some(base_url),
         "openai",

--- a/qq-maid-llm/src/provider/openai_compatible.rs
+++ b/qq-maid-llm/src/provider/openai_compatible.rs
@@ -54,7 +54,13 @@ impl OpenAiCompatibleProvider {
         let timeout = config
             .request_timeout_seconds
             .unwrap_or(request_timeout_seconds);
-        let http_client = reqwest::Client::builder()
+        let http_client = qq_maid_common::http_client::try_builder()
+            .map_err(|err| {
+                LlmError::config(format!(
+                    "failed to configure {} TLS: {err}",
+                    config.id.as_str()
+                ))
+            })?
             .timeout(Duration::from_secs(timeout))
             .build()
             .map_err(|err| {

--- a/qq-maid-llm/src/web_search/gemini.rs
+++ b/qq-maid-llm/src/web_search/gemini.rs
@@ -49,7 +49,10 @@ impl GeminiWebSearchExecutor {
             .gemini_api_key
             .clone()
             .ok_or_else(|| LlmError::config("GEMINI_API_KEY is required"))?;
-        let client = reqwest::Client::builder()
+        let client = qq_maid_common::http_client::try_builder()
+            .map_err(|err| {
+                LlmError::config(format!("failed to configure Gemini query TLS: {err}"))
+            })?
             .timeout(std::time::Duration::from_secs(
                 config.request_timeout_seconds,
             ))

--- a/qq-maid-llm/src/web_search/openai.rs
+++ b/qq-maid-llm/src/web_search/openai.rs
@@ -67,7 +67,10 @@ impl OpenAiWebSearchExecutor {
             .openai_api_key
             .clone()
             .ok_or_else(|| LlmError::config("OPENAI_API_KEY is required"))?;
-        let client = reqwest::Client::builder()
+        let client = qq_maid_common::http_client::try_builder()
+            .map_err(|err| {
+                LlmError::config(format!("failed to configure OpenAI query TLS: {err}"))
+            })?
             .timeout(std::time::Duration::from_secs(
                 config.request_timeout_seconds,
             ))
@@ -687,7 +690,7 @@ mod tests {
         .to_owned();
         let (base_url, state) = spawn_mock_search(body).await;
         let executor = OpenAiWebSearchExecutor {
-            client: reqwest::Client::new(),
+            client: qq_maid_common::http_client::client(),
             api_key: "test-key".to_owned(),
             base_url: Some(base_url),
             search_model: "gpt-search".to_owned(),
@@ -721,7 +724,7 @@ mod tests {
             .to_owned();
         let (base_url, _state) = spawn_mock_search(body).await;
         let executor = OpenAiWebSearchExecutor {
-            client: reqwest::Client::new(),
+            client: qq_maid_common::http_client::client(),
             api_key: "test-key".to_owned(),
             base_url: Some(base_url),
             search_model: "gpt-search".to_owned(),


### PR DESCRIPTION
## 变更

- 将三个直接 `reqwest` 依赖切换为 `rustls-no-provider`，移除 reqwest 通过 `hyper-rustls` / `tokio-rustls` 引入的 `aws-lc-rs`。
- 在 `qq-maid-common` 集中构造显式 `ring` + 系统证书校验的 rustls ClientConfig，并通过 reqwest 预配置 TLS 客户端复用，避免入口调用 `install_default()`。
- 保留 fastembed 的 `hf-hub-rustls-tls`、ORT 下载、Gateway WebSocket WebPKI roots、RSS 和各 Provider 功能。

## 根因

`reqwest 0.13.4` 的 `rustls` feature 默认启用 `aws-lc-rs`，而 `fastembed -> hf-hub/ort -> ureq` 启用 `ring`；rustls 0.23 在运行时无法从混合 Provider 中自动选择，导致 Client/WebSocket 初始化 panic。

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace --release --all-features`
- `cargo test --workspace --all-features`；一次已有 ops progress 时序测试抖动后，单测重跑通过，其余 1126 个 Core 测试通过。
- `cargo tree -e features -i aws-lc-rs`：包不存在；`ring` 覆盖 reqwest、tokio-tungstenite 和 fastembed 链路。
- `bash scripts/validate-runtime.sh restart-source`：本地服务启动，`/healthz` 返回 `ok: true`，`/console/` 返回 HTTP 200。

用户已有的 `README.md` 修改未纳入本 PR。
