### PR TITLE
[codex] refactor: 收敛工具领域边界

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@
 - Tool 文件只作为工具入口，负责参数解析、上下文校验和结果返回。
 - 多步业务流程应抽到 `<domain>/ops.rs`，例如同时更新任务、取消 outbox、生成下一次提醒。
 - storage 只负责底层持久化读写；只有需要新增数据库读写或事务语义时才扩展 storage。
+- 领域模块必须通过 `tools/<domain>/mod.rs` 提供少量明确门面；不得用 `pub use storage::*` 等通配导出把 Repository 内部类型重新暴露给 Runtime。
+- 通用 Tool 注册、整轮投影和状态提示层只能装配领域门面或消费通用 adapter；具体 Tool 名称、业务动作、结果索引合并、成功验真和领域状态分类必须留在 `tools/<domain>/`。
 - 不要在 respond/chat_flow/session/prompt 层新增零散 Todo/Reminder/Command 业务判断。
 
 依赖方向保持：

--- a/qq-maid-core/src/runtime/respond/tool_runtime.rs
+++ b/qq-maid-core/src/runtime/respond/tool_runtime.rs
@@ -12,11 +12,9 @@ use crate::{
     runtime::tools::rss::RssFetcher,
     runtime::tools::weather::WEATHER_TOOL_NAME,
     runtime::tools::{
-        CompleteTodoTool, CreateTodoTool, DeleteTodoTool, EditTodoTool, GetTodoTool,
-        KnowledgeSearchTool, ListTodoTool, ManageRecurringReminderTool, MergeTodoTool,
-        RestoreTodoTool, RssManageSubscriptionsTool, RssRecentItemsTool, SaveMemoryTool, TaskStore,
-        TodoScopedToolInputs, ToolTurnPostprocess, TrainScheduleTool, WEB_SEARCH_TOOL_NAME,
-        WeatherTool, WebSearchTimeouts, WebSearchTool, postprocess_tool_turn,
+        KnowledgeSearchTool, RssManageSubscriptionsTool, RssRecentItemsTool, SaveMemoryTool,
+        TaskStore, TodoScopedToolInputs, ToolTurnPostprocess, TrainScheduleTool,
+        WEB_SEARCH_TOOL_NAME, WeatherTool, WebSearchTimeouts, WebSearchTool, postprocess_tool_turn,
         replace_scoped_todo_tools_from_visible_snapshot, todo,
     },
     storage::notification::NotificationOutboxStore,
@@ -74,51 +72,13 @@ impl ToolRuntime {
                 knowledge_index,
                 tool_result_max_chars,
             )),
-            Arc::new(ListTodoTool::new(
-                stores.task_store.clone(),
-                stores.session_store.clone(),
-            )),
-            Arc::new(GetTodoTool::new(
-                stores.task_store.clone(),
-                stores.session_store.clone(),
-            )),
-            Arc::new(CreateTodoTool::new(
-                stores.task_store.clone(),
-                stores.session_store.clone(),
-                stores.notification_store.clone(),
-            )),
-            Arc::new(CompleteTodoTool::new(
-                stores.task_store.clone(),
-                stores.session_store.clone(),
-                stores.notification_store.clone(),
-            )),
-            Arc::new(EditTodoTool::new(
-                stores.task_store.clone(),
-                stores.session_store.clone(),
-                stores.notification_store.clone(),
-            )),
-            Arc::new(RestoreTodoTool::new(
-                stores.task_store.clone(),
-                stores.session_store.clone(),
-                stores.notification_store.clone(),
-            )),
-            Arc::new(DeleteTodoTool::new(
-                stores.task_store.clone(),
-                stores.session_store.clone(),
-                stores.notification_store.clone(),
-            )),
-            Arc::new(MergeTodoTool::new(
-                stores.task_store.clone(),
-                stores.session_store.clone(),
-                stores.notification_store.clone(),
-            )),
-            Arc::new(ManageRecurringReminderTool::new(
-                stores.task_store.clone(),
-                stores.session_store.clone(),
-                stores.notification_store.clone(),
-            )),
             Arc::new(save_memory_tool.clone()),
         ];
