### PR TITLE
fix: 修复联网搜索长结果截断与结果语义

### DIFF
--- a/qq-maid-common/src/time_context/mod.rs
+++ b/qq-maid-common/src/time_context/mod.rs
@@ -514,6 +514,9 @@ impl RequestTimeContext {
         if text.contains("今天") {
             resolved.push(ResolvedTimeExpression::date("今天", date));
         }
+        if text.contains("今日") {
+            resolved.push(ResolvedTimeExpression::date("今日", date));
+        }
         if text.contains("明天") {
             resolved.push(ResolvedTimeExpression::date(
                 "明天",

--- a/qq-maid-core/src/runtime/respond/agent_outcome.rs
+++ b/qq-maid-core/src/runtime/respond/agent_outcome.rs
@@ -249,17 +249,13 @@ impl AgentTurnOutcome {
             return false;
         }
 
-        // `empty_result` 表示查询已完成但没有可用证据。此时仍沿用已有的模型回复拼接
-        // 路径；其他失败继续由确定性工具回执覆盖，避免把执行失败误当成可用结果。
-        let all_succeeded = self
-            .outcomes
-            .iter()
-            .all(|outcome| outcome.status == ToolOutcomeStatus::Succeeded);
-        let all_empty_results = self.outcomes.iter().all(|outcome| {
-            outcome.status == ToolOutcomeStatus::Failed
-                && outcome.error_code.as_deref() == Some("empty_result")
-        });
-        all_succeeded || all_empty_results
+        // `empty_result` 表示查询已完成但没有可用证据，可与同轮成功结果共同沿用模型回复；
+        // 真实执行失败继续由确定性工具回执覆盖，避免把失败误当成可用结果。
+        self.outcomes.iter().all(|outcome| {
+            outcome.status == ToolOutcomeStatus::Succeeded
+                || (outcome.status == ToolOutcomeStatus::Failed
+                    && outcome.error_code.as_deref() == Some("empty_result"))
+        })
     }
 
     pub(crate) fn has_unhandled_outcome(&self) -> bool {
@@ -626,6 +622,28 @@ mod tests {
         );
         empty.error_code = Some("empty_result".to_owned());
         let turn = AgentTurnOutcome::from_outcomes(vec![empty]);
+
+        assert!(turn.should_preserve_model_reply());
+    }
+
+    #[test]
+    fn readonly_success_and_empty_result_preserve_model_reply() {
+        let success = outcome(
+            "web_search",
+            "search",
+            ToolOutcomeStatus::Succeeded,
+            ToolEffect::ReadOnly,
+            vec![ResponseBlock::FactCard(CommandBody::plain("有效搜索事实"))],
+        );
+        let mut empty = outcome(
+            "web_search",
+            "search",
+            ToolOutcomeStatus::Failed,
+            ToolEffect::ReadOnly,
+            vec![ResponseBlock::Warning(CommandBody::plain("没查到明确结果"))],
+        );
+        empty.error_code = Some("empty_result".to_owned());
+        let turn = AgentTurnOutcome::from_outcomes(vec![success, empty]);
 
         assert!(turn.should_preserve_model_reply());
     }

--- a/qq-maid-core/src/runtime/respond/agent_outcome.rs
+++ b/qq-maid-core/src/runtime/respond/agent_outcome.rs
@@ -240,12 +240,26 @@ impl AgentTurnOutcome {
     }
 
     pub(crate) fn should_preserve_model_reply(&self) -> bool {
-        !self.blocks.is_empty()
+        let readonly_trusted = !self.blocks.is_empty()
             && self.outcomes.iter().all(|outcome| {
                 outcome.effect == ToolEffect::ReadOnly
-                    && outcome.status == ToolOutcomeStatus::Succeeded
                     && outcome.presentation != OutcomePresentation::Unhandled
-            })
+            });
+        if !readonly_trusted {
+            return false;
+        }
+
+        // `empty_result` 表示查询已完成但没有可用证据。此时仍沿用已有的模型回复拼接
+        // 路径；其他失败继续由确定性工具回执覆盖，避免把执行失败误当成可用结果。
+        let all_succeeded = self
+            .outcomes
+            .iter()
+            .all(|outcome| outcome.status == ToolOutcomeStatus::Succeeded);
+        let all_empty_results = self.outcomes.iter().all(|outcome| {
+            outcome.status == ToolOutcomeStatus::Failed
+                && outcome.error_code.as_deref() == Some("empty_result")
+        });
+        all_succeeded || all_empty_results
     }
 
     pub(crate) fn has_unhandled_outcome(&self) -> bool {
@@ -598,6 +612,21 @@ mod tests {
         )]);
 
         assert!(turn.can_replace_model_reply());
+        assert!(turn.should_preserve_model_reply());
+    }
+
+    #[test]
+    fn readonly_empty_results_preserve_model_reply() {
+        let mut empty = outcome(
+            "web_search",
+            "search",
+            ToolOutcomeStatus::Failed,
+            ToolEffect::ReadOnly,
+            vec![ResponseBlock::Warning(CommandBody::plain("没查到明确结果"))],
+        );
+        empty.error_code = Some("empty_result".to_owned());
+        let turn = AgentTurnOutcome::from_outcomes(vec![empty]);
+
         assert!(turn.should_preserve_model_reply());
     }
 

--- a/qq-maid-core/src/runtime/respond/llm_service/mod.rs
+++ b/qq-maid-core/src/runtime/respond/llm_service/mod.rs
@@ -287,6 +287,8 @@ fn tool_context_from_request(req: &RespondRequest) -> ToolContext {
             interaction_scope_id,
         },
         tool_call_id: None,
+        tool_round: None,
+        retry_of: None,
         execution_deadline: None,
     }
 }

--- a/qq-maid-core/src/runtime/respond/tests/agent_turn/web_search.rs
+++ b/qq-maid-core/src/runtime/respond/tests/agent_turn/web_search.rs
@@ -152,6 +152,55 @@ async fn first_empty_web_search_still_renders_empty_result_hint() {
 }
 
 #[tokio::test]
+async fn multi_entity_all_empty_search_renders_one_empty_hint_without_retry() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_raw_tool_results(
+            vec![raw_tool_result(
+                "web_search",
+                serde_json::json!({
+                    "ok": false,
+                    "execution_succeeded": true,
+                    "mode": "multi_entity_research",
+                    "successful": 0,
+                    "failed": 2,
+                    "result_count": 0,
+                    "error": {"code": "empty_result", "stage": "web_search"},
+                    "results": [{
+                        "entity": "项目甲",
+                        "status": "failed",
+                        "error": {"code": "empty_result", "stage": "web_search"}
+                    }, {
+                        "entity": "项目乙",
+                        "status": "failed",
+                        "error": {"code": "empty_result", "stage": "web_search"}
+                    }]
+                }),
+                false,
+            )],
+            "模型不应补充无证据的比较结论。",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector, true);
+
+    let response = service
+        .respond(private_message("联网对比两个没有公开资料的项目"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert_eq!(text.matches("【联网查询").count(), 1);
+    assert_eq!(text.matches("没查到明确结果").count(), 1);
+    assert!(!text.contains("模型不应补充"));
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["tool_retry_count"], 0);
+    assert_eq!(diagnostics["tool_outcomes"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        diagnostics["tool_outcomes"][0]["error_code"],
+        "empty_result"
+    );
+}
+
+#[tokio::test]
 async fn web_search_execution_failure_retry_renders_only_final_error_and_keeps_attempt_trace() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)

--- a/qq-maid-core/src/runtime/respond/tests/agent_turn/web_search.rs
+++ b/qq-maid-core/src/runtime/respond/tests/agent_turn/web_search.rs
@@ -158,7 +158,7 @@ async fn duplicate_web_search_keeps_first_card_and_model_reply_without_counting_
 }
 
 #[tokio::test]
-async fn first_empty_web_search_still_renders_empty_result_hint() {
+async fn empty_web_search_with_empty_final_text_only_renders_empty_result_hint() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
         .with_raw_tool_results(
@@ -173,7 +173,7 @@ async fn first_empty_web_search_still_renders_empty_result_hint() {
                 }),
                 true,
             )],
-            "模型确认当前没有更明确的公开结果。",
+            "  ",
         );
     let service = test_service_with_provider_and_tool_calling(inspector, true);
 
@@ -186,7 +186,6 @@ async fn first_empty_web_search_still_renders_empty_result_hint() {
     assert_eq!(text.matches("【联网查询】").count(), 1);
     assert_eq!(text.matches("没查到明确结果").count(), 1);
     assert!(!text.contains("联网查询服务暂时不可用"));
-    assert!(!text.contains("模型确认当前没有更明确的公开结果"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["tool_outcomes"].as_array().unwrap().len(), 1);
     assert_eq!(diagnostics["tool_outcomes"][0]["status"], "failed");
@@ -224,7 +223,7 @@ async fn multi_entity_all_empty_search_renders_one_empty_hint_without_retry() {
                 }),
                 false,
             )],
-            "模型不应补充无证据的比较结论。",
+            "  ",
         );
     let service = test_service_with_provider_and_tool_calling(inspector, true);
 
