### PR TITLE
[codex] 保护知识工具循环上下文预算

### DIFF
--- a/qq-maid-core/src/runtime/tools/agent_presenters.rs
+++ b/qq-maid-core/src/runtime/tools/agent_presenters.rs
@@ -208,6 +208,16 @@ pub(crate) fn tool_outcome_from_knowledge_result(
 
     let evidence_status = string_field(&result.output, "status");
     let (status, presentation, blocks, error_code) = match evidence_status.as_deref() {
+        _ if result.output.get("deduplicated").and_then(Value::as_bool) == Some(true)
+            || structured_error_code(&result.output).as_deref() == Some("tool_call_limit") =>
+        {
+            (
+                ToolOutcomeStatus::Skipped,
+                OutcomePresentation::Internal,
+                Vec::new(),
+                None,
+            )
+        }
         Some("ok" | "truncated") if result.succeeded => (
             ToolOutcomeStatus::Succeeded,
             OutcomePresentation::Internal,

--- a/qq-maid-core/src/runtime/tools/knowledge/tool.rs
+++ b/qq-maid-core/src/runtime/tools/knowledge/tool.rs
@@ -15,6 +15,7 @@ pub const KNOWLEDGE_SEARCH_TOOL_NAME: &str = "knowledge_search";
 const MAX_QUERY_CHARS: usize = 2_000;
 const MAX_QUERIES: usize = 4;
 const MAX_RESULTS: usize = 8;
+const MAX_CALLS_PER_REQUEST: usize = 2;
 const BODY_TRUNCATION_MARKER: &str = "\n[正文因字符预算已裁剪]";
 
 /// 只读知识证据查询，不负责生成最终答案或写入知识文件。
@@ -70,6 +71,42 @@ impl Tool for KnowledgeSearchTool {
         ToolEffect::ReadOnly
     }
 
+    fn max_calls_per_request(&self) -> Option<usize> {
+        Some(MAX_CALLS_PER_REQUEST)
+    }
+
+    fn deduplication_key(&self, arguments: &Value) -> Option<String> {
+        // 查询语义对大小写、连续空白和 additional_queries 顺序不敏感；使用规范化
+        // 参数复用 ToolLoopExecutor 的统一只读缓存，避免重复执行和重复注入证据。
+        let query = arguments
+            .get("query")
+            .and_then(Value::as_str)
+            .map(normalize_query)?;
+        let mut additional = arguments
+            .get("additional_queries")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(normalize_query)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        additional.sort();
+        additional.dedup();
+        let max_results = arguments
+            .get("max_results")
+            .and_then(Value::as_u64)
+            .unwrap_or(MAX_RESULTS as u64);
+        serde_json::to_string(&json!({
+            "query": query,
+            "additional_queries": additional,
+            "max_results": max_results,
+        }))
+        .ok()
+    }
+
     async fn execute(
         &self,
         _context: ToolContext,
@@ -123,6 +160,14 @@ impl Tool for KnowledgeSearchTool {
             self.output_max_chars,
         )))
     }
+}
+
+fn normalize_query(value: &str) -> String {
+    value
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
 }
 
 fn parse_max_results(value: Option<&Value>) -> Result<usize, LlmError> {
@@ -379,6 +424,22 @@ mod tests {
         assert_eq!(tool.effect(), ToolEffect::ReadOnly);
         assert!(tool.metadata().description.contains("只读"));
         assert!(!tool.metadata().parameters.to_string().contains("path"));
+    }
+
+    #[test]
+    fn equivalent_queries_share_normalized_deduplication_key() {
+        let tool = tool();
+        let left = tool.deduplication_key(&json!({
+            "query": " RAG-504  是什么 ",
+            "max_results": null,
+            "additional_queries": ["超时", "错误码"]
+        }));
+        let right = tool.deduplication_key(&json!({
+            "query": "rag-504 是什么",
+            "max_results": 8,
+            "additional_queries": ["错误码", "超时"]
+        }));
+        assert_eq!(left, right);
     }
 
     #[tokio::test]

--- a/qq-maid-core/src/service/errors.rs
+++ b/qq-maid-core/src/service/errors.rs
@@ -105,6 +105,7 @@ impl CoreRespondFailure {
             ("timeout", "query" | "search" | "web_search") => CoreFailureKind::SearchTimeout,
             ("timeout", _) => CoreFailureKind::LlmTimeout,
             (_, "query" | "search" | "web_search") => CoreFailureKind::SearchFailed,
+            ("context_budget_exceeded", _) => CoreFailureKind::ContextBudgetExceeded,
             ("provider_error" | "http_error" | "upstream_unavailable" | "rate_limited", _) => {
                 CoreFailureKind::LlmFailed
             }
@@ -132,6 +133,9 @@ fn user_visible_failure_message(kind: CoreFailureKind) -> String {
         CoreFailureKind::SearchFailed => "联网查询暂时不可用，请稍后再试。",
         CoreFailureKind::LlmTimeout => "LLM 服务处理超时，请稍后再试。",
         CoreFailureKind::LlmFailed => "上游服务暂时不可用，请稍后再试。",
+        CoreFailureKind::ContextBudgetExceeded => {
+            "本次查阅的资料较多，已超出当前对话可处理范围，请缩小查询范围后重试。"
+        }
         CoreFailureKind::Cancelled => "请求已取消。",
         CoreFailureKind::Internal => "处理失败，请稍后再试。",
     }
@@ -259,6 +263,19 @@ mod tests {
         ));
         assert_eq!(max_rounds.kind, CoreFailureKind::Internal);
         assert!(!max_rounds.retryable);
+    }
+
+    #[test]
+    fn context_budget_failure_has_capacity_message() {
+        let failure = CoreRespondFailure::from_llm_error(&agent_error(
+            "context_budget_exceeded",
+            "tool_loop",
+            AgentStopReason::Failed,
+        ));
+        assert_eq!(failure.kind, CoreFailureKind::ContextBudgetExceeded);
+        assert!(failure.message.contains("资料较多"));
+        assert!(!failure.message.contains("上游服务"));
+        assert!(!failure.retryable);
     }
 
     #[test]

--- a/qq-maid-core/src/service/types.rs
+++ b/qq-maid-core/src/service/types.rs
@@ -244,6 +244,7 @@ pub enum CoreFailureKind {
     SearchFailed,
     LlmTimeout,
     LlmFailed,
+    ContextBudgetExceeded,
     Cancelled,
     Internal,
 }

--- a/qq-maid-gateway-rs/src/gateway/onebot11/dispatch/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/dispatch/mod.rs
@@ -415,9 +415,10 @@ fn stream_failure_text(failure: &CoreRespondFailure) -> &'static str {
     match failure.kind {
         CoreFailureKind::SearchTimeout | CoreFailureKind::LlmTimeout => STREAM_TIMEOUT_TEXT,
         CoreFailureKind::Cancelled => STREAM_CANCELLED_TEXT,
-        CoreFailureKind::SearchFailed | CoreFailureKind::LlmFailed | CoreFailureKind::Internal => {
-            STREAM_FAILED_TEXT
-        }
+        CoreFailureKind::SearchFailed
+        | CoreFailureKind::LlmFailed
+        | CoreFailureKind::ContextBudgetExceeded
+        | CoreFailureKind::Internal => STREAM_FAILED_TEXT,
     }
 }
 

--- a/qq-maid-llm/src/agent_loop/runner.rs
+++ b/qq-maid-llm/src/agent_loop/runner.rs
@@ -150,8 +150,8 @@ pub(super) async fn run_agent_loop_with_timeouts(
                 attempt_baseline,
             ));
         }
-        // 最后一轮或最终回答预算阶段都在协议层显式禁用工具；Provider 若忽略
-        // tool_choice=none，下面会直接受控终止，不能再开启模型轮次。
+        // 最后一轮或最终回答预算阶段都在协议层禁用工具；Provider 若仍返回
+        // tool call，下面会直接受控终止，不能再开启模型轮次。
         let preserve_finalization_budget = force_finalization_without_tools
             || (run_handle.has_completed_tool_result_since(attempt_baseline.tool_results)
                 && run_handle.should_preserve_finalization_budget());
