### PR TITLE
[codex] 补充 Todo 每日摘要状态帮助

### DIFF
--- a/qq-maid-core/src/runtime/respond/help.rs
+++ b/qq-maid-core/src/runtime/respond/help.rs
@@ -48,6 +48,7 @@ const HELP_MODULES: &[HelpModule] = &[
             "- `/todo all`：查看全部待办",
             "- `/todo search 关键词`：搜索未完成待办",
             "- `/todo done`、`/todo undo`：查看已完成待办",
+            "- `/todo daily status`",
             "- 写操作请直接用自然语言，例如：`帮我新增待办：明天检查日志`、`完成第一条待办`、`删除已完成待办`。",
         ],
         notes: &[

--- a/qq-maid-core/src/runtime/respond/tests/session.rs
+++ b/qq-maid-core/src/runtime/respond/tests/session.rs
@@ -168,6 +168,7 @@ async fn help_all_lists_public_commands_by_module() {
     }
     for command in [
         "/todo undo",
+        "/todo daily status",
         "/rss recent",
         "/rss add",
         "/rss delete",
@@ -282,10 +283,12 @@ async fn help_todo_returns_module_details() {
 
     assert!(text.starts_with("✅ 待办帮助"));
     assert!(text.contains("/todo done"));
+    assert!(text.contains("/todo daily status"));
     assert!(text.contains("Tool 调用"));
     assert!(text.contains("自然语言"));
     assert!(markdown.starts_with("# ✅ 待办帮助"));
     assert!(markdown.contains("`/todo done`"));
+    assert!(markdown.contains("`/todo daily status`"));
     assert!(markdown.contains("Tool 调用"));
 }
 


### PR DESCRIPTION
## 变更

- 在 Todo 模块帮助和完整帮助中加入 `/todo daily status`。
- 增加纯文本与 Markdown 帮助输出的回归断言。

## 背景

`/todo daily status` 已有实际命令处理，但此前没有出现在帮助列表中，用户无法通过 `/help` 发现该用法。

## 验证

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p qq-maid-core help_ --lib`
