### PR TITLE
[codex] 收口未知 Slash 命令

### DIFF
--- a/qq-maid-core/src/runtime/command/mod.rs
+++ b/qq-maid-core/src/runtime/command/mod.rs
@@ -13,7 +13,7 @@ pub struct ParsedCommand {
 
 /// 判断文本是否为需要由 Core 继续解析的斜杠命令候选。
 ///
-/// 这里只识别前缀，不判断命令是否注册；未知群命令会在确定性分派末尾静默收口。
+/// 这里只识别前缀，不判断命令是否注册；未知命令会在 Core 确定性分派中统一收口。
 pub fn is_slash_command_candidate(text: &str) -> bool {
     let text = text.trim_start();
     text.starts_with('/') || text.starts_with('／')

--- a/qq-maid-core/src/runtime/respond/command_dispatcher.rs
+++ b/qq-maid-core/src/runtime/respond/command_dispatcher.rs
@@ -8,13 +8,13 @@ use crate::error::LlmError;
 use super::{
     PlannedRespond, RespondRequest, RespondResponse, RustRespondService,
     chat_flow::PreparedChat,
-    common::{session_error, suppressed_response},
+    common::{command_response, session_error, suppressed_response},
     interaction_state::{
         command_bypasses_pending, prepare_message_context_for_model, respond_interaction_meta,
         respond_meta, session_pending_visible_to_user, shared_session_turn_actor,
         should_try_todo_flow,
     },
-    memory_flow, radar_flow, search_flow, session_flow,
+    memory_flow, radar_flow, rss_flow, search_flow, session_flow,
     set_flow::{parse_set_command, parse_unset_command},
     train_flow, translation_flow, weather_flow,
 };
@@ -116,6 +116,27 @@ impl<'a> CommandDispatcher<'a> {
             return Ok(DispatchOutcome::Respond(Box::new(
                 self.service.handle_session_command(command, &meta).await?,
             )));
+        }
+
+        // 只有所有剩余注册 parser 都明确 NotMatched 时才进入未知命令兜底。
+        // 该判断必须早于 get_or_create_active，保证未知 slash 不创建 session；已知命令的
+        // 缺参、参数错误、权限拒绝和执行失败仍由原 handler 收口。
+        if command_text.is_some_and(|text| !matches_remaining_registered_command(text)) {
+            let response = if req
+                .group_id
+                .as_deref()
+                .is_some_and(|id| !id.trim().is_empty())
+                && !req.addressed_to_bot
+            {
+                suppressed_response("unknown_group_slash_command")
+            } else {
+                command_response(
+                    "未知命令，发送 `/help` 查看可用命令。",
+                    None,
+                    Some("unknown_command"),
+                )
+            };
+            return Ok(DispatchOutcome::Respond(Box::new(response)));
         }
 
         // 确保存在活跃会话（无则创建）
@@ -265,19 +286,6 @@ impl<'a> CommandDispatcher<'a> {
             }
         }
 
-        // 所有已注册命令解析器都已尝试；群聊中的剩余斜杠候选属于未知命令。
-        // Core 在这里明确静默收口，避免把命令文本当普通聊天交给模型。
-        if req
-            .group_id
-            .as_deref()
-            .is_some_and(|id| !id.trim().is_empty())
-            && command_text.is_some()
-        {
-            return Ok(DispatchOutcome::Respond(Box::new(suppressed_response(
-                "unknown_group_slash_command",
-            ))));
-        }
-
         // 兜底：进入普通 LLM 聊天流程。共享历史 actor 快照已在上方准备；这里把
         // 同一快照的 actor_ref 注入当前 MessageContext，供模型可靠映射当前发言人。
         prepare_message_context_for_model(
@@ -303,4 +311,17 @@ impl<'a> CommandDispatcher<'a> {
             status_hint,
         })))
     }
+}
+
+fn matches_remaining_registered_command(text: &str) -> bool {
+    translation_flow::parse_translation_command(text).is_some()
+        || parse_set_command(text).is_some()
+        || parse_unset_command(text).is_some()
+        || weather_flow::parse_weather_command(text).is_some()
+        || train_flow::parse_train_command(text).is_some()
+        || radar_flow::parse_radar_command(text).is_some()
+        || search_flow::parse_web_search_command(text).is_some()
+        || rss_flow::parse_rss_command(text).is_some()
+        || should_try_todo_flow(text)
+        || memory_flow::parse_memory_command(text).is_some()
 }

--- a/qq-maid-core/src/runtime/respond/command_dispatcher.rs
+++ b/qq-maid-core/src/runtime/respond/command_dispatcher.rs
@@ -3,7 +3,7 @@
 //! 本模块只处理 pending、session command、slash/确定性命令和进入聊天前的状态准备。
 //! 若没有命中确定性路径，则返回 `PreparedChat` 交给 Chat flow 继续处理。
 
