### PR TITLE
release: 发布 v0.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 本文档基于 [keep a changelog](https://keepachangelog.com/zh-CN/1.0.0/) 格式，记录每个已发布版本的变更。
 
+## [v0.21.2] - 2026-07-23
+
+### Added
+
+* **`/ping` 显示主包版本**（PR #572）：`/ping` 展示根包 `qq-maid-bot` 的版本号，由主程序入口注入 Gateway，避免误用 Gateway 子 crate 版本。
+
+### Changed
+
+* **工具状态语义收紧**（PR #572）：自然语言状态分类只生成用户提示和 diagnostics，不再参与 Tool 暴露或执行；Search / RSS 等弱关键词与技术讨论更不易被误判成正在调用工具。
+* **Web Search 结果投影收敛**（PR #572）：同轮重复只读搜索只展示首次真实结果，缓存命中仍保留在 Agent 原始轨迹；不再为缓存命中发送额外 Started / Finished / Failed 进度事件。
+* **Todo 成功验真覆盖省略式请求**（PR #572）：当模型声称已新增、已记录、已修改、已完成或已删除 Todo 时，要求本轮存在真实成功的 Todo 写工具结果；“明天开会”“下午整理一下”等省略式任务声明同样进入验真。
+
+### Fixed
+
+* **后置 Todo 创建声明拦截**（PR #572）：模型未调用写工具却声称“已记录”时返回 `todo_success_not_verified`，不再把伪造成功文案展示给用户；普通创作、解释和分析中的“已完成”不会被误拦截。
+
+### Compatibility
+
+* 根包 `qq-maid-bot` 版本号提升到 `0.21.2`，内部 crate 版本不统一提升。
+* 本版本无数据库 migration、无必需配置迁移。Todo pending、用户编号快照、权限与持久化语义不变。
+* 状态提示继续保持严格，不影响模型调用已注册白名单 Tool；重复只读搜索的 `tool_results` / `tool_attempts` / `deduplicated` 与模型可见原始轨迹保持完整。
+
 ## [v0.21.1] - 2026-07-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,7 +1966,7 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "qq-maid-bot"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "anyhow",
  "qq-maid-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-bot"
-version = "0.21.1"
+version = "0.21.2"
 edition = "2024"
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@
 
 > 💡 仓库早期以 QQ 机器人为主，因此仍保留 `qq-maid-bot` 名称。当前项目正在从 QQ 官方机器人演进为多入口平台型小女仆机器人。
 
-当前稳定版本为 `v0.21.1`，项目处于 `21.x` 版本线；版本线能力与升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)。
+当前稳定版本为 `v0.21.2`，项目处于 `21.x` 版本线；版本线能力与升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)。
 
 使用、安装和配置优先看 [项目 Wiki](https://github.com/kuliantnt/qq-maid-bot/wiki)：从第一次对话、一键安装、Docker / GHCR、配置中心与 `/console/` 首次向导，到 NapCat、`/ops` 运维和 Codex 长任务，都按场景拆开了。仓库内 `docs/` 与各 crate README 更偏开发边界和实现细节。
 
 ## 21.x 版本线更新
+- **主包版本诊断与工具结果验真**（v0.21.2）：`/ping` 显示根主包版本；收紧自然语言状态提示，并要求 Todo 成功文案必须由真实写工具结果支撑；同轮重复只读搜索只展示首次结果。
 - **群管理员 Todo 与 Agent 模板**（v0.21.1）：群主 / 管理员可用 `/todo group` 查看并删除本群未完成 Todo；Release 提供 `agent.example.toml`，首次启动从内嵌模板生成活动 `config/agent.toml`。
 - **多平台部署主线**（v0.21.0）：同一二进制覆盖 QQ 官方、OneBot、微信入口，以及 Linux / Windows / Docker 部署路径；新增 GHCR 多架构镜像、Compose 覆盖、配置迁移与备份恢复 CLI。
 - **Docker 与测试环境**（PR #562）：`linux/amd64` / `linux/arm64` 原生构建推送 GHCR，默认不映射管理端口，按需叠加 console / OneBot / 微信 override；测试环境可按 digest 自动部署与失败回滚。


### PR DESCRIPTION
## 变更

- 根包版本提升到 `0.21.2`，同步 `Cargo.lock`、`CHANGELOG.md`、`README.md`。
- 覆盖已合并的 PR #572：`/ping` 显示主包版本、工具状态语义收紧、Todo 成功验真与搜索结果投影。

## 兼容性

- 无数据库 migration、无必需配置迁移。
- 内部 crate 版本不统一提升。

## 验证

- 对照 v0.21.1 发版格式更新 CHANGELOG / README。
- `git diff --check`
- PR #572 已在 master 完成 fmt / clippy / test / release build。

合并后请在 master 上打 tag `v0.21.2` 触发 Release workflow。

Wiki 同步更新将在本 PR 创建后单独推送到 `qq-maid-bot.wiki`。