### PR TITLE
[codex] 修复 QQ 群消息触发与 mention 污染

### DIFF
--- a/qq-maid-gateway-rs/README.md
+++ b/qq-maid-gateway-rs/README.md
@@ -153,7 +153,7 @@ QQ_SECRET=你的QQ机器人AppSecret
 
 普通群消息由 `QQ_MAID_GROUP_MESSAGE_MODE` 控制，默认 `mention` 保持有限触发；`off` 完全关闭普通群消息，其余模式都会先把 `/` 或全角 `／` 开头的候选原样交给 Core 判定，Gateway 不维护业务命令白名单。`command` 除斜杠候选外不处理普通文本，`mention` 额外处理平台 @ 标记和回复机器人消息，`active` 额外处理包含 `QQ_MAID_GROUP_ACTIVE_KEYWORDS` 指定提示词的普通群消息。提示词默认 `小女仆`，多个用英文逗号分隔。第一个有效关键词同时作为程序生成状态提示和兜底文案中的机器人主称呼，其余关键词仍作为 active 模式别名；仅当新变量完全未设置时，旧变量 `QQ_MAID_STATUS_DISPLAY_NAME` 才作为主称呼回退，且不会加入 active 关键词。旧变量 `QQ_MAID_ENABLE_GROUP_MESSAGES` 仅在未设置新变量时兼容，`false` 映射为 `off`，`true` 映射为 `active`，未设置时默认 `mention`。这些策略只对 QQ 官方已经推送到 Gateway 的群事件生效；如果平台没有推送普通非 @ 群消息，Gateway 无法通过关键词提前收到或登记该消息。群聊不会开放通用 Harness、文件处理或代码执行；Tool Calling 只由 Core 加载的 `agent.toml` 群聊 Scene 和工具白名单控制。Gateway 只负责把群聊目标传给 Core，由 Core 按既有命令和普通聊天边界处理；未知群聊斜杠候选由 Core 静默拦截。
 
-普通群事件是否 @ 当前机器人只信任官方结构化 `mentions[].is_you == true`；旧的 AppID、openid、member_openid、CQ 文本和 `<@...>` 文本不再作为触发依据。`QQ_MAID_BOT_MENTION_IDS` 仅保留为旧配置兼容，不应再用于修正普通群 @ 判定。不要把真实 ID 写入公开文档或提交到仓库。
+`GROUP_AT_MESSAGE_CREATE` 事件本身表示 @ 当前机器人；普通 `GROUP_MESSAGE_CREATE` 事件优先保留 QQ 结构化的当前机器人标记，并用 mention 的 `target_id` 与 READY 学到的机器人身份及 `QQ_MAID_BOT_MENTION_IDS` 补充匹配。没有当前机器人结构化证据的 mention（包括其它机器人）不触发；CQ 文本和 `<@...>` 文本本身不作为身份依据。不要把真实 ID 写入公开文档或提交到仓库。
 
 普通群消息会过滤自己发送的消息、可识别的其它机器人消息、空内容/无附件消息和重复 `message_id`，并使用群级与群成员级内存冷却避免刷屏；但发送给 Core 的 `scope_key` 仍保持群会话维度，actor 仅表示群内发言人，避免同一个用户的私聊与群聊 session / pending / visible snapshot / ref_index 串用。只有 QQ 官方实际推送且 payload 带 `current_msg_idx / msg_idx` 的群消息，才能提前登记到运行期 ref_index；平台未推送或缺字段时，后续引用只能依赖当前引用事件 payload 兜底或已有索引。
 

