### PR TITLE
ci: 更新 Docker 登录 Action 到 Node.js 24

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Log in to GHCR
         if: github.event_name == 'push'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -209,7 +209,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,14 +171,14 @@ jobs:
           done
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## 变更

- 将 `container.yml` 和 `release.yml` 中的 `docker/login-action` 从 `@v3` 更新到 `@v4`。

## 原因

GitHub Actions 已提示 Node.js 20 运行时逐步弃用；`docker/login-action@v4` 默认使用 Node.js 24，消除相关警告。

## 验证

- `git diff --check`