### PR TITLE
[codex] 准备 v0.20.4：支持完整管理员令牌输入

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 本文档基于 [keep a changelog](https://keepachangelog.com/zh-CN/1.0.0/) 格式，记录每个已发布版本的变更。
 
+## [v0.20.4] - 2026-07-20
+
+### Fixed
+
+* **管理员完整令牌输入**（PR #547）：管理员初始化和密码重置接口支持裸 token，以及项目生成的 `qq-maid-bootstrap-v1:<时间>:<token>` 和 `qq-maid-password-reset-v1:<时间>:<token>` 完整令牌字符串；严格校验前缀、字段与用途，并区分输入格式错误和 token 无效或过期。
+* **群聊 Markdown 输出保留**（PR #546）：Provider 同时返回 Text part 与 Markdown 通道时优先保留 Markdown，避免群聊非流式回复被降级为纯文本。
+
+### Compatibility
+
+* 本版本无数据库 migration、配置项变更或令牌有效期调整；原有裸 token 输入保持兼容，Bootstrap token 与密码重置 token 仍不可跨用途使用。
+* 根包 `qq-maid-bot` 版本号提升到 `0.20.4`，内部 crate 版本不统一提升。
+
 ## [v0.20.3] - 2026-07-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,7 +1966,7 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "qq-maid-bot"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "anyhow",
  "qq-maid-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-bot"
-version = "0.20.3"
+version = "0.20.4"
 edition = "2024"
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@
 
 > 💡 仓库早期以 QQ 机器人为主，因此仍保留 `qq-maid-bot` 名称。当前项目正在从 QQ 官方机器人演进为多入口平台型小女仆机器人。
 
-当前稳定版本为 `v0.20.3`，项目处于 `20.x` 版本线；版本线能力与升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)。
+当前稳定版本为 `v0.20.4`，项目处于 `20.x` 版本线；版本线能力与升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)。
 
 使用、安装和配置优先看 [项目 Wiki](https://github.com/kuliantnt/qq-maid-bot/wiki)：从第一次对话、一键安装、配置中心与 `/console/` 首次向导，到 NapCat、`/ops` 运维和 Codex 长任务，都按场景拆开了。仓库内 `docs/` 与各 crate README 更偏开发边界和实现细节。
 
 ## 20.x 版本线更新
-- **配置与部署升级**（v0.20.0 - v0.20.3）：新增安全配置中心、`/console/` 管理入口、Agent 配置迁移和工具白名单，支持在网页中配置 Provider、QQ / OneBot / 微信入口及主要运行能力。
+- **配置与部署升级**（v0.20.0 - v0.20.4）：新增安全配置中心、`/console/` 管理入口、Agent 配置迁移和工具白名单，支持在网页中配置 Provider、QQ / OneBot / 微信入口及主要运行能力；管理员初始化与密码重置可直接粘贴完整令牌字符串。
 - **知识库 Agent 化**（PR #528、#534）：知识检索改为按需调用的受控工具，支持结构化证据、混合召回和相关性评测。
 - **QQ 语音与命令前缀**（v0.20.1）：QQ 语音转写进入普通对话链路，所有入口支持统一可配置的聊天命令前缀。
 - **图片生成与多平台发送**（v0.20.3）：支持 QQ 官方与 OneBot 11 图片发送，并兼容 Windows 本地图片的 `file://` URI。

--- a/qq-maid-core/src/http/management/auth_routes.rs
+++ b/qq-maid-core/src/http/management/auth_routes.rs
@@ -699,7 +699,7 @@ pub(super) fn auth_error(error: AdminAuthError) -> Response {
         "rate_limited" => StatusCode::TOO_MANY_REQUESTS,
         "not_initialized" => StatusCode::CONFLICT,
         "session_capacity_reached" => StatusCode::SERVICE_UNAVAILABLE,
-        "validation_error" => StatusCode::BAD_REQUEST,
+        "validation_error" | "invalid_bootstrap_token_format" => StatusCode::BAD_REQUEST,
         _ => StatusCode::INTERNAL_SERVER_ERROR,
     };
     api_error(status, error.code(), error.message())

--- a/qq-maid-core/src/management/auth.rs
+++ b/qq-maid-core/src/management/auth.rs
@@ -398,10 +398,20 @@ impl AdminAuth {
                 "deployment administrator has already been initialized",
             ));
         }
