### PR TITLE
fix: 修复容器发布门禁竞态

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ notepad "$HOME\qq-maid-bot\config\.env"
 测试环境自动部署见 [Docker 与 Compose 部署](./docs/deployment/docker.md)。配置迁移、
 备份恢复与 schema 回滚边界见 [配置迁移、备份恢复与安全升级](./docs/deployment/migration-backup.md)。
 
+普通用户也可以直接从 Docker Hub 拉取最新正式镜像：
+
+```bash
+docker pull kuliantnt/qq-maid-bot:latest
+```
+
 ### 从源码运行
 
 需要已安装 Rust 工具链：

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -152,7 +152,8 @@ GHCR 镜像为 `ghcr.io/kuliantnt/qq-maid-bot`；Docker Hub 正式镜像为
 `docker.io/kuliantnt/qq-maid-bot`。Docker Hub 不接收 `sha-*` 或 `master`。`master` 和
 `latest` 都是可变标签，不能作为回滚依据。测试服和正式环境均应把完整
 `仓库@sha256:digest` 记录为部署事实。tag 对应的 commit 镜像不存在时 Release workflow
-明确失败，不会在 tag 阶段补建另一份镜像。任一 Registry 登录、复制、打标签或 digest
+会等待最多 10 分钟，让并发触发的 master Container workflow 完成；超时后明确失败，
+不会在 tag 阶段补建另一份镜像。任一 Registry 登录、复制、打标签或 digest
 校验失败，正式发布 job 都会失败，不能视为双渠道发布成功。现有 GitHub Release 原生包仍由
 同一个 tag 工作流生成；创建 tag 不会自动更新正式服务器。
 

--- a/scripts/tests/test-container-release-gate.sh
+++ b/scripts/tests/test-container-release-gate.sh
@@ -15,7 +15,15 @@ set -euo pipefail
 printf '%s\n' "$*" >> "${FAKE_GH_LOG}"
 case "$*" in
     *'/actions/workflows/container.yml/runs'*)
-        printf '%s\n' "${FAKE_GH_RUN_IDS:-}"
+        call_count=0
+        if [[ -f "${FAKE_GH_CONTAINER_CALLS_FILE}" ]]; then
+            read -r call_count < "${FAKE_GH_CONTAINER_CALLS_FILE}"
+        fi
+        call_count=$((call_count + 1))
+        printf '%s\n' "${call_count}" > "${FAKE_GH_CONTAINER_CALLS_FILE}"
+        if ((call_count > FAKE_GH_EMPTY_RESPONSES_BEFORE_SUCCESS)); then
+            printf '%s\n' "${FAKE_GH_RUN_IDS:-}"
+        fi
         ;;
     *'/jobs'*)
         [[ "${FAKE_GH_FAIL_ON_JOBS:-false}" != "true" ]] || exit 42
