### PR TITLE
[codex] 简化 Agent 配置升级

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 本文档基于 [keep a changelog](https://keepachangelog.com/zh-CN/1.0.0/) 格式，记录每个已发布版本的变更。
 
+## [Unreleased]
+
+### Changed
+
+* **Agent 配置升级兼容**（#533）：在 `v0.20.2` 的一次性升级中，Unix/Windows 更新器和远程部署会先将现有 `config/agent.toml` 备份为不覆盖历史备份的 `.old` 文件，再启用新版模板；之后的版本升级不会再次覆盖用户策略。Agent 配置新增普通可选字段时由代码默认值兜底，旧文件无需每次手动改模板。
+
 ## [v0.20.1] - 2026-07-19
 
 ### Release Focus

--- a/qq-maid-core/src/config/agent/mod.rs
+++ b/qq-maid-core/src/config/agent/mod.rs
@@ -284,6 +284,8 @@ pub struct AgentProfileConfig {
     pub aux_route: Option<String>,
     #[serde(default)]
     pub reasoning_effort: Option<ReasoningEffort>,
+    /// 新增 profile 字段时保持旧配置可启动；5 轮与 balanced 默认档位一致。
+    #[serde(default = "default_max_tool_rounds")]
     pub max_tool_rounds: usize,
     #[serde(default)]
     pub max_output_tokens: Option<u64>,
@@ -312,7 +314,10 @@ pub struct AgentSceneConfig {
     pub max_tool_rounds: Option<usize>,
     #[serde(default)]
     pub max_output_tokens: Option<u64>,
+    /// Tool Calling 默认关闭，避免旧配置升级后意外开放写入类工具。
+    #[serde(default)]
     pub tool_calling_enabled: bool,
+    #[serde(default)]
     pub enabled_tools: Vec<String>,
 }
 
@@ -813,6 +818,10 @@ fn validate_positive(name: &str, value: usize) -> Result<(), LlmError> {
 
 fn default_true() -> bool {
     true
+}
+
+fn default_max_tool_rounds() -> usize {
+    5
 }
 
 fn default_auth_header() -> String {

--- a/qq-maid-core/src/config/agent/tests.rs
+++ b/qq-maid-core/src/config/agent/tests.rs
@@ -85,6 +85,40 @@ enabled_tools = ["get_weather", "list_todos", "get_weather"]
 }
 
 #[test]
+fn toml_config_defaults_new_optional_profile_and_scene_fields() {
+    let text = r#"
+version = 1
+
+[model_routes.main]
+candidates = ["openai:gpt-main"]
+
+[search_routes.search]
+model = "gpt-search"
+
+[profiles.balanced]
+main_route = "main"
+
+[scenes.private]
+profile = "balanced"
+
+[scenes.group]
+profile = "balanced"
+"#;
+
+    let config = AgentRuntimeConfig::from_toml(
+        text,
+        AgentConfigSource::File("config/agent.toml".to_owned()),
+    )
+    .unwrap();
+
+    let private = config.resolve(ChatScene::Private).unwrap();
+    assert!(private.enabled);
+    assert_eq!(private.max_tool_rounds, 5);
+    assert!(!private.tool_calling_enabled);
+    assert!(private.enabled_tools.is_empty());
+}
+
+#[test]
 fn toml_config_accepts_openai_compatible_mimo_provider() {
     let text = r#"
 version = 1

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -89,9 +89,36 @@ echo "==> Installing artifacts..."
 # 设置可执行权限后，将临时文件原子地替换为目标文件；清理旧 qq-maid-* 时需保留
 # 当前二进制、健康检查脚本和 systemd 管理脚本，避免远端巡检/自启动入口在部署后被误删。
 ssh "${REMOTE_HOST}" "cd '${REMOTE_APP_DIR}' && chmod 0755 .qq-maid-bot.new .botctl.sh.new .diagnose-network.sh.new .validate-runtime.sh.new .qq-maid-healthcheck.sh.new .botmon.sh.new .qq-maid-systemd.sh.new && mv -f .qq-maid-bot.new qq-maid-bot && mv -f .botctl.sh.new botctl.sh && mv -f .diagnose-network.sh.new diagnose-network.sh && mv -f .validate-runtime.sh.new validate-runtime.sh && mv -f .qq-maid-healthcheck.sh.new qq-maid-healthcheck.sh && mv -f .botmon.sh.new botmon.sh && mv -f .qq-maid-systemd.sh.new qq-maid-systemd.sh && mv -f config/.env.example.new config/.env.example && mv -f config/ops.example.toml.new config/ops.example.toml && mv -f config/runtime.example.toml.new config/runtime.example.toml && find . -maxdepth 1 -type f -name 'qq-maid-*' ! -name 'qq-maid-bot' ! -name 'qq-maid-healthcheck.sh' ! -name 'qq-maid-systemd.sh' -delete && find . -maxdepth 1 -type f -name '*ctl.sh' ! -name 'botctl.sh' -delete && rm -f botctl.ps1 botctl.cmd windows-startup-example.bat .env.example && rm -rf static .static.new static.old"
-# agent.toml 是运行期活动策略文件。远端已存在时只留下新版本供人工比对，
-# 避免部署覆盖本机模型路线、profile 或 Tool Calling 开关。
-ssh "${REMOTE_HOST}" "cd '${REMOTE_APP_DIR}' && { test -f config/agent.toml || mv config/agent.toml.new config/agent.toml; }"
+# Agent 策略模板随 Release 一起升级：先保留远端旧文件，再原子启用新版。
+# 这是本次版本升级的唯一自动替换点；后续新增普通可选字段由程序默认值兼容。
+ssh "${REMOTE_HOST}" "cd '${REMOTE_APP_DIR}' && bash -s" <<'REMOTE_AGENT_CONFIG'
+set -euo pipefail
+marker=config/.agent-config-v0.20.2
+if test ! -e "$marker"; then
+    if test -L config/agent.toml; then
+        echo "refuse to replace symbolic-link config/agent.toml" >&2
+        exit 1
+    fi
+    if test -f config/agent.toml; then
+        backup=config/agent.toml.old
+        suffix=0
+        while test -e "$backup" || test -L "$backup"; do
+            suffix=$((suffix + 1))
+            backup="config/agent.toml.old.${suffix}"
+        done
+        mv config/agent.toml "$backup"
+        if ! mv config/agent.toml.new config/agent.toml; then
+            mv "$backup" config/agent.toml || true
+            exit 1
+        fi
+    else
+        mv config/agent.toml.new config/agent.toml
+    fi
+    : > "$marker"
+else
+    rm -f config/agent.toml.new
+fi
+REMOTE_AGENT_CONFIG
 # runtime.toml 是 WebUI 与人工编辑共享的活动配置，部署只更新公开示例，不能覆盖它。
 
 echo "==> Restarting remote services..."

--- a/scripts/qbot.ps1
+++ b/scripts/qbot.ps1
@@ -80,6 +80,8 @@ $script:ObsoleteEnvKeys = @(
     "TOOL_CALLING_ENABLED", "TOOL_CALLING_GROUP_ENABLED", "TOOL_CALLING_MAX_ROUNDS",
     "TODO_MODEL", "MEMBER_ID_MAPPING_FILE"
 )
+$script:AgentConfigMigrationVersion = [Version]"0.20.2"
+$script:AgentConfigMigrationMarkerName = ".agent-config-v0.20.2"
 
 function Show-QbotUsage {
     @"
@@ -138,15 +140,33 @@ function ConvertTo-AgentConfigVersion {
 function Test-AgentConfigResetRequired {
     param(
         [AllowEmptyString()][string]$CurrentVersion,
-        [Parameter(Mandatory = $true)][string]$TargetVersion
+        [Parameter(Mandatory = $true)][string]$TargetVersion,
+        [AllowEmptyString()][string]$MarkerFile
     )
-    $resetVersion = [Version]"0.20.2"
+    if (-not [string]::IsNullOrWhiteSpace($MarkerFile) -and (Test-Path -LiteralPath $MarkerFile)) {
+        return $false
+    }
     $target = ConvertTo-AgentConfigVersion $TargetVersion
-    if ($null -eq $target -or $target -lt $resetVersion) {
+    if ($null -eq $target -or $target -lt $script:AgentConfigMigrationVersion) {
         return $false
     }
     $current = ConvertTo-AgentConfigVersion $CurrentVersion
-    return $null -eq $current -or $current -lt $resetVersion
+    return $null -eq $current -or $current -lt $script:AgentConfigMigrationVersion
+}
+
+function Complete-AgentConfigMigration {
+    param(
+        [AllowEmptyString()][string]$CurrentVersion,
+        [Parameter(Mandatory = $true)][string]$TargetVersion
+    )
+    $current = ConvertTo-AgentConfigVersion $CurrentVersion
+    $target = ConvertTo-AgentConfigVersion $TargetVersion
+    if (($null -eq $current -or $current -lt $script:AgentConfigMigrationVersion) -and
+        ($null -eq $target -or $target -lt $script:AgentConfigMigrationVersion)) {
+        return
+    }
+    $marker = Join-Path $script:AppDir "config\$($script:AgentConfigMigrationMarkerName)"
+    New-Item -ItemType File -Path $marker -Force | Out-Null
 }
 
 function Get-LatestVersion {
@@ -474,12 +494,14 @@ function Install-OrUpdate {
 
         if ($Mode -eq "update" -and $null -ne $current -and (Normalize-Version $current) -eq $version) {
             Remove-ObsoleteEnvConfig -ConfigFile (Join-Path $script:AppDir "config\.env")
+            Complete-AgentConfigMigration -CurrentVersion $current -TargetVersion $version
             Write-Output "already installed: $current"
             return
         }
 
         # v0.20.2 完成一次结构升级；跨过门槛后只靠字段默认值兼容，不再覆盖用户策略。
-        if ($Mode -eq "update" -and (Test-AgentConfigResetRequired -CurrentVersion $current -TargetVersion $version)) {
+        $agentConfigMarker = Join-Path $script:AppDir "config\$($script:AgentConfigMigrationMarkerName)"
+        if ($Mode -eq "update" -and (Test-AgentConfigResetRequired -CurrentVersion $current -TargetVersion $version -MarkerFile $agentConfigMarker)) {
             Update-AgentConfigFromRelease `
                 -ConfigFile (Join-Path $script:AppDir "config\agent.toml") `
                 -TemplateFile (Join-Path $releaseDir "config\agent.toml")
@@ -491,6 +513,7 @@ function Install-OrUpdate {
             Invoke-BotControl "stop"
         }
         Install-ReleasePayload -ReleaseDir $releaseDir -Version $version
+        Complete-AgentConfigMigration -CurrentVersion $current -TargetVersion $version
         Write-Output "qbot $Mode completed: $version"
         Write-Output "directory: $($script:AppDir)"
         Write-Output "config: $(Join-Path $script:AppDir 'config\.env')"

--- a/scripts/qbot.ps1
+++ b/scripts/qbot.ps1
@@ -118,6 +118,37 @@ function Normalize-Version {
     return "v$Version"
 }
 
+function ConvertTo-AgentConfigVersion {
+    param([AllowEmptyString()][string]$Version)
+    if ([string]::IsNullOrWhiteSpace($Version)) {
+        return $null
+    }
+    $normalized = $Version.Trim()
+    if ($normalized.StartsWith("v")) {
+        $normalized = $normalized.Substring(1)
+    }
+    $normalized = ($normalized -split '[-+]', 2)[0]
+    $parsed = $null
+    if (-not [Version]::TryParse($normalized, [ref]$parsed)) {
+        return $null
+    }
+    return $parsed
+}
+
+function Test-AgentConfigResetRequired {
+    param(
+        [AllowEmptyString()][string]$CurrentVersion,
+        [Parameter(Mandatory = $true)][string]$TargetVersion
+    )
+    $resetVersion = [Version]"0.20.2"
+    $target = ConvertTo-AgentConfigVersion $TargetVersion
+    if ($null -eq $target -or $target -lt $resetVersion) {
+        return $false
+    }
+    $current = ConvertTo-AgentConfigVersion $CurrentVersion
+    return $null -eq $current -or $current -lt $resetVersion
+}
+
 function Get-LatestVersion {
     $headers = @{ "User-Agent" = "qq-maid-bot-windows-installer" }
     $release = Invoke-RestMethod -Uri $script:LatestApiUrl -Headers $headers -UseBasicParsing
@@ -409,40 +440,15 @@ function Replace-AgentConfigFromRelease {
     Write-Output "请参考备份重新填写 Provider、模型路线、Scene 和工具白名单等自定义配置。"
 }
 
-function Request-AgentConfigReplacement {
+function Update-AgentConfigFromRelease {
     param(
         [Parameter(Mandatory = $true)][string]$ConfigFile,
-        [Parameter(Mandatory = $true)][string]$TemplateFile,
-        [AllowEmptyString()][string]$Response,
-        [switch]$NonInteractive
+        [Parameter(Mandatory = $true)][string]$TemplateFile
     )
     if (-not (Test-Path -LiteralPath $ConfigFile)) {
         return
     }
-
-    Write-Output "检测到现有 agent.toml，当前版本的配置结构可能已更新。"
-    $responseProvided = $PSBoundParameters.ContainsKey("Response")
-    $inputRedirected = $false
-    try {
-        $inputRedirected = [Console]::IsInputRedirected
-    } catch {
-        $inputRedirected = $true
-    }
-
-    if (-not $responseProvided -and
-        ($NonInteractive -or -not [Environment]::UserInteractive -or $inputRedirected)) {
-        Write-Output "当前为非交互环境，默认保留现有 agent.toml。"
-        Write-Output "旧配置可能不兼容；请手工检查，或在交互终端重新运行 qbot update。"
-        return
-    }
-    if (-not $responseProvided) {
-        $Response = Read-Host "是否使用新版默认配置替换？原文件将备份为 agent.toml.old。[y/N]"
-    }
-    if ($Response -notin @("y", "Y")) {
-        Write-Output "已保留现有 agent.toml；旧配置可能不兼容，请自行检查。"
-        return
-    }
-
+    Write-Output "检测到跨版本升级，自动备份并更新 agent.toml。"
     Replace-AgentConfigFromRelease -ConfigFile $ConfigFile -TemplateFile $TemplateFile
 }
 
@@ -466,14 +472,17 @@ function Install-OrUpdate {
         Expand-Archive -LiteralPath $archive -DestinationPath $tempDir -Force
         $releaseDir = Join-Path $tempDir $package
 
-        Request-AgentConfigReplacement `
-            -ConfigFile (Join-Path $script:AppDir "config\agent.toml") `
-            -TemplateFile (Join-Path $releaseDir "config\agent.toml")
-
         if ($Mode -eq "update" -and $null -ne $current -and (Normalize-Version $current) -eq $version) {
             Remove-ObsoleteEnvConfig -ConfigFile (Join-Path $script:AppDir "config\.env")
             Write-Output "already installed: $current"
             return
+        }
+
+        # v0.20.2 完成一次结构升级；跨过门槛后只靠字段默认值兼容，不再覆盖用户策略。
+        if ($Mode -eq "update" -and (Test-AgentConfigResetRequired -CurrentVersion $current -TargetVersion $version)) {
+            Update-AgentConfigFromRelease `
+                -ConfigFile (Join-Path $script:AppDir "config\agent.toml") `
+                -TemplateFile (Join-Path $releaseDir "config\agent.toml")
         }
 
         $wasRunning = Test-InstalledBotRunning

--- a/scripts/qbot.sh
+++ b/scripts/qbot.sh
@@ -34,6 +34,8 @@ OBSOLETE_ENV_KEYS=(
     TOOL_CALLING_ENABLED TOOL_CALLING_GROUP_ENABLED TOOL_CALLING_MAX_ROUNDS
     TODO_MODEL MEMBER_ID_MAPPING_FILE
 )
+AGENT_CONFIG_MIGRATION_VERSION="v0.20.2"
+AGENT_CONFIG_MIGRATION_MARKER_NAME=".agent-config-v0.20.2"
 
 cleanup_tmp_dir() {
     if [[ -n "${TMP_DIR_TO_CLEAN}" && -d "${TMP_DIR_TO_CLEAN}" ]]; then
@@ -383,11 +385,24 @@ version_at_least() {
 agent_config_reset_required() {
     local current="$1"
     local target="$2"
-    local reset_version="v0.20.2"
+    local marker="${3:-${APP_DIR}/config/${AGENT_CONFIG_MIGRATION_MARKER_NAME}}"
 
-    version_at_least "${target}" "${reset_version}" || return 1
+    [[ ! -e "${marker}" ]] || return 1
+    version_at_least "${target}" "${AGENT_CONFIG_MIGRATION_VERSION}" || return 1
     [[ -z "${current}" ]] && return 0
-    ! version_at_least "${current}" "${reset_version}"
+    ! version_at_least "${current}" "${AGENT_CONFIG_MIGRATION_VERSION}"
+}
+
+mark_agent_config_migration_complete() {
+    local current="$1"
+    local target="$2"
+    local marker="${APP_DIR}/config/${AGENT_CONFIG_MIGRATION_MARKER_NAME}"
+
+    if ! version_at_least "${current}" "${AGENT_CONFIG_MIGRATION_VERSION}" &&
+        ! version_at_least "${target}" "${AGENT_CONFIG_MIGRATION_VERSION}"; then
+        return 0
+    fi
+    : > "${marker}"
 }
 
 latest_version() {
@@ -2014,6 +2029,7 @@ install_or_update() {
 
     if [[ "${command_name}" == "update" && -n "${current}" && "$(normalize_version "${current}")" == "${version}" ]]; then
         migrate_obsolete_env_config
+        mark_agent_config_migration_complete "${current}" "${version}"
         rm -rf "${tmp_dir}"
         TMP_DIR_TO_CLEAN=""
         echo "当前已是目标版本: ${current}"
@@ -2035,6 +2051,7 @@ install_or_update() {
     fi
 
     copy_release_into_app "${release_dir}" "${version}"
+    mark_agent_config_migration_complete "${current}" "${version}"
     rm -rf "${tmp_dir}"
     TMP_DIR_TO_CLEAN=""
 

--- a/scripts/qbot.sh
+++ b/scripts/qbot.sh
@@ -359,6 +359,37 @@ normalize_version() {
     fi
 }
 
+version_at_least() {
+    local left="${1#v}"
+    local right="${2#v}"
+    local left_major left_minor left_patch left_extra
+    local right_major right_minor right_patch right_extra
+
+    left="${left%%[-+]*}"
+    right="${right%%[-+]*}"
+    IFS=. read -r left_major left_minor left_patch left_extra <<< "${left}"
+    IFS=. read -r right_major right_minor right_patch right_extra <<< "${right}"
+    [[ -z "${left_extra:-}" && -z "${right_extra:-}" ]] || return 1
+    [[ "${left_major:-}" =~ ^[0-9]+$ && "${left_minor:-}" =~ ^[0-9]+$ && "${left_patch:-}" =~ ^[0-9]+$ ]] || return 1
+    [[ "${right_major:-}" =~ ^[0-9]+$ && "${right_minor:-}" =~ ^[0-9]+$ && "${right_patch:-}" =~ ^[0-9]+$ ]] || return 1
+
+    ((10#${left_major} > 10#${right_major})) && return 0
+    ((10#${left_major} < 10#${right_major})) && return 1
+    ((10#${left_minor} > 10#${right_minor})) && return 0
+    ((10#${left_minor} < 10#${right_minor})) && return 1
+    ((10#${left_patch} >= 10#${right_patch}))
+}
+
+agent_config_reset_required() {
+    local current="$1"
+    local target="$2"
+    local reset_version="v0.20.2"
+
+    version_at_least "${target}" "${reset_version}" || return 1
+    [[ -z "${current}" ]] && return 0
+    ! version_at_least "${current}" "${reset_version}"
+}
+
 latest_version() {
     need_cmd curl
 
@@ -717,34 +748,12 @@ replace_agent_config_from_release() {
     echo "请参考备份重新填写 Provider、模型路线、Scene 和工具白名单等自定义配置。"
 }
 
-prompt_agent_config_replacement() {
+upgrade_agent_config_from_release() {
     local file="$1"
     local template="$2"
-    local reply=""
-    local reply_provided=0
 
     [[ -f "${file}" || -L "${file}" ]] || return 0
-    echo "检测到现有 agent.toml，当前版本的配置结构可能已更新。"
-
-    # 第三个参数只供脚本回归测试注入回答；真实更新必须来自交互终端。
-    if (($# >= 3)); then
-        reply="${3}"
-        reply_provided=1
-    elif [[ -t 0 ]]; then
-        read -r -p "是否使用新版默认配置替换？原文件将备份为 agent.toml.old。[y/N] " reply || reply=""
-        reply_provided=1
-    fi
-
-    if ((reply_provided == 0)); then
-        echo "当前为非交互环境，默认保留现有 agent.toml。"
-        echo "旧配置可能不兼容；请手工检查，或在交互终端重新运行 qbot update。"
-        return 0
-    fi
-    if [[ "${reply}" != "y" && "${reply}" != "Y" ]]; then
-        echo "已保留现有 agent.toml；旧配置可能不兼容，请自行检查。"
-        return 0
-    fi
-
+    echo "检测到跨版本升级，自动备份并更新 agent.toml。"
     replace_agent_config_from_release "${file}" "${template}"
 }
 
@@ -2003,16 +2012,19 @@ install_or_update() {
 
     release_dir="$(download_release "${version}" "${target}" "${tmp_dir}")"
 
-    prompt_agent_config_replacement \
-        "${APP_DIR}/config/agent.toml" \
-        "${release_dir}/config/agent.toml" || die "替换 agent.toml 失败，已停止本次更新"
-
     if [[ "${command_name}" == "update" && -n "${current}" && "$(normalize_version "${current}")" == "${version}" ]]; then
         migrate_obsolete_env_config
         rm -rf "${tmp_dir}"
         TMP_DIR_TO_CLEAN=""
         echo "当前已是目标版本: ${current}"
         return 0
+    fi
+
+    # v0.20.2 完成一次结构升级；跨过门槛后只靠字段默认值兼容，不再覆盖用户策略。
+    if [[ "${command_name}" == "update" ]] && agent_config_reset_required "${current}" "${version}"; then
+        upgrade_agent_config_from_release \
+            "${APP_DIR}/config/agent.toml" \
+            "${release_dir}/config/agent.toml" || die "替换 agent.toml 失败，已停止本次更新"
     fi
 
     was_running=0

--- a/scripts/test-qbot-install.sh
+++ b/scripts/test-qbot-install.sh
@@ -24,10 +24,11 @@ assert_target Linux aarch64 linux-aarch64
 assert_target Darwin x86_64 macos-x86_64
 assert_target Darwin arm64 macos-aarch64
 
-agent_config_reset_required v0.20.1 v0.20.2
-agent_config_reset_required v0.20.1 v0.21.0
-! agent_config_reset_required v0.20.2 v0.20.3
-! agent_config_reset_required v0.20.3 v0.21.0
+version_marker="${TMPDIR:-/tmp}/qbot-agent-version-marker-$$"
+agent_config_reset_required v0.20.1 v0.20.2 "${version_marker}"
+agent_config_reset_required v0.20.1 v0.21.0 "${version_marker}"
+! agent_config_reset_required v0.20.2 v0.20.3 "${version_marker}"
+! agent_config_reset_required v0.20.3 v0.21.0 "${version_marker}"
 
 # Unix 安装器不得再包含 Windows target、ZIP 或原生 Windows 二进制分支。
 if rg -n 'MINGW|MSYS|CYGWIN|windows-(x86_64|aarch64)|\.zip|qq-maid-bot\.exe' \
@@ -89,6 +90,43 @@ output="$(upgrade_agent_config_from_release "${agent_noninteractive}" "${agent_t
 cmp -s "${agent_noninteractive}" "${agent_template}"
 grep -Fqx 'noninteractive-must-update' "${agent_noninteractive}.old"
 [[ "${output}" == *"自动备份并更新"* ]]
+
+# 两个升级入口共享 marker：任一入口完成迁移后，另一入口不得再次覆盖用户配置。
+mixed_app="${tmp_dir}/mixed-upgrade"
+APP_DIR="${mixed_app}"
+mkdir -p "${APP_DIR}/config"
+mixed_agent="${APP_DIR}/config/agent.toml"
+mixed_marker="${APP_DIR}/config/.agent-config-v0.20.2"
+printf '%s\n' 'before-updater' > "${mixed_agent}"
+upgrade_agent_config_from_release "${mixed_agent}" "${agent_template}" >/dev/null
+mark_agent_config_migration_complete v0.20.1 v0.20.2
+[[ -f "${mixed_marker}" ]]
+printf '%s\n' 'user-config-after-updater' > "${mixed_agent}"
+if [[ ! -e "${mixed_marker}" ]]; then
+    cp "${agent_template}" "${mixed_agent}"
+fi
+grep -Fqx 'user-config-after-updater' "${mixed_agent}"
+
+printf '%s\n' 'user-config-after-remote' > "${mixed_agent}"
+! agent_config_reset_required v0.20.1 v0.20.2 "${mixed_marker}"
+grep -Fqx 'user-config-after-remote' "${mixed_agent}"
+grep -Fqx 'marker=config/.agent-config-v0.20.2' "${REPO_DIR}/scripts/deploy-remote.sh"
+
+current_version_app="${tmp_dir}/current-version"
+APP_DIR="${current_version_app}"
+mkdir -p "${APP_DIR}/config"
+mark_agent_config_migration_complete v0.20.3 v0.21.0
+[[ -f "${APP_DIR}/config/.agent-config-v0.20.2" ]]
+
+failed_marker_app="${tmp_dir}/failed-migration"
+APP_DIR="${failed_marker_app}"
+mkdir -p "${APP_DIR}/config"
+set +e
+replace_agent_config_from_release "${APP_DIR}/config/missing.toml" "${agent_template}" >/dev/null 2>&1
+replacement_status=$?
+set -e
+[[ "${replacement_status}" -ne 0 ]]
+[[ ! -e "${APP_DIR}/config/.agent-config-v0.20.2" ]]
 
 fixture="${tmp_dir}/fixture"
 output="${tmp_dir}/output"

--- a/scripts/test-qbot-install.sh
+++ b/scripts/test-qbot-install.sh
@@ -24,6 +24,11 @@ assert_target Linux aarch64 linux-aarch64
 assert_target Darwin x86_64 macos-x86_64
 assert_target Darwin arm64 macos-aarch64
 
+agent_config_reset_required v0.20.1 v0.20.2
+agent_config_reset_required v0.20.1 v0.21.0
+! agent_config_reset_required v0.20.2 v0.20.3
+! agent_config_reset_required v0.20.3 v0.21.0
+
 # Unix 安装器不得再包含 Windows target、ZIP 或原生 Windows 二进制分支。
 if rg -n 'MINGW|MSYS|CYGWIN|windows-(x86_64|aarch64)|\.zip|qq-maid-bot\.exe' \
     "${REPO_DIR}/scripts/qbot.sh" >/dev/null; then
@@ -39,26 +44,16 @@ printf '%s\n' 'version = 1' '[scenes.private]' 'enabled_tools = ["new_tool"]' > 
 
 agent_yes="${tmp_dir}/agent-yes.toml"
 printf '%s\n' 'version = 1' 'custom = "keep-before-replacement"' > "${agent_yes}"
-output="$(prompt_agent_config_replacement "${agent_yes}" "${agent_template}" y)"
+output="$(upgrade_agent_config_from_release "${agent_yes}" "${agent_template}")"
 cmp -s "${agent_yes}" "${agent_template}"
 grep -Fqx 'custom = "keep-before-replacement"' "${agent_yes}.old"
 [[ "${output}" == *"旧配置备份: ${agent_yes}.old"* ]]
 [[ "${output}" == *"Provider、模型路线、Scene 和工具白名单"* ]]
 
-for response in n ""; do
-    agent_keep="${tmp_dir}/agent-keep-${response:-empty}.toml"
-    printf '%s\n' 'version = 1' "custom = \"keep-${response:-empty}\"" > "${agent_keep}"
-    original_hash="$(sha256sum "${agent_keep}")"
-    output="$(prompt_agent_config_replacement "${agent_keep}" "${agent_template}" "${response}")"
-    [[ "$(sha256sum "${agent_keep}")" == "${original_hash}" ]]
-    [[ ! -e "${agent_keep}.old" ]]
-    [[ "${output}" == *"已保留现有 agent.toml"* ]]
-done
-
 agent_collision="${tmp_dir}/agent-collision.toml"
 printf '%s\n' 'current-old-config' > "${agent_collision}"
 printf '%s\n' 'earlier-backup' > "${agent_collision}.old"
-prompt_agent_config_replacement "${agent_collision}" "${agent_template}" y >/dev/null
+upgrade_agent_config_from_release "${agent_collision}" "${agent_template}" >/dev/null
 grep -Fqx 'earlier-backup' "${agent_collision}.old"
 grep -Fqx 'current-old-config' "${agent_collision}.old.1"
 cmp -s "${agent_collision}" "${agent_template}"
@@ -89,11 +84,11 @@ fi
 [[ "${failure_output}" == *"已恢复原文件"* ]]
 
 agent_noninteractive="${tmp_dir}/agent-noninteractive.toml"
-printf '%s\n' 'noninteractive-must-stay' > "${agent_noninteractive}"
-output="$(prompt_agent_config_replacement "${agent_noninteractive}" "${agent_template}" < /dev/null)"
-grep -Fqx 'noninteractive-must-stay' "${agent_noninteractive}"
-[[ ! -e "${agent_noninteractive}.old" ]]
-[[ "${output}" == *"非交互环境，默认保留"* ]]
+printf '%s\n' 'noninteractive-must-update' > "${agent_noninteractive}"
+output="$(upgrade_agent_config_from_release "${agent_noninteractive}" "${agent_template}" < /dev/null)"
+cmp -s "${agent_noninteractive}" "${agent_template}"
+grep -Fqx 'noninteractive-must-update' "${agent_noninteractive}.old"
+[[ "${output}" == *"自动备份并更新"* ]]
 
 fixture="${tmp_dir}/fixture"
 output="${tmp_dir}/output"

--- a/scripts/test-windows-qbot.ps1
+++ b/scripts/test-windows-qbot.ps1
@@ -117,7 +117,8 @@ try {
     Complete-AgentConfigMigration -CurrentVersion "v0.20.3" -TargetVersion "v0.21.0"
     Assert-True (Test-Path -LiteralPath $mixedMarker -PathType Leaf) "installed v0.20.2+ did not get the shared marker"
 
-    $failedMarker = Join-Path $appDir "config\failed\.agent-config-v0.20.2"
+    $failedMarker = Join-Path $appDir "config\.agent-config-v0.20.2"
+    Remove-Item -LiteralPath $failedMarker -Force -ErrorAction SilentlyContinue
     $failedReplacementError = $null
     try {
         Replace-AgentConfigFromRelease -ConfigFile (Join-Path $appDir "config\missing.toml") -TemplateFile $agentTemplate

--- a/scripts/test-windows-qbot.ps1
+++ b/scripts/test-windows-qbot.ps1
@@ -108,6 +108,25 @@ try {
     Assert-True ((Get-Content -LiteralPath "${agentNonInteractive}.old" -Raw).Contains("noninteractive-must-update")) "non-interactive upgrade did not create a backup"
     Assert-True ($nonInteractiveOutput.Contains("自动备份并更新")) "non-interactive upgrade did not explain the automatic migration"
 
+    $mixedMarker = Join-Path $appDir "config\.agent-config-v0.20.2"
+    New-Item -ItemType Directory -Path (Split-Path -Parent $mixedMarker) -Force | Out-Null
+    Complete-AgentConfigMigration -CurrentVersion "v0.20.1" -TargetVersion "v0.20.2"
+    Assert-True (Test-Path -LiteralPath $mixedMarker -PathType Leaf) "successful updater migration did not create the shared marker"
+    Assert-True (-not (Test-AgentConfigResetRequired -CurrentVersion "v0.20.1" -TargetVersion "v0.20.2" -MarkerFile $mixedMarker)) "remote migration marker did not prevent a second updater reset"
+    Remove-Item -LiteralPath $mixedMarker -Force
+    Complete-AgentConfigMigration -CurrentVersion "v0.20.3" -TargetVersion "v0.21.0"
+    Assert-True (Test-Path -LiteralPath $mixedMarker -PathType Leaf) "installed v0.20.2+ did not get the shared marker"
+
+    $failedMarker = Join-Path $appDir "config\failed\.agent-config-v0.20.2"
+    $failedReplacementError = $null
+    try {
+        Replace-AgentConfigFromRelease -ConfigFile (Join-Path $appDir "config\missing.toml") -TemplateFile $agentTemplate
+    } catch {
+        $failedReplacementError = $_.Exception.Message
+    }
+    Assert-True ($null -ne $failedReplacementError) "failed agent migration did not return an error"
+    Assert-True (-not (Test-Path -LiteralPath $failedMarker)) "failed agent migration left a marker"
+
     New-Item -ItemType Directory -Path (Join-Path $appDir "config") -Force | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $appDir "data\storage") -Force | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $appDir "logs") -Force | Out-Null

--- a/scripts/test-windows-qbot.ps1
+++ b/scripts/test-windows-qbot.ps1
@@ -27,6 +27,10 @@ try {
     Assert-True (Test-SupportedWindowsArchitecture "AMD64") "Windows AMD64 should be supported"
     Assert-True (Test-SupportedWindowsArchitecture "x86_64") "Windows x86_64 should be supported"
     Assert-True (-not (Test-SupportedWindowsArchitecture "ARM64")) "Windows ARM64 should be rejected"
+    Assert-True (Test-AgentConfigResetRequired -CurrentVersion "v0.20.1" -TargetVersion "v0.20.2") "v0.20.1 -> v0.20.2 should reset agent.toml"
+    Assert-True (Test-AgentConfigResetRequired -CurrentVersion "v0.20.1" -TargetVersion "v0.21.0") "skipped upgrade should reset agent.toml"
+    Assert-True (-not (Test-AgentConfigResetRequired -CurrentVersion "v0.20.2" -TargetVersion "v0.20.3")) "post-reset upgrade should preserve agent.toml"
+    Assert-True (-not (Test-AgentConfigResetRequired -CurrentVersion "v0.20.3" -TargetVersion "v0.21.0")) "later upgrade should preserve agent.toml"
     $arm64Error = $null
     try {
         Assert-SupportedWindowsArchitecture "ARM64"
@@ -60,26 +64,16 @@ try {
 
     $agentYes = Join-Path $agentTestDir "yes.toml"
     Set-Content -LiteralPath $agentYes -Value "custom-before-replacement" -Encoding ASCII
-    $yesOutput = (Request-AgentConfigReplacement -ConfigFile $agentYes -TemplateFile $agentTemplate -Response "y") -join "`n"
-    Assert-True ((Get-FileHash $agentYes).Hash -eq (Get-FileHash $agentTemplate).Hash) "y did not install the Release agent template"
-    Assert-True ((Get-Content -LiteralPath "${agentYes}.old" -Raw).Contains("custom-before-replacement")) "y did not preserve the old agent config"
-    Assert-True ($yesOutput.Contains("旧配置备份: ${agentYes}.old")) "y did not report the agent backup path"
-    Assert-True ($yesOutput.Contains("Provider、模型路线、Scene 和工具白名单")) "y did not report required custom configuration work"
-
-    foreach ($case in @(@{ Name = "no"; Response = "n" }, @{ Name = "empty"; Response = "" })) {
-        $agentKeep = Join-Path $agentTestDir ("keep-" + $case.Name + ".toml")
-        Set-Content -LiteralPath $agentKeep -Value ("keep-" + $case.Name) -Encoding ASCII
-        $beforeHash = (Get-FileHash -LiteralPath $agentKeep -Algorithm SHA256).Hash
-        $keepOutput = (Request-AgentConfigReplacement -ConfigFile $agentKeep -TemplateFile $agentTemplate -Response $case.Response) -join "`n"
-        Assert-True ((Get-FileHash -LiteralPath $agentKeep -Algorithm SHA256).Hash -eq $beforeHash) "$($case.Name) changed agent.toml"
-        Assert-True (-not (Test-Path -LiteralPath "${agentKeep}.old")) "$($case.Name) created an unexpected backup"
-        Assert-True ($keepOutput.Contains("已保留现有 agent.toml")) "$($case.Name) did not report that agent.toml was preserved"
-    }
+    $yesOutput = (Update-AgentConfigFromRelease -ConfigFile $agentYes -TemplateFile $agentTemplate) -join "`n"
+    Assert-True ((Get-FileHash $agentYes).Hash -eq (Get-FileHash $agentTemplate).Hash) "upgrade did not install the Release agent template"
+    Assert-True ((Get-Content -LiteralPath "${agentYes}.old" -Raw).Contains("custom-before-replacement")) "upgrade did not preserve the old agent config"
+    Assert-True ($yesOutput.Contains("旧配置备份: ${agentYes}.old")) "upgrade did not report the agent backup path"
+    Assert-True ($yesOutput.Contains("Provider、模型路线、Scene 和工具白名单")) "upgrade did not report required custom configuration work"
 
     $agentCollision = Join-Path $agentTestDir "collision.toml"
     Set-Content -LiteralPath $agentCollision -Value "current-old-config" -Encoding ASCII
     Set-Content -LiteralPath "${agentCollision}.old" -Value "earlier-backup" -Encoding ASCII
-    Request-AgentConfigReplacement -ConfigFile $agentCollision -TemplateFile $agentTemplate -Response "Y" | Out-Null
+    Update-AgentConfigFromRelease -ConfigFile $agentCollision -TemplateFile $agentTemplate | Out-Null
     Assert-True ((Get-Content -LiteralPath "${agentCollision}.old" -Raw).Contains("earlier-backup")) "existing .old backup was overwritten"
     Assert-True ((Get-Content -LiteralPath "${agentCollision}.old.1" -Raw).Contains("current-old-config")) "replacement did not use the next backup suffix"
 
@@ -108,11 +102,11 @@ try {
     Assert-True (@(Get-ChildItem -LiteralPath $agentTestDir -Filter ".agent.toml.new.*").Count -eq 0) "replacement failure left a temporary file"
 
     $agentNonInteractive = Join-Path $agentTestDir "noninteractive.toml"
-    Set-Content -LiteralPath $agentNonInteractive -Value "noninteractive-must-stay" -Encoding ASCII
-    $nonInteractiveOutput = (Request-AgentConfigReplacement -ConfigFile $agentNonInteractive -TemplateFile $agentTemplate -NonInteractive) -join "`n"
-    Assert-True ((Get-Content -LiteralPath $agentNonInteractive -Raw).Contains("noninteractive-must-stay")) "non-interactive update replaced agent.toml"
-    Assert-True (-not (Test-Path -LiteralPath "${agentNonInteractive}.old")) "non-interactive update created an unexpected backup"
-    Assert-True ($nonInteractiveOutput.Contains("非交互环境，默认保留")) "non-interactive update did not explain the default"
+    Set-Content -LiteralPath $agentNonInteractive -Value "noninteractive-must-update" -Encoding ASCII
+    $nonInteractiveOutput = (Update-AgentConfigFromRelease -ConfigFile $agentNonInteractive -TemplateFile $agentTemplate) -join "`n"
+    Assert-True ((Get-FileHash $agentNonInteractive).Hash -eq (Get-FileHash $agentTemplate).Hash) "non-interactive upgrade did not replace agent.toml"
+    Assert-True ((Get-Content -LiteralPath "${agentNonInteractive}.old" -Raw).Contains("noninteractive-must-update")) "non-interactive upgrade did not create a backup"
+    Assert-True ($nonInteractiveOutput.Contains("自动备份并更新")) "non-interactive upgrade did not explain the automatic migration"
 
     New-Item -ItemType Directory -Path (Join-Path $appDir "config") -Force | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $appDir "data\storage") -Force | Out-Null


### PR DESCRIPTION
## 变更

- 将 `v0.20.2` 的 Agent 配置升级收敛为一次性迁移：Unix/Windows 更新器和远程部署先备份旧 `agent.toml`，再启用新版模板，并避免覆盖已有历史备份。
- 同版本重复更新和完成迁移后的后续版本不会再次覆盖用户策略。
- 为 `max_tool_rounds`、`tool_calling_enabled`、`enabled_tools` 增加安全默认值，旧配置缺少这些普通可选字段时仍可启动。
- 更新安装器回归测试、配置解析测试和变更记录。

## 背景

旧流程每次发现配置模板变化都要求人工决定是否替换，非交互升级还会保留可能不兼容的旧文件。#533 要求下一版本完成一次备份替换，后续通过代码默认值兼容普通新增字段，仅真正结构变化才需要迁移。

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo build --workspace --release --all-features`
- `bash scripts/test-qbot-install.sh`
- `bash scripts/test-qbot-config.sh`
- `bash -n scripts/qbot.sh scripts/deploy-remote.sh scripts/test-qbot-install.sh`
- `pwsh -NoProfile -File scripts/test-windows-qbot.ps1`（GitHub Actions Windows）

Closes #533
