### PR TITLE
fix: 修复群聊 Markdown 被 Text parts 降级

### DIFF
--- a/qq-maid-core/src/service/handle.rs
+++ b/qq-maid-core/src/service/handle.rs
@@ -309,19 +309,7 @@ impl From<RespondResponse> for CoreResponse {
     fn from(value: RespondResponse) -> Self {
         // `RespondResponse` 仍按 text/markdown 双通道组装正文，属于 Core 内部中间结构；
         // 这里将其合成为唯一的结构化 `AssistantOutput` 输出，不再向 Gateway 暴露旧字段。
-        let output = if value.output_parts.is_empty() {
-            match (value.text, value.markdown) {
-                (Some(text), Some(markdown)) => Some(AssistantOutput::markdown(text, markdown)),
-                (Some(text), None) => Some(AssistantOutput::text(text)),
-                _ => None,
-            }
-        } else {
-            Some(AssistantOutput {
-                text_fallback: value.text.unwrap_or_default(),
-                markdown: value.markdown,
-                parts: value.output_parts,
-            })
-        };
+        let output = synthesize_assistant_output(value.text, value.markdown, value.output_parts);
         Self {
             output,
             handled: value.handled,
@@ -331,6 +319,68 @@ impl From<RespondResponse> for CoreResponse {
             visible_entity_snapshot: value.visible_entity_snapshot,
         }
     }
+}
+
+/// 把 Core 内部 text/markdown 双通道与结构化 parts 合成 Gateway 可渲染的 `AssistantOutput`。
+///
+/// Provider 可能把最终聊天正文放进 `OutputPart::Text`；若同时存在 markdown 通道，
+/// 这些 Text part 只是 markdown 的重复表示，不能优先于 markdown 出站，否则群聊等
+/// 非流式路径会退化成纯文本。图片/文件等富媒体 part 继续保留。
+fn synthesize_assistant_output(
+    text: Option<String>,
+    markdown: Option<String>,
+    output_parts: Vec<qq_maid_common::output_part::OutputPart>,
+) -> Option<AssistantOutput> {
+    use qq_maid_common::output_part::OutputPart;
+
+    let markdown = markdown
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty());
+    let text_parts = output_parts
+        .iter()
+        .filter_map(|part| match part {
+            OutputPart::Text { text } if !text.trim().is_empty() => Some(text.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let media_parts = output_parts
+        .into_iter()
+        .filter(|part| !matches!(part, OutputPart::Text { .. } | OutputPart::Markdown { .. }))
+        .collect::<Vec<_>>();
+
+    if media_parts.is_empty() {
+        return match (text, markdown) {
+            (Some(text), Some(markdown)) => Some(AssistantOutput::markdown(text, markdown)),
+            (Some(text), None) => Some(AssistantOutput::text(text)),
+            (None, Some(markdown)) => {
+                let text = qq_maid_common::markdown::to_chat_text(&markdown);
+                Some(AssistantOutput::markdown(text, markdown))
+            }
+            (None, None) if !text_parts.is_empty() => {
+                // 没有 markdown 通道时，保留 Provider 仅返回的 Text parts，避免丢正文。
+                Some(AssistantOutput::text(text_parts.join("\n\n")))
+            }
+            (None, None) => None,
+        };
+    }
+
+    let text_fallback = text.unwrap_or_else(|| text_parts.join("\n\n"));
+    let mut parts = Vec::with_capacity(media_parts.len() + usize::from(markdown.is_some()));
+    if let Some(markdown) = markdown.clone() {
+        parts.push(OutputPart::Markdown { markdown });
+    } else if !text_fallback.trim().is_empty() {
+        // 有富媒体但没有 markdown 时，保留纯文本 part，保证图文顺序可渲染。
+        parts.push(OutputPart::Text {
+            text: text_fallback.clone(),
+        });
+    }
+    parts.extend(media_parts);
+
+    Some(AssistantOutput {
+        text_fallback,
+        markdown,
+        parts,
+    })
 }
 
 fn respond_options(config: &AppConfig) -> RespondServiceOptions {

--- a/qq-maid-core/src/service/tests/response.rs
+++ b/qq-maid-core/src/service/tests/response.rs
@@ -43,6 +43,101 @@ fn core_response_keeps_public_fields_from_respond_response() {
 }
 
 #[test]
+fn provider_text_parts_do_not_downgrade_markdown_channel() {
+    // OpenAI Responses 可能把最终聊天正文同时放进 Text part 与 markdown 通道。
+    // 合成后必须保留 Markdown part，避免群聊等非流式路径被 parts 优先逻辑降级成纯文本。
+    let response = CoreResponse::from(RespondResponse {
+        ok: true,
+        text: Some("Markdown 测试\n加粗 斜体 代码".to_owned()),
+        markdown: Some("# Markdown 测试\n\n- **加粗**\n- *斜体*\n- `代码`".to_owned()),
+        output_parts: vec![OutputPart::Text {
+            text: "# Markdown 测试\n\n- **加粗**\n- *斜体*\n- `代码`".to_owned(),
+        }],
+        handled: Some(true),
+        session_id: None,
+        command: None,
+        diagnostics: None,
+        visible_entity_snapshot: None,
+        metrics: LlmMetrics {
+            provider: "test".to_owned(),
+            model: "test".to_owned(),
+            stream: false,
+            ttfe_ms: None,
+            ttft_ms: None,
+            total_latency_ms: 1,
+        },
+        usage: None,
+        error: None,
+    });
+
+    let output = response.output.as_ref().expect("assistant output");
+    assert_eq!(
+        response.markdown_content(),
+        Some("# Markdown 测试\n\n- **加粗**\n- *斜体*\n- `代码`")
+    );
+    assert_eq!(
+        output.parts,
+        vec![OutputPart::Markdown {
+            markdown: "# Markdown 测试\n\n- **加粗**\n- *斜体*\n- `代码`".to_owned()
+        }]
+    );
+}
+
+#[test]
+fn media_parts_keep_markdown_channel_ahead_of_images() {
+    let response = CoreResponse::from(RespondResponse {
+        ok: true,
+        text: Some("先看图".to_owned()),
+        markdown: Some("# 标题".to_owned()),
+        output_parts: vec![
+            OutputPart::Text {
+                text: "# 标题".to_owned(),
+            },
+            OutputPart::Image {
+                media: OutputMedia {
+                    media_id: Some("image-1".to_owned()),
+                    fallback_text: Some("图片：封面".to_owned()),
+                    ..OutputMedia::default()
+                },
+            },
+        ],
+        handled: Some(true),
+        session_id: None,
+        command: None,
+        diagnostics: None,
+        visible_entity_snapshot: None,
+        metrics: LlmMetrics {
+            provider: "test".to_owned(),
+            model: "test".to_owned(),
+            stream: false,
+            ttfe_ms: None,
+            ttft_ms: None,
+            total_latency_ms: 1,
+        },
+        usage: None,
+        error: None,
+    });
+
+    let output = response.output.as_ref().expect("assistant output");
+    assert_eq!(output.markdown.as_deref(), Some("# 标题"));
+    assert_eq!(
+        output.parts,
+        vec![
+            OutputPart::Markdown {
+                markdown: "# 标题".to_owned()
+            },
+            OutputPart::Image {
+                media: OutputMedia {
+                    media_id: Some("image-1".to_owned()),
+                    fallback_text: Some("图片：封面".to_owned()),
+                    ..OutputMedia::default()
+                },
+            },
+        ]
+    );
+}
+
+#[test]
 fn assistant_output_text_builds_plain_fallback_part() {
     let output = AssistantOutput::text("hello");
 

--- a/qq-maid-gateway-rs/src/render.rs
+++ b/qq-maid-gateway-rs/src/render.rs
@@ -167,26 +167,26 @@ fn render_assistant_output_parts_for_profile(
             }
         }
         // parts 只有重复 Text、没有 Markdown part 时，补上 markdown 字段，避免直接落到纯文本。
-        if prefer_markdown && !saw_markdown_part {
-            if let Some(markdown) = output
+        if prefer_markdown
+            && !saw_markdown_part
+            && let Some(markdown) = output
                 .markdown
                 .as_deref()
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
-            {
-                let fallback_text = if !output.text_fallback.trim().is_empty() {
-                    output.text_fallback.clone()
-                } else {
-                    qq_maid_common::markdown::to_chat_text(markdown)
-                };
-                rendered.insert(
-                    0,
-                    OutboundMessage::Markdown {
-                        markdown: MarkdownPayload::new(markdown),
-                        fallback_text,
-                    },
-                );
-            }
+        {
+            let fallback_text = if !output.text_fallback.trim().is_empty() {
+                output.text_fallback.clone()
+            } else {
+                qq_maid_common::markdown::to_chat_text(markdown)
+            };
+            rendered.insert(
+                0,
+                OutboundMessage::Markdown {
+                    markdown: MarkdownPayload::new(markdown),
+                    fallback_text,
+                },
+            );
         }
         if !rendered.is_empty() {
             return rendered;

--- a/qq-maid-gateway-rs/src/render.rs
+++ b/qq-maid-gateway-rs/src/render.rs
@@ -112,13 +112,20 @@ fn render_assistant_output_parts_for_profile(
     profile: &RenderProfile,
 ) -> Vec<OutboundMessage> {
     if !output.parts.is_empty() {
+        // 存在 markdown 通道时，Text part 通常是同一正文的重复表示；优先渲染 Markdown，
+        // 避免群聊等非流式路径被 Provider Text part 抢先降级成纯文本。
+        let prefer_markdown = profile.supports_markdown && output_has_markdown_channel(output);
         let mut rendered = Vec::new();
+        let mut saw_markdown_part = false;
         for part in &output.parts {
             match part {
-                OutputPart::Text { text } if profile.supports_text && !text.trim().is_empty() => {
+                OutputPart::Text { text }
+                    if profile.supports_text && !prefer_markdown && !text.trim().is_empty() =>
+                {
                     rendered.push(OutboundMessage::Text { text: text.clone() });
                 }
                 OutputPart::Markdown { markdown } if !markdown.trim().is_empty() => {
+                    saw_markdown_part = true;
                     let fallback_text =
                         if output.parts.len() == 1 && !output.text_fallback.trim().is_empty() {
                             output.text_fallback.clone()
@@ -157,6 +164,28 @@ fn render_assistant_output_parts_for_profile(
                     });
                 }
                 _ => {}
+            }
+        }
+        // parts 只有重复 Text、没有 Markdown part 时，补上 markdown 字段，避免直接落到纯文本。
+        if prefer_markdown && !saw_markdown_part {
+            if let Some(markdown) = output
+                .markdown
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                let fallback_text = if !output.text_fallback.trim().is_empty() {
+                    output.text_fallback.clone()
+                } else {
+                    qq_maid_common::markdown::to_chat_text(markdown)
+                };
+                rendered.insert(
+                    0,
+                    OutboundMessage::Markdown {
+                        markdown: MarkdownPayload::new(markdown),
+                        fallback_text,
+                    },
+                );
             }
         }
         if !rendered.is_empty() {
@@ -414,17 +443,13 @@ mod tests {
             visible_entity_snapshot: None,
         };
 
+        // 已有 Markdown part 时，重复 Text part 不再单独出站，避免群聊先发一段纯文本。
         assert_eq!(
             render_respond_response_parts_for_profile(&response, &render_profile(true, true)),
-            vec![
-                OutboundMessage::Text {
-                    text: "hello *plain*".to_owned()
-                },
-                OutboundMessage::Markdown {
-                    markdown: MarkdownPayload::new("## title\n- item"),
-                    fallback_text: "title\n· item".to_owned(),
-                },
-            ]
+            vec![OutboundMessage::Markdown {
+                markdown: MarkdownPayload::new("## title\n- item"),
+                fallback_text: "title\n· item".to_owned(),
+            }]
         );
     }
 
@@ -537,6 +562,32 @@ mod tests {
                 markdown: MarkdownPayload::new("**output markdown**"),
                 fallback_text: "output fallback".to_owned(),
             })
+        );
+    }
+
+    #[test]
+    fn markdown_channel_wins_over_duplicate_text_parts() {
+        let response = RespondResponse {
+            output: Some(AssistantOutput {
+                text_fallback: "Markdown 测试".to_owned(),
+                markdown: Some("# Markdown 测试\n\n- **加粗**".to_owned()),
+                parts: vec![OutputPart::Text {
+                    text: "# Markdown 测试\n\n- **加粗**".to_owned(),
+                }],
+            }),
+            handled: Some(true),
+            session_id: None,
+            command: None,
+            diagnostics: None,
+            visible_entity_snapshot: None,
+        };
+
+        assert_eq!(
+            render_respond_response_parts_for_profile(&response, &render_profile(true, true)),
+            vec![OutboundMessage::Markdown {
+                markdown: MarkdownPayload::new("# Markdown 测试\n\n- **加粗**"),
+                fallback_text: "Markdown 测试".to_owned(),
+            }]
         );
     }
 }


### PR DESCRIPTION
## Summary
- 修复群聊普通聊天最终回复被降级成纯文本的问题。
- 根因是 #542 后 Provider 会把最终正文放进 `OutputPart::Text`，Core 合成时原样塞入 `parts`，Gateway 优先按 parts 渲染，忽略 markdown 通道。
- Core 合成时过滤与 markdown 重复的 Text parts，图文混排时把 Markdown 放在媒体前；Gateway 渲染时同样优先 markdown 通道。

## Test plan
- [x] `cargo test -p qq-maid-core --lib service::tests::response`
- [x] `cargo test -p qq-maid-gateway-rs --lib render::`
- [x] `cargo fmt --all`
- [x] `cargo check -p qq-maid-core -p qq-maid-gateway-rs`
- [x] 远程部署后群聊发送“测试输出一段 markdown”，确认出站 `kind=markdown` / `message_type=markdown`
- [x] 对照 C2C 同一内容仍正常