### PR TITLE
refactor: 清理 Core/Gateway 响应链路冗余包装

### DIFF
--- a/docs/design/tool-calling-qq-delivery.md
+++ b/docs/design/tool-calling-qq-delivery.md
@@ -113,8 +113,8 @@
 
 #### 私聊普通 complete 路径
 
-1. Tool Loop 或普通聊天最终都先变成 `RespondResponse` / `CoreResponse`。  
-  参考：`qq-maid-core/src/runtime/respond/llm_service/mod.rs::response_from_output`、`qq-maid-core/src/service/mod.rs::impl From<RespondResponse> for CoreResponse`
+1. Tool Loop 或普通聊天先在 Core 内部组装 `RespondResponse`，再于调用边界转换为 `CoreResponse`；两者的消息内容都复用 `qq-maid-common` 的统一内容类型。
+  参考：`qq-maid-core/src/runtime/respond/llm_service/mod.rs::response_from_output`、`qq-maid-core/src/service/handle.rs::impl From<RespondResponse> for CoreResponse`
 
 2. Gateway 在 `send_c2c_respond_response_with_sender` 中调用 `render_respond_response` 把 CoreResponse 渲染成：
    - `OutboundMessage::Text`
@@ -198,14 +198,14 @@
 
 - 只在文本 payload 中作为顶层字段生成。  
   参考：`qq-maid-gateway-rs/src/api/mod.rs::build_c2c_text_payload`、`build_group_text_payload`
-- 内容来源一般是 `RespondResponse.text`，由 `render_respond_response` 或 fallback 逻辑决定。  
+- 内容来源一般是 common `AssistantOutput` 经 `CoreResponse::text_content()` 暴露的纯文本 fallback，由 Gateway render 或 fallback 逻辑决定。
   参考：`qq-maid-gateway-rs/src/render.rs::render_respond_response`
 - Markdown/流式路径下，正文不走顶层 `content`，而走 `markdown.content`。  
   参考：`qq-maid-gateway-rs/src/markdown.rs`、`qq-maid-gateway-rs/src/api/mod.rs::build_c2c_markdown_stream_payload`
 
 ### `markdown`
 
-- `RespondResponse.markdown` 在 Gateway 渲染层被包装成 `MarkdownPayload`。  
+- common `AssistantOutput` 的 Markdown 通道经 `CoreResponse::markdown_content()` 读取，并在 Gateway 渲染层包装成 `MarkdownPayload`。
   参考：`qq-maid-gateway-rs/src/render.rs::render_respond_response`
 - 普通 Markdown payload 由 `build_c2c_markdown_payload` / `build_group_markdown_payload` 生成。  
   参考：`qq-maid-gateway-rs/src/markdown.rs`
@@ -315,7 +315,7 @@
 
 它的实际路径是：
 
-`WeatherTool.execute` / Todo Tool execute → `ToolRegistry::execute_json` → OpenAI `function_call_output` → 模型继续生成最终答案 → `ChatOutcome.reply` → `RespondResponse` → Gateway 渲染/发送。
+`WeatherTool.execute` / Todo Tool execute → `ToolRegistry::execute_json` → OpenAI `function_call_output` → 模型继续生成最终答案 → `ChatOutcome.reply` → Core 内部 `RespondResponse` → `CoreResponse` → Gateway 渲染/发送。
 
 也就是说，当前工具结果默认只作为**模型上下文的一部分**回到 LLM，不直接变成一条 QQ 中间消息。  
 参考：`qq-maid-core/src/runtime/tools/weather.rs::WeatherTool::execute`、`qq-maid-core/src/runtime/tools/todo/mod.rs`、`qq-maid-llm/src/tool.rs::ToolRegistry::execute_json`、`qq-maid-llm/src/provider/openai/tool_loop.rs::openai_responses_tool_loop`
@@ -346,7 +346,7 @@
   参考：`qq-maid-gateway-rs/src/gateway/qq_official/c2c/mod.rs::handle_c2c_message`
 - 私聊普通非 Tool Loop 流式聊天：最终收尾仍由 `gateway/stream/mod.rs` 发送结束帧。
   参考：`qq-maid-gateway-rs/src/gateway/stream/mod.rs::send_stream_end`
-- 群聊：统一在拿到 `RespondResponse` 后一次性发出。  
+- 群聊：统一在拿到 `CoreResponse` 后一次性发出。
   参考：`qq-maid-gateway-rs/src/gateway/qq_official/group/mod.rs::send_group_respond_response`
 
 ## 4.3 当前是否存在“Tool Calling 直接依赖 QQ 字段”或“QQ 层理解 Tool 协议”的问题
@@ -363,11 +363,11 @@
 
 2. **Gateway 不理解模型 Tool Call 协议**。  
    Gateway 只知道：
-   - `RespondTransport::Complete`
-   - `RespondTransport::Stream`
-   - `RespondEvent::TextDelta/Completed/Failed`  
+   - `CoreRespondOutput::Complete`
+   - `CoreRespondOutput::Stream`
+   - `CoreResponseEvent::TextDelta/Completed/Failed`
    它不解析 `function_call`、`function_call_output`、Tool schema。  
-   参考：`qq-maid-gateway-rs/src/respond.rs::RespondTransport`、`qq-maid-gateway-rs/src/gateway/stream/mod.rs`
+   参考：`qq-maid-core/src/service/types.rs::CoreRespondOutput`、`qq-maid-core/src/service/types.rs::CoreResponseEvent`、`qq-maid-gateway-rs/src/gateway/stream/mod.rs`
 
 3. **具体 QQ 提及语法、群回复前缀、msg_type/msg_seq、stream payload 都仍在 Gateway**。  
    Core 和 LLM 没有去理解 `<@member_openid>`、`/v2/users/{openid}/messages` 等平台细节。  
@@ -464,7 +464,7 @@
 - 工具失败发生在哪一步
 
 证据：当前没有任何 Tool status event 类型；Gateway 只消费 `TextDelta/Completed/Failed`。  
-参考：`qq-maid-core/src/service/mod.rs::CoreResponseEvent`、`qq-maid-gateway-rs/src/gateway/stream/mod.rs`
+参考：`qq-maid-core/src/service/types.rs::CoreResponseEvent`、`qq-maid-gateway-rs/src/gateway/stream/mod.rs`
 
 ### 2）`task_id` 还不是独立任务身份
 

--- a/qq-maid-core/src/runtime/respond/llm_service/mod.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service/mod.rs
@@ -22,19 +22,19 @@ use qq_maid_llm::{
     },
     provider::{
         AgentRunDiagnostics, ChatOutcome, DynLlmProvider, LlmStreamEvent, ToolChatRequest,
-        types::{ChatMessage, ChatRequest, ChatRole},
+        types::{ChatMessage, ChatRequest, ChatRole, TokenUsage},
     },
     tool::{ToolContext, ToolRegistry},
 };
 
 use crate::{
-    error::LlmError, runtime::session::redact_sensitive_text, util::metrics::MetricsRecorder,
+    error::LlmError,
+    runtime::session::redact_sensitive_text,
+    util::metrics::{LlmMetrics, MetricsRecorder},
 };
 use qq_maid_common::markdown::to_chat_text;
 
-use super::{
-    RespondPurpose, RespondRequest, RespondResponse, common::truncate_chars, types::ChatResponse,
-};
+use super::{RespondPurpose, RespondRequest, RespondResponse, common::truncate_chars};
 
 mod compact_messages;
 mod message_parts;
@@ -52,7 +52,7 @@ pub trait ChatService: Send + Sync {
 
 /// LLM 调用后的输出结果。
 ///
-/// 包含加工后的展示文本 `reply` 和原始 `ChatResponse`（含 Token 用量）。
+/// 包含加工后的展示通道、Provider 指标、Token 用量和 Agent 执行轨迹。
 #[derive(Debug, Clone)]
 pub struct RespondOutput {
     /// 内部主回复；聊天场景优先保留原始 Markdown 版，供会话历史继续使用。
@@ -63,8 +63,10 @@ pub struct RespondOutput {
     pub markdown: Option<String>,
     /// Provider 返回的顺序化富媒体结果。
     pub parts: Vec<OutputPart>,
-    /// 原始的 LLM 响应（含 Token 用量、指标等）
-    pub chat: ChatResponse,
+    /// Provider 调用指标。
+    pub metrics: LlmMetrics,
+    /// Provider Token 用量统计。
+    pub usage: Option<TokenUsage>,
     /// Agent Runtime 的结构化执行轨迹。
     pub agent: AgentRunDiagnostics,
 }
@@ -383,14 +385,13 @@ fn output_from_raw_reply(
         }
     };
     trace_chat_final_reply(req, &text);
-    let chat = ChatResponse::ok(raw_reply.clone(), outcome.metrics, outcome.usage);
-
     Ok(RespondOutput {
         reply,
         text,
         markdown,
         parts: outcome.output_parts,
-        chat,
+        metrics: outcome.metrics,
+        usage: outcome.usage,
         agent: outcome.agent,
     })
 }
@@ -478,7 +479,7 @@ fn trace_chat_raw_reply(req: &RespondRequest, raw_reply: &str) {
     );
 }
 
-/// 在 TRACE 级别输出最终返回给上层 facade 的回复。
+/// 在 TRACE 级别输出最终进入 Core 响应编排链路的回复。
 ///
 /// 这样可以直接比对“provider 原文”和“QQ 最终可见文本”之间是否被清洗、
 /// 截断或降级，从而快速判断问题是在上游模型还是在本地后处理。
