### PR TITLE
[codex] 修复 QQ 引用图文消息超时

### DIFF
--- a/qq-maid-gateway-rs/src/gateway/event/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/event/mod.rs
@@ -127,7 +127,7 @@ pub struct Attachment {
     pub size_bytes: Option<u64>,
     #[serde(default, alias = "media_id")]
     pub media_id: Option<String>,
-    #[serde(default, alias = "file_id")]
+    #[serde(default, alias = "file_id", alias = "fileid")]
     pub file_id: Option<String>,
     #[serde(default, alias = "attachment_id", alias = "id")]
     pub attachment_id: Option<String>,
@@ -163,6 +163,8 @@ struct RawC2cMessage {
     message_type: Option<u64>,
     #[serde(default)]
     msg_elements: Vec<RawMsgElement>,
+    #[serde(default)]
+    parallel_message: Option<RawParallelMessage>,
     #[serde(default)]
     timestamp: Option<String>,
     #[serde(default)]
@@ -200,6 +202,8 @@ struct RawGroupMessage {
     message_type: Option<u64>,
     #[serde(default)]
     msg_elements: Vec<RawMsgElement>,
+    #[serde(default)]
+    parallel_message: Option<RawParallelMessage>,
     #[serde(default)]
     timestamp: Option<String>,
     #[serde(default)]
@@ -259,6 +263,12 @@ struct RawMessageReply {
     message_id: Option<String>,
 }
 
+#[derive(Debug, Deserialize, Default)]
+struct RawParallelMessage {
+    #[serde(default)]
+    msg_nodes: Vec<Value>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 struct QuotedPayloadFallback {
     content: Option<String>,
@@ -311,7 +321,11 @@ pub fn parse_c2c_message(envelope: &GatewayEnvelope) -> Result<Option<C2cMessage
         raw.reply.as_ref(),
         raw.quote.as_ref(),
         ref_indices.ref_msg_idx.clone(),
-        quoted_payload_fallback(raw.message_type, &raw.msg_elements),
+        quoted_payload_fallback(
+            raw.message_type,
+            &raw.msg_elements,
+            raw.parallel_message.as_ref(),
+        ),
     );
     let timestamp = raw.timestamp;
     let input_parts = input_parts_from_content_and_attachments(
@@ -390,7 +404,11 @@ pub fn parse_group_message(envelope: &GatewayEnvelope) -> Result<Option<GroupMes
         raw.reply.as_ref(),
         raw.quote.as_ref(),
         ref_indices.ref_msg_idx.clone(),
-        quoted_payload_fallback(raw.message_type, &raw.msg_elements),
+        quoted_payload_fallback(
+            raw.message_type,
+            &raw.msg_elements,
+            raw.parallel_message.as_ref(),
+        ),
     );
     let input_parts = input_parts_from_content_and_attachments(
         &base_content,
@@ -487,23 +505,52 @@ fn extract_message_reply(
 fn quoted_payload_fallback(
     message_type: Option<u64>,
     msg_elements: &[RawMsgElement],
+    parallel_message: Option<&RawParallelMessage>,
 ) -> QuotedPayloadFallback {
     if message_type != Some(MSG_TYPE_QUOTE) {
         return QuotedPayloadFallback::default();
     }
-    let Some(element) = msg_elements.first() else {
-        return QuotedPayloadFallback::default();
-    };
-    let raw_content = element.content.as_deref().unwrap_or_default();
-    let parsed = parse_safe_content_parts(raw_content, "qq_official");
-    let content = parsed.text.trim().to_owned();
-    let input_parts = input_parts_from_content_and_attachments(
-        &content,
-        parsed.input_parts,
-        &element.attachments,
-        "qq_official",
-        TextSource::Quote,
-    );
+
+    // QQ 可能把一条引用消息拆成多个 element。解析层先按原始顺序完整保留；
+    // 媒体取回阶段再依据 QQ 官方实测的稳定文件名规则收敛重复图片。
+    let mut content_fragments = Vec::new();
+    let mut input_parts = Vec::new();
+    for element in msg_elements {
+        let raw_content = element.content.as_deref().unwrap_or_default();
+        let cleaned_content = strip_qq_image_placeholders(raw_content);
+        let parsed = parse_safe_content_parts(&cleaned_content, "qq_official");
+        let element_content = parsed.text.trim().to_owned();
+        if !element_content.is_empty() {
+            content_fragments.push(element_content.clone());
+        }
+        let mut element_parts = input_parts_from_content_and_attachments(
+            &element_content,
+            parsed.input_parts,
+            &element.attachments,
+            "qq_official",
+            TextSource::Quote,
+        );
+        for part in &mut element_parts {
+            if let MessageInputPart::Text { source, .. } = part {
+                *source = Some(TextSource::Quote);
+            }
+        }
+        input_parts.extend(element_parts);
+    }
+
+    let mut content = content_fragments.join("\n");
+    if content.is_empty()
+        && let Some(fallback) = parallel_message_display_text(parallel_message)
+    {
+        content = fallback;
+        input_parts.insert(
+            0,
+            MessageInputPart::Text {
+                text: content.clone(),
+                source: Some(TextSource::Quote),
+            },
+        );
+    }
     let media_summaries = input_parts
         .iter()
         .filter_map(QuotedMediaSummary::from_input_part)
@@ -514,6 +561,35 @@ fn quoted_payload_fallback(
         input_parts,
         media_summaries,
     }
+}
+
+fn parallel_message_display_text(parallel_message: Option<&RawParallelMessage>) -> Option<String> {
+    let parallel_message = parallel_message?;
+    let text = parallel_message
+        .msg_nodes
+        .iter()
+        .filter_map(parallel_message_node_text)
+        .map(strip_qq_image_placeholders)
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+    (!text.is_empty()).then_some(text)
+}
+
+fn parallel_message_node_text(node: &Value) -> Option<&str> {
+    if let Some(text) = node.as_str() {
+        return Some(text);
+    }
+    let object = node.as_object()?;
+    // 只读取明确的展示文本键，避免把 message_scene.ext 中的 auth_token 等
+    // 临时凭证混入模型上下文或日志。
+    ["content", "text", "msg_content"]
+        .into_iter()
+        .find_map(|key| object.get(key).and_then(Value::as_str))
+}
+
+fn strip_qq_image_placeholders(value: &str) -> String {
+    value.replace("[图片]", "").trim().to_owned()
 }
 
 fn extract_cq_reply_message_id(content: &str) -> Option<&str> {

--- a/qq-maid-gateway-rs/src/gateway/event/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/event/tests.rs
@@ -757,6 +757,159 @@ fn parses_qq_quote_msg_element_as_payload_fallback() {
 }
 
 #[test]
+fn parses_plain_group_quote_from_structured_element_without_parallel_duplication() {
+    let envelope = GatewayEnvelope {
+        op: 0,
+        s: None,
+        t: Some(EVENT_GROUP_MESSAGE_CREATE.to_owned()),
+        id: Some("event-current".to_owned()),
+        d: json!({
+            "id": "msg-current",
+            "group_openid": "group-1",
+            "author": {"member_openid": "member-1", "member_role": "admin"},
+            "content": " 取event",
+            "message_scene": {
+                "ext": [
+                    "ref_msg_idx=REFIDX_quoted",
+                    "msg_idx=REFIDX_current",
+                    "auth_token=redacted-test-token"
+                ]
+            },
+            "message_type": 103,
+            "parallel_message": {
+                "msg_nodes": [{"message_type": 0, "content": "感谢"}]
+            },
+            "msg_elements": [{
+                "msg_idx": "REFIDX_quoted",
+                "message_type": 103,
+                "content": "感谢"
+            }]
+        }),
+    };
+
+    let message = parse_group_message(&envelope).unwrap().unwrap();
+    let reply = message.reply.unwrap();
+
+    assert_eq!(message.content, "取event");
+    assert_eq!(message.current_msg_idx.as_deref(), Some("REFIDX_current"));
+    assert_eq!(reply.ref_msg_idx.as_deref(), Some("REFIDX_quoted"));
+    assert_eq!(reply.content.as_deref(), Some("感谢"));
+    assert_eq!(reply.input_parts.len(), 1);
+    assert!(matches!(
+        &reply.input_parts[0],
+        MessageInputPart::Text { text, source: Some(TextSource::Quote) } if text == "感谢"
+    ));
+    assert!(reply.media_summaries.is_empty());
+}
+
+#[test]
+fn quoted_images_keep_original_order_when_metadata_matches() {
+    let envelope = GatewayEnvelope {
+        op: 0,
+        s: None,
+        t: Some(EVENT_GROUP_MESSAGE_CREATE.to_owned()),
+        id: None,
+        d: json!({
+            "id": "msg-current",
+            "group_openid": "group-1",
+            "author": {"member_openid": "member-1"},
+            "content": "解释这些图",
+            "message_type": 103,
+            "parallel_message": {
+                "msg_nodes": [{"content": "[图片][图片][图片] 展示文本"}]
+            },
+            "msg_elements": [{
+                "msg_idx": "REFIDX_quoted",
+                "content": "[图片][图片][图片] 结构化正文",
+                "attachments": [
+                    {
+                        "content_type": "image/png",
+                        "filename": "same.png",
+                        "size": 123,
+                        "url": "https://example.test/1.png",
+                        "fileid": "file-1"
+                    },
+                    {
+                        "content_type": "image/png",
+                        "filename": "same.png",
+                        "size": 123,
+                        "url": "https://example.test/2.png",
+                        "fileid": "file-2"
+                    },
+                    {
+                        "content_type": "image/png",
+                        "filename": "same.png",
+                        "size": 123,
+                        "url": "https://example.test/3.png",
+                        "fileid": "file-3"
+                    }
+                ]
+            }]
+        }),
+    };
+
+    let message = parse_group_message(&envelope).unwrap().unwrap();
+    let reply = message.reply.unwrap();
+
+    assert_eq!(reply.content.as_deref(), Some("结构化正文"));
+    let images = reply
+        .input_parts
+        .iter()
+        .filter_map(MessageInputPart::media)
+        .collect::<Vec<_>>();
+    assert_eq!(images.len(), 3);
+    assert_eq!(
+        images
+            .iter()
+            .filter_map(|media| media.file_id.as_deref())
+            .collect::<Vec<_>>(),
+        vec!["file-1", "file-2", "file-3"]
+    );
+    assert_eq!(reply.media_summaries.len(), 3);
+}
+
+#[test]
+fn parallel_message_is_only_used_when_structured_quote_text_is_missing() {
+    let envelope = GatewayEnvelope {
+        op: 0,
+        s: None,
+        t: Some(EVENT_GROUP_MESSAGE_CREATE.to_owned()),
+        id: None,
+        d: json!({
+            "id": "msg-current",
+            "group_openid": "group-1",
+            "author": {"member_openid": "member-1"},
+            "content": "解释图片",
+            "message_type": 103,
+            "parallel_message": {
+                "msg_nodes": [{"content": "[图片][图片] 展示兜底"}]
+            },
+            "msg_elements": [{
+                "msg_idx": "REFIDX_quoted",
+                "attachments": [{
+                    "content_type": "image/png",
+                    "filename": "quoted.png",
+                    "url": "https://example.test/quoted.png"
+                }]
+            }]
+        }),
+    };
+
+    let message = parse_group_message(&envelope).unwrap().unwrap();
+    let reply = message.reply.unwrap();
+
+    assert_eq!(reply.content.as_deref(), Some("展示兜底"));
+    assert!(matches!(
+        &reply.input_parts[0],
+        MessageInputPart::Text { text, source: Some(TextSource::Quote) } if text == "展示兜底"
+    ));
+    assert!(matches!(
+        reply.input_parts[1],
+        MessageInputPart::Image { .. }
+    ));
+}
+
+#[test]
 fn parses_quoted_audio_asr_as_quoted_user_content() {
     let envelope = GatewayEnvelope {
         op: 0,

--- a/qq-maid-gateway-rs/src/gateway/media_fetch/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/media_fetch/mod.rs
@@ -12,7 +12,7 @@ use futures_util::future::join_all;
 use qq_maid_common::input_part::{MediaStatus, MessageInputPart, MessageMedia};
 use tracing::{debug, warn};
 
-use super::event::Attachment;
+use super::event::{Attachment, MessageReply};
 
 mod local_cache;
 
@@ -47,6 +47,7 @@ pub(crate) async fn fetch_qq_official_image_attachments(
 ) {
     if attachments.is_empty() {
         mark_unreadable_image_parts(input_parts);
+        clear_remote_image_urls(input_parts);
         return;
     }
 
@@ -89,6 +90,7 @@ pub(crate) async fn fetch_qq_official_image_attachments(
 
     if fetches.is_empty() {
         mark_unreadable_image_parts(input_parts);
+        clear_remote_image_urls(input_parts);
         return;
     }
 
@@ -135,6 +137,75 @@ pub(crate) async fn fetch_qq_official_image_attachments(
     }
 
     mark_unreadable_image_parts(input_parts);
+    clear_remote_image_urls(input_parts);
+}
+
+/// 引用附件不位于当前消息顶层 attachments，需要直接从已经归一化的 quote parts
+/// 中取回。下载失败只更新媒体可读状态，Core 随后会把它转换成摘要文本继续回复。
+pub(crate) async fn fetch_qq_official_quoted_images(
+    client: &reqwest::Client,
+    context: &MediaFetchContext,
+    message_id: &str,
+    reply: Option<&mut MessageReply>,
+) {
+    let Some(reply) = reply else {
+        return;
+    };
+    deduplicate_quoted_images_by_filename(&mut reply.input_parts);
+    let attachments = reply
+        .input_parts
+        .iter()
+        .filter_map(|part| {
+            let MessageInputPart::Image { media } = part else {
+                return None;
+            };
+            Some(Attachment {
+                content_type: media.mime_type.clone(),
+                filename: media.filename.clone(),
+                url: media.url.clone(),
+                size_bytes: media.size_bytes,
+                media_id: media.media_id.clone(),
+                file_id: media.file_id.clone(),
+                attachment_id: media.attachment_id.clone(),
+                asr_refer_text: None,
+                voice_wav_url: None,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    fetch_qq_official_image_attachments(
+        client,
+        context,
+        message_id,
+        &mut reply.input_parts,
+        &attachments,
+    )
+    .await;
+    reply.media_summaries = reply
+        .input_parts
+        .iter()
+        .filter_map(qq_maid_common::input_part::QuotedMediaSummary::from_input_part)
+        .collect();
+}
+
+fn deduplicate_quoted_images_by_filename(input_parts: &mut Vec<MessageInputPart>) {
+    let mut seen = std::collections::HashSet::new();
+    input_parts.retain(|part| {
+        let MessageInputPart::Image { media } = part else {
+            return true;
+        };
+        let Some(filename) = media
+            .filename
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            return true;
+        };
+        // QQ 官方图片文件名实测按内容摘要稳定生成；同一引用内保留首个即可，
+        // 避免相同图片因临时 URL/fileid 不同而重复下载、重复发送给模型。
+        seen.insert(filename.to_ascii_lowercase())
+    });
 }
 
 pub(crate) fn normalize_download_url(value: &str) -> Option<String> {
@@ -326,16 +397,34 @@ fn update_matching_image_part(
 }
 
 fn media_matches_attachment(media: &MessageMedia, attachment: &Attachment) -> bool {
-    attachment
-        .url
-        .as_deref()
-        .zip(media.url.as_deref())
-        .is_some_and(|(left, right)| left.trim() == right.trim())
-        || attachment
-            .filename
-            .as_deref()
-            .zip(media.filename.as_deref())
-            .is_some_and(|(left, right)| left.trim() == right.trim())
+    if let Some(matches) =
+        exact_optional_field_match(attachment.url.as_deref(), media.url.as_deref())
+    {
+        return matches;
+    }
+    for (attachment_id, media_id) in [
+        (attachment.file_id.as_deref(), media.file_id.as_deref()),
+        (attachment.media_id.as_deref(), media.media_id.as_deref()),
+        (
+            attachment.attachment_id.as_deref(),
+            media.attachment_id.as_deref(),
+        ),
+    ] {
+        if let Some(matches) = exact_optional_field_match(attachment_id, media_id) {
+            return matches;
+        }
+    }
+    exact_optional_field_match(attachment.filename.as_deref(), media.filename.as_deref())
+        .unwrap_or(false)
+}
+
+fn exact_optional_field_match(left: Option<&str>, right: Option<&str>) -> Option<bool> {
+    let left = left.map(str::trim).filter(|value| !value.is_empty());
+    let right = right.map(str::trim).filter(|value| !value.is_empty());
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left == right),
+        _ => None,
+    }
 }
 
 fn mark_unreadable_image_parts(parts: &mut [MessageInputPart]) {
@@ -348,6 +437,18 @@ fn mark_unreadable_image_parts(parts: &mut [MessageInputPart]) {
             MediaStatus::Available | MediaStatus::MissingReadableUrl
         ) {
             media.status = media.inferred_readability_status();
+        }
+    }
+}
+
+fn clear_remote_image_urls(parts: &mut [MessageInputPart]) {
+    for part in parts {
+        if let MessageInputPart::Image { media } = part {
+            // QQ 图片 URL 可能携带短期鉴权参数；下载结果落盘或降级后不再向 Core 透传。
+            media.url = None;
+            if media.local_path.is_none() && media.status == MediaStatus::Available {
+                media.status = MediaStatus::MissingReadableUrl;
+            }
         }
     }
 }
@@ -368,6 +469,8 @@ mod tests {
         atomic::{AtomicUsize, Ordering},
     };
     use tokio::net::TcpListener;
+
+    mod quoted;
 
     fn media_file_count(root: &std::path::Path) -> usize {
         if !root.exists() {
@@ -517,6 +620,7 @@ mod tests {
         };
         let local_path = media.local_path.as_deref().unwrap();
         assert_eq!(media.status, MediaStatus::Available);
+        assert_eq!(media.url, None);
         assert_eq!(std::fs::read(local_path).unwrap(), b"fake-jpeg");
     }
 
@@ -728,6 +832,7 @@ mod tests {
             panic!("expected image part");
         };
         assert_eq!(media.status, MediaStatus::SizeExceeded);
+        assert_eq!(media.url, None);
         assert!(media.local_path.is_none());
         assert_eq!(media_file_count(&root_dir), 0);
     }

--- a/qq-maid-gateway-rs/src/gateway/media_fetch/tests/quoted.rs
+++ b/qq-maid-gateway-rs/src/gateway/media_fetch/tests/quoted.rs
@@ -1,0 +1,198 @@
+use super::*;
+
+#[tokio::test]
+async fn quoted_images_with_same_filename_keep_only_first_image() {
+    let app = Router::new()
+        .route(
+            "/1.png",
+            get(|| async { ([(header::CONTENT_TYPE.as_str(), "image/png")], "one") }),
+        )
+        .route(
+            "/2.png",
+            get(|| async { ([(header::CONTENT_TYPE.as_str(), "image/png")], "two") }),
+        );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let make_media = |number: u8| MessageMedia {
+        mime_type: Some("image/png".to_owned()),
+        filename: Some("same.png".to_owned()),
+        size_bytes: Some(3),
+        url: Some(format!("http://{addr}/{number}.png")),
+        file_id: Some(format!("file-{number}")),
+        status: MediaStatus::Available,
+        ..Default::default()
+    };
+    let mut reply = MessageReply {
+        message_id: "quoted".to_owned(),
+        ref_msg_idx: Some("quoted".to_owned()),
+        content: Some("引用正文".to_owned()),
+        input_parts: vec![
+            MessageInputPart::text("引用正文"),
+            MessageInputPart::image(make_media(1)),
+            MessageInputPart::image(make_media(2)),
+        ],
+        media_summaries: Vec::new(),
+    };
+    let root_dir = std::env::temp_dir().join(format!(
+        "qq-maid-quoted-media-test-{}",
+        MEDIA_FILE_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    let context = MediaFetchContext {
+        platform: "qq_official",
+        app_id: "app".to_owned(),
+        peer_id: "peer".to_owned(),
+        root_dir,
+        timeout: Duration::from_secs(3),
+        max_bytes: 1024,
+    };
+
+    fetch_qq_official_quoted_images(
+        &qq_maid_common::http_client::client(),
+        &context,
+        "msg-current",
+        Some(&mut reply),
+    )
+    .await;
+
+    let media = reply
+        .input_parts
+        .iter()
+        .filter_map(MessageInputPart::media)
+        .collect::<Vec<_>>();
+    assert_eq!(media.len(), 1);
+    assert_eq!(media[0].url, None);
+    assert_eq!(
+        std::fs::read(media[0].local_path.as_ref().unwrap()).unwrap(),
+        b"one"
+    );
+    assert_eq!(reply.media_summaries.len(), 1);
+}
+
+#[tokio::test]
+async fn quoted_images_with_different_filenames_keep_original_order() {
+    let app = Router::new()
+        .route(
+            "/1.png",
+            get(|| async { ([(header::CONTENT_TYPE.as_str(), "image/png")], "one") }),
+        )
+        .route(
+            "/2.png",
+            get(|| async { ([(header::CONTENT_TYPE.as_str(), "image/png")], "two") }),
+        );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let mut reply = MessageReply {
+        message_id: "quoted".to_owned(),
+        ref_msg_idx: Some("quoted".to_owned()),
+        content: None,
+        input_parts: [1_u8, 2]
+            .into_iter()
+            .map(|number| {
+                MessageInputPart::image(MessageMedia {
+                    mime_type: Some("image/png".to_owned()),
+                    filename: Some(format!("image-{number}.png")),
+                    url: Some(format!("http://{addr}/{number}.png")),
+                    status: MediaStatus::Available,
+                    ..Default::default()
+                })
+            })
+            .collect(),
+        media_summaries: Vec::new(),
+    };
+    let context = MediaFetchContext {
+        platform: "qq_official",
+        app_id: "app".to_owned(),
+        peer_id: "peer".to_owned(),
+        root_dir: std::env::temp_dir().join(format!(
+            "qq-maid-quoted-media-order-test-{}",
+            MEDIA_FILE_COUNTER.fetch_add(1, Ordering::Relaxed)
+        )),
+        timeout: Duration::from_secs(3),
+        max_bytes: 1024,
+    };
+
+    fetch_qq_official_quoted_images(
+        &qq_maid_common::http_client::client(),
+        &context,
+        "msg-current",
+        Some(&mut reply),
+    )
+    .await;
+
+    let media = reply
+        .input_parts
+        .iter()
+        .filter_map(MessageInputPart::media)
+        .collect::<Vec<_>>();
+    assert_eq!(media.len(), 2);
+    assert_eq!(
+        std::fs::read(media[0].local_path.as_ref().unwrap()).unwrap(),
+        b"one"
+    );
+    assert_eq!(
+        std::fs::read(media[1].local_path.as_ref().unwrap()).unwrap(),
+        b"two"
+    );
+}
+
+#[tokio::test]
+async fn quoted_image_timeout_marks_media_failed_without_losing_text() {
+    let app = Router::new().route(
+        "/slow.png",
+        get(|| async {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            ([(header::CONTENT_TYPE.as_str(), "image/png")], "late")
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let mut reply = MessageReply {
+        message_id: "quoted".to_owned(),
+        ref_msg_idx: Some("quoted".to_owned()),
+        content: Some("引用正文".to_owned()),
+        input_parts: vec![
+            MessageInputPart::text("引用正文"),
+            MessageInputPart::image(MessageMedia {
+                mime_type: Some("image/png".to_owned()),
+                filename: Some("slow.png".to_owned()),
+                url: Some(format!("http://{addr}/slow.png")),
+                status: MediaStatus::Available,
+                ..Default::default()
+            }),
+        ],
+        media_summaries: Vec::new(),
+    };
+    let context = MediaFetchContext {
+        platform: "qq_official",
+        app_id: "app".to_owned(),
+        peer_id: "peer".to_owned(),
+        root_dir: std::env::temp_dir(),
+        timeout: Duration::from_millis(20),
+        max_bytes: 1024,
+    };
+
+    fetch_qq_official_quoted_images(
+        &qq_maid_common::http_client::client(),
+        &context,
+        "msg-current",
+        Some(&mut reply),
+    )
+    .await;
+
+    assert_eq!(reply.content.as_deref(), Some("引用正文"));
+    assert_eq!(reply.input_parts[0].text_content(), Some("引用正文"));
+    let media = reply.input_parts[1].media().unwrap();
+    assert_eq!(media.status, MediaStatus::DownloadFailed);
+    assert_eq!(media.url, None);
+    assert!(media.local_path.is_none());
+}

--- a/qq-maid-gateway-rs/src/gateway/qq_official/c2c/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/qq_official/c2c/mod.rs
@@ -13,7 +13,9 @@ use super::super::{
     dedupe::MessageDedupe,
     event::C2cMessage,
     logging::{c2c_message_log_summary, mask_openid},
-    media_fetch::{MediaFetchContext, fetch_qq_official_image_attachments},
+    media_fetch::{
+        MediaFetchContext, fetch_qq_official_image_attachments, fetch_qq_official_quoted_images,
+    },
     outbound::{
         DeliveryMode, ReplyCapability, ReplyTarget, RuntimeRecordingSender,
         send_c2c_text_with_status,
@@ -278,22 +280,31 @@ pub(crate) async fn handle_c2c_message(
             })?;
         return Ok(());
     }
+    let media_client = qq_maid_common::http_client::client();
+    let media_context = MediaFetchContext {
+        platform: "qq_official",
+        app_id: config
+            .app_id
+            .clone()
+            .context("QQ C2C handler requires a bound channel")?,
+        peer_id: message.user_openid.clone(),
+        root_dir: config.media_dir.clone(),
+        timeout: config.media_download_timeout,
+        max_bytes: config.media_max_bytes,
+    };
     fetch_qq_official_image_attachments(
-        &qq_maid_common::http_client::client(),
-        &MediaFetchContext {
-            platform: "qq_official",
-            app_id: config
-                .app_id
-                .clone()
-                .context("QQ C2C handler requires a bound channel")?,
-            peer_id: message.user_openid.clone(),
-            root_dir: config.media_dir.clone(),
-            timeout: config.media_download_timeout,
-            max_bytes: config.media_max_bytes,
-        },
+        &media_client,
+        &media_context,
         &message.message_id,
         &mut message.input_parts,
         &message.attachments,
+    )
+    .await;
+    fetch_qq_official_quoted_images(
+        &media_client,
+        &media_context,
+        &message.message_id,
+        message.reply.as_mut(),
     )
     .await;
 

--- a/qq-maid-gateway-rs/src/gateway/qq_official/group/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/qq_official/group/mod.rs
@@ -39,7 +39,9 @@ use super::super::{
         should_ignore_group_message, should_process_group_message_with_prefix,
     },
     logging::{group_message_log_summary, mask_openid},
-    media_fetch::{MediaFetchContext, fetch_qq_official_image_attachments},
+    media_fetch::{
+        MediaFetchContext, fetch_qq_official_image_attachments, fetch_qq_official_quoted_images,
+    },
     outbound::{
         ReplyCapability, ReplyTarget, RuntimeRecordingGroupSender, send_group_text_with_status,
     },
@@ -308,22 +310,31 @@ pub(crate) async fn handle_group_message(
         return Ok(());
     }
 
+    let media_client = qq_maid_common::http_client::client();
+    let media_context = MediaFetchContext {
+        platform: "qq_official",
+        app_id: config
+            .app_id
+            .clone()
+            .context("QQ group handler requires a bound channel")?,
+        peer_id: message.group_openid.clone(),
+        root_dir: config.media_dir.clone(),
+        timeout: config.media_download_timeout,
+        max_bytes: config.media_max_bytes,
+    };
     fetch_qq_official_image_attachments(
-        &qq_maid_common::http_client::client(),
-        &MediaFetchContext {
-            platform: "qq_official",
-            app_id: config
-                .app_id
-                .clone()
-                .context("QQ group handler requires a bound channel")?,
-            peer_id: message.group_openid.clone(),
-            root_dir: config.media_dir.clone(),
-            timeout: config.media_download_timeout,
-            max_bytes: config.media_max_bytes,
-        },
+        &media_client,
+        &media_context,
         &message.message_id,
         &mut message.input_parts,
         &message.attachments,
+    )
+    .await;
+    fetch_qq_official_quoted_images(
+        &media_client,
+        &media_context,
+        &message.message_id,
+        message.reply.as_mut(),
     )
     .await;
 


### PR DESCRIPTION
## 变更说明

- 按 QQ 官方原始事件解析 message_type=103：当前正文使用 raw.d.content，引用正文优先合并 msg_elements[].content
- 从 msg_elements[].attachments 提取引用图片，解析层保持原始顺序，媒体阶段按 QQ 官方实测的稳定文件名保留首张重复图片
- 仅在结构化引用正文缺失时使用 parallel_message.msg_nodes 展示文本，并移除 [图片] 占位符
- C2C 与群聊入口都为引用图片执行有限时下载；失败、超时或文件过大时降级为媒体摘要，不阻断当前文字回复
- 下载或降级完成后清除临时远端 URL，避免鉴权参数进入 Core、LLM 或普通日志
- 支持附件 fileid 字段，并修复同名图片映射时可能更新错误 part 的问题

## 根因

现有事件解析虽然能从首个 msg_element 构造部分引用上下文，但引用附件没有进入 QQ 官方媒体取回流程，仍以临时远端 URL 传入后续多模态链路；不可达或过期地址最终表现为 LLM 等待/超时。同时，仅取首个 element、未建模 parallel_message，以及按文件名兜底匹配媒体 part，会导致多 element 或同名图片场景不稳定。

## 验证

- cargo fmt --all -- --check
- cargo test -p qq-maid-gateway-rs --all-features（538 passed）
- cargo clippy -p qq-maid-gateway-rs --all-targets --all-features -- -D warnings
- cargo build -p qq-maid-gateway-rs --release --all-features
- git diff --check

测试覆盖普通引用纯文本、引用图文、同名图片去重、异名多图顺序、parallel_message 降级、下载超时降级及临时 URL 清理。

Fixes #578
