### PR TITLE
[codex] 准备 v0.21.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 本文档基于 [keep a changelog](https://keepachangelog.com/zh-CN/1.0.0/) 格式，记录每个已发布版本的变更。
 
+## [v0.21.5] - 2026-07-25
+
+### Fixed
+
+* **QQ 群消息触发与 mention 归一化**（PR #587）：将 `GROUP_AT_MESSAGE_CREATE` 直接视为当前机器人被 @，并结合 READY 阶段学习的稳定机器人身份与兼容 ID 判定普通群消息中的目标，避免其它机器人或普通成员 mention 误触发。
+* **群聊 mention 文本污染**（PR #587）：归一化 QQ Markdown mention 时只移除当前机器人的寻址前缀，保留其它成员 mention 和正文，避免模型上下文丢失原始消息或重复出现机器人称呼。
+
+### Compatibility
+
+* 根包 `qq-maid-bot` 版本号提升到 `0.21.5`，其他内部 crate 版本不统一提升。
+* 本版本无数据库 migration、无必需配置迁移。群聊 `off`、`command`、`mention`、`active` 模式仍由现有配置控制，OneBot / 微信入口行为不变。
+* 群聊触发修复通过本地 Gateway 事件、mention 归一化、回复引用和冷却行为测试覆盖；未进行真实 QQ 环境联调。
+
 ## [v0.21.4] - 2026-07-25
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,7 +1976,7 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "qq-maid-bot"
-version = "0.21.4"
+version = "0.21.5"
 dependencies = [
  "anyhow",
  "qq-maid-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-bot"
-version = "0.21.4"
+version = "0.21.5"
 edition = "2024"
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@
 
 > 💡 仓库早期以 QQ 机器人为主，因此仍保留 `qq-maid-bot` 名称。当前项目正在从 QQ 官方机器人演进为多入口平台型小女仆机器人。
 
-当前稳定版本为 `v0.21.4`，项目处于 `21.x` 版本线；版本线能力与升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)。
+当前稳定版本为 `v0.21.5`，项目处于 `21.x` 版本线；版本线能力与升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)。
 
 使用、安装和配置优先看 [项目 Wiki](https://github.com/kuliantnt/qq-maid-bot/wiki)：从第一次对话、一键安装、Docker / GHCR、配置中心与 `/console/` 首次向导，到 NapCat、`/ops` 运维和 Codex 长任务，都按场景拆开了。仓库内 `docs/` 与各 crate README 更偏开发边界和实现细节。
 
 ## 21.x 版本线更新
+- **QQ 群消息触发修复**（v0.21.5）：修复群聊 @ 机器人识别和 mention 文本污染，兼容 `GROUP_AT_MESSAGE_CREATE`、稳定机器人身份匹配及旧事件字段，同时避免误触发其它机器人。
 - **QQ API v2 消息协议与富媒体上传**（v0.21.4）：对齐图片分片上传、入站消息归一化、稳定群聊 @ 判断和复合消息去重；收紧 ARK、临时上传 URL 与被动回复分段的安全边界。
 - **引用图文与工具领域边界**（v0.21.3）：修复 QQ 引用图文消息超时与 `/ping` 应用版本注入；收敛 Todo / Memory / RSS 等工具领域边界，降低跨领域耦合。
 - **主包版本诊断与工具结果验真**（v0.21.2）：`/ping` 显示根主包版本；收紧自然语言状态提示，并要求 Todo 成功文案必须由真实写工具结果支撑；同轮重复只读搜索只展示首次结果。


### PR DESCRIPTION
## What changed

- Prepare the `v0.21.5` patch release metadata for the QQ group trigger and mention normalization fix from PR #587.
- Update the root package version, lockfile, README stable-version summary, and changelog.

## Why

The merged gateway fix makes `GROUP_AT_MESSAGE_CREATE` reliably address the current bot, uses learned stable bot identity for ordinary group events, and prevents other-member or other-bot mentions from polluting the normalized prompt or triggering the bot.

## Compatibility

- No database migration or required configuration migration.
- Existing `off`, `command`, `mention`, and `active` group modes remain supported.
- OneBot and WeChat behavior is unchanged.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p qq-maid-gateway-rs --all-features` (590 passed)
- `cargo check --workspace --all-features --locked`
- `cargo build --workspace --release --all-features`
- `make release RELEASE_VERSION=v0.21.5`
