### PR TITLE
release: 发布 v0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 本文档基于 [keep a changelog](https://keepachangelog.com/zh-CN/1.0.0/) 格式，记录每个已发布版本的变更。
 
+## [v0.21.1] - 2026-07-23
+
+### Added
+
+* **群管理员管理 Todo**（PR #568）：群主或管理员可在群聊使用 `/todo group` 查看当前群未完成 Todo / 提醒，并用 `/todo group delete <编号>` 删除；列表编号绑定操作者、平台、机器人账号与完整群 scope，删除时再次校验目标记录所属群，避免跨群或个人快照误删。
+* **Agent 配置示例模板**（PR #568）：仓库与 Release 包中的默认策略文件改为 `agent.example.toml`；首次启动从二进制内嵌的同版模板生成未跟踪的 `config/agent.toml`，修改外部示例不会改变首次生成内容。只读 `config check` 在默认路径缺失时直接校验内嵌模板而不落盘。
+
+### Fixed
+
+* **Todo 提醒并发取消**（PR #568）：取消或删除带提醒的 Todo 时更可靠地终止已租约的提醒通知，降低重复推送风险。
+* **容器发布门禁竞态**（PR #567）：收紧 GHCR 正式 Release 门禁对 tag / digest 就绪状态的判定，降低并发构建误判失败的概率。
+
+### Compatibility
+
+* 根包 `qq-maid-bot` 版本号提升到 `0.21.1`，内部 crate 版本不统一提升。
+* 本版本无数据库 migration、无必需配置迁移。已有 `config/agent.toml` 不会被覆盖；新实例首次启动才生成活动配置。
+* 群 Todo 管理仅限当前群、且操作者为群主或管理员；普通成员和个人 `/todo` 查询语义不变。编号来自最近一次 `/todo group` 列表快照，过期或跨会话后需重新列出。
+* Release / Docker 中的 `agent.example.toml` 仅供参考与升级迁移；活动策略仍为本地 `config/agent.toml`。
+
 ## [v0.21.0] - 2026-07-22
 
 ### Release Focus

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,7 +1966,7 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "qq-maid-bot"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "qq-maid-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-bot"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2024"
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@
 
 > 💡 仓库早期以 QQ 机器人为主，因此仍保留 `qq-maid-bot` 名称。当前项目正在从 QQ 官方机器人演进为多入口平台型小女仆机器人。
 
-当前稳定版本为 `v0.21.0`，项目处于 `21.x` 版本线；版本线能力与升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)。
+当前稳定版本为 `v0.21.1`，项目处于 `21.x` 版本线；版本线能力与升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)。
 
 使用、安装和配置优先看 [项目 Wiki](https://github.com/kuliantnt/qq-maid-bot/wiki)：从第一次对话、一键安装、Docker / GHCR、配置中心与 `/console/` 首次向导，到 NapCat、`/ops` 运维和 Codex 长任务，都按场景拆开了。仓库内 `docs/` 与各 crate README 更偏开发边界和实现细节。
 
 ## 21.x 版本线更新
+- **群管理员 Todo 与 Agent 模板**（v0.21.1）：群主 / 管理员可用 `/todo group` 查看并删除本群未完成 Todo；Release 提供 `agent.example.toml`，首次启动从内嵌模板生成活动 `config/agent.toml`。
 - **多平台部署主线**（v0.21.0）：同一二进制覆盖 QQ 官方、OneBot、微信入口，以及 Linux / Windows / Docker 部署路径；新增 GHCR 多架构镜像、Compose 覆盖、配置迁移与备份恢复 CLI。
 - **Docker 与测试环境**（PR #562）：`linux/amd64` / `linux/arm64` 原生构建推送 GHCR，默认不映射管理端口，按需叠加 console / OneBot / 微信 override；测试环境可按 digest 自动部署与失败回滚。
 - **配置迁移与备份恢复**（PR #565）：`config migrate`、`backup create/verify/restore` 默认 dry-run，支持旧 dotenv 保守导入、SQLite 一致性快照和干净目录恢复。
@@ -39,7 +40,7 @@
 ## 能做什么
 
 - **聊天与上下文**：管理多轮会话，理解图片，并结合引用消息继续追问；共享群聊历史会区分发言成员，降低昵称、偏好和身份信息串线风险。
-- **Todo 与提醒**：新增、修改、完成、恢复和删除待办，支持单次提醒、重复提醒和每日摘要；列表可按今天 / 明天 / 本周 / 逾期 / 关键词组合筛选。
+- **Todo 与提醒**：新增、修改、完成、恢复和删除待办，支持单次提醒、重复提醒和每日摘要；列表可按今天 / 明天 / 本周 / 逾期 / 关键词组合筛选。群主或管理员可用 `/todo group` 管理本群未完成 Todo。
 - **查询与订阅**：查询天气、火车时刻和网页信息，支持多对象对比式联网搜索；订阅 RSS/Atom 并主动推送更新。
 - **记忆与知识库**：个人记忆、群内个人画像和群公共记忆分域管理，并按场景与可见性召回。用户明确要求“记住”时可直接保存；可选的确定性整理（`MEMORY_CONSOLIDATION_ENABLED`）与 Session Dream（`MEMORY_DREAM_ENABLED`）分开开关。Dream 只从会话消息提取安全长期事实，写入个人记忆或当前成员群画像，不覆盖已确认记忆；本地 Markdown 可自动索引并按需检索。
 - **受控工具与运维命令**：模型只能调用服务端注册并按场景放行的工具；管理员可通过默认关闭的 `/ops` 白名单命令触发固定程序，结果以真实执行或持久化结果为准。


### PR DESCRIPTION
## Summary
- 将根包版本提升到 `0.21.1`，更新 `CHANGELOG.md` 与 `README.md`。
- 汇总 PR #568 / #567：群管理员 `/todo group`、Agent `agent.example.toml` 示例模板、提醒并发取消与容器发布门禁修复。
- 已同步 GitHub Wiki（HOME / 使用说明 / 安装手册 / 配置中心 / 开发维护 / 插件开发）。

## Test plan
- [x] `git diff --check`
- [ ] CI：`cargo fmt` / `clippy` / `test` / `release` 构建
- [ ] 合并后在 `master` 打 tag `v0.21.1` 触发 Release 工作流
- [x] Wiki 已推送