-use crate::error::LlmError;
+use crate::{error::LlmError, runtime::command::ParsedCommand};
 
 use super::{
     PlannedRespond, RespondRequest, RespondResponse, RustRespondService,
@@ -22,6 +22,60 @@ use super::{
 pub(super) enum DispatchOutcome {
     Respond(Box<RespondResponse>),
     Chat(Box<PreparedChat>),
+}
+
+/// 已注册 Slash 的一次性解析结果。
+///
+/// 识别结果既用于 pending 前的未知命令收口，也供后续原 handler 分派，避免两处各自
+/// 维护 parser 清单。Todo、Memory 与 RSS 的 handler 仍保留领域内参数解析和校验。
+enum RegisteredSlashCommand {
+    Session(ParsedCommand),
+    Translation(translation_flow::ParsedTranslationCommand),
+    Set(ParsedCommand),
+    Unset(ParsedCommand),
+    Weather(ParsedCommand),
+    Train(train_flow::ParsedTrainCommand),
+    Radar(ParsedCommand),
+    WebSearch(ParsedCommand),
+    Rss,
+    Todo,
+    Memory,
+}
+
+impl RegisteredSlashCommand {
+    fn parse(text: &str) -> Option<Self> {
+        if let Some(command) = session_flow::parse_session_command(text) {
+            return Some(Self::Session(command));
+        }
+        if let Some(command) = translation_flow::parse_translation_command(text) {
+            return Some(Self::Translation(command));
+        }
+        if let Some(command) = parse_set_command(text) {
+            return Some(Self::Set(command));
+        }
+        if let Some(command) = parse_unset_command(text) {
+            return Some(Self::Unset(command));
+        }
+        if let Some(command) = weather_flow::parse_weather_command(text) {
+            return Some(Self::Weather(command));
+        }
+        if let Some(command) = train_flow::parse_train_command(text) {
+            return Some(Self::Train(command));
+        }
+        if let Some(command) = radar_flow::parse_radar_command(text) {
+            return Some(Self::Radar(command));
+        }
+        if let Some(command) = search_flow::parse_web_search_command(text) {
+            return Some(Self::WebSearch(command));
+        }
+        if rss_flow::parse_rss_command(text).is_some() {
+            return Some(Self::Rss);
+        }
+        if should_try_todo_flow(text) {
+            return Some(Self::Todo);
+        }
+        memory_flow::parse_memory_command(text).map(|_| Self::Memory)
+    }
 }
 
 pub(super) struct CommandDispatcher<'a> {
@@ -64,6 +118,27 @@ impl<'a> CommandDispatcher<'a> {
             return Ok(DispatchOutcome::Respond(Box::new(
                 self.service.handle_ops_command(command, &req),
             )));
+        }
+
+        // 未知 Slash 必须在读取 session 和进入 pending 前收口。只有一次性分类确认属于
+        // 已注册命令的输入，才允许继续沿用既有 pending 优先级和命令 handler。
+        let registered_slash_command = command_text.and_then(RegisteredSlashCommand::parse);
+        if command_text.is_some() && registered_slash_command.is_none() {
+            let response = if req
+                .group_id
+                .as_deref()
+                .is_some_and(|id| !id.trim().is_empty())
+                && !req.addressed_to_bot
+            {
+                suppressed_response("unknown_group_slash_command")
+            } else {
+                command_response(
+                    "未知命令，发送 `/help` 查看可用命令。",
+                    None,
+                    Some("unknown_command"),
+                )
+            };
+            return Ok(DispatchOutcome::Respond(Box::new(response)));
         }
 
         // pending、Todo 可见编号和 Memory 列表序号属于群内个人交互状态；
@@ -112,31 +187,12 @@ impl<'a> CommandDispatcher<'a> {
         }
 
         // 检查是否为会话管理指令（/new, /clear, /state 等）
-        if let Some(command) = command_text.and_then(session_flow::parse_session_command) {
+        if let Some(RegisteredSlashCommand::Session(command)) = registered_slash_command.as_ref() {
             return Ok(DispatchOutcome::Respond(Box::new(
-                self.service.handle_session_command(command, &meta).await?,
+                self.service
+                    .handle_session_command(command.clone(), &meta)
+                    .await?,
             )));
-        }
-
-        // 只有所有剩余注册 parser 都明确 NotMatched 时才进入未知命令兜底。
-        // 该判断必须早于 get_or_create_active，保证未知 slash 不创建 session；已知命令的
-        // 缺参、参数错误、权限拒绝和执行失败仍由原 handler 收口。
-        if command_text.is_some_and(|text| !matches_remaining_registered_command(text)) {
-            let response = if req
-                .group_id
-                .as_deref()
-                .is_some_and(|id| !id.trim().is_empty())
-                && !req.addressed_to_bot
-            {
-                suppressed_response("unknown_group_slash_command")
-            } else {
-                command_response(
-                    "未知命令，发送 `/help` 查看可用命令。",
-                    None,
-                    Some("unknown_command"),
-                )
-            };
-            return Ok(DispatchOutcome::Respond(Box::new(response)));
         }
 
         // 确保存在活跃会话（无则创建）
@@ -154,20 +210,22 @@ impl<'a> CommandDispatcher<'a> {
             .is_some_and(|decision| decision.uses_agent_runtime());
 
         // 检查是否为翻译指令（如 "/翻译 文本"、"/翻译日语 文本"）
-        if let Some(command) = command_text.and_then(translation_flow::parse_translation_command) {
+        if let Some(RegisteredSlashCommand::Translation(command)) =
+            registered_slash_command.as_ref()
+        {
             return Ok(DispatchOutcome::Respond(Box::new(
                 self.service
-                    .handle_translation_command(command, &meta, &user_text, &mut session)
+                    .handle_translation_command(command.clone(), &meta, &user_text, &mut session)
                     .await?,
             )));
         }
 
         // 检查是否为用户偏好设置指令（如 "/set 昵称 脸脸"、"/unset 昵称"）
-        if let Some(command) = command_text.and_then(parse_set_command) {
+        if let Some(RegisteredSlashCommand::Set(command)) = registered_slash_command.as_ref() {
             return Ok(DispatchOutcome::Respond(Box::new(
                 self.service
                     .handle_set_command(
-                        command,
+                        command.clone(),
                         &req,
                         &user_text,
                         meta.user_id.as_deref(),
@@ -176,11 +234,11 @@ impl<'a> CommandDispatcher<'a> {
                     .await?,
             )));
         }
-        if let Some(command) = command_text.and_then(parse_unset_command) {
+        if let Some(RegisteredSlashCommand::Unset(command)) = registered_slash_command.as_ref() {
             return Ok(DispatchOutcome::Respond(Box::new(
                 self.service
                     .handle_unset_command(
-                        command,
+                        command.clone(),
                         &req,
                         &user_text,
                         meta.user_id.as_deref(),
@@ -191,43 +249,47 @@ impl<'a> CommandDispatcher<'a> {
         }
 
         // 检查是否为天气查询指令（如 "/北京天气" 或 "/天气北京"）
-        if let Some(command) = command_text.and_then(weather_flow::parse_weather_command) {
+        if let Some(RegisteredSlashCommand::Weather(command)) = registered_slash_command.as_ref() {
             return Ok(DispatchOutcome::Respond(Box::new(
                 self.service
-                    .handle_weather_command(command, &user_text, &mut session)
+                    .handle_weather_command(command.clone(), &user_text, &mut session)
                     .await?,
             )));
         }
 
         // 检查是否为列车时刻查询指令（如 "/火车 G1 明天"）
-        if let Some(command) = command_text.and_then(train_flow::parse_train_command) {
+        if let Some(RegisteredSlashCommand::Train(command)) = registered_slash_command.as_ref() {
             return Ok(DispatchOutcome::Respond(Box::new(
                 self.service
-                    .handle_train_command(command, &user_text, &mut session)
+                    .handle_train_command(command.clone(), &user_text, &mut session)
                     .await?,
             )));
         }
 
         // 检查是否为雷达看板指令（如 "/rader codex" 或 "/雷达"）
-        if let Some(command) = command_text.and_then(radar_flow::parse_radar_command) {
+        if let Some(RegisteredSlashCommand::Radar(command)) = registered_slash_command.as_ref() {
             return Ok(DispatchOutcome::Respond(Box::new(
                 self.service
-                    .handle_radar_command(command, &user_text, &mut session)
+                    .handle_radar_command(command.clone(), &user_text, &mut session)
                     .await?,
             )));
         }
 
         // 检查是否为联网搜索指令（如 "/查 关键词"）。
-        if let Some(command) = command_text.and_then(search_flow::parse_web_search_command) {
+        if let Some(RegisteredSlashCommand::WebSearch(command)) = registered_slash_command.as_ref()
+        {
             return Ok(DispatchOutcome::Respond(Box::new(
                 self.service
-                    .handle_web_search_command(command, &req, &mut session)
+                    .handle_web_search_command(command.clone(), &req, &mut session)
                     .await?,
             )));
         }
 
         // 检查是否为 RSS 订阅指令（如 "/rss add ..." 或 "/订阅"）
-        if let Some(command_text) = command_text
+        if matches!(
+            registered_slash_command.as_ref(),
+            Some(RegisteredSlashCommand::Rss)
+        ) && let Some(command_text) = command_text
             && let Some(response) = self
                 .service
                 .handle_rss_flow(&req, command_text, &meta, &mut session)
@@ -241,7 +303,13 @@ impl<'a> CommandDispatcher<'a> {
         if !force_tool_loop {
             // 检查是否为待办相关操作（新增、查看、完成、编辑、删除等）
             let todo_text = command_text.unwrap_or(&user_text);
-            if !foreign_command_text && should_try_todo_flow(todo_text) {
+            let registered_todo = matches!(
+                registered_slash_command.as_ref(),
+                Some(RegisteredSlashCommand::Todo)
+            );
+            if !foreign_command_text
+                && (registered_todo || (command_text.is_none() && should_try_todo_flow(todo_text)))
+            {
                 let mut interaction_session = match active_interaction_session.take() {
                     Some(session) => session,
                     None => self
@@ -264,9 +332,15 @@ impl<'a> CommandDispatcher<'a> {
 
         // 检查是否为长期记忆相关操作（记忆新增、查看、更新、删除等）
         let memory_text = command_text.unwrap_or(&user_text);
+        let registered_memory = matches!(
+            registered_slash_command.as_ref(),
+            Some(RegisteredSlashCommand::Memory)
+        );
         if !force_tool_loop
             && !foreign_command_text
-            && memory_flow::parse_memory_command(memory_text).is_some()
+            && (registered_memory
+                || (command_text.is_none()
+                    && memory_flow::parse_memory_command(memory_text).is_some()))
         {
             let mut interaction_session = match active_interaction_session.take() {
                 Some(session) => session,
@@ -311,17 +385,4 @@ impl<'a> CommandDispatcher<'a> {
             status_hint,
         })))
     }
-}
-
-fn matches_remaining_registered_command(text: &str) -> bool {
-    translation_flow::parse_translation_command(text).is_some()
-        || parse_set_command(text).is_some()
-        || parse_unset_command(text).is_some()
-        || weather_flow::parse_weather_command(text).is_some()
-        || train_flow::parse_train_command(text).is_some()
-        || radar_flow::parse_radar_command(text).is_some()
-        || search_flow::parse_web_search_command(text).is_some()
-        || rss_flow::parse_rss_command(text).is_some()
-        || should_try_todo_flow(text)
-        || memory_flow::parse_memory_command(text).is_some()
 }

--- a/qq-maid-core/src/runtime/respond/common.rs
+++ b/qq-maid-core/src/runtime/respond/common.rs
@@ -112,6 +112,7 @@ pub(super) fn empty_respond_request() -> RespondRequest {
         timestamp: None,
         platform: String::new(),
         account_id: None,
+        addressed_to_bot: false,
         event_type: String::new(),
         system_prompts: Vec::new(),
         memory_context: String::new(),

--- a/qq-maid-core/src/runtime/respond/router.rs
+++ b/qq-maid-core/src/runtime/respond/router.rs
@@ -161,7 +161,7 @@ impl<'a> RespondRouter<'a> {
             .map_err(session_error)?;
 
         // Gateway 只提交候选，Core 负责后续注册表与权限判断；所有斜杠候选都应绕过
-        // Gateway 普通聊天冷却，确保未知命令也能在 Core 静默收口。
+        // Gateway 普通聊天冷却，确保未知命令也能在 Core 确定性收口。
         if self.service.command_prefix().is_candidate(&user_text) {
             return Ok(CoreInboundClassification {
                 kind: CoreInboundKind::Immediate,

--- a/qq-maid-core/src/runtime/respond/tests/chat/mod.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat/mod.rs
@@ -917,7 +917,7 @@ async fn slash_command_does_not_enter_tool_loop() {
 }
 
 #[tokio::test]
-async fn unknown_slash_command_falls_back_to_standard_chat_with_router_decision() {
+async fn unknown_slash_command_returns_deterministic_hint_without_model_request() {
     let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
 
@@ -931,16 +931,12 @@ async fn unknown_slash_command_falls_back_to_standard_chat_with_router_decision(
     let response = service.respond_with_plan(req, planned).await.unwrap();
 
     assert_eq!(inspector.tool_call_count(), 0);
-    assert_eq!(inspector.requests().len(), 1);
-    assert!(
-        response
-            .text
-            .as_deref()
-            .is_some_and(|text| text.contains("回复：/unknown-route-command"))
+    assert!(inspector.requests().is_empty());
+    assert_eq!(
+        response.text.as_deref(),
+        Some("未知命令，发送 `/help` 查看可用命令。")
     );
-    let diagnostics = response.diagnostics.unwrap();
-    assert_eq!(diagnostics["respond_route"], "standard_chat");
-    assert_eq!(diagnostics["route_reason"], "deterministic_slash_fallback");
+    assert_eq!(response.command.as_deref(), Some("unknown_command"));
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/runtime/respond/tests/mod.rs
+++ b/qq-maid-core/src/runtime/respond/tests/mod.rs
@@ -11,6 +11,7 @@ mod radar;
 mod rss;
 mod search;
 mod session;
+mod slash_pending;
 pub(crate) mod support;
 mod todo;
 mod todo_agent;

--- a/qq-maid-core/src/runtime/respond/tests/slash_pending.rs
+++ b/qq-maid-core/src/runtime/respond/tests/slash_pending.rs
@@ -1,0 +1,251 @@
+use qq_maid_llm::provider::ToolCallingProtocol;
+use serde_json::json;
+
+use super::support::*;
+use crate::runtime::{
+    pending::PreparedAction,
+    session::{SessionMeta, now_iso_cn},
+    tools::{
+        memory::MemoryPendingPayload,
+        todo::{
+            ClarificationCandidate, PendingTodoClarification, TodoItem, TodoPendingPayload,
+            TodoStatus, TodoStore,
+        },
+    },
+};
+
+const UNKNOWN_COMMAND_REPLY: &str = "未知命令，发送 `/help` 查看可用命令。";
+
+fn assert_provider_unused(provider: &MockProvider) {
+    assert_eq!(provider.tool_call_count(), 0);
+    assert!(provider.tool_requests().is_empty());
+    assert!(provider.requests().is_empty());
+}
+
+fn save_todo_pending(
+    service: &crate::runtime::respond::RustRespondService,
+    meta: &SessionMeta,
+    payload: TodoPendingPayload,
+) -> PreparedAction {
+    let mut session = service.session_store.get_or_create_active(meta).unwrap();
+    let pending = payload.into_prepared_action(&session.scope_key);
+    session.pending_operation = Some(pending.clone());
+    service.session_store.save(&mut session).unwrap();
+    pending
+}
+
+fn save_memory_pending(
+    service: &crate::runtime::respond::RustRespondService,
+    meta: &SessionMeta,
+    payload: MemoryPendingPayload,
+) -> PreparedAction {
+    let mut session = service.session_store.get_or_create_active(meta).unwrap();
+    let pending = payload.into_prepared_action(&session.scope_key);
+    session.pending_operation = Some(pending.clone());
+    service.session_store.save(&mut session).unwrap();
+    pending
+}
+
+fn completed_todo(
+    service: &crate::runtime::respond::RustRespondService,
+    owner: &crate::runtime::tools::todo::TodoOwner,
+    title: &str,
+) -> TodoItem {
+    let item = service.task_store.create(owner, todo_draft(title)).unwrap();
+    service.task_store.complete(owner, &item.id).unwrap();
+    service
+        .task_store
+        .get_by_id(owner, &item.id)
+        .unwrap()
+        .unwrap()
+}
+
+fn todo_delete_pending(item: TodoItem, owner_key: &str) -> TodoPendingPayload {
+    TodoPendingPayload::TodoDelete {
+        initiator_user_id: Some("u1".to_owned()),
+        owner_key: owner_key.to_owned(),
+        item,
+        created_at: now_iso_cn(),
+    }
+}
+
+fn assert_private_pending_unchanged(
+    service: &crate::runtime::respond::RustRespondService,
+    expected: &PreparedAction,
+) {
+    let current = service
+        .session_store
+        .get_active(&private_test_meta())
+        .unwrap()
+        .unwrap()
+        .pending_operation;
+    assert_eq!(current.as_ref(), Some(expected));
+}
+
+#[tokio::test]
+async fn unknown_slash_does_not_consume_todo_delete_confirmation() {
+    let provider = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(provider.clone(), true);
+    let owner = private_todo_owner();
+    let item = completed_todo(&service, &owner, "保留的已完成待办");
+    let pending = save_todo_pending(
+        &service,
+        &private_test_meta(),
+        todo_delete_pending(item.clone(), &owner.key),
+    );
+
+    let response = service.respond(private_message("/unknown")).await.unwrap();
+
+    assert_eq!(response.text.as_deref(), Some(UNKNOWN_COMMAND_REPLY));
+    assert_eq!(response.command.as_deref(), Some("unknown_command"));
+    assert_private_pending_unchanged(&service, &pending);
+    assert_eq!(
+        service
+            .task_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Completed
+    );
+    assert_provider_unused(&provider);
+}
+
+#[tokio::test]
+async fn unknown_slash_does_not_resume_todo_clarification_tool_loop() {
+    let provider = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json(
+            "delete_todos",
+            r#"{"numbers":[1],"reference":null}"#,
+            "不应执行删除",
+        );
+    let service = test_service_with_provider_and_tool_calling(provider.clone(), true);
+    let owner = private_todo_owner();
+    let item = completed_todo(&service, &owner, "澄清中的已完成待办");
+    let created_at = now_iso_cn();
+    let pending = save_todo_pending(
+        &service,
+        &private_test_meta(),
+        TodoPendingPayload::TodoClarify {
+            initiator_user_id: Some("u1".to_owned()),
+            owner_key: owner.key.clone(),
+            request: PendingTodoClarification {
+                tool_name: "delete_todos".to_owned(),
+                arguments: json!({"numbers": null, "reference": "last"}),
+                allow_many: false,
+                error_code: "todo_reference_unavailable".to_owned(),
+                question: "请补充要删除哪条待办。".to_owned(),
+                candidates: vec![ClarificationCandidate {
+                    id: item.id.clone(),
+                    display_number: 1,
+                    title: item.title.clone(),
+                    status: item.status.clone(),
+                }],
+                created_at: created_at.clone(),
+            },
+            created_at,
+        },
+    );
+
+    let response = service.respond(private_message("/unknown")).await.unwrap();
+
+    assert_eq!(response.text.as_deref(), Some(UNKNOWN_COMMAND_REPLY));
+    assert_eq!(response.command.as_deref(), Some("unknown_command"));
+    assert_private_pending_unchanged(&service, &pending);
+    assert!(
+        service
+            .task_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .is_some()
+    );
+    assert_provider_unused(&provider);
+}
+
+#[tokio::test]
+async fn compact_unknown_memory_slash_does_not_consume_memory_pending() {
+    let provider = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(provider.clone(), true);
+    let created_at = now_iso_cn();
+    let pending = save_memory_pending(
+        &service,
+        &private_test_meta(),
+        MemoryPendingPayload::ClarifyScope {
+            initiator_user_id: "u1".to_owned(),
+            owner_key: "u1".to_owned(),
+            normalized_content: "保留这条待澄清记忆".to_owned(),
+            source_text: "记住这条内容".to_owned(),
+            source_ref: None,
+            created_at,
+        },
+    );
+
+    let response = service
+        .respond(private_message("/记忆查看1"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.text.as_deref(), Some(UNKNOWN_COMMAND_REPLY));
+    assert_eq!(response.command.as_deref(), Some("unknown_command"));
+    assert_private_pending_unchanged(&service, &pending);
+    assert_provider_unused(&provider);
+}
+
+#[tokio::test]
+async fn unaddressed_group_unknown_slash_is_silent_without_consuming_pending() {
+    let provider = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(provider.clone(), true);
+    let meta = test_meta();
+    let owner = TodoStore::owner(Some("u1"), "group:g1");
+    let item = completed_todo(&service, &owner, "群内保留的已完成待办");
+    let pending = save_todo_pending(
+        &service,
+        &meta,
+        todo_delete_pending(item.clone(), &owner.key),
+    );
+
+    let response = service.respond(message("/unknown")).await.unwrap();
+
+    assert!(response.text.is_none());
+    assert_eq!(response.diagnostics.as_ref().unwrap()["suppressed"], true);
+    assert_eq!(
+        response.diagnostics.as_ref().unwrap()["reason"],
+        "unknown_group_slash_command"
+    );
+    let current = service
+        .session_store
+        .get_active(&meta)
+        .unwrap()
+        .unwrap()
+        .pending_operation;
+    assert_eq!(current.as_ref(), Some(&pending));
+    assert!(
+        service
+            .task_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .is_some()
+    );
+    assert_provider_unused(&provider);
+}
+
+#[tokio::test]
+async fn registered_todo_command_keeps_existing_pending_priority() {
+    let provider = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(provider.clone(), true);
+    let owner = private_todo_owner();
+    let item = completed_todo(&service, &owner, "仍等待确认的已完成待办");
+    let pending = save_todo_pending(
+        &service,
+        &private_test_meta(),
+        todo_delete_pending(item, &owner.key),
+    );
+
+    let response = service.respond(private_message("/todo")).await.unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("todo_delete"));
+    assert_ne!(response.command.as_deref(), Some("todo_list"));
+    assert_private_pending_unchanged(&service, &pending);
+    assert_provider_unused(&provider);
+}

--- a/qq-maid-core/src/runtime/respond/types.rs
+++ b/qq-maid-core/src/runtime/respond/types.rs
@@ -116,6 +116,9 @@ pub struct RespondRequest {
     /// 平台账号/机器人账号标识；只参与业务隔离键，不作为发送目标。
     #[serde(default)]
     pub account_id: Option<String>,
+    /// 当前群消息是否由 Gateway 判定为明确指向机器人；私聊不依赖此字段。
+    #[serde(default)]
+    pub addressed_to_bot: bool,
     /// 事件类型（如 "message"）
     #[serde(default)]
     pub event_type: String,
@@ -233,6 +236,7 @@ impl Default for RespondRequest {
             timestamp: None,
             platform: String::new(),
             account_id: None,
+            addressed_to_bot: false,
             event_type: String::new(),
             system_prompts: Vec::new(),
             memory_context: String::new(),

--- a/qq-maid-core/src/service/handle.rs
+++ b/qq-maid-core/src/service/handle.rs
@@ -298,6 +298,7 @@ impl From<CoreRequest> for RespondRequest {
             channel_id,
             platform: value.platform.as_str().to_owned(),
             account_id: value.account_id,
+            addressed_to_bot: value.addressed_to_bot,
             event_type: event_type.to_owned(),
             message_id: value.message_id,
             ..Default::default()

--- a/qq-maid-core/src/service/tests/commands.rs
+++ b/qq-maid-core/src/service/tests/commands.rs
@@ -108,18 +108,83 @@ async fn core_unknown_group_slash_is_silent_without_model_call() {
 }
 
 #[tokio::test]
-async fn core_unknown_private_slash_keeps_existing_chat_behavior() {
-    let provider = TestProvider::replying("私聊仍按普通聊天处理");
+async fn core_unknown_private_slash_is_deterministic_without_session_or_model_call() {
+    let provider = TestProvider::replying("不应调用");
     let state = test_state(provider.clone(), 5);
+    let session_store = state.stores.session_store.clone();
     let service = CoreHandle::new(state);
-    let CoreRespondOutput::Complete(response) =
-        service.respond(private_request("/unknown")).await.unwrap()
+
+    for input in ["/unknown", "/记忆查看1"] {
+        let CoreRespondOutput::Complete(response) =
+            service.respond(private_request(input)).await.unwrap()
+        else {
+            panic!("unknown private slash should complete synchronously");
+        };
+
+        assert_eq!(
+            response.text_content(),
+            Some("未知命令，发送 `/help` 查看可用命令。")
+        );
+        assert_eq!(response.command.as_deref(), Some("unknown_command"));
+        assert!(!response.suppresses_reply());
+    }
+    let meta = SessionMeta::new(
+        private_scope(),
+        Some("u1".to_owned()),
+        None,
+        None,
+        None,
+        "qq_official",
+    );
+    assert!(session_store.get_active(&meta).unwrap().is_none());
+    assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn core_addressed_group_unknown_slash_returns_hint_without_model_call() {
+    let provider =
+        TestProvider::replying("不应调用").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let state = test_state_with_tool_calling(provider.clone(), 5, true);
+    let service = CoreHandle::new(state);
+
+    for input in ["/unknown", "/记忆查看1"] {
+        let mut request = group_request(input);
+        request.addressed_to_bot = true;
+        let CoreRespondOutput::Complete(response) = service.respond(request).await.unwrap() else {
+            panic!("addressed unknown group slash should complete synchronously");
+        };
+
+        assert_eq!(
+            response.text_content(),
+            Some("未知命令，发送 `/help` 查看可用命令。")
+        );
+        assert_eq!(response.command.as_deref(), Some("unknown_command"));
+        assert!(!response.suppresses_reply());
+    }
+    assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn core_valid_memory_show_still_uses_registered_handler() {
+    let provider =
+        TestProvider::replying("不应调用").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let state = test_state_with_tool_calling(provider.clone(), 5, true);
+    let service = CoreHandle::new(state);
+
+    let CoreRespondOutput::Complete(response) = service
+        .respond(private_request("/记忆 查看 1"))
+        .await
+        .unwrap()
     else {
-        panic!("immediate private fallback should complete synchronously");
+        panic!("memory show should complete synchronously");
     };
 
-    assert_eq!(response.text_content(), Some("私聊仍按普通聊天处理"));
-    assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(response.command.as_deref(), Some("memory_show"));
+    assert_ne!(response.command.as_deref(), Some("unknown_command"));
+    assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/service/tests/request.rs
+++ b/qq-maid-core/src/service/tests/request.rs
@@ -19,6 +19,7 @@ fn private_conversation_derives_private_scope() {
             is_bot: false,
             identity_source: IdentitySource::Event,
         },
+        addressed_to_bot: false,
         conversation: CoreConversation::Private {
             peer_id: "u1".to_owned(),
         },
@@ -54,6 +55,7 @@ fn group_conversation_derives_group_scope_without_member_split() {
             is_bot: false,
             identity_source: IdentitySource::Event,
         },
+        addressed_to_bot: false,
         conversation: CoreConversation::Group {
             group_id: "g1".to_owned(),
         },
@@ -103,6 +105,7 @@ fn message_context_is_derived_from_core_request_authoritative_fields() {
             is_bot: false,
             identity_source: IdentitySource::MemberApi,
         },
+        addressed_to_bot: false,
         conversation: CoreConversation::Group {
             group_id: "g1".to_owned(),
         },

--- a/qq-maid-core/src/service/tests/support.rs
+++ b/qq-maid-core/src/service/tests/support.rs
@@ -522,6 +522,7 @@ pub(super) fn private_request(text: &str) -> CoreRequest {
             is_bot: false,
             identity_source: IdentitySource::Event,
         },
+        addressed_to_bot: false,
         conversation: CoreConversation::Private {
             peer_id: "u1".to_owned(),
         },
@@ -550,6 +551,7 @@ pub(super) fn group_request(text: &str) -> CoreRequest {
             is_bot: false,
             identity_source: IdentitySource::Event,
         },
+        addressed_to_bot: false,
         conversation: CoreConversation::Group {
             group_id: "g1".to_owned(),
         },
@@ -574,6 +576,7 @@ pub(super) fn wechat_service_request(text: &str) -> CoreRequest {
             is_bot: false,
             identity_source: IdentitySource::Event,
         },
+        addressed_to_bot: false,
         conversation: CoreConversation::ServiceAccount {
             account_id: Some("gh_test".to_owned()),
             peer_id: "openid-u1".to_owned(),

--- a/qq-maid-core/src/service/types.rs
+++ b/qq-maid-core/src/service/types.rs
@@ -42,6 +42,9 @@ pub struct CoreRequest {
     pub account_id: Option<String>,
     pub actor: CoreActor,
     pub mentions: Vec<MentionIdentity>,
+    /// Gateway 根据平台结构化 @ 或已支持的唤醒词判定本轮是否明确指向机器人。
+    /// 该字段只表达寻址语义，不参与平台协议解析或权限判断。
+    pub addressed_to_bot: bool,
     pub conversation: CoreConversation,
 }
 

--- a/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/aggregator/tests.rs
@@ -1196,6 +1196,7 @@ fn request_scope_key_matches_private_message() {
             is_bot: false,
             identity_source: IdentitySource::Event,
         },
+        addressed_to_bot: false,
         conversation: CoreConversation::Private {
             peer_id: "u1".to_owned(),
         },

--- a/qq-maid-gateway-rs/src/gateway/group_filter/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/group_filter/mod.rs
@@ -187,7 +187,7 @@ pub(crate) fn mentions_current_bot(message: &GroupMessage) -> bool {
 }
 
 /// `active` 模式只按显式提示词触发，避免普通群聊闲谈被机器人自动插话。
-fn contains_active_keyword(content: &str, keywords: &[String]) -> bool {
+pub(crate) fn contains_active_keyword(content: &str, keywords: &[String]) -> bool {
     let content = content.to_ascii_lowercase();
     keywords
         .iter()

--- a/qq-maid-gateway-rs/src/gateway/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/mod.rs
@@ -44,6 +44,7 @@ use tracing::{info, warn};
 pub(crate) use cache::BotOutboundCache;
 use dedupe::MessageDedupe;
 use group_filter::GroupCooldowns;
+pub(crate) use group_filter::contains_active_keyword;
 use ping::GatewayRuntimeStatus;
 use protocol::ResumeState;
 use push::GatewayPushSink;

--- a/qq-maid-gateway-rs/src/gateway/platform/core.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/core.rs
@@ -60,6 +60,7 @@ pub(crate) fn to_core_request(
             identity_source: inbound.actor.source,
         },
         mentions: inbound.mentions.clone(),
+        addressed_to_bot: inbound.mentioned_bot,
         conversation,
     })
 }

--- a/qq-maid-gateway-rs/src/gateway/platform/model.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/model.rs
@@ -46,6 +46,7 @@ pub(crate) struct InboundMessage {
     pub(crate) visible_entity_snapshot: Option<VisibleEntitySnapshot>,
     /// 平台事件提供的结构化 mention 目标。文本 @昵称 不应伪造成稳定身份。
     pub(crate) mentions: Vec<MentionIdentity>,
+    /// 平台已确认的机器人寻址信号。QQ 归一化阶段还会合并配置唤醒词命中结果。
     pub(crate) mentioned_bot: bool,
 }
 

--- a/qq-maid-gateway-rs/src/gateway/platform/onebot11/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/platform/onebot11/mod.rs
@@ -426,7 +426,7 @@ mod tests {
     use super::*;
     use crate::gateway::{
         dedupe::MessageDedupe,
-        platform::{core_scope_key, render_text_for_core},
+        platform::{core_scope_key, render_text_for_core, to_core_request},
     };
 
     fn event(value: Value) -> OneBotEvent {
@@ -601,6 +601,19 @@ mod tests {
                 target_id: "30003".to_owned()
             }
         );
+        let request = to_core_request(&inbound, inbound.text.clone()).unwrap();
+        assert!(!request.addressed_to_bot);
+    }
+
+    #[test]
+    fn structured_bot_at_maps_to_addressed_core_request() {
+        let inbound = message(inbound_from_event(&group_event(json!([
+            {"type": "at", "data": {"qq": "10001"}},
+            {"type": "text", "data": {"text": " /unknown"}}
+        ]))));
+
+        let request = to_core_request(&inbound, inbound.text.clone()).unwrap();
+        assert!(request.addressed_to_bot);
     }
 
     #[test]

--- a/qq-maid-gateway-rs/src/respond.rs
+++ b/qq-maid-gateway-rs/src/respond.rs
@@ -449,6 +449,10 @@ pub(crate) fn normalized_group_inbound_with_prefix(
     );
     let mut inbound = platform::qq_official::inbound_from_group(message);
     inbound.text = content.clone();
+    // Core 只消费平台无关的寻址事实。QQ 结构化 @ 已由 adapter 标记，Active 模式
+    // 的配置唤醒词在归一化边界补充，不能让 Core 理解 GROUP_ACTIVE_KEYWORDS。
+    inbound.mentioned_bot |=
+        crate::gateway::contains_active_keyword(&message.content, active_keywords);
 
     // 有序内容块存在时 Core 会优先使用 input_parts。寻址 mention 只改写正文文本块，
     // 因此仅同步首个正文文本块，媒体块及其相对顺序、状态和元数据保持原样。
@@ -926,6 +930,41 @@ mod tests {
             missing_member.scope_key(),
             "platform:qq_official:account:-:group:g1"
         );
+    }
+
+    #[test]
+    fn qq_group_mapping_marks_structured_at_and_active_keyword_as_addressed() {
+        let keywords = vec!["召唤词".to_owned()];
+
+        let structured = normalized_group_inbound_with_prefix(
+            &group_message("/unknown", Some("member1")),
+            &keywords,
+            CommandPrefix::default(),
+        );
+        let structured_request =
+            platform::to_core_request(&structured, structured.text.clone()).unwrap();
+        assert!(structured_request.addressed_to_bot);
+
+        let mut keyword_message = group_message("召唤词 /unknown", Some("member1"));
+        keyword_message.event_type = GroupEventType::GroupMessage;
+        let keyword = normalized_group_inbound_with_prefix(
+            &keyword_message,
+            &keywords,
+            CommandPrefix::default(),
+        );
+        let keyword_request = platform::to_core_request(&keyword, keyword.text.clone()).unwrap();
+        assert_eq!(keyword_request.text, "/unknown");
+        assert!(keyword_request.addressed_to_bot);
+
+        let mut direct_message = group_message("/unknown", Some("member1"));
+        direct_message.event_type = GroupEventType::GroupMessage;
+        let direct = normalized_group_inbound_with_prefix(
+            &direct_message,
+            &keywords,
+            CommandPrefix::default(),
+        );
+        let direct_request = platform::to_core_request(&direct, direct.text.clone()).unwrap();
+        assert!(!direct_request.addressed_to_bot);
     }
 
     #[test]


### PR DESCRIPTION
## 变更说明

- 在所有已注册命令 parser 均未匹配后，确定性收口未知 slash，不再进入 LLM 或 Tool Loop。
- 私聊未知 slash 返回统一提示；群聊仅在消息明确指向机器人时回复，否则保持静默。
- 在 Gateway 到 Core 的请求中增加平台无关的 `addressed_to_bot` 标记。
- QQ 官方入口同时覆盖结构化 @ 和 `GROUP_ACTIVE_KEYWORDS` 命中；OneBot 保持当前仅支持结构化 @ 的触发语义。
- 保持严格命令语法，`/记忆 查看 1` 仍进入 `memory_show`，`/记忆查看1` 返回未知命令。

## 根因

未知私聊 slash 原先会沿普通聊天兜底调用模型；群聊未知 slash 虽然会静默，但兜底位置晚于活跃 session 创建。与此同时，Core 请求没有平台无关的明确寻址标记，无法区分群聊中被 @ 或唤醒词触发的未知命令与未寻址的直接 slash。

## 影响

- 未知 slash 不调用模型、业务 Tool、外部工具，也不创建 session。
- 已知命令的缺参、参数错误、权限不足、执行失败及已消费静默仍由原 handler 处理，不会被改写为未知命令。
- 不改变群聊模式、唤醒词配置、已知命令权限或 OneBot 当前触发能力。

## 验证

- `make test-core`（1243 项 Core 测试通过）
- `make test-gateway`（594 项 Gateway 测试通过）
- `cargo clippy -p qq-maid-core -p qq-maid-gateway-rs --all-targets --all-features -- -D warnings`
- `git diff --check`

未执行 QQ 官方或 OneBot 真实环境联调；本次不涉及 migration、运行配置或敏感信息。
