### PR TITLE
[codex] 修复未闭合反引号导致 LLM 超时

### DIFF
--- a/qq-maid-common/src/markdown/backticks.rs
+++ b/qq-maid-common/src/markdown/backticks.rs
@@ -1,0 +1,135 @@
+//! Markdown 反引号分隔符的字面量兼容处理。
+
+#[derive(Debug, Clone, Copy)]
+struct BacktickRun {
+    start: usize,
+    end: usize,
+    len: usize,
+    escaped: bool,
+    fence_indented: bool,
+    line_suffix_blank: bool,
+}
+
+/// 把没有同长度闭合分隔符的反引号 run 转成 Markdown 字面量转义。
+///
+/// 已闭合的行内代码、围栏代码块与其中使用不同长度分隔符的反引号保持原样。
+pub fn escape_unclosed_backticks(text: &str) -> String {
+    let runs = collect_backtick_runs(text);
+    let mut unmatched = Vec::new();
+    let mut index = 0;
+    while index < runs.len() {
+        if runs[index].escaped {
+            index += 1;
+            continue;
+        }
+        let opening = runs[index];
+        let fenced_closing = (opening.len >= 3 && opening.fence_indented)
+            .then(|| {
+                runs[index + 1..].iter().position(|run| {
+                    !run.escaped
+                        && run.len >= opening.len
+                        && run.fence_indented
+                        && run.line_suffix_blank
+                })
+            })
+            .flatten();
+        let inline_closing = runs[index + 1..]
+            .iter()
+            .position(|run| !run.escaped && run.len == opening.len);
+        let closing = fenced_closing
+            .or(inline_closing)
+            .map(|offset| index + 1 + offset);
+        if let Some(closing) = closing {
+            // 不同长度的 run 可以作为已闭合 code span 的正文，不能单独转义。
+            index = closing + 1;
+        } else {
+            unmatched.push(runs[index]);
+            index += 1;
+        }
+    }
+
+    if unmatched.is_empty() {
+        return text.to_owned();
+    }
+
+    let added_chars = unmatched.iter().map(|run| run.len).sum::<usize>();
+    let mut escaped = String::with_capacity(text.len() + added_chars);
+    let mut cursor = 0;
+    for run in unmatched {
+        escaped.push_str(&text[cursor..run.start]);
+        for _ in 0..run.len {
+            escaped.push_str("\\`");
+        }
+        cursor = run.end;
+    }
+    escaped.push_str(&text[cursor..]);
+    escaped
+}
+
+fn collect_backtick_runs(text: &str) -> Vec<BacktickRun> {
+    let bytes = text.as_bytes();
+    let mut runs = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'`' {
+            index += 1;
+            continue;
+        }
+
+        let start = index;
+        while index < bytes.len() && bytes[index] == b'`' {
+            index += 1;
+        }
+        let preceding_backslashes = bytes[..start]
+            .iter()
+            .rev()
+            .take_while(|byte| **byte == b'\\')
+            .count();
+        let line_start = text[..start].rfind('\n').map_or(0, |position| position + 1);
+        let line_prefix = &text[line_start..start];
+        let line_end = text[index..]
+            .find('\n')
+            .map_or(text.len(), |offset| index + offset);
+        runs.push(BacktickRun {
+            start,
+            end: index,
+            len: index - start,
+            escaped: preceding_backslashes % 2 == 1,
+            fence_indented: line_prefix.len() <= 3 && line_prefix.bytes().all(|byte| byte == b' '),
+            line_suffix_blank: text[index..line_end]
+                .bytes()
+                .all(|byte| matches!(byte, b' ' | b'\t')),
+        });
+    }
+    runs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escapes_only_unclosed_backtick_runs() {
+        let cases = [
+            ("测试`", "测试\\`"),
+            ("`测试", "\\`测试"),
+            ("测试`内容", "测试\\`内容"),
+            (
+                "BAAI/bge-small-zh-v1.5` 这模型配置要求多少",
+                "BAAI/bge-small-zh-v1.5\\` 这模型配置要求多少",
+            ),
+            (
+                "`BAAI/bge-small-zh-v1.5` 这模型配置要求多少",
+                "`BAAI/bge-small-zh-v1.5` 这模型配置要求多少",
+            ),
+            ("```rust\nfn main() {}\n```", "```rust\nfn main() {}\n```"),
+            ("```rust\nfn main() {}\n````", "```rust\nfn main() {}\n````"),
+            ("``code ` tick``", "``code ` tick``"),
+            (r"已经转义 \`", r"已经转义 \`"),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(escape_unclosed_backticks(input), expected, "input={input}");
+        }
+    }
+}

