### PR TITLE
[codex] 修复 Agent 工具重试结果聚合

### DIFF
--- a/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
+++ b/qq-maid-core/src/runtime/respond/chat_flow/mod.rs
@@ -342,6 +342,12 @@ impl RustRespondService {
                 })
             })
             .collect::<Vec<_>>();
+        let tool_retry_count = output
+            .agent
+            .tool_attempts
+            .iter()
+            .filter(|attempt| attempt.retry_of.is_some())
+            .count();
         let agent_result = output
             .agent
             .stop_reason
@@ -407,7 +413,7 @@ impl RustRespondService {
             "agent_tool_results": agent_tool_results,
             "agent_turn_status": agent_diagnostics["agent_turn_status"].clone(),
             "tool_outcomes": agent_diagnostics["tool_outcomes"].clone(),
-            "tool_retry_count": 0,
+            "tool_retry_count": tool_retry_count,
             "error_code": if let Some(error_code) = agent_turn_outcome
                 .as_ref()
                 .and_then(AgentTurnOutcome::primary_error_code)

--- a/qq-maid-core/src/runtime/respond/tests/agent_turn.rs
+++ b/qq-maid-core/src/runtime/respond/tests/agent_turn.rs
@@ -3,7 +3,7 @@
 //! 这里只验证 Respond 对可信 Tool outcome 的组合、顺序、状态和用户可见结果；
 //! 具体工具参数、存储和领域状态机由各工具域测试负责。
 
-use qq_maid_llm::provider::ToolCallingProtocol;
+use qq_maid_llm::provider::{ToolCallingProtocol, ToolExecutionAttempt};
 use serde_json::Value;
 
 use crate::runtime::tools::todo::{TodoItemDraft, TodoStore, TodoTimePrecision};
@@ -54,6 +54,160 @@ async fn multi_entity_web_search_fact_card_preserves_model_summary_without_empty
     assert_eq!(response.command.as_deref(), Some("web_search"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["tool_outcomes"][0]["presentation"], "trusted");
+}
+
+#[tokio::test]
+async fn web_search_retry_renders_only_final_empty_result_and_keeps_attempt_trace() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_raw_tool_results_and_attempts(
+            vec![
+                raw_tool_result(
+                    "web_search",
+                    serde_json::json!({
+                        "ok": false,
+                        "error": {"code": "empty_result", "stage": "web_search"}
+                    }),
+                    false,
+                ),
+                raw_tool_result(
+                    "web_search",
+                    serde_json::json!({"ok": true, "answer": ""}),
+                    true,
+                ),
+            ],
+            vec![
+                ToolExecutionAttempt {
+                    result_index: 0,
+                    call_id: "call-1".to_owned(),
+                    round: 0,
+                    retry_of: None,
+                },
+                ToolExecutionAttempt {
+                    result_index: 1,
+                    call_id: "call-2".to_owned(),
+                    round: 1,
+                    retry_of: Some(0),
+                },
+            ],
+            "模型最终回复",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector, true);
+
+    let response = service
+        .respond(private_message("搜索公开项目"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert_eq!(text.matches("【联网查询】").count(), 1);
+    assert_eq!(text.matches("没查到明确结果").count(), 1);
+    assert!(!text.contains("联网查询服务暂时不可用"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(
+        diagnostics["agent_tool_results"].as_array().unwrap().len(),
+        2
+    );
+    assert_eq!(diagnostics["tool_outcomes"].as_array().unwrap().len(), 1);
+    assert_eq!(diagnostics["tool_outcomes"][0]["status"], "succeeded");
+    assert_eq!(diagnostics["tool_retry_count"], 1);
+    assert!(diagnostics.get("tool_attempts").is_none());
+}
+
+#[tokio::test]
+async fn web_search_retry_renders_final_success_without_previous_failure() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_raw_tool_results_and_attempts(
+            vec![
+                raw_tool_result(
+                    "web_search",
+                    serde_json::json!({
+                        "ok": false,
+                        "error": {"code": "empty_result", "stage": "web_search"}
+                    }),
+                    false,
+                ),
+                raw_tool_result(
+                    "web_search",
+                    serde_json::json!({"ok": true, "answer": "项目最终结果"}),
+                    true,
+                ),
+            ],
+            vec![
+                ToolExecutionAttempt {
+                    result_index: 0,
+                    call_id: "call-1".to_owned(),
+                    round: 0,
+                    retry_of: None,
+                },
+                ToolExecutionAttempt {
+                    result_index: 1,
+                    call_id: "call-2".to_owned(),
+                    round: 1,
+                    retry_of: Some(0),
+                },
+            ],
+            "模型最终回复",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector, true);
+
+    let response = service
+        .respond(private_message("搜索公开项目"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert_eq!(text.matches("【联网查询】").count(), 1);
+    assert!(text.contains("项目最终结果"));
+    assert!(!text.contains("联网查询服务暂时不可用"));
+}
+
+#[tokio::test]
+async fn independent_web_search_results_are_rendered_separately() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_raw_tool_results_and_attempts(
+            vec![
+                raw_tool_result(
+                    "web_search",
+                    serde_json::json!({"ok": true, "answer": "项目甲结果"}),
+                    true,
+                ),
+                raw_tool_result(
+                    "web_search",
+                    serde_json::json!({"ok": true, "answer": "项目乙结果"}),
+                    true,
+                ),
+            ],
+            vec![
+                ToolExecutionAttempt {
+                    result_index: 0,
+                    call_id: "call-1".to_owned(),
+                    round: 0,
+                    retry_of: None,
+                },
+                ToolExecutionAttempt {
+                    result_index: 1,
+                    call_id: "call-2".to_owned(),
+                    round: 0,
+                    retry_of: None,
+                },
+            ],
+            "模型最终回复",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector, true);
+
+    let response = service
+        .respond(private_message("搜索两个项目"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert_eq!(text.matches("【联网查询】").count(), 2);
+    assert!(text.contains("项目甲结果"));
+    assert!(text.contains("项目乙结果"));
+    assert_eq!(response.diagnostics.unwrap()["tool_retry_count"], 0);
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tests/agent_turn.rs
+++ b/qq-maid-core/src/runtime/respond/tests/agent_turn.rs
@@ -164,6 +164,77 @@ async fn web_search_retry_renders_final_success_without_previous_failure() {
 }
 
 #[tokio::test]
+async fn cross_candidate_retry_projection_keeps_prior_result_and_hides_only_retried_failure() {
+    // 模拟累计 diagnostics：候选 A 成功一次，候选 B 失败后重试成功。
+    // retry_of 使用全局下标 1，不得把候选 A 的结果 0 误隐藏。
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_raw_tool_results_and_attempts(
+            vec![
+                raw_tool_result(
+                    "web_search",
+                    serde_json::json!({"ok": true, "answer": "候选A结果"}),
+                    true,
+                ),
+                raw_tool_result(
+                    "web_search",
+                    serde_json::json!({
+                        "ok": false,
+                        "error": {"code": "empty_result", "stage": "web_search"}
+                    }),
+                    false,
+                ),
+                raw_tool_result(
+                    "web_search",
+                    serde_json::json!({"ok": true, "answer": "候选B最终结果"}),
+                    true,
+                ),
+            ],
+            vec![
+                ToolExecutionAttempt {
+                    result_index: 0,
+                    call_id: "a1".to_owned(),
+                    round: 0,
+                    retry_of: None,
+                },
+                ToolExecutionAttempt {
+                    result_index: 1,
+                    call_id: "b1".to_owned(),
+                    round: 0,
+                    retry_of: None,
+                },
+                ToolExecutionAttempt {
+                    result_index: 2,
+                    call_id: "b2".to_owned(),
+                    round: 1,
+                    retry_of: Some(1),
+                },
+            ],
+            "模型最终回复",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector, true);
+
+    let response = service
+        .respond(private_message("搜索公开项目"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert_eq!(text.matches("【联网查询】").count(), 2);
+    assert!(text.contains("候选A结果"));
+    assert!(text.contains("候选B最终结果"));
+    assert!(!text.contains("联网查询服务暂时不可用"));
+    assert!(!text.contains("没查到明确结果"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(
+        diagnostics["agent_tool_results"].as_array().unwrap().len(),
+        3
+    );
+    assert_eq!(diagnostics["tool_outcomes"].as_array().unwrap().len(), 2);
+    assert_eq!(diagnostics["tool_retry_count"], 1);
+}
+
+#[tokio::test]
 async fn independent_web_search_results_are_rendered_separately() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)

--- a/qq-maid-core/src/runtime/respond/tests/support/mock_provider.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support/mock_provider.rs
@@ -15,6 +15,7 @@ fn agent_tool_trace(
         side_effecting_tools_started: executed_tools.clone(),
         executed_tools,
         tool_results,
+        tool_attempts: Vec::new(),
         tools_with_unknown_result: Vec::new(),
         streaming_fallback_used: false,
         stop_reason: Some(AgentStopReason::ToolUsed),
@@ -66,6 +67,7 @@ enum MockToolAction {
     },
     ReturnToolResults {
         results: Vec<ToolExecutionResult>,
+        attempts: Vec<ToolExecutionAttempt>,
         reply: String,
     },
     ReplyWithoutTool {
@@ -248,6 +250,24 @@ impl MockProvider {
             .unwrap()
             .push(MockToolAction::ReturnToolResults {
                 results,
+                attempts: Vec::new(),
+                reply: reply.into(),
+            });
+        self
+    }
+
+    pub(crate) fn with_raw_tool_results_and_attempts(
+        self,
+        results: Vec<ToolExecutionResult>,
+        attempts: Vec<ToolExecutionAttempt>,
+        reply: impl Into<String>,
+    ) -> Self {
+        self.tool_actions
+            .lock()
+            .unwrap()
+            .push(MockToolAction::ReturnToolResults {
+                results,
+                attempts,
                 reply: reply.into(),
             });
         self
@@ -634,7 +654,11 @@ impl LlmProvider for MockProvider {
                     diagnostics.stop_reason = Some(AgentStopReason::Failed);
                     return Err(error.with_agent(diagnostics));
                 }
-                MockToolAction::ReturnToolResults { results, reply } => {
+                MockToolAction::ReturnToolResults {
+                    results,
+                    attempts,
+                    reply,
+                } => {
                     let emitted_tools = results
                         .iter()
                         .map(|result| result.name.clone())
@@ -661,7 +685,21 @@ impl LlmProvider for MockProvider {
                             total_tokens: None,
                         }),
                         fallback_used: false,
-                        agent: agent_tool_trace(emitted_tools, results),
+                        agent: AgentRunDiagnostics {
+                            model_rounds: 3,
+                            emitted_tools,
+                            tool_execution_attempted: true,
+                            executed_tools: results
+                                .iter()
+                                .map(|result| result.name.clone())
+                                .collect(),
+                            side_effecting_tools_started: Vec::new(),
+                            tool_results: results,
+                            tool_attempts: attempts,
+                            tools_with_unknown_result: Vec::new(),
+                            streaming_fallback_used: false,
+                            stop_reason: Some(AgentStopReason::ToolUsed),
+                        },
                     });
                 }
                 MockToolAction::ReplyWithoutTool { reply } => {
@@ -715,6 +753,7 @@ impl LlmProvider for MockProvider {
                             executed_tools: Vec::new(),
                             side_effecting_tools_started: Vec::new(),
                             tool_results: Vec::new(),
+                            tool_attempts: Vec::new(),
                             tools_with_unknown_result: Vec::new(),
                             streaming_fallback_used: false,
                             stop_reason: Some(AgentStopReason::Rejected),

--- a/qq-maid-core/src/runtime/respond/tests/support/mod.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support/mod.rs
@@ -12,7 +12,7 @@ use chrono::{Duration, NaiveDate};
 use qq_maid_llm::{
     provider::{
         AgentRunDiagnostics, AgentStopReason, ChatOutcome, LlmProvider, ToolCallingProtocol,
-        ToolChatRequest, ToolExecutionResult,
+        ToolChatRequest, ToolExecutionAttempt, ToolExecutionResult,
         types::{ChatRequest, ChatRole, TokenUsage},
     },
     web_search::{WebSearchExecutor, WebSearchOutcome, WebSearchRequest, WebSearchSource},

--- a/qq-maid-core/src/runtime/tools/agent_turn.rs
+++ b/qq-maid-core/src/runtime/tools/agent_turn.rs
@@ -197,6 +197,17 @@ fn project_tool_turn(
     let mut todo_outcomes = todo_projection.outcomes.into_iter().peekable();
 
     for (index, result) in output.agent.tool_results.iter().enumerate() {
+        if output
+            .agent
+            .tool_attempts
+            .iter()
+            .any(|attempt| attempt.retry_of == Some(index))
+        {
+            // 旧尝试仍保留在 Agent diagnostics；这里只丢弃它对应的用户展示块。
+            let mut discarded = Vec::new();
+            drain_todo_outcomes_for_result(index, &mut todo_outcomes, &mut discarded);
+            continue;
+        }
         if todo_projection.consumed_result_indexes.contains(&index) {
             drain_todo_outcomes_for_result(index, &mut todo_outcomes, &mut outcomes);
         } else if let Some(outcome) = tool_outcome_from_weather_result(result) {

--- a/qq-maid-llm/src/agent_loop/mod.rs
+++ b/qq-maid-llm/src/agent_loop/mod.rs
@@ -44,8 +44,8 @@ pub use runner::{run_agent_loop, run_agent_loop_with_handle};
 pub use session::{AgentStepSession, AgentStreamingDiagnostics};
 pub use types::{
     AgentRunDiagnostics, AgentRunHandle, AgentSessionRequest, AgentStep, AgentStopReason,
-    AgentTextDeltaFuture, AgentTextDeltaSink, AgentToolCall, AgentToolResult, ToolExecutionResult,
-    ToolLoopProgressEvent, ToolLoopProgressFuture, ToolLoopProgressSink,
+    AgentTextDeltaFuture, AgentTextDeltaSink, AgentToolCall, AgentToolResult, ToolExecutionAttempt,
+    ToolExecutionResult, ToolLoopProgressEvent, ToolLoopProgressFuture, ToolLoopProgressSink,
 };
 
 #[cfg(test)]

--- a/qq-maid-llm/src/agent_loop/runner.rs
+++ b/qq-maid-llm/src/agent_loop/runner.rs
@@ -660,8 +660,19 @@ fn sync_diagnostics(
         diagnostics.executed_tools.extend(executor.executed_tools());
         diagnostics.tool_results.truncate(baseline.tool_results);
         diagnostics.tool_results.extend(executor.tool_results());
-        diagnostics.tool_attempts.truncate(baseline.tool_results);
-        diagnostics.tool_attempts.extend(executor.tool_attempts());
+        // ToolLoopExecutor 内 result_index / retry_of 是候选局部下标；累计
+        // diagnostics 需要换成全局下标，否则跨 Provider 候选时会误指向前一个
+        // 候选的结果。tool_attempts 长度也独立截断，不假设与 tool_results 相等。
+        diagnostics.tool_attempts.truncate(baseline.tool_attempts);
+        diagnostics
+            .tool_attempts
+            .extend(executor.tool_attempts().into_iter().map(|mut attempt| {
+                attempt.result_index += baseline.tool_results;
+                if let Some(retry_of) = attempt.retry_of.as_mut() {
+                    *retry_of += baseline.tool_results;
+                }
+                attempt
+            }));
     });
 }
 

--- a/qq-maid-llm/src/agent_loop/runner.rs
+++ b/qq-maid-llm/src/agent_loop/runner.rs
@@ -660,6 +660,8 @@ fn sync_diagnostics(
         diagnostics.executed_tools.extend(executor.executed_tools());
         diagnostics.tool_results.truncate(baseline.tool_results);
         diagnostics.tool_results.extend(executor.tool_results());
+        diagnostics.tool_attempts.truncate(baseline.tool_results);
+        diagnostics.tool_attempts.extend(executor.tool_attempts());
     });
 }
 
@@ -737,10 +739,12 @@ async fn execute_tool_batch(
                 },
                 round,
                 index,
+                calls.len(),
                 run_handle.tool_execution_deadline(),
             )
         })
         .collect::<Vec<_>>();
+    executor.begin_batch();
     let mut results = Vec::with_capacity(calls.len());
     let mut skipped_for_finalization = false;
     for (call, prepared) in calls.iter().zip(prepared_calls) {
@@ -792,6 +796,7 @@ async fn execute_tool_batch(
             output: output.output,
         });
     }
+    executor.finish_batch();
     Ok(ToolBatchOutcome {
         results,
         skipped_for_finalization,

--- a/qq-maid-llm/src/agent_loop/tests/mod.rs
+++ b/qq-maid-llm/src/agent_loop/tests/mod.rs
@@ -306,6 +306,42 @@ struct NamedSlowReadOnlyTool {
     delay: std::time::Duration,
 }
 
+struct FailOnceReadOnlyTool {
+    calls: Arc<StdMutex<usize>>,
+}
+
+#[async_trait]
+impl crate::tool::Tool for FailOnceReadOnlyTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            name: "search".to_owned(),
+            description: "fails once then returns a read-only result".to_owned(),
+            parameters: json!({
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+                "required": ["value"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn effect(&self) -> ToolEffect {
+        ToolEffect::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: ToolContext, arguments: Value) -> Result<ToolOutput, LlmError> {
+        let mut calls = self.calls.lock().unwrap();
+        *calls += 1;
+        if *calls == 1 {
+            return Err(LlmError::new("tool_failed", "simulated failure", "tool"));
+        }
+        Ok(ToolOutput::json(json!({
+            "ok": true,
+            "value": arguments["value"],
+        })))
+    }
+}
+
 #[async_trait]
 impl crate::tool::Tool for NamedSlowReadOnlyTool {
     fn metadata(&self) -> ToolMetadata {

--- a/qq-maid-llm/src/agent_loop/tests/tool_execution.rs
+++ b/qq-maid-llm/src/agent_loop/tests/tool_execution.rs
@@ -82,6 +82,89 @@ async fn failed_tool_followed_by_same_singleton_call_is_recorded_as_retry() {
 }
 
 #[tokio::test]
+async fn cross_candidate_retry_indexes_are_offset_to_global() {
+    let handle = AgentRunHandle::default();
+
+    // 候选 A：先产生一个成功工具结果，再因模型错误退出。
+    handle.begin_candidate_attempt().unwrap();
+    let calls_a = Arc::new(StdMutex::new(0));
+    let registry_a = registry_with(vec![Arc::new(SlowReadOnlyTool {
+        calls: calls_a.clone(),
+        delay: std::time::Duration::ZERO,
+    }) as _]);
+    let err = run_agent_loop_with_handle(
+        Box::new(ErrorScriptSession {
+            script: VecDeque::from([
+                Ok(tool_calls(vec![tool_call(
+                    "search",
+                    "a1",
+                    r#"{"value":"a"}"#,
+                )])),
+                Err(LlmError::provider("candidate a failed", "provider")),
+            ]),
+        }),
+        registry_a,
+        test_context(),
+        3,
+        None,
+        None,
+        Some(handle.clone()),
+    )
+    .await
+    .unwrap_err();
+    let after_a = err.agent.expect("candidate a diagnostics");
+    assert_eq!(after_a.tool_results.len(), 1);
+    assert!(after_a.tool_results[0].succeeded);
+    assert_eq!(after_a.tool_attempts.len(), 1);
+    assert_eq!(after_a.tool_attempts[0].result_index, 0);
+    assert_eq!(after_a.tool_attempts[0].retry_of, None);
+
+    // 候选 B：同一 AgentRunHandle 上失败后重试成功。
+    handle.begin_candidate_attempt().unwrap();
+    let calls_b = Arc::new(StdMutex::new(0));
+    let registry_b = registry_with(vec![Arc::new(FailOnceReadOnlyTool {
+        calls: calls_b.clone(),
+    }) as _]);
+    let outcome = run_agent_loop_with_handle(
+        Box::new(ScriptedSession::new(
+            "mock",
+            "m",
+            vec![
+                tool_calls(vec![tool_call("search", "b1", r#"{"value":"rust"}"#)]),
+                tool_calls(vec![tool_call("search", "b2", r#"{"value":"rust"}"#)]),
+                final_reply("done"),
+            ],
+        )),
+        registry_b,
+        test_context(),
+        3,
+        None,
+        None,
+        Some(handle.clone()),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(*calls_a.lock().unwrap(), 1);
+    assert_eq!(*calls_b.lock().unwrap(), 2);
+    assert_eq!(outcome.agent.tool_results.len(), 3);
+    assert_eq!(outcome.agent.tool_attempts.len(), 3);
+
+    // 候选 A 的全局下标保持不变。
+    assert_eq!(outcome.agent.tool_attempts[0].result_index, 0);
+    assert_eq!(outcome.agent.tool_attempts[0].retry_of, None);
+    assert!(outcome.agent.tool_results[0].succeeded);
+
+    // 候选 B 的局部 0/1 应偏移为全局 1/2，retry_of 指向 B 的失败结果而非 A。
+    assert_eq!(outcome.agent.tool_attempts[1].result_index, 1);
+    assert_eq!(outcome.agent.tool_attempts[1].retry_of, None);
+    assert!(!outcome.agent.tool_results[1].succeeded);
+    assert_eq!(outcome.agent.tool_attempts[2].result_index, 2);
+    assert_eq!(outcome.agent.tool_attempts[2].retry_of, Some(1));
+    assert!(outcome.agent.tool_results[2].succeeded);
+}
+
+#[tokio::test]
 async fn independent_same_round_calls_are_not_recorded_as_retry() {
     let calls = Arc::new(StdMutex::new(0));
     let registry = registry_with(vec![Arc::new(FailOnceReadOnlyTool {

--- a/qq-maid-llm/src/agent_loop/tests/tool_execution.rs
+++ b/qq-maid-llm/src/agent_loop/tests/tool_execution.rs
@@ -53,6 +53,68 @@ async fn duplicate_read_only_tool_call_replays_success_and_keeps_dependency_chai
 }
 
 #[tokio::test]
+async fn failed_tool_followed_by_same_singleton_call_is_recorded_as_retry() {
+    let calls = Arc::new(StdMutex::new(0));
+    let registry = registry_with(vec![Arc::new(FailOnceReadOnlyTool {
+        calls: calls.clone(),
+    }) as _]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![tool_call("search", "c1", r#"{"value":"rust"}"#)]),
+            tool_calls(vec![tool_call("search", "c2", r#"{"value":"rust"}"#)]),
+            final_reply("done"),
+        ],
+    ));
+
+    let outcome = run_agent_loop(session, registry, test_context(), 3, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(*calls.lock().unwrap(), 2);
+    assert_eq!(outcome.agent.tool_results.len(), 2);
+    assert!(!outcome.agent.tool_results[0].succeeded);
+    assert!(outcome.agent.tool_results[1].succeeded);
+    assert_eq!(outcome.agent.tool_attempts.len(), 2);
+    assert_eq!(outcome.agent.tool_attempts[0].retry_of, None);
+    assert_eq!(outcome.agent.tool_attempts[1].retry_of, Some(0));
+}
+
+#[tokio::test]
+async fn independent_same_round_calls_are_not_recorded_as_retry() {
+    let calls = Arc::new(StdMutex::new(0));
+    let registry = registry_with(vec![Arc::new(FailOnceReadOnlyTool {
+        calls: calls.clone(),
+    }) as _]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![
+                tool_call("search", "c1", r#"{"value":"rust"}"#),
+                tool_call("search", "c2", r#"{"value":"rust"}"#),
+            ]),
+            final_reply("done"),
+        ],
+    ));
+
+    let outcome = run_agent_loop(session, registry, test_context(), 3, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(*calls.lock().unwrap(), 2);
+    assert_eq!(outcome.agent.tool_attempts.len(), 2);
+    assert!(
+        outcome
+            .agent
+            .tool_attempts
+            .iter()
+            .all(|attempt| attempt.retry_of.is_none())
+    );
+}
+
+#[tokio::test]
 async fn side_effecting_tool_invalidates_read_only_deduplication() {
     let search_calls = Arc::new(StdMutex::new(0));
     let write_calls = Arc::new(StdMutex::new(0));

--- a/qq-maid-llm/src/agent_loop/types.rs
+++ b/qq-maid-llm/src/agent_loop/types.rs
@@ -32,6 +32,18 @@ pub struct ToolExecutionResult {
     pub succeeded: bool,
 }
 
+/// Tool 结果在 Agent Loop 内部的尝试关系。
+///
+/// 该轨迹不属于 LLM 工具返回 JSON，只用于 Core 在最终响应组装时选择重试链的
+/// 最后一次结果；原始 `tool_results` 仍完整保留，便于诊断和错误分析。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ToolExecutionAttempt {
+    pub result_index: usize,
+    pub call_id: String,
+    pub round: usize,
+    pub retry_of: Option<usize>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentStopReason {
@@ -75,6 +87,9 @@ pub struct AgentRunDiagnostics {
     pub side_effecting_tools_started: Vec<String>,
     /// 已经明确完成的工具执行摘要，包含成功结果和结构化失败结果。
     pub tool_results: Vec<ToolExecutionResult>,
+    /// 与 `tool_results` 按结果下标对应的内部尝试关系；不序列化到公共诊断 JSON。
+    #[serde(skip)]
+    pub tool_attempts: Vec<ToolExecutionAttempt>,
     /// 已开始但尚未形成可信结果的工具名。
     ///
     /// Core 取消或超时等待预算耗尽时，该字段明确表示副作用结果仍不确定，

--- a/qq-maid-llm/src/agent_loop/types.rs
+++ b/qq-maid-llm/src/agent_loop/types.rs
@@ -36,6 +36,10 @@ pub struct ToolExecutionResult {
 ///
 /// 该轨迹不属于 LLM 工具返回 JSON，只用于 Core 在最终响应组装时选择重试链的
 /// 最后一次结果；原始 `tool_results` 仍完整保留，便于诊断和错误分析。
+///
+/// 写入累计 `AgentRunDiagnostics` 后，`result_index` 与 `retry_of` 都是相对整次
+/// 请求 `tool_results` 的全局下标；`ToolLoopExecutor` 内部短暂使用的局部下标
+/// 会在候选同步时按 baseline 偏移。
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ToolExecutionAttempt {
     pub result_index: usize,
@@ -409,6 +413,8 @@ pub(crate) struct AgentAttemptBaseline {
     pub(crate) emitted_tools: usize,
     pub(crate) executed_tools: usize,
     pub(crate) tool_results: usize,
+    /// 与 `tool_results` 独立维护；两者长度在失败截断或历史兼容路径下可能不一致。
+    pub(crate) tool_attempts: usize,
 }
 
 impl AgentAttemptBaseline {
@@ -417,6 +423,7 @@ impl AgentAttemptBaseline {
             emitted_tools: diagnostics.emitted_tools.len(),
             executed_tools: diagnostics.executed_tools.len(),
             tool_results: diagnostics.tool_results.len(),
+            tool_attempts: diagnostics.tool_attempts.len(),
         }
     }
 }

--- a/qq-maid-llm/src/provider/mod.rs
+++ b/qq-maid-llm/src/provider/mod.rs
@@ -44,7 +44,7 @@ use crate::{
 use qq_maid_common::output_part::OutputPart;
 
 pub use crate::agent_loop::{
-    AgentRunDiagnostics, AgentRunHandle, AgentStopReason, ToolExecutionResult,
+    AgentRunDiagnostics, AgentRunHandle, AgentStopReason, ToolExecutionAttempt, ToolExecutionResult,
 };
 
 // 候选链构建与 provider 预检 helper 来源于拆分后的子模块，这里 `use` 进来同时供

--- a/qq-maid-llm/src/provider/tool_loop.rs
+++ b/qq-maid-llm/src/provider/tool_loop.rs
@@ -12,7 +12,7 @@ use tracing::debug;
 use crate::{
     agent_loop::{ToolLoopProgressEvent, ToolLoopProgressSink},
     error::LlmError,
-    provider::ToolExecutionResult,
+    provider::{ToolExecutionAttempt, ToolExecutionResult},
     tool::{PreparedToolCall, ToolCallDependency, ToolContext, ToolEffect, ToolRegistry},
 };
 
@@ -22,10 +22,13 @@ pub(crate) struct ToolLoopExecutor<'a> {
     previous_call_succeeded: bool,
     executed_tools: Vec<String>,
     tool_results: Vec<ToolExecutionResult>,
+    tool_attempts: Vec<ToolExecutionAttempt>,
     progress_sink: Option<ToolLoopProgressSink>,
     execution_attempted: bool,
     rejected_call: bool,
     completed_read_only_calls: HashMap<String, String>,
+    last_batch: Vec<BatchAttempt>,
+    current_batch: Vec<BatchAttempt>,
 }
 
 pub(crate) struct ToolLoopCall<'a> {
@@ -47,6 +50,20 @@ pub(crate) enum ToolCallStartDecision {
 pub(crate) struct PreparedToolLoopCall {
     tool_name: String,
     prepared: Result<PreparedToolCall, LlmError>,
+    call_id: String,
+    round: usize,
+    batch_len: usize,
+}
+
+#[derive(Debug, Clone)]
+struct BatchAttempt {
+    result_index: usize,
+    call_id: String,
+    name: String,
+    arguments: Value,
+    succeeded: bool,
+    executed: bool,
+    round: usize,
 }
 
 impl<'a> ToolLoopExecutor<'a> {
@@ -65,6 +82,9 @@ impl<'a> ToolLoopExecutor<'a> {
             execution_attempted: false,
             rejected_call: false,
             completed_read_only_calls: HashMap::new(),
+            tool_attempts: Vec::new(),
+            last_batch: Vec::new(),
+            current_batch: Vec::new(),
         }
     }
 
@@ -77,6 +97,7 @@ impl<'a> ToolLoopExecutor<'a> {
         call: ToolLoopCall<'_>,
         round: usize,
         index: usize,
+        batch_len: usize,
         execution_deadline: Option<tokio::time::Instant>,
     ) -> PreparedToolLoopCall {
         self.execution_attempted = true;
@@ -91,7 +112,18 @@ impl<'a> ToolLoopExecutor<'a> {
         PreparedToolLoopCall {
             tool_name: call.name.to_owned(),
             prepared: self.tools.prepare_json(&context, call.name, call.arguments),
+            call_id: call.call_id.to_owned(),
+            round,
+            batch_len,
         }
+    }
+
+    pub(crate) fn begin_batch(&mut self) {
+        self.current_batch.clear();
+    }
+
+    pub(crate) fn finish_batch(&mut self) {
+        self.last_batch = std::mem::take(&mut self.current_batch);
     }
 
     pub(crate) async fn execute_prepared_call(
@@ -104,8 +136,24 @@ impl<'a> ToolLoopExecutor<'a> {
         let PreparedToolLoopCall {
             tool_name: requested_tool_name,
             prepared,
+            call_id,
+            round,
+            batch_len,
         } = call;
         let mut skipped_for_finalization = false;
+        let mut tool_started = false;
+        let prepared_arguments = prepared
+            .as_ref()
+            .ok()
+            .map(|call| (call.name.clone(), call.arguments.clone()));
+        let retry_of = self.retry_parent(
+            &call_id,
+            round,
+            batch_len,
+            prepared_arguments
+                .as_ref()
+                .map(|(name, arguments)| (name.as_str(), arguments)),
+        );
         let (tool_name, output, succeeded) = match prepared {
             Ok(prepared) => {
                 let tool_name = prepared.name.clone();
@@ -140,6 +188,7 @@ impl<'a> ToolLoopExecutor<'a> {
                             )
                         }
                         ToolCallStartDecision::Execute => {
+                            tool_started = true;
                             self.emit_progress(ToolLoopProgressEvent::ToolCallStarted {
                                 tool_name: tool_name.clone(),
                             })
@@ -183,7 +232,25 @@ impl<'a> ToolLoopExecutor<'a> {
             }
         };
         let result = tool_execution_result(&tool_name, &output, succeeded);
+        let result_index = self.tool_results.len();
         self.tool_results.push(result.clone());
+        self.tool_attempts.push(ToolExecutionAttempt {
+            result_index,
+            call_id: call_id.clone(),
+            round,
+            retry_of,
+        });
+        if let Some((name, arguments)) = prepared_arguments {
+            self.current_batch.push(BatchAttempt {
+                result_index,
+                call_id,
+                name,
+                arguments,
+                succeeded,
+                executed: tool_started,
+                round,
+            });
+        }
         // 工具已经完成后先落可信轨迹，再通知上层；receiver 此时关闭不能抹掉结果。
         on_result(result);
         self.emit_progress(event).await?;
@@ -201,6 +268,10 @@ impl<'a> ToolLoopExecutor<'a> {
         self.tool_results.clone()
     }
 
+    pub(crate) fn tool_attempts(&self) -> Vec<ToolExecutionAttempt> {
+        self.tool_attempts.clone()
+    }
+
     pub(crate) fn execution_attempted(&self) -> bool {
         self.execution_attempted
     }
@@ -216,6 +287,38 @@ impl<'a> ToolLoopExecutor<'a> {
         // progress sink 是 Core stream 的取消边界：返回 Err 表示上层不再消费事件，
         // 继续执行工具可能产生无人接收的副作用，因此必须把错误向外传播。
         sink(event).await
+    }
+
+    fn retry_parent(
+        &self,
+        call_id: &str,
+        round: usize,
+        batch_len: usize,
+        prepared: Option<(&str, &Value)>,
+    ) -> Option<usize> {
+        // Provider 协议没有统一的 parent-call 字段。只有“上一轮单个调用失败、
+        // 当前轮仍是单个同工具调用”才建立保守的重试关系；没有复用 call_id 时还
+        // 要求参数完全一致。同轮多个调用和跨轮不同参数调用均保持独立，避免按
+        // 工具名或展示文本误合并。
+        if batch_len != 1 || self.last_batch.len() != 1 {
+            return None;
+        }
+        let previous = &self.last_batch[0];
+        let (name, arguments) = prepared?;
+        if previous.succeeded
+            || !previous.executed
+            || previous.round + 1 != round
+            || previous.name != name
+        {
+            return None;
+        }
+        // 优先使用 provider 复用的真实 call_id；不同协议的重试通常会生成新 ID，
+        // 此时才退回到严格的单例批次 + 同参数边界。
+        let same_call_id = !call_id.trim().is_empty() && previous.call_id == call_id;
+        if !same_call_id && previous.arguments != *arguments {
+            return None;
+        }
+        Some(previous.result_index)
     }
 }
 


### PR DESCRIPTION
## 变更

- 在 Agent Loop 内记录工具尝试关系，保留完整原始 `tool_results`。
- 响应聚合时只展示明确重试链的最终结果，独立工具调用继续分别展示。
- 继续复用 #552 的联网查询可信结果卡片，不修改 `web_search` 公共返回结构，也不修改 Gateway 发送逻辑。
- 增加重试次数诊断字段，并补充 Agent Loop 与 Core Agent Turn 测试。
- **补充修复**：跨 Provider 候选回退时，将 `result_index` / `retry_of` 从候选局部下标转换为累计全局下标；`AgentAttemptBaseline` 独立维护 `tool_attempts` 长度。

## 根因

同一 Agent Turn 中，`web_search` 第一次失败后模型发起第二次尝试。原响应组装逻辑将两次结果都投影成用户可见区块，因此重复显示联网查询失败提示。问题发生在 Agent Turn 结果聚合，不在 Gateway。

跨 Provider 候选时，`ToolLoopExecutor` 内 `result_index` / `retry_of` 是候选局部下标，但累计 `AgentRunDiagnostics` 与 Core `project_tool_turn()` 按全局下标判断重试覆盖。候选 B 的 `retry_of: Some(0)` 会误指向候选 A 的结果 0，错误隐藏 A 的结果并留下 B 的失败卡片。

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy -p qq-maid-llm -p qq-maid-core --all-targets --all-features -- -D warnings`
- `cargo test -p qq-maid-llm`（260 passed）
- `cargo test -p qq-maid-core runtime::respond::tests::agent_turn`（20 passed）
- `git diff --check`

## 边界

当前 Provider 协议没有统一 parent tool-call 字段。系统优先使用复用的 `call_id`；否则只对上一轮单个失败调用与下一轮单个同工具同参数调用建立保守重试关系。完全相同的独立单例调用在协议层仍可能无法与模型重试区分。