### PR TITLE
[codex] 修复配置中心字段溢出

### DIFF
--- a/web-console/dist/styles.css
+++ b/web-console/dist/styles.css
@@ -354,7 +354,8 @@ textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(13, 138
 .configuration-panel details > button { margin: 0 1rem 1rem; }
 .config-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .8rem; padding: 1rem; }
 .grouped-config-grid { display: grid; gap: 1rem; padding: 1rem; }
-.config-field-group { display: grid; gap: .6rem; }
+.config-field-group { display: grid; min-width: 0; gap: .6rem; }
+.config-grid > .config-field-group { grid-column: 1 / -1; }
 .config-field-group h3 {
   margin: 0;
   padding: 0 .15rem;
@@ -365,6 +366,7 @@ textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(13, 138
 .config-field-group-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .8rem; }
 .config-row {
   display: grid;
+  min-width: 0;
   grid-template-columns: minmax(10rem, 1fr) minmax(12rem, 1.4fr) auto;
   align-items: center;
   gap: .65rem;
@@ -374,11 +376,12 @@ textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(13, 138
   background: #fff;
   transition: border-color .15s ease, box-shadow .15s ease;
 }
+.config-row > * { min-width: 0; }
 .config-row:focus-within { border-color: #9fd3bd; box-shadow: 0 0 0 3px rgba(13, 138, 95, .08); }
 .config-row > label:first-child { margin: 0; color: var(--ink); }
 .config-row > input:not([type="checkbox"]) { width: 100%; }
 .config-row .password-field { width: 100%; }
-.field-meta { display: block; margin-top: .3rem; color: var(--muted); font-size: .68rem; font-weight: 500; }
+.field-meta { display: block; overflow-wrap: anywhere; margin-top: .3rem; color: var(--muted); font-size: .68rem; font-weight: 500; }
 .clear-secret { display: flex; align-items: center; gap: .3rem; margin: 0; white-space: nowrap; font-weight: 500; }
 .compact-row { grid-template-columns: 1fr auto; }
 .tool-whitelist { grid-column: 1 / -1; margin: 0; padding: .8rem; border: 1px solid var(--line); border-radius: 8px; }

--- a/web-console/src/styles.css
+++ b/web-console/src/styles.css
@@ -354,7 +354,8 @@ textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(13, 138
 .configuration-panel details > button { margin: 0 1rem 1rem; }
 .config-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .8rem; padding: 1rem; }
 .grouped-config-grid { display: grid; gap: 1rem; padding: 1rem; }
-.config-field-group { display: grid; gap: .6rem; }
+.config-field-group { display: grid; min-width: 0; gap: .6rem; }
+.config-grid > .config-field-group { grid-column: 1 / -1; }
 .config-field-group h3 {
   margin: 0;
   padding: 0 .15rem;
@@ -365,6 +366,7 @@ textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(13, 138
 .config-field-group-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .8rem; }
 .config-row {
   display: grid;
+  min-width: 0;
   grid-template-columns: minmax(10rem, 1fr) minmax(12rem, 1.4fr) auto;
   align-items: center;
   gap: .65rem;
@@ -374,11 +376,12 @@ textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(13, 138
   background: #fff;
   transition: border-color .15s ease, box-shadow .15s ease;
 }
+.config-row > * { min-width: 0; }
 .config-row:focus-within { border-color: #9fd3bd; box-shadow: 0 0 0 3px rgba(13, 138, 95, .08); }
 .config-row > label:first-child { margin: 0; color: var(--ink); }
 .config-row > input:not([type="checkbox"]) { width: 100%; }
 .config-row .password-field { width: 100%; }
-.field-meta { display: block; margin-top: .3rem; color: var(--muted); font-size: .68rem; font-weight: 500; }
+.field-meta { display: block; overflow-wrap: anywhere; margin-top: .3rem; color: var(--muted); font-size: .68rem; font-weight: 500; }
 .clear-secret { display: flex; align-items: center; gap: .3rem; margin: 0; white-space: nowrap; font-weight: 500; }
 .compact-row { grid-template-columns: 1fr auto; }
 .tool-whitelist { grid-column: 1 / -1; margin: 0; padding: .8rem; border: 1px solid var(--line); border-radius: 8px; }


### PR DESCRIPTION
## 修改内容

- 让 Agent 配置中的复合字段组横跨外层双列网格，恢复知识检索区域的正常可用宽度
- 为配置分组、字段行和行内元素补充可收缩约束，并允许状态说明在必要时换行
- 同步重新生成并提交 Web Console 的嵌入式 `dist` 样式产物

## 问题原因与影响

知识检索本身是一个双列子网格，但此前作为普通网格项被放入 Agent 配置外层的半宽列。字段内部仍保留固定最小轨道宽度，导致选择框和说明文本越过卡片边界，并把同一行的私聊主路线异常拉高。

修复后，知识检索组使用完整行宽，普通模型路线继续保持桌面双列布局；在较大字体、浏览器缩放及窄屏断点下，字段内容也能正常收缩或换行。

## 验证

- `npm run check`
- `npm test`
- `git diff --check`
- 确认 `web-console/src/styles.css` 与重新构建的 `web-console/dist/styles.css` 一致

无头 Chromium 截图检查因当前容器中的 Snap Chromium 固定写入只读 `/run/user/1000` 而未执行成功。
