### PR TITLE
release: 发布 v0.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 本文档基于 [keep a changelog](https://keepachangelog.com/zh-CN/1.0.0/) 格式，记录每个已发布版本的变更。
 
+## [v0.21.3] - 2026-07-24
+
+### Changed
+
+* **工具领域边界收敛**（PR #576）：将 Todo 工具注册、结果投影、状态提示和成功校验收敛到 Todo 领域 facade；为 RSS、Knowledge、Memory、Search、Train、Weather 增加各自状态 adapter，通用 Tool Loop 只保留跨领域的结果顺序、重试覆盖和回退。
+* **领域存储导出收紧**（PR #576）：Todo、Memory、RSS 的存储导出改为显式 facade；维护文档同步明确二开时的领域边界，避免公共状态模块继续承载具体领域名称和意图判断。
+
+### Fixed
+
+* **QQ 引用图文消息超时**（PR #580）：按 QQ 官方 `message_type=103` 正确解析引用正文与附件，下载引用图片并在失败、超时或文件过大时降级为媒体摘要，避免不可达临时 URL 拖垮多模态链路；下载后清除临时远端 URL，防止鉴权参数进入 Core / LLM / 普通日志。
+* **`/ping` 应用版本注入**（PR #579）：QQ 官方 Dispatcher 复用已注入主包版本的命令服务，私聊与群聊 `/ping` 与根程序 `--version` 使用同一版本来源，不再回退到 Gateway 子 crate 版本。
+
+### Compatibility
+
+* 根包 `qq-maid-bot` 版本号提升到 `0.21.3`，内部 crate 版本不统一提升。
+* 本版本无数据库 migration、无必需配置迁移。Todo 工具名称、参数、返回语义，以及 `/todo` 可见编号与跨轮编号语义保持不变。
+* 引用图文修复仅影响 QQ 官方入口的引用媒体解析与下载降级路径；OneBot / 微信入口行为不变。
+
 ## [v0.21.2] - 2026-07-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,7 +1966,7 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "qq-maid-bot"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "anyhow",
  "qq-maid-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-bot"
-version = "0.21.2"
+version = "0.21.3"
 edition = "2024"
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@
 
 > 💡 仓库早期以 QQ 机器人为主，因此仍保留 `qq-maid-bot` 名称。当前项目正在从 QQ 官方机器人演进为多入口平台型小女仆机器人。
 
-当前稳定版本为 `v0.21.2`，项目处于 `21.x` 版本线；版本线能力与升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)。
+当前稳定版本为 `v0.21.3`，项目处于 `21.x` 版本线；版本线能力与升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)。
 
 使用、安装和配置优先看 [项目 Wiki](https://github.com/kuliantnt/qq-maid-bot/wiki)：从第一次对话、一键安装、Docker / GHCR、配置中心与 `/console/` 首次向导，到 NapCat、`/ops` 运维和 Codex 长任务，都按场景拆开了。仓库内 `docs/` 与各 crate README 更偏开发边界和实现细节。
 
 ## 21.x 版本线更新
+- **引用图文与工具领域边界**（v0.21.3）：修复 QQ 引用图文消息超时与 `/ping` 应用版本注入；收敛 Todo / Memory / RSS 等工具领域边界，降低跨领域耦合。
 - **主包版本诊断与工具结果验真**（v0.21.2）：`/ping` 显示根主包版本；收紧自然语言状态提示，并要求 Todo 成功文案必须由真实写工具结果支撑；同轮重复只读搜索只展示首次结果。
 - **群管理员 Todo 与 Agent 模板**（v0.21.1）：群主 / 管理员可用 `/todo group` 查看并删除本群未完成 Todo；Release 提供 `agent.example.toml`，首次启动从内嵌模板生成活动 `config/agent.toml`。
 - **多平台部署主线**（v0.21.0）：同一二进制覆盖 QQ 官方、OneBot、微信入口，以及 Linux / Windows / Docker 部署路径；新增 GHCR 多架构镜像、Compose 覆盖、配置迁移与备份恢复 CLI。


### PR DESCRIPTION
## 摘要

- 将根包 qq-maid-bot 版本提升到 0.21.3
- 更新 CHANGELOG.md / README.md，汇总自 v0.21.2 以来的已合并变更

## 本版本包含

- 工具领域边界收敛（#576）
- /ping 应用版本注入修复（#579）
- QQ 引用图文消息超时修复（#580）

## 兼容性

- 无数据库 migration、无必需配置迁移
- 内部 crate 版本不统一提升
- Todo 工具名称 / 参数 / 返回语义与 /todo 编号语义不变

## 验证

- git diff --check
- cargo check -p qq-maid-bot

## 合并后

在 master 上打 tag v0.21.3 以触发 Release / 容器正式发布流程。