@@ -899,13 +900,20 @@ fn build_todo_parse_messages(req: &RespondRequest) -> Vec<ChatMessage> {
 
 /// 将 `RespondOutput` 转换为统一的 `RespondResponse`。
 pub fn response_from_output(output: RespondOutput) -> RespondResponse {
-    let mut response = RespondResponse::from_chat(
-        output.chat,
-        (!output.text.trim().is_empty()).then_some(output.text),
-        output.markdown,
-    );
-    response.output_parts = output.parts;
-    response
+    RespondResponse {
+        ok: true,
+        text: (!output.text.trim().is_empty()).then_some(output.text),
+        markdown: output.markdown,
+        output_parts: output.parts,
+        handled: Some(true),
+        session_id: None,
+        command: None,
+        diagnostics: None,
+        metrics: output.metrics,
+        usage: output.usage,
+        error: None,
+        visible_entity_snapshot: None,
+    }
 }
 
 /// 构造聊天的纯文本 / Markdown 双通道。

--- a/qq-maid-core/src/runtime/respond/llm_service/tests/mod.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service/tests/mod.rs
@@ -492,10 +492,19 @@ fn empty_chat_reply_uses_configured_bot_display_name() {
 }
 
 #[test]
-fn respond_response_only_exposes_text_for_python() {
-    let chat = ChatResponse::ok(
-        "raw",
-        LlmMetrics {
+fn respond_response_serialization_only_exposes_display_channels() {
+    let usage = TokenUsage {
+        input_tokens: Some(2),
+        cached_input_tokens: Some(1),
+        output_tokens: Some(3),
+        total_tokens: Some(5),
+    };
+    let output = RespondOutput {
+        reply: "reply".to_owned(),
+        text: "reply".to_owned(),
+        markdown: None,
+        parts: Vec::new(),
+        metrics: LlmMetrics {
             provider: "mock".to_owned(),
             model: "mock".to_owned(),
             stream: true,
@@ -503,14 +512,14 @@ fn respond_response_only_exposes_text_for_python() {
             ttft_ms: Some(2),
             total_latency_ms: 3,
         },
-        Some(TokenUsage {
-            input_tokens: None,
-            cached_input_tokens: None,
-            output_tokens: None,
-            total_tokens: None,
-        }),
-    );
-    let response = RespondResponse::from_chat(chat, Some("reply".to_owned()), None);
+        usage: Some(usage.clone()),
+        agent: Default::default(),
+    };
+    let response = response_from_output(output);
+    assert_eq!(response.metrics.provider, "mock");
+    assert_eq!(response.metrics.model, "mock");
+    assert_eq!(response.usage, Some(usage));
+
     let json = serde_json::to_value(response).unwrap();
     assert_eq!(json["text"], "reply");
     assert!(json.get("markdown").is_none());

--- a/qq-maid-core/src/runtime/respond/mod.rs
+++ b/qq-maid-core/src/runtime/respond/mod.rs
@@ -1,8 +1,8 @@
 //! 请求响应路由与分派。
 //!
-//! 本模块是 LLM 响应的入口层，负责接收外部（HTTP facade 或内部子 flow）
-//! 发来的 `RespondRequest`，根据请求类型和会话状态将其分派到对应的子处理
-//! 模块（聊天、翻译、待办、记忆、天气、搜索、会话管理），最终返回 `RespondResponse`。
+//! 本模块是 Core 内部 LLM 响应编排入口，接收 service 层或内部子 flow 的请求，
+//! 按请求类型和会话状态分派到聊天、翻译、待办、记忆、天气、搜索和会话管理，
+//! 最终返回内部 `RespondResponse`，再由 service 层转换为稳定响应类型。
 
 use std::{future::Future, pin::Pin};
 
@@ -34,7 +34,7 @@ use crate::{
 };
 
 mod types;
-pub use types::{ChatResponse, RespondPurpose, RespondRequest, RespondResponse};
+pub use types::{RespondPurpose, RespondRequest, RespondResponse};
 
 pub(crate) mod agent_outcome;
 mod agent_route;

--- a/qq-maid-core/src/runtime/respond/types.rs
+++ b/qq-maid-core/src/runtime/respond/types.rs
@@ -1,8 +1,8 @@
 //! 请求 / 响应类型定义。
 //!
-//! 提供 `RespondRequest`、`RespondResponse`、`ChatResponse` 以及
-//! `RespondPurpose` 等核心数据类型，用于在 HTTP facade 层与 Rust 内部
-//! 各子模块之间传递请求与响应。
+//! 提供 `RespondRequest`、`RespondResponse` 和 `RespondPurpose` 等 Core 内部
+//! 业务编排类型。消息内容块统一复用 `qq-maid-common`，`service` 模块只负责
+//! 转换 Core 与 Gateway 之间的调用和事件 envelope。
 
 use std::collections::HashMap;
 
@@ -36,14 +36,14 @@ pub enum RespondPurpose {
 
 /// 聊天 / 功能请求。
 ///
-/// 承载来自 HTTP facade 或内部子 flow 的所有参数，
-/// 包括用户输入、会话上下文、系统提示词等。
+/// 承载 Core 业务入口或内部子 flow 的所有参数，包括用户输入、会话上下文、
+/// 系统提示词等；该结构暂时保留在 Core 内部编排链路中。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RespondRequest {
     /// 会话 ID，用于关联历史对话
     #[serde(default)]
     pub session_id: String,
-    /// 内部调用可按业务用途指定模型；外部 HTTP facade 不反序列化这个字段。
+    /// Core 内部调用可按业务用途指定模型。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     /// 请求级输出预算覆盖。
@@ -242,29 +242,10 @@ impl Default for RespondRequest {
     }
 }
 
-/// LLM 聊天的原始响应。
-///
-/// 与 `RespondResponse` 的区别：`ChatResponse` 包含 LLM 返回的原始 `reply`
-/// 和 Token 用量等信息，供调用方进一步加工后再组装成 `RespondResponse`。
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ChatResponse {
-    /// 是否成功
-    pub ok: bool,
-    /// LLM 原始回复内容
-    pub reply: Option<String>,
-    /// 调用指标（模型名、延迟等）
-    pub metrics: LlmMetrics,
-    /// Token 用量统计
-    pub usage: Option<TokenUsage>,
-    /// 错误信息（ok 为 false 时存在）
-    pub error: Option<ErrorInfo>,
-}
-
 /// 统一的响应结构。
 ///
-/// 所有路由分派最终都返回 `RespondResponse`。
-/// `text` 是对 `ChatResponse.reply` 进一步加工后的展示文本
-/// （如去除 Markdown 格式、翻译等），供 HTTP facade 直接发送给用户。
+/// Core 内部所有路由分派最终都返回 `RespondResponse`，再由 service 层转换为
+/// Gateway 消费的 `CoreResponse`。`text` 是对 Provider 回复进一步加工后的展示文本。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RespondResponse {
     /// 是否成功
@@ -297,51 +278,7 @@ pub struct RespondResponse {
     /// 错误信息
     pub error: Option<ErrorInfo>,
     /// 当前回复绑定的工具可见实体快照。该字段只供 Gateway 写入引用索引，
-    /// 序列化时跳过，避免内部实体 ID 暴露到 HTTP/诊断面。
+    /// 序列化时跳过，避免内部实体 ID 暴露到稳定响应或诊断面。
     #[serde(default, skip)]
     pub visible_entity_snapshot: Option<VisibleEntitySnapshot>,
-}
-
-impl ChatResponse {
-    /// 构造成功响应。
-    pub fn ok(reply: impl Into<String>, metrics: LlmMetrics, usage: Option<TokenUsage>) -> Self {
-        Self {
-            ok: true,
-            reply: Some(reply.into()),
-            metrics,
-            usage,
-            error: None,
-        }
-    }
-
-    /// 构造错误响应。
-    pub fn error(metrics: LlmMetrics, error: ErrorInfo) -> Self {
-        Self {
-            ok: false,
-            reply: None,
-            metrics,
-            usage: None,
-            error: Some(error),
-        }
-    }
-}
-
-impl RespondResponse {
-    /// 从 `ChatResponse` 构造统一的响应。
-    pub fn from_chat(chat: ChatResponse, text: Option<String>, markdown: Option<String>) -> Self {
-        Self {
-            ok: chat.ok,
-            text,
-            markdown,
-            output_parts: Vec::new(),
-            handled: Some(chat.ok),
-            session_id: None,
-            command: None,
-            diagnostics: None,
-            metrics: chat.metrics,
-            usage: chat.usage,
-            error: chat.error,
-            visible_entity_snapshot: None,
-        }
-    }
 }

--- a/qq-maid-core/src/runtime/tools/agent_turn.rs
+++ b/qq-maid-core/src/runtime/tools/agent_turn.rs
@@ -243,7 +243,6 @@ fn apply_agent_turn_outcome(output: &mut RespondOutput, outcome: &AgentTurnOutco
     output.reply = body.markdown.clone().unwrap_or_else(|| body.text.clone());
     output.text = body.text;
     output.markdown = body.markdown;
-    output.chat.reply = Some(output.reply.clone());
 }
 
 fn apply_agent_turn_outcome_with_model_reply(
@@ -270,7 +269,6 @@ fn apply_agent_turn_outcome_with_model_reply(
     output.reply = markdown.clone().unwrap_or_else(|| text.clone());
     output.text = text;
     output.markdown = markdown;
-    output.chat.reply = Some(output.reply.clone());
 }
 
 fn apply_agent_turn_compat_output(output: &mut RespondOutput, outcome: &AgentTurnOutcome) {
@@ -278,5 +276,4 @@ fn apply_agent_turn_compat_output(output: &mut RespondOutput, outcome: &AgentTur
     output.reply = body.markdown.clone().unwrap_or_else(|| body.text.clone());
     output.text = body.text;
     output.markdown = body.markdown;
-    output.chat.reply = Some(output.reply.clone());
 }

--- a/qq-maid-core/src/runtime/tools/todo/agent_turn.rs
+++ b/qq-maid-core/src/runtime/tools/todo/agent_turn.rs
@@ -7,7 +7,6 @@ use crate::{
     error::LlmError,
     runtime::{
         respond::{
-            ChatResponse,
             agent_outcome::{AgentTurnOutcome, ToolEffect, ToolOutcomeStatus},
             llm_service::RespondOutput,
         },
@@ -139,18 +138,15 @@ pub(crate) fn fallback_output_after_agent_failure(
         text: reply.clone(),
         markdown: None,
         parts: Vec::new(),
-        chat: ChatResponse::ok(
-            reply,
-            LlmMetrics {
-                provider: "rust".to_owned(),
-                model: format!("{model}:todo-tool-result-fallback"),
-                stream: false,
-                ttfe_ms: None,
-                ttft_ms: None,
-                total_latency_ms: 0,
-            },
-            None,
-        ),
+        metrics: LlmMetrics {
+            provider: "rust".to_owned(),
+            model: format!("{model}:todo-tool-result-fallback"),
+            stream: false,
+            ttfe_ms: None,
+            ttft_ms: None,
+            total_latency_ms: 0,
+        },
+        usage: None,
         agent: agent.clone(),
     })
 }
@@ -164,18 +160,15 @@ pub(crate) fn success_not_verified_output(output: RespondOutput) -> RespondOutpu
         text: reply.clone(),
         markdown: None,
         parts: Vec::new(),
-        chat: ChatResponse::ok(
-            reply,
-            LlmMetrics {
-                provider: "rust".to_owned(),
-                model: "tool-loop-guard".to_owned(),
-                stream: false,
-                ttfe_ms: None,
-                ttft_ms: None,
-                total_latency_ms: 0,
-            },
-            None,
-        ),
+        metrics: LlmMetrics {
+            provider: "rust".to_owned(),
+            model: "tool-loop-guard".to_owned(),
+            stream: false,
+            ttfe_ms: None,
+            ttft_ms: None,
+            total_latency_ms: 0,
+        },
+        usage: None,
         agent: output.agent,
     }
 }

--- a/qq-maid-core/src/service/handle.rs
+++ b/qq-maid-core/src/service/handle.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use qq_maid_common::identity_context::ConversationKind;
+use qq_maid_common::{identity_context::ConversationKind, output_part::AssistantOutput};
 use qq_maid_llm::provider::types::{ChatMessage, ChatRequest, ChatRole};
 use tokio::time::timeout;
 use tracing::warn;
@@ -19,10 +19,10 @@ use crate::{
 };
 
 use super::{
-    AgentRequestBudget, AssistantOutput, CoreActor, CoreConversation, CoreError,
-    CoreGroupMemberRole, CoreHealthSnapshot, CoreInboundClassification, CoreRequest,
-    CoreRespondOutput, CoreResponse, CoreService, Platform, ProgressStatusConfig, error_core_error,
-    output_policy_for_stream, start_core_response_stream, warn_core_error,
+    AgentRequestBudget, CoreActor, CoreConversation, CoreError, CoreGroupMemberRole,
+    CoreHealthSnapshot, CoreInboundClassification, CoreRequest, CoreRespondOutput, CoreResponse,
+    CoreService, Platform, ProgressStatusConfig, error_core_error, output_policy_for_stream,
+    start_core_response_stream, warn_core_error,
 };
 
 #[derive(Clone)]

--- a/qq-maid-core/src/service/tests/mod.rs
+++ b/qq-maid-core/src/service/tests/mod.rs
@@ -7,6 +7,7 @@ use std::{
 use qq_maid_common::{
     identity_context::{ConversationKind, IdentitySource},
     input_part::QuotedMessageContext,
+    output_part::{AssistantOutput, OutputMedia, OutputPart},
 };
 use qq_maid_llm::provider::{LlmStreamEvent, ToolCallingProtocol};
 use tokio::sync::Notify;

--- a/qq-maid-core/src/service/types.rs
+++ b/qq-maid-core/src/service/types.rs
@@ -7,12 +7,9 @@ use async_trait::async_trait;
 use qq_maid_common::{
     identity_context::{ConversationContext, MentionIdentity, MessageActorContext, MessageContext},
     input_part::{MessageInputPart, QuotedMessageContext},
+    output_part::AssistantOutput,
 };
 use serde::{Deserialize, Serialize};
-
-// 平台无关出站内容模型已下沉到 common，这里重新导出以维持
-// `crate::service::{AssistantOutput, OutputPart, OutputMedia}` 的对外路径稳定。
-pub use qq_maid_common::output_part::{AssistantOutput, OutputMedia, OutputPart};
 use tokio::sync::mpsc;
 
 use crate::identity::conversation_scope_key;
@@ -135,13 +132,13 @@ pub enum CoreConversation {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CoreResponse {
-    /// 结构化出站内容，Core → Gateway 完整回复的唯一正文契约。
+    /// Core → Gateway 完整回复 envelope 中的结构化正文。
     ///
     /// Gateway 出站渲染、ref_index 文本回填、流式收尾、日志等读取用户可见正文
     /// 时，应统一通过 [`CoreResponse::text_content`] / [`CoreResponse::markdown_content`]
     /// 访问，不再存在平行的旧 `text` / `markdown` 字段。Core 内部 `RespondResponse`
     /// 仍可按 text/markdown 双通道组装正文，但只在转换为 `CoreResponse` 时合成为
-    /// 该结构化 output，不外泄到 Core→Gateway 边界。
+    /// common 的 `AssistantOutput`，不再创建平行正文类型。
     pub output: Option<AssistantOutput>,
     pub handled: Option<bool>,
     pub session_id: Option<String>,

--- a/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
@@ -12,6 +12,7 @@ use crate::{
 use async_trait::async_trait;
 use qq_maid_common::{
     command_prefix::CommandPrefix, identity_context::IdentitySource, input_part::MessageInputPart,
+    output_part::AssistantOutput,
 };
 use qq_maid_core::service::{
     CoreActor, CoreConversation, CoreError, CoreHealthSnapshot, CoreInboundClassification,
@@ -42,7 +43,7 @@ struct MockCore {
 impl CoreService for MockCore {
     async fn respond(&self, _request: CoreRequest) -> Result<CoreRespondOutput, CoreError> {
         Ok(CoreRespondOutput::Complete(Box::new(CoreResponse {
-            output: Some(qq_maid_core::service::AssistantOutput::text("ok")),
+            output: Some(AssistantOutput::text("ok")),
             handled: Some(true),
             session_id: None,
             command: None,

--- a/qq-maid-gateway-rs/src/gateway/onebot11/dispatch/image_tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/dispatch/image_tests.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use qq_maid_core::service::{AssistantOutput, CoreResponse, OutputMedia, OutputPart};
+use qq_maid_common::output_part::{AssistantOutput, OutputMedia, OutputPart};
+use qq_maid_core::service::CoreResponse;
 
 use super::OneBotCoreTransport;
 use super::tests::{FakeSender, dispatcher, inbound};

--- a/qq-maid-gateway-rs/src/gateway/onebot11/dispatch/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/dispatch/mod.rs
@@ -8,8 +8,8 @@ use std::{future::Future, pin::Pin, sync::Arc};
 use async_trait::async_trait;
 use qq_maid_common::command_prefix::CommandPrefix;
 use qq_maid_core::service::{
-    CoreFailureKind, CoreRespondFailure, CoreResponse, CoreResponseEvent, CoreResponseStream,
-    VisibleEntitySnapshot,
+    CoreFailureKind, CoreRespondFailure, CoreRespondOutput, CoreResponse, CoreResponseEvent,
+    CoreResponseStream, VisibleEntitySnapshot,
 };
 use thiserror::Error;
 use tracing::{debug, warn};
@@ -22,7 +22,7 @@ use crate::{
     },
     media::ImagePayload,
     render::{OutboundMessage, render_respond_response_parts_for_profile},
-    respond::{RespondClient, RespondError, RespondTransport, respond_error_to_qq_text},
+    respond::{RespondClient, RespondError, respond_error_to_qq_text},
 };
 
 use super::{OneBotSendError, OneBotSendResult, OneBotSender};
@@ -66,8 +66,8 @@ impl OneBotCoreResponder for RespondClient {
         content: String,
     ) -> Result<OneBotCoreTransport, RespondError> {
         match self.respond_inbound(inbound, content).await? {
-            RespondTransport::Complete(response) => Ok(OneBotCoreTransport::Complete(response)),
-            RespondTransport::Stream(stream) => Ok(OneBotCoreTransport::Stream(Box::new(stream))),
+            CoreRespondOutput::Complete(response) => Ok(OneBotCoreTransport::Complete(response)),
+            CoreRespondOutput::Stream(stream) => Ok(OneBotCoreTransport::Stream(Box::new(stream))),
         }
     }
 }
@@ -431,9 +431,10 @@ mod tests {
     use qq_maid_common::{
         identity_context::IdentitySource,
         input_part::{MessageInputPart, QuotedMessageContext},
+        output_part::AssistantOutput,
     };
     use qq_maid_core::service::{
-        AssistantOutput, CoreError, CoreResponseStatus, CoreResponseStatusKind, VisibleEntityItem,
+        CoreError, CoreResponseStatus, CoreResponseStatusKind, VisibleEntityItem,
     };
 
     use super::*;

--- a/qq-maid-gateway-rs/src/gateway/onebot11/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/tests.rs
@@ -10,6 +10,7 @@ use std::{
 
 use async_trait::async_trait;
 use futures_util::{SinkExt, StreamExt};
+use qq_maid_common::output_part::AssistantOutput;
 use qq_maid_core::service::{
     CoreError, CoreHealthSnapshot, CoreInboundClassification, CoreInboundKind, CoreRequest,
     CoreRespondOutput, CoreResponse, CoreService, UpstreamStatusSnapshot,
@@ -161,9 +162,7 @@ impl CoreService for RecordingCore {
     async fn respond(&self, request: CoreRequest) -> Result<CoreRespondOutput, CoreError> {
         self.requests.lock().unwrap().push(request);
         Ok(CoreRespondOutput::Complete(Box::new(CoreResponse {
-            output: Some(qq_maid_core::service::AssistantOutput::text(
-                self.reply.clone(),
-            )),
+            output: Some(AssistantOutput::text(self.reply.clone())),
             handled: Some(true),
             session_id: Some("session-1".to_owned()),
             command: None,
@@ -226,10 +225,7 @@ impl CoreService for CoordinatedCore {
         self.active.fetch_sub(1, Ordering::SeqCst);
 
         Ok(CoreRespondOutput::Complete(Box::new(CoreResponse {
-            output: Some(qq_maid_core::service::AssistantOutput::text(format!(
-                "完成:{}",
-                request.text
-            ))),
+            output: Some(AssistantOutput::text(format!("完成:{}", request.text))),
             handled: Some(true),
             session_id: Some(format!("session-{call_index}")),
             command: request.text.starts_with("/new").then(|| "new".to_owned()),

--- a/qq-maid-gateway-rs/src/gateway/qq_official/c2c/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/qq_official/c2c/mod.rs
@@ -29,13 +29,11 @@ use crate::{
     config::AppConfig,
     message_chunk::{ChunkLimits, OutboundSendError, send_c2c_outbound_chunked},
     render::{OutboundMessage, render_respond_response_parts_for_profile},
-    respond::{
-        RespondClient, RespondEvent, RespondResponse, RespondTransport, build_respond_content,
-        respond_error_to_qq_text,
-    },
+    respond::{RespondClient, build_respond_content, respond_error_to_qq_text},
 };
 use qq_maid_core::service::{
-    CoreFailureKind, CoreInboundKind, CoreOutputPolicy, CoreRespondFailure, CoreResponseStatus,
+    CoreFailureKind, CoreInboundKind, CoreOutputPolicy, CoreRespondFailure, CoreRespondOutput,
+    CoreResponse, CoreResponseEvent, CoreResponseStatus,
 };
 
 const CORE_STREAM_CLOSED_FALLBACK_TEXT: &str = "处理失败，请稍后再试。";
@@ -44,7 +42,7 @@ fn empty_reply_fallback_text(bot_display_name: &str) -> String {
     format!("唔，{bot_display_name}刚刚没整理出可用回复。可以再说一次。")
 }
 
-type RespondEventFuture<'a> = Pin<Box<dyn Future<Output = Option<RespondEvent>> + Send + 'a>>;
+type RespondEventFuture<'a> = Pin<Box<dyn Future<Output = Option<CoreResponseEvent>> + Send + 'a>>;
 
 trait RespondEventStream: Send {
     fn recv_event<'a>(&'a mut self) -> RespondEventFuture<'a>;
@@ -73,7 +71,7 @@ async fn send_c2c_respond_response(
     api: &QqApiClient,
     runtime: &GatewayRuntimeStatus,
     message: &C2cMessage,
-    response: &RespondResponse,
+    response: &CoreResponse,
     config: &AppConfig,
     ref_index: &SharedRefIndex,
 ) -> anyhow::Result<()> {
@@ -125,7 +123,7 @@ pub(crate) fn record_c2c_bot_outbound_refs(
 pub(crate) async fn send_c2c_respond_response_with_sender<S: OutboundSender + ?Sized>(
     sender: &S,
     message: &C2cMessage,
-    response: &RespondResponse,
+    response: &CoreResponse,
     config: &AppConfig,
     capability: &ReplyCapability,
 ) -> anyhow::Result<(Vec<SendMessageIds>, String)> {
@@ -362,11 +360,11 @@ pub(crate) async fn handle_c2c_message(
     };
 
     match transport {
-        RespondTransport::Complete(response) => {
+        CoreRespondOutput::Complete(response) => {
             stop_typing(&mut typing, TypingStopReason::FinalReply);
             send_c2c_respond_response(api, runtime, &message, &response, config, ref_index).await?;
         }
-        RespondTransport::Stream(stream) => {
+        CoreRespondOutput::Stream(stream) => {
             let capability = ReplyCapability::qq_official_c2c(config);
             if should_use_c2c_streaming(&capability) {
                 stream_respond_c2c(stream, api, runtime, &message, config, typing, ref_index)
@@ -451,7 +449,7 @@ where
     let mut progress_status_send_attempted = false;
     while let Some(event) = stream.recv_event().await {
         match event {
-            RespondEvent::Status(status) => {
+            CoreResponseEvent::Status(status) => {
                 status_event_count += 1;
                 debug!(
                     message_id = %message.message_id,
@@ -471,12 +469,12 @@ where
                     send_disabled_progress_status(sender, message, &status).await;
                 }
             }
-            RespondEvent::TextDelta(delta) => {
+            CoreResponseEvent::TextDelta(delta) => {
                 if !delta.is_empty() {
                     text_delta_count += 1;
                 }
             }
-            RespondEvent::Completed(response) => {
+            CoreResponseEvent::Completed(response) => {
                 stop_typing(typing, TypingStopReason::FinalReply);
                 let capability = ReplyCapability::qq_official_c2c(config);
                 let (sent_ids, fallback_text) = send_c2c_respond_response_with_sender(
@@ -522,7 +520,7 @@ where
                 }
                 return Ok(DisabledStreamOutcome::Completed);
             }
-            RespondEvent::Failed(failure) => {
+            CoreResponseEvent::Failed(failure) => {
                 stop_typing(typing, failure_stop_reason(&failure));
                 warn!(
                     message_id = %message.message_id,

--- a/qq-maid-gateway-rs/src/gateway/qq_official/c2c/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/qq_official/c2c/tests.rs
@@ -22,12 +22,12 @@ use std::{collections::VecDeque, sync::Mutex};
 
 #[derive(Debug)]
 struct FakeEventStream {
-    events: VecDeque<RespondEvent>,
+    events: VecDeque<CoreResponseEvent>,
     output_policy: CoreOutputPolicy,
 }
 
 impl FakeEventStream {
-    fn new(events: impl IntoIterator<Item = RespondEvent>) -> Self {
+    fn new(events: impl IntoIterator<Item = CoreResponseEvent>) -> Self {
         Self {
             events: events.into_iter().collect(),
             output_policy: CoreOutputPolicy::DirectStream,
@@ -206,8 +206,8 @@ fn complete_c2c_reply_does_not_record_message_id_as_ref_index() {
 #[tokio::test]
 async fn disabled_stream_completed_sends_single_ordinary_reply() {
     let events = FakeEventStream::new([
-        RespondEvent::TextDelta("不应外发".to_owned()),
-        RespondEvent::Completed(Box::new(respond_response("最终回复"))),
+        CoreResponseEvent::TextDelta("不应外发".to_owned()),
+        CoreResponseEvent::Completed(Box::new(respond_response("最终回复"))),
     ]);
     let sender = FakeOutboundSender::default();
     let mut typing = None;
@@ -236,7 +236,7 @@ async fn disabled_stream_completed_sends_single_ordinary_reply() {
 #[tokio::test]
 async fn disabled_stream_completed_records_ref_index() {
     let config = test_config();
-    let events = FakeEventStream::new([RespondEvent::Completed(Box::new(respond_response(
+    let events = FakeEventStream::new([CoreResponseEvent::Completed(Box::new(respond_response(
         "最终回复",
     )))]);
     let sender = FakeOutboundSender::default();
@@ -268,18 +268,18 @@ async fn disabled_stream_completed_records_ref_index() {
 #[tokio::test]
 async fn disabled_stream_completed_records_rendered_parts_fallback_ref_index() {
     let config = test_config();
-    let response = RespondResponse {
-        output: Some(qq_maid_core::service::AssistantOutput {
+    let response = CoreResponse {
+        output: Some(qq_maid_common::output_part::AssistantOutput {
             text_fallback: String::new(),
             markdown: None,
             parts: vec![
-                qq_maid_core::service::OutputPart::Markdown {
+                qq_maid_common::output_part::OutputPart::Markdown {
                     markdown: "# 标题".to_owned(),
                 },
-                qq_maid_core::service::OutputPart::Image {
-                    media: qq_maid_core::service::OutputMedia {
+                qq_maid_common::output_part::OutputPart::Image {
+                    media: qq_maid_common::output_part::OutputMedia {
                         fallback_text: Some("图片：天气雷达".to_owned()),
-                        ..qq_maid_core::service::OutputMedia::default()
+                        ..qq_maid_common::output_part::OutputMedia::default()
                     },
                 },
             ],
@@ -290,7 +290,7 @@ async fn disabled_stream_completed_records_rendered_parts_fallback_ref_index() {
         diagnostics: None,
         visible_entity_snapshot: None,
     };
-    let events = FakeEventStream::new([RespondEvent::Completed(Box::new(response))]);
+    let events = FakeEventStream::new([CoreResponseEvent::Completed(Box::new(response))]);
     let sender = FakeOutboundSender::default();
     let mut typing = None;
     let ref_index = crate::gateway::ref_index::ref_index();
@@ -316,11 +316,11 @@ async fn disabled_stream_completed_records_rendered_parts_fallback_ref_index() {
 #[tokio::test]
 async fn disabled_stream_status_does_not_create_extra_reply() {
     let events = FakeEventStream::new([
-        RespondEvent::Status(CoreResponseStatus {
+        CoreResponseEvent::Status(CoreResponseStatus {
             kind: CoreResponseStatusKind::AgentStarted,
             text: "正在处理".to_owned(),
         }),
-        RespondEvent::Completed(Box::new(respond_response("最终回复"))),
+        CoreResponseEvent::Completed(Box::new(respond_response("最终回复"))),
     ]);
     let sender = FakeOutboundSender::default();
     let mut typing = None;
@@ -349,15 +349,15 @@ async fn disabled_stream_status_does_not_create_extra_reply() {
 #[tokio::test]
 async fn disabled_stream_progress_policy_sends_one_visible_hint_then_final_reply() {
     let events = FakeEventStream::new([
-        RespondEvent::Status(CoreResponseStatus {
+        CoreResponseEvent::Status(CoreResponseStatus {
             kind: CoreResponseStatusKind::AgentStarted,
             text: "小女仆正在处理…".to_owned(),
         }),
-        RespondEvent::Status(CoreResponseStatus {
+        CoreResponseEvent::Status(CoreResponseStatus {
             kind: CoreResponseStatusKind::AgentFinalizing,
             text: "小女仆正在确认结果…".to_owned(),
         }),
-        RespondEvent::Completed(Box::new(respond_response("最终回复"))),
+        CoreResponseEvent::Completed(Box::new(respond_response("最终回复"))),
     ])
     .with_policy(CoreOutputPolicy::ProgressThenComplete);
     let sender = FakeOutboundSender::default();
@@ -393,16 +393,16 @@ async fn disabled_stream_progress_policy_sends_one_visible_hint_then_final_reply
 #[tokio::test]
 async fn disabled_stream_progress_then_stream_sends_one_visible_hint_then_final_reply() {
     let events = FakeEventStream::new([
-        RespondEvent::Status(CoreResponseStatus {
+        CoreResponseEvent::Status(CoreResponseStatus {
             kind: CoreResponseStatusKind::AgentStarted,
             text: "小女仆正在处理…".to_owned(),
         }),
-        RespondEvent::Status(CoreResponseStatus {
+        CoreResponseEvent::Status(CoreResponseStatus {
             kind: CoreResponseStatusKind::AgentFinalizing,
             text: "小女仆正在确认结果…".to_owned(),
         }),
-        RespondEvent::TextDelta("不应外发".to_owned()),
-        RespondEvent::Completed(Box::new(respond_response("最终回复"))),
+        CoreResponseEvent::TextDelta("不应外发".to_owned()),
+        CoreResponseEvent::Completed(Box::new(respond_response("最终回复"))),
     ])
     .with_policy(CoreOutputPolicy::ProgressThenStream);
     let sender = FakeOutboundSender::default();
@@ -438,11 +438,11 @@ async fn disabled_stream_progress_then_stream_sends_one_visible_hint_then_final_
 #[tokio::test]
 async fn disabled_stream_progress_status_respects_visible_progress_config() {
     let events = FakeEventStream::new([
-        RespondEvent::Status(CoreResponseStatus {
+        CoreResponseEvent::Status(CoreResponseStatus {
             kind: CoreResponseStatusKind::AgentStarted,
             text: "小女仆正在处理…".to_owned(),
         }),
-        RespondEvent::Completed(Box::new(respond_response("最终回复"))),
+        CoreResponseEvent::Completed(Box::new(respond_response("最终回复"))),
     ])
     .with_policy(CoreOutputPolicy::ProgressThenComplete);
     let sender = FakeOutboundSender::default();
@@ -468,8 +468,8 @@ async fn disabled_stream_progress_status_respects_visible_progress_config() {
 #[tokio::test]
 async fn disabled_stream_failed_sends_safe_failure_without_reinvoking_core() {
     let events = FakeEventStream::new([
-        RespondEvent::TextDelta("不完整".to_owned()),
-        RespondEvent::Failed(CoreRespondFailure {
+        CoreResponseEvent::TextDelta("不完整".to_owned()),
+        CoreResponseEvent::Failed(CoreRespondFailure {
             kind: CoreFailureKind::LlmFailed,
             message: "上游服务暂时不可用，请稍后再试。".to_owned(),
             retryable: true,
@@ -505,7 +505,7 @@ async fn disabled_stream_failed_sends_safe_failure_without_reinvoking_core() {
 
 #[tokio::test]
 async fn disabled_stream_closed_before_completed_sends_fixed_failure_not_delta() {
-    let events = FakeEventStream::new([RespondEvent::TextDelta("半截回复".to_owned())]);
+    let events = FakeEventStream::new([CoreResponseEvent::TextDelta("半截回复".to_owned())]);
     let sender = FakeOutboundSender::default();
     let mut typing = None;
 

--- a/qq-maid-gateway-rs/src/gateway/qq_official/group/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/qq_official/group/mod.rs
@@ -9,7 +9,9 @@ use std::{
 };
 
 use anyhow::Context;
-use qq_maid_core::service::{CoreInboundKind, CoreRespondFailure};
+use qq_maid_core::service::{
+    CoreInboundKind, CoreRespondFailure, CoreRespondOutput, CoreResponse, CoreResponseEvent,
+};
 use tracing::{debug, info, warn};
 
 fn empty_group_reply_fallback_text(bot_display_name: &str) -> String {
@@ -51,9 +53,7 @@ use crate::{
     config::AppConfig,
     message_chunk::{ChunkLimits, OutboundSendError, send_group_outbound_chunked},
     render::{OutboundMessage, render_respond_response_parts_for_profile},
-    respond::{
-        RespondClient, RespondEvent, RespondResponse, RespondTransport, respond_error_to_qq_text,
-    },
+    respond::{RespondClient, respond_error_to_qq_text},
 };
 
 fn group_reply_mention_prefix(
@@ -392,7 +392,7 @@ pub(crate) async fn handle_group_message(
     };
 
     match transport {
-        RespondTransport::Complete(response) => {
+        CoreRespondOutput::Complete(response) => {
             send_group_respond_response(
                 api,
                 runtime,
@@ -404,7 +404,7 @@ pub(crate) async fn handle_group_message(
             )
             .await?;
         }
-        RespondTransport::Stream(stream) => match consume_respond_stream(stream).await {
+        CoreRespondOutput::Stream(stream) => match consume_respond_stream(stream).await {
             GroupStreamOutcome::Completed(response) => {
                 send_group_respond_response(
                     api,
@@ -486,7 +486,7 @@ async fn send_group_respond_response(
     config: &AppConfig,
     group_outbound_cache: &Arc<Mutex<BotOutboundCache>>,
     message: &GroupMessage,
-    response: &RespondResponse,
+    response: &CoreResponse,
     ref_index: &SharedRefIndex,
 ) -> anyhow::Result<()> {
     if response.suppresses_reply() {
@@ -559,7 +559,7 @@ fn record_group_bot_outbound_send(
     group_outbound_cache: &Arc<Mutex<BotOutboundCache>>,
     ref_index: &SharedRefIndex,
     message: &GroupMessage,
-    response: &RespondResponse,
+    response: &CoreResponse,
     config: &AppConfig,
     sent_ids: &SendMessageIds,
     text: &str,
@@ -582,7 +582,7 @@ fn record_group_bot_outbound_send(
 
 #[derive(Debug)]
 enum GroupStreamOutcome {
-    Completed(RespondResponse),
+    Completed(CoreResponse),
     Failed(CoreRespondFailure),
     ClosedBeforeCompleted,
 }
@@ -596,7 +596,7 @@ where
     let mut text_delta_count = 0_usize;
     while let Some(event) = stream.recv_event().await {
         match event {
-            RespondEvent::Status(status) => {
+            CoreResponseEvent::Status(status) => {
                 status_event_count += 1;
                 debug!(
                     status_kind = status.kind.as_str(),
@@ -606,12 +606,12 @@ where
                     "group stream status event recorded without group progress send"
                 );
             }
-            RespondEvent::TextDelta(delta) => {
+            CoreResponseEvent::TextDelta(delta) => {
                 if !delta.is_empty() {
                     text_delta_count += 1;
                 }
             }
-            RespondEvent::Completed(response) => {
+            CoreResponseEvent::Completed(response) => {
                 debug!(
                     response_delivery_mode = output_policy.as_str(),
                     text_delta_count,
@@ -620,7 +620,7 @@ where
                 );
                 return GroupStreamOutcome::Completed(*response);
             }
-            RespondEvent::Failed(failure) => {
+            CoreResponseEvent::Failed(failure) => {
                 warn!(
                     kind = ?failure.kind,
                     retryable = failure.retryable,

--- a/qq-maid-gateway-rs/src/gateway/qq_official/group/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/qq_official/group/tests.rs
@@ -14,7 +14,7 @@ fn local_group_hints_use_configured_bot_display_name() {
 
 #[tokio::test]
 async fn group_stream_timeout_sends_core_safe_failure_text() {
-    let stream = FakeGroupEventStream::new([RespondEvent::Failed(CoreRespondFailure {
+    let stream = FakeGroupEventStream::new([CoreResponseEvent::Failed(CoreRespondFailure {
         kind: CoreFailureKind::LlmTimeout,
         message: "LLM 服务处理超时，请稍后再试。".to_owned(),
         retryable: true,
@@ -73,11 +73,11 @@ use tokio::net::TcpListener;
 
 #[derive(Debug)]
 struct FakeGroupEventStream {
-    events: VecDeque<RespondEvent>,
+    events: VecDeque<CoreResponseEvent>,
 }
 
 impl FakeGroupEventStream {
-    fn new(events: impl IntoIterator<Item = RespondEvent>) -> Self {
+    fn new(events: impl IntoIterator<Item = CoreResponseEvent>) -> Self {
         Self {
             events: events.into_iter().collect(),
         }
@@ -157,7 +157,7 @@ fn qq_group_capability() -> ReplyCapability {
 }
 
 struct MockCore {
-    response: RespondResponse,
+    response: CoreResponse,
     respond_calls: Arc<AtomicUsize>,
     classify_calls: Arc<AtomicUsize>,
     immediate_inputs: Vec<String>,
@@ -220,7 +220,7 @@ fn respond_client_with_classification(
         respond_calls,
         classify_calls,
         immediate_inputs,
-        RespondResponse {
+        CoreResponse {
             output: None,
             handled: Some(true),
             session_id: None,
@@ -235,7 +235,7 @@ fn respond_client_with_response(
     respond_calls: Arc<AtomicUsize>,
     classify_calls: Arc<AtomicUsize>,
     immediate_inputs: Vec<&str>,
-    response: RespondResponse,
+    response: CoreResponse,
 ) -> RespondClient {
     RespondClient::new(Arc::new(MockCore {
         response,

--- a/qq-maid-gateway-rs/src/gateway/qq_official/group/tests/behavior.rs
+++ b/qq-maid-gateway-rs/src/gateway/qq_official/group/tests/behavior.rs
@@ -264,7 +264,7 @@ async fn slash_candidates_reach_core_and_explicit_suppression_sends_nothing() {
         respond_calls.clone(),
         classify_calls.clone(),
         vec!["/help"],
-        RespondResponse {
+        CoreResponse {
             output: None,
             handled: Some(true),
             session_id: None,
@@ -596,8 +596,8 @@ fn group_send_records_message_id_for_cache_and_refidx_for_ref_index() {
     let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
     let ref_index = crate::gateway::ref_index::ref_index();
     let message = group_message("小女仆 你好", GroupEventType::GroupMessage);
-    let response = RespondResponse {
-        output: Some(qq_maid_core::service::AssistantOutput::markdown(
+    let response = CoreResponse {
+        output: Some(qq_maid_common::output_part::AssistantOutput::markdown(
             "机器人回复",
             "机器人回复",
         )),
@@ -658,14 +658,14 @@ fn group_send_records_rendered_fallback_when_output_text_field_is_empty() {
     let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
     let ref_index = crate::gateway::ref_index::ref_index();
     let message = group_message("小女仆 看图", GroupEventType::GroupMessage);
-    let response = RespondResponse {
-        output: Some(qq_maid_core::service::AssistantOutput {
+    let response = CoreResponse {
+        output: Some(qq_maid_common::output_part::AssistantOutput {
             text_fallback: String::new(),
             markdown: None,
-            parts: vec![qq_maid_core::service::OutputPart::Image {
-                media: qq_maid_core::service::OutputMedia {
+            parts: vec![qq_maid_common::output_part::OutputPart::Image {
+                media: qq_maid_common::output_part::OutputMedia {
                     fallback_text: Some("图片：天气雷达".to_owned()),
-                    ..qq_maid_core::service::OutputMedia::default()
+                    ..qq_maid_common::output_part::OutputMedia::default()
                 },
             }],
         }),
@@ -712,8 +712,10 @@ fn group_send_records_rendered_fallback_when_output_text_field_is_empty() {
 #[test]
 fn group_send_does_not_cross_use_message_id_and_refidx_when_one_is_missing() {
     let config = test_config();
-    let response = RespondResponse {
-        output: Some(qq_maid_core::service::AssistantOutput::text("机器人回复")),
+    let response = CoreResponse {
+        output: Some(qq_maid_common::output_part::AssistantOutput::text(
+            "机器人回复",
+        )),
         handled: Some(true),
         session_id: None,
         command: None,

--- a/qq-maid-gateway-rs/src/gateway/stream/delivery.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/delivery.rs
@@ -26,9 +26,10 @@ use crate::{
         typing::{C2cTypingStatusGuard, TypingStopReason},
     },
     render::{OutboundMessage, render_respond_response_parts_for_profile},
-    respond::RespondEvent,
 };
-use qq_maid_core::service::{CoreOutputPolicy, CoreResponseStatus};
+use qq_maid_core::service::{
+    CoreOutputPolicy, CoreResponse, CoreResponseEvent, CoreResponseStatus,
+};
 
 /// QQ C2C 流式发送的节流间隔（毫秒）。
 ///
@@ -38,7 +39,7 @@ pub(crate) const STREAM_THROTTLE_MS: u64 = 500;
 async fn send_completed_media_after_stream<S: C2cStreamSender + ?Sized>(
     sender: &S,
     message: &C2cMessage,
-    response: &crate::respond::RespondResponse,
+    response: &CoreResponse,
     config: &AppConfig,
 ) -> anyhow::Result<()> {
     let capability = ReplyCapability::qq_official_c2c(config);
@@ -199,7 +200,7 @@ where
 
     while let Some(event) = stream.recv_event().await {
         match event {
-            RespondEvent::Status(status) => {
+            CoreResponseEvent::Status(status) => {
                 status_event_count += 1;
                 trace!(
                     user = %masked_user,
@@ -228,7 +229,7 @@ where
                     .await;
                 }
             }
-            RespondEvent::TextDelta(delta) => {
+            CoreResponseEvent::TextDelta(delta) => {
                 if delta.is_empty() {
                     continue;
                 }
@@ -396,7 +397,7 @@ where
                     C2cStreamingPhase::Completed => {}
                 }
             }
-            RespondEvent::Completed(response) => {
+            CoreResponseEvent::Completed(response) => {
                 if let Some(typing) = typing.as_mut() {
                     typing.stop(TypingStopReason::FinalReply);
                 }
@@ -754,7 +755,7 @@ where
                     }
                 }
             }
-            RespondEvent::Failed(failure) => {
+            CoreResponseEvent::Failed(failure) => {
                 if let Some(typing) = typing.as_mut() {
                     typing.stop(failure_stop_reason(&failure));
                 }

--- a/qq-maid-gateway-rs/src/gateway/stream/event_stream.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/event_stream.rs
@@ -4,12 +4,13 @@ use super::super::{outbound::RuntimeRecordingSender, typing::TypingStopReason};
 use crate::{
     api::{C2cStreamState, OutboundSender, StreamSendResult},
     markdown::MarkdownPayload,
-    respond::RespondEvent,
 };
-use qq_maid_core::service::{CoreFailureKind, CoreOutputPolicy, CoreRespondFailure};
+use qq_maid_core::service::{
+    CoreFailureKind, CoreOutputPolicy, CoreRespondFailure, CoreResponseEvent,
+};
 
 pub(crate) type RespondEventFuture<'a> =
-    Pin<Box<dyn Future<Output = Option<RespondEvent>> + Send + 'a>>;
+    Pin<Box<dyn Future<Output = Option<CoreResponseEvent>> + Send + 'a>>;
 pub(crate) type StreamSendFuture<'a> = Pin<Box<dyn Future<Output = StreamSendResult> + Send + 'a>>;
 
 /// Core 流事件来源抽象，用于把 QQ 流事件消费者与真实 Core channel 解耦，便于覆盖异常分支。

--- a/qq-maid-gateway-rs/src/gateway/stream/send.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/send.rs
@@ -2,13 +2,14 @@ use super::event_stream::C2cStreamSender;
 use crate::{
     api::{C2cStreamState, StreamSendResult},
     markdown::MarkdownPayload,
-    respond::RespondResponse,
 };
+use qq_maid_common::output_part::AssistantOutput;
+use qq_maid_core::service::CoreResponse;
 
 /// QQ 结束帧要求 Markdown content 非空；零宽空格满足非空校验，且不会把完整正文再次追加到已发送内容后。
 pub(crate) const STREAM_FINAL_MARKER: &str = "\u{200B}";
 
-pub(crate) fn completed_response_content(response: &RespondResponse) -> Option<&str> {
+pub(crate) fn completed_response_content(response: &CoreResponse) -> Option<&str> {
     response.markdown_content().or(response.text_content())
 }
 
@@ -20,11 +21,9 @@ pub(crate) fn stream_final_packet_content(pending_delta: &str) -> &str {
     }
 }
 
-pub(crate) fn response_from_incomplete_stream_text(content: &str) -> RespondResponse {
-    RespondResponse {
-        output: Some(qq_maid_core::service::AssistantOutput::markdown(
-            content, content,
-        )),
+pub(crate) fn response_from_incomplete_stream_text(content: &str) -> CoreResponse {
+    CoreResponse {
+        output: Some(AssistantOutput::markdown(content, content)),
         handled: Some(true),
         session_id: None,
         command: None,

--- a/qq-maid-gateway-rs/src/gateway/stream/tests/completion.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests/completion.rs
@@ -5,9 +5,9 @@ use super::*;
 #[tokio::test]
 async fn stream_completed_flushes_pending_delta_before_final() {
     let events = FakeEventStream::new([
-        RespondEvent::TextDelta("晚".to_owned()),
-        RespondEvent::TextDelta("上".to_owned()),
-        RespondEvent::Completed(Box::new(respond_response("晚上"))),
+        CoreResponseEvent::TextDelta("晚".to_owned()),
+        CoreResponseEvent::TextDelta("上".to_owned()),
+        CoreResponseEvent::Completed(Box::new(respond_response("晚上"))),
     ]);
     let sender = FakeStreamSender::new([Ok(Some("stream-1".to_owned())), Ok(None), Ok(None)]);
 
@@ -48,7 +48,7 @@ async fn stream_completed_flushes_pending_delta_before_final() {
 
 #[tokio::test]
 async fn stream_completed_without_delta_uses_ordinary_reply_path() {
-    let events = FakeEventStream::new([RespondEvent::Completed(Box::new(respond_response(
+    let events = FakeEventStream::new([CoreResponseEvent::Completed(Box::new(respond_response(
         "晚上好",
     )))]);
     let sender = FakeStreamSender::new([]);
@@ -69,7 +69,7 @@ async fn stream_completed_without_delta_uses_ordinary_reply_path() {
 
 #[tokio::test]
 async fn stream_pending_completed_stops_typing_before_ordinary_reply() {
-    let events = FakeEventStream::new([RespondEvent::Completed(Box::new(respond_response(
+    let events = FakeEventStream::new([CoreResponseEvent::Completed(Box::new(respond_response(
         "晚上好",
     )))]);
     let sender = FakeStreamSender::new([]);
@@ -108,8 +108,8 @@ async fn stream_pending_completed_stops_typing_before_ordinary_reply() {
 #[tokio::test]
 async fn stream_pending_completed_sends_ordinary_reply_once() {
     let events = FakeEventStream::new([
-        RespondEvent::Completed(Box::new(respond_response("晚上好"))),
-        RespondEvent::Completed(Box::new(respond_response("不应重复发送"))),
+        CoreResponseEvent::Completed(Box::new(respond_response("晚上好"))),
+        CoreResponseEvent::Completed(Box::new(respond_response("不应重复发送"))),
     ]);
     let sender = FakeStreamSender::new([]);
 
@@ -129,9 +129,9 @@ async fn stream_pending_completed_sends_ordinary_reply_once() {
 #[tokio::test]
 async fn stream_completed_sends_single_final_chunk() {
     let events = FakeEventStream::new([
-        RespondEvent::TextDelta("好".to_owned()),
-        RespondEvent::Completed(Box::new(respond_response("好"))),
-        RespondEvent::Completed(Box::new(respond_response("好"))),
+        CoreResponseEvent::TextDelta("好".to_owned()),
+        CoreResponseEvent::Completed(Box::new(respond_response("好"))),
+        CoreResponseEvent::Completed(Box::new(respond_response("好"))),
     ]);
     let sender = FakeStreamSender::new([Ok(Some("stream-1".to_owned())), Ok(None)]);
 
@@ -175,8 +175,8 @@ async fn active_text_stream_sends_completed_image_then_only_its_fallback() {
         ],
     });
     let events = FakeEventStream::new([
-        RespondEvent::TextDelta("说明".to_owned()),
-        RespondEvent::Completed(Box::new(response)),
+        CoreResponseEvent::TextDelta("说明".to_owned()),
+        CoreResponseEvent::Completed(Box::new(response)),
     ]);
     let sender = FakeStreamSender::new([Ok(Some("stream-1".to_owned())), Ok(None)]);
     let config = test_config();

--- a/qq-maid-gateway-rs/src/gateway/stream/tests/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests/mod.rs
@@ -17,11 +17,11 @@ use crate::{
     },
     markdown::MarkdownPayload,
     media::ImagePayload,
-    respond::RespondEvent,
 };
+use qq_maid_common::output_part::{AssistantOutput, OutputMedia, OutputPart};
 use qq_maid_core::service::{
-    AssistantOutput, CoreFailureKind, CoreOutputPolicy, CoreRespondFailure, CoreResponseStatus,
-    CoreResponseStatusKind, OutputMedia, OutputPart,
+    CoreFailureKind, CoreOutputPolicy, CoreRespondFailure, CoreResponseEvent, CoreResponseStatus,
+    CoreResponseStatusKind,
 };
 use std::{collections::VecDeque, sync::Arc, time::Duration};
 
@@ -33,12 +33,12 @@ fn test_config() -> AppConfig {
 
 #[derive(Debug)]
 struct FakeEventStream {
-    events: VecDeque<(Duration, RespondEvent)>,
+    events: VecDeque<(Duration, CoreResponseEvent)>,
     output_policy: CoreOutputPolicy,
 }
 
 impl FakeEventStream {
-    fn new(events: impl IntoIterator<Item = RespondEvent>) -> Self {
+    fn new(events: impl IntoIterator<Item = CoreResponseEvent>) -> Self {
         Self {
             events: events
                 .into_iter()
@@ -48,7 +48,7 @@ impl FakeEventStream {
         }
     }
 
-    fn with_delays(events: impl IntoIterator<Item = (Duration, RespondEvent)>) -> Self {
+    fn with_delays(events: impl IntoIterator<Item = (Duration, CoreResponseEvent)>) -> Self {
         Self {
             events: events.into_iter().collect(),
             output_policy: CoreOutputPolicy::DirectStream,
@@ -228,9 +228,9 @@ fn quoted_lookup_found(
 #[tokio::test]
 async fn stream_first_send_error_falls_back_to_completed_response() {
     let events = FakeEventStream::new([
-        RespondEvent::TextDelta("晚上".to_owned()),
-        RespondEvent::TextDelta("好".to_owned()),
-        RespondEvent::Completed(Box::new(respond_response("晚上好"))),
+        CoreResponseEvent::TextDelta("晚上".to_owned()),
+        CoreResponseEvent::TextDelta("好".to_owned()),
+        CoreResponseEvent::Completed(Box::new(respond_response("晚上好"))),
     ]);
     let sender = FakeStreamSender::new([Err(ApiError::Unsupported("stream"))]);
 
@@ -261,8 +261,8 @@ async fn stream_first_send_error_falls_back_to_completed_response() {
 async fn stream_pending_fallback_records_ref_index() {
     let config = test_config();
     let events = FakeEventStream::new([
-        RespondEvent::TextDelta("晚上".to_owned()),
-        RespondEvent::Completed(Box::new(respond_response("晚上好"))),
+        CoreResponseEvent::TextDelta("晚上".to_owned()),
+        CoreResponseEvent::Completed(Box::new(respond_response("晚上好"))),
     ]);
     let sender = FakeStreamSender::new([Err(ApiError::Unsupported("stream"))]);
     let ref_index = crate::gateway::ref_index::ref_index();
@@ -291,8 +291,8 @@ async fn stream_pending_fallback_records_ref_index() {
 async fn active_stream_does_not_fake_ref_index_from_stream_id() {
     let config = test_config();
     let events = FakeEventStream::new([
-        RespondEvent::TextDelta("晚上好".to_owned()),
-        RespondEvent::Completed(Box::new(respond_response("晚上好"))),
+        CoreResponseEvent::TextDelta("晚上好".to_owned()),
+        CoreResponseEvent::Completed(Box::new(respond_response("晚上好"))),
     ]);
     let sender = FakeStreamSender::new([Ok(Some("stream-1".to_owned())), Ok(None)]);
     let ref_index = crate::gateway::ref_index::ref_index();
@@ -314,11 +314,11 @@ async fn active_stream_does_not_fake_ref_index_from_stream_id() {
 #[tokio::test]
 async fn stream_status_event_does_not_start_qq_stream_or_extra_send() {
     let events = FakeEventStream::new([
-        RespondEvent::Status(CoreResponseStatus {
+        CoreResponseEvent::Status(CoreResponseStatus {
             kind: CoreResponseStatusKind::AgentStarted,
             text: "正在处理".to_owned(),
         }),
-        RespondEvent::Completed(Box::new(respond_response("最终回复"))),
+        CoreResponseEvent::Completed(Box::new(respond_response("最终回复"))),
     ]);
     let sender = FakeStreamSender::new([]);
 
@@ -338,15 +338,15 @@ async fn stream_status_event_does_not_start_qq_stream_or_extra_send() {
 #[tokio::test]
 async fn progress_policy_status_sends_one_visible_hint_then_final_reply() {
     let events = FakeEventStream::new([
-        RespondEvent::Status(CoreResponseStatus {
+        CoreResponseEvent::Status(CoreResponseStatus {
             kind: CoreResponseStatusKind::AgentStarted,
             text: "小女仆正在处理…".to_owned(),
         }),
-        RespondEvent::Status(CoreResponseStatus {
+        CoreResponseEvent::Status(CoreResponseStatus {
             kind: CoreResponseStatusKind::AgentFinalizing,
             text: "小女仆正在确认结果…".to_owned(),
         }),
-        RespondEvent::Completed(Box::new(respond_response("最终回复"))),
+        CoreResponseEvent::Completed(Box::new(respond_response("最终回复"))),
     ])
     .with_policy(CoreOutputPolicy::ProgressThenComplete);
     let sender = FakeStreamSender::new([]);
@@ -373,16 +373,16 @@ async fn progress_policy_status_sends_one_visible_hint_then_final_reply() {
 #[tokio::test]
 async fn progress_then_stream_sends_one_visible_hint_then_streams_final_answer() {
     let events = FakeEventStream::new([
-        RespondEvent::Status(CoreResponseStatus {
+        CoreResponseEvent::Status(CoreResponseStatus {
             kind: CoreResponseStatusKind::AgentStarted,
             text: "小女仆正在处理…".to_owned(),
         }),
-        RespondEvent::Status(CoreResponseStatus {
+        CoreResponseEvent::Status(CoreResponseStatus {
             kind: CoreResponseStatusKind::AgentFinalizing,
             text: "小女仆正在确认结果…".to_owned(),
         }),
-        RespondEvent::TextDelta("最终".to_owned()),
-        RespondEvent::Completed(Box::new(respond_response("最终回复"))),
+        CoreResponseEvent::TextDelta("最终".to_owned()),
+        CoreResponseEvent::Completed(Box::new(respond_response("最终回复"))),
     ])
     .with_policy(CoreOutputPolicy::ProgressThenStream);
     let sender = FakeStreamSender::new([Ok(Some("stream-1".to_owned())), Ok(None)]);
@@ -421,9 +421,9 @@ async fn progress_then_stream_sends_one_visible_hint_then_streams_final_answer()
 #[tokio::test]
 async fn stream_first_send_without_id_falls_back_to_completed_response() {
     let events = FakeEventStream::new([
-        RespondEvent::TextDelta("晚上".to_owned()),
-        RespondEvent::TextDelta("好".to_owned()),
-        RespondEvent::Completed(Box::new(respond_response("晚上好"))),
+        CoreResponseEvent::TextDelta("晚上".to_owned()),
+        CoreResponseEvent::TextDelta("好".to_owned()),
+        CoreResponseEvent::Completed(Box::new(respond_response("晚上好"))),
     ]);
     let sender = FakeStreamSender::new([Ok(None)]);
 
@@ -453,11 +453,11 @@ async fn stream_first_send_without_id_falls_back_to_completed_response() {
 #[tokio::test]
 async fn progress_policy_status_respects_visible_progress_config() {
     let events = FakeEventStream::new([
-        RespondEvent::Status(CoreResponseStatus {
+        CoreResponseEvent::Status(CoreResponseStatus {
             kind: CoreResponseStatusKind::AgentStarted,
             text: "小女仆正在处理…".to_owned(),
         }),
-        RespondEvent::Completed(Box::new(respond_response("最终回复"))),
+        CoreResponseEvent::Completed(Box::new(respond_response("最终回复"))),
     ])
     .with_policy(CoreOutputPolicy::ProgressThenComplete);
     let sender = FakeStreamSender::new([]);
@@ -480,8 +480,8 @@ async fn progress_policy_status_respects_visible_progress_config() {
 #[tokio::test]
 async fn stream_single_content_packet_then_final_keeps_stream_id() {
     let events = FakeEventStream::new([
-        RespondEvent::TextDelta("测试成功".to_owned()),
-        RespondEvent::Completed(Box::new(respond_response("测试成功"))),
+        CoreResponseEvent::TextDelta("测试成功".to_owned()),
+        CoreResponseEvent::Completed(Box::new(respond_response("测试成功"))),
     ]);
     let sender = FakeStreamSender::new([Ok(Some("stream-1".to_owned())), Ok(None)]);
 
@@ -516,14 +516,17 @@ async fn stream_single_content_packet_then_final_keeps_stream_id() {
 #[tokio::test]
 async fn stream_active_path_reuses_id_and_increments_content_index() {
     let events = FakeEventStream::with_delays([
-        (Duration::ZERO, RespondEvent::TextDelta("晚上".to_owned())),
+        (
+            Duration::ZERO,
+            CoreResponseEvent::TextDelta("晚上".to_owned()),
+        ),
         (
             Duration::from_millis(STREAM_THROTTLE_MS + 50),
-            RespondEvent::TextDelta("好".to_owned()),
+            CoreResponseEvent::TextDelta("好".to_owned()),
         ),
         (
             Duration::ZERO,
-            RespondEvent::Completed(Box::new(respond_response("晚上好"))),
+            CoreResponseEvent::Completed(Box::new(respond_response("晚上好"))),
         ),
     ]);
     let sender = FakeStreamSender::new([Ok(Some("stream-1".to_owned())), Ok(None), Ok(None)]);
@@ -566,9 +569,9 @@ async fn stream_active_path_reuses_id_and_increments_content_index() {
 #[tokio::test]
 async fn stream_empty_delta_does_not_consume_index() {
     let events = FakeEventStream::new([
-        RespondEvent::TextDelta(String::new()),
-        RespondEvent::TextDelta("好".to_owned()),
-        RespondEvent::Completed(Box::new(respond_response("好"))),
+        CoreResponseEvent::TextDelta(String::new()),
+        CoreResponseEvent::TextDelta("好".to_owned()),
+        CoreResponseEvent::Completed(Box::new(respond_response("好"))),
     ]);
     let sender = FakeStreamSender::new([Ok(Some("stream-1".to_owned())), Ok(None)]);
 
@@ -602,14 +605,17 @@ async fn stream_empty_delta_does_not_consume_index() {
 #[tokio::test]
 async fn stream_middle_returned_id_does_not_replace_first_stream_id() {
     let events = FakeEventStream::with_delays([
-        (Duration::ZERO, RespondEvent::TextDelta("晚".to_owned())),
+        (
+            Duration::ZERO,
+            CoreResponseEvent::TextDelta("晚".to_owned()),
+        ),
         (
             Duration::from_millis(STREAM_THROTTLE_MS + 50),
-            RespondEvent::TextDelta("上".to_owned()),
+            CoreResponseEvent::TextDelta("上".to_owned()),
         ),
         (
             Duration::ZERO,
-            RespondEvent::Completed(Box::new(respond_response("晚上"))),
+            CoreResponseEvent::Completed(Box::new(respond_response("晚上"))),
         ),
     ]);
     let sender = FakeStreamSender::new([
@@ -656,15 +662,21 @@ async fn stream_middle_returned_id_does_not_replace_first_stream_id() {
 #[tokio::test]
 async fn stream_middle_chunks_coalesce_only_unsent_delta() {
     let events = FakeEventStream::with_delays([
-        (Duration::ZERO, RespondEvent::TextDelta("晚".to_owned())),
-        (Duration::ZERO, RespondEvent::TextDelta("上".to_owned())),
         (
-            Duration::from_millis(STREAM_THROTTLE_MS + 50),
-            RespondEvent::TextDelta("好".to_owned()),
+            Duration::ZERO,
+            CoreResponseEvent::TextDelta("晚".to_owned()),
         ),
         (
             Duration::ZERO,
-            RespondEvent::Completed(Box::new(respond_response("晚上好"))),
+            CoreResponseEvent::TextDelta("上".to_owned()),
+        ),
+        (
+            Duration::from_millis(STREAM_THROTTLE_MS + 50),
+            CoreResponseEvent::TextDelta("好".to_owned()),
+        ),
+        (
+            Duration::ZERO,
+            CoreResponseEvent::Completed(Box::new(respond_response("晚上好"))),
         ),
     ]);
     let sender = FakeStreamSender::new([Ok(Some("stream-1".to_owned())), Ok(None), Ok(None)]);
@@ -707,8 +719,8 @@ async fn stream_middle_chunks_coalesce_only_unsent_delta() {
 #[tokio::test]
 async fn stream_final_failure_does_not_send_ordinary_fallback_after_active() {
     let events = FakeEventStream::new([
-        RespondEvent::TextDelta("晚上".to_owned()),
-        RespondEvent::Completed(Box::new(respond_response("晚上好"))),
+        CoreResponseEvent::TextDelta("晚上".to_owned()),
+        CoreResponseEvent::Completed(Box::new(respond_response("晚上好"))),
     ]);
     let sender = FakeStreamSender::new([
         Ok(Some("stream-1".to_owned())),
@@ -808,7 +820,7 @@ async fn stream_final_success_commits_next_index() {
 
 #[tokio::test]
 async fn stream_closed_before_completed_is_not_silent_success() {
-    let events = FakeEventStream::new([RespondEvent::TextDelta("晚上".to_owned())]);
+    let events = FakeEventStream::new([CoreResponseEvent::TextDelta("晚上".to_owned())]);
     let sender = FakeStreamSender::new([Err(ApiError::Unsupported("stream"))]);
 
     let result =
@@ -831,14 +843,17 @@ async fn stream_closed_before_completed_is_not_silent_success() {
 #[tokio::test]
 async fn stream_middle_failure_does_not_send_ordinary_fallback_on_completed() {
     let events = FakeEventStream::with_delays([
-        (Duration::ZERO, RespondEvent::TextDelta("晚".to_owned())),
+        (
+            Duration::ZERO,
+            CoreResponseEvent::TextDelta("晚".to_owned()),
+        ),
         (
             Duration::from_millis(STREAM_THROTTLE_MS + 50),
-            RespondEvent::TextDelta("上".to_owned()),
+            CoreResponseEvent::TextDelta("上".to_owned()),
         ),
         (
             Duration::ZERO,
-            RespondEvent::Completed(Box::new(respond_response("晚上"))),
+            CoreResponseEvent::Completed(Box::new(respond_response("晚上"))),
         ),
     ]);
     let sender = FakeStreamSender::new([
@@ -884,7 +899,7 @@ async fn stream_middle_failure_does_not_send_ordinary_fallback_on_completed() {
 
 #[tokio::test]
 async fn pending_core_failure_sends_safe_ordinary_failure_reply() {
-    let events = FakeEventStream::new([RespondEvent::Failed(CoreRespondFailure {
+    let events = FakeEventStream::new([CoreResponseEvent::Failed(CoreRespondFailure {
         kind: CoreFailureKind::Internal,
         message: "处理失败，请稍后再试。".to_owned(),
         retryable: false,
@@ -907,7 +922,7 @@ async fn pending_core_failure_sends_safe_ordinary_failure_reply() {
 
 #[tokio::test]
 async fn stream_timeout_failure_stops_typing_with_timeout_reason() {
-    let events = FakeEventStream::new([RespondEvent::Failed(CoreRespondFailure {
+    let events = FakeEventStream::new([CoreResponseEvent::Failed(CoreRespondFailure {
         kind: CoreFailureKind::LlmTimeout,
         message: "LLM 服务处理超时，请稍后再试。".to_owned(),
         retryable: true,
@@ -952,8 +967,8 @@ async fn stream_timeout_failure_stops_typing_with_timeout_reason() {
 #[tokio::test]
 async fn active_core_failure_finalizes_stream_without_ordinary_failure_reply() {
     let events = FakeEventStream::new([
-        RespondEvent::TextDelta("已发送".to_owned()),
-        RespondEvent::Failed(CoreRespondFailure {
+        CoreResponseEvent::TextDelta("已发送".to_owned()),
+        CoreResponseEvent::Failed(CoreRespondFailure {
             kind: CoreFailureKind::LlmTimeout,
             message: "LLM 服务处理超时，请稍后再试。".to_owned(),
             retryable: true,

--- a/qq-maid-gateway-rs/src/gateway/test_support.rs
+++ b/qq-maid-gateway-rs/src/gateway/test_support.rs
@@ -5,20 +5,18 @@
 
 use std::time::Duration;
 
-use qq_maid_core::service::AssistantOutput;
+use qq_maid_common::output_part::AssistantOutput;
+use qq_maid_core::service::CoreResponse;
 
 use super::event::C2cMessage;
-use crate::{
-    config::{
-        AgentTypingConfig, AppConfig, DEFAULT_CONVERSATION_QUEUE_CAPACITY,
-        DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT, DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS,
-        DEFAULT_MEDIA_MAX_BYTES, DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS,
-        DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS, DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES,
-        DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS, DEFAULT_MESSAGE_AGGREGATION_QUIET_MS,
-        DEFAULT_TEXT_CHUNK_SOFT_LIMIT, GroupMessageMode, MessageAggregationConfig, OneBot11Config,
-        WechatServiceConfig,
-    },
-    respond::RespondResponse,
+use crate::config::{
+    AgentTypingConfig, AppConfig, DEFAULT_CONVERSATION_QUEUE_CAPACITY,
+    DEFAULT_MARKDOWN_CHUNK_SOFT_LIMIT, DEFAULT_MAX_ACTIVE_CONVERSATION_WORKERS,
+    DEFAULT_MEDIA_MAX_BYTES, DEFAULT_MESSAGE_AGGREGATION_MAX_ACTIVE_KEYS,
+    DEFAULT_MESSAGE_AGGREGATION_MAX_CHARS, DEFAULT_MESSAGE_AGGREGATION_MAX_MESSAGES,
+    DEFAULT_MESSAGE_AGGREGATION_MAX_WAIT_MS, DEFAULT_MESSAGE_AGGREGATION_QUIET_MS,
+    DEFAULT_TEXT_CHUNK_SOFT_LIMIT, GroupMessageMode, MessageAggregationConfig, OneBot11Config,
+    WechatServiceConfig,
 };
 
 /// 返回已绑定 QQ 官方渠道的稳定测试基线。
@@ -88,8 +86,8 @@ pub(crate) fn c2c_message_fixture() -> C2cMessage {
     }
 }
 
-pub(crate) fn respond_response_fixture(text: &str) -> RespondResponse {
-    RespondResponse {
+pub(crate) fn respond_response_fixture(text: &str) -> CoreResponse {
+    CoreResponse {
         output: Some(AssistantOutput::markdown(text, text)),
         handled: Some(true),
         session_id: None,

--- a/qq-maid-gateway-rs/src/gateway/wechat_service/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/wechat_service/mod.rs
@@ -17,6 +17,7 @@ use axum::{
     response::{IntoResponse, Response},
     routing::get,
 };
+use qq_maid_core::service::CoreRespondOutput;
 use serde::Deserialize;
 use tokio::{net::TcpListener, sync::oneshot, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
@@ -41,7 +42,7 @@ use crate::{
     },
     logging::mask_openid,
     render::render_respond_response_for_profile,
-    respond::{RespondClient, RespondError, RespondTransport, respond_error_to_qq_text},
+    respond::{RespondClient, RespondError, respond_error_to_qq_text},
 };
 
 mod customer;
@@ -309,8 +310,8 @@ async fn build_reply_text(
     let content = platform::render_text_for_core(inbound);
     let capability = ReplyCapability::wechat_service_text_sync(reply_timeout);
     let response = match respond.respond_inbound(inbound, content).await {
-        Ok(RespondTransport::Complete(response)) => Some(response),
-        Ok(RespondTransport::Stream(mut stream)) => {
+        Ok(CoreRespondOutput::Complete(response)) => Some(response),
+        Ok(CoreRespondOutput::Stream(mut stream)) => {
             // 微信服务号同步回复不支持流式；这里只消费到 Completed，超时由外层统一处理。
             let mut completed = None;
             while let Some(event) = stream.recv().await {

--- a/qq-maid-gateway-rs/src/gateway/wechat_service/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/wechat_service/tests.rs
@@ -9,6 +9,7 @@ use std::{
 
 use async_trait::async_trait;
 use axum::{Router, body::to_bytes, routing::get};
+use qq_maid_common::output_part::AssistantOutput;
 use qq_maid_core::service::{
     CoreError, CoreHealthSnapshot, CoreInboundClassification, CoreInboundKind, CoreRequest,
     CoreRespondOutput, CoreResponse, CoreService, UpstreamStatusSnapshot,
@@ -183,10 +184,7 @@ impl CoreService for MockCore {
             tokio::time::sleep(delay).await;
         }
         Ok(CoreRespondOutput::Complete(Box::new(CoreResponse {
-            output: Some(qq_maid_core::service::AssistantOutput::markdown(
-                "hello <wx> & user",
-                "**hello**",
-            )),
+            output: Some(AssistantOutput::markdown("hello <wx> & user", "**hello**")),
             handled: Some(true),
             session_id: None,
             command: None,

--- a/qq-maid-gateway-rs/src/render.rs
+++ b/qq-maid-gateway-rs/src/render.rs
@@ -1,8 +1,6 @@
-use crate::{
-    gateway::outbound::RenderProfile, markdown::MarkdownPayload, media::ImagePayload,
-    respond::RespondResponse,
-};
-use qq_maid_core::service::{AssistantOutput, OutputPart};
+use crate::{gateway::outbound::RenderProfile, markdown::MarkdownPayload, media::ImagePayload};
+use qq_maid_common::output_part::{AssistantOutput, OutputMedia, OutputPart};
+use qq_maid_core::service::CoreResponse;
 
 const UNSUPPORTED_IMAGE_FALLBACK_TEXT: &str = "当前平台暂不支持发送这类图片内容。";
 const UNSUPPORTED_FILE_FALLBACK_TEXT: &str = "当前平台暂不支持发送这类文件内容。";
@@ -78,7 +76,7 @@ impl OutboundMessage {
 }
 
 pub(crate) fn render_respond_response_for_profile(
-    response: &RespondResponse,
+    response: &CoreResponse,
     profile: &RenderProfile,
 ) -> Option<OutboundMessage> {
     let rendered = render_respond_response_parts_for_profile(response, profile);
@@ -97,7 +95,7 @@ pub(crate) fn render_respond_response_for_profile(
 }
 
 pub(crate) fn render_respond_response_parts_for_profile(
-    response: &RespondResponse,
+    response: &CoreResponse,
     profile: &RenderProfile,
 ) -> Vec<OutboundMessage> {
     response
@@ -224,7 +222,7 @@ fn render_assistant_output_parts_for_profile(
         .collect()
 }
 
-fn image_payload(media: &qq_maid_core::service::OutputMedia) -> Option<ImagePayload> {
+fn image_payload(media: &OutputMedia) -> Option<ImagePayload> {
     if let Some(file_info) = media
         .media_id
         .as_deref()
@@ -270,7 +268,6 @@ fn output_has_markdown_channel(output: &AssistantOutput) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use qq_maid_core::service::OutputMedia;
 
     fn render_profile(enable_markdown: bool, enable_image: bool) -> RenderProfile {
         RenderProfile {
@@ -282,16 +279,14 @@ mod tests {
         }
     }
 
-    fn response_with_body(text: Option<&str>, markdown: Option<&str>) -> RespondResponse {
+    fn response_with_body(text: Option<&str>, markdown: Option<&str>) -> CoreResponse {
         // 测试直接构造 Core->Gateway 的结构化 output，不再绕旧 text/markdown 字段。
         let output = match (text, markdown) {
-            (Some(text), Some(markdown)) => Some(qq_maid_core::service::AssistantOutput::markdown(
-                text, markdown,
-            )),
-            (Some(text), None) => Some(qq_maid_core::service::AssistantOutput::text(text)),
+            (Some(text), Some(markdown)) => Some(AssistantOutput::markdown(text, markdown)),
+            (Some(text), None) => Some(AssistantOutput::text(text)),
             _ => None,
         };
-        RespondResponse {
+        CoreResponse {
             output,
             handled: Some(true),
             session_id: None,
@@ -301,9 +296,9 @@ mod tests {
         }
     }
 
-    fn response_with_empty_output() -> RespondResponse {
+    fn response_with_empty_output() -> CoreResponse {
         // 渲染层在 output 缺失时返回 None，对应旧空正文路径。
-        RespondResponse {
+        CoreResponse {
             output: None,
             handled: Some(true),
             session_id: None,
@@ -423,7 +418,7 @@ mod tests {
 
     #[test]
     fn structured_output_parts_render_markdown_when_supported() {
-        let response = RespondResponse {
+        let response = CoreResponse {
             output: Some(AssistantOutput {
                 text_fallback: "plain fallback".to_owned(),
                 markdown: None,
@@ -455,7 +450,7 @@ mod tests {
 
     #[test]
     fn structured_output_degrades_to_text_for_text_only_profile() {
-        let response = RespondResponse {
+        let response = CoreResponse {
             output: Some(AssistantOutput {
                 text_fallback: String::new(),
                 markdown: None,
@@ -488,7 +483,7 @@ mod tests {
 
     #[test]
     fn structured_image_part_renders_real_image_when_supported() {
-        let response = RespondResponse {
+        let response = CoreResponse {
             output: Some(AssistantOutput {
                 text_fallback: String::new(),
                 markdown: None,
@@ -518,7 +513,7 @@ mod tests {
 
     #[test]
     fn unsupported_structured_part_uses_explicit_fallback_text() {
-        let response = RespondResponse {
+        let response = CoreResponse {
             output: Some(AssistantOutput {
                 text_fallback: String::new(),
                 markdown: None,
@@ -543,7 +538,7 @@ mod tests {
 
     #[test]
     fn output_with_empty_parts_falls_back_to_text_fallback_and_markdown() {
-        let response = RespondResponse {
+        let response = CoreResponse {
             output: Some(AssistantOutput {
                 text_fallback: "output fallback".to_owned(),
                 markdown: Some("**output markdown**".to_owned()),
@@ -567,7 +562,7 @@ mod tests {
 
     #[test]
     fn markdown_channel_wins_over_duplicate_text_parts() {
-        let response = RespondResponse {
+        let response = CoreResponse {
             output: Some(AssistantOutput {
                 text_fallback: "Markdown 测试".to_owned(),
                 markdown: Some("# Markdown 测试\n\n- **加粗**".to_owned()),

--- a/qq-maid-gateway-rs/src/respond.rs
+++ b/qq-maid-gateway-rs/src/respond.rs
@@ -9,9 +9,10 @@ use qq_maid_common::{
     command_prefix::CommandPrefix,
     input_part::{MediaStatus, MessageInputPart},
 };
+#[cfg(test)]
+use qq_maid_core::service::CoreResponse;
 use qq_maid_core::service::{
-    CoreError, CoreInboundClassification, CoreRequest, CoreRespondOutput, CoreResponse,
-    CoreResponseEvent, CoreResponseStream, CoreService,
+    CoreError, CoreInboundClassification, CoreRequest, CoreRespondOutput, CoreService,
 };
 use thiserror::Error;
 use tracing::{debug, info, warn};
@@ -27,16 +28,6 @@ pub struct RespondClient {
     core: Arc<dyn CoreService>,
     qq_official_account_id: Option<String>,
 }
-
-pub type RespondResponse = CoreResponse;
-
-#[derive(Debug)]
-pub enum RespondTransport {
-    Complete(Box<CoreResponse>),
-    Stream(CoreResponseStream),
-}
-
-pub type RespondEvent = CoreResponseEvent;
 
 #[derive(Debug, Error)]
 pub enum RespondError {
@@ -94,7 +85,7 @@ impl RespondClient {
         &self,
         message: &C2cMessage,
         content: String,
-    ) -> Result<RespondTransport, RespondError> {
+    ) -> Result<CoreRespondOutput, RespondError> {
         let request = self.core_request_from_c2c_message(message, content);
         let masked_user = mask_openid(&message.user_openid);
         let output = self.core.respond(request).await.map_err(|error| {
@@ -107,7 +98,7 @@ impl RespondClient {
             RespondError::Core(error)
         })?;
         log_core_output_success(&message.message_id, Some(&masked_user), None, &output);
-        Ok(output.into())
+        Ok(output)
     }
 
     pub async fn classify_c2c(
@@ -126,7 +117,7 @@ impl RespondClient {
         &self,
         message: &GroupMessage,
         content: String,
-    ) -> Result<RespondTransport, RespondError> {
+    ) -> Result<CoreRespondOutput, RespondError> {
         let request = self.core_request_from_group_message(message, content);
         let masked_group = mask_openid(&message.group_openid);
         let output = self.core.respond(request).await.map_err(|error| {
@@ -139,7 +130,7 @@ impl RespondClient {
             RespondError::Core(error)
         })?;
         log_core_output_success(&message.message_id, None, Some(&masked_group), &output);
-        Ok(output.into())
+        Ok(output)
     }
 
     pub async fn classify_group(
@@ -163,7 +154,7 @@ impl RespondClient {
         &self,
         inbound: &platform::InboundMessage,
         content: String,
-    ) -> Result<RespondTransport, RespondError> {
+    ) -> Result<CoreRespondOutput, RespondError> {
         let (masked_user, masked_group) = masked_log_context_from_inbound(inbound);
         let request = platform::to_core_request(inbound, content).map_err(|error| {
             warn!(
@@ -197,7 +188,7 @@ impl RespondClient {
             masked_group.as_deref(),
             &output,
         );
-        Ok(output.into())
+        Ok(output)
     }
 
     pub(crate) async fn classify_inbound(
@@ -266,15 +257,6 @@ impl RespondClient {
     }
 }
 
-impl From<CoreRespondOutput> for RespondTransport {
-    fn from(value: CoreRespondOutput) -> Self {
-        match value {
-            CoreRespondOutput::Complete(response) => Self::Complete(response),
-            CoreRespondOutput::Stream(stream) => Self::Stream(stream),
-        }
-    }
-}
-
 fn log_core_output_success(
     message_id: &str,
     masked_user: Option<&str>,
@@ -323,20 +305,6 @@ fn masked_log_context_from_inbound(
         "group" => (None, Some(mask_openid(inbound.conversation.target_id()))),
         _ => (None, None),
     }
-}
-
-pub fn core_request_from_c2c_message(message: &C2cMessage, content: String) -> CoreRequest {
-    let inbound = platform::qq_official::inbound_from_c2c(message);
-    log_inbound_media_diagnostics(&inbound);
-    platform::to_core_request(&inbound, content)
-        .expect("QQ C2C inbound message should map to CoreRequest")
-}
-
-pub fn core_request_from_group_message(message: &GroupMessage, content: String) -> CoreRequest {
-    let inbound = platform::qq_official::inbound_from_group(message);
-    log_inbound_media_diagnostics(&inbound);
-    platform::to_core_request(&inbound, content)
-        .expect("QQ group inbound message should map to CoreRequest")
 }
 
 /// Gateway 侧需要在入队前拿到与 Core 完全一致的 scope_key，用于会话串行调度和 reply cache 隔离。
@@ -857,6 +825,10 @@ mod tests {
         }
     }
 
+    fn mapping_client() -> RespondClient {
+        RespondClient::new(Arc::new(NoopCore))
+    }
+
     fn c2c_message(content: &str) -> C2cMessage {
         C2cMessage {
             message_id: "m1".to_owned(),
@@ -904,7 +876,8 @@ mod tests {
 
     #[test]
     fn c2c_message_maps_to_private_core_request() {
-        let request = core_request_from_c2c_message(&c2c_message("/todo"), "/todo".to_owned());
+        let request = mapping_client()
+            .core_request_from_c2c_message(&c2c_message("/todo"), "/todo".to_owned());
 
         assert_eq!(request.text, "/todo");
         assert_eq!(request.platform, Platform::QqOfficial);
@@ -919,7 +892,8 @@ mod tests {
 
     #[test]
     fn group_message_maps_to_group_scope_without_member_split() {
-        let request = core_request_from_group_message(
+        let client = mapping_client();
+        let request = client.core_request_from_group_message(
             &group_message("/rss", Some("member1")),
             "/rss".to_owned(),
         );
@@ -933,7 +907,7 @@ mod tests {
         );
 
         let missing_member =
-            core_request_from_group_message(&group_message("/rss", None), "/rss".to_owned());
+            client.core_request_from_group_message(&group_message("/rss", None), "/rss".to_owned());
         assert_eq!(missing_member.actor.user_id, None);
         assert_eq!(
             missing_member.scope_key(),
@@ -1013,7 +987,8 @@ mod tests {
         let mut message = group_message("/rss add https://example.test/feed.xml", Some("member1"));
         message.member_role = Some(GroupMemberRole::Admin);
 
-        let request = core_request_from_group_message(&message, message.content.clone());
+        let request =
+            mapping_client().core_request_from_group_message(&message, message.content.clone());
 
         assert_eq!(
             request.actor.group_member_role,
@@ -1457,7 +1432,7 @@ mod tests {
 
     #[test]
     fn unsafe_error_detail_is_not_shown_to_user() {
-        let _response = RespondResponse {
+        let _response = CoreResponse {
             output: None,
             handled: Some(false),
             session_id: None,


### PR DESCRIPTION
## 变更

- 删除 Gateway 的 RespondTransport、RespondResponse/RespondEvent 别名及重复转换，直接消费 CoreRespondOutput/CoreResponse/CoreResponseEvent
- 删除未使用的自由 core_request_from_* helper，保留账号感知的 RespondClient 方法与聚合/调度所需 scope helper
- 删除 Core ChatResponse，将 metrics、usage 和 Agent diagnostics 收敛到 RespondOutput 单一路径
- 删除 Core service 对 common 出站内容类型的过时 re-export，输入/输出内容统一从 qq-maid-common 引入
- 更新相关 HTTP facade 与响应边界说明

## 验证

- cargo fmt --all -- --check
- cargo check --workspace --all-targets --all-features
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features（1992 tests passed）
- git diff --check
- 旧类型、旧 helper 与过时 re-export 残留搜索无结果