@@ -757,6 +757,7 @@ async fn execute_tool_batch(
         .collect::<Vec<_>>();
     executor.begin_batch();
     let mut results = Vec::with_capacity(calls.len());
+    let mut stop_remaining_batch = false;
     let mut skipped_for_finalization = false;
     for (call, prepared) in calls.iter().zip(prepared_calls) {
         let tool_started_at = Instant::now();
@@ -764,7 +765,7 @@ async fn execute_tool_batch(
             .execute_prepared_call(
                 prepared,
                 |tool_name, _effect| {
-                    if skipped_for_finalization {
+                    if stop_remaining_batch {
                         return Ok(ToolCallStartDecision::SkipForFinalAnswer);
                     }
                     let has_completed_result =
@@ -805,6 +806,7 @@ async fn execute_tool_batch(
         sync_diagnostics(run_handle, executor, &emitted_tools, baseline);
         let output = output?;
         skipped_for_finalization |= output.skipped_for_finalization;
+        stop_remaining_batch |= output.stop_remaining_batch;
         results.push(AgentToolResult {
             call_id: call.call_id.clone(),
             output: output.output,

--- a/qq-maid-llm/src/agent_loop/runner.rs
+++ b/qq-maid-llm/src/agent_loop/runner.rs
@@ -764,6 +764,9 @@ async fn execute_tool_batch(
             .execute_prepared_call(
                 prepared,
                 |tool_name, _effect| {
+                    if skipped_for_finalization {
+                        return Ok(ToolCallStartDecision::SkipForFinalAnswer);
+                    }
                     let has_completed_result =
                         run_handle.has_completed_tool_result_since(baseline.tool_results);
                     let reserve_reached = run_handle.should_preserve_finalization_budget();

--- a/qq-maid-llm/src/agent_loop/session.rs
+++ b/qq-maid-llm/src/agent_loop/session.rs
@@ -49,8 +49,8 @@ pub trait AgentStepSession: Send {
     ///
     /// - `results`：上一轮工具执行结果；首轮为空切片。
     /// - `allow_tool_calls`：是否允许本轮产生工具调用。当为 `false` 时，协议层
-    ///   必须显式设置等价于 `tool_choice=none` 的禁用选项；Provider 违反约束仍
-    ///   返回工具调用时，由 `run_agent_loop` 受控终止。
+    ///   必须使用该 Provider 兼容的禁用方式（可移除工具字段，或使用等价于
+    ///   `tool_choice=none` 的选项）；Provider 违反约束仍由 `run_agent_loop` 受控终止。
     async fn advance(
         &mut self,
         results: &[AgentToolResult],

--- a/qq-maid-llm/src/agent_loop/tests/budget_timeout.rs
+++ b/qq-maid-llm/src/agent_loop/tests/budget_timeout.rs
@@ -460,7 +460,8 @@ async fn read_only_cache_hit_replays_at_budget_boundary_without_real_execution()
     assert_eq!(outcome.agent.executed_tools, ["search"]);
     assert_eq!(outcome.agent.tool_results.len(), 2);
     let observed = observed.lock().unwrap();
-    assert_eq!(observed[1].0[0].output, observed[2].0[0].output);
+    assert_ne!(observed[1].0[0].output, observed[2].0[0].output);
+    assert!(observed[2].0[0].output.contains("deduplicated"));
     assert!(!observed[2].1);
 }
 

--- a/qq-maid-llm/src/agent_loop/tests/mod.rs
+++ b/qq-maid-llm/src/agent_loop/tests/mod.rs
@@ -310,6 +310,36 @@ struct FailOnceReadOnlyTool {
     calls: Arc<StdMutex<usize>>,
 }
 
+struct LimitedReadOnlyTool {
+    calls: Arc<StdMutex<usize>>,
+}
+
+#[async_trait]
+impl crate::tool::Tool for LimitedReadOnlyTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            name: "knowledge_search".to_owned(),
+            description: "limited read-only knowledge search".to_owned(),
+            parameters: json!({"type": "object", "properties": {"query": {"type": "string"}}}),
+        }
+    }
+
+    fn effect(&self) -> ToolEffect {
+        ToolEffect::ReadOnly
+    }
+
+    fn max_calls_per_request(&self) -> Option<usize> {
+        Some(2)
+    }
+
+    async fn execute(&self, _ctx: ToolContext, arguments: Value) -> Result<ToolOutput, LlmError> {
+        *self.calls.lock().unwrap() += 1;
+        Ok(ToolOutput::json(
+            json!({"ok": true, "evidence": arguments["query"]}),
+        ))
+    }
+}
+
 #[async_trait]
 impl crate::tool::Tool for FailOnceReadOnlyTool {
     fn metadata(&self) -> ToolMetadata {

--- a/qq-maid-llm/src/agent_loop/tests/tool_execution.rs
+++ b/qq-maid-llm/src/agent_loop/tests/tool_execution.rs
@@ -41,6 +41,141 @@ async fn request_limited_read_only_tool_forces_final_answer_after_two_calls() {
 }
 
 #[tokio::test]
+async fn request_limit_only_rejects_knowledge_call_in_same_batch() {
+    let knowledge_calls = Arc::new(StdMutex::new(0));
+    let other_calls = Arc::new(StdMutex::new(0));
+    let registry = registry_with(vec![
+        Arc::new(LimitedReadOnlyTool {
+            calls: knowledge_calls.clone(),
+        }) as _,
+        Arc::new(CountingTool {
+            name: "web_search",
+            calls: other_calls.clone(),
+            fail: false,
+            soft_fail: false,
+            dependency: ToolCallDependency::None,
+        }) as _,
+    ]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![
+                tool_call("knowledge_search", "k1", r#"{"query":"a"}"#),
+                tool_call("knowledge_search", "k2", r#"{"query":"b"}"#),
+            ]),
+            tool_calls(vec![
+                tool_call("knowledge_search", "k3", r#"{"query":"c"}"#),
+                tool_call("web_search", "w1", r#"{"value":"d"}"#),
+            ]),
+            final_reply("done"),
+        ],
+    ));
+
+    let outcome = run_agent_loop(session, registry, test_context(), 5, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(*knowledge_calls.lock().unwrap(), 2);
+    assert_eq!(*other_calls.lock().unwrap(), 1);
+    assert_eq!(outcome.reply, "done");
+    assert_eq!(
+        outcome.agent.executed_tools,
+        ["knowledge_search", "knowledge_search", "web_search"]
+    );
+    assert_eq!(outcome.agent.tool_results.len(), 4);
+    assert_eq!(
+        outcome.agent.tool_results[2].output["error_code"],
+        "tool_call_limit"
+    );
+    assert!(outcome.agent.tool_results[3].succeeded);
+}
+
+#[tokio::test]
+async fn request_limit_does_not_skip_same_batch_side_effect_tool() {
+    let knowledge_calls = Arc::new(StdMutex::new(0));
+    let todo_calls = Arc::new(StdMutex::new(0));
+    let registry = registry_with(vec![
+        Arc::new(LimitedReadOnlyTool {
+            calls: knowledge_calls.clone(),
+        }) as _,
+        Arc::new(CountingTool {
+            name: "add_todo",
+            calls: todo_calls.clone(),
+            fail: false,
+            soft_fail: false,
+            dependency: ToolCallDependency::None,
+        }) as _,
+    ]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![
+                tool_call("knowledge_search", "k1", r#"{"query":"a"}"#),
+                tool_call("knowledge_search", "k2", r#"{"query":"b"}"#),
+            ]),
+            tool_calls(vec![
+                tool_call("knowledge_search", "k3", r#"{"query":"c"}"#),
+                tool_call("add_todo", "t1", r#"{"value":"write"}"#),
+            ]),
+            final_reply("done"),
+        ],
+    ));
+
+    let outcome = run_agent_loop(session, registry, test_context(), 5, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(*knowledge_calls.lock().unwrap(), 2);
+    assert_eq!(*todo_calls.lock().unwrap(), 1);
+    assert_eq!(outcome.agent.side_effecting_tools_started, ["add_todo"]);
+    assert!(outcome.agent.tool_results[3].succeeded);
+    assert_eq!(outcome.reply, "done");
+}
+
+#[tokio::test]
+async fn read_only_cache_hit_does_not_consume_execution_limit() {
+    let calls = Arc::new(StdMutex::new(0));
+    let registry = registry_with(vec![Arc::new(LimitedReadOnlyTool {
+        calls: calls.clone(),
+    }) as _]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![tool_call(
+                "knowledge_search",
+                "k1",
+                r#"{"query":"a"}"#,
+            )]),
+            tool_calls(vec![
+                tool_call("knowledge_search", "k2", r#"{"query":"a"}"#),
+                tool_call("knowledge_search", "k3", r#"{"query":"b"}"#),
+            ]),
+            tool_calls(vec![tool_call(
+                "knowledge_search",
+                "k4",
+                r#"{"query":"c"}"#,
+            )]),
+            final_reply("done"),
+        ],
+    ));
+
+    let outcome = run_agent_loop(session, registry, test_context(), 5, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(*calls.lock().unwrap(), 2);
+    assert_eq!(outcome.agent.tool_results[1].output["deduplicated"], true);
+    assert_eq!(
+        outcome.agent.tool_results[3].output["error_code"],
+        "tool_call_limit"
+    );
+    assert_eq!(outcome.reply, "done");
+}
+
+#[tokio::test]
 async fn duplicate_read_only_tool_call_replays_success_and_keeps_dependency_chain() {
     let calls = Arc::new(StdMutex::new(0));
     let dependent_calls = Arc::new(StdMutex::new(0));

--- a/qq-maid-llm/src/agent_loop/tests/tool_execution.rs
+++ b/qq-maid-llm/src/agent_loop/tests/tool_execution.rs
@@ -1,6 +1,46 @@
 use super::*;
 
 #[tokio::test]
+async fn request_limited_read_only_tool_forces_final_answer_after_two_calls() {
+    let calls = Arc::new(StdMutex::new(0));
+    let registry = registry_with(vec![Arc::new(LimitedReadOnlyTool {
+        calls: calls.clone(),
+    }) as _]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![tool_call(
+                "knowledge_search",
+                "c1",
+                r#"{"query":"a"}"#,
+            )]),
+            tool_calls(vec![tool_call(
+                "knowledge_search",
+                "c2",
+                r#"{"query":"b"}"#,
+            )]),
+            tool_calls(vec![tool_call(
+                "knowledge_search",
+                "c3",
+                r#"{"query":"c"}"#,
+            )]),
+            final_reply("based on the available evidence"),
+        ],
+    ));
+    let observed = session.observed.clone();
+    let outcome = run_agent_loop(session, registry, test_context(), 5, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(*calls.lock().unwrap(), 2);
+    assert_eq!(outcome.reply, "based on the available evidence");
+    let observed = observed.lock().unwrap();
+    assert!(!observed[3].1, "final answer round must disable tool calls");
+    assert!(outcome.agent.tool_results[2].output["error_code"] == "tool_call_limit");
+}
+
+#[tokio::test]
 async fn duplicate_read_only_tool_call_replays_success_and_keeps_dependency_chain() {
     let calls = Arc::new(StdMutex::new(0));
     let dependent_calls = Arc::new(StdMutex::new(0));
@@ -48,7 +88,8 @@ async fn duplicate_read_only_tool_call_replays_success_and_keeps_dependency_chai
             .all(|result| result.succeeded)
     );
     let observed = observed.lock().unwrap();
-    assert_eq!(observed[1].0[0].output, observed[2].0[0].output);
+    assert_ne!(observed[1].0[0].output, observed[2].0[0].output);
+    assert!(observed[2].0[0].output.contains("deduplicated"));
     assert!(observed[2].0[1].output.contains("continue"));
 }
 

--- a/qq-maid-llm/src/context_budget.rs
+++ b/qq-maid-llm/src/context_budget.rs
@@ -5,6 +5,7 @@
 //! retention policy 的预算项，本模块只负责按策略保留、淘汰和生成统一日志。
 
 use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
 use tracing::{debug, warn};
 
 use crate::error::LlmError;
@@ -292,6 +293,150 @@ pub fn ensure_required_budget(
     }
 }
 
+/// 为 Tool Loop 计算一次可发送的上下文。
+///
+/// 工具结果是可压缩的输入；当它们把输入推过 `window - output_reserve` 时，
+/// 先裁剪结果并关闭后续工具调用，给最终回答留出既定 reserve。只有用户历史和
+/// 必须保留的协议内容本身仍然超限时，才返回 `context_budget_exceeded`。
+pub fn fit_tool_loop_payload(
+    config: ContextBudgetConfig,
+    mut payload: Value,
+    stage: &'static str,
+) -> Result<(Value, bool), LlmError> {
+    config.validate()?;
+    let max_input_chars = config.effective_input_limit();
+    let estimate = |value: &Value| {
+        let model_context = if value.get("input").is_some() {
+            json!({"input": value.get("input"), "tools": value.get("tools")})
+        } else {
+            json!({"messages": value.get("messages"), "tools": value.get("tools")})
+        };
+        estimated_json_chars(&model_context, stage)
+    };
+    if estimate(&payload)? <= max_input_chars {
+        return Ok((payload, false));
+    }
+
+    // 工具定义只服务于下一次工具调用；进入收尾轮后移除定义，避免定义本身侵占
+    // 最终回答预算。协议层同时使用 tool_choice=none（若该字段存在）。
+    if let Some(object) = payload.as_object_mut()
+        && object.contains_key("tools")
+    {
+        object.insert("tools".to_owned(), Value::Array(Vec::new()));
+        object.insert("tool_choice".to_owned(), Value::String("none".to_owned()));
+    }
+    compact_tool_outputs(&mut payload, max_input_chars, &estimate)?;
+    let retained_chars = estimate(&payload)?;
+    if retained_chars > max_input_chars {
+        let report = BudgetReport {
+            unit: BudgetUnit::Chars,
+            max_input_chars,
+            output_reserve_chars: config.output_reserve_chars,
+            retained_chars,
+            evicted_chars: 0,
+            actions: vec![BudgetLogEntry {
+                kind: BudgetItemKind::ToolLoopAtomicTurn,
+                action: BudgetAction::RequiredExceeded,
+                chars: retained_chars,
+            }],
+        };
+        return Err(context_budget_exceeded(&report, stage));
+    }
+    let report = BudgetReport {
+        unit: BudgetUnit::Chars,
+        max_input_chars,
+        output_reserve_chars: config.output_reserve_chars,
+        retained_chars,
+        evicted_chars: max_input_chars.saturating_sub(retained_chars),
+        actions: vec![BudgetLogEntry {
+            kind: BudgetItemKind::ToolLoopAtomicTurn,
+            action: BudgetAction::Evicted,
+            chars: retained_chars,
+        }],
+    };
+    log_budget_report(stage, &report);
+    tracing::debug!(
+        stage,
+        retained_chars,
+        max_input_chars,
+        output_reserve_chars = config.output_reserve_chars,
+        tools_disabled = true,
+        "tool loop entered forced finalization budget"
+    );
+    Ok((payload, true))
+}
+
+fn compact_tool_outputs(
+    value: &mut Value,
+    max_input_chars: usize,
+    estimate: &impl Fn(&Value) -> Result<usize, LlmError>,
+) -> Result<(), LlmError> {
+    while estimate(value)? > max_input_chars {
+        let mut candidates = Vec::new();
+        collect_tool_output_paths(value, &mut Vec::new(), &mut candidates);
+        let Some((path, current_len)) = candidates.into_iter().max_by_key(|(_, len)| *len) else {
+            break;
+        };
+        let target =
+            current_len.saturating_sub(estimate(value)?.saturating_sub(max_input_chars).max(64));
+        let Some(slot) = value.pointer_mut(&path) else {
+            break;
+        };
+        let Some(text) = slot.as_str() else { break };
+        let marker = "\n[工具结果已为最终回答预算裁剪]";
+        let keep = target.saturating_sub(marker.chars().count());
+        let mut shortened = text.chars().take(keep).collect::<String>();
+        shortened.push_str(marker);
+        if shortened.chars().count() >= text.chars().count() {
+            *slot = json!({"truncated": true, "original_chars": text.chars().count()});
+        } else {
+            *slot = Value::String(shortened);
+        }
+    }
+    Ok(())
+}
+
+fn collect_tool_output_paths(
+    value: &Value,
+    path: &mut Vec<String>,
+    output: &mut Vec<(String, usize)>,
+) {
+    match value {
+        Value::Object(map) => {
+            let is_tool = map.get("type").and_then(Value::as_str) == Some("function_call_output")
+                || map.get("role").and_then(Value::as_str) == Some("tool");
+            for (key, child) in map {
+                path.push(key.clone());
+                if is_tool
+                    && (key == "output" || key == "content")
+                    && let Some(text) = child.as_str()
+                {
+                    output.push((
+                        format!(
+                            "/{}",
+                            path.iter()
+                                .map(|p| p.replace('~', "~0").replace('/', "~1"))
+                                .collect::<Vec<_>>()
+                                .join("/")
+                        ),
+                        text.chars().count(),
+                    ));
+                }
+                collect_tool_output_paths(child, path, output);
+                path.pop();
+            }
+        }
+        Value::Array(items) => {
+            for (index, child) in items.iter().enumerate() {
+                path.push(index.to_string());
+                collect_tool_output_paths(child, path, output);
+                path.pop();
+            }
+        }
+        _ => {}
+    }
+}
+
 pub fn context_budget_exceeded(report: &BudgetReport, stage: &'static str) -> LlmError {
     log_budget_report(stage, report);
     LlmError::new(
@@ -415,6 +560,39 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(err.code, "config");
+    }
+
+    #[test]
+    fn tool_loop_compaction_keeps_call_and_result_pairing() {
+        let payload = json!({
+            "messages": [
+                {"role": "user", "content": "请查资料"},
+                {"role": "assistant", "tool_calls": [{"id": "call-1", "type": "function", "function": {"name": "knowledge_search", "arguments": "{}"}}]},
+                {"role": "tool", "tool_call_id": "call-1", "content": "重要证据".repeat(80)}
+            ],
+            "tools": [{"type": "function", "function": {"name": "knowledge_search"}}],
+            "tool_choice": "auto"
+        });
+        let (fitted, disabled) = fit_tool_loop_payload(
+            ContextBudgetConfig {
+                context_window_chars: 420,
+                output_reserve_chars: 40,
+                protected_recent_turns: 0,
+            },
+            payload,
+            "tool_loop",
+        )
+        .unwrap();
+        assert!(disabled);
+        assert_eq!(fitted["messages"][1]["tool_calls"][0]["id"], "call-1");
+        assert_eq!(fitted["messages"][2]["tool_call_id"], "call-1");
+        assert_eq!(fitted["tool_choice"], "none");
+        assert!(
+            fitted["messages"][2]["content"]
+                .as_str()
+                .unwrap()
+                .contains("裁剪")
+        );
     }
 
     struct FailingSerialize;

--- a/qq-maid-llm/src/context_budget.rs
+++ b/qq-maid-llm/src/context_budget.rs
@@ -317,13 +317,12 @@ pub fn fit_tool_loop_payload(
         return Ok((payload, false));
     }
 
-    // 工具定义只服务于下一次工具调用；进入收尾轮后移除定义，避免定义本身侵占
-    // 最终回答预算。协议层同时使用 tool_choice=none（若该字段存在）。
-    if let Some(object) = payload.as_object_mut()
-        && object.contains_key("tools")
-    {
-        object.insert("tools".to_owned(), Value::Array(Vec::new()));
-        object.insert("tool_choice".to_owned(), Value::String("none".to_owned()));
+    // 工具定义只服务于下一次工具调用；进入收尾轮后移除所有工具控制字段，
+    // 避免空 tools 与 tool_choice=none 在部分兼容 Provider 上组成非法组合。
+    if let Some(object) = payload.as_object_mut() {
+        object.remove("tools");
+        object.remove("tool_choice");
+        object.remove("parallel_tool_calls");
     }
     compact_tool_outputs(&mut payload, max_input_chars, &estimate)?;
     let retained_chars = estimate(&payload)?;
@@ -371,27 +370,27 @@ fn compact_tool_outputs(
     max_input_chars: usize,
     estimate: &impl Fn(&Value) -> Result<usize, LlmError>,
 ) -> Result<(), LlmError> {
+    let mut compacted_paths = std::collections::HashSet::new();
     while estimate(value)? > max_input_chars {
         let mut candidates = Vec::new();
         collect_tool_output_paths(value, &mut Vec::new(), &mut candidates);
-        let Some((path, current_len)) = candidates.into_iter().max_by_key(|(_, len)| *len) else {
+        let Some((path, _current_len)) = candidates
+            .into_iter()
+            .filter(|(path, _)| !compacted_paths.contains(path))
+            .max_by_key(|(_, len)| *len)
+        else {
             break;
         };
-        let target =
-            current_len.saturating_sub(estimate(value)?.saturating_sub(max_input_chars).max(64));
         let Some(slot) = value.pointer_mut(&path) else {
             break;
         };
         let Some(text) = slot.as_str() else { break };
-        let marker = "\n[工具结果已为最终回答预算裁剪]";
-        let keep = target.saturating_sub(marker.chars().count());
-        let mut shortened = text.chars().take(keep).collect::<String>();
-        shortened.push_str(marker);
-        if shortened.chars().count() >= text.chars().count() {
-            *slot = json!({"truncated": true, "original_chars": text.chars().count()});
-        } else {
-            *slot = Value::String(shortened);
-        }
+        let original_chars = text.chars().count();
+        let marker = format!("[工具结果已省略，原始长度 {original_chars} 字符]");
+        // 工具输出字段的协议类型不能改变：Chat Completions 的 content 和
+        // Responses 的 function_call_output.output 都必须继续是字符串。
+        *slot = Value::String(marker);
+        compacted_paths.insert(path);
     }
     Ok(())
 }
@@ -586,13 +585,101 @@ mod tests {
         assert!(disabled);
         assert_eq!(fitted["messages"][1]["tool_calls"][0]["id"], "call-1");
         assert_eq!(fitted["messages"][2]["tool_call_id"], "call-1");
-        assert_eq!(fitted["tool_choice"], "none");
+        assert!(fitted.get("tools").is_none());
+        assert!(fitted.get("tool_choice").is_none());
         assert!(
             fitted["messages"][2]["content"]
                 .as_str()
                 .unwrap()
-                .contains("裁剪")
+                .contains("工具结果已省略")
         );
+    }
+
+    #[test]
+    fn short_chat_tool_outputs_are_compacted_as_strings_and_keep_pairing() {
+        let payload = json!({
+            "messages": [
+                {"role": "user", "content": "查资料"},
+                {"role": "assistant", "tool_calls": [
+                    {"id": "call-1", "type": "function", "function": {"name": "search", "arguments": "{}"}},
+                    {"id": "call-2", "type": "function", "function": {"name": "weather", "arguments": "{}"}}
+                ]},
+                {"role": "tool", "tool_call_id": "call-1", "content": "a".repeat(80)},
+                {"role": "tool", "tool_call_id": "call-2", "content": "b".repeat(80)}
+            ],
+            "tools": [{"type": "function", "function": {"name": "search"}}],
+            "tool_choice": "auto",
+            "parallel_tool_calls": false
+        });
+        let (fitted, disabled) = fit_tool_loop_payload(
+            ContextBudgetConfig {
+                context_window_chars: 440,
+                output_reserve_chars: 20,
+                protected_recent_turns: 0,
+            },
+            payload,
+            "tool_loop",
+        )
+        .unwrap();
+
+        assert!(disabled);
+        assert!(fitted.get("tools").is_none());
+        assert!(fitted.get("tool_choice").is_none());
+        assert!(fitted.get("parallel_tool_calls").is_none());
+        assert_eq!(fitted["messages"][1]["tool_calls"][0]["id"], "call-1");
+        assert_eq!(fitted["messages"][1]["tool_calls"][1]["id"], "call-2");
+        for (index, call_id) in [(2, "call-1"), (3, "call-2")] {
+            assert_eq!(fitted["messages"][index]["tool_call_id"], call_id);
+            assert!(fitted["messages"][index]["content"].is_string());
+            assert!(
+                fitted["messages"][index]["content"]
+                    .as_str()
+                    .unwrap()
+                    .contains("工具结果已省略")
+            );
+        }
+        serde_json::to_string(&fitted).unwrap();
+    }
+
+    #[test]
+    fn short_responses_tool_outputs_are_compacted_as_strings_and_keep_pairing() {
+        let payload = json!({
+            "input": [
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "查资料"}]},
+                {"type": "function_call", "call_id": "call-1", "name": "search", "arguments": "{}"},
+                {"type": "function_call_output", "call_id": "call-1", "output": "a".repeat(80)},
+                {"type": "function_call", "call_id": "call-2", "name": "weather", "arguments": "{}"},
+                {"type": "function_call_output", "call_id": "call-2", "output": "b".repeat(80)}
+            ],
+            "tools": [{"type": "function", "name": "search"}],
+            "parallel_tool_calls": false
+        });
+        let (fitted, disabled) = fit_tool_loop_payload(
+            ContextBudgetConfig {
+                context_window_chars: 445,
+                output_reserve_chars: 20,
+                protected_recent_turns: 0,
+            },
+            payload,
+            "tool_loop",
+        )
+        .unwrap();
+
+        assert!(disabled);
+        assert!(fitted.get("tools").is_none());
+        assert!(fitted.get("tool_choice").is_none());
+        assert!(fitted.get("parallel_tool_calls").is_none());
+        for (index, call_id) in [(2, "call-1"), (4, "call-2")] {
+            assert_eq!(fitted["input"][index]["call_id"], call_id);
+            assert!(fitted["input"][index]["output"].is_string());
+            assert!(
+                fitted["input"][index]["output"]
+                    .as_str()
+                    .unwrap()
+                    .contains("工具结果已省略")
+            );
+        }
+        serde_json::to_string(&fitted).unwrap();
     }
 
     struct FailingSerialize;

--- a/qq-maid-llm/src/provider/openai/chat_tool_loop/mod.rs
+++ b/qq-maid-llm/src/provider/openai/chat_tool_loop/mod.rs
@@ -29,7 +29,10 @@ use super::chat::{
     ChatCompletionsClient, chat_completions_messages, extract_chat_completion_text,
     extract_chat_completion_usage, send_chat_completions_request,
 };
-use super::responses::{incomplete_stream_eof_error, stream_transport_error};
+use super::{
+    responses::{incomplete_stream_eof_error, stream_transport_error},
+    tool_calls_disabled_error,
+};
 
 /// Chat Completions 协议的 Agent Loop 单步会话。
 ///
@@ -98,7 +101,7 @@ impl AgentStepSession for ChatCompletionsAgentSession {
             allow_tool_calls,
             false,
         );
-        let (payload, _tools_disabled) = enforce_tool_loop_budget(self.context_budget, payload)?;
+        let (payload, tools_disabled) = enforce_tool_loop_budget(self.context_budget, payload)?;
         let response = send_chat_completions_request(&self.client, &payload, false).await?;
         let body: Value = response.json().await.map_err(|err| {
             LlmError::provider(
@@ -108,6 +111,9 @@ impl AgentStepSession for ChatCompletionsAgentSession {
         })?;
         let step_usage = extract_chat_completion_usage(&body);
         let tool_rounds = extract_tool_call_rounds(&body)?;
+        if !tool_rounds.is_empty() && (!allow_tool_calls || tools_disabled) {
+            return Err(tool_calls_disabled_error());
+        }
         if tool_rounds.is_empty() {
             let reply = extract_chat_completion_text(&body).ok_or_else(|| {
                 LlmError::provider(
@@ -523,11 +529,7 @@ async fn finalize_chat_completions_tool_loop_stream(
     let calls = streaming_tool_calls_to_function_calls(tool_calls)?;
     if !calls.is_empty() {
         if !allow_tool_calls {
-            return Err(LlmError::new(
-                "tool_loop_limit",
-                "tool loop returned tool calls when tool calls are disabled",
-                "tool_loop",
-            ));
+            return Err(tool_calls_disabled_error());
         }
         let assistant_message = streaming_assistant_message(&calls);
         messages.push(assistant_message);

--- a/qq-maid-llm/src/provider/openai/chat_tool_loop/mod.rs
+++ b/qq-maid-llm/src/provider/openai/chat_tool_loop/mod.rs
@@ -251,14 +251,17 @@ fn chat_completions_tool_loop_payload(
     allow_tool_calls: bool,
     stream: bool,
 ) -> Value {
-    json!({
+    let mut payload = json!({
         "model": model,
         "messages": messages,
         "max_tokens": max_output_tokens,
-        "tools": tools,
-        "tool_choice": if allow_tool_calls { "auto" } else { "none" },
         "stream": stream,
-    })
+    });
+    if allow_tool_calls {
+        payload["tools"] = json!(tools);
+        payload["tool_choice"] = json!("auto");
+    }
+    payload
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/qq-maid-llm/src/provider/openai/chat_tool_loop/mod.rs
+++ b/qq-maid-llm/src/provider/openai/chat_tool_loop/mod.rs
@@ -5,6 +5,8 @@
 //! 工具执行和退出条件由 `qq_maid_llm::agent_loop::run_agent_loop` 统一控制；
 //! 本模块不再维护自己的循环，避免 provider 侧重复维护同一套退出逻辑。
 
+use std::borrow::Borrow;
+
 use serde_json::{Value, json};
 
 use crate::{
@@ -12,16 +14,16 @@ use crate::{
         AgentSessionRequest, AgentStep, AgentStepSession, AgentTextDeltaSink, AgentToolCall,
         AgentToolResult,
     },
-    context_budget::{
-        BudgetItemKind, ContextBudgetConfig, ensure_required_budget, estimated_json_chars,
-        log_budget_report,
-    },
+    context_budget::{ContextBudgetConfig, fit_tool_loop_payload},
     error::LlmError,
     metrics::MetricsRecorder,
     provider::types::{ChatMessage, TokenUsage},
     sse::{parse_sse_frame, take_sse_frame},
     tool::{ToolMetadata, ToolRegistry},
 };
+
+#[cfg(test)]
+use crate::context_budget::estimated_json_chars;
 
 use super::chat::{
     ChatCompletionsClient, chat_completions_messages, extract_chat_completion_text,
@@ -96,7 +98,7 @@ impl AgentStepSession for ChatCompletionsAgentSession {
             allow_tool_calls,
             false,
         );
-        enforce_tool_loop_budget(self.context_budget, &payload)?;
+        let (payload, _tools_disabled) = enforce_tool_loop_budget(self.context_budget, payload)?;
         let response = send_chat_completions_request(&self.client, &payload, false).await?;
         let body: Value = response.json().await.map_err(|err| {
             LlmError::provider(
@@ -155,12 +157,12 @@ impl AgentStepSession for ChatCompletionsAgentSession {
             allow_tool_calls,
             true,
         );
-        enforce_tool_loop_budget(self.context_budget, &payload)?;
+        let (payload, tools_disabled) = enforce_tool_loop_budget(self.context_budget, payload)?;
         let response = send_chat_completions_request(&self.client, &payload, true).await?;
         let step = collect_chat_completions_tool_loop_stream(
             response,
             &mut messages,
-            allow_tool_calls,
+            allow_tool_calls && !tools_disabled,
             text_delta_sink,
         )
         .await?;
@@ -214,29 +216,15 @@ where
         .map(|_| crate::provider::ToolCallingProtocol::ChatCompletionsToolCalls)
 }
 
-fn enforce_tool_loop_budget(
+fn enforce_tool_loop_budget<P: Borrow<Value>>(
     context_budget: Option<ContextBudgetConfig>,
-    payload: &Value,
-) -> Result<(), LlmError> {
+    payload: P,
+) -> Result<(Value, bool), LlmError> {
+    let payload = payload.borrow().clone();
     let Some(config) = context_budget else {
-        return Ok(());
+        return Ok((payload, false));
     };
-    // Chat Completions 的 assistant tool_calls 与对应 tool messages 必须成组保留；
-    // 首期只做完整 payload 检查，不静默删除任何工具轮次。
-    // 只估算模型实际可见的 messages 与 tools，排除 stream、model、max_tokens
-    // 等传输控制字段，避免在上下文预算临界点误报超限。
-    let model_context = json!({
-        "messages": payload.get("messages"),
-        "tools": payload.get("tools"),
-    });
-    let report = ensure_required_budget(
-        config,
-        BudgetItemKind::ToolLoopAtomicTurn,
-        estimated_json_chars(&model_context, "tool_loop")?,
-        "tool_loop",
-    )?;
-    log_budget_report("chat_completions_tool_loop", &report);
-    Ok(())
+    fit_tool_loop_payload(config, payload, "tool_loop")
 }
 
 fn chat_completions_tool_defs(metadata: Vec<ToolMetadata>) -> Vec<Value> {

--- a/qq-maid-llm/src/provider/openai/chat_tool_loop/tests.rs
+++ b/qq-maid-llm/src/provider/openai/chat_tool_loop/tests.rs
@@ -398,7 +398,7 @@ async fn tool_loop_prepares_same_round_calls_before_executing_any_tool() {
 }
 
 #[tokio::test]
-async fn tool_loop_budget_exceeded_before_first_provider_request() {
+async fn tool_loop_budget_before_first_request_disables_tools_for_answer() {
     let (base_url, state) = spawn_mock_tool_loop(vec![json!({
         "choices": [{
             "message": {
@@ -417,7 +417,7 @@ async fn tool_loop_budget_exceeded_before_first_provider_request() {
         .register(WeatherToolStub::new("小雨"))
         .unwrap();
 
-    let err = run_session(
+    let outcome = run_session(
         client,
         "deepseek",
         "deepseek-chat",
@@ -432,11 +432,13 @@ async fn tool_loop_budget_exceeded_before_first_provider_request() {
         2,
     )
     .await
-    .unwrap_err();
+    .unwrap();
 
-    assert_eq!(err.code, "context_budget_exceeded");
-    assert_eq!(err.stage, "tool_loop");
-    assert!(state.lock().await.requests.is_empty());
+    assert_eq!(outcome.reply, "should not be requested");
+    let requests = &state.lock().await.requests;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0]["tool_choice"], "none");
+    assert!(requests[0]["tools"].as_array().is_some_and(Vec::is_empty));
 }
 
 #[test]
@@ -488,7 +490,7 @@ fn payload_disables_tool_calls_explicitly() {
 }
 
 #[tokio::test]
-async fn tool_loop_budget_exceeded_after_tool_result_skips_next_provider_request() {
+async fn tool_loop_budget_after_tool_result_disables_tools_for_final_answer() {
     let (base_url, state) = spawn_mock_tool_loop(vec![
         json!({
             "choices": [{
@@ -525,7 +527,7 @@ async fn tool_loop_budget_exceeded_after_tool_result_skips_next_provider_request
         .register(WeatherToolStub::new("小雨"))
         .unwrap();
 
-    let err = run_session(
+    let outcome = run_session(
         client,
         "deepseek",
         "deepseek-chat",
@@ -540,13 +542,14 @@ async fn tool_loop_budget_exceeded_after_tool_result_skips_next_provider_request
         2,
     )
     .await
-    .unwrap_err();
+    .unwrap();
 
-    assert_eq!(err.code, "context_budget_exceeded");
-    assert_eq!(err.stage, "tool_loop");
+    assert_eq!(outcome.reply, "should not be requested");
     let requests = &state.lock().await.requests;
-    assert_eq!(requests.len(), 1);
+    assert_eq!(requests.len(), 2);
     assert_eq!(requests[0]["tools"][0]["function"]["name"], "get_weather");
+    assert_eq!(requests[1]["tool_choice"], "none");
+    assert!(requests[1]["tools"].as_array().is_some_and(Vec::is_empty));
 }
 
 #[tokio::test]

--- a/qq-maid-llm/src/provider/openai/chat_tool_loop/tests.rs
+++ b/qq-maid-llm/src/provider/openai/chat_tool_loop/tests.rs
@@ -441,6 +441,65 @@ async fn tool_loop_budget_before_first_request_disables_tools_for_answer() {
     assert!(requests[0].get("tool_choice").is_none());
 }
 
+#[tokio::test]
+async fn non_stream_budget_finalization_rejects_provider_tool_calls_without_execution() {
+    let (base_url, state) = spawn_mock_tool_loop(vec![json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_forbidden",
+                    "type": "function",
+                    "function": {
+                        "name": "first_order_tool",
+                        "arguments": r#"{"value":"must-not-run"}"#
+                    }
+                }]
+            }
+        }]
+    })])
+    .await;
+    let client = ChatCompletionsClient::new(
+        "test-key",
+        Some(&base_url),
+        qq_maid_common::http_client::client(),
+    );
+    let sequence = Arc::new(StdMutex::new(Vec::new()));
+    let mut tools = ToolRegistry::new();
+    tools
+        .insert(Arc::new(PrepareOrderToolStub {
+            name: "first_order_tool",
+            sequence: sequence.clone(),
+        }))
+        .unwrap();
+
+    let err = run_session(
+        client,
+        "deepseek",
+        "deepseek-chat",
+        1200,
+        &[ChatMessage::user("杭州天气怎么样")],
+        tools,
+        Some(crate::context_budget::ContextBudgetConfig {
+            context_window_chars: 120,
+            output_reserve_chars: 20,
+            protected_recent_turns: 0,
+        }),
+        2,
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(err.code, "tool_loop_limit");
+    assert_eq!(err.stage, "tool_loop");
+    assert!(sequence.lock().unwrap().is_empty());
+    let requests = &state.lock().await.requests;
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0].get("tools").is_none());
+    assert!(requests[0].get("tool_choice").is_none());
+}
+
 #[test]
 fn tool_loop_budget_ignores_transport_only_payload_fields() {
     let messages = vec![json!({"role": "user", "content": "完成待办"})];

--- a/qq-maid-llm/src/provider/openai/chat_tool_loop/tests.rs
+++ b/qq-maid-llm/src/provider/openai/chat_tool_loop/tests.rs
@@ -437,8 +437,8 @@ async fn tool_loop_budget_before_first_request_disables_tools_for_answer() {
     assert_eq!(outcome.reply, "should not be requested");
     let requests = &state.lock().await.requests;
     assert_eq!(requests.len(), 1);
-    assert_eq!(requests[0]["tool_choice"], "none");
-    assert!(requests[0]["tools"].as_array().is_some_and(Vec::is_empty));
+    assert!(requests[0].get("tools").is_none());
+    assert!(requests[0].get("tool_choice").is_none());
 }
 
 #[test]
@@ -486,7 +486,20 @@ fn payload_disables_tool_calls_explicitly() {
         false,
     );
 
-    assert_eq!(payload["tool_choice"], "none");
+    assert!(payload.get("tools").is_none());
+    assert!(payload.get("tool_choice").is_none());
+
+    let streaming_payload = chat_completions_tool_loop_payload(
+        &[json!({"role": "user", "content": "总结已有结果"})],
+        &[json!({"type": "function", "function": {"name": "search"}})],
+        "test-model",
+        1200,
+        false,
+        true,
+    );
+    assert!(streaming_payload.get("tools").is_none());
+    assert!(streaming_payload.get("tool_choice").is_none());
+    assert_eq!(streaming_payload["stream"], true);
 }
 
 #[tokio::test]
@@ -548,8 +561,8 @@ async fn tool_loop_budget_after_tool_result_disables_tools_for_final_answer() {
     let requests = &state.lock().await.requests;
     assert_eq!(requests.len(), 2);
     assert_eq!(requests[0]["tools"][0]["function"]["name"], "get_weather");
-    assert_eq!(requests[1]["tool_choice"], "none");
-    assert!(requests[1]["tools"].as_array().is_some_and(Vec::is_empty));
+    assert!(requests[1].get("tools").is_none());
+    assert!(requests[1].get("tool_choice").is_none());
 }
 
 #[tokio::test]

--- a/qq-maid-llm/src/provider/openai/mod.rs
+++ b/qq-maid-llm/src/provider/openai/mod.rs
@@ -31,6 +31,15 @@ use crate::{
 
 const IMAGE_GENERATION_METADATA_KEY: &str = "image_generation";
 
+/// Provider 在强制最终回答阶段仍返回工具调用时的统一协议错误。
+pub(crate) fn tool_calls_disabled_error() -> LlmError {
+    LlmError::new(
+        "tool_loop_limit",
+        "tool loop returned tool calls when tool calls are disabled",
+        "tool_loop",
+    )
+}
+
 fn image_generation_enabled(req: &ChatRequest) -> bool {
     req.metadata
         .get(IMAGE_GENERATION_METADATA_KEY)

--- a/qq-maid-llm/src/provider/openai/tool_loop/payload.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/payload.rs
@@ -1,12 +1,11 @@
 //! Responses Tool Loop 的 input、工具定义、请求 payload 与上下文预算。
 
+use std::borrow::Borrow;
+
 use serde_json::{Value, json};
 
 use crate::{
-    context_budget::{
-        BudgetItemKind, ContextBudgetConfig, ensure_required_budget, estimated_json_chars,
-        log_budget_report,
-    },
+    context_budget::{ContextBudgetConfig, fit_tool_loop_payload},
     error::LlmError,
     provider::types::{ChatMessage, ReasoningEffort},
     tool::ToolMetadata,
@@ -14,29 +13,15 @@ use crate::{
 
 use crate::provider::openai::payload::{openai_model_supports_reasoning, openai_responses_message};
 
-pub(super) fn enforce_tool_loop_budget(
+pub(super) fn enforce_tool_loop_budget<P: Borrow<Value>>(
     context_budget: Option<ContextBudgetConfig>,
-    payload: &Value,
-) -> Result<(), LlmError> {
+    payload: P,
+) -> Result<(Value, bool), LlmError> {
+    let payload = payload.borrow().clone();
     let Some(config) = context_budget else {
-        return Ok(());
+        return Ok((payload, false));
     };
-    // Responses Tool Loop 首期不拆分、不淘汰已进入循环的结构化轮次；
-    // 工具结果增长依靠单项结果上限和 max_rounds 控制，超预算时显式失败。
-    // 只估算模型实际可见的 input 与 tools；model、stream、输出上限等 HTTP
-    // 传输字段不占模型上下文，计入它们会在预算边界产生几十字符的误判。
-    let model_context = json!({
-        "input": payload.get("input"),
-        "tools": payload.get("tools"),
-    });
-    let report = ensure_required_budget(
-        config,
-        BudgetItemKind::ToolLoopAtomicTurn,
-        estimated_json_chars(&model_context, "tool_loop")?,
-        "tool_loop",
-    )?;
-    log_budget_report("responses_tool_loop", &report);
-    Ok(())
+    fit_tool_loop_payload(config, payload, "tool_loop")
 }
 
 pub(super) fn openai_tool_loop_input(

--- a/qq-maid-llm/src/provider/openai/tool_loop/payload.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/payload.rs
@@ -71,15 +71,14 @@ pub(super) fn openai_tool_loop_payload(
         "model": model,
         "input": input,
         "max_output_tokens": max_output_tokens,
-        "tools": tools,
-        // 首期只支持串行工具循环；后续多工具并行需要结果聚合和更细的权限审计。
-        "parallel_tool_calls": false,
     });
+    if allow_tool_calls {
+        payload["tools"] = json!(tools);
+        // 首期只支持串行工具循环；后续多工具并行需要结果聚合和更细的权限审计。
+        payload["parallel_tool_calls"] = json!(false);
+    }
     if let Some(effort) = reasoning_effort.filter(|_| openai_model_supports_reasoning(model)) {
         payload["reasoning"] = json!({ "effort": effort.as_str() });
-    }
-    if !allow_tool_calls {
-        payload["tool_choice"] = json!("none");
     }
     if stream {
         payload["stream"] = json!(true);

--- a/qq-maid-llm/src/provider/openai/tool_loop/session.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/session.rs
@@ -161,7 +161,7 @@ impl AgentStepSession for ResponsesAgentSession {
             allow_tool_calls,
             false,
         );
-        enforce_tool_loop_budget(self.context_budget, &payload)?;
+        let (payload, _tools_disabled) = enforce_tool_loop_budget(self.context_budget, payload)?;
         let response = send_openai_responses_request(
             &self.client,
             &self.api_key,
@@ -229,7 +229,7 @@ impl AgentStepSession for ResponsesAgentSession {
             allow_tool_calls,
             true,
         );
-        enforce_tool_loop_budget(self.context_budget, &payload)?;
+        let (payload, tools_disabled) = enforce_tool_loop_budget(self.context_budget, payload)?;
         let response = send_openai_responses_request(
             &self.client,
             &self.api_key,
@@ -241,7 +241,7 @@ impl AgentStepSession for ResponsesAgentSession {
         let step = collect_responses_tool_loop_stream(
             response,
             &mut input,
-            allow_tool_calls,
+            allow_tool_calls && !tools_disabled,
             text_delta_sink,
             self.streaming_diagnostics.clone(),
             self.streaming_activity_counter.clone(),

--- a/qq-maid-llm/src/provider/openai/tool_loop/session.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/session.rs
@@ -31,6 +31,7 @@ use crate::provider::openai::{
     extract::{
         extract_response_output_parts, extract_response_output_text, extract_response_usage,
     },
+    tool_calls_disabled_error,
     transport::send_openai_responses_request,
 };
 
@@ -161,7 +162,7 @@ impl AgentStepSession for ResponsesAgentSession {
             allow_tool_calls,
             false,
         );
-        let (payload, _tools_disabled) = enforce_tool_loop_budget(self.context_budget, payload)?;
+        let (payload, tools_disabled) = enforce_tool_loop_budget(self.context_budget, payload)?;
         let response = send_openai_responses_request(
             &self.client,
             &self.api_key,
@@ -175,6 +176,9 @@ impl AgentStepSession for ResponsesAgentSession {
         })?;
         let step_usage = extract_response_usage(&body);
         let calls = extract_function_calls(&body)?;
+        if !calls.is_empty() && (!allow_tool_calls || tools_disabled) {
+            return Err(tool_calls_disabled_error());
+        }
         if calls.is_empty() {
             let output_parts = extract_response_output_parts(&body);
             let reply = extract_response_output_text(&body).unwrap_or_default();

--- a/qq-maid-llm/src/provider/openai/tool_loop/streaming.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/streaming.rs
@@ -24,6 +24,7 @@ use crate::provider::openai::{
         handle_openai_chat_stream_event, is_openai_responses_done_sentinel,
         responses_stream_is_complete,
     },
+    tool_calls_disabled_error,
 };
 
 use super::{
@@ -299,11 +300,7 @@ pub(super) async fn finalize_responses_tool_loop_stream(
     let calls = extract_function_calls(&body)?;
     if !calls.is_empty() {
         if !allow_tool_calls {
-            return Err(LlmError::new(
-                "tool_loop_limit",
-                "tool loop returned tool calls when tool calls are disabled",
-                "tool_loop",
-            ));
+            return Err(tool_calls_disabled_error());
         }
         append_response_output_items(input, &body)?;
         return Ok(AgentStep::ToolCalls {

--- a/qq-maid-llm/src/provider/openai/tool_loop/tests/integration.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/tests/integration.rs
@@ -92,6 +92,63 @@ async fn tool_loop_budget_before_first_request_disables_tools_for_answer() {
 }
 
 #[tokio::test]
+async fn non_stream_budget_finalization_rejects_provider_function_call_without_execution() {
+    let (base_url, state) = spawn_disabled_tools_function_call_mock().await;
+    let execute_calls = Arc::new(AtomicUsize::new(0));
+    let registry = ToolRegistry::new()
+        .register(SequenceToolStub {
+            fail: false,
+            calls: execute_calls.clone(),
+        })
+        .unwrap();
+    let client = qq_maid_common::http_client::client();
+
+    let err = run_agent_loop(
+        Box::new(
+            ResponsesAgentSession::new(
+                client,
+                "test-key".to_owned(),
+                Some(base_url),
+                "openai",
+                "gpt-test".to_owned(),
+                10 * 1024 * 1024,
+                1200,
+                None,
+                &[ChatMessage::user("杭州今天需要带伞吗？")],
+                &registry,
+                Some(crate::context_budget::ContextBudgetConfig {
+                    context_window_chars: 150,
+                    output_reserve_chars: 20,
+                    protected_recent_turns: 0,
+                }),
+            )
+            .unwrap(),
+        ),
+        registry,
+        test_context(),
+        3,
+        None,
+        None,
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(err.code, "tool_loop_limit");
+    assert_eq!(err.stage, "tool_loop");
+    assert_eq!(execute_calls.load(Ordering::SeqCst), 0);
+    let requests = &state.lock().await.requests;
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0].get("tools").is_none());
+    assert!(requests[0].get("tool_choice").is_none());
+    assert!(requests[0].get("parallel_tool_calls").is_none());
+    assert!(
+        requests[0]["input"]
+            .as_array()
+            .is_some_and(|input| input.iter().all(|item| item["type"] != "function_call"))
+    );
+}
+
+#[tokio::test]
 async fn tool_loop_budget_after_tool_result_disables_tools_for_final_answer() {
     let (base_url, state) = spawn_tool_loop_mock().await;
     let registry = ToolRegistry::new().register(WeatherToolStub).unwrap();

--- a/qq-maid-llm/src/provider/openai/tool_loop/tests/integration.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/tests/integration.rs
@@ -86,8 +86,9 @@ async fn tool_loop_budget_before_first_request_disables_tools_for_answer() {
     assert_eq!(outcome.reply, "杭州今天有小雨，建议带伞。");
     let requests = &state.lock().await.requests;
     assert_eq!(requests.len(), 1);
-    assert_eq!(requests[0]["tool_choice"], "none");
-    assert!(requests[0]["tools"].as_array().is_some_and(Vec::is_empty));
+    assert!(requests[0].get("tools").is_none());
+    assert!(requests[0].get("tool_choice").is_none());
+    assert!(requests[0].get("parallel_tool_calls").is_none());
 }
 
 #[tokio::test]
@@ -130,8 +131,9 @@ async fn tool_loop_budget_after_tool_result_disables_tools_for_final_answer() {
     let requests = &state.lock().await.requests;
     assert_eq!(requests.len(), 2);
     assert_eq!(requests[0]["tools"][0]["name"], "get_weather");
-    assert_eq!(requests[1]["tool_choice"], "none");
-    assert!(requests[1]["tools"].as_array().is_some_and(Vec::is_empty));
+    assert!(requests[1].get("tools").is_none());
+    assert!(requests[1].get("tool_choice").is_none());
+    assert!(requests[1].get("parallel_tool_calls").is_none());
 }
 
 #[tokio::test]

--- a/qq-maid-llm/src/provider/openai/tool_loop/tests/integration.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/tests/integration.rs
@@ -48,12 +48,12 @@ async fn tool_loop_executes_function_call_and_returns_output_to_model() {
 }
 
 #[tokio::test]
-async fn tool_loop_budget_exceeded_before_first_provider_request() {
+async fn tool_loop_budget_before_first_request_disables_tools_for_answer() {
     let (base_url, state) = spawn_tool_loop_mock().await;
     let registry = ToolRegistry::new().register(WeatherToolStub).unwrap();
     let client = qq_maid_common::http_client::client();
 
-    let err = run_agent_loop(
+    let outcome = run_agent_loop(
         Box::new(
             ResponsesAgentSession::new(
                 client,
@@ -67,7 +67,7 @@ async fn tool_loop_budget_exceeded_before_first_provider_request() {
                 &[ChatMessage::user("杭州今天需要带伞吗？")],
                 &registry,
                 Some(crate::context_budget::ContextBudgetConfig {
-                    context_window_chars: 120,
+                    context_window_chars: 150,
                     output_reserve_chars: 20,
                     protected_recent_turns: 0,
                 }),
@@ -81,20 +81,22 @@ async fn tool_loop_budget_exceeded_before_first_provider_request() {
         None,
     )
     .await
-    .unwrap_err();
+    .unwrap();
 
-    assert_eq!(err.code, "context_budget_exceeded");
-    assert_eq!(err.stage, "tool_loop");
-    assert!(state.lock().await.requests.is_empty());
+    assert_eq!(outcome.reply, "杭州今天有小雨，建议带伞。");
+    let requests = &state.lock().await.requests;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0]["tool_choice"], "none");
+    assert!(requests[0]["tools"].as_array().is_some_and(Vec::is_empty));
 }
 
 #[tokio::test]
-async fn tool_loop_budget_exceeded_after_tool_result_skips_next_provider_request() {
+async fn tool_loop_budget_after_tool_result_disables_tools_for_final_answer() {
     let (base_url, state) = spawn_tool_loop_mock().await;
     let registry = ToolRegistry::new().register(WeatherToolStub).unwrap();
     let client = qq_maid_common::http_client::client();
 
-    let err = run_agent_loop(
+    let outcome = run_agent_loop(
         Box::new(
             ResponsesAgentSession::new(
                 client,
@@ -122,13 +124,14 @@ async fn tool_loop_budget_exceeded_after_tool_result_skips_next_provider_request
         None,
     )
     .await
-    .unwrap_err();
+    .unwrap();
 
-    assert_eq!(err.code, "context_budget_exceeded");
-    assert_eq!(err.stage, "tool_loop");
+    assert_eq!(outcome.reply, "杭州今天有小雨，建议带伞。");
     let requests = &state.lock().await.requests;
-    assert_eq!(requests.len(), 1);
+    assert_eq!(requests.len(), 2);
     assert_eq!(requests[0]["tools"][0]["name"], "get_weather");
+    assert_eq!(requests[1]["tool_choice"], "none");
+    assert!(requests[1]["tools"].as_array().is_some_and(Vec::is_empty));
 }
 
 #[tokio::test]

--- a/qq-maid-llm/src/provider/openai/tool_loop/tests/mod.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/tests/mod.rs
@@ -318,6 +318,21 @@ async fn mock_tool_loop_handler(
     }))
 }
 
+async fn mock_disabled_tools_function_call_handler(
+    State(state): State<Arc<Mutex<ToolLoopMockState>>>,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    state.lock().await.requests.push(body);
+    Json(json!({
+        "output": [{
+            "type": "function_call",
+            "name": "ok_tool",
+            "call_id": "call_forbidden",
+            "arguments": "{\"value\":\"must-not-run\"}"
+        }]
+    }))
+}
+
 async fn mock_multi_tool_handler(
     State(state): State<Arc<Mutex<ToolLoopMockState>>>,
     Json(body): Json<Value>,
@@ -456,6 +471,24 @@ async fn spawn_tool_loop_mock() -> (String, Arc<Mutex<ToolLoopMockState>>) {
     }));
     let app = Router::new()
         .route("/v1/responses", post(mock_tool_loop_handler))
+        .with_state(state.clone());
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{addr}/v1"), state)
+}
+
+async fn spawn_disabled_tools_function_call_mock() -> (String, Arc<Mutex<ToolLoopMockState>>) {
+    let state = Arc::new(Mutex::new(ToolLoopMockState {
+        requests: Vec::new(),
+    }));
+    let app = Router::new()
+        .route(
+            "/v1/responses",
+            post(mock_disabled_tools_function_call_handler),
+        )
         .with_state(state.clone());
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/qq-maid-llm/src/provider/openai/tool_loop/tests/mod.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/tests/mod.rs
@@ -286,6 +286,17 @@ async fn mock_tool_loop_handler(
 ) -> Json<Value> {
     let mut state = state.lock().await;
     state.requests.push(body);
+    if state.requests[0].get("tool_choice") == Some(&json!("none"))
+        || state.requests[0]
+            .get("tools")
+            .and_then(Value::as_array)
+            .is_some_and(Vec::is_empty)
+    {
+        return Json(json!({
+            "output_text": "杭州今天有小雨，建议带伞。",
+            "output": [{"type":"message","content":[{"type":"output_text","text":"杭州今天有小雨，建议带伞。"}]}]
+        }));
+    }
     if state.requests.len() == 1 {
         return Json(json!({
             "output": [{

--- a/qq-maid-llm/src/provider/openai/tool_loop/tests/mod.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/tests/mod.rs
@@ -286,8 +286,10 @@ async fn mock_tool_loop_handler(
 ) -> Json<Value> {
     let mut state = state.lock().await;
     state.requests.push(body);
-    if state.requests[0].get("tool_choice") == Some(&json!("none"))
-        || state.requests[0]
+    let latest = state.requests.last().expect("request recorded");
+    if (latest.get("tools").is_none() && latest.get("tool_choice").is_none())
+        || latest.get("tool_choice") == Some(&json!("none"))
+        || latest
             .get("tools")
             .and_then(Value::as_array)
             .is_some_and(Vec::is_empty)

--- a/qq-maid-llm/src/provider/openai/tool_loop/tests/payload.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/tests/payload.rs
@@ -29,7 +29,23 @@ fn payload_disables_tool_calls_explicitly() {
         false,
     );
 
-    assert_eq!(payload["tool_choice"], "none");
+    assert!(payload.get("tools").is_none());
+    assert!(payload.get("tool_choice").is_none());
+    assert!(payload.get("parallel_tool_calls").is_none());
+
+    let streaming_payload = openai_tool_loop_payload(
+        &[json!({"role": "user", "content": "总结已有结果"})],
+        &[json!({"type": "function", "name": "search"})],
+        "gpt-test",
+        1200,
+        None,
+        false,
+        true,
+    );
+    assert!(streaming_payload.get("tools").is_none());
+    assert!(streaming_payload.get("tool_choice").is_none());
+    assert!(streaming_payload.get("parallel_tool_calls").is_none());
+    assert_eq!(streaming_payload["stream"], true);
 }
 
 #[test]

--- a/qq-maid-llm/src/provider/route_error.rs
+++ b/qq-maid-llm/src/provider/route_error.rs
@@ -125,6 +125,16 @@ pub(crate) fn aggregate_route_error(task: &str, failures: Vec<ModelAttemptFailur
             .expect("unsupported_input_part failures should not be empty")
             .error;
     }
+    if failures
+        .iter()
+        .all(|failure| failure.error.code == "context_budget_exceeded")
+    {
+        return failures
+            .into_iter()
+            .next()
+            .expect("context budget failures should not be empty")
+            .error;
+    }
     let details = failures
         .into_iter()
         .map(|failure| {

--- a/qq-maid-llm/src/provider/routing.rs
+++ b/qq-maid-llm/src/provider/routing.rs
@@ -332,8 +332,11 @@ impl LlmProvider for ModelRouteProvider {
                         !diagnostics.side_effecting_tools_started.is_empty()
                             || !diagnostics.tools_with_unknown_result.is_empty()
                     };
+                    // Tool Loop 本地上下文超限不代表 Provider 不可用；在尚未外发
+                    // 内容且未启动副作用时可安全换候选，但绝不重跑已产生副作用的轮次。
+                    let local_budget_fallback = err.code == "context_budget_exceeded";
                     let fallback = index + 1 < candidates.len()
-                        && should_try_next_model(&err)
+                        && (should_try_next_model(&err) || local_budget_fallback)
                         && !visible_delta_sent
                         && !tool_side_effect_started;
                     tracing::warn!(

--- a/qq-maid-llm/src/provider/tool_loop.rs
+++ b/qq-maid-llm/src/provider/tool_loop.rs
@@ -27,6 +27,7 @@ pub(crate) struct ToolLoopExecutor<'a> {
     execution_attempted: bool,
     rejected_call: bool,
     completed_read_only_calls: HashMap<String, String>,
+    call_counts: HashMap<String, usize>,
     last_batch: Vec<BatchAttempt>,
     current_batch: Vec<BatchAttempt>,
 }
@@ -82,6 +83,7 @@ impl<'a> ToolLoopExecutor<'a> {
             execution_attempted: false,
             rejected_call: false,
             completed_read_only_calls: HashMap::new(),
+            call_counts: HashMap::new(),
             tool_attempts: Vec::new(),
             last_batch: Vec::new(),
             current_batch: Vec::new(),
@@ -161,14 +163,33 @@ impl<'a> ToolLoopExecutor<'a> {
                     .deduplication_key
                     .as_ref()
                     .map(|key| format!("{}:{key}", prepared.name));
-                if let Some(cached_output) = read_only_key
+                if prepared.max_calls_per_request.is_some_and(|limit| {
+                    self.call_counts.get(&tool_name).copied().unwrap_or(0) >= limit
+                }) {
+                    // 达到请求级上限不是工具故障；返回结构化提示，让模型在下一轮
+                    // 基于已有证据收尾，而不是重试同一个查询。
+                    tracing::warn!(
+                        tool = %tool_name,
+                        calls = self.call_counts.get(&tool_name).copied().unwrap_or(0),
+                        max_calls = prepared.max_calls_per_request,
+                        force_finalization = true,
+                        "tool request limit reached"
+                    );
+                    skipped_for_finalization = true;
+                    (
+                        tool_name,
+                        tool_limit_output(prepared.max_calls_per_request.unwrap_or(0)),
+                        false,
+                    )
+                } else if let Some(cached_output) = read_only_key
                     .as_ref()
                     .and_then(|key| self.completed_read_only_calls.get(key))
                 {
-                    // 缓存只保存已明确成功的只读结果；回放原始输出，避免模型把去重
-                    // 误判为失败，也不能把缓存命中计作一次真实工具执行。
+                    // 缓存只保存已明确成功的只读结果；命中只回传紧凑引用，避免把
+                    // 完整证据再次写入上下文。缓存命中仍计入请求级调用次数。
                     debug!(tool = %tool_name, "agent read-only tool cache hit");
-                    (tool_name, cached_output.clone(), true)
+                    *self.call_counts.entry(tool_name.clone()).or_default() += 1;
+                    (tool_name, compact_cached_output(cached_output), true)
                 } else if prepared.dependency == ToolCallDependency::PreviousCallSuccess
                     && !self.previous_call_succeeded
                 {
@@ -188,6 +209,7 @@ impl<'a> ToolLoopExecutor<'a> {
                             )
                         }
                         ToolCallStartDecision::Execute => {
+                            *self.call_counts.entry(tool_name.clone()).or_default() += 1;
                             tool_started = true;
                             self.emit_progress(ToolLoopProgressEvent::ToolCallStarted {
                                 tool_name: tool_name.clone(),
@@ -371,4 +393,24 @@ fn tool_execution_result(name: &str, output: &str, succeeded: bool) -> ToolExecu
         output,
         succeeded,
     }
+}
+
+fn compact_cached_output(output: &str) -> String {
+    // 保留成功语义和去重标记，不重复注入首次检索的完整证据。
+    serde_json::to_string(&json!({
+        "ok": true,
+        "deduplicated": true,
+        "message": "已使用本次请求中相同检索的已有证据。",
+    }))
+    .unwrap_or_else(|_| output.to_owned())
+}
+
+fn tool_limit_output(limit: usize) -> String {
+    serde_json::to_string(&json!({
+        "ok": false,
+        "error_code": "tool_call_limit",
+        "limit": limit,
+        "message": "本次请求的知识检索次数已达上限，请基于已有证据直接回答。",
+    }))
+    .unwrap_or_else(|_| r#"{"ok":false,"error_code":"tool_call_limit"}"#.to_owned())
 }

--- a/qq-maid-llm/src/provider/tool_loop.rs
+++ b/qq-maid-llm/src/provider/tool_loop.rs
@@ -27,7 +27,7 @@ pub(crate) struct ToolLoopExecutor<'a> {
     execution_attempted: bool,
     rejected_call: bool,
     completed_read_only_calls: HashMap<String, String>,
-    call_counts: HashMap<String, usize>,
+    execution_counts: HashMap<String, usize>,
     last_batch: Vec<BatchAttempt>,
     current_batch: Vec<BatchAttempt>,
 }
@@ -41,6 +41,8 @@ pub(crate) struct ToolLoopCall<'a> {
 pub(crate) struct ToolLoopCallOutput {
     pub(crate) output: String,
     pub(crate) skipped_for_finalization: bool,
+    /// 预算保护才会阻止同批次后续调用；单个工具达到请求上限不能影响其他工具。
+    pub(crate) stop_remaining_batch: bool,
 }
 
 pub(crate) enum ToolCallStartDecision {
@@ -83,7 +85,7 @@ impl<'a> ToolLoopExecutor<'a> {
             execution_attempted: false,
             rejected_call: false,
             completed_read_only_calls: HashMap::new(),
-            call_counts: HashMap::new(),
+            execution_counts: HashMap::new(),
             tool_attempts: Vec::new(),
             last_batch: Vec::new(),
             current_batch: Vec::new(),
@@ -143,6 +145,7 @@ impl<'a> ToolLoopExecutor<'a> {
             batch_len,
         } = call;
         let mut skipped_for_finalization = false;
+        let mut stop_remaining_batch = false;
         let mut tool_started = false;
         let prepared_arguments = prepared
             .as_ref()
@@ -163,17 +166,25 @@ impl<'a> ToolLoopExecutor<'a> {
                     .deduplication_key
                     .as_ref()
                     .map(|key| format!("{}:{key}", prepared.name));
-                if prepared.max_calls_per_request.is_some_and(|limit| {
-                    self.call_counts.get(&tool_name).copied().unwrap_or(0) >= limit
+                if let Some(cached_output) = read_only_key
+                    .as_ref()
+                    .and_then(|key| self.completed_read_only_calls.get(key))
+                {
+                    // 缓存只保存已明确成功的只读结果；命中只回传紧凑引用，避免把
+                    // 完整证据再次写入上下文。缓存命中不增加真实执行次数。
+                    debug!(tool = %tool_name, "agent read-only tool cache hit");
+                    (tool_name, compact_cached_output(cached_output), true)
+                } else if prepared.max_calls_per_request.is_some_and(|limit| {
+                    self.execution_counts.get(&tool_name).copied().unwrap_or(0) >= limit
                 }) {
-                    // 达到请求级上限不是工具故障；返回结构化提示，让模型在下一轮
-                    // 基于已有证据收尾，而不是重试同一个查询。
+                    // 达到请求级上限只拒绝当前工具调用；同批次其他工具仍需执行。
+                    // 下一轮由上层根据该标记切换到无工具最终回答。
                     tracing::warn!(
                         tool = %tool_name,
-                        calls = self.call_counts.get(&tool_name).copied().unwrap_or(0),
-                        max_calls = prepared.max_calls_per_request,
+                        executions = self.execution_counts.get(&tool_name).copied().unwrap_or(0),
+                        max_executions = prepared.max_calls_per_request,
                         force_finalization = true,
-                        "tool request limit reached"
+                        "tool execution limit reached"
                     );
                     skipped_for_finalization = true;
                     (
@@ -181,15 +192,6 @@ impl<'a> ToolLoopExecutor<'a> {
                         tool_limit_output(prepared.max_calls_per_request.unwrap_or(0)),
                         false,
                     )
-                } else if let Some(cached_output) = read_only_key
-                    .as_ref()
-                    .and_then(|key| self.completed_read_only_calls.get(key))
-                {
-                    // 缓存只保存已明确成功的只读结果；命中只回传紧凑引用，避免把
-                    // 完整证据再次写入上下文。缓存命中仍计入请求级调用次数。
-                    debug!(tool = %tool_name, "agent read-only tool cache hit");
-                    *self.call_counts.entry(tool_name.clone()).or_default() += 1;
-                    (tool_name, compact_cached_output(cached_output), true)
                 } else if prepared.dependency == ToolCallDependency::PreviousCallSuccess
                     && !self.previous_call_succeeded
                 {
@@ -202,6 +204,7 @@ impl<'a> ToolLoopExecutor<'a> {
                     match before_start(&tool_name, prepared.effect)? {
                         ToolCallStartDecision::SkipForFinalAnswer => {
                             skipped_for_finalization = true;
+                            stop_remaining_batch = true;
                             (
                                 tool_name,
                                 tool_skip_output("request_budget_reserved_for_final_answer"),
@@ -209,7 +212,6 @@ impl<'a> ToolLoopExecutor<'a> {
                             )
                         }
                         ToolCallStartDecision::Execute => {
-                            *self.call_counts.entry(tool_name.clone()).or_default() += 1;
                             tool_started = true;
                             self.emit_progress(ToolLoopProgressEvent::ToolCallStarted {
                                 tool_name: tool_name.clone(),
@@ -218,6 +220,7 @@ impl<'a> ToolLoopExecutor<'a> {
                             // progress await 返回后仍需在共享生命周期锁内重新检查取消；只有
                             // 原子启动转换成功，才创建工具 future 并越过副作用边界。
                             on_started(&tool_name, prepared.effect)?;
+                            *self.execution_counts.entry(tool_name.clone()).or_default() += 1;
                             if prepared.effect == ToolEffect::SideEffecting {
                                 // 写操作可能改变后续查询结果；只读去重只能跨越没有状态变化的
                                 // 连续查询段，不能让“查询 -> 修改 -> 再查询”复用旧判断。
@@ -279,6 +282,7 @@ impl<'a> ToolLoopExecutor<'a> {
         Ok(ToolLoopCallOutput {
             output,
             skipped_for_finalization,
+            stop_remaining_batch,
         })
     }
 

--- a/qq-maid-llm/src/tool.rs
+++ b/qq-maid-llm/src/tool.rs
@@ -138,7 +138,7 @@ pub trait Tool: Send + Sync {
             .then(|| serde_json::to_string(arguments).ok())
             .flatten()
     }
-    /// 同一 Agent 请求内允许启动的最大调用次数；默认不限制。
+    /// 同一 Agent 请求内允许真实执行的最大次数；只读缓存命中不消耗该额度，默认不限制。
     fn max_calls_per_request(&self) -> Option<usize> {
         None
     }
@@ -175,7 +175,7 @@ pub struct PreparedToolCall {
     pub effect: ToolEffect,
     /// 同一 Agent 请求内的只读调用去重键。
     pub deduplication_key: Option<String>,
-    /// 请求级调用上限，供统一 Tool Loop 执行器计数。
+    /// 请求级真实执行上限，供统一 Tool Loop 执行器计数；缓存命中不计入。
     pub max_calls_per_request: Option<usize>,
     /// 与同轮前一项调用的依赖关系。
     pub dependency: ToolCallDependency,

--- a/qq-maid-llm/src/tool.rs
+++ b/qq-maid-llm/src/tool.rs
@@ -138,6 +138,10 @@ pub trait Tool: Send + Sync {
             .then(|| serde_json::to_string(arguments).ok())
             .flatten()
     }
+    /// 同一 Agent 请求内允许启动的最大调用次数；默认不限制。
+    fn max_calls_per_request(&self) -> Option<usize> {
+        None
+    }
     /// 执行前的本地预处理。
     ///
     /// 默认直接沿用模型参数；有状态工具可在这里把用户可见编号预绑定成稳定内部 ID，
@@ -171,6 +175,8 @@ pub struct PreparedToolCall {
     pub effect: ToolEffect,
     /// 同一 Agent 请求内的只读调用去重键。
     pub deduplication_key: Option<String>,
+    /// 请求级调用上限，供统一 Tool Loop 执行器计数。
+    pub max_calls_per_request: Option<usize>,
     /// 与同轮前一项调用的依赖关系。
     pub dependency: ToolCallDependency,
 }
@@ -314,6 +320,7 @@ impl ToolRegistry {
         Ok(PreparedToolCall {
             effect,
             deduplication_key,
+            max_calls_per_request: tool.max_calls_per_request(),
             tool,
             name: name.to_owned(),
             context: context.clone(),


### PR DESCRIPTION
## 变更
- 在通用 Tool Loop payload 层预留最终回答预算，接近上限时压缩工具输出并强制无工具最终回答。
- Chat Completions 与 Responses 的流式、非流式路径都会拒绝强制最终回答阶段出现的工具调用，统一返回 `tool_loop_limit`，且不会执行工具或把违规调用写回协议会话。
- 保留 Chat Completions / Responses 的调用与结果配对，仅压缩工具输出正文；重复只读缓存命中使用紧凑引用。
- 为 knowledge_search 增加请求级最多 2 次限制并复用 `Tool::deduplication_key` 去重。
- 修正 `context_budget_exceeded` 的 Core 提示与 Provider candidate fallback 条件，避免误报上游不可用。
- 补充预算压缩、结果配对、重复查询、调用上限、候选回退，以及非流式 Provider 违规返回工具调用的回归测试。

## 根因
连续知识检索会把完整工具结果重复追加到模型上下文，侵占最终回答所需预算；本地 Tool Loop 预算错误此前又被统一映射成 Provider 不可用。预算适配层移除工具字段并进入强制最终回答后，Chat Completions 和 Responses 的非流式 `advance` 还忽略了 `tools_disabled`，可能继续接受兼容 Provider 返回的工具调用并执行，造成流式与非流式行为不一致。

## 验证
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p qq-maid-llm --all-features`
- `cargo test --workspace --all-features`
- `git diff --check`

该 PR 创建为 Draft，未合并。
