### PR TITLE
fix: 修复 /ping 应用版本注入

### DIFF
--- a/qq-maid-gateway-rs/src/gateway/command/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/command/mod.rs
@@ -105,19 +105,15 @@ impl GatewayCommandService {
         runtime: GatewayRuntimeStatus,
         respond: RespondClient,
         qq_auth: Option<AccessTokenManager>,
+        application_version: &'static str,
     ) -> Self {
         Self {
             config,
             runtime,
             respond,
             qq_auth,
-            application_version: env!("CARGO_PKG_VERSION"),
+            application_version,
         }
-    }
-
-    pub(crate) fn with_application_version(mut self, application_version: &'static str) -> Self {
-        self.application_version = application_version;
-        self
     }
 
     pub(crate) fn from_config(
@@ -135,7 +131,7 @@ impl GatewayCommandService {
                     config.token_refresh_margin,
                 )
             });
-        Self::new(config, runtime, respond, qq_auth)
+        Self::new(config, runtime, respond, qq_auth, env!("CARGO_PKG_VERSION"))
     }
 
     /// 返回 `Some` 表示本地命令已完全接管本轮消息，平台必须直接回包并停止后续 Core 流程。
@@ -304,6 +300,7 @@ mod tests {
             GatewayRuntimeStatus::new(),
             RespondClient::new(core.clone()),
             None,
+            env!("CARGO_PKG_VERSION"),
         );
 
         assert!(
@@ -323,6 +320,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ping_renders_injected_application_version_instead_of_gateway_crate_version() {
+        let core = Arc::new(CountingCore::default());
+        let config = AppConfig::from_map(&std::collections::HashMap::new()).unwrap();
+        let commands = GatewayCommandService::new(
+            config,
+            GatewayRuntimeStatus::new(),
+            RespondClient::new(core),
+            None,
+            // 聚合二进制必须注入主包版本，避免 Gateway crate 的内部版本泄漏到 `/ping`。
+            "application-version-test",
+        );
+
+        let output = commands
+            .try_handle("/ping", &qq_context(GatewayCommandConversation::Private))
+            .await
+            .expect("/ping 应由 Gateway 本地处理");
+        let rendered = output.render(&ReplyCapability::onebot11_text());
+
+        assert!(
+            rendered
+                .fallback_text()
+                .contains("版本 / application-version-test")
+        );
+        assert!(
+            !rendered
+                .fallback_text()
+                .contains(&format!("版本 / {}", env!("CARGO_PKG_VERSION")))
+        );
+    }
+
+    #[tokio::test]
     async fn custom_prefix_handles_ping_and_disables_old_or_repeated_prefixes() {
         let core = Arc::new(CountingCore::default());
         let mut config = AppConfig::from_map(&std::collections::HashMap::from([(
@@ -336,6 +364,7 @@ mod tests {
             GatewayRuntimeStatus::new(),
             RespondClient::new(core.clone()),
             None,
+            env!("CARGO_PKG_VERSION"),
         );
 
         let output = commands
@@ -372,6 +401,7 @@ mod tests {
             GatewayRuntimeStatus::new(),
             RespondClient::new(core.clone()),
             None,
+            env!("CARGO_PKG_VERSION"),
         );
 
         let output = commands
@@ -397,6 +427,7 @@ mod tests {
             GatewayRuntimeStatus::new(),
             RespondClient::new(core.clone()),
             None,
+            env!("CARGO_PKG_VERSION"),
         );
 
         let output = commands
@@ -426,6 +457,7 @@ mod tests {
             GatewayRuntimeStatus::new(),
             RespondClient::new(core.clone()),
             None,
+            env!("CARGO_PKG_VERSION"),
         );
 
         assert!(

--- a/qq-maid-gateway-rs/src/gateway/dispatcher/actor.rs
+++ b/qq-maid-gateway-rs/src/gateway/dispatcher/actor.rs
@@ -46,9 +46,7 @@ use super::types::{
     WorkerExitReason,
 };
 use super::worker::{WorkerContext, run_worker};
-use crate::{
-    api::QqApiClient, auth::AccessTokenManager, config::AppConfig, respond::RespondClient,
-};
+use crate::{api::QqApiClient, config::AppConfig, respond::RespondClient};
 
 pub(super) type HandlerFuture<'a> = Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
 
@@ -79,7 +77,7 @@ impl RealMessageHandler {
     #[allow(clippy::new_ret_no_self, clippy::too_many_arguments)]
     pub(super) fn new(
         config: AppConfig,
-        auth: AccessTokenManager,
+        commands: GatewayCommandService,
         respond: RespondClient,
         api: QqApiClient,
         dedupe: Arc<MessageDedupe>,
@@ -89,12 +87,6 @@ impl RealMessageHandler {
         bot_identity: SharedBotIdentity,
         runtime: GatewayRuntimeStatus,
     ) -> Arc<dyn MessageHandler> {
-        let commands = GatewayCommandService::new(
-            config.clone(),
-            runtime.clone(),
-            respond.clone(),
-            Some(auth),
-        );
         Arc::new(Self {
             config,
             commands,

--- a/qq-maid-gateway-rs/src/gateway/dispatcher/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/dispatcher/mod.rs
@@ -56,15 +56,14 @@ use tracing::warn;
 use super::{
     BotOutboundCache,
     bot_identity::SharedBotIdentity,
+    command::GatewayCommandService,
     dedupe::MessageDedupe,
     event::{C2cMessage, GroupMessage},
     group_filter::GroupCooldowns,
     ping::GatewayRuntimeStatus,
     ref_index::SharedRefIndex,
 };
-use crate::{
-    api::QqApiClient, auth::AccessTokenManager, config::AppConfig, respond::RespondClient,
-};
+use crate::{api::QqApiClient, config::AppConfig, respond::RespondClient};
 
 #[derive(Clone)]
 pub(super) struct MessageDispatcherHandle {
@@ -190,10 +189,12 @@ pub(super) struct MessageDispatcher {
 }
 
 impl MessageDispatcher {
+    /// 统一 Gateway 启动链路传入同一个命令服务，确保 QQ 官方入口的 `/ping`
+    /// 与 OneBot、微信入口使用相同的应用版本和诊断配置。
     #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         config: AppConfig,
-        auth: AccessTokenManager,
+        commands: GatewayCommandService,
         respond: RespondClient,
         api: QqApiClient,
         dedupe: Arc<MessageDedupe>,
@@ -216,7 +217,7 @@ impl MessageDispatcher {
         let handle_respond = respond.clone();
         let handler = RealMessageHandler::new(
             config.clone(),
-            auth,
+            commands,
             respond,
             api.clone(),
             dedupe,

--- a/qq-maid-gateway-rs/src/gateway/dispatcher/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/dispatcher/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::auth::AccessTokenManager;
 use crate::gateway::test_support::qq_official_test_config;
 use crate::respond::{RespondClient, scope_key_from_c2c_message, scope_key_from_group_message};
 use qq_maid_core::service::{

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -107,8 +107,8 @@ pub async fn run_with_application_version(
         runtime.clone(),
         respond.clone(),
         qq_auth.clone(),
-    )
-    .with_application_version(application_version);
+        application_version,
+    );
     // 微信与 QQ 共用 Core；监听器只创建一次，之后统一交给渠道监督器管理生命周期。
     let dedupe = Arc::new(MessageDedupe::new(DEDUPE_TTL));
     // QQ 官方 REFIDX 与 OneBot message_id 共用同一进程内索引实现，但 key 始终包含
@@ -177,6 +177,7 @@ pub async fn run_with_application_version(
     let qq_official_handle = match config.qq_official_binding_state() {
         QqOfficialBindingState::Enabled => Some(tokio::spawn(run_qq_official(
             config,
+            commands,
             respond,
             push_sink,
             runtime,
@@ -301,6 +302,7 @@ fn finish_channel_results(
 #[allow(clippy::too_many_arguments)]
 async fn run_qq_official(
     config: AppConfig,
+    commands: GatewayCommandService,
     respond: RespondClient,
     push_sink: GatewayPushSink,
     runtime: GatewayRuntimeStatus,
@@ -335,7 +337,7 @@ async fn run_qq_official(
     let aggregator_shutdown = CancellationToken::new();
     let dispatcher = MessageDispatcher::new(
         config.clone(),
-        auth.clone(),
+        commands,
         respond.clone(),
         api.clone(),
         dedupe.clone(),


### PR DESCRIPTION
## 变更内容

- 让 QQ 官方入口的 Dispatcher 复用顶层已经注入应用版本的 `GatewayCommandService`。
- 命令服务构造时强制显式传入版本，避免未来新增装配路径再次静默回退到 Gateway crate 版本。
- 增加回归测试，证明 `/ping` 使用注入的应用版本，而不是 `qq-maid-gateway-rs` 的内部版本。

## 根因与影响

根应用已把 `qq-maid-bot` 版本传入 Gateway，但 QQ 官方消息随后进入 `MessageDispatcher`。Dispatcher 内部重新构造了命令服务，没有携带顶层版本，因此 `/ping` 实际回退为 `qq-maid-gateway-rs` 的 `0.1.10`。OneBot 和微信入口没有经过这次二次构造。

修复后，`make run` 启动的 QQ 官方私聊和群聊 `/ping` 与根程序 `--version` 使用同一版本来源。

Closes #575

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy -p qq-maid-gateway-rs --all-targets --all-features -- -D warnings`
- `cargo test -p qq-maid-gateway-rs --all-features`（532 项通过）
- `cargo check -p qq-maid-bot`
- `cargo run --quiet -p qq-maid-bot -- --version`（`qq-maid-bot 0.21.2`）
- `make -n run`（确认启动根包 `qq-maid-bot`）