+        let provided = match normalize_bootstrap_token_input(bootstrap_token) {
+            Ok(provided) => provided,
+            Err(error) => {
+                self.audit(None, "admin.initialize", "denied")?;
+                return Err(error);
+            }
+        };
         let expected = self.read_bootstrap_token()?;
         if expected.purpose != BootstrapTokenPurpose::Initialize
             || !token_is_valid(&expected)
-            || !constant_time_token_eq(bootstrap_token.trim(), &expected.token)
+            || provided
+                .purpose
+                .is_some_and(|purpose| purpose != BootstrapTokenPurpose::Initialize)
+            || !constant_time_token_eq(provided.token, &expected.token)
         {
             self.audit(None, "admin.initialize", "denied")?;
             return Err(AdminAuthError::new(
@@ -523,10 +533,20 @@ impl AdminAuth {
             .bootstrap_lock
             .lock()
             .map_err(|_| AdminAuthError::storage("bootstrap token lock is poisoned"))?;
+        let provided = match normalize_bootstrap_token_input(bootstrap_token) {
+            Ok(provided) => provided,
+            Err(error) => {
+                self.audit(None, "admin.password_reset", "denied")?;
+                return Err(error);
+            }
+        };
         let expected = self.read_bootstrap_token()?;
         if expected.purpose != BootstrapTokenPurpose::PasswordReset
             || !token_is_valid(&expected)
-            || !constant_time_token_eq(bootstrap_token.trim(), &expected.token)
+            || provided
+                .purpose
+                .is_some_and(|purpose| purpose != BootstrapTokenPurpose::PasswordReset)
+            || !constant_time_token_eq(provided.token, &expected.token)
         {
             self.audit(None, "admin.password_reset", "denied")?;
             return Err(AdminAuthError::new(
@@ -1075,7 +1095,13 @@ struct BootstrapToken {
     token: String,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
+struct BootstrapTokenInput<'a> {
+    purpose: Option<BootstrapTokenPurpose>,
+    token: &'a str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BootstrapTokenPurpose {
     Initialize,
     PasswordReset,
@@ -1088,6 +1114,50 @@ impl BootstrapTokenPurpose {
             Self::PasswordReset => PASSWORD_RESET_PREFIX,
         }
     }
+}
+
+fn normalize_bootstrap_token_input(input: &str) -> Result<BootstrapTokenInput<'_>, AdminAuthError> {
+    let input = input.trim();
+    if input.is_empty() {
+        return Err(invalid_bootstrap_token_format());
+    }
+    if !input.contains(':') {
+        return Ok(BootstrapTokenInput {
+            purpose: None,
+            token: input,
+        });
+    }
+
+    let mut parts = input.split(':');
+    let purpose = match parts.next() {
+        Some(BOOTSTRAP_PREFIX) => BootstrapTokenPurpose::Initialize,
+        Some(PASSWORD_RESET_PREFIX) => BootstrapTokenPurpose::PasswordReset,
+        _ => return Err(invalid_bootstrap_token_format()),
+    };
+    let issued_at = parts.next().ok_or_else(invalid_bootstrap_token_format)?;
+    let token = parts.next().ok_or_else(invalid_bootstrap_token_format)?;
+    // 完整输入只接受本项目实际生成的三段格式，避免把任意冒号文本误当成令牌。
+    if parts.next().is_some()
+        || issued_at.is_empty()
+        || !issued_at.bytes().all(|byte| byte.is_ascii_digit())
+        || issued_at.parse::<i64>().is_err()
+        || token.len() != 22
+        || !matches!(URL_SAFE_NO_PAD.decode(token), Ok(decoded) if decoded.len() == 16)
+    {
+        return Err(invalid_bootstrap_token_format());
+    }
+
+    Ok(BootstrapTokenInput {
+        purpose: Some(purpose),
+        token,
+    })
+}
+
+fn invalid_bootstrap_token_format() -> AdminAuthError {
+    AdminAuthError::new(
+        "invalid_bootstrap_token_format",
+        "bootstrap token input format is not recognized",
+    )
 }
 
 fn hash_password(password: &str) -> Result<String, AdminAuthError> {

--- a/qq-maid-core/src/management/auth/tests.rs
+++ b/qq-maid-core/src/management/auth/tests.rs
@@ -8,13 +8,15 @@ fn auth(name: &str) -> (AdminAuth, PathBuf) {
 }
 
 fn bootstrap_token(path: &Path) -> String {
-    fs::read_to_string(path)
-        .unwrap()
-        .trim()
+    bootstrap_token_text(path)
         .splitn(3, ':')
         .nth(2)
         .unwrap()
         .to_owned()
+}
+
+fn bootstrap_token_text(path: &Path) -> String {
+    fs::read_to_string(path).unwrap().trim().to_owned()
 }
 
 fn bootstrap_prefix(path: &Path) -> String {
@@ -25,6 +27,138 @@ fn bootstrap_prefix(path: &Path) -> String {
         .next()
         .unwrap()
         .to_owned()
+}
+
+#[test]
+fn bootstrap_token_input_normalizes_only_supported_complete_formats() {
+    const TOKEN: &str = "AAAAAAAAAAAAAAAAAAAAAA";
+
+    assert_eq!(
+        normalize_bootstrap_token_input(&format!(" \n{TOKEN}\n ")).unwrap(),
+        BootstrapTokenInput {
+            purpose: None,
+            token: TOKEN,
+        }
+    );
+    assert_eq!(
+        normalize_bootstrap_token_input(&format!(" \n{BOOTSTRAP_PREFIX}:123:{TOKEN}\n ")).unwrap(),
+        BootstrapTokenInput {
+            purpose: Some(BootstrapTokenPurpose::Initialize),
+            token: TOKEN,
+        }
+    );
+    assert_eq!(
+        normalize_bootstrap_token_input(&format!("{PASSWORD_RESET_PREFIX}:456:{TOKEN}")).unwrap(),
+        BootstrapTokenInput {
+            purpose: Some(BootstrapTokenPurpose::PasswordReset),
+            token: TOKEN,
+        }
+    );
+
+    for invalid in [
+        format!("unknown-prefix:123:{TOKEN}"),
+        format!("{BOOTSTRAP_PREFIX}:123"),
+        "random:text".to_owned(),
+        format!("{BOOTSTRAP_PREFIX}:123:{TOKEN}:extra"),
+        format!("{BOOTSTRAP_PREFIX}:not-a-time:{TOKEN}"),
+    ] {
+        assert_eq!(
+            normalize_bootstrap_token_input(&invalid)
+                .unwrap_err()
+                .code(),
+            "invalid_bootstrap_token_format"
+        );
+    }
+}
+
+#[test]
+fn complete_token_input_preserves_purpose_and_expiry_checks() {
+    let (admin_auth, directory) = auth("qq-maid-admin-complete-token-input");
+    let path = directory.join("config/secrets/bootstrap.token");
+    let bootstrap = bootstrap_token_text(&path);
+    let wrong_reset = bootstrap.replacen(BOOTSTRAP_PREFIX, PASSWORD_RESET_PREFIX, 1);
+    let setup = admin_auth.issue_preauth_for("operator").unwrap();
+    assert_eq!(
+        admin_auth
+            .initialize_for(
+                &setup.cookie_value,
+                &setup.session.csrf_token,
+                &wrong_reset,
+                "admin",
+                "123456",
+                "operator",
+            )
+            .unwrap_err()
+            .code(),
+        "invalid_bootstrap_token"
+    );
+    admin_auth
+        .initialize_for(
+            &setup.cookie_value,
+            &setup.session.csrf_token,
+            &format!(" \n{bootstrap}\n "),
+            "admin",
+            "123456",
+            "operator",
+        )
+        .unwrap();
+
+    let reset = admin_auth.issue_preauth_for("reset-operator").unwrap();
+    admin_auth
+        .request_password_reset_for(
+            &reset.cookie_value,
+            &reset.session.csrf_token,
+            "reset-operator",
+        )
+        .unwrap();
+    let password_reset = bootstrap_token_text(&path);
+    let wrong_bootstrap = password_reset.replacen(PASSWORD_RESET_PREFIX, BOOTSTRAP_PREFIX, 1);
+    assert_eq!(
+        admin_auth
+            .reset_password_for(
+                &reset.cookie_value,
+                &reset.session.csrf_token,
+                &wrong_bootstrap,
+                "654321",
+                "reset-operator",
+            )
+            .unwrap_err()
+            .code(),
+        "invalid_bootstrap_token"
+    );
+    admin_auth
+        .reset_password_for(
+            &reset.cookie_value,
+            &reset.session.csrf_token,
+            &password_reset,
+            "654321",
+            "reset-operator",
+        )
+        .unwrap();
+
+    let (expired_auth, expired_directory) = auth("qq-maid-admin-expired-complete-token");
+    let expired_path = expired_directory.join("config/secrets/bootstrap.token");
+    let token = bootstrap_token(&expired_path);
+    let expired = format!(
+        "{BOOTSTRAP_PREFIX}:{}:{token}\n",
+        unix_seconds() - BOOTSTRAP_TTL.as_secs() as i64 - 1
+    );
+    fs::write(&expired_path, &expired).unwrap();
+    let expired_setup = expired_auth.issue_preauth_for("expired-operator").unwrap();
+    assert_eq!(
+        expired_auth
+            .initialize_for(
+                &expired_setup.cookie_value,
+                &expired_setup.session.csrf_token,
+                &expired,
+                "admin",
+                "123456",
+                "expired-operator",
+            )
+            .unwrap_err()
+            .code(),
+        "invalid_bootstrap_token"
+    );
 }
 
 fn audit_count(auth: &AdminAuth, event_type: &str, outcome: &str) -> i64 {

--- a/web-console/dist/app.js
+++ b/web-console/dist/app.js
@@ -118,10 +118,10 @@ function renderAuth(status) {
     reset.hidden = !status.initialized;
     reset.textContent = resetting ? "返回密码登录" : "重置管理员密码";
     setText("bootstrap-help", resetting
-        ? `请在运行目录读取 ${status.tokenFile}；可粘贴完整命令输出或仅粘贴 token。同一个短时单次重置令牌也只在新生成时输出一次到控制台。重置成功后令牌与旧管理员会话全部失效。`
+        ? `请在运行目录读取 ${status.tokenFile}；可粘贴完整令牌字符串或仅粘贴 token。同一个短时单次重置令牌也只在新生成时输出一次到控制台。重置成功后令牌与旧管理员会话全部失效。`
         : status.initialized
             ? "管理员会话与聊天 session 相互独立。"
-            : `请在运行目录读取 ${status.tokenFile}；可粘贴完整命令输出或仅粘贴 token。同一个短时单次令牌只在新生成时输出一次到控制台，使用成功后立即失效。`);
+            : `请在运行目录读取 ${status.tokenFile}；可粘贴完整令牌字符串或仅粘贴 token。同一个短时单次令牌只在新生成时输出一次到控制台，使用成功后立即失效。`);
 }
 async function submitAuth() {
     const username = requiredElement("auth-username", HTMLInputElement).value;

--- a/web-console/dist/app.js
+++ b/web-console/dist/app.js
@@ -118,10 +118,10 @@ function renderAuth(status) {
     reset.hidden = !status.initialized;
     reset.textContent = resetting ? "返回密码登录" : "重置管理员密码";
     setText("bootstrap-help", resetting
-        ? `请在运行目录读取 ${status.tokenFile}；同一个短时单次重置令牌也只在新生成时输出一次到控制台。重置成功后令牌与旧管理员会话全部失效。`
+        ? `请在运行目录读取 ${status.tokenFile}；可粘贴完整命令输出或仅粘贴 token。同一个短时单次重置令牌也只在新生成时输出一次到控制台。重置成功后令牌与旧管理员会话全部失效。`
         : status.initialized
             ? "管理员会话与聊天 session 相互独立。"
-            : `请在运行目录读取 ${status.tokenFile}；同一个短时单次令牌只在新生成时输出一次到控制台，使用成功后立即失效。`);
+            : `请在运行目录读取 ${status.tokenFile}；可粘贴完整命令输出或仅粘贴 token。同一个短时单次令牌只在新生成时输出一次到控制台，使用成功后立即失效。`);
 }
 async function submitAuth() {
     const username = requiredElement("auth-username", HTMLInputElement).value;

--- a/web-console/src/main.ts
+++ b/web-console/src/main.ts
@@ -135,10 +135,10 @@ function renderAuth(status: BootstrapStatus): void {
   setText(
     "bootstrap-help",
     resetting
-      ? `请在运行目录读取 ${status.tokenFile}；可粘贴完整命令输出或仅粘贴 token。同一个短时单次重置令牌也只在新生成时输出一次到控制台。重置成功后令牌与旧管理员会话全部失效。`
+      ? `请在运行目录读取 ${status.tokenFile}；可粘贴完整令牌字符串或仅粘贴 token。同一个短时单次重置令牌也只在新生成时输出一次到控制台。重置成功后令牌与旧管理员会话全部失效。`
       : status.initialized
       ? "管理员会话与聊天 session 相互独立。"
-      : `请在运行目录读取 ${status.tokenFile}；可粘贴完整命令输出或仅粘贴 token。同一个短时单次令牌只在新生成时输出一次到控制台，使用成功后立即失效。`,
+      : `请在运行目录读取 ${status.tokenFile}；可粘贴完整令牌字符串或仅粘贴 token。同一个短时单次令牌只在新生成时输出一次到控制台，使用成功后立即失效。`,
   );
 }
 

--- a/web-console/src/main.ts
+++ b/web-console/src/main.ts
@@ -135,10 +135,10 @@ function renderAuth(status: BootstrapStatus): void {
   setText(
     "bootstrap-help",
     resetting
-      ? `请在运行目录读取 ${status.tokenFile}；同一个短时单次重置令牌也只在新生成时输出一次到控制台。重置成功后令牌与旧管理员会话全部失效。`
+      ? `请在运行目录读取 ${status.tokenFile}；可粘贴完整命令输出或仅粘贴 token。同一个短时单次重置令牌也只在新生成时输出一次到控制台。重置成功后令牌与旧管理员会话全部失效。`
       : status.initialized
       ? "管理员会话与聊天 session 相互独立。"
-      : `请在运行目录读取 ${status.tokenFile}；同一个短时单次令牌只在新生成时输出一次到控制台，使用成功后立即失效。`,
+      : `请在运行目录读取 ${status.tokenFile}；可粘贴完整命令输出或仅粘贴 token。同一个短时单次令牌只在新生成时输出一次到控制台，使用成功后立即失效。`,
   );
 }
 


### PR DESCRIPTION
## 修改内容

- 在服务端管理员认证共享层严格解析裸 token，以及项目生成的 Bootstrap / 密码重置完整 token 字符串
- 保留用途、有效期和常量时间 token 比对，阻止两种用途互换
- 为未知前缀、缺失字段、额外字段等输入返回独立格式错误
- 更新初始化和密码重置页面提示，并同步生成 Web Console 嵌入产物
- 补充裸 token、完整格式、首尾空白、格式错误、用途不匹配和过期场景测试

## 根因

令牌文件使用 `<purpose-prefix>:<issued-at>:<token>` 三段格式保存，但管理员初始化和密码重置接口此前仅对请求值执行 `trim()` 后直接与文件中的裸 token 段比较。用户粘贴完整字符串时，服务端因此把合法令牌误判为无效或过期。

## 用户影响

初始化管理员和重置密码页面现在可以直接粘贴完整命令/文件输出，也继续兼容裸 token。随机冒号文本不会被宽松截取，格式错误与 token 无效或过期会返回不同错误码和文案。

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy -p qq-maid-core --all-targets --all-features -- -D warnings`
- `cargo test -p qq-maid-core --all-features --quiet`（1132 passed）
- `cargo build -p qq-maid-core --all-features --quiet`
- `npm run check`（`web-console`）
- `npm test`（`web-console`，3 passed）
- `git diff --check`