+        tools.extend(todo::registered_tools(
+            stores.task_store.clone(),
+            stores.session_store.clone(),
+            stores.notification_store.clone(),
+        ));
         if weather_available {
             tools.push(Arc::new(WeatherTool::new(
                 executors.weather_executor.clone(),

--- a/qq-maid-core/src/runtime/tools/AGENTS.md
+++ b/qq-maid-core/src/runtime/tools/AGENTS.md
@@ -17,6 +17,11 @@
 
 禁止把具体业务规则散落到 `respond/chat_flow/session/prompt/gateway/llm` 中。Respond 层只负责通用编排、工具调用、结果投影和必要上下文维护；Gateway 只负责平台消息收发；LLM crate 只负责模型协议和 Tool Loop 协议。
 
+领域 `mod.rs` 是跨模块唯一门面：只导出实际调用方需要的稳定类型和函数，禁止用
+`pub use storage::*` 或大量转发重新暴露 Repository 子模块。通用 `agent_turn.rs`、状态
+提示和 Tool Registry 只能注册领域 adapter / 集合；具体 Tool 名称、操作分类、结果索引
+合并、成功验真和领域状态判断必须留在对应 `<domain>/`。
+
 ## 开发自己的业务工具
 
 新增一个独立业务能力时，先把它当作一个 `<domain>` 设计，而不是只写一个模型函数。可以参考 `todo/` 的拆分方式，但不要照搬 Todo 的所有复杂度；按业务是否需要持久化、用户后续引用、主动通知、确认/澄清来决定交付面。
@@ -58,10 +63,13 @@
 
 ## 工具注册
 
-新增工具通常需要同步注册：
+在已有领域内新增 Tool 时，通常只修改该领域的 Tool 实现、`registered_tools` 集合、
+配置白名单和测试，不应继续改 `runtime/tools/mod.rs`、通用 `agent_turn.rs` 或在
+`respond/tool_runtime.rs` 逐个构造 Tool。只有新增一个全新领域时，才在通用层增加一次
+领域模块声明和注册集合接线。
 
-* `qq-maid-core/src/runtime/tools/mod.rs`
-* `qq-maid-core/src/runtime/respond/tool_runtime.rs`
+仍需同步检查：
+
 * `qq-maid-core/src/config/agent.rs`
 * `runtime/config/agent.example.toml`
 * 必要时更新 `qq-maid-core/src/runtime/respond/help.rs`
@@ -70,13 +78,19 @@
 
 注册检查清单：
 
-* 在 domain `mod.rs` 中导出 Tool 类型和必要的 domain helper；跨模块只暴露稳定门面，不暴露临时解析细节。
-* 在 `runtime/tools/mod.rs` 中 `mod` / `pub use` 新 Tool，保持 Core 其他层只依赖工具门面。
-* 在 `respond/tool_runtime.rs` 的服务端 `ToolRegistry` 注册实例，并注入所需 store、executor、session 或 notification 依赖。
+* 在 domain `mod.rs` 中提供稳定门面；有多个 Tool 时由领域构造 `registered_tools` 一类的注册集合，跨模块不得逐个导出或构造具体 Tool。
+* 在 `runtime/tools/mod.rs` 中只声明领域模块和必要的通用抽象，避免成为领域 Tool 的转发清单。
+* 在 `respond/tool_runtime.rs` 的服务端 `ToolRegistry` 追加领域注册集合，并注入领域所需 store、executor、session 或 notification 依赖；Respond 不得维护领域 Tool 名称、构造顺序或参数差异。
 * 在 `config/agent.rs` 的默认白名单中决定私聊和群聊是否开放；写入类或持久化类默认只考虑私聊，群聊必须显式评估 owner 语义。
 * 在 `runtime/config/agent.example.toml` 更新可版本管理的工具白名单示例和注释，保持默认策略与代码默认值一致。
 * 如果用户需要知道显式命令或能力边界，更新 `respond/help.rs` 或对应 README；文档不要复制大段实现细节。
 * 如果 Tool 会产生用户可见列表或单条对象，接入通用 visible entity 快照，并在 Respond 请求进入 Tool Runtime 时替换为带作用域限制的 Tool。
+* 有 Tool Loop 整轮回执、重试覆盖、结果索引合并、成功验真或自然语言状态提示时，在领域目录提供 adapter；通用层只调度 adapter 和通用结果，不枚举领域 Tool 名称或业务动作。
+
+二开新增全新领域时，最小通用接线应只有：在 `runtime/tools/mod.rs` 声明领域、在
+`respond/tool_runtime.rs` 注册领域集合、在通用结果/状态 adapter 列表中登记领域入口。
+如果还需要把 SQL、业务字段、Tool 名称分支或用户文案写进这些通用文件，说明领域门面
+仍不完整，应先回到 `<domain>/` 补齐，而不是继续扩大通用层。
 
 ## 测试要求
 

--- a/qq-maid-core/src/runtime/tools/agent_turn.rs
+++ b/qq-maid-core/src/runtime/tools/agent_turn.rs
@@ -15,6 +15,7 @@ use crate::{
         session::{SessionMeta, SessionRecord, SessionStore},
         tools::{TaskStore, memory, todo},
     },
+    service::VisibleEntitySnapshot,
 };
 
 use super::agent_presenters::{
@@ -24,6 +25,16 @@ use super::agent_presenters::{
 use super::search::agent_turn::{SearchResultProjection, project_result as project_search_result};
 
 pub(crate) type IndexedToolOutcomes = Vec<(usize, ToolExecutionOutcome)>;
+
+/// 单个业务域对整轮 Tool 结果的结构化投影。
+///
+/// 领域只报告它消费的结果和对应回执；跨领域的原始调用顺序、重试覆盖和未知 Tool
+/// 回退统一由本模块处理，避免把整轮编排错误地下沉到任一业务域。
+pub(crate) struct DomainResultProjection {
+    pub(crate) consumed_result_indexes: std::collections::HashSet<usize>,
+    pub(crate) outcomes: IndexedToolOutcomes,
+    pub(crate) visible_entity_snapshot: Option<VisibleEntitySnapshot>,
+}
 
 pub(crate) trait DomainTurnDiagnostics {
     fn log_tool_loop_results(&self, executed_tools: &[String]);
@@ -203,11 +214,11 @@ fn project_tool_turn(
         if is_retry_superseded_result(index, &output.agent.tool_attempts) {
             // 旧尝试仍保留在 Agent diagnostics；这里只丢弃它对应的用户展示块。
             let mut discarded = Vec::new();
-            drain_todo_outcomes_for_result(index, &mut todo_outcomes, &mut discarded);
+            drain_domain_outcomes_for_result(index, &mut todo_outcomes, &mut discarded);
             continue;
         }
         if todo_projection.consumed_result_indexes.contains(&index) {
-            drain_todo_outcomes_for_result(index, &mut todo_outcomes, &mut outcomes);
+            drain_domain_outcomes_for_result(index, &mut todo_outcomes, &mut outcomes);
         } else if let Some(outcome) = tool_outcome_from_weather_result(result) {
             outcomes.push(outcome);
         } else if let Some(outcome) = tool_outcome_from_train_result(result) {
@@ -234,6 +245,23 @@ fn project_tool_turn(
     ))
 }
 
+fn drain_domain_outcomes_for_result(
+    result_index: usize,
+    domain_outcomes: &mut std::iter::Peekable<impl Iterator<Item = (usize, ToolExecutionOutcome)>>,
+    outcomes: &mut Vec<ToolExecutionOutcome>,
+) {
+    while domain_outcomes
+        .peek()
+        .is_some_and(|(outcome_index, _)| *outcome_index == result_index)
+    {
+        if let Some((_, outcome)) = domain_outcomes.next() {
+            outcomes.push(outcome);
+        }
+    }
+}
+
+/// 重试后的旧结果仍保留在原始 Agent 轨迹中，但不能再参与用户展示或领域回执。
+/// 这是所有领域共用的 Tool Loop 语义，不属于 Todo 专用逻辑。
 pub(crate) fn is_retry_superseded_result(
     result_index: usize,
     attempts: &[qq_maid_llm::provider::ToolExecutionAttempt],
@@ -241,21 +269,6 @@ pub(crate) fn is_retry_superseded_result(
     attempts
         .iter()
         .any(|attempt| attempt.retry_of == Some(result_index))
-}
-
-fn drain_todo_outcomes_for_result(
-    result_index: usize,
-    todo_outcomes: &mut std::iter::Peekable<impl Iterator<Item = (usize, ToolExecutionOutcome)>>,
-    outcomes: &mut Vec<ToolExecutionOutcome>,
-) {
-    while todo_outcomes
-        .peek()
-        .is_some_and(|(outcome_index, _)| *outcome_index == result_index)
-    {
-        if let Some((_, outcome)) = todo_outcomes.next() {
-            outcomes.push(outcome);
-        }
-    }
 }
 
 fn apply_agent_turn_outcome(output: &mut RespondOutput, outcome: &AgentTurnOutcome) {

--- a/qq-maid-core/src/runtime/tools/knowledge/mod.rs
+++ b/qq-maid-core/src/runtime/tools/knowledge/mod.rs
@@ -1,6 +1,7 @@
 //! 只读知识检索 Tool。
 
 mod index;
+pub(crate) mod status;
 mod storage;
 mod tool;
 

--- a/qq-maid-core/src/runtime/tools/knowledge/status.rs
+++ b/qq-maid-core/src/runtime/tools/knowledge/status.rs
@@ -1,0 +1,8 @@
+//! 知识检索领域的用户可见状态适配。
+
+use crate::runtime::tools::status::{StatusAction, StatusHint, StatusSubject};
+
+pub(crate) fn status_hint_for_tool_name(tool_name: &str) -> Option<StatusHint> {
+    (tool_name == super::KNOWLEDGE_SEARCH_TOOL_NAME)
+        .then_some(StatusHint::new(StatusSubject::Search, StatusAction::Query))
+}

--- a/qq-maid-core/src/runtime/tools/memory/mod.rs
+++ b/qq-maid-core/src/runtime/tools/memory/mod.rs
@@ -14,6 +14,7 @@ mod recall;
 mod receipt;
 pub(crate) mod route;
 mod save;
+pub(crate) mod status;
 pub mod storage;
 mod types;
 
@@ -37,7 +38,16 @@ pub(crate) use receipt::{
 };
 pub(crate) use route::infer_group_memory_kind;
 pub use save::SaveMemoryTool;
-pub use storage::*;
+// 只暴露 Memory 领域的稳定持久化门面；storage 内部查询/行映射不应通过通配导出
+// 扩散到 respond 或其他业务域。
+pub use storage::{
+    CreateMemoryRequest, CreateScopedMemoryRequest, ListMemoryQuery,
+    MEMORY_CONSOLIDATION_SCHEMA_V4, MEMORY_DOMAIN_SCHEMA_V3, MEMORY_MIGRATIONS, MEMORY_SCHEMA_V1,
+    MEMORY_SCOPE_SCHEMA_V2, MemoryCategory, MemoryDeleteResponse, MemoryError, MemoryErrorInfo,
+    MemoryItemResponse, MemoryKind, MemoryListResponse, MemoryQuery, MemoryRecord, MemoryScopeType,
+    MemorySourceType, MemoryStatus, MemoryStore, MemoryTarget, MemoryVisibility, ScopedMemoryQuery,
+    UpdateMemoryRequest,
+};
 pub(crate) use types::MemoryRecall;
 pub use types::{
     MemoryActor, MemoryMutationResult, MemoryWriteResult, ProfilePreferenceResult,

--- a/qq-maid-core/src/runtime/tools/memory/status.rs
+++ b/qq-maid-core/src/runtime/tools/memory/status.rs
@@ -1,0 +1,13 @@
+//! Memory 领域的用户可见状态适配。
+
+use crate::runtime::tools::status::{StatusAction, StatusHint, StatusSubject};
+
+pub(crate) fn status_hint_for_tool_name(tool_name: &str) -> Option<StatusHint> {
+    (tool_name == super::SAVE_MEMORY_TOOL_NAME)
+        .then_some(StatusHint::new(StatusSubject::Record, StatusAction::Write))
+}
+
+pub(crate) fn classify_status_hint(text: &str) -> Option<StatusHint> {
+    super::route::has_memory_status_intent(text)
+        .then_some(StatusHint::new(StatusSubject::Record, StatusAction::Write))
+}

--- a/qq-maid-core/src/runtime/tools/mod.rs
+++ b/qq-maid-core/src/runtime/tools/mod.rs
@@ -37,10 +37,6 @@ pub(crate) use status::{
 pub(crate) use status_classifier::{
     InteractionDomain, InteractionDomainState, InteractionStateSnapshot, classify_status_hint,
 };
-pub use todo::{
-    CompleteTodoTool, CreateTodoTool, DeleteTodoTool, EditTodoTool, GetTodoTool, ListTodoTool,
-    ManageRecurringReminderTool, MergeTodoTool, RestoreTodoTool,
-};
 /// Respond 层只依赖任务存储抽象名；当前实现由 Todo 业务模块提供。
 pub type TaskStore = todo::TodoStore;
 /// Respond 层只依赖任务 owner 抽象名；当前实现由 Todo 业务模块提供。

--- a/qq-maid-core/src/runtime/tools/rss/mod.rs
+++ b/qq-maid-core/src/runtime/tools/rss/mod.rs
@@ -5,10 +5,18 @@
 
 pub mod feed;
 pub mod scheduler;
+pub(crate) mod status;
 pub mod storage;
 mod tool;
 
 pub use feed::{RssFetchConfig, RssFetcher};
 pub use scheduler::{RssScheduler, RssSchedulerConfig};
-pub use storage::*;
+// RSS storage 已经提供领域级数据模型；显式列出导出面，避免内部持久化类型随 wildcard
+// 导出向 Runtime 扩散。
+pub use storage::{
+    RSS_ITEM_STATES_SCHEMA, RSS_LEGACY_SEEN_ITEMS_MIGRATION, RSS_MIGRATIONS,
+    RSS_PENDING_REBASELINE_MIGRATION, RSS_SUBSCRIPTIONS_SCHEMA, RSS_TITLE_SANITIZE_MIGRATION,
+    RssFeedItem, RssPendingItem, RssRecentItem, RssStore, RssStoreError, RssSubscription,
+    RssTarget, RssTargetType,
+};
 pub use tool::{RssManageSubscriptionsTool, RssRecentItemsTool};

--- a/qq-maid-core/src/runtime/tools/rss/status.rs
+++ b/qq-maid-core/src/runtime/tools/rss/status.rs
@@ -1,0 +1,12 @@
+//! RSS 领域的用户可见状态适配。
+
+use crate::runtime::tools::status::{StatusAction, StatusHint, StatusSubject};
+
+pub(crate) fn status_hint_for_tool_name(tool_name: &str) -> Option<StatusHint> {
+    let action = match tool_name {
+        "get_rss_recent_items" => StatusAction::Query,
+        "manage_rss_subscriptions" => StatusAction::Process,
+        _ => return None,
+    };
+    Some(StatusHint::new(StatusSubject::Rss, action))
+}

--- a/qq-maid-core/src/runtime/tools/search/mod.rs
+++ b/qq-maid-core/src/runtime/tools/search/mod.rs
@@ -64,6 +64,7 @@ impl Default for WebSearchTimeouts {
 
 pub(crate) mod agent_turn;
 mod ops;
+pub(crate) mod status;
 
 pub(crate) type WebSearchDeltaHandler<'a> = Box<
     dyn FnMut(String) -> Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send>> + Send + 'a,

--- a/qq-maid-core/src/runtime/tools/search/status.rs
+++ b/qq-maid-core/src/runtime/tools/search/status.rs
@@ -1,0 +1,8 @@
+//! 联网搜索领域的用户可见状态适配。
+
+use crate::runtime::tools::status::{StatusAction, StatusHint, StatusSubject};
+
+pub(crate) fn status_hint_for_tool_name(tool_name: &str) -> Option<StatusHint> {
+    (tool_name == super::WEB_SEARCH_TOOL_NAME)
+        .then_some(StatusHint::new(StatusSubject::Search, StatusAction::Query))
+}

--- a/qq-maid-core/src/runtime/tools/status.rs
+++ b/qq-maid-core/src/runtime/tools/status.rs
@@ -75,26 +75,20 @@ impl StatusHint {
 /// 这里不读取用户原文，也不参与 Tool Registry、权限或执行判断；未知工具统一回退到
 /// 通用处理状态，避免为状态提示再维护一套自然语言意图分类器。
 pub(crate) fn status_hint_for_tool_name(tool_name: &str) -> Option<StatusHint> {
-    let hint = match tool_name {
-        "web_search" | "knowledge_search" => {
-            StatusHint::new(StatusSubject::Search, StatusAction::Query)
+    for classify in [
+        super::todo::status::status_hint_for_tool_name,
+        super::memory::status::status_hint_for_tool_name,
+        super::rss::status::status_hint_for_tool_name,
+        super::search::status::status_hint_for_tool_name,
+        super::knowledge::status::status_hint_for_tool_name,
+        super::weather::status::status_hint_for_tool_name,
+        super::train::status::status_hint_for_tool_name,
+    ] {
+        if let Some(hint) = classify(tool_name) {
+            return Some(hint);
         }
-        "get_weather" => StatusHint::new(StatusSubject::Weather, StatusAction::Query),
-        "get_train_schedule" => StatusHint::new(StatusSubject::Train, StatusAction::Query),
-        "get_rss_recent_items" => StatusHint::new(StatusSubject::Rss, StatusAction::Query),
-        "manage_rss_subscriptions" => StatusHint::new(StatusSubject::Rss, StatusAction::Process),
-        "list_todos" | "get_todo" => StatusHint::new(StatusSubject::Todo, StatusAction::Query),
-        "create_todo" | "edit_todo" | "merge_todos" | "manage_recurring_reminder" => {
-            StatusHint::new(StatusSubject::Todo, StatusAction::Write)
-        }
-        "complete_todos" | "restore_todos" | "delete_todos" => {
-            StatusHint::new(StatusSubject::Todo, StatusAction::Confirm)
-        }
-        "clarification_control" => StatusHint::new(StatusSubject::Todo, StatusAction::Process),
-        "save_memory" => StatusHint::new(StatusSubject::Record, StatusAction::Write),
-        _ => return None,
-    };
-    Some(hint)
+    }
+    None
 }
 
 pub(crate) fn status_hint_text(

--- a/qq-maid-core/src/runtime/tools/status_classifier.rs
+++ b/qq-maid-core/src/runtime/tools/status_classifier.rs
@@ -2,13 +2,7 @@
 //!
 //! 这些轻量规则只用于用户可见状态，不参与工具暴露或执行决策。
 
-use super::{
-    memory,
-    status::{StatusAction, StatusHint, StatusSubject},
-    todo,
-    todo::route::TodoIntentAction,
-    train, weather,
-};
+use super::{status::StatusHint, todo};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum InteractionDomain {
@@ -64,31 +58,25 @@ pub(crate) fn classify_status_hint(
     interaction_state: &InteractionStateSnapshot,
 ) -> Option<StatusHint> {
     let has_recent_todo_context = interaction_state.has_recent_context(InteractionDomain::Todo);
-    let lower = text.to_ascii_lowercase();
-    let todo_intent = todo::route::classify_todo_intent(text, &lower, has_recent_todo_context);
-    if todo_intent.is_confident() {
-        let action = match todo::route::todo_intent_action(text) {
-            TodoIntentAction::Confirm => StatusAction::Confirm,
-            TodoIntentAction::Write => StatusAction::Write,
-            TodoIntentAction::Query => StatusAction::Query,
-            TodoIntentAction::Process => StatusAction::Process,
-        };
-        return Some(StatusHint::new(StatusSubject::Todo, action));
+    if let Some(hint) = todo::status::classify_status_hint(text, has_recent_todo_context) {
+        return Some(hint);
     }
-    if memory::route::has_memory_status_intent(text) {
-        return Some(StatusHint::new(StatusSubject::Record, StatusAction::Write));
-    }
-    if weather::route::has_weather_status_intent(text) {
-        return Some(StatusHint::new(StatusSubject::Weather, StatusAction::Query));
-    }
-    if train::route::has_train_status_intent(text) {
-        return Some(StatusHint::new(StatusSubject::Train, StatusAction::Query));
+    for classify in [
+        super::memory::status::classify_status_hint,
+        super::weather::status::classify_status_hint,
+        super::train::status::classify_status_hint,
+    ] {
+        if let Some(hint) = classify(text) {
+            return Some(hint);
+        }
     }
     None
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::runtime::tools::status::{StatusAction, StatusSubject};
+
     use super::*;
 
     #[test]

--- a/qq-maid-core/src/runtime/tools/todo/agent_turn.rs
+++ b/qq-maid-core/src/runtime/tools/todo/agent_turn.rs
@@ -14,19 +14,12 @@ use crate::{
         session::{SessionMeta, SessionRecord},
         tools::{
             TaskStore,
-            agent_turn::{DomainTurnDiagnostics, DomainTurnPostprocessor, IndexedToolOutcomes},
+            agent_turn::{DomainResultProjection, DomainTurnDiagnostics, DomainTurnPostprocessor},
             todo,
         },
     },
-    service::VisibleEntitySnapshot,
     util::metrics::LlmMetrics,
 };
-
-pub(crate) struct TodoAgentProjection {
-    pub(crate) consumed_result_indexes: std::collections::HashSet<usize>,
-    pub(crate) outcomes: IndexedToolOutcomes,
-    pub(crate) visible_entity_snapshot: Option<VisibleEntitySnapshot>,
-}
 
 /// 捕获投影前的 Todo 会话上下文和模型原始回复，避免通用 Tool Turn 调度层
 /// 感知验真候选细节，也避免事实卡或工具回执干扰成功声明判定。
@@ -95,12 +88,12 @@ pub(crate) fn project_results(
     meta: &SessionMeta,
     results: &[ToolExecutionResult],
     attempts: &[qq_maid_llm::provider::ToolExecutionAttempt],
-) -> Result<TodoAgentProjection, LlmError> {
+) -> Result<DomainResultProjection, LlmError> {
     let owner = TaskStore::owner(meta.user_id.as_deref(), &meta.scope_key);
     let aggregation =
         todo::flow::aggregate_todo_tool_results(task_store, session, &owner, results, attempts)?;
     let visible_entity_snapshot = aggregation.visible_entity_snapshot(session, meta);
-    Ok(TodoAgentProjection {
+    Ok(DomainResultProjection {
         consumed_result_indexes: aggregation.consumed_result_indexes,
         outcomes: aggregation.outcomes,
         visible_entity_snapshot,

--- a/qq-maid-core/src/runtime/tools/todo/flow/pending.rs
+++ b/qq-maid-core/src/runtime/tools/todo/flow/pending.rs
@@ -28,12 +28,9 @@ use crate::{
         pending::{PendingReplyKind, classify_reply},
         session::{LAST_QUERY_TTL_SECONDS, SessionRecord},
         tools::todo::{
-            PendingTodoClarification, TodoBulkDeleteOutcome, TodoOwner, TodoPendingPayload,
-            TodoStatus, todo_lexicon,
-        },
-        tools::{
             CompleteTodoTool, DeleteTodoTool, EditTodoTool, ManageRecurringReminderTool,
-            RestoreTodoTool,
+            PendingTodoClarification, RestoreTodoTool, TodoBulkDeleteOutcome, TodoOwner,
+            TodoPendingPayload, TodoStatus, todo_lexicon,
         },
         tools::{cancel_reminder_task, cancel_reminder_task_by_id},
     },

--- a/qq-maid-core/src/runtime/tools/todo/mod.rs
+++ b/qq-maid-core/src/runtime/tools/todo/mod.rs
@@ -1,8 +1,8 @@
-//! Todo Tool。
+//! Todo 领域模块。
 //!
-//! 这些 Tool 只把模型参数适配到现有 TodoStore、Session 快照和 pending 机制。
-//! 内部 ID 不返回给模型；跨轮次编号只来自用户实际看到的列表，Tool Loop 内部
-//! `list_todos` 查询只保留在当前 task 的临时选择上下文中。
+//! 这里是 Todo 的唯一业务边界：命令、Tool、业务编排、展示、查询模型和 SQLite
+//! Repository 都在本模块内协作。外层只依赖下面明确列出的领域入口，不直接依赖
+//! `storage` 的子模块，避免数据库字段和 SQL 细节向 Runtime 泄漏。
 //!
 //! 模块拆分（保持公共导出与历史不变）：
 //! - `common`：常量、选择/引用类型与参数解析 helper、错误转换。
@@ -49,34 +49,102 @@ mod merge;
 mod recurring;
 mod restore;
 
-pub use complete::CompleteTodoTool;
-pub use create::CreateTodoTool;
-pub use delete::DeleteTodoTool;
-pub use edit::EditTodoTool;
+use std::sync::Arc;
+
+use qq_maid_llm::tool::DynTool;
+
+use crate::{runtime::session::SessionStore, storage::notification::NotificationOutboxStore};
+
+pub(crate) use complete::CompleteTodoTool;
+pub(crate) use create::CreateTodoTool;
+pub(crate) use delete::DeleteTodoTool;
+pub(crate) use edit::EditTodoTool;
 pub use edit_patch::TodoEditPatch;
 pub(crate) use freshness::valid_last_visible_todo_query;
-pub use get::GetTodoTool;
-pub use list::ListTodoTool;
-pub use merge::MergeTodoTool;
+pub(crate) use get::GetTodoTool;
+pub(crate) use list::ListTodoTool;
+pub(crate) use merge::MergeTodoTool;
 pub(crate) use pending::{
     ClarificationCandidate, PendingTodoClarification, TODO_PENDING_DOMAIN, TodoPendingPayload,
     todo_lexicon,
 };
 pub(crate) use query_snapshot::{remember_todo_query_snapshot, replay_todo_query, todo_query_type};
-pub use recurring::ManageRecurringReminderTool;
+pub(crate) use recurring::ManageRecurringReminderTool;
 pub(crate) use reminder::{
     TodoReminderSentHook, cancel_reminder_task, cancel_reminder_task_by_id, sync_reminder_task,
     validate_draft_reminder,
 };
 pub use reminder_worker::{TodoReminderScheduler, TodoReminderSchedulerConfig};
-pub use restore::RestoreTodoTool;
-pub use storage::*;
+pub(crate) use restore::RestoreTodoTool;
+
+// 这是 Todo 对外的领域 API。不要改回 `storage::*`：Repository 新增内部类型时，
+// 必须明确决定它是否属于业务边界，避免 SQL/行映射类型意外被 Runtime 使用。
+pub(crate) use storage::{
+    TODO_DAILY_REMINDER_PREF_SCHEMA_V5, TODO_QUERY_DEFAULT_LIMIT, TODO_QUERY_MAX_LIMIT,
+    TODO_RECURRENCE_RULE_SCHEMA_V4, TODO_RECURRENCE_SCHEMA_V3, TODO_REMINDER_SCHEMA_V2,
+    TODO_SCHEMA_V1, TodoBulkDeleteOutcome, TodoBulkRestoreOutcome, TodoCompleteProgressOutcome,
+    TodoEditRecurrencePatch, TodoError, TodoItem, TodoItemDraft, TodoListDateField,
+    TodoListDateFilter, TodoOwner, TodoQuery, TodoQueryPage, TodoQueryStatus, TodoQueryTimeFilter,
+    TodoRecurrenceKind, TodoRecurrenceRule, TodoRecurrenceUnit, TodoReminderOwnerQueryResult,
+    TodoReminderOwnerSkipReason, TodoStatus, TodoStore, TodoTimePrecision,
+    apply_recurrence_patch_to_draft, display_todo_time, enrich_draft_time_from_text,
+    preview_next_reminder_at, recurrence_kind_for_rule, recurrence_label,
+    recurrence_rule_from_interval_unit, resolve_todo_list_date_filter,
+};
 pub(crate) use template::{ReminderFieldMode, TodoCardOptions, TodoRenderItem, format_todo_cards};
 pub(crate) use visible_entity::{
     TodoScopedToolInputs, replace_scoped_todo_tools_from_visible_snapshot,
     todo_item_visible_entity_snapshot, todo_last_action_visible_entity_snapshot,
     todo_visible_entity_snapshot, visible_snapshot_has_todo_items,
 };
+
+/// 构造 Todo 领域完整 Tool 集合。外层 Registry 只注册该集合，不需要知道具体
+/// Tool 类型、数量或各 Tool 的存储依赖。
+pub(crate) fn registered_tools(
+    todo_store: TodoStore,
+    session_store: SessionStore,
+    notification_store: NotificationOutboxStore,
+) -> Vec<DynTool> {
+    vec![
+        Arc::new(ListTodoTool::new(todo_store.clone(), session_store.clone())),
+        Arc::new(GetTodoTool::new(todo_store.clone(), session_store.clone())),
+        Arc::new(CreateTodoTool::new(
+            todo_store.clone(),
+            session_store.clone(),
+            notification_store.clone(),
+        )),
+        Arc::new(CompleteTodoTool::new(
+            todo_store.clone(),
+            session_store.clone(),
+            notification_store.clone(),
+        )),
+        Arc::new(EditTodoTool::new(
+            todo_store.clone(),
+            session_store.clone(),
+            notification_store.clone(),
+        )),
+        Arc::new(RestoreTodoTool::new(
+            todo_store.clone(),
+            session_store.clone(),
+            notification_store.clone(),
+        )),
+        Arc::new(DeleteTodoTool::new(
+            todo_store.clone(),
+            session_store.clone(),
+            notification_store.clone(),
+        )),
+        Arc::new(MergeTodoTool::new(
+            todo_store.clone(),
+            session_store.clone(),
+            notification_store.clone(),
+        )),
+        Arc::new(ManageRecurringReminderTool::new(
+            todo_store,
+            session_store,
+            notification_store,
+        )),
+    ]
+}
 
 #[cfg(test)]
 mod pending_tests;

--- a/qq-maid-core/src/runtime/tools/todo/pending_tests.rs
+++ b/qq-maid-core/src/runtime/tools/todo/pending_tests.rs
@@ -2,12 +2,9 @@ use crate::runtime::respond::tests::support::{message, test_meta, test_service};
 use crate::runtime::{
     pending::PreparedAction,
     session::{SessionMeta, now_iso_cn},
-    tools::{
-        CompleteTodoTool,
-        todo::{
-            ClarificationCandidate, PendingTodoClarification, TodoItemDraft, TodoPendingPayload,
-            TodoStatus, TodoStore, TodoTimePrecision,
-        },
+    tools::todo::{
+        ClarificationCandidate, CompleteTodoTool, PendingTodoClarification, TodoItemDraft,
+        TodoPendingPayload, TodoStatus, TodoStore, TodoTimePrecision,
     },
 };
 use crate::service::CoreInboundKind;

--- a/qq-maid-core/src/runtime/tools/todo/status.rs
+++ b/qq-maid-core/src/runtime/tools/todo/status.rs
@@ -11,7 +11,40 @@
 //! - 短中文文案只用于行内状态点缀（`format_todo_*`），不得替换为带“待办”后缀的
 //!   长文案，否则会改变 QQ 侧确认/删除提示文案。
 
-use crate::runtime::tools::todo::TodoStatus;
+use crate::runtime::tools::{
+    status::{StatusAction, StatusHint, StatusSubject},
+    todo::{TodoStatus, route::TodoIntentAction},
+};
+
+/// 根据 Todo Tool 名称生成通用状态提示；具体工具集合由 Todo 模块维护。
+pub(crate) fn status_hint_for_tool_name(tool_name: &str) -> Option<StatusHint> {
+    let action = match tool_name {
+        "list_todos" | "get_todo" => StatusAction::Query,
+        "create_todo" | "edit_todo" | "merge_todos" | "manage_recurring_reminder" => {
+            StatusAction::Write
+        }
+        "complete_todos" | "restore_todos" | "delete_todos" => StatusAction::Confirm,
+        "clarification_control" => StatusAction::Process,
+        _ => return None,
+    };
+    Some(StatusHint::new(StatusSubject::Todo, action))
+}
+
+/// Todo 自然语言意图只在领域内分类，外层状态调度器不维护 Todo 词表和动作映射。
+pub(crate) fn classify_status_hint(text: &str, has_recent_context: bool) -> Option<StatusHint> {
+    let lower = text.to_ascii_lowercase();
+    let intent = super::route::classify_todo_intent(text, &lower, has_recent_context);
+    if !intent.is_confident() {
+        return None;
+    }
+    let action = match super::route::todo_intent_action(text) {
+        TodoIntentAction::Confirm => StatusAction::Confirm,
+        TodoIntentAction::Write => StatusAction::Write,
+        TodoIntentAction::Query => StatusAction::Query,
+        TodoIntentAction::Process => StatusAction::Process,
+    };
+    Some(StatusHint::new(StatusSubject::Todo, action))
+}
 
 /// 面向模型的机器格式状态串，与 `TodoStatus` 的 serde snake_case 口径一致。
 pub fn status_machine_str(status: &TodoStatus) -> &'static str {

--- a/qq-maid-core/src/runtime/tools/train/mod.rs
+++ b/qq-maid-core/src/runtime/tools/train/mod.rs
@@ -5,6 +5,7 @@
 //! - 将 HTTP 请求、JSON 解析和错误分类收敛在这里；
 //! - 上层 `/火车` flow 只依赖 trait，不直接感知 12306 接口细节。
 
+pub(crate) mod status;
 mod tool;
 
 pub use tool::TrainScheduleTool;

--- a/qq-maid-core/src/runtime/tools/train/status.rs
+++ b/qq-maid-core/src/runtime/tools/train/status.rs
@@ -1,0 +1,13 @@
+//! 列车查询领域的用户可见状态适配。
+
+use crate::runtime::tools::status::{StatusAction, StatusHint, StatusSubject};
+
+pub(crate) fn status_hint_for_tool_name(tool_name: &str) -> Option<StatusHint> {
+    (tool_name == "get_train_schedule")
+        .then_some(StatusHint::new(StatusSubject::Train, StatusAction::Query))
+}
+
+pub(crate) fn classify_status_hint(text: &str) -> Option<StatusHint> {
+    super::route::has_train_status_intent(text)
+        .then_some(StatusHint::new(StatusSubject::Train, StatusAction::Query))
+}

--- a/qq-maid-core/src/runtime/tools/weather/mod.rs
+++ b/qq-maid-core/src/runtime/tools/weather/mod.rs
@@ -5,6 +5,7 @@
 //! QWeather 的地点匹配、增强摘要和请求细节分别下沉到内部子模块。
 
 mod qweather;
+pub(crate) mod status;
 mod tool;
 mod types;
 

--- a/qq-maid-core/src/runtime/tools/weather/status.rs
+++ b/qq-maid-core/src/runtime/tools/weather/status.rs
@@ -1,0 +1,13 @@
+//! 天气领域的用户可见状态适配。
+
+use crate::runtime::tools::status::{StatusAction, StatusHint, StatusSubject};
+
+pub(crate) fn status_hint_for_tool_name(tool_name: &str) -> Option<StatusHint> {
+    (tool_name == super::WEATHER_TOOL_NAME)
+        .then_some(StatusHint::new(StatusSubject::Weather, StatusAction::Query))
+}
+
+pub(crate) fn classify_status_hint(text: &str) -> Option<StatusHint> {
+    super::route::has_weather_status_intent(text)
+        .then_some(StatusHint::new(StatusSubject::Weather, StatusAction::Query))
+}


### PR DESCRIPTION
Closes #556

## 变更

- 将 Todo 工具构造收敛为 `todo::registered_tools`，Runtime 仅装配领域 facade。
- 将 Todo 的结果投影、状态提示和成功校验留在 Todo 领域；通用 Tool Loop 只负责跨领域的结果顺序、重试覆盖和回退。
- 为 RSS、Knowledge、Memory、Search、Train、Weather 增加各自的状态 adapter，移除公共状态模块中的领域名称和意图判断。
- 将 Todo、Memory、RSS 的存储导出改为显式 facade，并在维护文档中明确二开时的领域边界。

## 原因与兼容性

此前新增或修改一个领域工具，往往需要同时改动中心注册、状态识别和结果处理，导致二开者需理解并触及无关领域。本次将既有领域新增工具的常规修改范围收敛到领域目录、领域注册、配置和测试。

不修改 Todo 工具名称、参数或返回语义，不修改 `/todo` 命令语义、可见编号和跨轮编号语义，也不涉及数据库表结构或已有数据格式。

## 验证

- `cargo check -p qq-maid-core`
- `cargo test -p qq-maid-core --lib`（1222 项通过）
- `cargo test -p qq-maid-core runtime::tools::todo --lib`（168 项通过）
- `cargo test -p qq-maid-core runtime::tools::status --lib`（7 项通过）
- `cargo clippy -p qq-maid-core --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## 未纳入本次

`agent_presenters.rs` 的跨领域 presenter 完整拆分，以及将所有单工具领域统一为领域级注册器，属于后续通用 Tool adapter 重构；本次避免扩大 #556 的行为变更和审查范围。