--- a/qq-maid-common/src/markdown/mod.rs
+++ b/qq-maid-common/src/markdown/mod.rs
@@ -12,10 +12,12 @@
 //! - 转义符号 `\\*` `\\_` 还原为字面量；
 //! - `<br>`、`</p>` 等 HTML 标签转换为换行后移除其余标签。
 
+mod backticks;
 mod chat_text;
 mod plain_text;
 mod qq;
 
+pub use backticks::escape_unclosed_backticks;
 pub use chat_text::to_chat_text;
 pub use plain_text::to_plain_text;
 pub use qq::{to_qq, to_qq_with_limit};

--- a/qq-maid-core/src/runtime/respond/llm_service/mod.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service/mod.rs
@@ -12,6 +12,8 @@ use futures::StreamExt;
 use qq_maid_common::output_part::OutputPart;
 use qq_maid_common::{
     identity_context::{ConversationKind, ExecutionActorContext, ExecutionConversationContext},
+    input_part::MessageInputPart,
+    markdown::escape_unclosed_backticks,
     time_context::{RequestTimeContext, request_time_context},
 };
 use qq_maid_llm::{
@@ -578,14 +580,37 @@ fn build_respond_messages_for_model(
 ) -> Vec<ChatMessage> {
     match req.purpose {
         RespondPurpose::Chat => build_chat_messages_for_model(req, supports_vision),
-        RespondPurpose::MemoryDraft => {
-            with_request_time_context_after_system_prefix(build_memory_draft_messages(req), 1)
+        RespondPurpose::MemoryDraft => normalize_user_messages_for_provider(
+            with_request_time_context_after_system_prefix(build_memory_draft_messages(req), 1),
+        ),
+        RespondPurpose::TodoParse => {
+            normalize_user_messages_for_provider(build_todo_parse_messages(req))
         }
-        RespondPurpose::TodoParse => build_todo_parse_messages(req),
-        RespondPurpose::Compact => {
-            with_request_time_context_after_system_prefix(build_compact_messages(req), 1)
+        RespondPurpose::Compact => normalize_user_messages_for_provider(
+            with_request_time_context_after_system_prefix(build_compact_messages(req), 1),
+        ),
+    }
+}
+
+fn normalize_user_messages_for_provider(messages: Vec<ChatMessage>) -> Vec<ChatMessage> {
+    messages
+        .into_iter()
+        .map(normalize_user_message_for_provider)
+        .collect()
+}
+
+fn normalize_user_message_for_provider(mut message: ChatMessage) -> ChatMessage {
+    if message.role != ChatRole::User {
+        return message;
+    }
+
+    message.content = escape_unclosed_backticks(&message.content);
+    for part in &mut message.content_parts {
+        if let MessageInputPart::Text { text, .. } = part {
+            *text = escape_unclosed_backticks(text);
         }
     }
+    message
 }
 
 /// 在消息列表头部注入时间上下文系统消息（如果尚未存在）。
@@ -663,11 +688,14 @@ fn build_chat_messages_for_model(req: &RespondRequest, supports_vision: bool) ->
         req.history_messages
             .iter()
             .filter(|message| !message.content.trim().is_empty())
-            .cloned(),
+            .cloned()
+            .map(normalize_user_message_for_provider),
     );
-    messages.push(ChatMessage::user_with_parts(
-        req.user_text.clone(),
-        current_user_parts_for_model(req, supports_vision),
+    messages.push(normalize_user_message_for_provider(
+        ChatMessage::user_with_parts(
+            req.user_text.clone(),
+            current_user_parts_for_model(req, supports_vision),
+        ),
     ));
     messages
 }
@@ -720,6 +748,7 @@ fn budget_chat_messages(
         .iter()
         .filter(|message| !message.content.trim().is_empty())
         .cloned()
+        .map(normalize_user_message_for_provider)
         .collect::<Vec<_>>();
     for (messages, protected) in
         partition_history_for_budget(&history, config.protected_recent_turns)
@@ -737,10 +766,10 @@ fn budget_chat_messages(
     push_message_item(
         &mut items,
         BudgetItemKind::Required,
-        ChatMessage::user_with_parts(
+        normalize_user_message_for_provider(ChatMessage::user_with_parts(
             req.user_text.clone(),
             current_user_parts_for_model(req, supports_vision),
-        ),
+        )),
     )?;
 
     let budgeted = apply_context_budget(items, config)?;

--- a/qq-maid-core/src/runtime/respond/tests/chat/mod.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat/mod.rs
@@ -49,6 +49,64 @@ async fn chat_returns_markdown_and_plaintext_fallback_for_structured_reply() {
 }
 
 #[tokio::test]
+async fn unclosed_backticks_reach_agent_provider_as_markdown_literals() {
+    let cases = [
+        ("测试`", "测试\\`"),
+        ("`测试", "\\`测试"),
+        ("测试`内容", "测试\\`内容"),
+        (
+            "BAAI/bge-small-zh-v1.5` 这模型配置要求多少",
+            "BAAI/bge-small-zh-v1.5\\` 这模型配置要求多少",
+        ),
+        (
+            "`BAAI/bge-small-zh-v1.5` 这模型配置要求多少",
+            "`BAAI/bge-small-zh-v1.5` 这模型配置要求多少",
+        ),
+        (
+            "```text\n中文 mixed English\n```",
+            "```text\n中文 mixed English\n```",
+        ),
+    ];
+
+    for (input, expected_provider_text) in cases {
+        let inspector = MockProvider::new()
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+            .with_tool_loop_reply_without_tool("正常回复");
+        let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+        let response = service.respond(private_message(input)).await.unwrap();
+
+        assert_eq!(response.text.as_deref(), Some("正常回复"), "input={input}");
+        let request = inspector.tool_requests().remove(0);
+        let current = request.chat.messages.last().unwrap();
+        assert_eq!(current.role, ChatRole::User, "input={input}");
+        assert_eq!(current.content, expected_provider_text, "input={input}");
+        assert!(
+            current
+                .content_parts
+                .iter()
+                .filter_map(|part| match part {
+                    qq_maid_common::input_part::MessageInputPart::Text { text, .. } => Some(text),
+                    _ => None,
+                })
+                .any(|text| text == expected_provider_text),
+            "input={input}"
+        );
+        let session = service
+            .session_store
+            .get_or_create_active(&private_test_meta())
+            .unwrap();
+        assert!(
+            session
+                .history
+                .iter()
+                .any(|message| message.content == input),
+            "session 应保存未经 Provider 兼容转义的用户原文，input={input}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn private_strong_todo_reference_without_context_enters_tool_loop_and_clarifies() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)


### PR DESCRIPTION
## 变更说明

- 在 `qq-maid-common::markdown` 新增未闭合反引号的通用字面量转义，只处理没有闭合分隔符的 run。
- Core 在构造 Provider 请求时统一规范化 user role 的正文、历史消息和文本 part；system / assistant 消息不变。
- session 继续保存用户原文，不把 Provider 兼容转义写回会话。
- 保留成对行内代码、三反引号代码块、不同长度闭合围栏和已转义反引号。

## 根因

当前本地输入链路没有等待反引号闭合的解析循环。问题发生在 Provider 边界：未闭合反引号此前会原样进入模型请求，异常上游不结束流式响应，随后非流式补偿也可能超时，最终向用户显示 LLM 处理超时。

本次修复在发送 Provider 前把未闭合分隔符表达为等价的 Markdown 字面量，避免触发该上游异常，同时不改变本地 session 原文。上游 Provider 内部为何不结束响应仍需结合真实环境日志确认，本 PR 不通过延长超时掩盖问题。

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- 回归测试覆盖 Issue 中 5 组输入、中文/英文混合、代码块、不同长度合法闭合围栏及 session 原文保持。

Closes #535