--- a/qq-maid-gateway-rs/src/app/mod.rs
+++ b/qq-maid-gateway-rs/src/app/mod.rs
@@ -110,6 +110,8 @@ fn log_startup(config: &AppConfig) {
         sandbox = config.sandbox,
         enable_markdown = config.enable_markdown,
         enable_group_messages = config.enable_group_messages,
+        group_message_mode = ?config.group_message_mode,
+        group_active_keyword_count = config.group_active_keywords.len(),
         verbose_log = config.verbose_log,
         conversation_queue_capacity = config.conversation_queue_capacity,
         max_active_conversation_workers = config.max_active_conversation_workers,

--- a/qq-maid-gateway-rs/src/gateway/bot_identity.rs
+++ b/qq-maid-gateway-rs/src/gateway/bot_identity.rs
@@ -1,7 +1,8 @@
 //! Gateway 侧机器人身份观测。
 //!
-//! 普通群消息优先以 mention 的稳定 ID 与 READY 学到的机器人身份集合比对；
-//! `is_you` 仅供没有稳定 ID 的旧事件兜底，READY 学习和旧配置仍用于兼容运行配置。
+//! `GROUP_AT_MESSAGE_CREATE` 事件本身表示当前机器人被 @；普通群消息优先保留 QQ 提供的
+//! 当前机器人标记，再用 mention 稳定 ID 与 READY 学到的机器人身份集合补充确认。
+//! `is_current_bot` 是 Gateway 内部语义，READY 学习和旧配置仍用于兼容不同 QQ 事件。
 
 use std::{
     collections::HashSet,

--- a/qq-maid-gateway-rs/src/gateway/event/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/event/mod.rs
@@ -87,7 +87,8 @@ pub struct GroupMessage {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GroupMention {
-    pub is_you: bool,
+    /// 是否已由 Gateway 判定为当前机器人；不是 QQ raw event 字段。
+    pub is_current_bot: bool,
     pub member_role: Option<GroupMemberRole>,
     /// 被提及者的平台结构化 ID（群场景优先 member openid，其次 user openid / id）。
     /// 仅当平台事件未提供任何稳定 ID 时为 None。
@@ -249,8 +250,12 @@ struct RawAuthor {
 
 #[derive(Debug, Deserialize)]
 struct RawMention {
+    /// 部分 QQ 全量群事件仍带有该兼容字段；稳定 target_id 存在时由 Gateway 优先校验 ID。
     #[serde(default)]
     is_you: Option<bool>,
+    /// QQ 全量群事件可能同时标记被提及者是否为机器人；仅用于约束兼容 is_you 证据。
+    #[serde(default)]
+    bot: Option<bool>,
     #[serde(default)]
     member_role: Option<String>,
     // QQ mention 对象可能以下任一字段携带被提及者稳定 ID。
@@ -365,8 +370,7 @@ pub fn parse_group_message(envelope: &GatewayEnvelope) -> Result<Option<GroupMes
         raw.member_openid.as_deref(),
         raw.user_openid.as_deref(),
     );
-    let member_role =
-        resolve_group_member_role(raw.member_role.as_deref(), author.as_ref(), &raw.mentions);
+    let member_role = resolve_group_member_role(raw.member_role.as_deref(), author.as_ref());
     let author_is_bot = raw.bot.or(raw.is_bot).unwrap_or(false)
         || author
             .as_ref()
@@ -418,32 +422,25 @@ pub fn parse_group_message(envelope: &GatewayEnvelope) -> Result<Option<GroupMes
 fn resolve_group_member_role(
     top_member_role: Option<&str>,
     author: Option<&RawAuthor>,
-    mentions: &[RawMention],
 ) -> Option<GroupMemberRole> {
     first_non_empty([
         top_member_role,
         author.and_then(|author| author.member_role.as_deref()),
-        mentions.iter().find_map(|mention| {
-            mention
-                .is_you
-                .unwrap_or(false)
-                .then_some(mention.member_role.as_deref())
-                .flatten()
-        }),
     ])
     .map(|value| GroupMemberRole::from_raw(&value))
 }
 
 fn raw_group_mention(mention: &RawMention) -> GroupMention {
     GroupMention {
-        // `is_you` 仅作为没有稳定 ID 的旧事件兼容；群处理入口会优先用 target_id 匹配 READY 身份。
-        is_you: mention.is_you.unwrap_or(false),
+        // 没有稳定 ID 时暂存协议兼容标记；明确标记为普通成员时不接受 is_you，避免
+        // 把普通成员误认为当前机器人。bot 缺失时保留旧 QQ 事件兼容行为。
+        is_current_bot: mention.is_you.unwrap_or(false) && mention.bot != Some(false),
         member_role: mention
             .member_role
             .as_deref()
             .map(GroupMemberRole::from_raw),
         // 群场景优先 member openid，其次 user openid / openid / id；
-        // 都缺失时返回 None，上游才可使用 is_you 兼容旧事件。
+        // 都缺失时返回 None，普通群消息无法确认该 mention 指向当前机器人。
         target_id: first_non_empty([
             mention.member_openid.as_deref(),
             mention.user_openid.as_deref(),

--- a/qq-maid-gateway-rs/src/gateway/event/tests/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/event/tests/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 use serde_json::json;
+use std::sync::Arc;
 
 mod media;
 mod quote_boundary;
@@ -285,9 +286,9 @@ fn parses_group_message_structured_mentions() {
             "author": {"member_openid": "member-2", "member_role": "owner"},
             "content": " /help ",
             "mentions": [
-                {"id": "owner-id", "is_you": false, "member_role": "owner"},
-                {"id": "appid", "is_you": true, "member_role": "admin"},
-                {"user_openid": "user-openid", "is_you": false, "member_role": "member"},
+                {"id": "owner-id", "member_role": "owner"},
+                {"id": "appid", "is_you": true, "bot": true, "member_role": "admin"},
+                {"user_openid": "user-openid", "member_role": "member"},
                 {"member_openid": "member-openid", "member_role": "future-role"}
             ]
         }),
@@ -301,27 +302,138 @@ fn parses_group_message_structured_mentions() {
         message.mentions,
         vec![
             GroupMention {
-                is_you: false,
+                is_current_bot: false,
                 member_role: Some(GroupMemberRole::Owner),
                 target_id: Some("owner-id".to_owned())
             },
             GroupMention {
-                is_you: true,
+                is_current_bot: true,
                 member_role: Some(GroupMemberRole::Admin),
                 target_id: Some("appid".to_owned())
             },
             GroupMention {
-                is_you: false,
+                is_current_bot: false,
                 member_role: Some(GroupMemberRole::Member),
                 target_id: Some("user-openid".to_owned())
             },
             GroupMention {
-                is_you: false,
+                is_current_bot: false,
                 member_role: Some(GroupMemberRole::Unknown),
                 target_id: Some("member-openid".to_owned())
             }
         ]
     );
+}
+
+#[test]
+fn normalizes_full_group_bot_mention_without_touching_plain_members() {
+    let envelope = GatewayEnvelope {
+        op: 0,
+        s: None,
+        t: Some(EVENT_GROUP_MESSAGE_CREATE.to_owned()),
+        id: None,
+        d: json!({
+            "id": "msg-full-group-mention",
+            "group_openid": "group-1",
+            "author": {"member_openid": "member-1"},
+            "content": "[@张三](mqqapi://markdown/mention?at_type=1&at_tinyid=member-1) 帮我问一下 [@汐雨](mqqapi://markdown/mention?at_type=1&at_tinyid=bot-openid) 原始数据",
+            "mentions": [
+                {"is_you": false, "member_openid": "member-1", "username": "张三"},
+                {"is_you": true, "bot": true, "member_openid": "bot-openid", "username": "汐雨"}
+            ]
+        }),
+    };
+
+    let mut message = parse_group_message(&envelope).unwrap().unwrap();
+    assert!(message.content.contains("mqqapi://markdown/mention"));
+    crate::gateway::group_filter::normalize_current_bot_mentions(
+        &mut message,
+        // 模拟 READY 未学习 member_openid：QQ 的结构化当前机器人标记仍是有效证据。
+        &Arc::new(crate::gateway::bot_identity::BotIdentity::new(
+            "app-id",
+            &[],
+        )),
+    );
+
+    assert_eq!(
+        message.content,
+        "[@张三](mqqapi://markdown/mention?at_type=1&at_tinyid=member-1) 帮我问一下 原始数据"
+    );
+    assert_eq!(
+        message.input_parts[0].text_content(),
+        Some("[@张三](mqqapi://markdown/mention?at_type=1&at_tinyid=member-1) 帮我问一下 原始数据")
+    );
+    assert!(
+        !message
+            .content
+            .contains("mqqapi://markdown/mention?at_type=1&at_tinyid=bot-openid")
+    );
+    assert!(!message.mentions[0].is_current_bot);
+    assert!(message.mentions[1].is_current_bot);
+
+    let inbound = crate::respond::normalized_group_inbound(&message, &[]);
+    assert_eq!(
+        inbound.text,
+        "[@张三](mqqapi://markdown/mention?at_type=1&at_tinyid=member-1) 帮我问一下 原始数据"
+    );
+    assert_eq!(
+        inbound.input_parts[0].text_content(),
+        Some(inbound.text.as_str())
+    );
+    assert_eq!(inbound.text.matches("原始数据").count(), 1);
+    assert!(!inbound.text.contains("at_tinyid=bot-openid"));
+}
+
+#[test]
+fn does_not_accept_is_you_for_a_mention_explicitly_marked_as_member() {
+    let envelope = GatewayEnvelope {
+        op: 0,
+        s: None,
+        t: Some(EVENT_GROUP_MESSAGE_CREATE.to_owned()),
+        id: None,
+        d: json!({
+            "id": "msg-member-mark",
+            "group_openid": "group-1",
+            "author": {"member_openid": "member-1"},
+            "content": "hello",
+            "mentions": [{
+                "is_you": true,
+                "bot": false,
+                "member_openid": "member-2"
+            }]
+        }),
+    };
+
+    let message = parse_group_message(&envelope).unwrap().unwrap();
+
+    assert!(!message.mentions[0].is_current_bot);
+}
+
+#[test]
+fn group_at_message_keeps_qq_cleaned_body() {
+    let envelope = GatewayEnvelope {
+        op: 0,
+        s: None,
+        t: Some(EVENT_GROUP_AT_MESSAGE_CREATE.to_owned()),
+        id: None,
+        d: json!({
+            "id": "msg-group-at-clean",
+            "group_openid": "group-1",
+            "content": "  原始数据",
+            "mentions": []
+        }),
+    };
+
+    let mut message = parse_group_message(&envelope).unwrap().unwrap();
+    crate::gateway::group_filter::normalize_current_bot_mentions(
+        &mut message,
+        &Arc::new(crate::gateway::bot_identity::BotIdentity::new(
+            "app-id",
+            &[],
+        )),
+    );
+    assert_eq!(message.content, "原始数据");
+    assert_eq!(message.input_parts[0].text_content(), Some("原始数据"));
 }
 
 #[test]

--- a/qq-maid-gateway-rs/src/gateway/event/tests/quote_boundary.rs
+++ b/qq-maid-gateway-rs/src/gateway/event/tests/quote_boundary.rs
@@ -1,4 +1,6 @@
 use super::*;
+use qq_maid_common::input_part::MessageInputPart;
+use std::sync::Arc;
 
 /// 官方单聊引用结构：顶层 content 为当前正文，msg_elements 为引用正文。
 /// 两者各出现一次，不会混合。
@@ -89,6 +91,56 @@ fn group_quote_without_element_msg_idx_parses_content() {
     assert_eq!(
         reply.input_parts[0].text_content(),
         Some("被引用的群聊消息")
+    );
+}
+
+#[test]
+fn full_group_mention_quote_keeps_current_and_quoted_body_separate() {
+    let envelope = GatewayEnvelope {
+        op: 0,
+        s: None,
+        t: Some(EVENT_GROUP_MESSAGE_CREATE.to_owned()),
+        id: None,
+        d: json!({
+            "id": "msg-full-group-quote",
+            "group_openid": "group-1",
+            "author": {"member_openid": "member-1"},
+            "content": "[@汐雨](mqqapi://markdown/mention?at_type=1&at_tinyid=bot-openid) 原始数据",
+            "mentions": [
+                {"is_you": true, "member_openid": "bot-openid", "username": "汐雨"}
+            ],
+            "message_type": 103,
+            "msg_elements": [{"content": " 测试"}]
+        }),
+    };
+
+    let mut message = parse_group_message(&envelope).unwrap().unwrap();
+    crate::gateway::group_filter::normalize_current_bot_mentions(
+        &mut message,
+        &Arc::new(crate::gateway::bot_identity::BotIdentity::new(
+            "app-id",
+            &[],
+        )),
+    );
+
+    assert_eq!(message.content, "原始数据");
+    assert_eq!(message.input_parts[0].text_content(), Some("原始数据"));
+    let reply = message.reply.as_ref().unwrap();
+    assert_eq!(reply.content.as_deref(), Some("测试"));
+    assert_eq!(reply.input_parts[0].text_content(), Some("测试"));
+
+    let inbound = crate::respond::normalized_group_inbound(&message, &[]);
+    assert_eq!(inbound.text, "原始数据");
+    assert_eq!(inbound.input_parts[0].text_content(), Some("原始数据"));
+    let quoted = inbound.quoted.as_ref().unwrap();
+    assert_eq!(quoted.text_summary.as_deref(), Some("测试"));
+    assert!(!inbound.text.contains("mqqapi://markdown/mention"));
+    assert!(
+        !quoted
+            .input_parts
+            .iter()
+            .filter_map(MessageInputPart::text_content)
+            .any(|text| text.contains("mqqapi://markdown/mention"))
     );
 }
 

--- a/qq-maid-gateway-rs/src/gateway/group_filter/mention_normalizer.rs
+++ b/qq-maid-gateway-rs/src/gateway/group_filter/mention_normalizer.rs
@@ -1,0 +1,126 @@
+//! QQ 全量群消息中的当前机器人 mention 归一化。
+//!
+//! 该模块只处理结构化身份确认和当前正文同步，不参与群消息模式、冷却或 Core 业务判断。
+
+use qq_maid_common::input_part::MessageInputPart;
+
+use crate::gateway::{
+    bot_identity::SharedBotIdentity,
+    event::{GroupEventType, GroupMessage},
+};
+
+/// 在群消息进入过滤、命令和 Core adapter 前统一解析“是否 @ 当前机器人”。
+/// `is_current_bot` 是 Gateway 内部语义。QQ 提供的当前机器人标记是正证据；普通 mention
+/// 的 target_id 命中 READY 或配置身份时也可补充确认，避免只依赖昵称或任意文本。
+pub(crate) fn normalize_current_bot_mentions(
+    message: &mut GroupMessage,
+    bot_identity: &SharedBotIdentity,
+) {
+    for mention in &mut message.mentions {
+        let marked_by_event = mention.is_current_bot;
+        if let Some(target_id) = mention.target_id.as_deref() {
+            // QQ 某些全量群事件的 member_openid 不在 READY 身份候选中；已有的官方
+            // 当前机器人标记不能被一次本地身份集合 miss 覆盖，否则 @ 会静默丢失。
+            mention.is_current_bot = marked_by_event || bot_identity.contains(target_id);
+        }
+    }
+    if message.event_type != GroupEventType::GroupAtMessage {
+        strip_current_bot_markdown_mentions(message);
+    }
+}
+
+/// 从全量群消息的当前正文中移除已由结构化 mentions 确认的当前机器人 Markdown mention。
+///
+/// QQ 的 `GROUP_AT_MESSAGE_CREATE` 已经移除了机器人 mention，不能在这里再次处理。普通
+/// `GROUP_MESSAGE_CREATE` 只按 Markdown mention token 与结构化 mentions 的顺序对应；两者
+/// 数量不一致时放弃清理，避免把普通成员正文或任意 Markdown 链接误删。
+fn strip_current_bot_markdown_mentions(message: &mut GroupMessage) {
+    let tokens = markdown_mention_tokens(&message.content);
+    if tokens.is_empty() || tokens.len() != message.mentions.len() {
+        return;
+    }
+
+    let mut spans = tokens
+        .into_iter()
+        .zip(&message.mentions)
+        .filter_map(|(token, mention)| mention.is_current_bot.then_some(token))
+        .collect::<Vec<_>>();
+    if spans.is_empty() {
+        return;
+    }
+
+    let mut cleaned = message.content.clone();
+    for (start, end) in spans.drain(..).rev() {
+        let end = consume_following_whitespace(&cleaned, end);
+        cleaned.replace_range(start..end, "");
+    }
+    let cleaned = cleaned.trim().to_owned();
+    message.content = cleaned.clone();
+    sync_top_level_text_part(&mut message.input_parts, cleaned);
+}
+
+fn sync_top_level_text_part(input_parts: &mut Vec<MessageInputPart>, content: String) {
+    let text_index = input_parts
+        .iter()
+        .position(|part| matches!(part, MessageInputPart::Text { .. }));
+    match (text_index, content.is_empty()) {
+        (Some(index), true) => {
+            input_parts.remove(index);
+        }
+        (Some(index), false) => {
+            if let MessageInputPart::Text { text, .. } = &mut input_parts[index] {
+                *text = content;
+            }
+        }
+        (None, false) => input_parts.insert(0, MessageInputPart::text(content)),
+        (None, true) => {}
+    }
+}
+
+fn markdown_mention_tokens(content: &str) -> Vec<(usize, usize)> {
+    let mut tokens = Vec::new();
+    let mut cursor = 0;
+    while let Some(relative_start) = content[cursor..].find("[@") {
+        let start = cursor + relative_start;
+        let Some(label_end) = content[start..].find("](").map(|offset| start + offset) else {
+            break;
+        };
+        let url_start = label_end + 2;
+        let Some(relative_end) = content[url_start..].find(')') else {
+            break;
+        };
+        let end = url_start + relative_end + 1;
+        if is_qq_markdown_mention_uri(&content[url_start..end - 1]) {
+            tokens.push((start, end));
+            cursor = end;
+        } else {
+            cursor = start + 2;
+        }
+    }
+    tokens
+}
+
+fn is_qq_markdown_mention_uri(uri: &str) -> bool {
+    let Some(query) = uri.strip_prefix("mqqapi://markdown/mention?") else {
+        return false;
+    };
+    let has_at_type = query.split('&').any(|item| item == "at_type=1");
+    let has_target = query.split('&').any(|item| {
+        item.strip_prefix("at_tinyid=")
+            .is_some_and(|value| !value.trim().is_empty())
+    });
+    has_at_type && has_target
+}
+
+fn consume_following_whitespace(text: &str, mut end: usize) -> usize {
+    while end < text.len() {
+        let Some(ch) = text[end..].chars().next() else {
+            break;
+        };
+        if !ch.is_whitespace() {
+            break;
+        }
+        end += ch.len_utf8();
+    }
+    end
+}

--- a/qq-maid-gateway-rs/src/gateway/group_filter/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/group_filter/mod.rs
@@ -17,6 +17,10 @@ use std::{
 use qq_maid_common::command_prefix::CommandPrefix;
 use tracing::debug;
 
+mod mention_normalizer;
+
+pub(crate) use mention_normalizer::normalize_current_bot_mentions;
+
 use super::{
     BotOutboundCache,
     bot_identity::SharedBotIdentity,
@@ -93,6 +97,7 @@ pub(crate) fn should_ignore_group_message(
     }
     if !mentions_current_bot(message)
         && respond_content.trim().is_empty()
+        && message.content.trim().is_empty()
         && !is_reply_to_bot(message, bot_outbound_cache)
     {
         debug!(
@@ -107,8 +112,8 @@ pub(crate) fn should_ignore_group_message(
 
 /// 按群消息模式策略判断是否应处理该消息。
 ///
-/// QQ 官方 at 事件直接视为提到当前机器人；普通群消息优先由 READY 阶段学习的稳定身份
-/// 字段匹配，`is_you` 仅用于没有稳定身份字段的旧事件兼容。
+/// QQ 官方 at 事件直接视为提到当前机器人；普通群消息保留 QQ 结构化的当前机器人标记，
+/// 并用 mention 的稳定 target_id 与 READY 阶段学习的机器人身份集合补充确认。
 /// 后续只按群消息模式决定是否进入 Core：
 /// - Off：不处理；
 /// - 其他模式：先放行斜杠命令候选，再应用各自的唤醒规则；
@@ -173,33 +178,12 @@ pub(crate) fn should_process_group_message_with_prefix(
     }
 }
 
-/// 在普通群消息进入过滤、命令和 Core adapter 前统一解析“是否 @ 当前机器人”。
-/// 稳定 ID 的判断优先级高于旧 `is_you`：即便旧字段为 true，只要事件同时给出
-/// 不匹配的稳定 ID，也不能把任意 mention 误判为当前机器人。
-pub(crate) fn normalize_current_bot_mentions(
-    message: &mut GroupMessage,
-    bot_identity: &SharedBotIdentity,
-) {
-    if message.event_type == GroupEventType::GroupAtMessage {
-        return;
-    }
-    for mention in &mut message.mentions {
-        if let Some(target_id) = mention.target_id.as_deref() {
-            mention.is_you = bot_identity.contains(target_id);
-        } else if mention.is_you {
-            // 旧事件没有稳定 mention ID 时才接受 is_you；不记录用户或群完整 ID。
-            debug!(
-                event_type = "group_message",
-                mention_identity_source = "legacy_is_you",
-                "QQ group mention used legacy is_you fallback"
-            );
-        }
-    }
-}
-
 pub(crate) fn mentions_current_bot(message: &GroupMessage) -> bool {
     message.event_type == GroupEventType::GroupAtMessage
-        || message.mentions.iter().any(|mention| mention.is_you)
+        || message
+            .mentions
+            .iter()
+            .any(|mention| mention.is_current_bot)
 }
 
 /// `active` 模式只按显式提示词触发，避免普通群聊闲谈被机器人自动插话。
@@ -281,7 +265,7 @@ mod tests {
 
     fn official_bot_mention() -> GroupMention {
         GroupMention {
-            is_you: true,
+            is_current_bot: true,
             member_role: None,
             target_id: None,
         }
@@ -464,7 +448,7 @@ mod tests {
         let active_keywords = vec!["小女仆".to_owned()];
         let mut message = group_message("@其他成员 /help", GroupEventType::GroupMessage);
         message.mentions = vec![GroupMention {
-            is_you: false,
+            is_current_bot: false,
             member_role: None,
             target_id: None,
         }];
@@ -518,7 +502,7 @@ mod tests {
     }
 
     #[test]
-    fn configured_bot_mention_id_no_longer_triggers_without_is_you() {
+    fn configured_bot_mention_id_no_longer_triggers_without_is_current_bot() {
         let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
         let active_keywords = vec!["小女仆".to_owned()];
         let message = group_message("@机器人 实在是睡不着", GroupEventType::GroupMessage);
@@ -533,13 +517,13 @@ mod tests {
                     &bot_identity(),
                     &cache
                 ),
-                "{mode:?} should ignore configured mention ids without official is_you"
+                "{mode:?} should ignore configured mention ids without official is_current_bot"
             );
         }
     }
 
     #[test]
-    fn content_mentions_do_not_trigger_without_official_is_you() {
+    fn content_mentions_do_not_trigger_without_official_is_current_bot() {
         let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
         let active_keywords = vec!["小女仆".to_owned()];
 
@@ -573,7 +557,7 @@ mod tests {
         let active_keywords = vec!["小女仆".to_owned()];
         let mut message = group_message("@其他成员 hello", GroupEventType::GroupAtMessage);
         message.mentions = vec![GroupMention {
-            is_you: false,
+            is_current_bot: false,
             member_role: None,
             target_id: None,
         }];
@@ -728,7 +712,7 @@ mod tests {
     }
 
     #[test]
-    fn mention_mode_accepts_structured_bot_mention_only_for_official_is_you() {
+    fn mention_mode_accepts_structured_bot_mention_only_for_official_is_current_bot() {
         let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
         let mut message = group_message("hello", GroupEventType::GroupMessage);
         message.mentions = vec![official_bot_mention()];
@@ -743,7 +727,7 @@ mod tests {
         ));
 
         message.mentions = vec![GroupMention {
-            is_you: false,
+            is_current_bot: false,
             member_role: None,
             target_id: None,
         }];
@@ -758,11 +742,11 @@ mod tests {
     }
 
     #[test]
-    fn normalizes_group_mentions_by_stable_bot_identity_before_legacy_is_you() {
+    fn normalizes_group_mentions_from_event_or_stable_bot_identity() {
         let identity = Arc::new(BotIdentity::new("appid", &["bot-openid".to_owned()]));
         let mut stable_match = group_message("hello", GroupEventType::GroupMessage);
         stable_match.mentions = vec![GroupMention {
-            is_you: false,
+            is_current_bot: false,
             member_role: None,
             target_id: Some("bot-openid".to_owned()),
         }];
@@ -771,30 +755,119 @@ mod tests {
 
         let mut stable_mismatch = group_message("hello", GroupEventType::GroupMessage);
         stable_mismatch.mentions = vec![GroupMention {
-            is_you: true,
+            is_current_bot: true,
             member_role: None,
             target_id: Some("another-member".to_owned()),
         }];
         normalize_current_bot_mentions(&mut stable_mismatch, &identity);
-        assert!(!mentions_current_bot(&stable_mismatch));
+        assert!(mentions_current_bot(&stable_mismatch));
 
         let mut legacy = group_message("hello", GroupEventType::GroupMessage);
         legacy.mentions = vec![GroupMention {
-            is_you: true,
+            is_current_bot: true,
             member_role: None,
             target_id: None,
         }];
         normalize_current_bot_mentions(&mut legacy, &identity);
         assert!(mentions_current_bot(&legacy));
 
+        let mut at_with_matching_target = group_message("hello", GroupEventType::GroupAtMessage);
+        at_with_matching_target.mentions = vec![GroupMention {
+            is_current_bot: false,
+            member_role: None,
+            target_id: Some("bot-openid".to_owned()),
+        }];
+        normalize_current_bot_mentions(&mut at_with_matching_target, &identity);
+        assert!(at_with_matching_target.mentions[0].is_current_bot);
+        assert!(mentions_current_bot(&at_with_matching_target));
+
         let mut at_event = group_message("hello", GroupEventType::GroupAtMessage);
         at_event.mentions = vec![GroupMention {
-            is_you: false,
+            is_current_bot: false,
             member_role: None,
             target_id: Some("another-member".to_owned()),
         }];
         normalize_current_bot_mentions(&mut at_event, &identity);
         assert!(mentions_current_bot(&at_event));
+    }
+
+    #[test]
+    fn active_keyword_survives_empty_normalized_body() {
+        let cache = Arc::new(Mutex::new(BotOutboundCache::default()));
+        let active_keywords = vec!["小女仆".to_owned()];
+        let message = group_message("小女仆", GroupEventType::GroupMessage);
+
+        // 唤醒词会被正文归一化剥掉，但 raw content 仍非空，不能在空内容过滤阶段丢弃。
+        assert!(!should_ignore_group_message(
+            &message,
+            "",
+            "masked-group",
+            &cache
+        ));
+        assert!(should_process_group_message(
+            GroupMessageMode::Active,
+            &active_keywords,
+            &message,
+            "",
+            &bot_identity(),
+            &cache
+        ));
+
+        let mut other_bot = group_message("你好", GroupEventType::GroupMessage);
+        other_bot.mentions = vec![GroupMention {
+            is_current_bot: false,
+            member_role: None,
+            target_id: Some("other-bot".to_owned()),
+        }];
+        normalize_current_bot_mentions(&mut other_bot, &bot_identity());
+        assert!(!should_process_group_message(
+            GroupMessageMode::Active,
+            &active_keywords,
+            &other_bot,
+            &other_bot.content,
+            &bot_identity(),
+            &cache
+        ));
+    }
+
+    #[test]
+    fn markdown_mention_cleanup_preserves_plain_and_other_member_content() {
+        let identity = Arc::new(BotIdentity::new("app", &[]));
+        let mut plain = group_message("原始数据", GroupEventType::GroupMessage);
+        normalize_current_bot_mentions(&mut plain, &identity);
+        assert_eq!(plain.content, "原始数据");
+        assert_eq!(plain.input_parts[0].text_content(), Some("原始数据"));
+
+        let mut repeated = group_message(
+            "[@张三](mqqapi://markdown/mention?at_type=1&at_tinyid=other) [@汐雨](mqqapi://markdown/mention?at_type=1&at_tinyid=app) [@汐雨](mqqapi://markdown/mention?at_type=1&at_tinyid=app) 原始数据",
+            GroupEventType::GroupMessage,
+        );
+        repeated.mentions = vec![
+            GroupMention {
+                is_current_bot: false,
+                member_role: None,
+                target_id: Some("other".to_owned()),
+            },
+            GroupMention {
+                is_current_bot: false,
+                member_role: None,
+                target_id: Some("app".to_owned()),
+            },
+            GroupMention {
+                is_current_bot: false,
+                member_role: None,
+                target_id: Some("app".to_owned()),
+            },
+        ];
+        normalize_current_bot_mentions(&mut repeated, &identity);
+        assert_eq!(
+            repeated.content,
+            "[@张三](mqqapi://markdown/mention?at_type=1&at_tinyid=other) 原始数据"
+        );
+        assert_eq!(
+            repeated.input_parts[0].text_content(),
+            Some(repeated.content.as_str())
+        );
     }
 
     #[test]

--- a/qq-maid-gateway-rs/src/gateway/platform/qq_official.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/qq_official.rs
@@ -80,35 +80,37 @@ pub(crate) fn inbound_from_group(message: &GroupMessage) -> InboundMessage {
         visible_entity_snapshot: None,
         mentions: mentions_from_group_event(message),
         mentioned_bot: message.event_type == GroupEventType::GroupAtMessage
-            || message.mentions.iter().any(|mention| mention.is_you),
+            || message
+                .mentions
+                .iter()
+                .any(|mention| mention.is_current_bot),
     }
 }
 
 /// 把群事件的结构化 mentions 映射为平台无关 `MentionIdentity`。
 ///
-/// - `mentions[]` 中每个条目按事件顺序映射：`is_you` -> `is_self`，`target_id` -> 稳定 ID，
-///   `member_role` -> 角色字符串，`confidence = Event`。
-/// - `is_self` 只来自平台结构化 `is_you` 字段，不因 `GROUP_AT_MESSAGE_CREATE` 事件类型
-///   把普通 mention 误标为机器人。
+/// - `mentions[]` 中每个条目按事件顺序映射：Gateway 推导的 `is_current_bot` -> `is_self`，
+///   `target_id` -> 稳定 ID，`member_role` -> 角色字符串，`confidence = Event`。
 /// - `GROUP_AT_MESSAGE_CREATE` 事件整体即代表 @ 当前机器人；若遍历完 mentions 仍未看到
-///   任何 `is_you=true` 条目，才追加一条 synthetic self mention，避免与结构化普通 mention 混淆。
-/// - 非 `is_you` 的 mention `is_bot` 保持 None（事件不提供），不伪造。
+///   Gateway 已标记的当前机器人条目，才追加一条 synthetic self mention，避免把普通 mention
+///   误标为机器人。
+/// - 未标记为当前机器人的 mention `is_bot` 保持 None（事件不提供），不伪造。
 /// - 文本 `@昵称` 弱候选由 `text_weak_mentions_from_content` 补充，采用保守去重策略。
 fn mentions_from_group_event(message: &GroupMessage) -> Vec<MentionIdentity> {
     let mut result = Vec::new();
     let has_self_event = message.event_type == GroupEventType::GroupAtMessage;
-    let mut saw_self = false;
     for mention in &message.mentions {
-        // is_self 只来自平台结构化 is_you；不因事件类型把普通 mention 强制标为 self。
-        let is_self = mention.is_you;
-        if is_self {
-            saw_self = true;
-        }
+        let is_self = mention.is_current_bot;
         result.push(mention_identity_from_group_mention(mention, is_self));
     }
-    // GROUP_AT_MESSAGE_CREATE 整体即 @ 当前机器人；仅当结构化 mentions 中无任何 is_you=true 时
-    // 才追加 synthetic self mention，不与普通 mention 混淆。
-    if has_self_event && !saw_self {
+    // GROUP_AT_MESSAGE_CREATE 整体即 @ 当前机器人；仅当结构化 mentions 中没有 Gateway
+    // 标记的当前机器人条目时才追加 synthetic self mention，不与普通 mention 混淆。
+    if has_self_event
+        && !message
+            .mentions
+            .iter()
+            .any(|mention| mention.is_current_bot)
+    {
         result.push(self_mention());
     }
     // 文本 @ 昵称弱候选：保守去重，避免与结构化 mention 拆成两个独立对象。
@@ -337,7 +339,7 @@ mod tests {
             member_role: Some(GroupMemberRole::Admin),
             content: "/rss".to_owned(),
             mentions: vec![GroupMention {
-                is_you: true,
+                is_current_bot: true,
                 member_role: Some(GroupMemberRole::Admin),
                 target_id: None,
             }],
@@ -460,18 +462,18 @@ mod tests {
 
     #[test]
     fn qq_group_multi_mention_maps_to_structured_identity_in_order() {
-        // 一条消息同时 @ 当前机器人（is_you）和 @ 普通成员（结构化），顺序与事件一致。
+        // 一条消息同时 @ 当前机器人（is_current_bot）和 @ 普通成员（结构化），顺序与事件一致。
         let mut message = group_message();
         message.event_type = GroupEventType::GroupMessage;
         message.content = "@当前机器人 帮我问一下".to_owned();
         message.mentions = vec![
             GroupMention {
-                is_you: true,
+                is_current_bot: true,
                 member_role: Some(GroupMemberRole::Admin),
                 target_id: Some("bot-appid".to_owned()),
             },
             GroupMention {
-                is_you: false,
+                is_current_bot: false,
                 member_role: Some(GroupMemberRole::Member),
                 target_id: Some("member-2".to_owned()),
             },
@@ -539,18 +541,18 @@ mod tests {
 
     #[test]
     fn qq_group_at_message_keeps_plain_mention_order_and_appends_synthetic_self() {
-        // GROUP_AT_MESSAGE_CREATE + mentions 全部 is_you=false：保留普通 mentions，
+        // GROUP_AT_MESSAGE_CREATE + mentions 全部 is_current_bot=false：保留普通 mentions，
         // 并额外追加一条 synthetic self mention，不把首条普通 mention 误标为 self。
         let mut message = group_message();
         message.event_type = GroupEventType::GroupAtMessage;
         message.mentions = vec![
             GroupMention {
-                is_you: false,
+                is_current_bot: false,
                 member_role: Some(GroupMemberRole::Member),
                 target_id: Some("member-plain".to_owned()),
             },
             GroupMention {
-                is_you: false,
+                is_current_bot: false,
                 member_role: Some(GroupMemberRole::Admin),
                 target_id: Some("member-admin".to_owned()),
             },
@@ -578,18 +580,18 @@ mod tests {
 
     #[test]
     fn qq_group_at_message_with_plain_then_self_keeps_order() {
-        // GROUP_AT_MESSAGE_CREATE + 首条普通 mention、其后 is_you=true 的 self：
+        // GROUP_AT_MESSAGE_CREATE + 首条普通 mention、其后 is_current_bot=true 的 self：
         // 首条保持 is_self=false，第二条 is_self=true，不再追加 synthetic self。
         let mut message = group_message();
         message.event_type = GroupEventType::GroupAtMessage;
         message.mentions = vec![
             GroupMention {
-                is_you: false,
+                is_current_bot: false,
                 member_role: Some(GroupMemberRole::Member),
                 target_id: Some("member-plain".to_owned()),
             },
             GroupMention {
-                is_you: true,
+                is_current_bot: true,
                 member_role: Some(GroupMemberRole::Admin),
                 target_id: Some("bot-appid".to_owned()),
             },
@@ -615,7 +617,7 @@ mod tests {
         let mut message = group_message();
         message.event_type = GroupEventType::GroupMessage;
         message.mentions = vec![GroupMention {
-            is_you: false,
+            is_current_bot: false,
             member_role: Some(GroupMemberRole::Member),
             target_id: Some("member-2".to_owned()),
         }];
@@ -638,7 +640,7 @@ mod tests {
         let mut message = group_message();
         message.event_type = GroupEventType::GroupMessage;
         message.mentions = vec![GroupMention {
-            is_you: true,
+            is_current_bot: true,
             member_role: Some(GroupMemberRole::Admin),
             target_id: None,
         }];

--- a/qq-maid-gateway-rs/src/gateway/qq_official/group/tests/behavior.rs
+++ b/qq-maid-gateway-rs/src/gateway/qq_official/group/tests/behavior.rs
@@ -55,9 +55,9 @@ fn group_at_reply_markdown_outbound_mentions_sender() {
 fn structured_group_mention_markdown_reply_mentions_sender_like_at_event() {
     let mut message = group_message("hello", GroupEventType::GroupMessage);
     message.mentions = vec![crate::gateway::event::GroupMention {
-        is_you: true,
+        is_current_bot: true,
         member_role: None,
-        target_id: None,
+        target_id: Some("app".to_owned()),
     }];
     let capability = qq_group_capability();
     let outbound = OutboundMessage::Markdown {
@@ -170,6 +170,138 @@ async fn plain_group_message_ignored_by_mode_policy_is_not_ref_indexed() {
         quoted_context.fallback_reason.as_deref(),
         Some("ref_index_miss")
     );
+}
+
+struct GroupHandlerHarness {
+    config: AppConfig,
+    respond: RespondClient,
+    api: QqApiClient,
+    dedupe: crate::gateway::dedupe::MessageDedupe,
+    outbound_cache: Arc<Mutex<BotOutboundCache>>,
+    cooldowns: Arc<Mutex<GroupCooldowns>>,
+    identity: crate::gateway::bot_identity::SharedBotIdentity,
+    runtime: GatewayRuntimeStatus,
+    ref_index: crate::gateway::ref_index::SharedRefIndex,
+    respond_calls: Arc<AtomicUsize>,
+}
+
+impl GroupHandlerHarness {
+    fn new(mode: GroupMessageMode) -> Self {
+        let mut config = test_config();
+        config.group_message_mode = mode;
+        let respond_calls = Arc::new(AtomicUsize::new(0));
+        Self {
+            config,
+            respond: respond_client_with_counter(respond_calls.clone()),
+            api: api_client(),
+            dedupe: crate::gateway::dedupe::MessageDedupe::new(Duration::from_secs(60)),
+            outbound_cache: Arc::new(Mutex::new(BotOutboundCache::default())),
+            cooldowns: Arc::new(Mutex::new(GroupCooldowns::default())),
+            identity: bot_identity(),
+            runtime: GatewayRuntimeStatus::new(),
+            ref_index: crate::gateway::ref_index::ref_index(),
+            respond_calls,
+        }
+    }
+
+    async fn handle(&self, message: GroupMessage) -> anyhow::Result<()> {
+        handle_group_message_for_test(
+            message,
+            &self.config,
+            &self.respond,
+            &self.api,
+            &self.dedupe,
+            &self.outbound_cache,
+            &self.cooldowns,
+            &self.identity,
+            &self.runtime,
+            &self.ref_index,
+        )
+        .await
+    }
+}
+
+#[tokio::test]
+async fn raw_like_group_mention_uses_target_id_and_rejects_other_bot() {
+    let harness = GroupHandlerHarness::new(GroupMessageMode::Mention);
+
+    // 贴近 QQ raw event：解析层保留平台结构化身份，handler 根据 target_id 和官方标记归一化。
+    let mut current_bot = group_message("请帮我看看", GroupEventType::GroupMessage);
+    current_bot.message_id = "raw-like-current-bot".to_owned();
+    current_bot.mentions = vec![crate::gateway::event::GroupMention {
+        is_current_bot: false,
+        member_role: None,
+        target_id: Some("app".to_owned()),
+    }];
+    assert_group_send_error(harness.handle(current_bot).await.unwrap_err());
+    assert_eq!(harness.respond_calls.load(Ordering::SeqCst), 1);
+
+    let mut other_bot = group_message("请帮我看看", GroupEventType::GroupMessage);
+    other_bot.message_id = "raw-like-other-bot".to_owned();
+    other_bot.mentions = vec![crate::gateway::event::GroupMention {
+        is_current_bot: false,
+        member_role: None,
+        target_id: Some("other-bot".to_owned()),
+    }];
+    harness.handle(other_bot).await.unwrap();
+
+    let mut ordinary = group_message("请帮我看看", GroupEventType::GroupMessage);
+    ordinary.message_id = "raw-like-ordinary".to_owned();
+    harness.handle(ordinary).await.unwrap();
+
+    assert_eq!(harness.respond_calls.load(Ordering::SeqCst), 1);
+
+    let unresolved_harness = GroupHandlerHarness::new(GroupMessageMode::Mention);
+    let mut official_mark = group_message(
+        "[@汐雨](mqqapi://markdown/mention?at_type=1&at_tinyid=unresolved-target) 原始数据",
+        GroupEventType::GroupMessage,
+    );
+    official_mark.message_id = "raw-like-official-mark".to_owned();
+    official_mark.mentions = vec![crate::gateway::event::GroupMention {
+        is_current_bot: true,
+        member_role: None,
+        target_id: Some("unresolved-target".to_owned()),
+    }];
+    assert_group_send_error(unresolved_harness.handle(official_mark).await.unwrap_err());
+    assert_eq!(unresolved_harness.respond_calls.load(Ordering::SeqCst), 1);
+
+    // QQ 专门的 GROUP_AT_MESSAGE_CREATE 事件本身就是当前机器人被 @，不能因 mention
+    // 的 target_id 缺失或暂时无法匹配而丢弃整条事件。
+    let at_harness = GroupHandlerHarness::new(GroupMessageMode::Mention);
+    let mut at_event = group_message("请帮我看看", GroupEventType::GroupAtMessage);
+    at_event.message_id = "raw-like-at-event".to_owned();
+    at_event.mentions = vec![crate::gateway::event::GroupMention {
+        is_current_bot: false,
+        member_role: None,
+        target_id: Some("unresolved-target".to_owned()),
+    }];
+    assert_group_send_error(at_harness.handle(at_event).await.unwrap_err());
+    assert_eq!(at_harness.respond_calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn active_wake_word_survives_normalization_and_dedupes_combined_trigger() {
+    let harness = GroupHandlerHarness::new(GroupMessageMode::Active);
+
+    // 唤醒词被剥离后正文仍可能为空，消息必须先通过空内容过滤，再由 active 策略命中。
+    let mut wake_only = group_message("小女仆", GroupEventType::GroupMessage);
+    wake_only.message_id = "wake-only".to_owned();
+    assert_group_send_error(harness.handle(wake_only).await.unwrap_err());
+    assert_eq!(harness.respond_calls.load(Ordering::SeqCst), 1);
+
+    // @ 与唤醒词同时存在时仍只走一次 handler；重复投递由复合去重键拦截。
+    let combined_harness = GroupHandlerHarness::new(GroupMessageMode::Active);
+    let mut combined = group_message("小女仆 请继续", GroupEventType::GroupMessage);
+    combined.message_id = "wake-and-mention".to_owned();
+    combined.mentions = vec![crate::gateway::event::GroupMention {
+        is_current_bot: false,
+        member_role: None,
+        target_id: Some("app".to_owned()),
+    }];
+    assert_group_send_error(combined_harness.handle(combined.clone()).await.unwrap_err());
+    combined_harness.handle(combined).await.unwrap();
+
+    assert_eq!(combined_harness.respond_calls.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]
@@ -304,12 +436,15 @@ async fn slash_candidates_reach_core_and_explicit_suppression_sends_nothing() {
     .await
     .unwrap();
 
-    let mut mentioned = group_message("@小女仆 /help", GroupEventType::GroupMessage);
+    let mut mentioned = group_message(
+        "[@汐雨](mqqapi://markdown/mention?at_type=1&at_tinyid=app) /help",
+        GroupEventType::GroupMessage,
+    );
     mentioned.message_id = "group-mentioned-command".to_owned();
     mentioned.mentions = vec![crate::gateway::event::GroupMention {
-        is_you: true,
+        is_current_bot: true,
         member_role: None,
-        target_id: None,
+        target_id: Some("app".to_owned()),
     }];
     handle_group_message_for_test(
         mentioned,
@@ -368,9 +503,9 @@ async fn normal_chat_mention_during_cooldown_skips_core_and_sends_hint() {
     let mut first = group_message("总结一下", GroupEventType::GroupMessage);
     first.message_id = "group-mention-1".to_owned();
     first.mentions = vec![crate::gateway::event::GroupMention {
-        is_you: true,
+        is_current_bot: true,
         member_role: None,
-        target_id: None,
+        target_id: Some("app".to_owned()),
     }];
 
     handle_group_message_for_test(
@@ -392,9 +527,9 @@ async fn normal_chat_mention_during_cooldown_skips_core_and_sends_hint() {
     let mut second = group_message("再总结一下", GroupEventType::GroupMessage);
     second.message_id = "group-mention-2".to_owned();
     second.mentions = vec![crate::gateway::event::GroupMention {
-        is_you: true,
+        is_current_bot: true,
         member_role: None,
-        target_id: None,
+        target_id: Some("app".to_owned()),
     }];
 
     handle_group_message_for_test(
@@ -438,9 +573,9 @@ async fn immediate_group_reply_bypasses_cooldown_without_sending_hint() {
     let mut first = group_message("@小女仆 先处理这一条", GroupEventType::GroupMessage);
     first.message_id = "group-immediate-1".to_owned();
     first.mentions = vec![crate::gateway::event::GroupMention {
-        is_you: true,
+        is_current_bot: true,
         member_role: None,
-        target_id: None,
+        target_id: Some("app".to_owned()),
     }];
     let first_err = handle_group_message_for_test(
         first,
@@ -461,9 +596,9 @@ async fn immediate_group_reply_bypasses_cooldown_without_sending_hint() {
     let mut second = group_message("@小女仆 确认", GroupEventType::GroupMessage);
     second.message_id = "group-immediate-2".to_owned();
     second.mentions = vec![crate::gateway::event::GroupMention {
-        is_you: true,
+        is_current_bot: true,
         member_role: None,
-        target_id: None,
+        target_id: Some("app".to_owned()),
     }];
     let second_err = handle_group_message_for_test(
         second,
@@ -513,9 +648,9 @@ async fn immediate_quoted_group_reply_bypasses_cooldown() {
     let mut first = group_message("@小女仆 先处理这一条", GroupEventType::GroupMessage);
     first.message_id = "group-quoted-immediate-1".to_owned();
     first.mentions = vec![crate::gateway::event::GroupMention {
-        is_you: true,
+        is_current_bot: true,
         member_role: None,
-        target_id: None,
+        target_id: Some("app".to_owned()),
     }];
     let first_err = handle_group_message_for_test(
         first,

--- a/qq-maid-gateway-rs/src/respond.rs
+++ b/qq-maid-gateway-rs/src/respond.rs
@@ -644,7 +644,7 @@ fn can_strip_encoded_mention(
     target_id: &str,
 ) -> bool {
     if let Some(mention) = message.mentions.get(mention_index) {
-        return mention.is_you
+        return mention.is_current_bot
             && mention
                 .target_id
                 .as_deref()
@@ -660,7 +660,7 @@ fn can_strip_display_mention(
     display_name: &str,
 ) -> bool {
     if let Some(mention) = message.mentions.get(mention_index) {
-        return mention.is_you;
+        return mention.is_current_bot;
     }
     // 缺少结构化身份时只兼容已配置的机器人展示名，不能把任意 @群成员当作寻址前缀。
     active_keywords.iter().any(|keyword| {
@@ -671,7 +671,7 @@ fn can_strip_display_mention(
 
 fn can_strip_encoded_mention_suffix(message: &GroupMessage, target_id: &str) -> bool {
     if let Some(mention) = message.mentions.last() {
-        return mention.is_you
+        return mention.is_current_bot
             && mention
                 .target_id
                 .as_deref()
@@ -686,7 +686,7 @@ fn can_strip_display_mention_suffix(
     display_name: &str,
 ) -> bool {
     if let Some(mention) = message.mentions.last() {
-        return mention.is_you;
+        return mention.is_current_bot;
     }
     active_keywords.iter().any(|keyword| {
         let keyword = keyword.trim();
@@ -1098,7 +1098,7 @@ mod tests {
                 let mut message = group_message(&input, Some("member1"));
                 message.event_type = GroupEventType::GroupMessage;
                 message.mentions = vec![GroupMention {
-                    is_you: true,
+                    is_current_bot: true,
                     member_role: None,
                     target_id: suffix.contains("bot-id").then(|| "bot-id".to_owned()),
                 }];
@@ -1188,7 +1188,7 @@ mod tests {
         let mut message = media_message(
             "@机器人 确认",
             GroupMention {
-                is_you: true,
+                is_current_bot: true,
                 member_role: None,
                 target_id: None,
             },
@@ -1232,7 +1232,7 @@ mod tests {
             let message = media_message(
                 input,
                 GroupMention {
-                    is_you: true,
+                    is_current_bot: true,
                     member_role: None,
                     target_id: Some("bot-id".to_owned()),
                 },
@@ -1275,7 +1275,7 @@ mod tests {
             let message = media_message(
                 input,
                 GroupMention {
-                    is_you: false,
+                    is_current_bot: false,
                     member_role: None,
                     target_id: Some("member-2".to_owned()),
                 },
@@ -1297,7 +1297,7 @@ mod tests {
         let mut message = media_message(
             "@其他成员 小女仆帮我看图",
             GroupMention {
-                is_you: false,
+                is_current_bot: false,
                 member_role: None,
                 target_id: None,
             },
@@ -1318,13 +1318,13 @@ mod tests {
         let mut message = media_message(
             "<@member-2> <@bot-id> 确认",
             GroupMention {
-                is_you: false,
+                is_current_bot: false,
                 member_role: None,
                 target_id: Some("member-2".to_owned()),
             },
         );
         message.mentions.push(GroupMention {
-            is_you: true,
+            is_current_bot: true,
             member_role: None,
             target_id: Some("bot-id".to_owned()),
         });
@@ -1343,7 +1343,7 @@ mod tests {
         let message = media_message(
             "<@bot-id>",
             GroupMention {
-                is_you: true,
+                is_current_bot: true,
                 member_role: None,
                 target_id: Some("bot-id".to_owned()),
             },


### PR DESCRIPTION
## 变更

- 修复 `GROUP_MESSAGE_CREATE` 中 QQ 明确标记当前机器人的 mention 被 READY 身份集合误判后静默丢弃。
- 保留 `is_you=true`、`bot=true` 和未知群作用域 `member_openid` 的有效平台证据；稳定 target ID 命中当前机器人时作为补充确认。
- 修复 active 唤醒词在正文归一化为空后被空内容过滤提前丢弃的问题。
- 清理全量群事件中当前机器人对应的 QQ Markdown mention，并同步 `GroupMessage.content` 与顶层正文 `input_parts`。
- 保留其他成员 mention、其他机器人、`GROUP_AT_MESSAGE_CREATE` 和引用正文边界。
- 将 mention 正文归一化拆到 `gateway/group_filter/mention_normalizer.rs`，过滤策略移动为 `gateway/group_filter/mod.rs`。
- 启动日志增加实际生效的 `group_message_mode` 和关键词数量，便于确认配置是否加载。

## 根因

全量群事件中的 `member_openid` 是群作用域身份，不保证出现在 READY 阶段身份集合中。旧逻辑只要存在 target ID 就用本地集合重算 `is_you`，导致 QQ 下发的 `is_you=true` 被覆盖为 false，随后在 mention 策略层被忽略。另一个问题是 active 唤醒词会被归一化为正文空字符串，旧空内容过滤在 active 策略前提前返回。

配置使用 `QQ_MAID_GROUP_MESSAGE_MODE=active` 和 `QQ_MAID_GROUP_ACTIVE_KEYWORDS=...`；`make run` 从 `runtime/` 启动，修改 `runtime/config/.env` 后需要重启。

## 验证

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p qq-maid-gateway-rs`，590 passed
- `cargo test --workspace --all-features`，全部通过
- 已在真实机器上验证 QQ 群 @ 机器人和 active 唤醒词恢复响应。