@@ -35,6 +43,7 @@ run_gate() {
     local deploy_conclusion="$3"
     local fail_on_jobs="$4"
     local case_name="$5"
+    local empty_responses_before_success="${6:-0}"
     local summary_file="${TEST_DIR}/${case_name}.summary"
 
     GH_BIN="${FAKE_GH}" \
@@ -44,8 +53,12 @@ run_gate() {
     GITHUB_STEP_SUMMARY="${summary_file}" \
     FAKE_GH_LOG="${TEST_DIR}/gh.log" \
     FAKE_GH_RUN_IDS="${run_ids}" \
+    FAKE_GH_EMPTY_RESPONSES_BEFORE_SUCCESS="${empty_responses_before_success}" \
+    FAKE_GH_CONTAINER_CALLS_FILE="${TEST_DIR}/${case_name}.container-calls" \
     FAKE_GH_DEPLOY_CONCLUSION="${deploy_conclusion}" \
     FAKE_GH_FAIL_ON_JOBS="${fail_on_jobs}" \
+    CONTAINER_WORKFLOW_WAIT_SECONDS=2 \
+    CONTAINER_WORKFLOW_POLL_SECONDS=1 \
         bash "${ROOT_DIR}/scripts/verify-container-release.sh"
 }
 
@@ -55,6 +68,13 @@ grep -Fqx 'verified master Container workflow run: 101' "${TEST_DIR}/default-dis
 grep -Fqx \
     'test Environment deployment gate: disabled (REQUIRE_TEST_DEPLOY_FOR_RELEASE != true)' \
     "${TEST_DIR}/default-disabled.summary"
+
+# tag 紧跟 master push 时，首次查询可能看不到尚未完成的 Container workflow；等待后应继续晋级。
+run_gate "" "105" "" true delayed-container-workflow 2
+grep -Fqx \
+    'verified master Container workflow run: 105' \
+    "${TEST_DIR}/delayed-container-workflow.summary"
+grep -Fqx '3' "${TEST_DIR}/delayed-container-workflow.container-calls"
 
 # 无论是否开启测试门禁，都必须存在对应 commit 的成功 master Container workflow。
 if run_gate "" "" "" true missing-container-workflow; then

--- a/scripts/verify-container-release.sh
+++ b/scripts/verify-container-release.sh
@@ -6,6 +6,10 @@ REPOSITORY="${GITHUB_REPOSITORY:-}"
 TAG_COMMIT="${TAG_COMMIT:-}"
 # 仓库未配置该变量时按 false 处理；只有精确的 true 才开启严格测试部署门禁。
 REQUIRE_TEST_DEPLOY="${REQUIRE_TEST_DEPLOY_FOR_RELEASE:-false}"
+# tag 与 master push 会分别触发 Release 和 Container workflow；两者并发时，
+# Release 必须给正在构建的 commit 镜像留出完成时间，避免把正常构建误判为缺失。
+CONTAINER_WAIT_SECONDS="${CONTAINER_WORKFLOW_WAIT_SECONDS:-600}"
+CONTAINER_POLL_SECONDS="${CONTAINER_WORKFLOW_POLL_SECONDS:-15}"
 
 fail() {
     printf '::error::%s\n' "$*" >&2
@@ -24,18 +28,38 @@ summary() {
     || fail "GITHUB_REPOSITORY 必须是 owner/repository"
 [[ "${TAG_COMMIT}" =~ ^[0-9a-f]{40}$ ]] \
     || fail "TAG_COMMIT 必须是 40 位小写 Git commit"
+[[ "${CONTAINER_WAIT_SECONDS}" =~ ^[0-9]+$ ]] \
+    || fail "CONTAINER_WORKFLOW_WAIT_SECONDS 必须是非负整数"
+[[ "${CONTAINER_POLL_SECONDS}" =~ ^[1-9][0-9]*$ ]] \
+    || fail "CONTAINER_WORKFLOW_POLL_SECONDS 必须是正整数"
 
-successful_run_ids="$("${GH_BIN}" api --method GET \
-    "repos/${REPOSITORY}/actions/workflows/container.yml/runs" \
-    -f branch=master \
-    -f event=push \
-    -f status=completed \
-    -f head_sha="${TAG_COMMIT}" \
-    --jq '.workflow_runs[] | select(.conclusion == "success") | .id')"
+successful_run_ids=""
+container_run_id=""
+waited_seconds=0
+while [[ -z "${container_run_id}" ]]; do
+    successful_run_ids="$("${GH_BIN}" api --method GET \
+        "repos/${REPOSITORY}/actions/workflows/container.yml/runs" \
+        -f branch=master \
+        -f event=push \
+        -f status=completed \
+        -f head_sha="${TAG_COMMIT}" \
+        --jq '.workflow_runs[] | select(.conclusion == "success") | .id')"
 
-container_run_id="$(printf '%s\n' "${successful_run_ids}" | sed -n '/[^[:space:]]/ { p; q; }')"
-[[ -n "${container_run_id}" ]] \
-    || fail "tag commit 没有成功的 master Container workflow，拒绝晋级容器镜像"
+    container_run_id="$(printf '%s\n' "${successful_run_ids}" | sed -n '/[^[:space:]]/ { p; q; }')"
+    [[ -z "${container_run_id}" ]] || break
+    ((waited_seconds < CONTAINER_WAIT_SECONDS)) \
+        || fail "tag commit 在 ${CONTAINER_WAIT_SECONDS} 秒内没有成功的 master Container workflow，拒绝晋级容器镜像"
+
+    remaining_seconds=$((CONTAINER_WAIT_SECONDS - waited_seconds))
+    sleep_seconds="${CONTAINER_POLL_SECONDS}"
+    if ((sleep_seconds > remaining_seconds)); then
+        sleep_seconds="${remaining_seconds}"
+    fi
+    printf '::notice::等待 tag commit 对应的 master Container workflow 完成（已等待 %s 秒）\n' \
+        "${waited_seconds}"
+    sleep "${sleep_seconds}"
+    waited_seconds=$((waited_seconds + sleep_seconds))
+done
 
 summary "verified master Container workflow run: ${container_run_id}"
 


### PR DESCRIPTION
## 变更

- Release 容器晋级门禁在对应 master Container workflow 尚未完成时，最多等待 10 分钟并每 15 秒轮询
- 保留成功 workflow、可选测试环境部署和真实镜像 digest 的既有校验
- 增加“首次查询为空、随后成功”和超时拒绝的 shell 测试覆盖
- 同步更新容器发布文档

## 根因与影响

创建版本 tag 后，Release 与 master Container workflow 会并发执行。原门禁只查询一次已完成且成功的 workflow，因此 Container 仍在构建时会被误判为缺失。修复后会等待同一 commit 的构建完成，不会重新构建或放宽发布门禁。

## 验证

- `shellcheck scripts/verify-container-release.sh scripts/tests/test-container-release-gate.sh`
- `bash -n scripts/verify-container-release.sh scripts/tests/test-container-release-gate.sh`
- `bash scripts/tests/test-container-release-gate.sh`
- `git diff --check`
- 使用 v0.21.0 对应 commit 调用真实 GitHub API，确认门禁识别到成功的 Container workflow