### PR TITLE
fix: 限制知识库 embedding 批处理内存

### DIFF
--- a/qq-maid-core/src/runtime/tools/knowledge/index/diagnostics.rs
+++ b/qq-maid-core/src/runtime/tools/knowledge/index/diagnostics.rs
@@ -1,0 +1,128 @@
+//! Markdown 分块诊断，只输出匿名聚合数值，不记录正文或标题内容。
+
+use std::collections::HashMap;
+
+use super::chunking::MarkdownChunk;
+
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct ChunkDiagnostics {
+    pub file_bytes: usize,
+    pub file_chars: usize,
+    pub chunk_count: usize,
+    pub chunk_chars_min: usize,
+    pub chunk_chars_avg: f64,
+    pub chunk_chars_p50: usize,
+    pub chunk_chars_p95: usize,
+    pub chunk_chars_max: usize,
+    pub chunks_with_heading: usize,
+    pub chunks_without_heading: usize,
+    pub heading_section_count: usize,
+    pub heading_chunks_min: usize,
+    pub heading_chunks_avg: f64,
+    pub heading_chunks_p50: usize,
+    pub heading_chunks_p95: usize,
+    pub heading_chunks_max: usize,
+}
+
+pub(super) fn summarize_chunks(content: &str, chunks: &[MarkdownChunk]) -> ChunkDiagnostics {
+    let mut chunk_chars = chunks
+        .iter()
+        .map(|chunk| chunk.body.chars().count())
+        .collect::<Vec<_>>();
+    let chunks_with_heading = chunks
+        .iter()
+        .filter(|chunk| chunk.heading_path.is_some())
+        .count();
+    let mut heading_counts = HashMap::<&str, usize>::new();
+    for heading in chunks
+        .iter()
+        .filter_map(|chunk| chunk.heading_path.as_deref())
+    {
+        *heading_counts.entry(heading).or_default() += 1;
+    }
+    let mut heading_chunks = heading_counts.into_values().collect::<Vec<_>>();
+    let chunk_distribution = Distribution::from_values(&mut chunk_chars);
+    let heading_distribution = Distribution::from_values(&mut heading_chunks);
+
+    ChunkDiagnostics {
+        file_bytes: content.len(),
+        file_chars: content.chars().count(),
+        chunk_count: chunks.len(),
+        chunk_chars_min: chunk_distribution.min,
+        chunk_chars_avg: chunk_distribution.avg,
+        chunk_chars_p50: chunk_distribution.p50,
+        chunk_chars_p95: chunk_distribution.p95,
+        chunk_chars_max: chunk_distribution.max,
+        chunks_with_heading,
+        chunks_without_heading: chunks.len().saturating_sub(chunks_with_heading),
+        heading_section_count: heading_chunks.len(),
+        heading_chunks_min: heading_distribution.min,
+        heading_chunks_avg: heading_distribution.avg,
+        heading_chunks_p50: heading_distribution.p50,
+        heading_chunks_p95: heading_distribution.p95,
+        heading_chunks_max: heading_distribution.max,
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct Distribution {
+    min: usize,
+    avg: f64,
+    p50: usize,
+    p95: usize,
+    max: usize,
+}
+
+impl Distribution {
+    fn from_values(values: &mut [usize]) -> Self {
+        if values.is_empty() {
+            return Self::default();
+        }
+        values.sort_unstable();
+        Self {
+            min: values[0],
+            avg: values.iter().sum::<usize>() as f64 / values.len() as f64,
+            p50: percentile(values, 50),
+            p95: percentile(values, 95),
+            max: values[values.len() - 1],
+        }
+    }
+}
+
+fn percentile(sorted: &[usize], percentile: usize) -> usize {
+    let rank = sorted.len().saturating_mul(percentile).div_ceil(100).max(1);
+    sorted[rank - 1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::tools::knowledge::index::chunking::chunk_markdown;
+
+    #[test]
+    fn large_markdown_reports_anonymous_chunk_statistics() {
+        let mut content = String::from("# 大型分块诊断\n\n");
+        for index in 0..1_200 {
+            content.push_str(&format!(
+                "## 章节 {index}\n\n第 {index} 节包含稳定的知识诊断文本，用于验证大型 Markdown 分块统计。\n\n"
+            ));
+        }
+
+        let chunks = chunk_markdown("generated-large.md", &content);
+        let diagnostics = summarize_chunks(&content, &chunks);
+        eprintln!("large markdown chunk diagnostics: {diagnostics:?}");
+
+        assert_eq!(diagnostics.file_bytes, content.len());
+        assert_eq!(diagnostics.file_chars, content.chars().count());
+        assert_eq!(diagnostics.chunk_count, chunks.len());
+        assert!(diagnostics.chunk_count >= 1_200);
+        assert_eq!(diagnostics.chunks_with_heading, diagnostics.chunk_count);
+        assert_eq!(diagnostics.chunks_without_heading, 0);
+        assert_eq!(diagnostics.heading_section_count, 1_200);
+        assert!(diagnostics.chunk_chars_min <= diagnostics.chunk_chars_p50);
+        assert!(diagnostics.chunk_chars_p50 <= diagnostics.chunk_chars_p95);
+        assert!(diagnostics.chunk_chars_p95 <= diagnostics.chunk_chars_max);
+        assert_eq!(diagnostics.heading_chunks_min, 1);
+        assert_eq!(diagnostics.heading_chunks_max, 1);
+    }
+}

--- a/qq-maid-core/src/runtime/tools/knowledge/index/embedding.rs
+++ b/qq-maid-core/src/runtime/tools/knowledge/index/embedding.rs
@@ -214,6 +214,16 @@ impl SemanticRuntime {
             completed += records.len();
             batch_number += 1;
             previous_batch = Some(batch_identity);
+            let batch_elapsed_ms = batch_started.elapsed().as_millis();
+            tracing::debug!(
+                model,
+                batch_number,
+                input_count = batch_size,
+                completed_chunks = completed,
+                remaining_chunks = total_missing.saturating_sub(completed),
+                elapsed_ms = batch_elapsed_ms,
+                "knowledge embedding batch diagnostics"
+            );
             // 大知识库可能产生数万批；保留首批、周期进度与末批，避免日志反向放大。
             if batch_number == 1
                 || batch_number % PROGRESS_LOG_INTERVAL_BATCHES == 0
@@ -226,7 +236,7 @@ impl SemanticRuntime {
                     batch_size,
                     completed_chunks = completed,
                     remaining_chunks = total_missing.saturating_sub(completed),
-                    elapsed_ms = batch_started.elapsed().as_millis(),
+                    elapsed_ms = batch_elapsed_ms,
                     "knowledge embedding batch completed"
                 );
             }

--- a/qq-maid-core/src/runtime/tools/knowledge/index/embedding.rs
+++ b/qq-maid-core/src/runtime/tools/knowledge/index/embedding.rs
@@ -6,6 +6,7 @@
 use std::{
     path::PathBuf,
     sync::{Arc, Mutex},
+    time::Instant,
 };
 
 use fastembed::{EmbeddingModel, TextEmbedding, TextInitOptions};
@@ -17,6 +18,12 @@ use crate::{
 
 pub const SEMANTIC_MODEL_ID: &str = "BAAI/bge-small-zh-v1.5";
 pub const SEMANTIC_EMBEDDING_VERSION: i64 = 1;
+
+// 常见部署只有 2 GiB 内存；同步分页与 ONNX 推理都使用保守小批次，避免 FastEmbed
+// 为全部缺失片段保留 tokenizer、推理输出和最终向量。
+pub(super) const SEMANTIC_SYNC_BATCH_SIZE: usize = 8;
+const FASTEMBED_INFERENCE_BATCH_SIZE: usize = 8;
+const PROGRESS_LOG_INTERVAL_BATCHES: usize = 32;
 
 /// 本地语义召回配置。默认关闭，避免升级后隐式下载模型或改变启动时延。
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -43,7 +50,7 @@ impl KnowledgeSemanticConfig {
 
 pub(super) trait KnowledgeEmbedder: Send + Sync {
     fn model_id(&self) -> &'static str;
-    fn embed_documents(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, LlmError>;
+    fn embed_documents(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, LlmError>;
     fn embed_query(&self, query: &str) -> Result<Vec<f32>, LlmError>;
 }
 
@@ -69,7 +76,7 @@ impl LocalKnowledgeEmbedder {
         }))
     }
 
-    fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, LlmError> {
+    fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, LlmError> {
         self.model
             .lock()
             .map_err(|_| {
@@ -79,7 +86,7 @@ impl LocalKnowledgeEmbedder {
                     "knowledge",
                 )
             })?
-            .embed(texts, None)
+            .embed(texts, Some(FASTEMBED_INFERENCE_BATCH_SIZE))
             .map_err(|error| {
                 LlmError::new(
                     "knowledge_embedding_error",
@@ -95,20 +102,23 @@ impl KnowledgeEmbedder for LocalKnowledgeEmbedder {
         SEMANTIC_MODEL_ID
     }
 
-    fn embed_documents(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, LlmError> {
+    fn embed_documents(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, LlmError> {
         self.embed(texts)
     }
 
     fn embed_query(&self, query: &str) -> Result<Vec<f32>, LlmError> {
         // BGE 的公开检索指令是模型能力的一部分，不承载业务词或注入 Gate。
         let text = format!("为这个句子生成表示以用于检索相关文章：{query}");
-        self.embed(&[text])?.into_iter().next().ok_or_else(|| {
-            LlmError::new(
-                "knowledge_embedding_empty",
-                "local knowledge embedding returned no vector",
-                "knowledge",
-            )
-        })
+        self.embed(&[text.as_str()])?
+            .into_iter()
+            .next()
+            .ok_or_else(|| {
+                LlmError::new(
+                    "knowledge_embedding_empty",
+                    "local knowledge embedding returned no vector",
+                    "knowledge",
+                )
+            })
     }
 }
 
@@ -142,41 +152,97 @@ impl SemanticRuntime {
     }
 
     pub(super) fn sync_missing(&self, store: &KnowledgeStore) -> Result<usize, LlmError> {
-        let sources = store
-            .missing_embedding_sources(self.embedder.model_id(), SEMANTIC_EMBEDDING_VERSION)
+        let started = Instant::now();
+        let model = self.embedder.model_id();
+        let total_missing = store
+            .missing_embedding_count(model, SEMANTIC_EMBEDDING_VERSION)
             .map_err(embedding_db_error)?;
-        if sources.is_empty() {
-            return Ok(0);
+        let mut completed = 0;
+        let mut batch_number = 0;
+        let mut previous_batch = None;
+
+        loop {
+            let batch_started = Instant::now();
+            let sources = store
+                .missing_embedding_sources(
+                    model,
+                    SEMANTIC_EMBEDDING_VERSION,
+                    SEMANTIC_SYNC_BATCH_SIZE,
+                )
+                .map_err(embedding_db_error)?;
+            if sources.is_empty() {
+                break;
+            }
+            let batch_identity = sources
+                .iter()
+                .map(|source| (source.chunk_id.clone(), source.content_hash.clone()))
+                .collect::<Vec<_>>();
+            if previous_batch.as_ref() == Some(&batch_identity) {
+                return Err(LlmError::new(
+                    "knowledge_embedding_no_progress",
+                    "knowledge embedding sync returned the same missing chunks after persistence",
+                    "knowledge",
+                ));
+            }
+            let batch_size = sources.len();
+            let texts = sources
+                .iter()
+                .map(|source| source.text.as_str())
+                .collect::<Vec<_>>();
+            let vectors = self.embedder.embed_documents(&texts)?;
+            if vectors.len() != batch_size {
+                return Err(LlmError::new(
+                    "knowledge_embedding_count_mismatch",
+                    "local knowledge embedding result count does not match chunks",
+                    "knowledge",
+                ));
+            }
+            drop(texts);
+
+            let records = sources
+                .into_iter()
+                .zip(vectors)
+                .map(|(source, vector)| KnowledgeEmbeddingRecord {
+                    chunk_id: source.chunk_id,
+                    content_hash: source.content_hash,
+                    vector,
+                })
+                .collect::<Vec<_>>();
+            store
+                .upsert_embeddings(model, SEMANTIC_EMBEDDING_VERSION, &records)
+                .map_err(embedding_db_error)?;
+            completed += records.len();
+            batch_number += 1;
+            previous_batch = Some(batch_identity);
+            // 大知识库可能产生数万批；保留首批、周期进度与末批，避免日志反向放大。
+            if batch_number == 1
+                || batch_number % PROGRESS_LOG_INTERVAL_BATCHES == 0
+                || batch_size < SEMANTIC_SYNC_BATCH_SIZE
+                || completed >= total_missing
+            {
+                tracing::info!(
+                    model,
+                    batch_number,
+                    batch_size,
+                    completed_chunks = completed,
+                    remaining_chunks = total_missing.saturating_sub(completed),
+                    elapsed_ms = batch_started.elapsed().as_millis(),
+                    "knowledge embedding batch completed"
+                );
+            }
         }
-        let texts = sources
-            .iter()
-            .map(|source| source.text.clone())
-            .collect::<Vec<_>>();
-        let vectors = self.embedder.embed_documents(&texts)?;
-        if vectors.len() != sources.len() {
-            return Err(LlmError::new(
-                "knowledge_embedding_count_mismatch",
-                "local knowledge embedding result count does not match chunks",
-                "knowledge",
-            ));
-        }
-        let records = sources
-            .into_iter()
-            .zip(vectors)
-            .map(|(source, vector)| KnowledgeEmbeddingRecord {
-                chunk_id: source.chunk_id,
-                content_hash: source.content_hash,
-                vector,
-            })
-            .collect::<Vec<_>>();
-        store
-            .upsert_embeddings(
-                self.embedder.model_id(),
-                SEMANTIC_EMBEDDING_VERSION,
-                &records,
-            )
-            .map_err(embedding_db_error)?;
-        Ok(records.len())
+
+        tracing::info!(
+            model,
+            completed_chunks = completed,
+            total_missing_chunks = total_missing,
+            total_batches = batch_number,
+            batch_size = SEMANTIC_SYNC_BATCH_SIZE,
+            inference_batch_size = FASTEMBED_INFERENCE_BATCH_SIZE,
+            elapsed_ms = started.elapsed().as_millis(),
+            "knowledge embedding sync completed"
+        );
+        Ok(completed)
     }
 
     pub(super) fn search(
@@ -204,4 +270,202 @@ fn embedding_db_error(error: crate::storage::database::DatabaseError) -> LlmErro
         format!("knowledge embedding database error: {}", error.message()),
         "knowledge",
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use crate::{
+        error::LlmError,
+        runtime::tools::knowledge::storage::{
+            KNOWLEDGE_MIGRATIONS, KnowledgeChunkDraft, KnowledgeStore,
+        },
+        storage::database::SqliteDatabase,
+    };
+
+    use super::{
+        KnowledgeEmbedder, SEMANTIC_EMBEDDING_VERSION, SEMANTIC_SYNC_BATCH_SIZE, SemanticRuntime,
+    };
+
+    struct RecordingEmbedder {
+        calls: Mutex<Vec<Vec<String>>>,
+        fail_on_call: Option<usize>,
+        mismatch_on_call: Option<usize>,
+    }
+
+    impl RecordingEmbedder {
+        fn new(fail_on_call: Option<usize>, mismatch_on_call: Option<usize>) -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                fail_on_call,
+                mismatch_on_call,
+            }
+        }
+
+        fn calls(&self) -> Vec<Vec<String>> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    impl KnowledgeEmbedder for RecordingEmbedder {
+        fn model_id(&self) -> &'static str {
+            "recording-embedding-v1"
+        }
+
+        fn embed_documents(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, LlmError> {
+            let call_number = {
+                let mut calls = self.calls.lock().unwrap();
+                calls.push(texts.iter().map(|text| (*text).to_owned()).collect());
+                calls.len()
+            };
+            if self.fail_on_call == Some(call_number) {
+                return Err(LlmError::new(
+                    "fixture_embedding_error",
+                    "fixture embedding failed",
+                    "knowledge",
+                ));
+            }
+            let vector_count = if self.mismatch_on_call == Some(call_number) {
+                texts.len().saturating_sub(1)
+            } else {
+                texts.len()
+            };
+            Ok((0..vector_count)
+                .map(|index| vec![index as f32, 1.0])
+                .collect())
+        }
+
+        fn embed_query(&self, _query: &str) -> Result<Vec<f32>, LlmError> {
+            Ok(vec![0.0, 1.0])
+        }
+    }
+
+    fn store_with_chunks(chunk_count: usize) -> KnowledgeStore {
+        let database =
+            SqliteDatabase::open_temp("qq-maid-knowledge-embedding-batch", KNOWLEDGE_MIGRATIONS)
+                .unwrap();
+        let store = KnowledgeStore::new(database);
+        let chunks = (0..chunk_count)
+            .map(|index| KnowledgeChunkDraft {
+                chunk_id: format!("batch-chunk-{index:05}"),
+                relative_path: "large.md".to_owned(),
+                document_title: Some("批处理测试".to_owned()),
+                heading_path: Some(format!("批处理测试 / 片段 {index}")),
+                chunk_index: index,
+                chunk_type: "text".to_owned(),
+                body: format!("第 {index} 个知识片段用于验证有界 embedding 同步。"),
+                content_hash: format!("content-hash-{index:05}"),
+                file_hash: "large-file-hash".to_owned(),
+                modified_at: None,
+                start_line: Some(index + 1),
+                end_line: Some(index + 1),
+                code_language: None,
+                chunking_version: 4,
+                search_text: format!("批处理 测试 片段 {index}"),
+            })
+            .collect::<Vec<_>>();
+        store
+            .replace_document("large.md", "large-file-hash", None, &chunks)
+            .unwrap();
+        store
+    }
+
+    fn missing_count(store: &KnowledgeStore) -> usize {
+        store
+            .missing_embedding_count("recording-embedding-v1", SEMANTIC_EMBEDDING_VERSION)
+            .unwrap()
+    }
+
+    #[test]
+    fn sync_missing_reads_and_persists_bounded_batches() {
+        let chunk_count = SEMANTIC_SYNC_BATCH_SIZE * 5 + 5;
+        let store = store_with_chunks(chunk_count);
+        let embedder = Arc::new(RecordingEmbedder::new(None, None));
+        let runtime = SemanticRuntime::from_embedder(embedder.clone());
+
+        assert_eq!(runtime.sync_missing(&store).unwrap(), chunk_count);
+        assert_eq!(missing_count(&store), 0);
+        let calls = embedder.calls();
+        assert_eq!(calls.len(), 6);
+        assert!(
+            calls
+                .iter()
+                .all(|batch| !batch.is_empty() && batch.len() <= SEMANTIC_SYNC_BATCH_SIZE)
+        );
+        assert_eq!(calls.iter().map(Vec::len).sum::<usize>(), chunk_count);
+    }
+
+    #[test]
+    fn completed_batches_survive_failure_and_resume_without_reembedding() {
+        let chunk_count = SEMANTIC_SYNC_BATCH_SIZE * 2 + 3;
+        let store = store_with_chunks(chunk_count);
+        let failing_embedder = Arc::new(RecordingEmbedder::new(Some(2), None));
+        let runtime = SemanticRuntime::from_embedder(failing_embedder.clone());
+
+        let error = runtime.sync_missing(&store).unwrap_err();
+        assert_eq!(error.code, "fixture_embedding_error");
+        assert_eq!(
+            missing_count(&store),
+            chunk_count - SEMANTIC_SYNC_BATCH_SIZE
+        );
+
+        let first_batch = failing_embedder.calls().remove(0);
+        let resumed_embedder = Arc::new(RecordingEmbedder::new(None, None));
+        let resumed_runtime = SemanticRuntime::from_embedder(resumed_embedder.clone());
+        assert_eq!(
+            resumed_runtime.sync_missing(&store).unwrap(),
+            chunk_count - SEMANTIC_SYNC_BATCH_SIZE
+        );
+        assert_eq!(missing_count(&store), 0);
+        let resumed_texts = resumed_embedder
+            .calls()
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        assert!(
+            first_batch
+                .iter()
+                .all(|completed_text| !resumed_texts.contains(completed_text))
+        );
+    }
+
+    #[test]
+    fn sync_missing_skips_embedder_for_empty_set() {
+        let store = store_with_chunks(0);
+        let embedder = Arc::new(RecordingEmbedder::new(None, None));
+        let runtime = SemanticRuntime::from_embedder(embedder.clone());
+
+        assert_eq!(runtime.sync_missing(&store).unwrap(), 0);
+        assert!(embedder.calls().is_empty());
+    }
+
+    #[test]
+    fn vector_count_mismatch_does_not_persist_partial_batch() {
+        let store = store_with_chunks(SEMANTIC_SYNC_BATCH_SIZE + 1);
+        let embedder = Arc::new(RecordingEmbedder::new(None, Some(1)));
+        let runtime = SemanticRuntime::from_embedder(embedder);
+
+        let error = runtime.sync_missing(&store).unwrap_err();
+        assert_eq!(error.code, "knowledge_embedding_count_mismatch");
+        assert_eq!(missing_count(&store), SEMANTIC_SYNC_BATCH_SIZE + 1);
+    }
+
+    #[test]
+    fn thousands_of_chunks_never_reach_embedder_as_one_collection() {
+        let chunk_count = 2_003;
+        let store = store_with_chunks(chunk_count);
+        let embedder = Arc::new(RecordingEmbedder::new(None, None));
+        let runtime = SemanticRuntime::from_embedder(embedder.clone());
+
+        assert_eq!(runtime.sync_missing(&store).unwrap(), chunk_count);
+        let calls = embedder.calls();
+        assert_eq!(calls.iter().map(Vec::len).sum::<usize>(), chunk_count);
+        assert!(
+            calls
+                .iter()
+                .all(|batch| batch.len() <= SEMANTIC_SYNC_BATCH_SIZE)
+        );
+        assert!(calls.len() > 1);
+    }
 }

--- a/qq-maid-core/src/runtime/tools/knowledge/index/mod.rs
+++ b/qq-maid-core/src/runtime/tools/knowledge/index/mod.rs
@@ -4,6 +4,7 @@
 //! 用户消息检索少量片段。它不替代固定系统 prompt，也不参与 Todo/Memory 等结构化 flow。
 
 mod chunking;
+mod diagnostics;
 mod embedding;
 pub mod eval;
 mod evidence;
@@ -33,6 +34,7 @@ use crate::{error::LlmError, storage::database::DatabaseError};
 use super::storage::{KnowledgeChunkDraft, KnowledgeStore};
 
 use chunking::{CHUNKING_VERSION, chunk_markdown};
+use diagnostics::summarize_chunks;
 use scan::{ScannedMarkdown, scan_markdown_files};
 use search::{KnowledgeSearchProfile, build_evidence, query_diagnostics, query_text};
 use text::hash_text;
@@ -301,7 +303,29 @@ impl KnowledgeIndex {
             return Ok(FileSyncOutcome::Unchanged);
         }
 
-        let chunks = chunk_markdown(&file.relative_path, &content)
+        let chunks = chunk_markdown(&file.relative_path, &content);
+        let diagnostics = summarize_chunks(&content, &chunks);
+        tracing::info!(
+            path = %file.relative_path,
+            file_bytes = diagnostics.file_bytes,
+            file_chars = diagnostics.file_chars,
+            chunk_count = diagnostics.chunk_count,
+            chunk_chars_min = diagnostics.chunk_chars_min,
+            chunk_chars_avg = diagnostics.chunk_chars_avg,
+            chunk_chars_p50 = diagnostics.chunk_chars_p50,
+            chunk_chars_p95 = diagnostics.chunk_chars_p95,
+            chunk_chars_max = diagnostics.chunk_chars_max,
+            chunks_with_heading = diagnostics.chunks_with_heading,
+            chunks_without_heading = diagnostics.chunks_without_heading,
+            heading_section_count = diagnostics.heading_section_count,
+            heading_chunks_min = diagnostics.heading_chunks_min,
+            heading_chunks_avg = diagnostics.heading_chunks_avg,
+            heading_chunks_p50 = diagnostics.heading_chunks_p50,
+            heading_chunks_p95 = diagnostics.heading_chunks_p95,
+            heading_chunks_max = diagnostics.heading_chunks_max,
+            "knowledge markdown chunking completed"
+        );
+        let chunks = chunks
             .into_iter()
             .map(|chunk| KnowledgeChunkDraft {
                 chunk_id: chunk.chunk_id,

--- a/qq-maid-core/src/runtime/tools/knowledge/index/semantic_tests.rs
+++ b/qq-maid-core/src/runtime/tools/knowledge/index/semantic_tests.rs
@@ -4,7 +4,7 @@ use crate::{error::LlmError, storage::database::SqliteDatabase};
 
 use super::{
     KnowledgeEvidenceStatus, KnowledgeIndex, KnowledgeInjectionReason, KnowledgeRecallType,
-    KnowledgeStore, embedding, render_context,
+    KnowledgeSemanticConfig, KnowledgeStore, embedding, render_context,
 };
 use crate::runtime::tools::knowledge::storage::KNOWLEDGE_MIGRATIONS;
 
@@ -15,7 +15,7 @@ impl embedding::KnowledgeEmbedder for FixtureEmbedder {
         "fixture-semantic-v1"
     }
 
-    fn embed_documents(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, LlmError> {
+    fn embed_documents(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, LlmError> {
         Ok(texts.iter().map(|text| fixture_vector(text)).collect())
     }
 
@@ -45,6 +45,30 @@ fn test_semantic_index(base: &Path) -> KnowledgeIndex {
         FixtureEmbedder,
     )));
     index
+}
+
+#[test]
+fn disabled_embedding_keeps_fts_search_available() {
+    let base = std::env::temp_dir().join(format!(
+        "qq-maid-knowledge-disabled-embedding-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let knowledge_dir = base.join("knowledge");
+    fs::create_dir_all(&knowledge_dir).unwrap();
+    fs::write(
+        knowledge_dir.join("fts.md"),
+        "# FTS 回退\n\nRAG-FTS-DISABLED 只通过本地 FTS 索引召回。",
+    )
+    .unwrap();
+    let index = test_index(&knowledge_dir)
+        .with_semantic_config(KnowledgeSemanticConfig::disabled(base.join("cache")))
+        .unwrap();
+
+    let summary = index.sync().unwrap();
+    let context = render_context(&index.search_auto_evidence("RAG-FTS-DISABLED"));
+
+    assert_eq!(summary.embedded_chunk_count, 0);
+    assert!(context.contains("RAG-FTS-DISABLED"));
 }
 
 #[test]

--- a/qq-maid-core/src/runtime/tools/knowledge/storage.rs
+++ b/qq-maid-core/src/runtime/tools/knowledge/storage.rs
@@ -547,7 +547,11 @@ impl KnowledgeStore {
         &self,
         model: &str,
         embedding_version: i64,
+        limit: usize,
     ) -> Result<Vec<KnowledgeEmbeddingSource>, DatabaseError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
         let conn = self.database.connection()?;
         let mut stmt = conn
             .prepare(
@@ -561,20 +565,52 @@ impl KnowledgeStore {
                   AND e.embedding_version = ?2
                   AND e.content_hash = c.content_hash
                  WHERE e.chunk_id IS NULL
-                 ORDER BY c.document_id, c.chunk_index",
+                 ORDER BY c.document_id, c.chunk_index
+                 LIMIT ?3",
             )
             .map_err(DatabaseError::from_sql)?;
         let rows = stmt
-            .query_map(params![model, embedding_version], |row| {
-                Ok(KnowledgeEmbeddingSource {
-                    chunk_id: row.get(0)?,
-                    content_hash: row.get(1)?,
-                    text: row.get(2)?,
-                })
-            })
+            .query_map(
+                params![
+                    model,
+                    embedding_version,
+                    i64::try_from(limit).unwrap_or(i64::MAX)
+                ],
+                |row| {
+                    Ok(KnowledgeEmbeddingSource {
+                        chunk_id: row.get(0)?,
+                        content_hash: row.get(1)?,
+                        text: row.get(2)?,
+                    })
+                },
+            )
             .map_err(DatabaseError::from_sql)?;
         rows.collect::<Result<Vec<_>, _>>()
             .map_err(DatabaseError::from_sql)
+    }
+
+    pub fn missing_embedding_count(
+        &self,
+        model: &str,
+        embedding_version: i64,
+    ) -> Result<usize, DatabaseError> {
+        let count = self
+            .database
+            .connection()?
+            .query_row(
+                "SELECT count(*)
+                 FROM knowledge_chunks c
+                 LEFT JOIN knowledge_chunk_embeddings e
+                   ON e.chunk_id = c.chunk_id
+                  AND e.model = ?1
+                  AND e.embedding_version = ?2
+                  AND e.content_hash = c.content_hash
+                 WHERE e.chunk_id IS NULL",
+                params![model, embedding_version],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(DatabaseError::from_sql)?;
+        Ok(count.max(0) as usize)
     }
 
     pub fn upsert_embeddings(
@@ -794,7 +830,9 @@ mod tests {
         assert_eq!(results[0].chunk_index, 0);
         assert_eq!(results[0].start_line, Some(3));
 
-        let missing = store.missing_embedding_sources("fixture-model", 1).unwrap();
+        let missing = store
+            .missing_embedding_sources("fixture-model", 1, 1)
+            .unwrap();
         assert_eq!(missing.len(), 1);
         store
             .upsert_embeddings(
@@ -809,7 +847,7 @@ mod tests {
             .unwrap();
         assert!(
             store
-                .missing_embedding_sources("fixture-model", 1)
+                .missing_embedding_sources("fixture-model", 1, 1)
                 .unwrap()
                 .is_empty()
         );


### PR DESCRIPTION
## 修改内容

- 缺失 embedding 查询增加固定 `LIMIT 8`，每批推理后立即事务写入 SQLite
- FastEmbed 5.17.3 显式使用推理 batch size 8，避免依赖默认值 256
- 文本通过借用传入 embedder，避免为当前批次再次 clone 正文
- 保留已完成批次以支持失败后断点续跑，并增加无进展保护与低噪音进度日志
- 增加匿名 Markdown 分块统计：文件字节/字符、chunk 长度分位数、heading 覆盖和章节 chunk 分布
- 保持 embedding 配置格式、分块规则、content hash/向量版本和 FTS/BM25 语义不变

## 根因

旧实现会一次性从 SQLite 读取全部缺失 chunk，同时持有 `sources`、克隆后的 `texts`、全部 `vectors` 和 `records`。FastEmbed 5.17.3 默认 batch size 为 256，且内部会先收集各子批 ONNX 输出后统一导出，因此内存会随缺失 chunk 总量增长，初次构建大型本地 embedding 索引时可能触发 OOM。

## 验证

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-features`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace --release --all-features`
- 用户提供的 405,656 字节 Markdown：1,193 chunk，真实 BGE/FastEmbed 全量完成，最大 RSS 517,384 KB（Ubuntu 26.04 测试环境）
- 内核日志未出现本轮 `Out of memory` 或 `Killed process`

## 影响

大型 Markdown 的 embedding 初始化内存改为受固定批次约束；前序成功批次立即持久化，失败重启只继续缺失项。关闭 embedding 时仍走纯 FTS/BM25。分块命中率优化不在本 PR 范围内。