### PR TITLE
[codex] 忽略群聊全体成员 mention

### DIFF
--- a/qq-maid-gateway-rs/src/gateway/event/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/event/mod.rs
@@ -253,6 +253,9 @@ struct RawMention {
     /// 部分 QQ 全量群事件仍带有该兼容字段；稳定 target_id 存在时由 Gateway 优先校验 ID。
     #[serde(default)]
     is_you: Option<bool>,
+    /// `all` 表示 @全体成员。QQ 可能同时下发 `is_you=true`，但这不代表单独 @ 当前机器人。
+    #[serde(default)]
+    scope: Option<String>,
     /// QQ 全量群事件可能同时标记被提及者是否为机器人；仅用于约束兼容 is_you 证据。
     #[serde(default)]
     bot: Option<bool>,
@@ -431,22 +434,33 @@ fn resolve_group_member_role(
 }
 
 fn raw_group_mention(mention: &RawMention) -> GroupMention {
+    let is_everyone = mention
+        .scope
+        .as_deref()
+        .is_some_and(|scope| scope.trim().eq_ignore_ascii_case("all"));
     GroupMention {
         // 没有稳定 ID 时暂存协议兼容标记；明确标记为普通成员时不接受 is_you，避免
-        // 把普通成员误认为当前机器人。bot 缺失时保留旧 QQ 事件兼容行为。
-        is_current_bot: mention.is_you.unwrap_or(false) && mention.bot != Some(false),
+        // 把普通成员误认为当前机器人。@全体成员即使带 is_you=true 也不得触发机器人。
+        // bot 缺失时保留旧 QQ 事件兼容行为。
+        is_current_bot: !is_everyone
+            && mention.is_you.unwrap_or(false)
+            && mention.bot != Some(false),
         member_role: mention
             .member_role
             .as_deref()
             .map(GroupMemberRole::from_raw),
         // 群场景优先 member openid，其次 user openid / openid / id；
-        // 都缺失时返回 None，普通群消息无法确认该 mention 指向当前机器人。
-        target_id: first_non_empty([
-            mention.member_openid.as_deref(),
-            mention.user_openid.as_deref(),
-            mention.openid.as_deref(),
-            mention.mention_id.as_deref(),
-        ]),
+        // @全体成员不绑定单个身份，必须丢弃可能伴随下发的兼容 ID，避免后续误判。
+        target_id: if is_everyone {
+            None
+        } else {
+            first_non_empty([
+                mention.member_openid.as_deref(),
+                mention.user_openid.as_deref(),
+                mention.openid.as_deref(),
+                mention.mention_id.as_deref(),
+            ])
+        },
     }
 }
 

--- a/qq-maid-gateway-rs/src/gateway/event/tests/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/event/tests/mod.rs
@@ -410,6 +410,42 @@ fn does_not_accept_is_you_for_a_mention_explicitly_marked_as_member() {
 }
 
 #[test]
+fn does_not_treat_everyone_mention_as_current_bot() {
+    let envelope = GatewayEnvelope {
+        op: 0,
+        s: None,
+        t: Some(EVENT_GROUP_MESSAGE_CREATE.to_owned()),
+        id: None,
+        d: json!({
+            "id": "msg-everyone-mention",
+            "group_openid": "group-1",
+            "author": {"member_openid": "member-1"},
+            "content": "通知大家",
+            "mentions": [{
+                "username": "全体成员",
+                "scope": "all",
+                "is_you": true,
+                "member_openid": "bot-openid"
+            }]
+        }),
+    };
+
+    let mut message = parse_group_message(&envelope).unwrap().unwrap();
+    let identity = Arc::new(crate::gateway::bot_identity::BotIdentity::new(
+        "app-id",
+        &["bot-openid".to_owned()],
+    ));
+    crate::gateway::group_filter::normalize_current_bot_mentions(&mut message, &identity);
+
+    assert_eq!(message.mentions.len(), 1);
+    assert!(!message.mentions[0].is_current_bot);
+    assert_eq!(message.mentions[0].target_id, None);
+    assert!(!crate::gateway::group_filter::mentions_current_bot(
+        &message
+    ));
+}
+
+#[test]
 fn group_at_message_keeps_qq_cleaned_body() {
     let envelope = GatewayEnvelope {
         op: 0,


### PR DESCRIPTION
## 修改内容

- 解析 QQ 官方群消息的 `mentions[].scope` 字段。
- 将 `scope = "all"` 明确识别为 `@全体成员`，不再因兼容字段 `is_you = true` 触发当前机器人。
- 丢弃全体 mention 可能伴随下发的目标 ID，避免后续机器人身份归一化重新误判。
- 增加回归测试覆盖全体 mention 及稳定 ID 冲突场景。

## 根因与影响

QQ 全量群事件可能为 `@全体成员` 同时下发 `scope = "all"` 和 `is_you = true`。原实现只依据 `is_you` 与 `bot` 判断当前机器人，导致 Mention 模式错误响应全体通知。本修复使该事件不再作为单独 @ 机器人触发，同时保留结构化 mention 的顺序信息。

## 验证

- `make test-gateway`
  - Gateway 592 项测试通过
  - Common 71 项测试通过
  - Gateway / Common 格式检查通过
  - Gateway / Common `cargo check` 通过
- `git diff --check`

未进行真实 QQ 群事件联调。
