### PR TITLE
[codex] 自然语言待办查询统一走 Tool Loop 并支持周期筛选

### DIFF
--- a/qq-maid-core/src/runtime/respond/interaction_state.rs
+++ b/qq-maid-core/src/runtime/respond/interaction_state.rs
@@ -142,8 +142,8 @@ pub(super) fn command_bypasses_pending(user_text: &str) -> bool {
 }
 
 pub(super) fn should_try_todo_flow(user_text: &str) -> bool {
+    // 普通自然语言待办查询不再进确定性 Todo flow，只保留显式命令与“查看完整结果”。
     todo_flow::parse_todo_command(user_text).is_some()
-        || todo_flow::is_natural_todo_query_text(user_text)
         || todo_flow::is_full_todo_result_request(user_text)
 }
 
@@ -215,7 +215,7 @@ pub(super) fn classify_inbound_with_active(
         || search_flow::parse_web_search_command(user_text).is_some()
         || rss_flow::parse_rss_command(user_text).is_some()
         || todo_flow::parse_todo_command(user_text).is_some()
-        || todo_flow::is_natural_todo_query_text(user_text)
+        || todo_flow::is_full_todo_result_request(user_text)
         || memory_flow::parse_memory_command(user_text).is_some();
 
     CoreInboundClassification {

--- a/qq-maid-core/src/runtime/respond/router.rs
+++ b/qq-maid-core/src/runtime/respond/router.rs
@@ -92,8 +92,8 @@ impl<'a> RespondRouter<'a> {
             return self.plan_plain_chat(req);
         }
 
-        // 先保护已有确定性命令和自然语言 Todo 查询，避免简单列表查询绕过
-        // `handle_todo_flow()` 进入模型 Tool Loop，回归同义词和默认过滤语义。
+        // 只保护显式命令和“查看完整结果”等确定性入口；普通自然语言待办查询
+        // 统一进入后续 AgentRuntime / Tool Loop，由 `list_todos` 处理筛选。
         let classification = classify_inbound_with_active(
             &user_text,
             active_interaction_session.as_ref(),

--- a/qq-maid-core/src/runtime/respond/tests/support/mock_provider.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support/mock_provider.rs
@@ -57,6 +57,10 @@ enum MockToolAction {
         arguments: String,
         reply: String,
     },
+    ExecuteTodoListRetry {
+        arguments: String,
+        reply: String,
+    },
     ExecuteTools {
         calls: Vec<(String, String)>,
         reply: String,
@@ -198,6 +202,21 @@ impl MockProvider {
             .unwrap()
             .push(MockToolAction::ExecuteTool {
                 name: name.into(),
+                arguments: arguments.into(),
+                reply: reply.into(),
+            });
+        self
+    }
+
+    pub(crate) fn with_todo_list_retry(
+        self,
+        arguments: impl Into<String>,
+        reply: impl Into<String>,
+    ) -> Self {
+        self.tool_actions
+            .lock()
+            .unwrap()
+            .push(MockToolAction::ExecuteTodoListRetry {
                 arguments: arguments.into(),
                 reply: reply.into(),
             });
@@ -589,6 +608,86 @@ impl LlmProvider for MockProvider {
                         }),
                         fallback_used: false,
                         agent,
+                    });
+                }
+                MockToolAction::ExecuteTodoListRetry { arguments, reply } => {
+                    let call_id = "mock-call-0";
+                    let mut tool_context = req.tool_context.clone();
+                    tool_context.tool_call_id = Some(format!("{}:{call_id}", tool_context.task_id));
+                    let output = req
+                        .tools
+                        .execute_json(&tool_context, "list_todos", &arguments)
+                        .await?;
+                    let output = serde_json::from_str::<Value>(&output).unwrap_or_else(|_| {
+                        json!({
+                            "raw": output,
+                        })
+                    });
+                    let results = vec![
+                        qq_maid_llm::provider::ToolExecutionResult {
+                            name: "list_todos".to_owned(),
+                            output: json!({
+                                "ok": false,
+                                "error": {
+                                    "code": "old_retry_failure",
+                                    "message": "旧失败结果不应展示"
+                                }
+                            }),
+                            succeeded: false,
+                        },
+                        qq_maid_llm::provider::ToolExecutionResult {
+                            name: "list_todos".to_owned(),
+                            succeeded: output.get("ok").and_then(Value::as_bool) != Some(false),
+                            output,
+                        },
+                    ];
+                    return Ok(ChatOutcome {
+                        reply,
+                        output_parts: Vec::new(),
+                        metrics: LlmMetrics {
+                            provider: "mock".to_owned(),
+                            model: req
+                                .chat
+                                .model
+                                .clone()
+                                .unwrap_or_else(|| "mock-model".to_owned()),
+                            stream: false,
+                            ttfe_ms: None,
+                            ttft_ms: None,
+                            total_latency_ms: 1,
+                        },
+                        usage: Some(TokenUsage {
+                            input_tokens: None,
+                            cached_input_tokens: None,
+                            output_tokens: None,
+                            total_tokens: None,
+                        }),
+                        fallback_used: false,
+                        agent: AgentRunDiagnostics {
+                            model_rounds: 3,
+                            emitted_tools: vec!["list_todos".to_owned(), "list_todos".to_owned()],
+                            tool_execution_attempted: true,
+                            executed_tools: vec!["list_todos".to_owned(), "list_todos".to_owned()],
+                            side_effecting_tools_started: Vec::new(),
+                            tool_results: results,
+                            tool_attempts: vec![
+                                ToolExecutionAttempt {
+                                    result_index: 0,
+                                    call_id: call_id.to_owned(),
+                                    round: 0,
+                                    retry_of: None,
+                                },
+                                ToolExecutionAttempt {
+                                    result_index: 1,
+                                    call_id: call_id.to_owned(),
+                                    round: 1,
+                                    retry_of: Some(0),
+                                },
+                            ],
+                            tools_with_unknown_result: Vec::new(),
+                            streaming_fallback_used: false,
+                            stop_reason: Some(AgentStopReason::ToolUsed),
+                        },
                     });
                 }
                 MockToolAction::ExecuteTools { calls, reply } => {

--- a/qq-maid-core/src/runtime/respond/tests/support/mock_provider.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support/mock_provider.rs
@@ -540,9 +540,12 @@ impl LlmProvider for MockProvider {
                     arguments,
                     reply,
                 } => {
+                    let call_id = "mock-call-0";
+                    let mut tool_context = req.tool_context.clone();
+                    tool_context.tool_call_id = Some(format!("{}:{call_id}", tool_context.task_id));
                     let output = req
                         .tools
-                        .execute_json(&req.tool_context, &name, &arguments)
+                        .execute_json(&tool_context, &name, &arguments)
                         .await?;
                     let output = serde_json::from_str::<Value>(&output).unwrap_or_else(|_| {
                         json!({
@@ -556,6 +559,13 @@ impl LlmProvider for MockProvider {
                         output,
                         succeeded,
                     }];
+                    let mut agent = agent_tool_trace(vec![emitted_tool], tool_results);
+                    agent.tool_attempts.push(ToolExecutionAttempt {
+                        result_index: 0,
+                        call_id: call_id.to_owned(),
+                        round: 0,
+                        retry_of: None,
+                    });
                     return Ok(ChatOutcome {
                         reply,
                         output_parts: Vec::new(),
@@ -578,7 +588,7 @@ impl LlmProvider for MockProvider {
                             total_tokens: None,
                         }),
                         fallback_used: false,
-                        agent: agent_tool_trace(vec![emitted_tool], tool_results),
+                        agent,
                     });
                 }
                 MockToolAction::ExecuteTools { calls, reply } => {

--- a/qq-maid-core/src/runtime/respond/tests/todo/mod.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo/mod.rs
@@ -46,22 +46,6 @@ fn draft_due_date(title: &str, due_date: &str) -> TodoItemDraft {
     }
 }
 
-fn draft_due_at(title: &str, due_at: &str) -> TodoItemDraft {
-    TodoItemDraft {
-        title: title.to_owned(),
-        detail: None,
-        raw_text: None,
-        due_date: None,
-        due_at: Some(due_at.to_owned()),
-        reminder_at: None,
-        time_precision: TodoTimePrecision::DateTime,
-        recurrence_kind: crate::runtime::tools::todo::TodoRecurrenceKind::None,
-        recurrence_interval_days: 0,
-        recurrence_interval: 0,
-        recurrence_unit: crate::runtime::tools::todo::TodoRecurrenceUnit::Day,
-    }
-}
-
 fn assert_in_order(text: &str, needles: &[&str]) {
     let mut cursor = 0;
     for needle in needles {

--- a/qq-maid-core/src/runtime/respond/tests/todo/query.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo/query.rs
@@ -7,7 +7,7 @@ async fn todo_query_writes_visible_snapshot_for_tool_followup() {
     let first = service.task_store.create(&owner, draft("第一条")).unwrap();
     let second = service.task_store.create(&owner, draft("第二条")).unwrap();
 
-    let response = service.respond(message("看一下待办")).await.unwrap();
+    let response = service.respond(message("/todo")).await.unwrap();
     assert_eq!(response.command.as_deref(), Some("todo_list"));
     let text = response.text.as_deref().unwrap();
     assert!(text.contains("1. 第一条"));
@@ -265,158 +265,74 @@ async fn todo_list_command_supports_completed_no_due_and_keyword_filters() {
 }
 
 #[tokio::test]
-async fn natural_todo_date_query_filters_pending_by_local_due_date() {
+async fn todo_list_command_filters_recurring_type() {
     let service = test_service();
     let owner = TodoStore::owner(Some("u1"), "group:g1");
-    let today = qq_maid_common::time_context::request_time_context().local_date();
-    let tomorrow = today + Duration::days(1);
-    let explicit = today + Duration::days(2);
-    let today_text = today.format("%Y-%m-%d").to_string();
-    let tomorrow_text = tomorrow.format("%Y-%m-%d").to_string();
-    let explicit_text = explicit.format("%Y-%m-%d").to_string();
+    let tomorrow = (qq_maid_common::time_context::request_time_context().local_date()
+        + Duration::days(1))
+    .format("%Y-%m-%d")
+    .to_string();
+    let mut recurring_draft = draft_due_date("吃药", &tomorrow);
+    recurring_draft.recurrence_kind = crate::runtime::tools::todo::TodoRecurrenceKind::Daily;
+    recurring_draft.recurrence_interval_days = 1;
+    recurring_draft.recurrence_interval = 1;
+    recurring_draft.recurrence_unit = crate::runtime::tools::todo::TodoRecurrenceUnit::Day;
+    service.task_store.create(&owner, recurring_draft).unwrap();
+    service.task_store.create(&owner, draft("买香薰")).unwrap();
 
-    let today_date = service
-        .task_store
-        .create(&owner, draft_due_date("今天日期型", &today_text))
-        .unwrap();
-    let today_datetime = service
-        .task_store
-        .create(
-            &owner,
-            draft_due_at("今天带时间", &format!("{today_text} 09:30:00")),
-        )
-        .unwrap();
-    service
-        .task_store
-        .create(&owner, draft_due_date("明天事项", &tomorrow_text))
-        .unwrap();
-    service
-        .task_store
-        .create(&owner, draft_due_date("明确日期事项", &explicit_text))
-        .unwrap();
-    service
-        .task_store
-        .create(&owner, draft("无时间事项"))
-        .unwrap();
+    let recurring = service.respond(message("/todo list 周期性")).await.unwrap();
+    let recurring_text = recurring.text.unwrap();
+    assert_eq!(recurring.command.as_deref(), Some("todo_list"));
+    assert!(recurring_text.contains("吃药"));
+    assert!(!recurring_text.contains("买香薰"));
 
-    let response = service.respond(message("查看今天待办")).await.unwrap();
-    assert_eq!(response.command.as_deref(), Some("todo_due_date"));
-    let text = response.text.unwrap();
-    assert!(text.contains("今天日期型"));
-    assert!(text.contains("今天带时间"));
-    assert!(!text.contains("明天事项"));
-    assert!(!text.contains("无时间事项"));
-    let session = service
-        .session_store
-        .get_or_create_active(&test_meta())
-        .unwrap();
-    let snapshot = session.last_todo_query.expect("missing due date snapshot");
-    assert_eq!(snapshot.query_type, "due-date");
-    assert_eq!(snapshot.condition, today_text);
-    assert_eq!(snapshot.result_ids, vec![today_date.id, today_datetime.id]);
-
-    let tomorrow_response = service.respond(message("明天有什么待办")).await.unwrap();
-    assert_eq!(tomorrow_response.command.as_deref(), Some("todo_due_date"));
-    let tomorrow_text_reply = tomorrow_response.text.unwrap();
-    assert!(tomorrow_text_reply.contains("明天事项"));
-    assert!(!tomorrow_text_reply.contains("今天日期型"));
-
-    let natural_tomorrow = service
-        .respond(message("帮我看看明天的待办"))
-        .await
-        .unwrap();
-    assert_eq!(natural_tomorrow.command.as_deref(), Some("todo_due_date"));
-    let natural_tomorrow_text = natural_tomorrow.text.unwrap();
-    assert!(natural_tomorrow_text.contains("明天事项"));
-    assert!(!natural_tomorrow_text.contains("今天日期型"));
-    assert!(!natural_tomorrow_text.contains("无时间事项"));
-
-    let standard_chat_response = service.respond(message("明天要做什么")).await.unwrap();
-    assert_ne!(
-        standard_chat_response.command.as_deref(),
-        Some("todo_due_date")
-    );
-
-    let short_response = service.respond(message("明天待办")).await.unwrap();
-    assert_eq!(short_response.command.as_deref(), Some("todo_due_date"));
-    let short_text_reply = short_response.text.unwrap();
-    assert!(short_text_reply.contains("明天事项"));
-    assert!(!short_text_reply.contains("今天日期型"));
-
-    let explicit_response = service
-        .respond(message(&format!(
-            "查看 {} 的待办",
-            explicit.format("%-m月%-d日")
-        )))
-        .await
-        .unwrap();
-    assert_eq!(explicit_response.command.as_deref(), Some("todo_due_date"));
-    let explicit_reply = explicit_response.text.unwrap();
-    assert!(explicit_reply.contains("明确日期事项"));
-    assert!(!explicit_reply.contains("无时间事项"));
+    let one_off = service.respond(message("/todo list 一次性")).await.unwrap();
+    let one_off_text = one_off.text.unwrap();
+    assert_eq!(one_off.command.as_deref(), Some("todo_list"));
+    assert!(one_off_text.contains("买香薰"));
+    assert!(!one_off_text.contains("吃药"));
 }
 
 #[tokio::test]
-async fn todo_date_query_empty_result_does_not_fallback_to_pending_list() {
+async fn natural_todo_queries_no_longer_hit_deterministic_shortcuts() {
     let service = test_service();
     let owner = TodoStore::owner(Some("u1"), "group:g1");
     service
         .task_store
-        .create(&owner, draft("无时间事项"))
+        .create(&owner, draft("普通事项"))
         .unwrap();
 
-    let response = service.respond(message("查看明天待办")).await.unwrap();
-    assert_eq!(response.command.as_deref(), Some("todo_due_date"));
-    let text = response.text.unwrap();
-    assert!(text.contains("这一天暂无未完成待办"));
-    assert!(!text.contains("无时间事项"));
-    let session = service
-        .session_store
-        .get_or_create_active(&test_meta())
-        .unwrap();
-    let snapshot = session.last_todo_query.expect("missing empty snapshot");
-    assert_eq!(snapshot.query_type, "due-date");
-    assert!(snapshot.result_ids.is_empty());
-}
-
-#[tokio::test]
-async fn natural_todo_date_query_allows_negated_completed_marker() {
-    let service = test_service();
-    let owner = TodoStore::owner(Some("u1"), "group:g1");
-    let today = qq_maid_common::time_context::request_time_context().local_date();
-    let tomorrow = today + Duration::days(1);
-    let today_text = today.format("%Y-%m-%d").to_string();
-    let tomorrow_text = tomorrow.format("%Y-%m-%d").to_string();
-
-    service
-        .task_store
-        .create(&owner, draft_due_date("今天事项", &today_text))
-        .unwrap();
-    let tomorrow_item = service
-        .task_store
-        .create(&owner, draft_due_date("明天事项", &tomorrow_text))
-        .unwrap();
-    service
-        .task_store
-        .create(&owner, draft("无时间事项"))
-        .unwrap();
-
-    let response = service
-        .respond(message("明天有哪些未完成待办"))
-        .await
-        .unwrap();
-
-    assert_eq!(response.command.as_deref(), Some("todo_due_date"));
-    let text = response.text.unwrap();
-    assert!(text.contains("明天事项"));
-    assert!(!text.contains("今天事项"));
-    assert!(!text.contains("无时间事项"));
-    let session = service
-        .session_store
-        .get_or_create_active(&test_meta())
-        .unwrap();
-    let snapshot = session.last_todo_query.expect("missing due date snapshot");
-    assert_eq!(snapshot.query_type, "due-date");
-    assert_eq!(snapshot.condition, tomorrow_text);
-    assert_eq!(snapshot.result_ids, vec![tomorrow_item.id]);
+    for input in [
+        "看一下待办",
+        "查看今天待办",
+        "查看已完成待办",
+        "查看周期性待办",
+        "查看一次性待办",
+        "明天有什么待办",
+        "帮我看看明天的待办",
+        "明天待办",
+        "明天有哪些未完成待办",
+    ] {
+        let response = service.respond(message(input)).await.unwrap();
+        assert_ne!(
+            response.command.as_deref(),
+            Some("todo_list"),
+            "{input} should not hit deterministic list shortcut"
+        );
+        assert_ne!(
+            response.command.as_deref(),
+            Some("todo_due_date"),
+            "{input} should not hit deterministic date shortcut"
+        );
+        assert_ne!(
+            response.command.as_deref(),
+            Some("todo_done"),
+            "{input} should not hit deterministic completed shortcut"
+        );
+        assert_ne!(
+            response.command.as_deref(),
+            Some("todo_all"),
+            "{input} should not hit deterministic all shortcut"
+        );
+    }
 }

--- a/qq-maid-core/src/runtime/respond/tests/todo/rendering.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo/rendering.rs
@@ -84,7 +84,7 @@ async fn todo_pending_list_shows_reminder_without_due_time() {
 }
 
 #[tokio::test]
-async fn natural_and_slash_status_queries_use_same_visible_order() {
+async fn explicit_status_queries_remember_visible_order() {
     let service = test_service();
     let owner = TodoStore::owner(Some("u1"), "group:g1");
     service
@@ -92,9 +92,10 @@ async fn natural_and_slash_status_queries_use_same_visible_order() {
         .set_items_for_test(&owner, &status_list_items())
         .unwrap();
 
-    for (slash, natural, expected_ids) in [
-        ("/todo", "查看待办", vec!["3", "2", "1"]),
-        ("/todo done", "查看已完成待办", vec!["5", "4"]),
+    // 自然语言状态查询已不再走确定性短路；编号快照只由显式 /todo 命令或 Tool 回执写入。
+    for (slash, expected_ids) in [
+        ("/todo", vec!["3", "2", "1"]),
+        ("/todo done", vec!["5", "4"]),
     ] {
         let expected_ids = expected_ids
             .iter()
@@ -102,9 +103,6 @@ async fn natural_and_slash_status_queries_use_same_visible_order() {
             .collect::<Vec<_>>();
         service.respond(message(slash)).await.unwrap();
         assert_eq!(last_todo_result_ids(&service), expected_ids, "{slash}");
-
-        service.respond(message(natural)).await.unwrap();
-        assert_eq!(last_todo_result_ids(&service), expected_ids, "{natural}");
     }
 }
 

--- a/qq-maid-core/src/runtime/respond/tests/todo/write.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo/write.rs
@@ -7,7 +7,7 @@ async fn todo_deprecated_slash_write_prompts_preserve_visible_snapshot() {
     let first = service.task_store.create(&owner, draft("第一条")).unwrap();
     let second = service.task_store.create(&owner, draft("第二条")).unwrap();
 
-    service.respond(message("看一下待办")).await.unwrap();
+    service.respond(message("/todo")).await.unwrap();
     let original_snapshot = service
         .session_store
         .get_or_create_active(&test_meta())

--- a/qq-maid-core/src/runtime/respond/tests/todo_agent/guard.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo_agent/guard.rs
@@ -238,10 +238,7 @@ async fn todo_edit_guard_requires_successful_update_result() {
         )
         .unwrap();
 
-    service
-        .respond(private_message("看一下待办"))
-        .await
-        .unwrap();
+    service.respond(private_message("/todo")).await.unwrap();
     let response = service
         .respond(private_message("把第一条改成检查新版守卫"))
         .await
@@ -376,10 +373,7 @@ async fn todo_edit_tool_false_result_does_not_pass_success_guard() {
         )
         .unwrap();
 
-    service
-        .respond(private_message("看一下待办"))
-        .await
-        .unwrap();
+    service.respond(private_message("/todo")).await.unwrap();
     service.task_store.complete(&owner, &todo.id).unwrap();
     let response = service
         .respond(private_message("把第一条改成不应成功"))
@@ -436,10 +430,7 @@ async fn todo_delete_pending_item_false_deleted_text_does_not_pass_success_guard
         )
         .unwrap();
 
-    service
-        .respond(private_message("看一下待办"))
-        .await
-        .unwrap();
+    service.respond(private_message("/todo")).await.unwrap();
     let response = service
         .respond(private_message("永久删除第一条"))
         .await
@@ -499,7 +490,7 @@ async fn todo_delete_completed_tool_failure_cannot_be_reported_as_success() {
         .unwrap();
     service.task_store.complete(&owner, &todo.id).unwrap();
     service
-        .respond(private_message("查看已完成待办"))
+        .respond(private_message("/todo done"))
         .await
         .unwrap();
 

--- a/qq-maid-core/src/runtime/respond/tests/todo_agent/pending.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo_agent/pending.rs
@@ -41,7 +41,7 @@ async fn todo_delete_completed_item_accepts_delete_tool_pending_result() {
     service.task_store.complete(&owner, &todo.id).unwrap();
 
     service
-        .respond(private_message("看看已完成"))
+        .respond(private_message("/todo done"))
         .await
         .unwrap();
     let response = service
@@ -98,7 +98,7 @@ async fn todo_delete_completed_pending_confirmation_is_verified_by_real_tool_res
         .unwrap();
     service.task_store.complete(&owner, &todo.id).unwrap();
     service
-        .respond(private_message("查看已完成待办"))
+        .respond(private_message("/todo done"))
         .await
         .unwrap();
 

--- a/qq-maid-core/src/runtime/respond/tests/todo_agent/query.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo_agent/query.rs
@@ -154,6 +154,68 @@ async fn natural_language_tool_query_supports_fuzzy_keyword_search() {
 }
 
 #[tokio::test]
+async fn list_todos_recurring_receipt_preserves_filtered_visible_snapshot() {
+    let arguments = serde_json::json!({
+        "status": "pending",
+        "due_date": null,
+        "date_range_text": null,
+        "time_filter": null,
+        "keyword": null,
+        "recurring": true
+    })
+    .to_string();
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json("list_todos", arguments, "周期性待办");
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let tomorrow = (qq_maid_common::time_context::request_time_context().local_date()
+        + chrono::Duration::days(1))
+    .format("%Y-%m-%d")
+    .to_string();
+    let recurring = service
+        .task_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "吃药".to_owned(),
+                detail: None,
+                raw_text: None,
+                due_date: Some(tomorrow),
+                due_at: None,
+                reminder_at: None,
+                time_precision: TodoTimePrecision::Date,
+                recurrence_kind: crate::runtime::tools::todo::TodoRecurrenceKind::Daily,
+                recurrence_interval_days: 1,
+                recurrence_interval: 1,
+                recurrence_unit: crate::runtime::tools::todo::TodoRecurrenceUnit::Day,
+            },
+        )
+        .unwrap();
+    create_private_todo(&service, "买香薰");
+
+    let response = service
+        .respond(private_message("筛选出周期性待办"))
+        .await
+        .unwrap();
+    let text = response.text.unwrap();
+    assert!(text.contains("吃药"));
+    assert!(!text.contains("买香薰"));
+    assert_eq!(inspector.tool_call_count(), 1);
+
+    let session = service
+        .session_store
+        .get_or_create_active(&private_test_meta())
+        .unwrap();
+    let snapshot = session
+        .last_todo_query
+        .expect("missing recurring filtered snapshot");
+    assert_eq!(snapshot.query_type, "search");
+    assert_eq!(snapshot.condition, "周期性待办");
+    assert_eq!(snapshot.result_ids, vec![recurring.id]);
+}
+
+#[tokio::test]
 async fn list_todos_due_date_receipt_preserves_filtered_visible_snapshot() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
@@ -368,58 +430,9 @@ async fn list_todos_completed_date_range_receipt_uses_completed_at_snapshot() {
 }
 
 #[tokio::test]
-async fn natural_language_todo_query_prefers_listing_over_todo_parse_creation_chain() {
+async fn explicit_todo_command_aliases_and_filters_stay_deterministic() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
-    // Tool Calling 关闭时仍保留确定性 Todo 查询路径；开启时由前置路由交给 Tool Loop。
-    let service = test_service_with_provider_and_tool_calling(inspector.clone(), false);
-    let owner = TodoStore::owner(Some("u1"), "private:u1");
-    service
-        .task_store
-        .create(
-            &owner,
-            TodoItemDraft {
-                title: "待查看项目".to_owned(),
-                detail: None,
-                raw_text: None,
-                due_date: None,
-                due_at: None,
-                reminder_at: None,
-                time_precision: TodoTimePrecision::None,
-                recurrence_kind: crate::runtime::tools::todo::TodoRecurrenceKind::None,
-                recurrence_interval_days: 0,
-                recurrence_interval: 0,
-                recurrence_unit: crate::runtime::tools::todo::TodoRecurrenceUnit::Day,
-            },
-        )
-        .unwrap();
-
-    let response = service
-        .respond(private_message("看看我的待办"))
-        .await
-        .unwrap();
-
-    assert_eq!(response.command.as_deref(), Some("todo_list"));
-    assert!(
-        response
-            .text
-            .as_deref()
-            .unwrap()
-            .contains("🚧 进行中 · 共 1 项")
-    );
-    let session = service
-        .session_store
-        .get_or_create_active(&private_test_meta())
-        .unwrap();
-    assert!(session.pending_operation.is_none());
-    assert!(inspector.requests().is_empty());
-    assert_eq!(inspector.tool_call_count(), 0);
-}
-
-#[tokio::test]
-async fn natural_language_todo_query_aliases_and_filters_stay_deterministic() {
-    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
-    // Tool Calling 关闭时仍保留确定性 Todo 查询路径；开启时由前置路由交给 Tool Loop。
-    let service = test_service_with_provider_and_tool_calling(inspector.clone(), false);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
     let pending = service
         .task_store
@@ -460,62 +473,55 @@ async fn natural_language_todo_query_aliases_and_filters_stay_deterministic() {
         )
         .unwrap();
     service.task_store.complete(&owner, &completed.id).unwrap();
-    for input in ["看一下待办", "看一下代办", "查询待办", "查询代办"] {
+
+    for input in ["/todo", "/todo list", "/todo list 未完成"] {
         let response = service.respond(private_message(input)).await.unwrap();
         let text = response.text.unwrap();
         assert_eq!(response.command.as_deref(), Some("todo_list"), "{input}");
         assert!(text.contains("未完成条目"), "{input}");
         assert!(!text.contains("已完成条目"), "{input}");
-        assert!(!text.contains("已取消条目"), "{input}");
     }
 
-    for input in [
-        "查看未完成的待办",
-        "看看没做完的任务",
-        "查看还没做完的任务",
-        "查看未结束的待办",
-    ] {
-        let response = service.respond(private_message(input)).await.unwrap();
-        let text = response.text.unwrap();
-        assert_eq!(response.command.as_deref(), Some("todo_list"), "{input}");
-        assert!(text.contains("未完成条目"), "{input}");
-        assert!(!text.contains("已完成条目"), "{input}");
-        assert!(!text.contains("已取消条目"), "{input}");
-    }
-
-    for input in ["查看所有待办", "查看全部待办"] {
-        let all = service.respond(private_message(input)).await.unwrap();
-        let all_text = all.text.unwrap();
-        assert_eq!(all.command.as_deref(), Some("todo_all"), "{input}");
-        assert!(all_text.contains("全部待办"), "{input}");
-        assert!(all_text.contains("进行中"), "{input}");
-        assert!(all_text.contains("已完成"), "{input}");
-        assert!(all_text.contains("未完成条目"), "{input}");
-        assert!(all_text.contains("已完成条目"), "{input}");
-    }
+    let all = service.respond(private_message("/todo all")).await.unwrap();
+    let all_text = all.text.unwrap();
+    assert_eq!(all.command.as_deref(), Some("todo_all"));
+    assert!(all_text.contains("全部待办"));
+    assert!(all_text.contains("未完成条目"));
+    assert!(all_text.contains("已完成条目"));
 
     let completed_only = service
-        .respond(private_message("查看已完成待办"))
+        .respond(private_message("/todo done"))
         .await
         .unwrap();
     let completed_text = completed_only.text.unwrap();
     assert_eq!(completed_only.command.as_deref(), Some("todo_done"));
     assert!(!completed_text.contains("未完成条目"));
     assert!(completed_text.contains("已完成条目"));
-    assert!(!completed_text.contains("已取消条目"));
-
-    for input in ["查看完成的待办", "看看做完的任务"] {
-        let response = service.respond(private_message(input)).await.unwrap();
-        let text = response.text.unwrap();
-        assert_eq!(response.command.as_deref(), Some("todo_done"), "{input}");
-        assert!(!text.contains("未完成条目"), "{input}");
-        assert!(text.contains("已完成条目"), "{input}");
-        assert!(!text.contains("已取消条目"), "{input}");
-    }
 
     assert_eq!(pending.status, TodoStatus::Pending);
     assert!(inspector.requests().is_empty());
     assert_eq!(inspector.tool_call_count(), 0);
+}
+
+#[tokio::test]
+async fn natural_language_todo_queries_enter_tool_loop_instead_of_shortcut() {
+    let list_args = r#"{"status":"pending","due_date":null,"date_range_text":null,"time_filter":null,"keyword":null,"recurring":null}"#;
+    // MockProvider 的 tool action 按次消费，多轮自然语言查询要预置同样次数的 list_todos。
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json("list_todos", list_args, "查询完成")
+        .with_tool_call_json("list_todos", list_args, "查询完成")
+        .with_tool_call_json("list_todos", list_args, "查询完成");
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    create_private_todo(&service, "自然语言待办");
+
+    // route 层识别“看一下/查看 + 待办/代办”为 Todo 查询意图后进入 Tool Loop。
+    for input in ["看一下待办", "看一下代办", "查看待办"] {
+        let response = service.respond(private_message(input)).await.unwrap();
+        assert_eq!(response.command.as_deref(), Some("todo_list"), "{input}");
+        assert!(response.text.unwrap().contains("自然语言待办"), "{input}");
+    }
+    assert_eq!(inspector.tool_call_count(), 3);
 }
 
 #[tokio::test]
@@ -532,7 +538,7 @@ async fn todo_completed_lists_show_up_to_ten_without_old_five_item_collapse() {
     }
 
     let completed = service
-        .respond(private_message("查看已完成待办"))
+        .respond(private_message("/todo done"))
         .await
         .unwrap();
     let completed_text = completed.text.unwrap();
@@ -589,7 +595,7 @@ async fn todo_all_caps_at_ten_and_reports_real_total() {
             .unwrap();
     }
 
-    let collapsed = service.respond(private_message("全部待办")).await.unwrap();
+    let collapsed = service.respond(private_message("/todo all")).await.unwrap();
     let collapsed_text = collapsed.text.unwrap();
     assert_eq!(collapsed.command.as_deref(), Some("todo_all"));
     assert!(collapsed_text.contains("📋 全部待办 · 共 11 项"));
@@ -600,7 +606,7 @@ async fn todo_all_caps_at_ten_and_reports_real_total() {
 }
 
 #[tokio::test]
-async fn complete_todo_phrase_lists_all_statuses_fully_with_tool_loop_enabled() {
+async fn explicit_todo_and_full_result_restore_use_visible_snapshot() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
     let owner = TodoStore::owner(Some("u1"), "private:u1");
@@ -617,35 +623,20 @@ async fn complete_todo_phrase_lists_all_statuses_fully_with_tool_loop_enabled() 
             .unwrap();
         service.task_store.complete(&owner, &item.id).unwrap();
     }
-    let pending = service.respond(private_message("查看待办")).await.unwrap();
+    let pending = service.respond(private_message("/todo")).await.unwrap();
     let pending_text = pending.text.unwrap();
     assert_eq!(pending.command.as_deref(), Some("todo_list"));
     assert!(pending_text.contains("🚧 进行中 · 共 6 项"));
     assert!(!pending_text.contains("已完成待办 1"));
 
+    // 先建立可见快照，再请求完整结果；普通自然语言“查看完整待办”不再短路。
     let full = service
-        .respond(private_message("查看完整待办"))
+        .respond(private_message("查看完整结果"))
         .await
         .unwrap();
     let full_text = full.text.unwrap();
-
-    assert_eq!(full.command.as_deref(), Some("todo_all"));
-    assert!(full_text.contains("📋 全部待办 · 共 8 项"));
+    assert_eq!(full.command.as_deref(), Some("todo_list"));
     assert!(full_text.contains("进行中待办 6"));
-    assert!(full_text.contains("已完成待办 1"));
-    assert!(!full_text.contains("还有 5 项待办"));
-    assert_eq!(inspector.tool_call_count(), 0);
-}
-
-#[tokio::test]
-async fn todo_write_or_question_phrases_do_not_enter_natural_query_path() {
-    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
-    let service = test_service_with_provider_and_tool_calling(inspector.clone(), false);
-
-    for input in ["取消这个待办", "怎么取消待办", "帮我取消第一条", "不做了"]
-    {
-        let response = service.respond(private_message(input)).await.unwrap();
-        assert_ne!(response.command.as_deref(), Some("todo_list"), "{input}");
-    }
+    assert!(!full_text.contains("已完成待办 1"));
     assert_eq!(inspector.tool_call_count(), 0);
 }

--- a/qq-maid-core/src/runtime/respond/tests/todo_agent/query.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo_agent/query.rs
@@ -1,10 +1,16 @@
 //! Todo 查询、过滤、折叠结果和用户可见快照的 Respond 集成测试。
 
+use std::collections::HashSet;
+
 use qq_maid_llm::provider::ToolCallingProtocol;
 
 use crate::runtime::{
+    respond::RustRespondService,
     session::SessionMeta,
-    tools::todo::{TodoItemDraft, TodoStatus, TodoStore, TodoTimePrecision},
+    tools::todo::{
+        TodoItemDraft, TodoRecurrenceKind, TodoRecurrenceUnit, TodoStatus, TodoStore,
+        TodoTimePrecision,
+    },
 };
 
 use super::super::support::*;
@@ -151,68 +157,6 @@ async fn natural_language_tool_query_supports_fuzzy_keyword_search() {
     assert_eq!(snapshot.query_type, "search");
     assert_eq!(snapshot.condition, "关键词“报销”");
     assert_eq!(snapshot.result_ids, vec![matched.id]);
-}
-
-#[tokio::test]
-async fn list_todos_recurring_receipt_preserves_filtered_visible_snapshot() {
-    let arguments = serde_json::json!({
-        "status": "pending",
-        "due_date": null,
-        "date_range_text": null,
-        "time_filter": null,
-        "keyword": null,
-        "recurring": true
-    })
-    .to_string();
-    let inspector = MockProvider::new()
-        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
-        .with_tool_call_json("list_todos", arguments, "周期性待办");
-    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
-    let owner = TodoStore::owner(Some("u1"), "private:u1");
-    let tomorrow = (qq_maid_common::time_context::request_time_context().local_date()
-        + chrono::Duration::days(1))
-    .format("%Y-%m-%d")
-    .to_string();
-    let recurring = service
-        .task_store
-        .create(
-            &owner,
-            TodoItemDraft {
-                title: "吃药".to_owned(),
-                detail: None,
-                raw_text: None,
-                due_date: Some(tomorrow),
-                due_at: None,
-                reminder_at: None,
-                time_precision: TodoTimePrecision::Date,
-                recurrence_kind: crate::runtime::tools::todo::TodoRecurrenceKind::Daily,
-                recurrence_interval_days: 1,
-                recurrence_interval: 1,
-                recurrence_unit: crate::runtime::tools::todo::TodoRecurrenceUnit::Day,
-            },
-        )
-        .unwrap();
-    create_private_todo(&service, "买香薰");
-
-    let response = service
-        .respond(private_message("筛选出周期性待办"))
-        .await
-        .unwrap();
-    let text = response.text.unwrap();
-    assert!(text.contains("吃药"));
-    assert!(!text.contains("买香薰"));
-    assert_eq!(inspector.tool_call_count(), 1);
-
-    let session = service
-        .session_store
-        .get_or_create_active(&private_test_meta())
-        .unwrap();
-    let snapshot = session
-        .last_todo_query
-        .expect("missing recurring filtered snapshot");
-    assert_eq!(snapshot.query_type, "search");
-    assert_eq!(snapshot.condition, "周期性待办");
-    assert_eq!(snapshot.result_ids, vec![recurring.id]);
 }
 
 #[tokio::test]
@@ -639,4 +583,261 @@ async fn explicit_todo_and_full_result_restore_use_visible_snapshot() {
     assert!(full_text.contains("进行中待办 6"));
     assert!(!full_text.contains("已完成待办 1"));
     assert_eq!(inspector.tool_call_count(), 0);
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ReplayCombination {
+    PendingDateRecurring,
+    CompletedRecurring,
+    AllOneOff,
+    PendingKeywordRecurring,
+    PendingOverdueOneOff,
+}
+
+impl ReplayCombination {
+    fn name(self) -> &'static str {
+        match self {
+            Self::PendingDateRecurring => "pending-date-recurring",
+            Self::CompletedRecurring => "completed-recurring",
+            Self::AllOneOff => "all-one-off",
+            Self::PendingKeywordRecurring => "pending-keyword-recurring",
+            Self::PendingOverdueOneOff => "pending-overdue-one-off",
+        }
+    }
+
+    fn arguments(self, target_date: &str) -> String {
+        let value = match self {
+            Self::PendingDateRecurring => serde_json::json!({
+                "status": "pending",
+                "due_date": target_date,
+                "date_range_text": null,
+                "time_filter": null,
+                "keyword": null,
+                "recurring": true
+            }),
+            Self::CompletedRecurring => serde_json::json!({
+                "status": "completed",
+                "due_date": null,
+                "date_range_text": null,
+                "time_filter": null,
+                "keyword": null,
+                "recurring": true
+            }),
+            Self::AllOneOff => serde_json::json!({
+                "status": "all",
+                "due_date": null,
+                "date_range_text": null,
+                "time_filter": null,
+                "keyword": null,
+                "recurring": false
+            }),
+            Self::PendingKeywordRecurring => serde_json::json!({
+                "status": "pending",
+                "due_date": null,
+                "date_range_text": null,
+                "time_filter": null,
+                "keyword": "专项",
+                "recurring": true
+            }),
+            Self::PendingOverdueOneOff => serde_json::json!({
+                "status": "pending",
+                "due_date": null,
+                "date_range_text": null,
+                "time_filter": "overdue",
+                "keyword": null,
+                "recurring": false
+            }),
+        };
+        value.to_string()
+    }
+}
+
+#[tokio::test]
+async fn full_result_replays_all_structured_todo_filter_combinations() {
+    let today = qq_maid_common::time_context::request_time_context().local_date();
+    let target_date = (today + chrono::Duration::days(1))
+        .format("%Y-%m-%d")
+        .to_string();
+    let overdue_date = (today - chrono::Duration::days(1))
+        .format("%Y-%m-%d")
+        .to_string();
+    let future_date = (today + chrono::Duration::days(2))
+        .format("%Y-%m-%d")
+        .to_string();
+
+    for combination in [
+        ReplayCombination::PendingDateRecurring,
+        ReplayCombination::CompletedRecurring,
+        ReplayCombination::AllOneOff,
+        ReplayCombination::PendingKeywordRecurring,
+        ReplayCombination::PendingOverdueOneOff,
+    ] {
+        let inspector = MockProvider::new()
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+            .with_tool_call_json(
+                "list_todos",
+                combination.arguments(&target_date),
+                "查询完成",
+            );
+        let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+        let owner = TodoStore::owner(Some("u1"), "private:u1");
+        let mut expected_ids = Vec::new();
+
+        for index in 1..=11 {
+            let title = format!("{} 匹配项 {index}", combination.name());
+            let mut draft = todo_draft(title);
+            match combination {
+                ReplayCombination::PendingDateRecurring => {
+                    draft.due_date = Some(target_date.clone());
+                    draft.time_precision = TodoTimePrecision::Date;
+                    make_draft_recurring(&mut draft);
+                }
+                ReplayCombination::CompletedRecurring => {
+                    draft.due_date = Some(target_date.clone());
+                    draft.time_precision = TodoTimePrecision::Date;
+                    make_draft_recurring(&mut draft);
+                }
+                ReplayCombination::AllOneOff => {}
+                ReplayCombination::PendingKeywordRecurring => {
+                    draft.title = format!("专项周期匹配项 {index}");
+                    draft.due_date = Some(target_date.clone());
+                    draft.time_precision = TodoTimePrecision::Date;
+                    make_draft_recurring(&mut draft);
+                }
+                ReplayCombination::PendingOverdueOneOff => {
+                    draft.due_date = Some(overdue_date.clone());
+                    draft.time_precision = TodoTimePrecision::Date;
+                }
+            }
+            let item = service.task_store.create(&owner, draft).unwrap();
+            if matches!(combination, ReplayCombination::CompletedRecurring)
+                || matches!(combination, ReplayCombination::AllOneOff) && index > 6
+            {
+                service.task_store.complete(&owner, &item.id).unwrap();
+            }
+            expected_ids.push(item.id);
+        }
+
+        let interference_title = format!("{} 干扰项", combination.name());
+        let mut interference = todo_draft(interference_title.clone());
+        match combination {
+            ReplayCombination::PendingDateRecurring => {
+                interference.due_date = Some(target_date.clone());
+                interference.time_precision = TodoTimePrecision::Date;
+            }
+            ReplayCombination::CompletedRecurring => {
+                let item = service.task_store.create(&owner, interference).unwrap();
+                service.task_store.complete(&owner, &item.id).unwrap();
+                assert_combination_replay(
+                    &service,
+                    &inspector,
+                    combination,
+                    &expected_ids,
+                    &interference_title,
+                )
+                .await;
+                continue;
+            }
+            ReplayCombination::AllOneOff | ReplayCombination::PendingKeywordRecurring => {
+                interference.due_date = Some(target_date.clone());
+                interference.time_precision = TodoTimePrecision::Date;
+                make_draft_recurring(&mut interference);
+            }
+            ReplayCombination::PendingOverdueOneOff => {
+                interference.due_date = Some(future_date.clone());
+                interference.time_precision = TodoTimePrecision::Date;
+            }
+        }
+        service.task_store.create(&owner, interference).unwrap();
+        assert_combination_replay(
+            &service,
+            &inspector,
+            combination,
+            &expected_ids,
+            &interference_title,
+        )
+        .await;
+    }
+}
+
+fn make_draft_recurring(draft: &mut TodoItemDraft) {
+    draft.recurrence_kind = TodoRecurrenceKind::Daily;
+    draft.recurrence_interval_days = 1;
+    draft.recurrence_interval = 1;
+    draft.recurrence_unit = TodoRecurrenceUnit::Day;
+}
+
+async fn assert_combination_replay(
+    service: &RustRespondService,
+    inspector: &MockProvider,
+    combination: ReplayCombination,
+    expected_ids: &[String],
+    interference_title: &str,
+) {
+    let collapsed = service
+        .respond(private_message(&format!("查询 {}", combination.name())))
+        .await
+        .unwrap();
+    let collapsed_text = collapsed.text.unwrap();
+    assert!(
+        !collapsed_text.contains(interference_title),
+        "{} collapsed result contains interference: {collapsed_text}",
+        combination.name()
+    );
+    let collapsed_snapshot = last_todo_snapshot(service, "collapsed combination");
+    let replay_context = collapsed_snapshot
+        .replay_context
+        .as_ref()
+        .expect("structured replay context");
+    let expected_recurring = match combination {
+        ReplayCombination::PendingDateRecurring
+        | ReplayCombination::CompletedRecurring
+        | ReplayCombination::PendingKeywordRecurring => Some(true),
+        ReplayCombination::AllOneOff | ReplayCombination::PendingOverdueOneOff => Some(false),
+    };
+    assert_eq!(
+        replay_context
+            .get("recurring")
+            .and_then(serde_json::Value::as_bool),
+        expected_recurring,
+        "{} replay context: {replay_context}",
+        combination.name()
+    );
+    let replayed = crate::runtime::tools::todo::replay_todo_query(&collapsed_snapshot)
+        .unwrap_or_else(|| panic!("{} replay context should decode", combination.name()));
+    assert_eq!(replayed.recurring, expected_recurring);
+    assert!(
+        active_private_session(service)
+            .extra
+            .get("tool_todo_task_query_history")
+            .is_none(),
+        "{} pending query context should be consumed by receipt",
+        combination.name()
+    );
+    assert_eq!(collapsed_snapshot.result_ids.len(), 10);
+    assert!(
+        collapsed_snapshot
+            .result_ids
+            .iter()
+            .all(|id| expected_ids.contains(id))
+    );
+
+    let full = service
+        .respond(private_message("查看完整结果"))
+        .await
+        .unwrap();
+    let full_text = full.text.unwrap();
+    assert!(
+        !full_text.contains(interference_title),
+        "{} full result contains interference: {full_text}",
+        combination.name()
+    );
+    let full_snapshot = last_todo_snapshot(service, "full combination");
+    assert!(full_snapshot.replay_context.is_some());
+    assert_eq!(full_snapshot.result_ids.len(), 11);
+    assert_eq!(
+        full_snapshot.result_ids.into_iter().collect::<HashSet<_>>(),
+        expected_ids.iter().cloned().collect::<HashSet<_>>()
+    );
+    assert_eq!(inspector.tool_call_count(), 1);
 }

--- a/qq-maid-core/src/runtime/respond/tests/todo_agent/query.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo_agent/query.rs
@@ -3,6 +3,7 @@
 use std::collections::HashSet;
 
 use qq_maid_llm::provider::ToolCallingProtocol;
+use serde_json::Value;
 
 use crate::runtime::{
     respond::RustRespondService,
@@ -758,6 +759,88 @@ async fn full_result_replays_all_structured_todo_filter_combinations() {
         )
         .await;
     }
+}
+
+#[tokio::test]
+async fn todo_retry_keeps_replay_context_on_final_truncated_list_result() {
+    let today = qq_maid_common::time_context::request_time_context().local_date();
+    let target_date = (today + chrono::Duration::days(1))
+        .format("%Y-%m-%d")
+        .to_string();
+    let arguments = serde_json::json!({
+        "status": "pending",
+        "due_date": target_date,
+        "date_range_text": null,
+        "time_filter": null,
+        "keyword": null,
+        "recurring": true
+    })
+    .to_string();
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_todo_list_retry(arguments, "查询完成");
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+    let owner = TodoStore::owner(Some("u1"), "private:u1");
+    let mut matching_ids = Vec::new();
+
+    for index in 1..=11 {
+        let mut draft = todo_draft(format!("周期查询匹配项 {index}"));
+        draft.due_date = Some(target_date.clone());
+        draft.time_precision = TodoTimePrecision::Date;
+        make_draft_recurring(&mut draft);
+        matching_ids.push(service.task_store.create(&owner, draft).unwrap().id);
+    }
+    let mut interference = todo_draft("周期查询一次性干扰项");
+    interference.due_date = Some(target_date);
+    interference.time_precision = TodoTimePrecision::Date;
+    service.task_store.create(&owner, interference).unwrap();
+
+    let collapsed = service
+        .respond(private_message("查询明天的周期性待办"))
+        .await
+        .unwrap();
+    let collapsed_text = collapsed.text.unwrap();
+    assert!(collapsed_text.contains("周期查询匹配项 1"));
+    assert!(collapsed_text.contains("周期查询匹配项 10"));
+    assert!(!collapsed_text.contains("周期查询匹配项 11"));
+    assert!(!collapsed_text.contains("周期查询一次性干扰项"));
+    assert!(!collapsed_text.contains("旧失败结果不应展示"));
+
+    let snapshot = last_todo_snapshot(&service, "retry collapsed");
+    assert_eq!(snapshot.result_ids.len(), 10);
+    assert!(
+        snapshot
+            .result_ids
+            .iter()
+            .all(|id| matching_ids.contains(id))
+    );
+    assert_eq!(
+        snapshot
+            .replay_context
+            .as_ref()
+            .and_then(|value| value.get("recurring"))
+            .and_then(Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        active_private_session(&service)
+            .extra
+            .get("tool_todo_task_query_history"),
+        None
+    );
+
+    let full = service
+        .respond(private_message("查看完整结果"))
+        .await
+        .unwrap();
+    let full_text = full.text.unwrap();
+    assert!(full_text.contains("周期查询匹配项 11"));
+    assert!(!full_text.contains("周期查询一次性干扰项"));
+    assert_eq!(
+        last_todo_snapshot(&service, "retry full").result_ids.len(),
+        11
+    );
+    assert_eq!(inspector.tool_call_count(), 1);
 }
 
 fn make_draft_recurring(draft: &mut TodoItemDraft) {

--- a/qq-maid-core/src/runtime/respond/tests/todo_receipt.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo_receipt.rs
@@ -15,10 +15,7 @@ async fn todo_complete_receipt_is_lightweight_and_refreshes_pending_snapshot() {
     let owner = private_todo_owner();
     create_numbered_private_todos(&service, "待办", 1..=7);
 
-    service
-        .respond(private_message("看一下待办"))
-        .await
-        .unwrap();
+    service.respond(private_message("/todo")).await.unwrap();
     let response = service
         .respond(private_message("完成第一条"))
         .await
@@ -44,10 +41,7 @@ async fn todo_complete_receipt_refreshes_pending_snapshot_at_ten_item_limit() {
     let owner = private_todo_owner();
     create_numbered_private_todos(&service, "待办", 1..=12);
 
-    service
-        .respond(private_message("看一下待办"))
-        .await
-        .unwrap();
+    service.respond(private_message("/todo")).await.unwrap();
     let response = service
         .respond(private_message("完成第一条"))
         .await

--- a/qq-maid-core/src/runtime/respond/tests/todo_tool_loop.rs
+++ b/qq-maid-core/src/runtime/respond/tests/todo_tool_loop.rs
@@ -335,10 +335,7 @@ async fn natural_language_undo_restores_most_recently_completed_todo() {
         let owner = private_todo_owner();
         let todo = create_private_todo(&service, "买牛奶");
 
-        service
-            .respond(private_message("看一下待办"))
-            .await
-            .unwrap();
+        service.respond(private_message("/todo")).await.unwrap();
         service
             .respond(private_message("完成第一条"))
             .await
@@ -552,17 +549,14 @@ async fn group_tool_loop_todo_visible_snapshot_uses_actor_interaction_session() 
 }
 
 #[tokio::test]
-async fn deterministic_pending_query_then_tool_loop_complete_first_uses_latest_snapshot() {
+async fn explicit_pending_query_then_tool_loop_complete_first_uses_latest_snapshot() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
     let owner = private_todo_owner();
     let first = create_private_todo(&service, "测试代办");
     let second = create_private_todo(&service, "明天晚上搬到16栋");
 
-    let listed = service
-        .respond(private_message("看一下待办"))
-        .await
-        .unwrap();
+    let listed = service.respond(private_message("/todo")).await.unwrap();
     assert_eq!(listed.command.as_deref(), Some("todo_list"));
     let listed_text = listed.text.unwrap();
     assert!(listed_text.contains("1. 测试代办"));
@@ -608,7 +602,7 @@ async fn deterministic_pending_query_then_tool_loop_complete_first_uses_latest_s
 }
 
 #[tokio::test]
-async fn deterministic_date_query_then_tool_loop_complete_first_uses_date_snapshot() {
+async fn explicit_date_query_then_tool_loop_complete_first_uses_date_snapshot() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
     let owner = private_todo_owner();
@@ -617,10 +611,10 @@ async fn deterministic_date_query_then_tool_loop_complete_first_uses_date_snapsh
     let no_time = create_private_todo(&service, "无时间待办");
 
     let listed = service
-        .respond(private_message("查看2099-07-15待办"))
+        .respond(private_message("/todo list 2099-07-15"))
         .await
         .unwrap();
-    assert_eq!(listed.command.as_deref(), Some("todo_due_date"));
+    assert_eq!(listed.command.as_deref(), Some("todo_list"));
     let listed_text = listed.text.unwrap();
     assert!(listed_text.contains("1. 指定日期要完成"));
     assert!(!listed_text.contains("无时间待办"));
@@ -660,17 +654,14 @@ async fn deterministic_date_query_then_tool_loop_complete_first_uses_date_snapsh
 }
 
 #[tokio::test]
-async fn deterministic_todo_query_alias_then_tool_loop_complete_first_uses_latest_snapshot() {
+async fn explicit_todo_query_then_tool_loop_complete_first_uses_latest_snapshot() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
     let owner = private_todo_owner();
     let first = create_private_todo(&service, "代办 A");
     create_private_todo(&service, "代办 B");
 
-    let listed = service
-        .respond(private_message("看一下代办"))
-        .await
-        .unwrap();
+    let listed = service.respond(private_message("/todo")).await.unwrap();
     assert_eq!(listed.command.as_deref(), Some("todo_list"));
     assert!(listed.text.as_deref().unwrap().contains("1. 代办 A"));
 
@@ -694,7 +685,7 @@ async fn deterministic_todo_query_alias_then_tool_loop_complete_first_uses_lates
 }
 
 #[tokio::test]
-async fn deterministic_completed_query_then_tool_loop_restore_first_uses_latest_snapshot() {
+async fn explicit_completed_query_then_tool_loop_restore_first_uses_latest_snapshot() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
     let owner = private_todo_owner();
@@ -704,7 +695,7 @@ async fn deterministic_completed_query_then_tool_loop_restore_first_uses_latest_
     service.task_store.complete(&owner, &second.id).unwrap();
 
     let listed = service
-        .respond(private_message("看看已完成"))
+        .respond(private_message("/todo done"))
         .await
         .unwrap();
     assert_eq!(listed.command.as_deref(), Some("todo_done"));
@@ -738,22 +729,16 @@ async fn deterministic_completed_query_then_tool_loop_restore_first_uses_latest_
 }
 
 #[tokio::test]
-async fn deterministic_empty_query_clears_old_snapshot_before_number_mutation() {
+async fn explicit_empty_query_clears_old_snapshot_before_number_mutation() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
     let owner = private_todo_owner();
     let todo = create_private_todo(&service, "旧快照条目");
 
-    service
-        .respond(private_message("看一下待办"))
-        .await
-        .unwrap();
+    service.respond(private_message("/todo")).await.unwrap();
     service.task_store.complete(&owner, &todo.id).unwrap();
 
-    let empty_list = service
-        .respond(private_message("看一下待办"))
-        .await
-        .unwrap();
+    let empty_list = service.respond(private_message("/todo")).await.unwrap();
     assert!(
         empty_list
             .text
@@ -776,16 +761,13 @@ async fn deterministic_empty_query_clears_old_snapshot_before_number_mutation() 
 }
 
 #[tokio::test]
-async fn deterministic_query_then_status_changes_returns_precise_missing_error() {
+async fn explicit_query_then_status_changes_returns_precise_missing_error() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
     let owner = private_todo_owner();
     let todo = create_private_todo(&service, "状态先被改掉");
 
-    service
-        .respond(private_message("看一下待办"))
-        .await
-        .unwrap();
+    service.respond(private_message("/todo")).await.unwrap();
     // 模拟用户看到列表后，条目已被其他操作提前完成。
     service.task_store.complete(&owner, &todo.id).unwrap();
 

--- a/qq-maid-core/src/runtime/tools/agent_turn.rs
+++ b/qq-maid-core/src/runtime/tools/agent_turn.rs
@@ -202,12 +202,7 @@ fn project_tool_turn(
     let mut todo_outcomes = todo_projection.outcomes.into_iter().peekable();
 
     for (index, result) in output.agent.tool_results.iter().enumerate() {
-        if output
-            .agent
-            .tool_attempts
-            .iter()
-            .any(|attempt| attempt.retry_of == Some(index))
-        {
+        if is_retry_superseded_result(index, &output.agent.tool_attempts) {
             // 旧尝试仍保留在 Agent diagnostics；这里只丢弃它对应的用户展示块。
             let mut discarded = Vec::new();
             drain_todo_outcomes_for_result(index, &mut todo_outcomes, &mut discarded);
@@ -237,6 +232,15 @@ fn project_tool_turn(
         outcomes,
         visible_entity_snapshot,
     ))
+}
+
+pub(crate) fn is_retry_superseded_result(
+    result_index: usize,
+    attempts: &[qq_maid_llm::provider::ToolExecutionAttempt],
+) -> bool {
+    attempts
+        .iter()
+        .any(|attempt| attempt.retry_of == Some(result_index))
 }
 
 fn drain_todo_outcomes_for_result(

--- a/qq-maid-core/src/runtime/tools/agent_turn.rs
+++ b/qq-maid-core/src/runtime/tools/agent_turn.rs
@@ -190,8 +190,13 @@ fn project_tool_turn(
     meta: &SessionMeta,
     output: &RespondOutput,
 ) -> Result<AgentTurnOutcome, LlmError> {
-    let todo_projection =
-        todo::agent_turn::project_results(task_store, session, meta, &output.agent.tool_results)?;
+    let todo_projection = todo::agent_turn::project_results(
+        task_store,
+        session,
+        meta,
+        &output.agent.tool_results,
+        &output.agent.tool_attempts,
+    )?;
     let visible_entity_snapshot = todo_projection.visible_entity_snapshot;
     let mut outcomes = Vec::new();
     let mut todo_outcomes = todo_projection.outcomes.into_iter().peekable();

--- a/qq-maid-core/src/runtime/tools/todo/agent_turn.rs
+++ b/qq-maid-core/src/runtime/tools/todo/agent_turn.rs
@@ -32,10 +32,11 @@ pub(crate) fn project_results(
     session: &mut SessionRecord,
     meta: &SessionMeta,
     results: &[ToolExecutionResult],
+    attempts: &[qq_maid_llm::provider::ToolExecutionAttempt],
 ) -> Result<TodoAgentProjection, LlmError> {
     let owner = TaskStore::owner(meta.user_id.as_deref(), &meta.scope_key);
     let aggregation =
-        todo::flow::aggregate_todo_tool_results(task_store, session, &owner, results)?;
+        todo::flow::aggregate_todo_tool_results(task_store, session, &owner, results, attempts)?;
     let visible_entity_snapshot = aggregation.visible_entity_snapshot(session, meta);
     Ok(TodoAgentProjection {
         consumed_result_indexes: aggregation.consumed_result_indexes,

--- a/qq-maid-core/src/runtime/tools/todo/flow/mod.rs
+++ b/qq-maid-core/src/runtime/tools/todo/flow/mod.rs
@@ -2,6 +2,9 @@
 //! Slash 写入口已移除：`/todo` 系列只保留列表/搜索等查询能力；新增、修改、
 //! 完成、恢复和删除由 Tool Loop 触发。这里仍处理删除确认、目标澄清，
 //! 以及旧版 `TodoAdd` pending 兼容。
+//!
+//! 普通自然语言待办查询不再在进入模型前做词表短路，统一走 Tool Loop 的
+//! `list_todos`；本模块只处理显式 `/todo` 命令、完整结果恢复与 pending 流程。
 
 use qq_maid_common::time_context::{parse_single_date_expression, request_time_context};
 
@@ -15,7 +18,7 @@ use crate::{
         },
         session::{SessionMeta, SessionRecord},
         tools::todo::{
-            TodoItem, TodoOwner, TodoQueryStatus, TodoStatus, TodoStore,
+            TodoItem, TodoOwner, TodoQuery, TodoQueryStatus, TodoStatus, TodoStore,
             query_filter::parse_todo_list_query, todo_visible_entity_snapshot,
             valid_last_visible_todo_query,
         },
@@ -36,80 +39,6 @@ pub(crate) use command::parse_todo_command;
 use completed_query::parse_completed_todo_time_query;
 use format::*;
 pub(crate) use receipt::aggregate_todo_tool_results;
-
-const TODO_QUERY_NOUNS: &[&str] = &["待办", "代办", "任务"];
-const TODO_QUERY_LIST_VERBS: &[&str] = &[
-    "看一下",
-    "看下",
-    "看看",
-    "查询",
-    "查看",
-    "列出",
-    "有哪些",
-    "我的",
-];
-const TODO_QUERY_ALL_MARKERS: &[&str] = &["全部", "所有", "包含已完成"];
-const TODO_QUERY_PENDING_EXACT: &[&str] = &["我的待办", "待办列表"];
-const TODO_QUERY_ALL_EXACT: &[&str] = &[
-    "全部待办",
-    "所有待办",
-    "全部代办",
-    "所有代办",
-    "全部任务",
-    "所有任务",
-];
-const TODO_QUERY_ALL_FULL_EXACT: &[&str] = &[
-    "完整待办",
-    "完整代办",
-    "完整任务",
-    "查看完整待办",
-    "查看完整代办",
-    "查看完整任务",
-    "看完整待办",
-    "看完整代办",
-    "看完整任务",
-    "显示完整待办",
-    "显示完整代办",
-    "显示完整任务",
-];
-const TODO_QUERY_COMPLETED_EXACT: &[&str] =
-    &["已完成的待办", "看看已完成", "查看已完成", "列出已完成"];
-const TODO_QUERY_COMPLETED_MARKERS: &[&str] =
-    &["已完成", "完成的", "做完", "做完的", "搞定的", "结束的"];
-const TODO_QUERY_PENDING_MARKERS: &[&str] = &["进行中", "待处理", "待完成"];
-const TODO_QUERY_PENDING_NEGATED_COMPLETED_MARKERS: &[&str] = &[
-    "未完成",
-    "没完成",
-    "没有完成",
-    "未做完",
-    "没做完",
-    "没有做完",
-    "还没做完",
-    "还没有做完",
-    "未结束",
-    "没结束",
-    "没有结束",
-    "还没结束",
-];
-const TODO_QUERY_WRITE_MARKERS: &[&str] = &[
-    "新增",
-    "添加",
-    "增加",
-    "创建",
-    "记下",
-    "加个",
-    "加一个",
-    "加一条",
-    "加一项",
-    "加到",
-    "完成",
-    "取消",
-    "恢复",
-    "删除",
-    "修改",
-    "更新",
-    "改成",
-];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DailyReminderCommand {
@@ -173,21 +102,9 @@ impl RustRespondService {
     ) -> Result<Option<RespondResponse>, LlmError> {
         // Todo 默认归属当前 actor；即使消息来自群聊，也不能隐式写入群共享 Todo。
         let owner = TodoStore::owner(meta.user_id.as_deref(), &meta.scope_key);
+        // “查看完整结果”只恢复最近一次可见列表截断，不承担普通自然语言查询。
         if is_full_todo_result_request(user_text) {
             let (reply, command_name) = self.full_todo_result_from_last_query(&owner, session)?;
-            return Ok(Some(self.append_todo_query_response(
-                meta,
-                session,
-                user_text,
-                reply,
-                command_name,
-            )?));
-        }
-        // 自然语言“看看我的待办 / 看看已完成的待办”优先按查询处理，
-        // 避免旧的隐式创建/解析链路把纯查询误判成 todo_add -> todo_parse。
-        if let Some((reply, command_name)) =
-            self.try_handle_natural_todo_query(user_text, &owner, session)?
-        {
             return Ok(Some(self.append_todo_query_response(
                 meta,
                 session,
@@ -214,6 +131,7 @@ impl RustRespondService {
                             TodoQueryStatus::Completed => "completed-list",
                             TodoQueryStatus::Pending
                                 if parsed.query.keyword.is_some()
+                                    || parsed.query.recurring.is_some()
                                     || matches!(
                                         parsed.query.time,
                                         Some(
@@ -260,7 +178,7 @@ impl RustRespondService {
                     }
                     Err(err) => (
                         simple_todo_notice(&format!(
-                            "筛选条件无效：{}\n用法：/todo list [今天|明天|本周|逾期|无截止时间] [未完成|已完成|全部] [关键词 文本]",
+                            "筛选条件无效：{}\n用法：/todo list [今天|明天|本周|逾期|无截止时间] [未完成|已完成|全部] [周期性|一次性] [关键词 文本]",
                             err.message()
                         )),
                         "todo_list_invalid".to_owned(),
@@ -504,72 +422,6 @@ impl RustRespondService {
         }
     }
 
-    fn try_handle_natural_todo_query(
-        &self,
-        user_text: &str,
-        owner: &TodoOwner,
-        session: &mut SessionRecord,
-    ) -> Result<Option<(CommandBody, String)>, LlmError> {
-        let Some(query) = detect_natural_todo_query(user_text) else {
-            return Ok(None);
-        };
-        let result = match query.kind {
-            NaturalTodoQueryKind::Pending => {
-                let items = self.task_store.list_pending(owner).map_err(todo_error)?;
-                remember_todo_query(session, owner, "list", "", &items, query.force_full);
-                (
-                    format_todo_list_reply(&items, query.force_full),
-                    "todo_list".to_owned(),
-                )
-            }
-            NaturalTodoQueryKind::DueDate(date_query) => {
-                let items = self
-                    .task_store
-                    .list_by_due_date(owner, TodoStatus::Pending, date_query.date)
-                    .map_err(todo_error)?;
-                remember_todo_query(
-                    session,
-                    owner,
-                    "due-date",
-                    date_query.condition.clone(),
-                    &items,
-                    query.force_full,
-                );
-                (
-                    format_todo_due_date_reply(&items, &date_query.label, query.force_full),
-                    "todo_due_date".to_owned(),
-                )
-            }
-            NaturalTodoQueryKind::All => {
-                let items = self
-                    .task_store
-                    .list_all_for_board(owner)
-                    .map_err(todo_error)?;
-                remember_todo_query(session, owner, "all", "全部待办", &items, query.force_full);
-                (
-                    format_todo_all_reply(&items, query.force_full),
-                    "todo_all".to_owned(),
-                )
-            }
-            NaturalTodoQueryKind::Completed => {
-                let items = self.task_store.list_completed(owner).map_err(todo_error)?;
-                remember_todo_query(
-                    session,
-                    owner,
-                    "completed-list",
-                    "已完成列表",
-                    &items,
-                    query.force_full,
-                );
-                (
-                    format_todo_done_list_reply(&items, query.force_full),
-                    "todo_done".to_owned(),
-                )
-            }
-        };
-        Ok(Some(result))
-    }
-
     fn full_todo_result_from_last_query(
         &self,
         owner: &TodoOwner,
@@ -605,18 +457,50 @@ impl RustRespondService {
             }
             "search" => {
                 let condition = query.condition.trim();
-                let items = if condition.is_empty() {
-                    self.task_store.list_pending(owner).map_err(todo_error)?
+                // 周期类型筛选的 condition 是展示标签，不是关键词；恢复完整结果时必须复用 TodoQuery。
+                if matches!(condition, "周期性待办" | "一次性待办") {
+                    let recurring = condition == "周期性待办";
+                    let page = self
+                        .task_store
+                        .query_todos(
+                            owner,
+                            &TodoQuery {
+                                status: TodoQueryStatus::Pending,
+                                recurring: Some(recurring),
+                                limit: crate::runtime::tools::todo::TODO_QUERY_MAX_LIMIT,
+                                ..TodoQuery::default()
+                            },
+                        )
+                        .map_err(todo_error)?;
+                    session.remember_last_todo_query(
+                        &owner.key,
+                        "search",
+                        condition.to_owned(),
+                        page.items.iter().map(|item| item.id.clone()).collect(),
+                    );
+                    Ok((
+                        format_todo_query_page_reply(
+                            &page,
+                            "🚧 进行中",
+                            "没有找到匹配的待办。",
+                            condition,
+                        ),
+                        "todo_list".to_owned(),
+                    ))
                 } else {
-                    self.task_store
-                        .search_pending(owner, condition)
-                        .map_err(todo_error)?
-                };
-                remember_todo_query(session, owner, "search", condition, &items, true);
-                Ok((
-                    format_todo_search_reply(&items, condition, true),
-                    "todo_search".to_owned(),
-                ))
+                    let items = if condition.is_empty() {
+                        self.task_store.list_pending(owner).map_err(todo_error)?
+                    } else {
+                        self.task_store
+                            .search_pending(owner, condition)
+                            .map_err(todo_error)?
+                    };
+                    remember_todo_query(session, owner, "search", condition, &items, true);
+                    Ok((
+                        format_todo_search_reply(&items, condition, true),
+                        "todo_search".to_owned(),
+                    ))
+                }
             }
             "completed-time" => {
                 let Some(completed_query) = parse_completed_todo_time_query(&query.condition)
@@ -695,249 +579,10 @@ fn parse_daily_reminder_command(argument: &str) -> Option<DailyReminderCommand> 
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum NaturalTodoQueryKind {
-    Pending,
-    DueDate(TodoDueDateQuery),
-    All,
-    Completed,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct NaturalTodoQuery {
-    kind: NaturalTodoQueryKind,
-    force_full: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
 struct TodoDueDateQuery {
     label: String,
     condition: String,
     date: NaiveDate,
-}
-
-fn detect_natural_todo_query(user_text: &str) -> Option<NaturalTodoQuery> {
-    let text = normalize_natural_todo_text(user_text);
-    if text.is_empty() {
-        return None;
-    }
-    // slash `/todo ...` 继续走显式命令解析，避免自然语言词表误抢 `/任务 搜 查询` 之类分支。
-    if text.starts_with('/') {
-        return None;
-    }
-    let force_full = contains_full_marker(&text);
-    if let Some(date_query) = detect_natural_todo_due_date_query(&text) {
-        return Some(NaturalTodoQuery {
-            kind: NaturalTodoQueryKind::DueDate(date_query),
-            force_full,
-        });
-    }
-    if TODO_QUERY_PENDING_EXACT.contains(&text.as_str()) {
-        return Some(NaturalTodoQuery {
-            kind: NaturalTodoQueryKind::Pending,
-            force_full,
-        });
-    }
-    if TODO_QUERY_ALL_EXACT.contains(&text.as_str()) {
-        return Some(NaturalTodoQuery {
-            kind: NaturalTodoQueryKind::All,
-            // “全部待办”表达跨状态范围，不等同于展开全部结果；展开仍由
-            // “查看完整结果”基于最近查询快照恢复。
-            force_full: false,
-        });
-    }
-    if TODO_QUERY_ALL_FULL_EXACT.contains(&text.as_str()) {
-        return Some(NaturalTodoQuery {
-            kind: NaturalTodoQueryKind::All,
-            force_full: true,
-        });
-    }
-    if TODO_QUERY_COMPLETED_EXACT.contains(&text.as_str()) {
-        return Some(NaturalTodoQuery {
-            kind: NaturalTodoQueryKind::Completed,
-            force_full,
-        });
-    }
-    let mentions_todo = contains_any(&text, TODO_QUERY_NOUNS);
-    let asks_list = TODO_QUERY_LIST_VERBS
-        .iter()
-        .any(|needle| text.contains(needle));
-    if !asks_list {
-        return None;
-    }
-    let mentions_list = text.contains("列表") || text.contains("清单");
-    let mentions_completed = contains_any(&text, TODO_QUERY_COMPLETED_MARKERS);
-    let mentions_pending = contains_any(&text, TODO_QUERY_PENDING_MARKERS);
-    let mentions_pending_by_negated_completed =
-        contains_any(&text, TODO_QUERY_PENDING_NEGATED_COMPLETED_MARKERS);
-    let mentions_state =
-        mentions_completed || mentions_pending || mentions_pending_by_negated_completed;
-    if contains_todo_due_date_write_marker(&text, mentions_pending_by_negated_completed)
-        && !mentions_state
-    {
-        return None;
-    }
-    if !(mentions_todo || mentions_list && mentions_state) {
-        return None;
-    }
-    // 否定状态必须先于肯定子串判断；例如“未完成的待办”包含“完成的”，
-    // 但语义是进行中列表，不是已完成列表。
-    if mentions_pending_by_negated_completed || mentions_pending {
-        return Some(NaturalTodoQuery {
-            kind: NaturalTodoQueryKind::Pending,
-            force_full,
-        });
-    }
-    let mentions_all = TODO_QUERY_ALL_MARKERS
-        .iter()
-        .any(|needle| text.contains(needle));
-    // “包含已完成”表达的是跨状态总览，不是单独的已完成列表。
-    if mentions_all && text.contains("包含") {
-        return Some(NaturalTodoQuery {
-            kind: NaturalTodoQueryKind::All,
-            force_full,
-        });
-    }
-    if mentions_all && !text.contains("已完成") && !mentions_completed {
-        return Some(NaturalTodoQuery {
-            kind: NaturalTodoQueryKind::All,
-            force_full,
-        });
-    }
-    // 状态判断只在“列表查询语义”确认后执行，避免写操作被抢走。
-    if mentions_completed {
-        return Some(NaturalTodoQuery {
-            kind: NaturalTodoQueryKind::Completed,
-            force_full,
-        });
-    }
-    if mentions_all {
-        return Some(NaturalTodoQuery {
-            kind: NaturalTodoQueryKind::All,
-            force_full,
-        });
-    }
-    Some(NaturalTodoQuery {
-        kind: NaturalTodoQueryKind::Pending,
-        force_full,
-    })
-}
-
-fn detect_natural_todo_due_date_query(text: &str) -> Option<TodoDueDateQuery> {
-    let date_query = parse_todo_due_date_query(text)?;
-    let mentions_pending_by_negated_completed =
-        contains_any(text, TODO_QUERY_PENDING_NEGATED_COMPLETED_MARKERS);
-    if contains_todo_due_date_write_marker(text, mentions_pending_by_negated_completed) {
-        return None;
-    }
-    let mentions_completed = contains_any(text, TODO_QUERY_COMPLETED_MARKERS);
-    if mentions_completed && !mentions_pending_by_negated_completed {
-        return None;
-    }
-    // 日期待办查询是 Tool Loop 前的确定性短路，只允许少量完整句式命中。
-    // 不再用“日期 + 通用疑问词”猜测，避免普通聊天和跨工具任务被抢走。
-    if is_pure_todo_due_date_query(text, &date_query) {
-        Some(date_query)
-    } else {
-        None
-    }
-}
-
-fn is_pure_todo_due_date_query(text: &str, date_query: &TodoDueDateQuery) -> bool {
-    let text = normalize_pure_todo_query_pattern(text);
-    pure_todo_due_date_query_patterns(date_query)
-        .into_iter()
-        .any(|pattern| text == pattern)
-}
-
-fn pure_todo_due_date_query_patterns(date_query: &TodoDueDateQuery) -> Vec<String> {
-    let mut patterns = Vec::new();
-    for date in todo_due_date_query_date_tokens(date_query) {
-        for pattern in [
-            format!("{date}待办"),
-            format!("我的{date}待办"),
-            format!("查看{date}待办"),
-            format!("看看{date}待办"),
-            format!("帮我看看{date}待办"),
-            format!("查询{date}待办"),
-            format!("列出{date}待办"),
-            format!("查看{date}的待办"),
-            format!("看看{date}的待办"),
-            format!("帮我看看{date}的待办"),
-            format!("查询{date}的待办"),
-            format!("列出{date}的待办"),
-            format!("{date}未完成待办"),
-            format!("查看{date}未完成待办"),
-            format!("{date}有什么待办"),
-            format!("{date}有哪些待办"),
-            format!("{date}有什么任务"),
-            format!("{date}有哪些任务"),
-            format!("{date}有什么未完成待办"),
-            format!("{date}有哪些未完成待办"),
-            format!("{date}有什么未完成任务"),
-            format!("{date}有哪些未完成任务"),
-        ] {
-            patterns.push(pattern);
-        }
-    }
-    patterns
-}
-
-fn todo_due_date_query_date_tokens(date_query: &TodoDueDateQuery) -> Vec<String> {
-    let mut tokens = Vec::new();
-    for value in [&date_query.label, &date_query.condition] {
-        let token = normalize_pure_todo_query_pattern(value);
-        if !token.is_empty() && !tokens.contains(&token) {
-            tokens.push(token);
-        }
-    }
-    tokens
-}
-
-fn normalize_pure_todo_query_pattern(text: &str) -> String {
-    let mut normalized = text
-        .trim()
-        .replace("代办", "待办")
-        .chars()
-        .filter(|ch| !ch.is_whitespace() && !is_query_punctuation(*ch))
-        .collect::<String>();
-    while normalized.ends_with(['吗', '呢', '啊', '呀', '吧', '嘛']) {
-        normalized.pop();
-    }
-    normalized
-}
-
-fn is_query_punctuation(ch: char) -> bool {
-    ch.is_ascii_punctuation()
-        || matches!(
-            ch,
-            '，' | '。'
-                | '、'
-                | '：'
-                | '；'
-                | '？'
-                | '！'
-                | '（'
-                | '）'
-                | '【'
-                | '】'
-                | '《'
-                | '》'
-                | '“'
-                | '”'
-                | '‘'
-                | '’'
-        )
-}
-
-fn contains_todo_due_date_write_marker(
-    text: &str,
-    mentions_pending_by_negated_completed: bool,
-) -> bool {
-    TODO_QUERY_WRITE_MARKERS.iter().any(|needle| {
-        // “未完成/没完成”是未完成状态查询，不是完成写操作；其他写词仍拦截，
-        // 避免“明天删除待办”等操作句误入确定性日期查询。
-        !(*needle == "完成" && mentions_pending_by_negated_completed) && text.contains(needle)
-    })
 }
 
 fn parse_todo_due_date_query(text: &str) -> Option<TodoDueDateQuery> {
@@ -950,29 +595,10 @@ fn parse_todo_due_date_query(text: &str) -> Option<TodoDueDateQuery> {
     })
 }
 
-fn contains_any(text: &str, needles: &[&str]) -> bool {
-    needles.iter().any(|needle| text.contains(needle))
-}
-
-/// 自然语言待办查询入口统一做别字归一化，避免“代办/待办”落到不同链路。
-pub(crate) fn normalize_natural_todo_text(text: &str) -> String {
-    text.trim().replace("代办", "待办")
-}
-
-/// 判断一段自然语言是否应走确定性的待办查询分支。
-///
-/// 这里与 Tool Loop 守卫、入站分类共享同一套词表，避免简单查询重新漂回 LLM 自由决策。
-pub(crate) fn is_natural_todo_query_text(text: &str) -> bool {
-    is_full_todo_result_request(text) || detect_natural_todo_query(text).is_some()
-}
-
-fn contains_full_marker(text: &str) -> bool {
-    text.contains("全部") || text.contains("所有") || text.contains("完整")
-}
-
+/// 折叠列表后的“查看完整结果”入口；普通自然语言待办查询不再做词表短路。
 pub(crate) fn is_full_todo_result_request(text: &str) -> bool {
     matches!(
-        normalize_natural_todo_text(text).as_str(),
+        text.trim().replace("代办", "待办").as_str(),
         "查看完整结果" | "显示完整结果" | "看完整结果" | "完整结果"
     )
 }

--- a/qq-maid-core/src/runtime/tools/todo/flow/mod.rs
+++ b/qq-maid-core/src/runtime/tools/todo/flow/mod.rs
@@ -18,9 +18,9 @@ use crate::{
         },
         session::{SessionMeta, SessionRecord},
         tools::todo::{
-            TodoItem, TodoOwner, TodoQuery, TodoQueryStatus, TodoStatus, TodoStore,
-            query_filter::parse_todo_list_query, todo_visible_entity_snapshot,
-            valid_last_visible_todo_query,
+            TodoItem, TodoOwner, TodoQueryStatus, TodoStatus, TodoStore,
+            query_filter::parse_todo_list_query, remember_todo_query_snapshot, replay_todo_query,
+            todo_visible_entity_snapshot, valid_last_visible_todo_query,
         },
     },
 };
@@ -145,10 +145,12 @@ impl RustRespondService {
                             TodoQueryStatus::Pending if parsed.query.time.is_some() => "due-date",
                             TodoQueryStatus::Pending => "list",
                         };
-                        session.remember_last_todo_query(
-                            &owner.key,
+                        remember_todo_query_snapshot(
+                            session,
+                            &owner,
                             query_type,
                             parsed.condition.clone(),
+                            &parsed.query,
                             page.items.iter().map(|item| item.id.clone()).collect(),
                         );
                         let title = match parsed.query.status {
@@ -433,6 +435,29 @@ impl RustRespondService {
                 "todo_full_result_unavailable".to_owned(),
             ));
         };
+        if let Some(replay_query) = replay_todo_query(&query) {
+            let page = self
+                .task_store
+                .query_todos(owner, &replay_query)
+                .map_err(todo_error)?;
+            remember_todo_query_snapshot(
+                session,
+                owner,
+                query.query_type.clone(),
+                query.condition.clone(),
+                &replay_query,
+                page.items.iter().map(|item| item.id.clone()).collect(),
+            );
+            let (title, empty_text) = match replay_query.status {
+                TodoQueryStatus::Pending => ("🚧 进行中", "没有找到匹配的待办。"),
+                TodoQueryStatus::Completed => ("✅ 已完成", "没有找到匹配的待办。"),
+                TodoQueryStatus::All => ("📋 全部待办", "当前没有待办。"),
+            };
+            return Ok((
+                format_todo_query_page_reply(&page, title, empty_text, query.condition.trim()),
+                "todo_list".to_owned(),
+            ));
+        }
         match query.query_type.as_str() {
             "list" => {
                 let items = self.task_store.list_pending(owner).map_err(todo_error)?;
@@ -457,50 +482,18 @@ impl RustRespondService {
             }
             "search" => {
                 let condition = query.condition.trim();
-                // 周期类型筛选的 condition 是展示标签，不是关键词；恢复完整结果时必须复用 TodoQuery。
-                if matches!(condition, "周期性待办" | "一次性待办") {
-                    let recurring = condition == "周期性待办";
-                    let page = self
-                        .task_store
-                        .query_todos(
-                            owner,
-                            &TodoQuery {
-                                status: TodoQueryStatus::Pending,
-                                recurring: Some(recurring),
-                                limit: crate::runtime::tools::todo::TODO_QUERY_MAX_LIMIT,
-                                ..TodoQuery::default()
-                            },
-                        )
-                        .map_err(todo_error)?;
-                    session.remember_last_todo_query(
-                        &owner.key,
-                        "search",
-                        condition.to_owned(),
-                        page.items.iter().map(|item| item.id.clone()).collect(),
-                    );
-                    Ok((
-                        format_todo_query_page_reply(
-                            &page,
-                            "🚧 进行中",
-                            "没有找到匹配的待办。",
-                            condition,
-                        ),
-                        "todo_list".to_owned(),
-                    ))
+                let items = if condition.is_empty() {
+                    self.task_store.list_pending(owner).map_err(todo_error)?
                 } else {
-                    let items = if condition.is_empty() {
-                        self.task_store.list_pending(owner).map_err(todo_error)?
-                    } else {
-                        self.task_store
-                            .search_pending(owner, condition)
-                            .map_err(todo_error)?
-                    };
-                    remember_todo_query(session, owner, "search", condition, &items, true);
-                    Ok((
-                        format_todo_search_reply(&items, condition, true),
-                        "todo_search".to_owned(),
-                    ))
-                }
+                    self.task_store
+                        .search_pending(owner, condition)
+                        .map_err(todo_error)?
+                };
+                remember_todo_query(session, owner, "search", condition, &items, true);
+                Ok((
+                    format_todo_search_reply(&items, condition, true),
+                    "todo_search".to_owned(),
+                ))
             }
             "completed-time" => {
                 let Some(completed_query) = parse_completed_todo_time_query(&query.condition)

--- a/qq-maid-core/src/runtime/tools/todo/list.rs
+++ b/qq-maid-core/src/runtime/tools/todo/list.rs
@@ -10,7 +10,7 @@ use chrono::NaiveDate;
 use crate::error::LlmError;
 use crate::runtime::tools::todo::{
     TodoQuery, TodoQueryStatus, TodoQueryTimeFilter, resolve_todo_list_date_filter,
-    storage::validate_todo_query,
+    storage::validate_todo_query, todo_query_type,
 };
 
 use super::common::{
@@ -196,7 +196,7 @@ impl Tool for ListTodoTool {
         } else {
             conditions.join("、")
         };
-        scope.remember_internal_query("list-query", &condition, &page.items)?;
+        scope.remember_internal_query(todo_query_type(&query), &condition, &query, &page.items)?;
 
         Ok(ToolOutput::json(json!({
             "status": status.as_str(),

--- a/qq-maid-core/src/runtime/tools/todo/list.rs
+++ b/qq-maid-core/src/runtime/tools/todo/list.rs
@@ -41,7 +41,7 @@ impl Tool for ListTodoTool {
     fn metadata(&self) -> ToolMetadata {
         ToolMetadata {
             name: LIST_TODOS_TOOL_NAME.to_owned(),
-            description: "查询当前私聊用户的待办列表。不会返回数据库内部 ID；visible_number 只供本轮 Tool Loop 内部推理和后续工具调用使用，不会覆盖用户跨轮次真正看到的列表编号。status=pending 查询未完成，completed 查询已完成，all 查询全部。查询今天、昨天、本周、上周、本月、最近 N 天等时间范围时，把用户原始中文范围传给 date_range_text；Rust 会按请求时间和时区归一化，模型不要自行换算绝对日期。".to_owned(),
+            description: "查询当前私聊用户的待办列表。不会返回数据库内部 ID；visible_number 只供本轮 Tool Loop 内部推理和后续工具调用使用，不会覆盖用户跨轮次真正看到的列表编号。status=pending 查询未完成，completed 查询已完成，all 查询全部。查询今天、昨天、本周、上周、本月、最近 N 天等时间范围时，把用户原始中文范围传给 date_range_text；Rust 会按请求时间和时区归一化，模型不要自行换算绝对日期。用户说“周期性/重复待办”时传 recurring=true；说“一次性/非周期待办”时传 recurring=false；不限周期类型时传 null。状态、日期、关键词和周期类型可组合使用。".to_owned(),
             parameters: json!({
                 "type": "object",
                 "properties": {

--- a/qq-maid-core/src/runtime/tools/todo/list.rs
+++ b/qq-maid-core/src/runtime/tools/todo/list.rs
@@ -66,9 +66,13 @@ impl Tool for ListTodoTool {
                     "keyword": {
                         "type": ["string", "null"],
                         "description": "在待办标题、详情和原文中模糊搜索；多个空格分隔词使用 AND 匹配。项目名称当前也按关键词搜索。"
+                    },
+                    "recurring": {
+                        "type": ["boolean", "null"],
+                        "description": "周期类型筛选：true 只查询周期性待办，false 只查询非周期性、一次性待办，null 不限制周期类型。"
                     }
                 },
-                "required": ["status", "due_date", "date_range_text", "time_filter", "keyword"],
+                "required": ["status", "due_date", "date_range_text", "time_filter", "keyword", "recurring"],
                 "additionalProperties": false
             }),
         }
@@ -151,6 +155,7 @@ impl Tool for ListTodoTool {
             },
             time,
             keyword: optional_text(&arguments, "keyword")?,
+            recurring: optional_recurring(&arguments)?,
             ..TodoQuery::default()
         };
         validate_todo_query(&query).map_err(todo_tool_error)?;
@@ -179,6 +184,13 @@ impl Tool for ListTodoTool {
         if let Some(value) = query.keyword.as_deref() {
             conditions.push(format!("关键词“{value}”"));
         }
+        if let Some(recurring) = query.recurring {
+            conditions.push(if recurring {
+                "周期性待办".to_owned()
+            } else {
+                "一次性待办".to_owned()
+            });
+        }
         let condition = if conditions.is_empty() {
             status.condition().to_owned()
         } else {
@@ -203,8 +215,17 @@ impl Tool for ListTodoTool {
             "displayed_count": page.items.len(),
             "truncated": page.offset + page.items.len() < page.total_count,
             "keyword": query.keyword,
+            "recurring": query.recurring,
             "numbering": "visible_number 是本轮工具查询编号，仅在当前 Tool Loop 内有效；用户跨轮次的第 N 条仍以最近实际展示给用户的 /todo 列表为准；未暴露数据库内部 ID。"
         })))
+    }
+}
+
+fn optional_recurring(arguments: &serde_json::Value) -> Result<Option<bool>, LlmError> {
+    match arguments.get("recurring") {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::Bool(value)) => Ok(Some(*value)),
+        Some(_) => Err(bad_tool_arguments("recurring must be true/false/null")),
     }
 }
 

--- a/qq-maid-core/src/runtime/tools/todo/mod.rs
+++ b/qq-maid-core/src/runtime/tools/todo/mod.rs
@@ -23,6 +23,7 @@ mod json;
 pub(crate) mod ops;
 pub(crate) mod pending;
 pub(crate) mod query_filter;
+mod query_snapshot;
 pub(crate) mod receipt;
 pub(crate) mod recurrence;
 pub(crate) mod reminder;
@@ -60,6 +61,7 @@ pub(crate) use pending::{
     ClarificationCandidate, PendingTodoClarification, TODO_PENDING_DOMAIN, TodoPendingPayload,
     todo_lexicon,
 };
+pub(crate) use query_snapshot::{remember_todo_query_snapshot, replay_todo_query, todo_query_type};
 pub use recurring::ManageRecurringReminderTool;
 pub(crate) use reminder::{
     TodoReminderSentHook, cancel_reminder_task, cancel_reminder_task_by_id, sync_reminder_task,

--- a/qq-maid-core/src/runtime/tools/todo/pending_tests.rs
+++ b/qq-maid-core/src/runtime/tools/todo/pending_tests.rs
@@ -291,7 +291,23 @@ fn inbound_classification_marks_business_commands_immediate() {
 }
 
 #[test]
-fn inbound_classification_marks_natural_todo_queries_immediate() {
+fn inbound_classification_marks_explicit_todo_commands_immediate() {
+    let service = test_service();
+
+    for input in [
+        "/todo",
+        "/todo list",
+        "/todo all",
+        "/todo done",
+        "查看完整结果",
+    ] {
+        let classification = service.classify_inbound(message(input)).unwrap();
+        assert_eq!(classification.kind, CoreInboundKind::Immediate, "{input}");
+    }
+}
+
+#[test]
+fn inbound_classification_marks_natural_todo_queries_as_normal_chat() {
     let service = test_service();
 
     for input in [
@@ -301,9 +317,10 @@ fn inbound_classification_marks_natural_todo_queries_immediate() {
         "查询代办",
         "查看所有待办",
         "查看已完成待办",
+        "查看周期性待办",
     ] {
         let classification = service.classify_inbound(message(input)).unwrap();
-        assert_eq!(classification.kind, CoreInboundKind::Immediate, "{input}");
+        assert_eq!(classification.kind, CoreInboundKind::NormalChat, "{input}");
     }
 }
 
@@ -663,11 +680,11 @@ async fn stable_group_visible_todo_snapshots_are_isolated_by_actor() {
         .unwrap();
 
     service
-        .respond(stable_group_message("看一下待办", "u1"))
+        .respond(stable_group_message("/todo", "u1"))
         .await
         .unwrap();
     service
-        .respond(stable_group_message("看一下待办", "u2"))
+        .respond(stable_group_message("/todo", "u2"))
         .await
         .unwrap();
 

--- a/qq-maid-core/src/runtime/tools/todo/query_filter.rs
+++ b/qq-maid-core/src/runtime/tools/todo/query_filter.rs
@@ -2,6 +2,7 @@
 
 use qq_maid_common::time_context::{
     RequestTimeContext, parse_date_range_expression, parse_local_datetime_for_comparison,
+    parse_single_date_expression,
 };
 
 use super::{
@@ -53,6 +54,12 @@ pub(crate) fn parse_todo_list_query(
                 set_time_filter(&mut query, TodoQueryTimeFilter::NoDueDate)?;
                 time_condition = Some("无截止时间".to_owned());
             }
+            "周期" | "周期性" | "重复" | "recurring" => {
+                set_recurring_filter(&mut query, true)?;
+            }
+            "一次" | "一次性" | "非周期" | "非重复" | "one-off" | "once" => {
+                set_recurring_filter(&mut query, false)?;
+            }
             "关键词" | "keyword" => {
                 let keyword = tokens[index + 1..].join(" ");
                 if keyword.trim().is_empty() {
@@ -74,6 +81,17 @@ pub(crate) fn parse_todo_list_query(
                         },
                     )?;
                     time_condition = Some(range.raw);
+                } else if let Some(date) = parse_single_date_expression(token, ctx) {
+                    // 支持 /todo list 2099-07-15 这类绝对日期；相对表达优先走 date_range。
+                    set_time_filter(
+                        &mut query,
+                        TodoQueryTimeFilter::DateRange {
+                            start: date.date,
+                            end: date.date,
+                            field: TodoListDateField::Planned,
+                        },
+                    )?;
+                    time_condition = Some(date.raw);
                 } else {
                     keyword_parts.push(token.to_owned());
                 }
@@ -102,6 +120,13 @@ pub(crate) fn parse_todo_list_query(
     }
     if let Some(keyword) = query.keyword.as_deref() {
         conditions.push(format!("关键词“{keyword}”"));
+    }
+    if let Some(recurring) = query.recurring {
+        conditions.push(if recurring {
+            "周期性待办".to_owned()
+        } else {
+            "一次性待办".to_owned()
+        });
     }
     Ok(ParsedTodoQuery {
         query,
@@ -139,4 +164,17 @@ fn set_time_filter(query: &mut TodoQuery, filter: TodoQueryTimeFilter) -> Result
     }
     query.time = Some(filter);
     Ok(())
+}
+
+fn set_recurring_filter(query: &mut TodoQuery, recurring: bool) -> Result<(), TodoError> {
+    match query.recurring {
+        Some(current) if current != recurring => {
+            Err(TodoError::bad_request("一次查询只能指定一个周期类型条件。"))
+        }
+        Some(_) => Ok(()),
+        None => {
+            query.recurring = Some(recurring);
+            Ok(())
+        }
+    }
 }

--- a/qq-maid-core/src/runtime/tools/todo/query_snapshot.rs
+++ b/qq-maid-core/src/runtime/tools/todo/query_snapshot.rs
@@ -1,0 +1,215 @@
+//! 最近一次用户可见 Todo 查询的结构化重放。
+//!
+//! Session 只持久化不透明 JSON；status、时间字段和周期类型等 Todo 语义必须留在本域。
+
+use chrono::NaiveDate;
+use serde::{Deserialize, Serialize};
+
+use crate::runtime::session::{LastTodoQuery, SessionRecord};
+
+use super::{
+    TODO_QUERY_MAX_LIMIT, TodoListDateField, TodoOwner, TodoQuery, TodoQueryStatus,
+    TodoQueryTimeFilter, storage::validate_todo_query,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct TodoQueryReplay {
+    status: ReplayStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    time: Option<ReplayTimeFilter>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    keyword: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    recurring: Option<bool>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum ReplayStatus {
+    Pending,
+    Completed,
+    All,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum ReplayTimeFilter {
+    DateRange {
+        start: String,
+        end: String,
+        field: ReplayDateField,
+    },
+    Overdue,
+    NoDueDate,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum ReplayDateField {
+    Planned,
+    CompletedAt,
+}
+
+/// 记录用户实际看到的编号，并附上可直接重放的 Todo 查询语义。
+pub(crate) fn remember_todo_query_snapshot(
+    session: &mut SessionRecord,
+    owner: &TodoOwner,
+    query_type: impl Into<String>,
+    condition: impl Into<String>,
+    query: &TodoQuery,
+    result_ids: Vec<String>,
+) {
+    session.remember_last_todo_query(&owner.key, query_type, condition, result_ids);
+    if let Some(last_query) = session.last_todo_query.as_mut() {
+        last_query.replay_context = todo_query_replay_context(query);
+    }
+}
+
+pub(super) fn todo_query_replay_context(query: &TodoQuery) -> Option<serde_json::Value> {
+    serde_json::to_value(TodoQueryReplay::from(query)).ok()
+}
+
+/// 从 session 的不透明上下文恢复 Todo 查询，只覆盖完整结果所需的分页参数。
+pub(crate) fn replay_todo_query(last_query: &LastTodoQuery) -> Option<TodoQuery> {
+    let replay =
+        serde_json::from_value::<TodoQueryReplay>(last_query.replay_context.as_ref()?.clone())
+            .ok()?;
+    let query = replay.into_query()?;
+    validate_todo_query(&query).ok()?;
+    Some(query)
+}
+
+pub(crate) fn todo_query_type(query: &TodoQuery) -> &'static str {
+    match query.status {
+        TodoQueryStatus::All => "all",
+        TodoQueryStatus::Completed => "completed-list",
+        TodoQueryStatus::Pending
+            if matches!(query.time, Some(TodoQueryTimeFilter::DateRange { .. })) =>
+        {
+            "due-date"
+        }
+        TodoQueryStatus::Pending
+            if query.keyword.is_some()
+                || query.recurring.is_some()
+                || matches!(
+                    query.time,
+                    Some(TodoQueryTimeFilter::Overdue { .. } | TodoQueryTimeFilter::NoDueDate)
+                ) =>
+        {
+            "search"
+        }
+        TodoQueryStatus::Pending => "list",
+    }
+}
+
+impl From<&TodoQuery> for TodoQueryReplay {
+    fn from(query: &TodoQuery) -> Self {
+        Self {
+            status: match query.status {
+                TodoQueryStatus::Pending => ReplayStatus::Pending,
+                TodoQueryStatus::Completed => ReplayStatus::Completed,
+                TodoQueryStatus::All => ReplayStatus::All,
+            },
+            time: query.time.as_ref().map(|time| match time {
+                TodoQueryTimeFilter::DateRange { start, end, field } => {
+                    ReplayTimeFilter::DateRange {
+                        start: format_date(*start),
+                        end: format_date(*end),
+                        field: match field {
+                            TodoListDateField::Planned => ReplayDateField::Planned,
+                            TodoListDateField::CompletedAt => ReplayDateField::CompletedAt,
+                        },
+                    }
+                }
+                TodoQueryTimeFilter::Overdue { .. } => ReplayTimeFilter::Overdue,
+                TodoQueryTimeFilter::NoDueDate => ReplayTimeFilter::NoDueDate,
+            }),
+            keyword: query.keyword.clone(),
+            recurring: query.recurring,
+        }
+    }
+}
+
+impl TodoQueryReplay {
+    fn into_query(self) -> Option<TodoQuery> {
+        let time = match self.time {
+            Some(ReplayTimeFilter::DateRange { start, end, field }) => {
+                Some(TodoQueryTimeFilter::DateRange {
+                    start: parse_date(&start)?,
+                    end: parse_date(&end)?,
+                    field: match field {
+                        ReplayDateField::Planned => TodoListDateField::Planned,
+                        ReplayDateField::CompletedAt => TodoListDateField::CompletedAt,
+                    },
+                })
+            }
+            Some(ReplayTimeFilter::Overdue) => Some(TodoQueryTimeFilter::Overdue {
+                now: qq_maid_common::time_context::parse_local_datetime_for_comparison(
+                    qq_maid_common::time_context::request_time_context().current_time(),
+                )
+                .expect("request time context must contain a valid local datetime"),
+            }),
+            Some(ReplayTimeFilter::NoDueDate) => Some(TodoQueryTimeFilter::NoDueDate),
+            None => None,
+        };
+        Some(TodoQuery {
+            status: match self.status {
+                ReplayStatus::Pending => TodoQueryStatus::Pending,
+                ReplayStatus::Completed => TodoQueryStatus::Completed,
+                ReplayStatus::All => TodoQueryStatus::All,
+            },
+            time,
+            keyword: self.keyword,
+            recurring: self.recurring,
+            limit: TODO_QUERY_MAX_LIMIT,
+            offset: 0,
+        })
+    }
+}
+
+fn format_date(date: NaiveDate) -> String {
+    date.format("%Y-%m-%d").to_string()
+}
+
+fn parse_date(value: &str) -> Option<NaiveDate> {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d").ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDate;
+
+    use super::*;
+
+    #[test]
+    fn replay_round_trip_preserves_combination_filters_and_replaces_pagination() {
+        let query = TodoQuery {
+            status: TodoQueryStatus::Completed,
+            time: Some(TodoQueryTimeFilter::DateRange {
+                start: NaiveDate::from_ymd_opt(2026, 7, 1).unwrap(),
+                end: NaiveDate::from_ymd_opt(2026, 7, 20).unwrap(),
+                field: TodoListDateField::CompletedAt,
+            }),
+            keyword: Some("项目 A".to_owned()),
+            recurring: Some(true),
+            limit: 3,
+            offset: 6,
+        };
+        let last_query = LastTodoQuery {
+            owner_key: "u1".to_owned(),
+            query_type: "completed-list".to_owned(),
+            condition: "组合条件".to_owned(),
+            replay_context: Some(serde_json::to_value(TodoQueryReplay::from(&query)).unwrap()),
+            result_ids: Vec::new(),
+            created_at: String::new(),
+        };
+
+        let restored = replay_todo_query(&last_query).unwrap();
+        assert_eq!(restored.status, query.status);
+        assert_eq!(restored.time, query.time);
+        assert_eq!(restored.keyword, query.keyword);
+        assert_eq!(restored.recurring, query.recurring);
+        assert_eq!(restored.limit, TODO_QUERY_MAX_LIMIT);
+        assert_eq!(restored.offset, 0);
+    }
+}

--- a/qq-maid-core/src/runtime/tools/todo/receipt.rs
+++ b/qq-maid-core/src/runtime/tools/todo/receipt.rs
@@ -21,12 +21,15 @@ use crate::{
             common::{CommandBody, todo_error, truncate_chars},
         },
         session::{SessionMeta, SessionRecord},
-        tools::todo::{
-            ReminderFieldMode, TodoCardOptions, TodoItem, TodoListDateField, TodoListDateFilter,
-            TodoOwner, TodoQuery, TodoQueryStatus, TodoQueryTimeFilter, TodoRecurrenceKind,
-            TodoRecurrenceUnit, TodoRenderItem, TodoStatus, TodoStore, format_todo_cards,
-            remember_todo_query_snapshot, replay_todo_query,
-            todo_last_action_visible_entity_snapshot, todo_visible_entity_snapshot,
+        tools::{
+            agent_turn::is_retry_superseded_result,
+            todo::{
+                ReminderFieldMode, TodoCardOptions, TodoItem, TodoListDateField,
+                TodoListDateFilter, TodoOwner, TodoQuery, TodoQueryStatus, TodoQueryTimeFilter,
+                TodoRecurrenceKind, TodoRecurrenceUnit, TodoRenderItem, TodoStatus, TodoStore,
+                format_todo_cards, remember_todo_query_snapshot, replay_todo_query,
+                todo_last_action_visible_entity_snapshot, todo_visible_entity_snapshot,
+            },
         },
     },
     service::VisibleEntitySnapshot,
@@ -151,12 +154,16 @@ pub(crate) fn aggregate_todo_tool_results(
     for index in todo_indexes.iter().copied() {
         let result = &results[index];
         let pending_query = if result.name == LIST_TODOS_TOOL_NAME {
-            attempts
-                .iter()
-                .find(|attempt| attempt.result_index == index)
-                .and_then(|attempt| {
-                    TodoToolScope::consume_internal_query(session, &owner.key, &attempt.call_id)
-                })
+            if is_retry_superseded_result(index, attempts) {
+                None
+            } else {
+                attempts
+                    .iter()
+                    .find(|attempt| attempt.result_index == index)
+                    .and_then(|attempt| {
+                        TodoToolScope::consume_internal_query(session, &owner.key, &attempt.call_id)
+                    })
+            }
         } else {
             None
         };

--- a/qq-maid-core/src/runtime/tools/todo/receipt.rs
+++ b/qq-maid-core/src/runtime/tools/todo/receipt.rs
@@ -69,6 +69,8 @@ struct RelatedListSpec {
     date_field: TodoListDateField,
     keyword: Option<String>,
     special_time_filter: Option<String>,
+    /// `Some(true)` 只展示周期待办，`Some(false)` 只展示一次性待办。
+    recurring: Option<bool>,
     shared_query: bool,
     title: &'static str,
     empty_text: &'static str,
@@ -621,6 +623,7 @@ fn remember_related_list_snapshot(
         let mut query = TodoQuery {
             status: spec.query_status,
             keyword: spec.keyword.clone(),
+            recurring: spec.recurring,
             ..TodoQuery::default()
         };
         query.time = match spec.special_time_filter.as_deref() {
@@ -893,6 +896,7 @@ fn pending_list_spec() -> RelatedListSpec {
         date_field: TodoListDateField::Planned,
         keyword: None,
         special_time_filter: None,
+        recurring: None,
         shared_query: false,
         title: "🚧 当前进行中",
         empty_text: "当前没有进行中的待办。",
@@ -911,6 +915,7 @@ fn completed_list_spec() -> RelatedListSpec {
         date_field: TodoListDateField::Planned,
         keyword: None,
         special_time_filter: None,
+        recurring: None,
         shared_query: false,
         title: "✅ 当前已完成",
         empty_text: "当前没有已完成待办。",
@@ -934,6 +939,7 @@ fn list_spec_from_output(output: &Value) -> RelatedListSpec {
     spec.condition = string_field(output, "condition").unwrap_or_default();
     spec.keyword = string_field(output, "keyword");
     spec.special_time_filter = string_field(output, "time_filter");
+    spec.recurring = bool_field(output, "recurring");
     if let Some(due_date) = string_field(output, "due_date")
         .and_then(|value| NaiveDate::parse_from_str(&value, "%Y-%m-%d").ok())
     {
@@ -955,10 +961,14 @@ fn list_spec_from_output(output: &Value) -> RelatedListSpec {
         Some("all") => "all",
         Some("completed") => "completed-list",
         _ if spec.due_date.is_some() || spec.due_range.is_some() => "due-date",
-        _ if spec.keyword.is_some() => "search",
+        _ if spec.keyword.is_some() || spec.recurring.is_some() => "search",
         _ => "list",
     };
     spec
+}
+
+fn bool_field(value: &Value, key: &str) -> Option<bool> {
+    value.get(key).and_then(Value::as_bool)
 }
 
 fn all_list_spec() -> RelatedListSpec {
@@ -972,6 +982,7 @@ fn all_list_spec() -> RelatedListSpec {
         date_field: TodoListDateField::Planned,
         keyword: None,
         special_time_filter: None,
+        recurring: None,
         shared_query: false,
         title: "📋 全部待办",
         empty_text: "当前没有待办。",

--- a/qq-maid-core/src/runtime/tools/todo/receipt.rs
+++ b/qq-maid-core/src/runtime/tools/todo/receipt.rs
@@ -7,7 +7,7 @@
 use std::collections::HashSet;
 
 use chrono::NaiveDate;
-use qq_maid_llm::provider::ToolExecutionResult;
+use qq_maid_llm::provider::{ToolExecutionAttempt, ToolExecutionResult};
 use serde_json::Value;
 
 use crate::{
@@ -25,6 +25,7 @@ use crate::{
             ReminderFieldMode, TodoCardOptions, TodoItem, TodoListDateField, TodoListDateFilter,
             TodoOwner, TodoQuery, TodoQueryStatus, TodoQueryTimeFilter, TodoRecurrenceKind,
             TodoRecurrenceUnit, TodoRenderItem, TodoStatus, TodoStore, format_todo_cards,
+            remember_todo_query_snapshot, replay_todo_query,
             todo_last_action_visible_entity_snapshot, todo_visible_entity_snapshot,
         },
     },
@@ -35,6 +36,7 @@ use super::format::{
     append_todo_collapse_hint, format_todo_natural_list_item, todo_due_chip, todo_timestamp_chip,
     visible_todo_all_board_items, visible_todo_items,
 };
+use super::scope::TodoToolScope;
 
 const LIST_TODOS_TOOL_NAME: &str = "list_todos";
 const GET_TODO_TOOL_NAME: &str = "get_todo";
@@ -137,6 +139,7 @@ pub(crate) fn aggregate_todo_tool_results(
     session: &mut SessionRecord,
     owner: &TodoOwner,
     results: &[ToolExecutionResult],
+    attempts: &[ToolExecutionAttempt],
 ) -> Result<TodoTurnAggregation, LlmError> {
     let todo_indexes = results
         .iter()
@@ -147,10 +150,26 @@ pub(crate) fn aggregate_todo_tool_results(
     let mut outcomes = Vec::new();
     for index in todo_indexes.iter().copied() {
         let result = &results[index];
+        let pending_query = if result.name == LIST_TODOS_TOOL_NAME {
+            attempts
+                .iter()
+                .find(|attempt| attempt.result_index == index)
+                .and_then(|attempt| {
+                    TodoToolScope::consume_internal_query(session, &owner.key, &attempt.call_id)
+                })
+        } else {
+            None
+        };
         if result.name == LIST_TODOS_TOOL_NAME && !is_user_visible_list_query(results, index) {
             continue;
         }
-        if let Some(outcome) = tool_outcome_from_todo_result(todo_store, session, owner, result)? {
+        if let Some(outcome) = tool_outcome_from_todo_result(
+            todo_store,
+            session,
+            owner,
+            result,
+            pending_query.as_ref(),
+        )? {
             outcomes.push((index, outcome));
         }
     }
@@ -178,9 +197,10 @@ fn tool_outcome_from_todo_result(
     session: &mut SessionRecord,
     owner: &TodoOwner,
     result: &ToolExecutionResult,
+    pending_query: Option<&crate::runtime::session::LastTodoQuery>,
 ) -> Result<Option<ToolExecutionOutcome>, LlmError> {
     if result.name == LIST_TODOS_TOOL_NAME {
-        return list_todos_outcome(todo_store, session, owner, result).map(Some);
+        return list_todos_outcome(todo_store, session, owner, result, pending_query).map(Some);
     }
     if result.name == GET_TODO_TOOL_NAME {
         return Ok(Some(get_todo_outcome(result)));
@@ -233,7 +253,7 @@ fn refresh_todo_snapshot_for_turn(
         return Ok(());
     }
     let spec = merge_related_list_specs(&specs);
-    remember_related_list_snapshot(todo_store, session, owner, &spec)?;
+    remember_related_list_snapshot(todo_store, session, owner, &spec, None)?;
     Ok(())
 }
 
@@ -270,6 +290,7 @@ fn list_todos_outcome(
     session: &mut SessionRecord,
     owner: &TodoOwner,
     result: &ToolExecutionResult,
+    pending_query: Option<&crate::runtime::session::LastTodoQuery>,
 ) -> Result<ToolExecutionOutcome, LlmError> {
     let status = ToolOutcomeStatus::from_tool_result(result);
     let error_code = structured_error_code(&result.output);
@@ -301,12 +322,37 @@ fn list_todos_outcome(
             command: Some("todo_tool_skipped".to_owned()),
         });
     }
+    if pending_query.is_none()
+        && result
+            .output
+            .get("truncated")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    {
+        return Ok(ToolExecutionOutcome {
+            tool_name: result.name.clone(),
+            domain: "todo".to_owned(),
+            status: ToolOutcomeStatus::RequiresClarification,
+            effect: ToolEffect::ReadOnly,
+            presentation: OutcomePresentation::Trusted,
+            blocks: vec![ResponseBlock::Warning(CommandBody::plain(
+                "待办查询结果已截断，且筛选上下文无法恢复，请重新输入查询条件。",
+            ))],
+            error_code: Some("todo_query_context_unavailable".to_owned()),
+            command: Some("todo_full_result_unavailable".to_owned()),
+        });
+    }
 
-    let spec = list_spec_from_output(&result.output);
+    let spec = pending_query
+        .and_then(|pending| {
+            replay_todo_query(pending)
+                .map(|query| list_spec_from_replay(&query, &pending.condition, &result.output))
+        })
+        .unwrap_or_else(|| list_spec_from_output(&result.output));
     // `list_todos` 若成为最终用户可见结果，必须同步写入真实可见快照；
     // 仅在 Tool 内部执行但未展示时，原有内部查询上下文仍由 TodoToolScope 保持。
     let (shown, total_count, truncated) =
-        remember_related_list_snapshot(todo_store, session, owner, &spec)?;
+        remember_related_list_snapshot(todo_store, session, owner, &spec, pending_query)?;
 
     let mut lines = Vec::new();
     let mut markdown_lines = Vec::new();
@@ -596,7 +642,7 @@ fn receipt_with_related_list(
     } = draft;
     // 写操作默认只返回轻量确认，但仍后台刷新同一范围的可见快照，
     // 保证下一轮“第一条 / 刚刚那条”等指代继续落到最新列表。
-    remember_related_list_snapshot(todo_store, session, owner, &spec)?;
+    remember_related_list_snapshot(todo_store, session, owner, &spec, None)?;
     let mut text = lines.join("\n");
     let mut markdown = markdown_lines.join("\n");
     if let Some(hint) = trailing_hint {
@@ -618,42 +664,21 @@ fn remember_related_list_snapshot(
     session: &mut SessionRecord,
     owner: &TodoOwner,
     spec: &RelatedListSpec,
+    pending_query: Option<&crate::runtime::session::LastTodoQuery>,
 ) -> Result<(Vec<TodoItem>, usize, bool), LlmError> {
     if spec.shared_query {
-        let mut query = TodoQuery {
-            status: spec.query_status,
-            keyword: spec.keyword.clone(),
-            recurring: spec.recurring,
-            ..TodoQuery::default()
-        };
-        query.time = match spec.special_time_filter.as_deref() {
-            Some("overdue") => Some(TodoQueryTimeFilter::Overdue {
-                now: qq_maid_common::time_context::parse_local_datetime_for_comparison(
-                    qq_maid_common::time_context::request_time_context().current_time(),
-                )
-                .expect("request time context must contain a valid local datetime"),
-            }),
-            Some("no_due_date") => Some(TodoQueryTimeFilter::NoDueDate),
-            _ => spec
-                .due_range
-                .map(|(start, end)| TodoQueryTimeFilter::DateRange {
-                    start,
-                    end,
-                    field: spec.date_field,
-                })
-                .or_else(|| {
-                    spec.due_date.map(|date| TodoQueryTimeFilter::DateRange {
-                        start: date,
-                        end: date,
-                        field: spec.date_field,
-                    })
-                }),
-        };
+        let mut query = pending_query
+            .and_then(replay_todo_query)
+            .unwrap_or_else(|| query_from_related_spec(spec));
+        query.limit = crate::runtime::tools::todo::TODO_QUERY_DEFAULT_LIMIT;
+        query.offset = 0;
         let page = todo_store.query_todos(owner, &query).map_err(todo_error)?;
-        session.remember_last_todo_query(
-            &owner.key,
+        remember_todo_query_snapshot(
+            session,
+            owner,
             spec.query_type,
             spec.condition.clone(),
+            &query,
             page.items.iter().map(|item| item.id.clone()).collect(),
         );
         let truncated = page.offset + page.items.len() < page.total_count;
@@ -672,6 +697,39 @@ fn remember_related_list_snapshot(
         shown.iter().map(|item| item.id.clone()).collect(),
     );
     Ok((shown, total_count, truncated))
+}
+
+fn query_from_related_spec(spec: &RelatedListSpec) -> TodoQuery {
+    let mut query = TodoQuery {
+        status: spec.query_status,
+        keyword: spec.keyword.clone(),
+        recurring: spec.recurring,
+        ..TodoQuery::default()
+    };
+    query.time = match spec.special_time_filter.as_deref() {
+        Some("overdue") => Some(TodoQueryTimeFilter::Overdue {
+            now: qq_maid_common::time_context::parse_local_datetime_for_comparison(
+                qq_maid_common::time_context::request_time_context().current_time(),
+            )
+            .expect("request time context must contain a valid local datetime"),
+        }),
+        Some("no_due_date") => Some(TodoQueryTimeFilter::NoDueDate),
+        _ => spec
+            .due_range
+            .map(|(start, end)| TodoQueryTimeFilter::DateRange {
+                start,
+                end,
+                field: spec.date_field,
+            })
+            .or_else(|| {
+                spec.due_date.map(|date| TodoQueryTimeFilter::DateRange {
+                    start: date,
+                    end: date,
+                    field: spec.date_field,
+                })
+            }),
+    };
+    query
 }
 
 fn visible_related_items<'a>(items: &'a [TodoItem], spec: &RelatedListSpec) -> &'a [TodoItem] {
@@ -964,6 +1022,41 @@ fn list_spec_from_output(output: &Value) -> RelatedListSpec {
         _ if spec.keyword.is_some() || spec.recurring.is_some() => "search",
         _ => "list",
     };
+    spec
+}
+
+fn list_spec_from_replay(query: &TodoQuery, condition: &str, output: &Value) -> RelatedListSpec {
+    let mut spec = match query.status {
+        TodoQueryStatus::Pending => pending_list_spec(),
+        TodoQueryStatus::Completed => completed_list_spec(),
+        TodoQueryStatus::All => all_list_spec(),
+    };
+    spec.query_status = query.status;
+    spec.query_type = crate::runtime::tools::todo::todo_query_type(query);
+    spec.condition = condition.to_owned();
+    spec.keyword = query.keyword.clone();
+    spec.recurring = query.recurring;
+    spec.shared_query = true;
+    match query.time.as_ref() {
+        Some(TodoQueryTimeFilter::DateRange { start, end, field }) => {
+            if start == end {
+                spec.due_date = Some(*start);
+            } else {
+                spec.due_range = Some((*start, *end));
+            }
+            spec.date_field = *field;
+        }
+        Some(TodoQueryTimeFilter::Overdue { .. }) => {
+            spec.special_time_filter = Some("overdue".to_owned())
+        }
+        Some(TodoQueryTimeFilter::NoDueDate) => {
+            spec.special_time_filter = Some("no_due_date".to_owned())
+        }
+        None => {}
+    }
+    if spec.condition.is_empty() {
+        spec.condition = string_field(output, "condition").unwrap_or_default();
+    }
     spec
 }
 

--- a/qq-maid-core/src/runtime/tools/todo/scope.rs
+++ b/qq-maid-core/src/runtime/tools/todo/scope.rs
@@ -14,10 +14,13 @@ use crate::{
     error::LlmError,
     runtime::{
         freshness::query_is_fresh,
-        session::{LAST_QUERY_TTL_SECONDS, LastTodoQuery, SessionMeta, SessionStore, now_iso_cn},
+        session::{
+            LAST_QUERY_TTL_SECONDS, LastTodoQuery, SessionMeta, SessionRecord, SessionStore,
+            now_iso_cn,
+        },
         tools::todo::{
             ClarificationCandidate, PendingTodoClarification, TodoItem, TodoOwner,
-            TodoPendingPayload, TodoStatus, TodoStore, valid_last_visible_todo_query,
+            TodoPendingPayload, TodoQuery, TodoStatus, TodoStore, valid_last_visible_todo_query,
         },
     },
 };
@@ -39,9 +42,13 @@ const TODO_TASK_QUERY_HISTORY_LIMIT: usize = 16;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct TodoTaskQueryEntry {
     task_id: String,
+    #[serde(default)]
+    tool_call_id: String,
     owner_key: String,
     query_type: String,
     condition: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    replay_context: Option<Value>,
     result_ids: Vec<String>,
     created_at: String,
 }
@@ -52,6 +59,7 @@ impl TodoTaskQueryEntry {
             owner_key: self.owner_key.clone(),
             query_type: self.query_type.clone(),
             condition: self.condition.clone(),
+            replay_context: self.replay_context.clone(),
             result_ids: self.result_ids.clone(),
             created_at: self.created_at.clone(),
         }
@@ -68,6 +76,8 @@ pub(in crate::runtime::tools::todo) struct TodoToolScope {
     pub session_store: SessionStore,
     /// 当前 Tool Loop 的任务 ID；内部 list_todos 结果只在同一 task 内复用。
     task_id: String,
+    /// 当前调用的稳定 ID；用于 receipt 精确消费查询上下文，避免同任务多次调用串台。
+    tool_call_id: String,
     /// 本次调用可选的请求级选择作用域覆盖；`None` 走默认 `last_todo_query` 解析。
     selection_scope: Option<SelectionScope>,
 }
@@ -236,6 +246,7 @@ impl TodoToolScope {
             session,
             session_store: session_store.clone(),
             task_id: context.task_id.clone(),
+            tool_call_id: context.tool_call_id.clone().unwrap_or_default(),
             selection_scope,
         })
     }
@@ -249,12 +260,14 @@ impl TodoToolScope {
         &mut self,
         query_type: &str,
         condition: &str,
+        replay_query: &TodoQuery,
         items: &[TodoItem],
     ) -> Result<(), LlmError> {
         let query = LastTodoQuery {
             owner_key: self.owner.key.clone(),
             query_type: query_type.to_owned(),
             condition: condition.to_owned(),
+            replay_context: super::query_snapshot::todo_query_replay_context(replay_query),
             result_ids: items.iter().map(|item| item.id.clone()).collect(),
             created_at: now_iso_cn(),
         };
@@ -423,12 +436,18 @@ impl TodoToolScope {
 
     fn remember_task_query(&mut self, query: &LastTodoQuery) -> Result<(), LlmError> {
         let mut entries = self.task_query_entries()?;
-        entries.retain(|entry| entry.task_id != self.task_id);
+        // 新任务开始查询时清理旧任务的 pending context；当前任务保留多次 list 调用，
+        // receipt 再按各自稳定 tool_call_id 逐条消费，避免 provider 重用 call ID 串台。
+        entries.retain(|entry| {
+            entry.task_id == self.task_id && entry.tool_call_id != self.tool_call_id
+        });
         entries.push(TodoTaskQueryEntry {
             task_id: self.task_id.clone(),
+            tool_call_id: self.tool_call_id.clone(),
             owner_key: query.owner_key.clone(),
             query_type: query.query_type.clone(),
             condition: query.condition.clone(),
+            replay_context: query.replay_context.clone(),
             result_ids: query.result_ids.clone(),
             created_at: query.created_at.clone(),
         });
@@ -447,6 +466,38 @@ impl TodoToolScope {
             })?,
         );
         self.save()
+    }
+
+    /// 按 Tool Loop 的原始 call ID 消费 pending 查询上下文；消费后立即从 session 清理。
+    pub(in crate::runtime::tools::todo) fn consume_internal_query(
+        session: &mut SessionRecord,
+        owner_key: &str,
+        call_id: &str,
+    ) -> Option<LastTodoQuery> {
+        let call_id = call_id.trim();
+        if call_id.is_empty() {
+            return None;
+        }
+        let mut entries = session
+            .extra
+            .get(TODO_TASK_QUERY_HISTORY_KEY)
+            .cloned()
+            .and_then(|value| serde_json::from_value::<Vec<TodoTaskQueryEntry>>(value).ok())?;
+        let position = entries.iter().position(|entry| {
+            entry.owner_key == owner_key
+                && query_is_fresh(&entry.created_at, LAST_QUERY_TTL_SECONDS)
+                && (entry.tool_call_id == call_id
+                    || entry.tool_call_id.ends_with(&format!(":{call_id}")))
+        })?;
+        let query = entries.remove(position).to_last_query();
+        if entries.is_empty() {
+            session.extra.remove(TODO_TASK_QUERY_HISTORY_KEY);
+        } else if let Ok(value) = serde_json::to_value(entries) {
+            session
+                .extra
+                .insert(TODO_TASK_QUERY_HISTORY_KEY.to_owned(), value);
+        }
+        Some(query)
     }
 
     fn valid_task_todo_query(&self) -> Result<Option<LastTodoQuery>, LlmError> {

--- a/qq-maid-core/src/runtime/tools/todo/storage/query_model.rs
+++ b/qq-maid-core/src/runtime/tools/todo/storage/query_model.rs
@@ -7,7 +7,7 @@ use rusqlite::{params_from_iter, types::Value as SqlValue};
 
 use super::{
     TODO_QUERY_MAX_LIMIT, TodoError, TodoListDateField, TodoQuery, TodoQueryPage, TodoQueryStatus,
-    TodoQueryTimeFilter, TodoStatus, TodoStore, query::todo_item_from_row,
+    TodoQueryTimeFilter, TodoRecurrenceKind, TodoStatus, TodoStore, query::todo_item_from_row,
 };
 
 const SELECT_COLUMNS: &str = "id, user_id, scope_key, title, detail, raw_text,
@@ -95,6 +95,14 @@ fn build_where(owner: &super::TodoOwner, query: &TodoQuery) -> (String, Vec<SqlV
     }
     if let Some(time) = &query.time {
         append_time_filter(&mut clauses, &mut params, time);
+    }
+    if let Some(recurring) = query.recurring {
+        clauses.push(if recurring {
+            "recurrence_kind <> ?".to_owned()
+        } else {
+            "recurrence_kind = ?".to_owned()
+        });
+        params.push(SqlValue::Text(TodoRecurrenceKind::None.as_str().to_owned()));
     }
     if let Some(keyword) = query
         .keyword

--- a/qq-maid-core/src/runtime/tools/todo/storage/types.rs
+++ b/qq-maid-core/src/runtime/tools/todo/storage/types.rs
@@ -196,6 +196,8 @@ pub struct TodoQuery {
     pub status: TodoQueryStatus,
     pub time: Option<TodoQueryTimeFilter>,
     pub keyword: Option<String>,
+    /// `Some(true)` 仅查询周期待办，`Some(false)` 仅查询一次性待办。
+    pub recurring: Option<bool>,
     pub limit: usize,
     pub offset: usize,
 }
@@ -206,6 +208,7 @@ impl Default for TodoQuery {
             status: TodoQueryStatus::Pending,
             time: None,
             keyword: None,
+            recurring: None,
             limit: TODO_QUERY_DEFAULT_LIMIT,
             offset: 0,
         }

--- a/qq-maid-core/src/runtime/tools/todo/tests/list.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests/list.rs
@@ -78,6 +78,89 @@ async fn list_tool_combines_tomorrow_status_and_keyword_filters() {
 }
 
 #[tokio::test]
+async fn list_tool_filters_recurring_true_false_and_null() {
+    let (todo_store, session_store, _notification_store, owner) = test_stores();
+    let tomorrow = (qq_maid_common::time_context::request_time_context().local_date()
+        + chrono::Duration::days(1))
+    .format("%Y-%m-%d")
+    .to_string();
+    todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "项目周期复盘".to_owned(),
+                due_date: Some(tomorrow.clone()),
+                time_precision: TodoTimePrecision::Date,
+                recurrence_kind: crate::runtime::tools::todo::TodoRecurrenceKind::Daily,
+                recurrence_interval_days: 1,
+                recurrence_interval: 1,
+                recurrence_unit: crate::runtime::tools::todo::TodoRecurrenceUnit::Day,
+                ..tool_test_draft("项目周期复盘")
+            },
+        )
+        .unwrap();
+    todo_store
+        .create(
+            &owner,
+            TodoItemDraft {
+                title: "项目一次复盘".to_owned(),
+                due_date: Some(tomorrow),
+                time_precision: TodoTimePrecision::Date,
+                ..tool_test_draft("项目一次复盘")
+            },
+        )
+        .unwrap();
+    let tool = ListTodoTool::new(todo_store, session_store);
+    let arguments = |recurring: Value| {
+        json!({
+            "status": "pending",
+            "due_date": null,
+            "date_range_text": "明天",
+            "time_filter": null,
+            "keyword": "项目",
+            "recurring": recurring,
+        })
+    };
+
+    let recurring = tool
+        .execute(test_context(), arguments(json!(true)))
+        .await
+        .unwrap()
+        .value;
+    let one_off = tool
+        .execute(test_context(), arguments(json!(false)))
+        .await
+        .unwrap()
+        .value;
+    let unrestricted = tool
+        .execute(test_context(), arguments(Value::Null))
+        .await
+        .unwrap()
+        .value;
+    let legacy_unrestricted = tool
+        .execute(
+            test_context(),
+            json!({
+                "status": "pending",
+                "due_date": null,
+                "date_range_text": "明天",
+                "time_filter": null,
+                "keyword": "项目",
+            }),
+        )
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(recurring["total_count"], 1);
+    assert_eq!(recurring["items"][0]["title"], "项目周期复盘");
+    assert_eq!(one_off["total_count"], 1);
+    assert_eq!(one_off["items"][0]["title"], "项目一次复盘");
+    assert_eq!(unrestricted["total_count"], 2);
+    assert_eq!(unrestricted["items"], legacy_unrestricted["items"]);
+}
+
+#[tokio::test]
 async fn list_tool_rejects_completed_or_all_with_overdue_before_querying() {
     for status in ["completed", "all"] {
         let (todo_store, session_store, _notification_store, _owner) = test_stores();

--- a/qq-maid-core/src/runtime/tools/todo/tests/schema.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests/schema.rs
@@ -82,6 +82,7 @@ fn list_todos_schema_exposes_structured_combination_filters() {
     assert!(required.contains(&json!("date_range_text")));
     assert!(required.contains(&json!("time_filter")));
     assert!(required.contains(&json!("keyword")));
+    assert!(required.contains(&json!("recurring")));
     assert!(json_type_contains(
         &schema["properties"]["due_date"],
         "string"
@@ -105,6 +106,14 @@ fn list_todos_schema_exposes_structured_combination_filters() {
     assert!(json_type_contains(
         &schema["properties"]["keyword"],
         "string"
+    ));
+    assert!(json_type_contains(
+        &schema["properties"]["recurring"],
+        "boolean"
+    ));
+    assert!(json_type_contains(
+        &schema["properties"]["recurring"],
+        "null"
     ));
 }
 

--- a/qq-maid-core/src/service/tests/agent.rs
+++ b/qq-maid-core/src/service/tests/agent.rs
@@ -345,8 +345,8 @@ async fn core_agent_stream_cancel_marks_shared_agent_diagnostics() {
 }
 
 #[tokio::test]
-async fn core_private_simple_todo_queries_use_deterministic_path() {
-    let provider = TestProvider::replying("不应调用模型")
+async fn core_private_simple_todo_queries_use_agent_runtime_instead_of_deterministic_path() {
+    let provider = TestProvider::replying("模型整理后的待办回复")
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_tool_calling(provider.clone(), 5, true);
     let owner = TodoStore::owner(Some("u1"), private_scope());
@@ -371,21 +371,19 @@ async fn core_private_simple_todo_queries_use_deterministic_path() {
         .unwrap();
     let service = CoreHandle::new(state);
 
-    let mut responses = Vec::new();
     for input in ["看一下待办", "看一下代办"] {
-        let output = service.respond(private_request(input)).await.unwrap();
-        let CoreRespondOutput::Complete(response) = output else {
-            panic!("expected complete output for deterministic todo query");
-        };
-        let response = *response;
-        assert_eq!(response.command.as_deref(), Some("todo_list"), "{input}");
-        assert!(response.text_content().unwrap().contains("待查看项目"));
-        responses.push(response.text_content().map(str::to_owned));
+        let response =
+            collect_stream_completed(service.respond(private_request(input)).await).await;
+        // 自然语言查询不再被确定性 Todo flow 短路，必须进入模型链路。
+        assert_ne!(response.command.as_deref(), Some("todo_list"), "{input}");
+        assert_eq!(
+            response.text_content(),
+            Some("模型整理后的待办回复"),
+            "{input}"
+        );
     }
 
-    assert_eq!(responses[0], responses[1]);
-    assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
-    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    assert!(provider.tool_calls.load(Ordering::SeqCst) >= 1);
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/service/tests/planning.rs
+++ b/qq-maid-core/src/service/tests/planning.rs
@@ -57,13 +57,37 @@ fn core_plan_routes_private_weather_message_to_agent_runtime_when_tools_availabl
 }
 
 #[test]
-fn core_plan_routes_simple_todo_queries_to_immediate() {
+fn core_plan_routes_simple_todo_queries_to_agent_runtime() {
     let provider =
         TestProvider::replying("工具回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let state = test_state_with_tool_calling(provider, 5, true);
     let service = CoreHandle::new(state).respond_service();
 
-    for input in ["看一下待办", "看一下代办", "看看已完成"] {
+    for input in ["看一下待办", "看一下代办", "看看已完成", "查看周期性待办"]
+    {
+        let req: RespondRequest = private_request(input).into();
+        assert_eq!(
+            service.plan_core_respond(&req).unwrap(),
+            RespondPlan::AgentRuntime,
+            "{input}"
+        );
+    }
+}
+
+#[test]
+fn core_plan_keeps_explicit_todo_commands_immediate() {
+    let provider =
+        TestProvider::replying("工具回复").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let state = test_state_with_tool_calling(provider, 5, true);
+    let service = CoreHandle::new(state).respond_service();
+
+    for input in [
+        "/todo",
+        "/todo list",
+        "/todo all",
+        "/todo done",
+        "查看完整结果",
+    ] {
         let req: RespondRequest = private_request(input).into();
         assert_eq!(
             service.plan_core_respond(&req).unwrap(),

--- a/qq-maid-core/src/storage/session/model.rs
+++ b/qq-maid-core/src/storage/session/model.rs
@@ -108,6 +108,9 @@ pub struct LastTodoQuery {
     pub owner_key: String,
     pub query_type: String,
     pub condition: String,
+    /// 由所属业务域解释的不透明查询重放上下文；session 层不得解析其内部字段。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replay_context: Option<Value>,
     #[serde(default)]
     pub result_ids: Vec<String>,
     pub created_at: String,
@@ -245,6 +248,7 @@ impl SessionRecord {
             owner_key: owner_key.to_owned(),
             query_type: query_type.into(),
             condition: condition.into(),
+            replay_context: None,
             result_ids,
             created_at: now_iso_cn(),
         });

--- a/qq-maid-core/src/storage/session/tests.rs
+++ b/qq-maid-core/src/storage/session/tests.rs
@@ -346,6 +346,7 @@ fn sqlite_reopen_restores_pending_and_last_queries() {
         owner_key: "u1".to_owned(),
         query_type: "pending".to_owned(),
         condition: "全部".to_owned(),
+        replay_context: None,
         result_ids: vec!["1".to_owned(), "2".to_owned()],
         created_at: now_iso_cn(),
     });
@@ -560,6 +561,7 @@ fn session_schema_migrations_keep_legacy_rows_compatible() {
         owner_key: "u1".to_owned(),
         query_type: "list".to_owned(),
         condition: String::new(),
+        replay_context: None,
         result_ids: vec!["1".to_owned()],
         created_at: now_iso_cn(),
     };


### PR DESCRIPTION
## 变更内容

- 删除 Todo 自然语言词表短路（“查看待办 / 查看周期性待办 / 查看今天待办”等）
- 普通自然语言待办查询统一进入 AgentRuntime / Tool Loop，由 `list_todos` 处理筛选
- 保留 `/todo`、`/todo list` 等显式命令的确定性路径
- `list_todos` 增加 `recurring` 参数；命令侧支持 `周期性|一次性` 与绝对日期筛选
- 修复 receipt 展示重查丢失 `recurring` 的问题，编号快照与完整结果恢复保持筛选一致

## 用户影响

- “查看周期性待办 / 查看一次性待办”不再被误判为普通待办列表
- 自然语言查询会走模型 Tool Calling，结果由可信列表回执渲染
- `/todo list 周期性`、`/todo list 一次性`、`/todo list 2099-07-15` 可确定性筛选
- `recurring=null` 时不限制周期类型，兼容旧调用

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy -p qq-maid-core --all-targets --all-features -- -D warnings`
- `cargo test -p qq-maid-core --lib runtime::respond::tests::todo::`
- `cargo test -p qq-maid-core --lib runtime::respond::tests::todo_tool_loop`
- `cargo test -p qq-maid-core --lib runtime::respond::tests::todo_agent`
- `cargo test -p qq-maid-core --lib runtime::tools::todo`
- planning / agent / inbound classification 相关用例