@@ -236,7 +235,6 @@ async fn multi_entity_all_empty_search_renders_one_empty_hint_without_retry() {
     let text = response.text.unwrap();
     assert_eq!(text.matches("【联网查询").count(), 1);
     assert_eq!(text.matches("没查到明确结果").count(), 1);
-    assert!(!text.contains("模型不应补充"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["tool_retry_count"], 0);
     assert_eq!(diagnostics["tool_outcomes"].as_array().unwrap().len(), 1);
@@ -308,7 +306,7 @@ async fn web_search_execution_failure_retry_renders_only_final_error_and_keeps_a
 }
 
 #[tokio::test]
-async fn group_two_empty_searches_emit_one_failure_without_model_news() {
+async fn group_two_empty_searches_keep_one_hint_and_one_final_text() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
         .with_raw_tool_results(
@@ -324,7 +322,7 @@ async fn group_two_empty_searches_emit_one_failure_without_model_news() {
                     true,
                 ),
             ],
-            "截至今天，Reuters、CNBC、TechCrunch 都报道了未经搜索结果支持的新闻。",
+            "模型确认本轮没有更明确的公开结果。",
         );
     let service = test_service_with_provider_and_group_tool_calling_tools(
         inspector,
@@ -338,12 +336,10 @@ async fn group_two_empty_searches_emit_one_failure_without_model_news() {
 
     assert_eq!(text.matches("【联网查询】").count(), 1);
     assert_eq!(text.matches("没查到明确结果").count(), 1);
-    for unsupported in ["Reuters", "CNBC", "TechCrunch", "截至今天"] {
-        assert!(
-            !text.contains(unsupported),
-            "unexpected model text: {unsupported}"
-        );
-    }
+    assert_eq!(
+        text.matches("模型确认本轮没有更明确的公开结果。").count(),
+        1
+    );
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["agent_turn_status"], "failed");
     assert_eq!(diagnostics["tool_outcomes"].as_array().unwrap().len(), 2);

--- a/qq-maid-core/src/runtime/respond/tests/agent_turn/web_search.rs
+++ b/qq-maid-core/src/runtime/respond/tests/agent_turn/web_search.rs
@@ -49,6 +49,52 @@ async fn multi_entity_web_search_fact_card_preserves_model_summary_without_empty
 }
 
 #[tokio::test]
+async fn nested_research_evidence_keeps_news_summary_when_top_level_fields_are_empty() {
+    // 多实体调研的可信来源位于 results 内；顶层 answer/sources 为空不能覆盖子项证据。
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_raw_tool_results(
+            vec![raw_tool_result(
+                "web_search",
+                serde_json::json!({
+                    "ok": true,
+                    "mode": "multi_entity_research",
+                    "answer": "",
+                    "sources": [],
+                    "results": [{
+                        "entity": "今日 AI 新闻",
+                        "status": "success",
+                        "facts": "Reuters 报道了可核实的 AI 新闻。",
+                        "sources": [{
+                            "title": "Reuters AI News",
+                            "url": "https://example.test/reuters-ai",
+                            "snippet": "嵌套搜索来源"
+                        }]
+                    }]
+                }),
+                true,
+            )],
+            "基于 Reuters 的结果，今日 AI 新闻已有明确来源。",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector, true);
+
+    let response = service
+        .respond(private_message("今日 AI 新闻"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert!(text.contains("Reuters 报道了可核实的 AI 新闻。"));
+    assert!(text.contains("Reuters AI News"));
+    assert!(text.contains("基于 Reuters 的结果"));
+    assert!(!text.contains("没查到明确结果"));
+    assert_eq!(
+        response.diagnostics.unwrap()["agent_turn_status"],
+        "succeeded"
+    );
+}
+
+#[tokio::test]
 async fn duplicate_web_search_keeps_first_card_and_model_reply_without_counting_cache_hit() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)

--- a/qq-maid-core/src/runtime/respond/tests/agent_turn/web_search.rs
+++ b/qq-maid-core/src/runtime/respond/tests/agent_turn/web_search.rs
@@ -118,7 +118,13 @@ async fn first_empty_web_search_still_renders_empty_result_hint() {
         .with_raw_tool_results(
             vec![raw_tool_result(
                 "web_search",
-                serde_json::json!({"ok": true, "answer": "", "sources": []}),
+                serde_json::json!({
+                    "ok": false,
+                    "execution_succeeded": true,
+                    "answer": "",
+                    "sources": [],
+                    "error": {"code": "empty_result", "stage": "web_search"}
+                }),
                 true,
             )],
             "模型确认当前没有更明确的公开结果。",
@@ -133,14 +139,20 @@ async fn first_empty_web_search_still_renders_empty_result_hint() {
     let text = response.text.unwrap();
     assert_eq!(text.matches("【联网查询】").count(), 1);
     assert_eq!(text.matches("没查到明确结果").count(), 1);
-    assert!(text.contains("模型确认当前没有更明确的公开结果"));
+    assert!(!text.contains("联网查询服务暂时不可用"));
+    assert!(!text.contains("模型确认当前没有更明确的公开结果"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(diagnostics["tool_outcomes"].as_array().unwrap().len(), 1);
-    assert_eq!(diagnostics["tool_outcomes"][0]["status"], "succeeded");
+    assert_eq!(diagnostics["tool_outcomes"][0]["status"], "failed");
+    assert_eq!(
+        diagnostics["tool_outcomes"][0]["error_code"],
+        "empty_result"
+    );
+    assert_eq!(diagnostics["tool_retry_count"], 0);
 }
 
 #[tokio::test]
-async fn web_search_retry_renders_only_final_empty_result_and_keeps_attempt_trace() {
+async fn web_search_execution_failure_retry_renders_only_final_error_and_keeps_attempt_trace() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
         .with_raw_tool_results_and_attempts(
@@ -149,14 +161,17 @@ async fn web_search_retry_renders_only_final_empty_result_and_keeps_attempt_trac
                     "web_search",
                     serde_json::json!({
                         "ok": false,
-                        "error": {"code": "empty_result", "stage": "web_search"}
+                        "error": {"code": "network_error", "stage": "web_search"}
                     }),
                     false,
                 ),
                 raw_tool_result(
                     "web_search",
-                    serde_json::json!({"ok": true, "answer": ""}),
-                    true,
+                    serde_json::json!({
+                        "ok": false,
+                        "error": {"code": "network_error", "stage": "web_search"}
+                    }),
+                    false,
                 ),
             ],
             vec![
@@ -184,17 +199,143 @@ async fn web_search_retry_renders_only_final_empty_result_and_keeps_attempt_trac
 
     let text = response.text.unwrap();
     assert_eq!(text.matches("【联网查询】").count(), 1);
-    assert_eq!(text.matches("没查到明确结果").count(), 1);
-    assert!(!text.contains("联网查询服务暂时不可用"));
+    assert_eq!(text.matches("联网查询服务暂时不可用").count(), 1);
+    assert!(!text.contains("没查到明确结果"));
     let diagnostics = response.diagnostics.unwrap();
     assert_eq!(
         diagnostics["agent_tool_results"].as_array().unwrap().len(),
         2
     );
     assert_eq!(diagnostics["tool_outcomes"].as_array().unwrap().len(), 1);
-    assert_eq!(diagnostics["tool_outcomes"][0]["status"], "succeeded");
+    assert_eq!(diagnostics["tool_outcomes"][0]["status"], "failed");
     assert_eq!(diagnostics["tool_retry_count"], 1);
     assert!(diagnostics.get("tool_attempts").is_none());
+}
+
+#[tokio::test]
+async fn group_two_empty_searches_emit_one_failure_without_model_news() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_raw_tool_results(
+            vec![
+                raw_tool_result(
+                    "web_search",
+                    serde_json::json!({"ok": true, "answer": "", "sources": []}),
+                    true,
+                ),
+                raw_tool_result(
+                    "web_search",
+                    serde_json::json!({"ok": true, "answer": "", "sources": []}),
+                    true,
+                ),
+            ],
+            "截至今天，Reuters、CNBC、TechCrunch 都报道了未经搜索结果支持的新闻。",
+        );
+    let service = test_service_with_provider_and_group_tool_calling_tools(
+        inspector,
+        true,
+        true,
+        Some(vec!["web_search".to_owned()]),
+    );
+
+    let response = service.respond(message("今日 ai 新闻")).await.unwrap();
+    let text = response.text.unwrap();
+
+    assert_eq!(text.matches("【联网查询】").count(), 1);
+    assert_eq!(text.matches("没查到明确结果").count(), 1);
+    for unsupported in ["Reuters", "CNBC", "TechCrunch", "截至今天"] {
+        assert!(
+            !text.contains(unsupported),
+            "unexpected model text: {unsupported}"
+        );
+    }
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["agent_turn_status"], "failed");
+    assert_eq!(diagnostics["tool_outcomes"].as_array().unwrap().len(), 2);
+    assert!(
+        diagnostics["tool_outcomes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|outcome| outcome["error_code"] == "empty_result")
+    );
+}
+
+#[tokio::test]
+async fn group_partial_search_keeps_only_success_evidence_without_model_fill() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_raw_tool_results(
+            vec![
+                raw_tool_result(
+                    "web_search",
+                    serde_json::json!({
+                        "ok": true,
+                        "answer": "有效搜索事实",
+                        "sources": [{"title": "有效来源", "url": "https://example.test/valid", "snippet": "有效摘要"}]
+                    }),
+                    true,
+                ),
+                raw_tool_result(
+                    "web_search",
+                    serde_json::json!({"ok": true, "answer": "", "sources": []}),
+                    true,
+                ),
+            ],
+            "Reuters 说这是额外新闻，不能补入结果。",
+        );
+    let service = test_service_with_provider_and_group_tool_calling_tools(
+        inspector,
+        true,
+        true,
+        Some(vec!["web_search".to_owned()]),
+    );
+
+    let response = service.respond(message("今日 ai 新闻")).await.unwrap();
+    let text = response.text.unwrap();
+
+    assert!(text.contains("有效搜索事实"));
+    assert!(!text.contains("没查到明确结果"));
+    assert!(!text.contains("Reuters"));
+    assert_eq!(
+        response.diagnostics.unwrap()["agent_turn_status"],
+        "partial_success"
+    );
+}
+
+#[tokio::test]
+async fn group_two_successful_searches_keep_both_evidence_and_supported_summary() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_raw_tool_results(
+            vec![
+                raw_tool_result(
+                    "web_search",
+                    serde_json::json!({"ok": true, "answer": "新闻一"}),
+                    true,
+                ),
+                raw_tool_result(
+                    "web_search",
+                    serde_json::json!({"ok": true, "answer": "新闻二"}),
+                    true,
+                ),
+            ],
+            "以上两条搜索结果的汇总。",
+        );
+    let service = test_service_with_provider_and_group_tool_calling_tools(
+        inspector,
+        true,
+        true,
+        Some(vec!["web_search".to_owned()]),
+    );
+
+    let response = service.respond(message("今日 ai 新闻")).await.unwrap();
+    let text = response.text.unwrap();
+
+    assert!(text.contains("新闻一"));
+    assert!(text.contains("新闻二"));
+    assert!(text.contains("以上两条搜索结果的汇总"));
+    assert!(!text.contains("没查到明确结果"));
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tests/agent_turn/web_search.rs
+++ b/qq-maid-core/src/runtime/respond/tests/agent_turn/web_search.rs
@@ -353,7 +353,7 @@ async fn group_two_empty_searches_keep_one_hint_and_one_final_text() {
 }
 
 #[tokio::test]
-async fn group_partial_search_keeps_only_success_evidence_without_model_fill() {
+async fn group_partial_search_keeps_success_evidence_and_model_final_text() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
         .with_raw_tool_results(
@@ -387,7 +387,11 @@ async fn group_partial_search_keeps_only_success_evidence_without_model_fill() {
 
     assert!(text.contains("有效搜索事实"));
     assert!(!text.contains("没查到明确结果"));
-    assert!(!text.contains("Reuters"));
+    assert_eq!(
+        text.matches("Reuters 说这是额外新闻，不能补入结果。")
+            .count(),
+        1
+    );
     assert_eq!(
         response.diagnostics.unwrap()["agent_turn_status"],
         "partial_success"

--- a/qq-maid-core/src/runtime/respond/tool_runtime.rs
+++ b/qq-maid-core/src/runtime/respond/tool_runtime.rs
@@ -54,8 +54,9 @@ impl ToolRuntime {
             ToolRegistry::new().with_limits(DEFAULT_TOOL_TIMEOUT, tool_result_max_chars);
         let save_memory_tool =
             SaveMemoryTool::new(stores.memory_store.clone(), stores.session_store.clone());
-        let web_search_tool =
-            WebSearchTool::new(executors.query_executor.clone()).with_timeouts(web_search_timeouts);
+        let web_search_tool = WebSearchTool::new(executors.query_executor.clone())
+            .with_timeouts(web_search_timeouts)
+            .with_output_max_chars(tool_result_max_chars);
         let weather_available = executors.weather_executor.is_available();
         // Tool 只通过服务端白名单注册；Todo Tool 复用现有 store、session 快照和 pending。
         let mut tools: Vec<qq_maid_llm::tool::DynTool> = vec![

--- a/qq-maid-core/src/runtime/tools/agent_turn.rs
+++ b/qq-maid-core/src/runtime/tools/agent_turn.rs
@@ -22,7 +22,7 @@ use super::agent_presenters::{
     tool_outcome_from_knowledge_result, tool_outcome_from_rss_result,
     tool_outcome_from_train_result, tool_outcome_from_weather_result,
 };
-use super::search::agent_turn::{SearchResultProjection, project_result as project_search_result};
+use super::search::agent_turn::project_results as project_search_results;
 
 pub(crate) type IndexedToolOutcomes = Vec<(usize, ToolExecutionOutcome)>;
 
@@ -207,28 +207,30 @@ fn project_tool_turn(
         &output.agent.tool_attempts,
     )?;
     let visible_entity_snapshot = todo_projection.visible_entity_snapshot;
+    let search_projection =
+        project_search_results(&output.agent.tool_results, &output.agent.tool_attempts);
     let mut outcomes = Vec::new();
     let mut todo_outcomes = todo_projection.outcomes.into_iter().peekable();
+    let mut search_outcomes = search_projection.outcomes.into_iter().peekable();
 
     for (index, result) in output.agent.tool_results.iter().enumerate() {
         if is_retry_superseded_result(index, &output.agent.tool_attempts) {
             // 旧尝试仍保留在 Agent diagnostics；这里只丢弃它对应的用户展示块。
             let mut discarded = Vec::new();
             drain_domain_outcomes_for_result(index, &mut todo_outcomes, &mut discarded);
+            drain_domain_outcomes_for_result(index, &mut search_outcomes, &mut discarded);
             continue;
         }
         if todo_projection.consumed_result_indexes.contains(&index) {
             drain_domain_outcomes_for_result(index, &mut todo_outcomes, &mut outcomes);
+        } else if search_projection.consumed_result_indexes.contains(&index) {
+            drain_domain_outcomes_for_result(index, &mut search_outcomes, &mut outcomes);
         } else if let Some(outcome) = tool_outcome_from_weather_result(result) {
             outcomes.push(outcome);
         } else if let Some(outcome) = tool_outcome_from_train_result(result) {
             outcomes.push(outcome);
         } else if let Some(outcome) = tool_outcome_from_rss_result(result) {
             outcomes.push(outcome);
-        } else if let Some(projection) = project_search_result(result) {
-            if let SearchResultProjection::Visible(outcome) = projection {
-                outcomes.push(outcome);
-            }
         } else if let Some(outcome) = tool_outcome_from_knowledge_result(result) {
             outcomes.push(outcome);
         } else if let Some(outcome) = memory::agent_turn::tool_outcome_from_result(result) {
@@ -238,6 +240,7 @@ fn project_tool_turn(
         }
     }
     outcomes.extend(todo_outcomes.map(|(_, outcome)| outcome));
+    outcomes.extend(search_outcomes.map(|(_, outcome)| outcome));
 
     Ok(AgentTurnOutcome::from_outcomes_with_visible_snapshot(
         outcomes,

--- a/qq-maid-core/src/runtime/tools/knowledge/tool.rs
+++ b/qq-maid-core/src/runtime/tools/knowledge/tool.rs
@@ -397,6 +397,8 @@ mod tests {
                 interaction_scope_id: "private:user-1".to_owned(),
             },
             tool_call_id: Some("call-1".to_owned()),
+            tool_round: None,
+            retry_of: None,
             execution_deadline: None,
         }
     }

--- a/qq-maid-core/src/runtime/tools/rss/tool_tests.rs
+++ b/qq-maid-core/src/runtime/tools/rss/tool_tests.rs
@@ -29,6 +29,8 @@ fn test_context() -> ToolContext {
             interaction_scope_id: "private:u1".to_owned(),
         },
         tool_call_id: Some("call-1".to_owned()),
+        tool_round: None,
+        retry_of: None,
         execution_deadline: None,
     }
 }

--- a/qq-maid-core/src/runtime/tools/search/agent_turn.rs
+++ b/qq-maid-core/src/runtime/tools/search/agent_turn.rs
@@ -3,8 +3,9 @@
 //! 搜索领域在这里决定单次工具轨迹应展示、隐藏还是交给其他领域处理；通用
 //! `tools/agent_turn.rs` 只负责调度，不理解 `deduplicated` 等搜索结果字段。
 
-use qq_maid_llm::provider::ToolExecutionResult;
+use qq_maid_llm::provider::{ToolExecutionAttempt, ToolExecutionResult};
 use serde_json::Value;
+use std::collections::HashSet;
 
 use crate::{
     error::LlmError,
@@ -27,6 +28,61 @@ pub(crate) enum SearchResultProjection {
     Visible(ToolExecutionOutcome),
 }
 
+pub(crate) struct SearchTurnProjection {
+    pub(crate) consumed_result_indexes: HashSet<usize>,
+    pub(crate) outcomes: Vec<(usize, ToolExecutionOutcome)>,
+}
+
+/// 搜索结果必须按整轮投影，才能区分“全部失败”和“部分成功”。
+/// 原始工具轨迹仍完整留在 diagnostics；这里只控制可信用户正文及模型 final_text
+/// 是否允许保留，避免空结果提示重复或被模型补成无证据的时效信息。
+pub(crate) fn project_results(
+    results: &[ToolExecutionResult],
+    attempts: &[ToolExecutionAttempt],
+) -> SearchTurnProjection {
+    let mut consumed_result_indexes = HashSet::new();
+    let mut projected = Vec::new();
+    for (index, result) in results.iter().enumerate() {
+        let Some(projection) = project_result(result) else {
+            continue;
+        };
+        consumed_result_indexes.insert(index);
+        if attempts
+            .iter()
+            .any(|attempt| attempt.retry_of == Some(index))
+        {
+            continue;
+        }
+        if let SearchResultProjection::Visible(outcome) = projection {
+            projected.push((index, outcome));
+        }
+    }
+
+    let has_success = projected
+        .iter()
+        .any(|(_, outcome)| outcome.status == ToolOutcomeStatus::Succeeded);
+    let mut visible_failure_keys = HashSet::new();
+    for (_, outcome) in &mut projected {
+        if outcome.status != ToolOutcomeStatus::Failed {
+            continue;
+        }
+        let failure_key = outcome
+            .error_code
+            .clone()
+            .unwrap_or_else(|| "provider_error".to_owned());
+        let hide_empty_beside_success = has_success && failure_key == "empty_result";
+        let duplicate_failure = !visible_failure_keys.insert(failure_key);
+        if hide_empty_beside_success || duplicate_failure {
+            outcome.blocks.clear();
+        }
+    }
+
+    SearchTurnProjection {
+        consumed_result_indexes,
+        outcomes: projected,
+    }
+}
+
 pub(crate) fn project_result(result: &ToolExecutionResult) -> Option<SearchResultProjection> {
     if result.name != WEB_SEARCH_TOOL_NAME {
         return None;
@@ -41,8 +97,14 @@ pub(crate) fn project_result(result: &ToolExecutionResult) -> Option<SearchResul
 }
 
 fn visible_outcome(result: &ToolExecutionResult) -> ToolExecutionOutcome {
-    let status = ToolOutcomeStatus::from_tool_result(result);
-    let error_code = structured_error_code(&result.output);
+    let mut status = ToolOutcomeStatus::from_tool_result(result);
+    let mut error_code = structured_error_code(&result.output);
+    // 兼容旧工具输出和跨版本累计轨迹：即使上游误标 succeeded，只要没有 answer
+    // 或可用 source，就不能作为搜索成功证据，也不能保留模型最终补全文。
+    if status == ToolOutcomeStatus::Succeeded && !output_has_evidence(&result.output) {
+        status = ToolOutcomeStatus::Failed;
+        error_code = Some("empty_result".to_owned());
+    }
     let block = match status {
         ToolOutcomeStatus::Succeeded => ResponseBlock::FactCard(structured_command_body(
             format_web_search_tool_reply(&result.output),
@@ -52,7 +114,7 @@ fn visible_outcome(result: &ToolExecutionResult) -> ToolExecutionOutcome {
             ResponseBlock::Clarification(CommandBody::plain("请说明要联网查询什么内容。"))
         }
         ToolOutcomeStatus::PendingConfirmation | ToolOutcomeStatus::Failed => {
-            ResponseBlock::Error(error_body(&result.output))
+            ResponseBlock::Error(error_body(&result.output, error_code.as_deref()))
         }
     };
 
@@ -68,8 +130,11 @@ fn visible_outcome(result: &ToolExecutionResult) -> ToolExecutionOutcome {
     }
 }
 
-fn error_body(output: &Value) -> CommandBody {
-    let code = structured_error_code(output).unwrap_or_else(|| "provider_error".to_owned());
+fn error_body(output: &Value, projected_error_code: Option<&str>) -> CommandBody {
+    let code = projected_error_code
+        .map(str::to_owned)
+        .or_else(|| structured_error_code(output))
+        .unwrap_or_else(|| "provider_error".to_owned());
     let stage = output
         .get("error")
         .and_then(|error| error.get("stage"))
@@ -81,6 +146,37 @@ fn error_body(output: &Value) -> CommandBody {
         return structured_command_body(format_web_search_research_error_reply(output, &reply));
     }
     structured_command_body(reply)
+}
+
+fn output_has_evidence(output: &Value) -> bool {
+    if string_field(output, "mode").as_deref() == Some("multi_entity_research") {
+        return output
+            .get("results")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .any(|item| {
+                string_field(item, "status").as_deref() == Some("success")
+                    && (string_field(item, "facts").is_some()
+                        || string_field(item, "summary").is_some()
+                        || string_field(item, "answer").is_some()
+                        || sources_have_evidence(item.get("sources")))
+            });
+    }
+    string_field(output, "answer").is_some() || sources_have_evidence(output.get("sources"))
+}
+
+fn sources_have_evidence(value: Option<&Value>) -> bool {
+    value
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .any(|source| {
+            source.as_str().is_some_and(|text| !text.trim().is_empty())
+                || string_field(source, "title").is_some()
+                || string_field(source, "url").is_some()
+                || string_field(source, "snippet").is_some()
+        })
 }
 
 fn skip_body(output: &Value) -> CommandBody {

--- a/qq-maid-core/src/runtime/tools/search/mod.rs
+++ b/qq-maid-core/src/runtime/tools/search/mod.rs
@@ -386,7 +386,9 @@ impl Tool for WebSearchTool {
                 ),
                 "max_results": max_results.unwrap_or(DEFAULT_MAX_RESULTS),
                 "context_size": context_size.as_deref().unwrap_or("low"),
-                "topic": topic.as_deref().unwrap_or("general"),
+                // Tavily 会根据未传 topic/time_range 的时效新闻请求改用 news/day。
+                // 因此不能将缺省值与模型显式指定的 general 视为同一搜索。
+                "topic": topic,
                 "time_range": time_range,
             }))
             .expect("web search deduplication key must serialize")
@@ -758,21 +760,21 @@ fn web_search_failure_output(backend: &str, error: &LlmError) -> Value {
     })
 }
 
-/// 搜索诊断只保留可定位重试的结构化字段；不记录 raw_question、聊天历史或上游正文。
+/// 搜索诊断只保留可定位重试的结构化字段；不记录 query、raw_question、聊天历史或上游正文。
 fn log_web_search_execution(
     context: &ToolContext,
     arguments: &Value,
     output: &Value,
     multi_entity_research: bool,
 ) {
-    let query = if multi_entity_research {
-        "multi_entity_research".to_owned()
+    let query_chars = if multi_entity_research {
+        0
     } else {
         arguments
             .get("query")
             .and_then(Value::as_str)
-            .map(normalize_dedup_text)
-            .unwrap_or_default()
+            .map(|query| query.chars().count())
+            .unwrap_or(0)
     };
     let source_count = output
         .get("sources")
@@ -795,7 +797,7 @@ fn log_web_search_execution(
         .get("execution_succeeded")
         .and_then(Value::as_bool)
         .unwrap_or_else(|| output.get("ok").and_then(Value::as_bool).unwrap_or(false));
-    tracing::info!(
+    tracing::debug!(
         tool = WEB_SEARCH_TOOL_NAME,
         tool_call_id = context.tool_call_id.as_deref().unwrap_or("direct"),
         round = ?context.tool_round,
@@ -803,7 +805,7 @@ fn log_web_search_execution(
             .get("backend")
             .and_then(|value| value.as_str())
             .unwrap_or("unknown"),
-        query = %query,
+        query_chars,
         topic = ?arguments.get("topic"),
         time_range = ?arguments.get("time_range"),
         max_results = ?arguments.get("max_results"),

--- a/qq-maid-core/src/runtime/tools/search/mod.rs
+++ b/qq-maid-core/src/runtime/tools/search/mod.rs
@@ -571,12 +571,45 @@ fn optional_string_field(arguments: &Value, key: &str) -> Option<String> {
 }
 
 fn web_search_tool_output(outcome: &WebSearchOutcome) -> Value {
+    let result_count = outcome
+        .sources
+        .iter()
+        .filter(|source| web_search_source_has_evidence(source))
+        .count();
+    if !web_search_outcome_has_evidence(outcome) {
+        return json!({
+            "ok": false,
+            "execution_succeeded": true,
+            "provider": outcome.provider,
+            "answer": "",
+            "sources": [],
+            "result_count": 0,
+            "elapsed_ms": outcome.elapsed_ms,
+            "error": {
+                "code": "empty_result",
+                "stage": "web_search",
+            },
+        });
+    }
+
     json!({
+        "ok": true,
         "provider": outcome.provider,
         "answer": outcome.answer,
         "sources": outcome.sources.iter().map(web_search_source_json).collect::<Vec<_>>(),
+        "result_count": result_count,
         "elapsed_ms": outcome.elapsed_ms,
     })
+}
+
+pub(super) fn web_search_outcome_has_evidence(outcome: &WebSearchOutcome) -> bool {
+    !outcome.answer.trim().is_empty() || outcome.sources.iter().any(web_search_source_has_evidence)
+}
+
+fn web_search_source_has_evidence(source: &WebSearchSource) -> bool {
+    !source.title.trim().is_empty()
+        || !source.url.trim().is_empty()
+        || !source.snippet.trim().is_empty()
 }
 
 fn web_search_source_json(source: &WebSearchSource) -> Value {

--- a/qq-maid-core/src/runtime/tools/search/mod.rs
+++ b/qq-maid-core/src/runtime/tools/search/mod.rs
@@ -17,8 +17,12 @@ use tokio::{
 use qq_maid_common::identity_context::{
     ConversationKind, ExecutionActorContext, ExecutionConversationContext,
 };
+use qq_maid_common::text::truncate_chars_with_ellipsis_trimmed;
 use qq_maid_llm::{
-    tool::{Tool, ToolContext, ToolEffect, ToolMetadata, ToolOutput, ToolTimeoutPolicy},
+    tool::{
+        DEFAULT_TOOL_OUTPUT_MAX_CHARS, Tool, ToolContext, ToolEffect, ToolMetadata, ToolOutput,
+        ToolTimeoutPolicy,
+    },
     web_search::{
         DEFAULT_MAX_RESULTS, DynWebSearchExecutor, WebSearchBackend, WebSearchOutcome,
         WebSearchRequest, WebSearchSource,
@@ -34,8 +38,14 @@ use crate::{
 };
 
 pub(crate) const WEB_SEARCH_TOOL_NAME: &str = "web_search";
+pub(super) const WEB_SEARCH_EMPTY_RESULT_MODEL_MESSAGE: &str =
+    "本次搜索没有找到可用结果；请说明没有联网证据，不要把未经搜索验证的信息描述成实时搜索结果。";
 pub(crate) const WEB_SEARCH_QUERY_MAX_LENGTH: usize = 200;
 const WEB_SEARCH_MAX_RESULTS_LIMIT: u8 = 10;
+const WEB_SEARCH_TOOL_SOURCE_LIMIT: usize = 4;
+const WEB_SEARCH_TOOL_SOURCE_TITLE_MAX_CHARS: usize = 100;
+const WEB_SEARCH_TOOL_SOURCE_URL_MAX_CHARS: usize = 300;
+const WEB_SEARCH_TOOL_SOURCE_SNIPPET_MAX_CHARS: usize = 160;
 /// 搜索流三段超时的默认值；绝对上限独立于 90 秒整体请求预算。
 pub const DEFAULT_WEB_SEARCH_FIRST_ACTIVITY_TIMEOUT: Duration =
     Duration::from_secs(DEFAULT_WEB_SEARCH_FIRST_ACTIVITY_TIMEOUT_SECONDS);
@@ -90,6 +100,7 @@ pub struct WebSearchTool {
     first_activity_timeout: Duration,
     idle_timeout: Duration,
     absolute_timeout: Duration,
+    output_max_chars: usize,
     backend_override: Option<WebSearchBackend>,
     model_override: Option<String>,
 }
@@ -102,6 +113,7 @@ impl WebSearchTool {
             first_activity_timeout: timeouts.first_activity,
             idle_timeout: timeouts.idle,
             absolute_timeout: timeouts.absolute,
+            output_max_chars: DEFAULT_TOOL_OUTPUT_MAX_CHARS,
             backend_override: None,
             model_override: None,
         }
@@ -115,6 +127,12 @@ impl WebSearchTool {
         self
     }
 
+    /// 与 Tool Registry 使用相同结果预算，避免搜索先生成超限 JSON 后丢失结构化证据。
+    pub(crate) fn with_output_max_chars(mut self, output_max_chars: usize) -> Self {
+        self.output_max_chars = output_max_chars;
+        self
+    }
+
     /// 自然语言 Tool Loop 必须使用服务端解析后的场景搜索路线，模型参数不能覆盖。
     pub fn with_model_override(mut self, model: String) -> Self {
         self.model_override = Some(model);
@@ -125,6 +143,12 @@ impl WebSearchTool {
     pub fn with_backend_override(mut self, backend: WebSearchBackend) -> Self {
         self.backend_override = Some(backend);
         self
+    }
+
+    pub(super) fn backend_label(&self) -> &'static str {
+        self.backend_override
+            .map(WebSearchBackend::as_str)
+            .unwrap_or("configured_default")
     }
 
     pub async fn query(&self, req: WebSearchToolRequest) -> Result<WebSearchOutcome, LlmError> {
@@ -375,22 +399,38 @@ impl Tool for WebSearchTool {
         arguments: Value,
     ) -> Result<ToolOutput, LlmError> {
         if let Some(targets) = ops::parse_research_targets(arguments.get("research_targets"))? {
-            return ops::execute_research(self, &context, &arguments, targets).await;
+            let output = ops::execute_research(self, &context, &arguments, targets).await?;
+            log_web_search_execution(&context, &arguments, &output.value, true);
+            return Ok(output);
         }
+        let request = request_from_arguments(
+            &context,
+            &arguments,
+            self.backend_override,
+            self.model_override.clone(),
+        )?;
         let outcome = self
             // Agent 最终回复仍由模型统一生成，但搜索上游必须复用 `/查` 的 SSE 路径，
             // 不能因进入 Tool Loop 退化成完整非流请求。
-            .query_stream_for_agent(
-                request_from_arguments(
-                    &context,
-                    &arguments,
-                    self.backend_override,
-                    self.model_override.clone(),
-                )?,
-                context.execution_deadline,
-            )
-            .await?;
-        Ok(ToolOutput::json(web_search_tool_output(&outcome)))
+            .query_stream_for_agent(request, context.execution_deadline)
+            .await;
+        let value = match outcome {
+            Ok(outcome) => {
+                web_search_tool_output(&outcome, self.backend_label(), self.output_max_chars)
+            }
+            Err(err) => {
+                let value = web_search_failure_output(self.backend_label(), &err);
+                log_web_search_execution(&context, &arguments, &value, false);
+                // 只有 Agent Tool Loop 需要把执行失败回填给模型，以便统一记录失败进度和
+                // 保守重试；显式查询等非 Agent 兼容入口仍保留原始 Err 语义。
+                if context.tool_call_id.is_some() {
+                    return Ok(ToolOutput::json(value));
+                }
+                return Err(err);
+            }
+        };
+        log_web_search_execution(&context, &arguments, &value, false);
+        Ok(ToolOutput::json(value))
     }
 }
 
@@ -570,7 +610,11 @@ fn optional_string_field(arguments: &Value, key: &str) -> Option<String> {
     }
 }
 
-fn web_search_tool_output(outcome: &WebSearchOutcome) -> Value {
+fn web_search_tool_output(
+    outcome: &WebSearchOutcome,
+    backend: &str,
+    output_max_chars: usize,
+) -> Value {
     let result_count = outcome
         .sources
         .iter()
@@ -580,6 +624,7 @@ fn web_search_tool_output(outcome: &WebSearchOutcome) -> Value {
         return json!({
             "ok": false,
             "execution_succeeded": true,
+            "backend": backend,
             "provider": outcome.provider,
             "answer": "",
             "sources": [],
@@ -588,18 +633,204 @@ fn web_search_tool_output(outcome: &WebSearchOutcome) -> Value {
             "error": {
                 "code": "empty_result",
                 "stage": "web_search",
+                "message": WEB_SEARCH_EMPTY_RESULT_MODEL_MESSAGE,
             },
         });
     }
 
-    json!({
+    let output = json!({
         "ok": true,
+        "execution_succeeded": true,
+        "backend": backend,
         "provider": outcome.provider,
         "answer": outcome.answer,
         "sources": outcome.sources.iter().map(web_search_source_json).collect::<Vec<_>>(),
         "result_count": result_count,
         "elapsed_ms": outcome.elapsed_ms,
+    });
+    if serialized_value_chars(&output) <= output_max_chars {
+        return output;
+    }
+
+    compact_web_search_tool_output(outcome, backend, result_count, output_max_chars)
+}
+
+/// Tool Registry 对超限输出只能保留通用 preview，搜索投影将因此失去结构化证据。
+/// 搜索领域先压缩重复的来源摘要，并在剩余预算内尽量保留 answer，确保事实卡仍可验真。
+fn compact_web_search_tool_output(
+    outcome: &WebSearchOutcome,
+    backend: &str,
+    result_count: usize,
+    output_max_chars: usize,
+) -> Value {
+    let mut sources = outcome
+        .sources
+        .iter()
+        .filter(|source| web_search_source_has_evidence(source))
+        .take(WEB_SEARCH_TOOL_SOURCE_LIMIT)
+        .map(compact_web_search_source_json)
+        .collect::<Vec<_>>();
+    while !sources.is_empty()
+        && serialized_value_chars(&successful_web_search_output(
+            outcome,
+            backend,
+            result_count,
+            "",
+            &sources,
+        )) > output_max_chars
+    {
+        sources.pop();
+    }
+
+    let answer_chars = outcome.answer.trim().chars().collect::<Vec<_>>();
+    let mut low = 0usize;
+    let mut high = answer_chars.len();
+    while low < high {
+        let mid = low + (high - low).div_ceil(2);
+        let answer = answer_chars[..mid].iter().collect::<String>();
+        let candidate =
+            successful_web_search_output(outcome, backend, result_count, &answer, &sources);
+        if serialized_value_chars(&candidate) <= output_max_chars {
+            low = mid;
+        } else {
+            high = mid - 1;
+        }
+    }
+    let answer = answer_chars[..low].iter().collect::<String>();
+    successful_web_search_output(outcome, backend, result_count, &answer, &sources)
+}
+
+fn successful_web_search_output(
+    outcome: &WebSearchOutcome,
+    backend: &str,
+    result_count: usize,
+    answer: &str,
+    sources: &[Value],
+) -> Value {
+    json!({
+        "ok": true,
+        "execution_succeeded": true,
+        "backend": backend,
+        "provider": outcome.provider,
+        "answer": answer,
+        "sources": sources,
+        "result_count": result_count,
+        "elapsed_ms": outcome.elapsed_ms,
     })
+}
+
+fn compact_web_search_source_json(source: &WebSearchSource) -> Value {
+    json!({
+        "title": truncate_chars_with_ellipsis_trimmed(
+            &source.title,
+            WEB_SEARCH_TOOL_SOURCE_TITLE_MAX_CHARS,
+        ),
+        "url": truncate_chars_with_ellipsis_trimmed(
+            &source.url,
+            WEB_SEARCH_TOOL_SOURCE_URL_MAX_CHARS,
+        ),
+        "snippet": truncate_chars_with_ellipsis_trimmed(
+            &source.snippet,
+            WEB_SEARCH_TOOL_SOURCE_SNIPPET_MAX_CHARS,
+        ),
+    })
+}
+
+fn serialized_value_chars(value: &Value) -> usize {
+    serde_json::to_string(value)
+        .map(|serialized| serialized.chars().count())
+        .unwrap_or(usize::MAX)
+}
+
+fn web_search_failure_output(backend: &str, error: &LlmError) -> Value {
+    json!({
+        "ok": false,
+        "execution_succeeded": false,
+        "backend": backend,
+        "answer": "",
+        "sources": [],
+        "result_count": 0,
+        "error": {
+            "code": error.code,
+            "message": error.message,
+            "stage": error.stage,
+        },
+    })
+}
+
+/// 搜索诊断只保留可定位重试的结构化字段；不记录 raw_question、聊天历史或上游正文。
+fn log_web_search_execution(
+    context: &ToolContext,
+    arguments: &Value,
+    output: &Value,
+    multi_entity_research: bool,
+) {
+    let query = if multi_entity_research {
+        "multi_entity_research".to_owned()
+    } else {
+        arguments
+            .get("query")
+            .and_then(Value::as_str)
+            .map(normalize_dedup_text)
+            .unwrap_or_default()
+    };
+    let source_count = output
+        .get("sources")
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or_else(|| {
+            output
+                .get("results")
+                .and_then(Value::as_array)
+                .map(|results| {
+                    results
+                        .iter()
+                        .filter_map(|result| result.get("sources").and_then(Value::as_array))
+                        .map(Vec::len)
+                        .sum()
+                })
+                .unwrap_or(0)
+        });
+    let execution_succeeded = output
+        .get("execution_succeeded")
+        .and_then(Value::as_bool)
+        .unwrap_or_else(|| output.get("ok").and_then(Value::as_bool).unwrap_or(false));
+    tracing::info!(
+        tool = WEB_SEARCH_TOOL_NAME,
+        tool_call_id = context.tool_call_id.as_deref().unwrap_or("direct"),
+        round = ?context.tool_round,
+        backend = output
+            .get("backend")
+            .and_then(|value| value.as_str())
+            .unwrap_or("unknown"),
+        query = %query,
+        topic = ?arguments.get("topic"),
+        time_range = ?arguments.get("time_range"),
+        max_results = ?arguments.get("max_results"),
+        multi_entity_research,
+        answer_chars = output
+            .get("answer")
+            .and_then(|value| value.as_str())
+            .map(|answer| answer.chars().count())
+            .unwrap_or(0),
+        source_count,
+        result_count = output
+            .get("result_count")
+            .and_then(|value| value.as_u64())
+            .unwrap_or(0),
+        ok = output
+            .get("ok")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false),
+        execution_succeeded,
+        error_code = output
+            .get("error")
+            .and_then(|error| error.get("code"))
+            .and_then(|value| value.as_str())
+            .unwrap_or(""),
+        retry_of = ?context.retry_of,
+        "web search tool execution completed"
+    );
 }
 
 pub(super) fn web_search_outcome_has_evidence(outcome: &WebSearchOutcome) -> bool {

--- a/qq-maid-core/src/runtime/tools/search/mod.rs
+++ b/qq-maid-core/src/runtime/tools/search/mod.rs
@@ -44,7 +44,6 @@ pub(crate) const WEB_SEARCH_QUERY_MAX_LENGTH: usize = 200;
 const WEB_SEARCH_MAX_RESULTS_LIMIT: u8 = 10;
 const WEB_SEARCH_TOOL_SOURCE_LIMIT: usize = 4;
 const WEB_SEARCH_TOOL_SOURCE_TITLE_MAX_CHARS: usize = 100;
-const WEB_SEARCH_TOOL_SOURCE_URL_MAX_CHARS: usize = 300;
 const WEB_SEARCH_TOOL_SOURCE_SNIPPET_MAX_CHARS: usize = 160;
 /// 搜索流三段超时的默认值；绝对上限独立于 90 秒整体请求预算。
 pub const DEFAULT_WEB_SEARCH_FIRST_ACTIVITY_TIMEOUT: Duration =
@@ -665,24 +664,19 @@ fn compact_web_search_tool_output(
     result_count: usize,
     output_max_chars: usize,
 ) -> Value {
-    let mut sources = outcome
+    let source_candidates = outcome
         .sources
         .iter()
         .filter(|source| web_search_source_has_evidence(source))
         .take(WEB_SEARCH_TOOL_SOURCE_LIMIT)
-        .map(compact_web_search_source_json)
         .collect::<Vec<_>>();
-    while !sources.is_empty()
-        && serialized_value_chars(&successful_web_search_output(
-            outcome,
-            backend,
-            result_count,
-            "",
-            &sources,
-        )) > output_max_chars
-    {
-        sources.pop();
-    }
+    let sources = compact_web_search_sources(
+        outcome,
+        backend,
+        result_count,
+        output_max_chars,
+        &source_candidates,
+    );
 
     let answer_chars = outcome.answer.trim().chars().collect::<Vec<_>>();
     let mut low = 0usize;
@@ -721,20 +715,68 @@ fn successful_web_search_output(
     })
 }
 
-fn compact_web_search_source_json(source: &WebSearchSource) -> Value {
+fn compact_web_search_sources(
+    outcome: &WebSearchOutcome,
+    backend: &str,
+    result_count: usize,
+    output_max_chars: usize,
+    candidates: &[&WebSearchSource],
+) -> Vec<Value> {
+    let fits = |sources: &[Value]| {
+        serialized_value_chars(&successful_web_search_output(
+            outcome,
+            backend,
+            result_count,
+            "",
+            sources,
+        )) <= output_max_chars
+    };
+    let with_snippets =
+        compact_web_search_source_jsons(candidates, WEB_SEARCH_TOOL_SOURCE_SNIPPET_MAX_CHARS);
+    if fits(&with_snippets) {
+        return with_snippets;
+    }
+
+    // URL 必须保持完整；预算不足时先压缩摘要，仍放不下才减少来源。
+    let without_snippets = compact_web_search_source_jsons(candidates, 0);
+    if fits(&without_snippets) {
+        return without_snippets;
+    }
+
+    let mut retained = Vec::new();
+    for source in candidates {
+        let mut candidate = retained.clone();
+        candidate.push(*source);
+        if fits(&compact_web_search_source_jsons(&candidate, 0)) {
+            retained = candidate;
+        }
+    }
+    compact_web_search_source_jsons(&retained, 0)
+}
+
+fn compact_web_search_source_jsons(
+    sources: &[&WebSearchSource],
+    snippet_max_chars: usize,
+) -> Vec<Value> {
+    sources
+        .iter()
+        .map(|source| compact_web_search_source_json(source, snippet_max_chars))
+        .collect()
+}
+
+fn compact_web_search_source_json(source: &WebSearchSource, snippet_max_chars: usize) -> Value {
+    let snippet = if snippet_max_chars == 0 {
+        String::new()
+    } else {
+        truncate_chars_with_ellipsis_trimmed(&source.snippet, snippet_max_chars)
+    };
     json!({
         "title": truncate_chars_with_ellipsis_trimmed(
             &source.title,
             WEB_SEARCH_TOOL_SOURCE_TITLE_MAX_CHARS,
         ),
-        "url": truncate_chars_with_ellipsis_trimmed(
-            &source.url,
-            WEB_SEARCH_TOOL_SOURCE_URL_MAX_CHARS,
-        ),
-        "snippet": truncate_chars_with_ellipsis_trimmed(
-            &source.snippet,
-            WEB_SEARCH_TOOL_SOURCE_SNIPPET_MAX_CHARS,
-        ),
+        "url": source.url,
+        "snippet": snippet,
     })
 }
 

--- a/qq-maid-core/src/runtime/tools/search/ops.rs
+++ b/qq-maid-core/src/runtime/tools/search/ops.rs
@@ -100,14 +100,40 @@ pub(super) async fn execute_research(
         .iter()
         .filter(|result| result["status"] == "success")
         .count();
-    Ok(ToolOutput::json(json!({
+    let all_empty = succeeded == 0
+        && results
+            .iter()
+            .all(|result| research_error_code(result).as_deref() == Some("empty_result"));
+    let mut output = json!({
         "ok": succeeded > 0,
         "mode": "multi_entity_research",
         "comparison_dimensions": dimensions,
         "successful": succeeded,
         "failed": total - succeeded,
         "results": results,
-    })))
+    });
+
+    if all_empty {
+        // 每个子查询都正常完成但没有证据时，向 Tool Loop 明确传递“执行完成、领域
+        // 无结果”。这不是网络失败，不能触发整批重试或失败进度事件。
+        output["execution_succeeded"] = Value::Bool(true);
+        output["result_count"] = Value::from(0);
+        output["error"] = json!({
+            "code": "empty_result",
+            "stage": "web_search",
+        });
+    } else if succeeded == 0
+        && let Some(error) = output["results"]
+            .as_array()
+            .and_then(|results| results.iter().find_map(real_research_error))
+    {
+        // 不能用同批中的空结果掩盖真实故障；按原始目标顺序选择第一个真实错误，
+        // 让上层按 timeout / provider / parse 等明确语义处理。
+        output["error"] = error;
+        output["result_count"] = Value::from(0);
+    }
+
+    Ok(ToolOutput::json(output))
 }
 
 pub(super) fn parse_research_targets(
@@ -304,6 +330,19 @@ fn research_result_json(
             }
         }),
     }
+}
+
+fn research_error_code(result: &Value) -> Option<String> {
+    result
+        .get("error")
+        .and_then(|error| error.get("code"))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+}
+
+fn real_research_error(result: &Value) -> Option<Value> {
+    let error = result.get("error")?;
+    (research_error_code(result).as_deref() != Some("empty_result")).then(|| error.clone())
 }
 
 fn compact_research_source_json(source: &WebSearchSource) -> Option<Value> {

--- a/qq-maid-core/src/runtime/tools/search/ops.rs
+++ b/qq-maid-core/src/runtime/tools/search/ops.rs
@@ -16,9 +16,9 @@ use tokio::time::Instant;
 use crate::error::LlmError;
 
 use super::{
-    WEB_SEARCH_QUERY_MAX_LENGTH, WEB_SEARCH_TOOL_NAME, WebSearchTool, WebSearchToolRequest,
-    optional_string_field, parse_context_size, parse_max_results, parse_time_range, parse_topic,
-    web_search_outcome_has_evidence,
+    WEB_SEARCH_EMPTY_RESULT_MODEL_MESSAGE, WEB_SEARCH_QUERY_MAX_LENGTH, WEB_SEARCH_TOOL_NAME,
+    WebSearchTool, WebSearchToolRequest, optional_string_field, parse_context_size,
+    parse_max_results, parse_time_range, parse_topic, web_search_outcome_has_evidence,
 };
 
 pub(super) const WEB_SEARCH_RESEARCH_MAX_TARGETS: usize = 5;
@@ -100,16 +100,23 @@ pub(super) async fn execute_research(
         .iter()
         .filter(|result| result["status"] == "success")
         .count();
+    let result_count = results
+        .iter()
+        .filter_map(|result| result.get("sources").and_then(Value::as_array))
+        .map(Vec::len)
+        .sum::<usize>();
     let all_empty = succeeded == 0
         && results
             .iter()
             .all(|result| research_error_code(result).as_deref() == Some("empty_result"));
     let mut output = json!({
         "ok": succeeded > 0,
+        "backend": tool.backend_label(),
         "mode": "multi_entity_research",
         "comparison_dimensions": dimensions,
         "successful": succeeded,
         "failed": total - succeeded,
+        "result_count": result_count,
         "results": results,
     });
 
@@ -121,6 +128,7 @@ pub(super) async fn execute_research(
         output["error"] = json!({
             "code": "empty_result",
             "stage": "web_search",
+            "message": WEB_SEARCH_EMPTY_RESULT_MODEL_MESSAGE,
         });
     } else if succeeded == 0
         && let Some(error) = output["results"]

--- a/qq-maid-core/src/runtime/tools/search/ops.rs
+++ b/qq-maid-core/src/runtime/tools/search/ops.rs
@@ -18,6 +18,7 @@ use crate::error::LlmError;
 use super::{
     WEB_SEARCH_QUERY_MAX_LENGTH, WEB_SEARCH_TOOL_NAME, WebSearchTool, WebSearchToolRequest,
     optional_string_field, parse_context_size, parse_max_results, parse_time_range, parse_topic,
+    web_search_outcome_has_evidence,
 };
 
 pub(super) const WEB_SEARCH_RESEARCH_MAX_TARGETS: usize = 5;
@@ -266,7 +267,7 @@ fn research_result_json(
     outcome: Result<WebSearchOutcome, LlmError>,
 ) -> Value {
     match outcome {
-        Ok(outcome) => json!({
+        Ok(outcome) if web_search_outcome_has_evidence(&outcome) => json!({
             "entity": target.entity,
             "assumption": target.assumption,
             "status": "success",
@@ -276,6 +277,19 @@ fn research_result_json(
             "facts": truncate_chars(&outcome.answer, WEB_SEARCH_RESEARCH_FACT_MAX_CHARS),
             "sources": outcome.sources.iter().take(WEB_SEARCH_RESEARCH_SOURCE_LIMIT)
                 .filter_map(compact_research_source_json).collect::<Vec<_>>(),
+        }),
+        Ok(outcome) => json!({
+            "entity": target.entity,
+            "assumption": target.assumption,
+            "status": "failed",
+            "model": truncate_chars(model, 100),
+            "provider": outcome.provider,
+            "elapsed_ms": outcome.elapsed_ms.max(elapsed_ms),
+            "error": {
+                "code": "empty_result",
+                "stage": "web_search",
+                "message": "web search returned no usable evidence",
+            }
         }),
         Err(err) => json!({
             "entity": target.entity,

--- a/qq-maid-core/src/runtime/tools/search/tests.rs
+++ b/qq-maid-core/src/runtime/tools/search/tests.rs
@@ -342,6 +342,14 @@ fn web_search_tool_is_read_only_and_deduplicates_normalized_query() {
         default_key,
         tool.deduplication_key(&json!({
             "query": "rust news",
+            "topic": "general"
+        }))
+        .unwrap()
+    );
+    assert_ne!(
+        default_key,
+        tool.deduplication_key(&json!({
+            "query": "rust news",
             "raw_question": "different context"
         }))
         .unwrap()

--- a/qq-maid-core/src/runtime/tools/search/tests.rs
+++ b/qq-maid-core/src/runtime/tools/search/tests.rs
@@ -106,8 +106,26 @@ async fn web_search_tool_reuses_query_executor() {
     assert_eq!(requests[0].time_range.as_deref(), Some("week"));
     assert_eq!(requests[0].model_override.as_deref(), Some("gpt-search"));
     assert_eq!(stream_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(output.value["ok"], true);
+    assert_eq!(output.value["result_count"], 1);
     assert_eq!(output.value["answer"], "answer: Rust 新闻");
     assert_eq!(output.value["sources"][0]["url"], "https://example.com");
+}
+
+#[test]
+fn web_search_tool_empty_outcome_is_structured_failure_not_success_evidence() {
+    let output = web_search_tool_output(&WebSearchOutcome {
+        answer: " \n ".to_owned(),
+        sources: Vec::new(),
+        provider: "mock-query".to_owned(),
+        elapsed_ms: 12,
+    });
+
+    assert_eq!(output["ok"], false);
+    assert_eq!(output["execution_succeeded"], true);
+    assert_eq!(output["result_count"], 0);
+    assert_eq!(output["error"]["code"], "empty_result");
+    assert_eq!(output["error"]["stage"], "web_search");
 }
 
 #[test]

--- a/qq-maid-core/src/runtime/tools/search/tests.rs
+++ b/qq-maid-core/src/runtime/tools/search/tests.rs
@@ -277,6 +277,45 @@ async fn large_search_result_keeps_structured_evidence_through_tool_registry() {
 }
 
 #[test]
+fn compact_search_result_drops_oversized_source_instead_of_truncating_url() {
+    const PREVIOUS_URL_MAX_CHARS: usize = 300;
+    const OUTPUT_MAX_CHARS: usize = 420;
+    let oversized_url = format!("https://example.com/{}", "a".repeat(PREVIOUS_URL_MAX_CHARS));
+    let output = web_search_tool_output(
+        &WebSearchOutcome {
+            answer: "搜索结果".repeat(100),
+            sources: vec![
+                WebSearchSource {
+                    title: "超长链接来源".to_owned(),
+                    url: oversized_url.clone(),
+                    snippet: "摘要".repeat(100),
+                },
+                WebSearchSource {
+                    title: "可保留来源".to_owned(),
+                    url: "https://example.com/valid".to_owned(),
+                    snippet: "有效摘要".to_owned(),
+                },
+            ],
+            provider: "mock-query".to_owned(),
+            elapsed_ms: 12,
+        },
+        "tavily",
+        OUTPUT_MAX_CHARS,
+    );
+
+    let urls = output["sources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|source| source["url"].as_str())
+        .collect::<Vec<_>>();
+    assert!(!urls.contains(&oversized_url.as_str()));
+    assert_eq!(urls, ["https://example.com/valid"]);
+    assert!(urls.iter().all(|url| !url.contains('…')));
+    assert!(serialized_value_chars(&output) <= OUTPUT_MAX_CHARS);
+}
+
+#[test]
 fn web_search_tool_empty_outcome_is_structured_failure_not_success_evidence() {
     let output = web_search_tool_output(
         &WebSearchOutcome {

--- a/qq-maid-core/src/runtime/tools/search/tests.rs
+++ b/qq-maid-core/src/runtime/tools/search/tests.rs
@@ -9,7 +9,7 @@ use std::{
 use async_trait::async_trait;
 
 use qq_maid_llm::{
-    tool::{DEFAULT_TOOL_OUTPUT_MAX_CHARS, ToolRegistry},
+    tool::{DEFAULT_TOOL_OUTPUT_MAX_CHARS, DEFAULT_TOOL_TIMEOUT, ToolRegistry},
     web_search::WebSearchExecutor,
 };
 
@@ -53,6 +53,65 @@ impl WebSearchExecutor for MockWebSearchExecutor {
     }
 }
 
+struct EmptyWebSearchExecutor;
+
+#[async_trait]
+impl WebSearchExecutor for EmptyWebSearchExecutor {
+    async fn query(&self, _req: WebSearchRequest) -> Result<WebSearchOutcome, LlmError> {
+        Ok(WebSearchOutcome {
+            answer: String::new(),
+            sources: Vec::new(),
+            provider: "tavily".to_owned(),
+            elapsed_ms: 12,
+        })
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "tavily"
+    }
+}
+
+struct FailingWebSearchExecutor;
+
+#[async_trait]
+impl WebSearchExecutor for FailingWebSearchExecutor {
+    async fn query(&self, _req: WebSearchRequest) -> Result<WebSearchOutcome, LlmError> {
+        Err(LlmError::new(
+            "tavily_auth_error",
+            "Tavily rejected the configured API key",
+            "tavily_http",
+        ))
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "tavily"
+    }
+}
+
+struct LargeWebSearchExecutor;
+
+#[async_trait]
+impl WebSearchExecutor for LargeWebSearchExecutor {
+    async fn query(&self, _req: WebSearchRequest) -> Result<WebSearchOutcome, LlmError> {
+        Ok(WebSearchOutcome {
+            answer: "昨日 AI 新闻重点。".repeat(220),
+            sources: (0..8)
+                .map(|index| WebSearchSource {
+                    title: format!("来源 {index} {}", "标题".repeat(80)),
+                    url: format!("https://example.com/news/{index}?query={}", "a".repeat(260)),
+                    snippet: "公开报道摘要。".repeat(180),
+                })
+                .collect(),
+            provider: "tavily".to_owned(),
+            elapsed_ms: 12,
+        })
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "tavily"
+    }
+}
+
 fn test_context() -> ToolContext {
     ToolContext {
         task_id: "task-1".to_owned(),
@@ -69,6 +128,8 @@ fn test_context() -> ToolContext {
             interaction_scope_id: "private:u1".to_owned(),
         },
         tool_call_id: None,
+        tool_round: None,
+        retry_of: None,
         execution_deadline: None,
     }
 }
@@ -112,20 +173,131 @@ async fn web_search_tool_reuses_query_executor() {
     assert_eq!(output.value["sources"][0]["url"], "https://example.com");
 }
 
+#[tokio::test]
+async fn tavily_empty_outcome_is_completed_without_tool_execution_failure() {
+    let tool = WebSearchTool::new(Arc::new(EmptyWebSearchExecutor))
+        .with_backend_override(WebSearchBackend::Tavily);
+
+    let output = tool
+        .execute(
+            test_context(),
+            json!({
+                "query": "今日 AI 新闻",
+                "raw_question": "今日 AI 新闻",
+                "max_results": null,
+                "context_size": null,
+                "topic": null,
+                "time_range": null,
+                "research_targets": null,
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(output.value["ok"], false);
+    assert_eq!(output.value["execution_succeeded"], true);
+    assert_eq!(output.value["backend"], "tavily");
+    assert_eq!(output.value["error"]["code"], "empty_result");
+    assert_eq!(
+        output.value["error"]["message"],
+        WEB_SEARCH_EMPTY_RESULT_MODEL_MESSAGE
+    );
+    assert_eq!(output.value["result_count"], 0);
+}
+
+#[tokio::test]
+async fn tavily_execution_failure_remains_retryable_tool_failure() {
+    let tool = WebSearchTool::new(Arc::new(FailingWebSearchExecutor))
+        .with_backend_override(WebSearchBackend::Tavily);
+    let mut context = test_context();
+    context.tool_call_id = Some("agent-call".to_owned());
+
+    let output = tool
+        .execute(
+            context,
+            json!({
+                "query": "今日 AI 新闻",
+                "raw_question": "今日 AI 新闻",
+                "max_results": null,
+                "context_size": null,
+                "topic": null,
+                "time_range": null,
+                "research_targets": null,
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(output.value["ok"], false);
+    assert_eq!(output.value["execution_succeeded"], false);
+    assert_eq!(output.value["backend"], "tavily");
+    assert_eq!(output.value["error"]["code"], "tavily_auth_error");
+    assert_eq!(
+        output.value["error"]["message"],
+        "Tavily rejected the configured API key"
+    );
+    assert_eq!(output.value["error"]["stage"], "tavily_http");
+}
+
+#[tokio::test]
+async fn large_search_result_keeps_structured_evidence_through_tool_registry() {
+    const OUTPUT_MAX_CHARS: usize = 1_200;
+    let registry = ToolRegistry::new()
+        .with_limits(DEFAULT_TOOL_TIMEOUT, OUTPUT_MAX_CHARS)
+        .register(
+            WebSearchTool::new(Arc::new(LargeWebSearchExecutor))
+                .with_backend_override(WebSearchBackend::Tavily)
+                .with_output_max_chars(OUTPUT_MAX_CHARS),
+        )
+        .unwrap();
+    let mut context = test_context();
+    context.tool_call_id = Some("agent-call".to_owned());
+
+    let serialized = registry
+        .execute_json(
+            &context,
+            WEB_SEARCH_TOOL_NAME,
+            r#"{"query":"昨日 AI 新闻","raw_question":"昨日 AI 新闻"}"#,
+        )
+        .await
+        .unwrap();
+    let output: Value = serde_json::from_str(&serialized).unwrap();
+
+    assert_eq!(output["ok"], true);
+    assert_eq!(output["execution_succeeded"], true);
+    assert_eq!(output["result_count"], 8);
+    assert_ne!(output["answer"], "");
+    assert!(!output["sources"].as_array().unwrap().is_empty());
+    assert_ne!(output["truncated"], true);
+    assert!(serialized.chars().count() <= OUTPUT_MAX_CHARS);
+
+    let rendered = crate::runtime::respond::search_flow::format_web_search_tool_reply(&output);
+    assert!(rendered.contains("昨日 AI 新闻重点"));
+    assert!(!rendered.contains("没查到明确结果"));
+}
+
 #[test]
 fn web_search_tool_empty_outcome_is_structured_failure_not_success_evidence() {
-    let output = web_search_tool_output(&WebSearchOutcome {
-        answer: " \n ".to_owned(),
-        sources: Vec::new(),
-        provider: "mock-query".to_owned(),
-        elapsed_ms: 12,
-    });
+    let output = web_search_tool_output(
+        &WebSearchOutcome {
+            answer: " \n ".to_owned(),
+            sources: Vec::new(),
+            provider: "mock-query".to_owned(),
+            elapsed_ms: 12,
+        },
+        "tavily",
+        DEFAULT_TOOL_OUTPUT_MAX_CHARS,
+    );
 
     assert_eq!(output["ok"], false);
     assert_eq!(output["execution_succeeded"], true);
     assert_eq!(output["result_count"], 0);
     assert_eq!(output["error"]["code"], "empty_result");
     assert_eq!(output["error"]["stage"], "web_search");
+    assert_eq!(
+        output["error"]["message"],
+        WEB_SEARCH_EMPTY_RESULT_MODEL_MESSAGE
+    );
 }
 
 #[test]
@@ -729,6 +901,10 @@ async fn multi_entity_research_all_empty_results_keep_execution_success() {
     assert_eq!(output.value["result_count"], 0);
     assert_eq!(output.value["error"]["code"], "empty_result");
     assert_eq!(output.value["error"]["stage"], "web_search");
+    assert_eq!(
+        output.value["error"]["message"],
+        WEB_SEARCH_EMPTY_RESULT_MODEL_MESSAGE
+    );
     assert!(
         output.value["results"]
             .as_array()

--- a/qq-maid-core/src/runtime/tools/search/tests.rs
+++ b/qq-maid-core/src/runtime/tools/search/tests.rs
@@ -544,6 +544,14 @@ impl WebSearchExecutor for ResearchExecutor {
         } else {
             tokio::time::sleep(Duration::from_millis(15)).await;
         }
+        if req.query.contains("无结果") {
+            return Ok(WebSearchOutcome {
+                answer: String::new(),
+                sources: Vec::new(),
+                provider: "research-mock".to_owned(),
+                elapsed_ms: 15,
+            });
+        }
         let _ = delta_tx.send("事实".to_owned()).await;
         let long_result = req.query.contains("长结果");
         Ok(WebSearchOutcome {
@@ -693,6 +701,8 @@ async fn multi_entity_research_reports_all_failed_without_tool_error() {
     assert_eq!(output.value["ok"], false);
     assert_eq!(output.value["successful"], 0);
     assert_eq!(output.value["failed"], 2);
+    assert_eq!(output.value["error"]["code"], "provider_error");
+    assert_eq!(output.value["error"]["stage"], "provider");
     assert!(
         output.value["results"]
             .as_array()
@@ -700,6 +710,51 @@ async fn multi_entity_research_reports_all_failed_without_tool_error() {
             .iter()
             .all(|result| result["status"] == "failed")
     );
+}
+
+#[tokio::test]
+async fn multi_entity_research_all_empty_results_keep_execution_success() {
+    let tool = WebSearchTool::new(Arc::new(ResearchExecutor::default()));
+
+    let output = tool
+        .execute(
+            test_context(),
+            research_arguments(&[("空结果一", "无结果查询一"), ("空结果二", "无结果查询二")]),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(output.value["ok"], false);
+    assert_eq!(output.value["execution_succeeded"], true);
+    assert_eq!(output.value["result_count"], 0);
+    assert_eq!(output.value["error"]["code"], "empty_result");
+    assert_eq!(output.value["error"]["stage"], "web_search");
+    assert!(
+        output.value["results"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|result| result["error"]["code"] == "empty_result")
+    );
+}
+
+#[tokio::test]
+async fn multi_entity_research_real_failure_is_not_masked_by_empty_results() {
+    let tool = WebSearchTool::new(Arc::new(ResearchExecutor::default()));
+
+    let output = tool
+        .execute(
+            test_context(),
+            research_arguments(&[("空结果", "无结果查询"), ("失败项", "失败查询")]),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(output.value["ok"], false);
+    assert_ne!(output.value["execution_succeeded"], true);
+    assert_eq!(output.value["result_count"], 0);
+    assert_eq!(output.value["error"]["code"], "provider_error");
+    assert_eq!(output.value["error"]["stage"], "provider");
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/tools/todo/flow/pending_clarification.rs
+++ b/qq-maid-core/src/runtime/tools/todo/flow/pending_clarification.rs
@@ -197,6 +197,8 @@ pub(super) fn clarification_tool_context(
             interaction_scope_id: session.scope_key.clone(),
         },
         tool_call_id: Some(format!("clarify-{}", session.session_id)),
+        tool_round: None,
+        retry_of: None,
         execution_deadline: None,
     }
 }

--- a/qq-maid-core/src/runtime/tools/todo/pending_tests.rs
+++ b/qq-maid-core/src/runtime/tools/todo/pending_tests.rs
@@ -732,6 +732,8 @@ async fn stable_group_visible_todo_snapshots_are_isolated_by_actor() {
                     interaction_scope_id: format!("{}:actor:u2", stable_group_scope()),
                 },
                 tool_call_id: Some("call-u2-complete".to_owned()),
+                tool_round: None,
+                retry_of: None,
                 execution_deadline: None,
             },
             json!({"numbers": [1], "reference": null}),

--- a/qq-maid-core/src/runtime/tools/todo/tests/support.rs
+++ b/qq-maid-core/src/runtime/tools/todo/tests/support.rs
@@ -16,6 +16,8 @@ pub(super) fn test_context() -> ToolContext {
             interaction_scope_id: "private:u1".to_owned(),
         },
         tool_call_id: Some("call-1".to_owned()),
+        tool_round: None,
+        retry_of: None,
         execution_deadline: None,
     }
 }

--- a/qq-maid-core/src/runtime/tools/train/tool.rs
+++ b/qq-maid-core/src/runtime/tools/train/tool.rs
@@ -301,6 +301,8 @@ mod tests {
                 interaction_scope_id: "private:u1".to_owned(),
             },
             tool_call_id: Some("call-1".to_owned()),
+            tool_round: None,
+            retry_of: None,
             execution_deadline: None,
         }
     }

--- a/qq-maid-core/src/runtime/tools/weather/tool.rs
+++ b/qq-maid-core/src/runtime/tools/weather/tool.rs
@@ -315,6 +315,8 @@ mod tests {
                 interaction_scope_id: "private:u1".to_owned(),
             },
             tool_call_id: None,
+            tool_round: None,
+            retry_of: None,
             execution_deadline: None,
         }
     }

--- a/qq-maid-gateway-rs/src/gateway/qq_official/group/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/qq_official/group/tests.rs
@@ -50,6 +50,28 @@ async fn group_stream_timeout_sends_core_safe_failure_text() {
             .contains_ref_index_id("REFIDX_failure")
     );
 }
+
+#[tokio::test]
+async fn group_stream_collapse_uses_completed_body_without_delta_concat() {
+    let completed = crate::gateway::test_support::respond_response_fixture(
+        "【联网查询】\n\n没查到明确结果。可以换一个关键词再试。",
+    );
+    let stream = FakeGroupEventStream::new([
+        CoreResponseEvent::TextDelta("Reuters、CNBC、TechCrunch 的未经验证新闻正文".to_owned()),
+        CoreResponseEvent::Completed(Box::new(completed)),
+    ]);
+
+    let response = match consume_respond_stream(stream).await {
+        GroupStreamOutcome::Completed(response) => response,
+        other => panic!("expected completed group stream, got {other:?}"),
+    };
+
+    let text = response.text_content().unwrap();
+    assert_eq!(text.matches("没查到明确结果").count(), 1);
+    assert!(!text.contains("Reuters"));
+    assert!(!text.contains("CNBC"));
+    assert!(!text.contains("TechCrunch"));
+}
 use crate::{
     api::{ApiError, GroupReplyTarget, QqApiClient, SendFuture},
     auth::AccessTokenManager,

--- a/qq-maid-llm/src/agent_loop/tests/mod.rs
+++ b/qq-maid-llm/src/agent_loop/tests/mod.rs
@@ -314,6 +314,11 @@ struct LimitedReadOnlyTool {
     calls: Arc<StdMutex<usize>>,
 }
 
+/// 模拟网络请求已完成但没有返回可用证据的只读搜索结果。
+struct EmptyResultReadOnlyTool {
+    calls: Arc<StdMutex<usize>>,
+}
+
 #[async_trait]
 impl crate::tool::Tool for LimitedReadOnlyTool {
     fn metadata(&self) -> ToolMetadata {
@@ -337,6 +342,39 @@ impl crate::tool::Tool for LimitedReadOnlyTool {
         Ok(ToolOutput::json(
             json!({"ok": true, "evidence": arguments["query"]}),
         ))
+    }
+}
+
+#[async_trait]
+impl crate::tool::Tool for EmptyResultReadOnlyTool {
+    fn metadata(&self) -> ToolMetadata {
+        ToolMetadata {
+            name: "web_search".to_owned(),
+            description: "empty result search".to_owned(),
+            parameters: json!({
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn effect(&self) -> ToolEffect {
+        ToolEffect::ReadOnly
+    }
+
+    fn max_calls_per_request(&self) -> Option<usize> {
+        Some(1)
+    }
+
+    async fn execute(&self, _ctx: ToolContext, _arguments: Value) -> Result<ToolOutput, LlmError> {
+        *self.calls.lock().unwrap() += 1;
+        Ok(ToolOutput::json(json!({
+            "ok": false,
+            "execution_succeeded": true,
+            "error": {"code": "empty_result", "stage": "web_search"},
+        })))
     }
 }
 

--- a/qq-maid-llm/src/agent_loop/tests/mod.rs
+++ b/qq-maid-llm/src/agent_loop/tests/mod.rs
@@ -39,6 +39,8 @@ fn test_context() -> ToolContext {
             interaction_scope_id: "private:u1".to_owned(),
         },
         tool_call_id: None,
+        tool_round: None,
+        retry_of: None,
         execution_deadline: None,
     }
 }
@@ -306,8 +308,11 @@ struct NamedSlowReadOnlyTool {
     delay: std::time::Duration,
 }
 
+type ToolAttemptContext = (Option<usize>, Option<usize>);
+
 struct FailOnceReadOnlyTool {
     calls: Arc<StdMutex<usize>>,
+    contexts: Arc<StdMutex<Vec<ToolAttemptContext>>>,
 }
 
 struct LimitedReadOnlyTool {
@@ -408,7 +413,11 @@ impl crate::tool::Tool for FailOnceReadOnlyTool {
         ToolEffect::ReadOnly
     }
 
-    async fn execute(&self, _ctx: ToolContext, arguments: Value) -> Result<ToolOutput, LlmError> {
+    async fn execute(&self, ctx: ToolContext, arguments: Value) -> Result<ToolOutput, LlmError> {
+        self.contexts
+            .lock()
+            .unwrap()
+            .push((ctx.tool_round, ctx.retry_of));
         let mut calls = self.calls.lock().unwrap();
         *calls += 1;
         if *calls == 1 {

--- a/qq-maid-llm/src/agent_loop/tests/mod.rs
+++ b/qq-maid-llm/src/agent_loop/tests/mod.rs
@@ -373,7 +373,18 @@ impl crate::tool::Tool for EmptyResultReadOnlyTool {
         Ok(ToolOutput::json(json!({
             "ok": false,
             "execution_succeeded": true,
+            "mode": "multi_entity_research",
+            "result_count": 0,
             "error": {"code": "empty_result", "stage": "web_search"},
+            "results": [{
+                "entity": "项目甲",
+                "status": "failed",
+                "error": {"code": "empty_result", "stage": "web_search"}
+            }, {
+                "entity": "项目乙",
+                "status": "failed",
+                "error": {"code": "empty_result", "stage": "web_search"}
+            }],
         })))
     }
 }
@@ -432,6 +443,14 @@ impl crate::tool::Tool for NamedSlowReadOnlyTool {
     async fn execute(&self, _ctx: ToolContext, arguments: Value) -> Result<ToolOutput, LlmError> {
         *self.calls.lock().unwrap() += 1;
         tokio::time::sleep(self.delay).await;
+        if self.name == "web_search" {
+            let value = arguments["value"].as_str().unwrap_or_default();
+            return Ok(ToolOutput::json(json!({
+                "ok": true,
+                "answer": format!("{value} 的完整搜索答案"),
+                "sources": [{"title": "搜索来源", "url": "https://example.test/source"}],
+            })));
+        }
         Ok(ToolOutput::json(json!({
             "ok": true,
             "value": arguments["value"],

--- a/qq-maid-llm/src/agent_loop/tests/tool_execution.rs
+++ b/qq-maid-llm/src/agent_loop/tests/tool_execution.rs
@@ -293,6 +293,82 @@ async fn duplicate_web_search_executes_once_and_returns_cache_marker_to_model() 
 }
 
 #[tokio::test]
+async fn empty_result_is_completed_once_without_retry_or_execution_failure() {
+    let calls = Arc::new(StdMutex::new(0));
+    let events = Arc::new(StdMutex::new(Vec::new()));
+    let progress_sink = {
+        let events = events.clone();
+        Arc::new(move |event: ToolLoopProgressEvent| {
+            let events = events.clone();
+            Box::pin(async move {
+                events.lock().unwrap().push(event);
+                Ok(())
+            }) as ToolLoopProgressFuture
+        })
+    };
+    let registry = registry_with(vec![Arc::new(EmptyResultReadOnlyTool {
+        calls: calls.clone(),
+    }) as _]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![tool_call(
+                "web_search",
+                "w1",
+                r#"{"query":"today ai news"}"#,
+            )]),
+            tool_calls(vec![tool_call(
+                "web_search",
+                "w2",
+                r#"{"query":"today ai news"}"#,
+            )]),
+            final_reply("没有新增证据。"),
+        ],
+    ));
+
+    let outcome = run_agent_loop(
+        session,
+        registry,
+        test_context(),
+        3,
+        Some(progress_sink),
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(*calls.lock().unwrap(), 1);
+    assert_eq!(outcome.agent.executed_tools, ["web_search"]);
+    assert_eq!(outcome.agent.tool_results.len(), 2);
+    assert!(
+        outcome
+            .agent
+            .tool_results
+            .iter()
+            .all(|result| result.succeeded)
+    );
+    assert_eq!(outcome.agent.tool_results[0].output["ok"], false);
+    assert_eq!(
+        outcome.agent.tool_results[0].output["execution_succeeded"],
+        true
+    );
+    assert_eq!(outcome.agent.tool_results[1].output["deduplicated"], true);
+    assert_eq!(outcome.agent.tool_attempts[1].retry_of, None);
+    assert_eq!(
+        *events.lock().unwrap(),
+        vec![
+            ToolLoopProgressEvent::ToolCallStarted {
+                tool_name: "web_search".to_owned()
+            },
+            ToolLoopProgressEvent::ToolCallFinished {
+                tool_name: "web_search".to_owned()
+            }
+        ]
+    );
+}
+
+#[tokio::test]
 async fn failed_tool_followed_by_same_singleton_call_is_recorded_as_retry() {
     let calls = Arc::new(StdMutex::new(0));
     let registry = registry_with(vec![Arc::new(FailOnceReadOnlyTool {

--- a/qq-maid-llm/src/agent_loop/tests/tool_execution.rs
+++ b/qq-maid-llm/src/agent_loop/tests/tool_execution.rs
@@ -274,8 +274,22 @@ async fn duplicate_web_search_executes_once_and_returns_cache_marker_to_model() 
     assert_eq!(outcome.agent.executed_tools, ["web_search"]);
     assert_eq!(outcome.agent.tool_results.len(), 2);
     assert_eq!(outcome.agent.tool_attempts.len(), 2);
-    assert_eq!(outcome.agent.tool_results[0].output["value"], "rust");
+    assert_eq!(
+        outcome.agent.tool_results[0].output["answer"],
+        "rust 的完整搜索答案"
+    );
+    assert_eq!(
+        outcome.agent.tool_results[0].output["sources"][0]["title"],
+        "搜索来源"
+    );
     assert_eq!(outcome.agent.tool_results[1].output["deduplicated"], true);
+    assert!(outcome.agent.tool_results[1].output.get("answer").is_none());
+    assert!(
+        outcome.agent.tool_results[1]
+            .output
+            .get("sources")
+            .is_none()
+    );
     assert_eq!(
         *events.lock().unwrap(),
         vec![
@@ -346,7 +360,7 @@ async fn empty_result_is_completed_once_without_retry_or_execution_failure() {
             .agent
             .tool_results
             .iter()
-            .all(|result| result.succeeded)
+            .all(|result| !result.succeeded)
     );
     assert_eq!(outcome.agent.tool_results[0].output["ok"], false);
     assert_eq!(
@@ -365,6 +379,49 @@ async fn empty_result_is_completed_once_without_retry_or_execution_failure() {
                 tool_name: "web_search".to_owned()
             }
         ]
+    );
+}
+
+#[tokio::test]
+async fn execution_success_without_domain_success_skips_dependent_tool() {
+    let empty_calls = Arc::new(StdMutex::new(0));
+    let dependent_calls = Arc::new(StdMutex::new(0));
+    let registry = registry_with(vec![
+        Arc::new(EmptyResultReadOnlyTool {
+            calls: empty_calls.clone(),
+        }) as _,
+        Arc::new(CountingTool {
+            name: "dependent",
+            calls: dependent_calls.clone(),
+            fail: false,
+            soft_fail: false,
+            dependency: ToolCallDependency::PreviousCallSuccess,
+        }) as _,
+    ]);
+    let session = Box::new(ScriptedSession::new(
+        "mock",
+        "m",
+        vec![
+            tool_calls(vec![
+                tool_call("web_search", "w1", r#"{"query":"no evidence"}"#),
+                tool_call("dependent", "d1", r#"{"value":"continue"}"#),
+            ]),
+            final_reply("done"),
+        ],
+    ));
+
+    let outcome = run_agent_loop(session, registry, test_context(), 3, None, None)
+        .await
+        .unwrap();
+
+    assert_eq!(*empty_calls.lock().unwrap(), 1);
+    assert_eq!(*dependent_calls.lock().unwrap(), 0);
+    assert!(!outcome.agent.tool_results[0].succeeded);
+    assert_eq!(outcome.agent.tool_attempts[0].retry_of, None);
+    assert_eq!(outcome.agent.tool_results[1].output["skipped"], true);
+    assert_eq!(
+        outcome.agent.tool_results[1].output["reason"],
+        "dependency_previous_call_failed"
     );
 }
 

--- a/qq-maid-llm/src/agent_loop/tests/tool_execution.rs
+++ b/qq-maid-llm/src/agent_loop/tests/tool_execution.rs
@@ -428,8 +428,10 @@ async fn execution_success_without_domain_success_skips_dependent_tool() {
 #[tokio::test]
 async fn failed_tool_followed_by_same_singleton_call_is_recorded_as_retry() {
     let calls = Arc::new(StdMutex::new(0));
+    let contexts = Arc::new(StdMutex::new(Vec::new()));
     let registry = registry_with(vec![Arc::new(FailOnceReadOnlyTool {
         calls: calls.clone(),
+        contexts: contexts.clone(),
     }) as _]);
     let session = Box::new(ScriptedSession::new(
         "mock",
@@ -452,6 +454,10 @@ async fn failed_tool_followed_by_same_singleton_call_is_recorded_as_retry() {
     assert_eq!(outcome.agent.tool_attempts.len(), 2);
     assert_eq!(outcome.agent.tool_attempts[0].retry_of, None);
     assert_eq!(outcome.agent.tool_attempts[1].retry_of, Some(0));
+    assert_eq!(
+        *contexts.lock().unwrap(),
+        [(Some(0), None), (Some(1), Some(0))]
+    );
 }
 
 #[tokio::test]
@@ -497,6 +503,7 @@ async fn cross_candidate_retry_indexes_are_offset_to_global() {
     let calls_b = Arc::new(StdMutex::new(0));
     let registry_b = registry_with(vec![Arc::new(FailOnceReadOnlyTool {
         calls: calls_b.clone(),
+        contexts: Arc::new(StdMutex::new(Vec::new())),
     }) as _]);
     let outcome = run_agent_loop_with_handle(
         Box::new(ScriptedSession::new(
@@ -542,6 +549,7 @@ async fn independent_same_round_calls_are_not_recorded_as_retry() {
     let calls = Arc::new(StdMutex::new(0));
     let registry = registry_with(vec![Arc::new(FailOnceReadOnlyTool {
         calls: calls.clone(),
+        contexts: Arc::new(StdMutex::new(Vec::new())),
     }) as _]);
     let session = Box::new(ScriptedSession::new(
         "mock",

--- a/qq-maid-llm/src/provider/openai/tool_loop/tests/mod.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/tests/mod.rs
@@ -92,6 +92,8 @@ fn test_context() -> ToolContext {
             interaction_scope_id: "private:u1".to_owned(),
         },
         tool_call_id: None,
+        tool_round: None,
+        retry_of: None,
         execution_deadline: None,
     }
 }

--- a/qq-maid-llm/src/provider/test_support.rs
+++ b/qq-maid-llm/src/provider/test_support.rs
@@ -81,6 +81,8 @@ pub(crate) fn test_tool_context() -> ToolContext {
             interaction_scope_id: "private:u1".to_owned(),
         },
         tool_call_id: None,
+        tool_round: None,
+        retry_of: None,
         execution_deadline: None,
     }
 }

--- a/qq-maid-llm/src/provider/tests/mod.rs
+++ b/qq-maid-llm/src/provider/tests/mod.rs
@@ -357,6 +357,8 @@ fn tool_request() -> ToolChatRequest {
                 interaction_scope_id: "private:u1".to_owned(),
             },
             tool_call_id: None,
+            tool_round: None,
+            retry_of: None,
             execution_deadline: None,
         },
         max_rounds: 3,

--- a/qq-maid-llm/src/provider/tool_loop.rs
+++ b/qq-maid-llm/src/provider/tool_loop.rs
@@ -150,7 +150,7 @@ impl<'a> ToolLoopExecutor<'a> {
     ) -> Result<ToolLoopCallOutput, LlmError> {
         let PreparedToolLoopCall {
             tool_name: requested_tool_name,
-            prepared,
+            mut prepared,
             call_id,
             round,
             batch_len,
@@ -170,6 +170,12 @@ impl<'a> ToolLoopExecutor<'a> {
                 .as_ref()
                 .map(|(name, arguments)| (name.as_str(), arguments)),
         );
+        if let Ok(prepared) = prepared.as_mut() {
+            // 轮次与重试关系属于执行器协议元数据；业务 Tool 只读取它们做低敏诊断，
+            // 不得据此改变领域执行语义。
+            prepared.context.tool_round = Some(round);
+            prepared.context.retry_of = retry_of;
+        }
         let (tool_name, output, domain_succeeded, execution_succeeded, progress_disposition) =
             match prepared {
                 Ok(prepared) => {

--- a/qq-maid-llm/src/provider/tool_loop.rs
+++ b/qq-maid-llm/src/provider/tool_loop.rs
@@ -423,12 +423,14 @@ fn tool_skip_output(reason: &str) -> String {
 }
 
 fn tool_output_indicates_success(output: &str) -> bool {
-    // 业务工具失败统一约定为 {"ok":false,...}；这里不理解具体业务字段，
-    // 只把明确失败用于依赖跳过和通用执行轨迹。
-    serde_json::from_str::<Value>(output)
-        .ok()
-        .and_then(|value| value.get("ok").and_then(Value::as_bool))
-        .unwrap_or(true)
+    // `ok` 表示领域目标是否达成；少数只读查询可正常完成却没有可用证据。
+    // 此时以 `execution_succeeded` 保留执行成功语义，避免进入通用失败重试、
+    // 依赖跳过和错误进度分支；领域层仍须按 `ok:false` 处理无结果。
+    let Ok(value) = serde_json::from_str::<Value>(output) else {
+        return true;
+    };
+    value.get("ok").and_then(Value::as_bool) != Some(false)
+        || value.get("execution_succeeded").and_then(Value::as_bool) == Some(true)
 }
 
 fn tool_execution_result(name: &str, output: &str, succeeded: bool) -> ToolExecutionResult {
@@ -441,13 +443,16 @@ fn tool_execution_result(name: &str, output: &str, succeeded: bool) -> ToolExecu
 }
 
 fn compact_cached_output(output: &str) -> String {
-    // 保留成功语义和去重标记，不重复注入首次检索的完整证据。
-    serde_json::to_string(&json!({
-        "ok": true,
-        "deduplicated": true,
-        "message": "已使用本次请求中相同检索的已有证据。",
-    }))
-    .unwrap_or_else(|_| output.to_owned())
+    // 缓存命中必须保留原始领域状态；例如 empty_result 的 ok:false 不能在这里被
+    // 改写成成功证据。只增加通用去重标记，避免再次真实执行相同的只读调用。
+    let Ok(mut value) = serde_json::from_str::<Value>(output) else {
+        return output.to_owned();
+    };
+    let Some(object) = value.as_object_mut() else {
+        return output.to_owned();
+    };
+    object.insert("deduplicated".to_owned(), Value::Bool(true));
+    serde_json::to_string(&value).unwrap_or_else(|_| output.to_owned())
 }
 
 fn tool_limit_output(limit: usize) -> String {

--- a/qq-maid-llm/src/provider/tool_loop.rs
+++ b/qq-maid-llm/src/provider/tool_loop.rs
@@ -75,7 +75,7 @@ struct BatchAttempt {
     call_id: String,
     name: String,
     arguments: Value,
-    succeeded: bool,
+    execution_succeeded: bool,
     executed: bool,
     round: usize,
 }
@@ -170,120 +170,135 @@ impl<'a> ToolLoopExecutor<'a> {
                 .as_ref()
                 .map(|(name, arguments)| (name.as_str(), arguments)),
         );
-        let (tool_name, output, succeeded, progress_disposition) = match prepared {
-            Ok(prepared) => {
-                let tool_name = prepared.name.clone();
-                let read_only_key = prepared
-                    .deduplication_key
-                    .as_ref()
-                    .map(|key| format!("{}:{key}", prepared.name));
-                if let Some(cached_output) = read_only_key
-                    .as_ref()
-                    .and_then(|key| self.completed_read_only_calls.get(key))
-                {
-                    // 缓存只保存已明确成功的只读结果；命中只回传紧凑引用，避免把
-                    // 完整证据再次写入上下文。缓存命中不增加真实执行次数。
-                    debug!(tool = %tool_name, "agent read-only tool cache hit");
-                    (
-                        tool_name,
-                        compact_cached_output(cached_output),
-                        true,
-                        ToolCallProgressDisposition::CacheHit,
-                    )
-                } else if prepared.max_calls_per_request.is_some_and(|limit| {
-                    self.execution_counts.get(&tool_name).copied().unwrap_or(0) >= limit
-                }) {
-                    // 达到请求级上限只拒绝当前工具调用；同批次其他工具仍需执行。
-                    // 下一轮由上层根据该标记切换到无工具最终回答。
-                    tracing::warn!(
-                        tool = %tool_name,
-                        executions = self.execution_counts.get(&tool_name).copied().unwrap_or(0),
-                        max_executions = prepared.max_calls_per_request,
-                        force_finalization = true,
-                        "tool execution limit reached"
-                    );
-                    skipped_for_finalization = true;
-                    (
-                        tool_name,
-                        tool_limit_output(prepared.max_calls_per_request.unwrap_or(0)),
-                        false,
-                        ToolCallProgressDisposition::FailedBeforeExecution,
-                    )
-                } else if prepared.dependency == ToolCallDependency::PreviousCallSuccess
-                    && !self.previous_call_succeeded
-                {
-                    (
-                        tool_name,
-                        tool_skip_output("dependency_previous_call_failed"),
-                        false,
-                        ToolCallProgressDisposition::FailedBeforeExecution,
-                    )
-                } else {
-                    match before_start(&tool_name, prepared.effect)? {
-                        ToolCallStartDecision::SkipForFinalAnswer => {
-                            skipped_for_finalization = true;
-                            stop_remaining_batch = true;
-                            (
-                                tool_name,
-                                tool_skip_output("request_budget_reserved_for_final_answer"),
-                                false,
-                                ToolCallProgressDisposition::FailedBeforeExecution,
-                            )
-                        }
-                        ToolCallStartDecision::Execute => {
-                            tool_started = true;
-                            self.emit_progress(ToolLoopProgressEvent::ToolCallStarted {
-                                tool_name: tool_name.clone(),
-                            })
-                            .await?;
-                            // progress await 返回后仍需在共享生命周期锁内重新检查取消；只有
-                            // 原子启动转换成功，才创建工具 future 并越过副作用边界。
-                            on_started(&tool_name, prepared.effect)?;
-                            *self.execution_counts.entry(tool_name.clone()).or_default() += 1;
-                            if prepared.effect == ToolEffect::SideEffecting {
-                                // 写操作可能改变后续查询结果；只读去重只能跨越没有状态变化的
-                                // 连续查询段，不能让“查询 -> 修改 -> 再查询”复用旧判断。
-                                self.completed_read_only_calls.clear();
-                            }
-                            self.executed_tools.push(tool_name.clone());
-                            match self.tools.execute_prepared(prepared).await {
-                                Ok(output) => {
-                                    let succeeded = tool_output_indicates_success(&output);
-                                    if succeeded && let Some(key) = read_only_key {
-                                        self.completed_read_only_calls.insert(key, output.clone());
-                                    }
-                                    (
-                                        tool_name,
-                                        output,
-                                        succeeded,
-                                        ToolCallProgressDisposition::Executed,
-                                    )
-                                }
-                                Err(err) => (
+        let (tool_name, output, domain_succeeded, execution_succeeded, progress_disposition) =
+            match prepared {
+                Ok(prepared) => {
+                    let tool_name = prepared.name.clone();
+                    let read_only_key = prepared
+                        .deduplication_key
+                        .as_ref()
+                        .map(|key| format!("{}:{key}", prepared.name));
+                    if let Some(cached_output) = read_only_key
+                        .as_ref()
+                        .and_then(|key| self.completed_read_only_calls.get(key))
+                    {
+                        // 缓存只保存已完成的只读结果；命中只回传紧凑引用，避免把
+                        // 完整证据再次写入上下文。缓存命中不增加真实执行次数。
+                        debug!(tool = %tool_name, "agent read-only tool cache hit");
+                        let output = compact_cached_output(cached_output);
+                        (
+                            tool_name,
+                            output.clone(),
+                            tool_output_indicates_domain_success(&output),
+                            true,
+                            ToolCallProgressDisposition::CacheHit,
+                        )
+                    } else if prepared.max_calls_per_request.is_some_and(|limit| {
+                        self.execution_counts.get(&tool_name).copied().unwrap_or(0) >= limit
+                    }) {
+                        // 达到请求级上限只拒绝当前工具调用；同批次其他工具仍需执行。
+                        // 下一轮由上层根据该标记切换到无工具最终回答。
+                        tracing::warn!(
+                            tool = %tool_name,
+                            executions = self.execution_counts.get(&tool_name).copied().unwrap_or(0),
+                            max_executions = prepared.max_calls_per_request,
+                            force_finalization = true,
+                            "tool execution limit reached"
+                        );
+                        skipped_for_finalization = true;
+                        (
+                            tool_name,
+                            tool_limit_output(prepared.max_calls_per_request.unwrap_or(0)),
+                            false,
+                            false,
+                            ToolCallProgressDisposition::FailedBeforeExecution,
+                        )
+                    } else if prepared.dependency == ToolCallDependency::PreviousCallSuccess
+                        && !self.previous_call_succeeded
+                    {
+                        (
+                            tool_name,
+                            tool_skip_output("dependency_previous_call_failed"),
+                            false,
+                            false,
+                            ToolCallProgressDisposition::FailedBeforeExecution,
+                        )
+                    } else {
+                        match before_start(&tool_name, prepared.effect)? {
+                            ToolCallStartDecision::SkipForFinalAnswer => {
+                                skipped_for_finalization = true;
+                                stop_remaining_batch = true;
+                                (
                                     tool_name,
-                                    tool_error_output(&err),
+                                    tool_skip_output("request_budget_reserved_for_final_answer"),
                                     false,
-                                    ToolCallProgressDisposition::Executed,
-                                ),
+                                    false,
+                                    ToolCallProgressDisposition::FailedBeforeExecution,
+                                )
+                            }
+                            ToolCallStartDecision::Execute => {
+                                tool_started = true;
+                                self.emit_progress(ToolLoopProgressEvent::ToolCallStarted {
+                                    tool_name: tool_name.clone(),
+                                })
+                                .await?;
+                                // progress await 返回后仍需在共享生命周期锁内重新检查取消；只有
+                                // 原子启动转换成功，才创建工具 future 并越过副作用边界。
+                                on_started(&tool_name, prepared.effect)?;
+                                *self.execution_counts.entry(tool_name.clone()).or_default() += 1;
+                                if prepared.effect == ToolEffect::SideEffecting {
+                                    // 写操作可能改变后续查询结果；只读去重只能跨越没有状态变化的
+                                    // 连续查询段，不能让“查询 -> 修改 -> 再查询”复用旧判断。
+                                    self.completed_read_only_calls.clear();
+                                }
+                                self.executed_tools.push(tool_name.clone());
+                                match self.tools.execute_prepared(prepared).await {
+                                    Ok(output) => {
+                                        let domain_succeeded =
+                                            tool_output_indicates_domain_success(&output);
+                                        let execution_succeeded =
+                                            tool_output_indicates_execution_success(&output);
+                                        if execution_succeeded && let Some(key) = read_only_key {
+                                            self.completed_read_only_calls
+                                                .insert(key, output.clone());
+                                        }
+                                        (
+                                            tool_name,
+                                            output,
+                                            domain_succeeded,
+                                            execution_succeeded,
+                                            ToolCallProgressDisposition::Executed,
+                                        )
+                                    }
+                                    Err(err) => (
+                                        tool_name,
+                                        tool_error_output(&err),
+                                        false,
+                                        false,
+                                        ToolCallProgressDisposition::Executed,
+                                    ),
+                                }
                             }
                         }
                     }
                 }
-            }
-            Err(err) => {
-                self.rejected_call = true;
-                (
-                    requested_tool_name,
-                    tool_error_output(&err),
-                    false,
-                    ToolCallProgressDisposition::FailedBeforeExecution,
-                )
-            }
-        };
-        self.previous_call_succeeded = succeeded;
+                Err(err) => {
+                    self.rejected_call = true;
+                    (
+                        requested_tool_name,
+                        tool_error_output(&err),
+                        false,
+                        false,
+                        ToolCallProgressDisposition::FailedBeforeExecution,
+                    )
+                }
+            };
+        // 前序依赖只能使用领域成功。`empty_result` 虽然已完成网络请求，但不能成为
+        // 依赖工具继续执行的事实依据。
+        self.previous_call_succeeded = domain_succeeded;
         let event = match progress_disposition {
             ToolCallProgressDisposition::CacheHit => None,
-            ToolCallProgressDisposition::Executed if succeeded => {
+            ToolCallProgressDisposition::Executed if execution_succeeded => {
                 Some(ToolLoopProgressEvent::ToolCallFinished {
                     tool_name: tool_name.clone(),
                 })
@@ -295,7 +310,7 @@ impl<'a> ToolLoopExecutor<'a> {
                 })
             }
         };
-        let result = tool_execution_result(&tool_name, &output, succeeded);
+        let result = tool_execution_result(&tool_name, &output, domain_succeeded);
         let result_index = self.tool_results.len();
         self.tool_results.push(result.clone());
         self.tool_attempts.push(ToolExecutionAttempt {
@@ -310,7 +325,7 @@ impl<'a> ToolLoopExecutor<'a> {
                 call_id,
                 name,
                 arguments,
-                succeeded,
+                execution_succeeded,
                 executed: tool_started,
                 round,
             });
@@ -372,7 +387,7 @@ impl<'a> ToolLoopExecutor<'a> {
         }
         let previous = &self.last_batch[0];
         let (name, arguments) = prepared?;
-        if previous.succeeded
+        if previous.execution_succeeded
             || !previous.executed
             || previous.round + 1 != round
             || previous.name != name
@@ -422,15 +437,22 @@ fn tool_skip_output(reason: &str) -> String {
     })
 }
 
-fn tool_output_indicates_success(output: &str) -> bool {
-    // `ok` 表示领域目标是否达成；少数只读查询可正常完成却没有可用证据。
-    // 此时以 `execution_succeeded` 保留执行成功语义，避免进入通用失败重试、
-    // 依赖跳过和错误进度分支；领域层仍须按 `ok:false` 处理无结果。
+fn tool_output_indicates_domain_success(output: &str) -> bool {
+    // `ok` 是工具领域目标是否达成的唯一依据，依赖工具和最终结果诊断均使用它。
     let Ok(value) = serde_json::from_str::<Value>(output) else {
         return true;
     };
     value.get("ok").and_then(Value::as_bool) != Some(false)
-        || value.get("execution_succeeded").and_then(Value::as_bool) == Some(true)
+}
+
+fn tool_output_indicates_execution_success(output: &str) -> bool {
+    // 空结果等可预期的只读查询完成状态会显式标记 execution_succeeded；它们可缓存、
+    // 不应重试，也应发送 Finished 进度，但不等同于领域成功。
+    let Ok(value) = serde_json::from_str::<Value>(output) else {
+        return true;
+    };
+    value.get("execution_succeeded").and_then(Value::as_bool) == Some(true)
+        || value.get("ok").and_then(Value::as_bool) != Some(false)
 }
 
 fn tool_execution_result(name: &str, output: &str, succeeded: bool) -> ToolExecutionResult {
@@ -443,16 +465,27 @@ fn tool_execution_result(name: &str, output: &str, succeeded: bool) -> ToolExecu
 }
 
 fn compact_cached_output(output: &str) -> String {
-    // 缓存命中必须保留原始领域状态；例如 empty_result 的 ok:false 不能在这里被
-    // 改写成成功证据。只增加通用去重标记，避免再次真实执行相同的只读调用。
-    let Ok(mut value) = serde_json::from_str::<Value>(output) else {
+    // 缓存命中只回传执行与领域状态，不把先前已回填给模型的完整答案、来源或原始
+    // 结果重复注入上下文。empty_result 必须保留其可预期空结果语义。
+    let Ok(value) = serde_json::from_str::<Value>(output) else {
         return output.to_owned();
     };
-    let Some(object) = value.as_object_mut() else {
+    let Some(object) = value.as_object() else {
         return output.to_owned();
     };
-    object.insert("deduplicated".to_owned(), Value::Bool(true));
-    serde_json::to_string(&value).unwrap_or_else(|_| output.to_owned())
+    let compact = if !tool_output_indicates_domain_success(output)
+        && tool_output_indicates_execution_success(output)
+    {
+        json!({
+            "ok": false,
+            "execution_succeeded": true,
+            "error": object.get("error").cloned().unwrap_or(Value::Null),
+            "deduplicated": true,
+        })
+    } else {
+        json!({"ok": true, "deduplicated": true})
+    };
+    serde_json::to_string(&compact).unwrap_or_else(|_| output.to_owned())
 }
 
 fn tool_limit_output(limit: usize) -> String {

--- a/qq-maid-llm/src/tool.rs
+++ b/qq-maid-llm/src/tool.rs
@@ -66,6 +66,10 @@ pub struct ToolContext {
     pub conversation: ExecutionConversationContext,
     /// 当前工具调用的稳定标识；由上游 Tool Loop 生成，用于幂等去重与审计关联。
     pub tool_call_id: Option<String>,
+    /// 当前 Tool Loop 轮次；非 Agent 兼容入口为 None，仅用于低敏诊断关联。
+    pub tool_round: Option<usize>,
+    /// 当前调用重试所替代的结果下标；非重试或非 Agent 兼容入口为 None。
+    pub retry_of: Option<usize>,
     /// 只读工具本次允许执行到的最晚时刻；由 Agent Runtime 从请求 deadline
     /// 扣除最终回答预留后注入，模型参数不能覆盖。非 Agent 兼容入口为 None。
     pub execution_deadline: Option<Instant>,
@@ -519,6 +523,8 @@ mod tests {
                 interaction_scope_id: "private:u1".to_owned(),
             },
             tool_call_id: None,
+            tool_round: None,
+            retry_of: None,
             execution_deadline: None,
         }
     }

--- a/qq-maid-llm/src/web_search/tavily.rs
+++ b/qq-maid-llm/src/web_search/tavily.rs
@@ -5,6 +5,7 @@ use reqwest::{StatusCode, Url};
 use serde::{Deserialize, Serialize};
 
 use crate::{error::LlmError, metrics::duration_ms};
+use qq_maid_common::time_context::{RequestTimeContext, request_time_context};
 
 use super::{
     MAX_RESULTS_LIMIT, WebSearchConfig, WebSearchExecutor, WebSearchOutcome, WebSearchRequest,
@@ -94,17 +95,13 @@ impl WebSearchExecutor for TavilyWebSearchExecutor {
         }
 
         let started = Instant::now();
-        let topic = request_topic(req.topic.as_deref(), self.config.topic)?;
-        let time_range = request_time_range(req.time_range.as_deref(), self.config.time_range)?;
+        let options = tavily_request_options(&req, &self.config, &request_time_context())?;
         let payload = TavilySearchRequest {
-            query,
+            query: &options.query,
             search_depth: self.config.search_depth.as_str(),
-            max_results: req
-                .max_results
-                .unwrap_or(self.config.max_results)
-                .clamp(1, MAX_RESULTS_LIMIT),
-            topic: topic.as_str(),
-            time_range: time_range.map(WebSearchTimeRange::as_str),
+            max_results: options.max_results,
+            topic: options.topic.as_str(),
+            time_range: options.time_range.map(WebSearchTimeRange::as_str),
             include_answer: "basic",
             include_raw_content: false,
             include_images: false,
@@ -128,11 +125,14 @@ impl WebSearchExecutor for TavilyWebSearchExecutor {
         })?;
         let sources = tavily_sources(body.results, usize::from(payload.max_results));
         if sources.is_empty() {
-            return Err(LlmError::new(
-                "empty_result",
-                "Tavily search returned no usable results",
-                "tavily_search",
-            ));
+            // HTTP 与协议都已成功；没有可引用网页是业务空结果，必须让 Core 统一投影为
+            // `ok:false + execution_succeeded:true`，不能伪装成可重试的执行故障。
+            return Ok(WebSearchOutcome {
+                answer: String::new(),
+                sources,
+                provider: "tavily".to_owned(),
+                elapsed_ms: duration_ms(started.elapsed()),
+            });
         }
 
         Ok(WebSearchOutcome {
@@ -146,6 +146,93 @@ impl WebSearchExecutor for TavilyWebSearchExecutor {
     fn provider_name(&self) -> &'static str {
         "tavily"
     }
+}
+
+struct TavilyRequestOptions {
+    query: String,
+    max_results: u8,
+    topic: WebSearchTopic,
+    time_range: Option<WebSearchTimeRange>,
+}
+
+fn tavily_request_options(
+    req: &WebSearchRequest,
+    config: &WebSearchConfig,
+    time_context: &RequestTimeContext,
+) -> Result<TavilyRequestOptions, LlmError> {
+    let query = req.query.trim();
+    let semantic_text = req
+        .raw_question
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(query);
+    let current_news = is_current_news_request(query, semantic_text);
+    let topic = match req.topic.as_deref() {
+        Some(value) => request_topic(Some(value), config.topic)?,
+        None if current_news => WebSearchTopic::News,
+        None => config.topic,
+    };
+    let time_range = match req.time_range.as_deref() {
+        Some(value) => request_time_range(Some(value), config.time_range)?,
+        None if current_news => Some(WebSearchTimeRange::Day),
+        None => config.time_range,
+    };
+
+    Ok(TavilyRequestOptions {
+        // Provider 原生后端需要长提示词来约束模型；Tavily 只接收检索词，
+        // 因此仅补入服务端已解析的日期，避免把聊天上下文误传给第三方搜索。
+        query: tavily_query_with_resolved_date(query, semantic_text, time_context),
+        max_results: req
+            .max_results
+            .unwrap_or(config.max_results)
+            .clamp(1, MAX_RESULTS_LIMIT),
+        topic,
+        time_range,
+    })
+}
+
+fn tavily_query_with_resolved_date(
+    query: &str,
+    semantic_text: &str,
+    time_context: &RequestTimeContext,
+) -> String {
+    let resolved = time_context.resolve_relative_time_text(semantic_text);
+    let resolved = if resolved.is_empty() {
+        time_context.resolve_relative_time_text(query)
+    } else {
+        resolved
+    };
+    let date_hint = resolved
+        .first()
+        .map(|item| item.value.as_str())
+        .or_else(|| {
+            (is_current_time_request(query) || is_current_time_request(semantic_text))
+                .then_some(time_context.current_date())
+        });
+    date_hint
+        .map(|date| format!("{query} {date}"))
+        .unwrap_or_else(|| query.to_owned())
+}
+
+fn is_current_news_request(query: &str, semantic_text: &str) -> bool {
+    (has_news_intent(query) || has_news_intent(semantic_text))
+        && (is_current_time_request(query) || is_current_time_request(semantic_text))
+}
+
+fn has_news_intent(value: &str) -> bool {
+    let value = value.to_ascii_lowercase();
+    ["新闻", "资讯", "报道", "news"]
+        .iter()
+        .any(|term| value.contains(term))
+}
+
+fn is_current_time_request(value: &str) -> bool {
+    let value = value.to_ascii_lowercase();
+    [
+        "今天", "今日", "最新", "最近", "近日", "today", "latest", "recent",
+    ]
+    .iter()
+    .any(|term| value.contains(term))
 }
 
 #[derive(Serialize)]
@@ -343,6 +430,7 @@ mod tests {
         response::IntoResponse,
         routing::post,
     };
+    use chrono::{FixedOffset, TimeZone};
     use serde_json::{Value, json};
     use std::sync::Arc;
     use tokio::{net::TcpListener, sync::Mutex};
@@ -445,7 +533,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn query_classifies_auth_quota_and_empty_results() {
+    async fn query_classifies_auth_quota_and_keeps_empty_results_completed() {
         let (executor, _) = test_executor(401, json!({"detail": "invalid key"})).await;
         assert_eq!(
             executor.query(request()).await.unwrap_err().code,
@@ -465,10 +553,34 @@ mod tests {
         );
 
         let (executor, _) = test_executor(200, json!({"results": []})).await;
-        assert_eq!(
-            executor.query(request()).await.unwrap_err().code,
-            "empty_result"
+        let outcome = executor.query(request()).await.unwrap();
+        assert!(outcome.answer.is_empty());
+        assert!(outcome.sources.is_empty());
+    }
+
+    #[test]
+    fn current_news_query_is_date_resolved_with_news_defaults() {
+        let offset = FixedOffset::east_opt(8 * 60 * 60).unwrap();
+        let context = RequestTimeContext::from_datetime(
+            offset.with_ymd_and_hms(2026, 7, 25, 9, 30, 0).unwrap(),
         );
+        let request = WebSearchRequest {
+            query: "今日 AI 新闻".to_owned(),
+            raw_question: Some("请查今日 AI 新闻".to_owned()),
+            max_results: None,
+            context_size: None,
+            topic: None,
+            time_range: None,
+            backend_override: None,
+            model_override: None,
+        };
+
+        let options =
+            tavily_request_options(&request, &WebSearchConfig::default(), &context).unwrap();
+
+        assert!(options.query.contains("2026-07-25"));
+        assert_eq!(options.topic, WebSearchTopic::News);
+        assert_eq!(options.time_range, Some(WebSearchTimeRange::Day));
     }
 
     #[tokio::test]

--- a/qq-maid-llm/src/web_search/tavily.rs
+++ b/qq-maid-llm/src/web_search/tavily.rs
@@ -228,11 +228,9 @@ fn has_news_intent(value: &str) -> bool {
 
 fn is_current_time_request(value: &str) -> bool {
     let value = value.to_ascii_lowercase();
-    [
-        "今天", "今日", "最新", "最近", "近日", "today", "latest", "recent",
-    ]
-    .iter()
-    .any(|term| value.contains(term))
+    ["今天", "今日", "最新", "today", "latest"]
+        .iter()
+        .any(|term| value.contains(term))
 }
 
 #[derive(Serialize)]
@@ -581,6 +579,35 @@ mod tests {
         assert!(options.query.contains("2026-07-25"));
         assert_eq!(options.topic, WebSearchTopic::News);
         assert_eq!(options.time_range, Some(WebSearchTimeRange::Day));
+    }
+
+    #[test]
+    fn recent_news_query_does_not_force_day_defaults() {
+        let context = RequestTimeContext::from_datetime(
+            FixedOffset::east_opt(8 * 60 * 60)
+                .unwrap()
+                .with_ymd_and_hms(2026, 7, 25, 9, 30, 0)
+                .unwrap(),
+        );
+
+        for query in ["最近 AI 新闻", "近日 AI 新闻", "recent AI news"] {
+            let request = WebSearchRequest {
+                query: query.to_owned(),
+                raw_question: None,
+                max_results: None,
+                context_size: None,
+                topic: None,
+                time_range: None,
+                backend_override: None,
+                model_override: None,
+            };
+
+            let options =
+                tavily_request_options(&request, &WebSearchConfig::default(), &context).unwrap();
+
+            assert_eq!(options.topic, WebSearchTopic::General, "{query}");
+            assert_eq!(options.time_range, None, "{query}");
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 修复内容

- 保留 Tool Loop 已生成的 `final_text`：全部搜索为空时仅去重展示一次“没查到明确结果”，再按通用聚合规则拼接非空最终回复；最终回复为空白时不补空段。
- 将无 answer 且无有效来源的 `web_search` 输出结构化为 `empty_result`，并回填简短说明，帮助模型明确本轮没有联网证据。
- 区分搜索领域结果与网络执行状态：Tavily 正常空结果标记为执行完成，不触发失败进度或无意义重试；真实网络、鉴权和解析失败仍可重试。
- 有效搜索继续展示事实卡并保留模型总结，兼容嵌套证据、私聊流式和群聊 `Completed` 聚合。
- 搜索结果超过 Tool 字符预算时，在搜索领域内压缩重复 answer/source 文本，保留 `ok`、`answer`、`sources` 和 `result_count`，避免通用 `truncated` preview 让有效证据被误判为空。
- Tavily 当前新闻查询补充服务端解析日期，并默认使用 news/day 搜索参数。

## 根因

空搜索此前会被最终结果聚合覆盖，导致 Tool Loop 已生成的 `final_text` 被丢弃。修复后又发现另一条独立触发链：Tavily 日志显示 8 条有效结果，但完整工具 JSON 超过 `AGENT_TOOL_RESULT_CHAR_LIMIT` 后被 Tool Registry 替换成只含 preview 的通用 `truncated` 输出；搜索投影看不到 `answer/sources`，因此错误展示空结果提示。

## 用户影响

- 空搜索仍会明确提示没有联网证据，同时保留模型本轮已经生成的非空最终回复。
- 多次空搜索只显示一次提示，空白最终回复不会产生额外段落。
- 有效搜索即使返回较长内容，也不会再因通用截断丢失事实卡。
- Tavily 空结果不再被当作网络故障重试。

## 验证

- `cargo test -p qq-maid-core --all-features runtime::tools::search::tests`（22 项通过）
- `cargo test -p qq-maid-core --all-features agent_turn::web_search`（12 项通过）
- `cargo test -p qq-maid-core --all-features runtime::tools::search::agent_turn::tests`（8 项通过）
- `cargo check -p qq-maid-core --all-features`
- `cargo clippy -p qq-maid-core --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

未执行真实 Tavily 请求、workspace 全量测试和 release 构建；GitHub CI 正在运行。
