### PR TITLE
feat: 发布 0.22.0 并补齐 TTS 控制台

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 本文档基于 [keep a changelog](https://keepachangelog.com/zh-CN/1.0.0/) 格式，记录每个已发布版本的变更。
 
+## [v0.22.0] - 2026-07-29
+
+### Release Focus
+
+* **QQ 语音回复与模型接入扩展**：在现有多入口文本机器人基础上增加 QQ 官方最终回复 TTS，并补齐 Web 全局配置体验；同时扩展 OpenCode Zen / Go 模型接入，收紧命令和本地 embedding 的运行边界。
+
+### Added
+
+* **QQ 官方语音回复与会话开关**（PR #600）：新增 `/语音`、`/语音 开启`、`/语音 关闭`，按平台、机器人账号和私聊/群聊目标隔离持久化偏好；开启时使用千问非流式 TTS 生成 WAV URL，再通过 QQ `/files` 与 `msg_type=7` 投递，失败时只回退一次原始文字。
+* **TTS Web 配置卡片**：Web 控制台新增独立“语音回复”分组、Provider 下拉框、千问配置中文标签、超时与朗读字符范围，并继续通过安全配置中心保存、替换或显式清除 API Key；关闭 Provider 只弱化显示，不删除已保存的千问配置。
+* **OpenCode Zen 与 Go Provider**（PR #598）：新增配置驱动的 `openai_responses` 能力和 Zen Responses、Zen Chat、Go 三个固定 Web 预设，共用受管 `OPENCODE_API_KEY`，支持模型路线模板、revision 冲突保护和官方匿名模型目录探测。
+* **社区反馈入口**（PR #594）：README 增加社区交流、问题反馈和功能建议入口。
+
+### Changed
+
+* **未知 Slash 命令确定性收口**（PR #595）：所有已注册命令均未匹配时不再进入 LLM、Tool Loop 或创建 Session；私聊返回统一提示，群聊仅在消息明确指向机器人时回复。
+* **知识库 embedding 内存限制**（PR #597）：缺失向量固定按 8 条分批读取、推理和事务写入，避免初次索引大型 Markdown 时同时持有全部文本与向量；已完成批次可在失败后断点续跑。
+
+### Compatibility
+
+* 根包 `qq-maid-bot` 提升到 `0.22.0`；`qq-maid-common`、`qq-maid-llm`、`qq-maid-core`、`qq-maid-gateway-rs` 分别提升到 `0.1.3`、`0.1.8`、`0.1.17`、`0.1.12`。
+* 本版本无数据库 migration、无必需配置迁移。TTS 默认 `disabled`；已有部署升级后仍保持文字回复，只有配置可用的千问 Key 并在具体私聊或群聊执行 `/语音 开启` 后才使用语音。
+* Web 控制台只管理全局 TTS 能力，不新增会话 scope 管理、试听、连接测试或音色在线枚举；会话开关、群管理员权限和已有保存语义保持不变。
+* QQ TTS、OpenCode 和配置中心已通过本地 mock / 单元测试覆盖；未使用真实 QQ AppID/AppSecret、千问 API Key 或 OpenCode 凭证进行生产环境联调，签名 WAV URL 的 QQ 拉取与真实模型调用仍需在目标部署环境确认。
+
 ## [v0.21.6] - 2026-07-25
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,7 +1976,7 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "qq-maid-bot"
-version = "0.21.6"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "qq-maid-core",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-common"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "pulldown-cmark",
@@ -2006,7 +2006,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-core"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-gateway-rs"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "aes",
  "anyhow",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-llm"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-bot"
-version = "0.21.6"
+version = "0.22.0"
 edition = "2024"
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,16 @@
 
 > 💡 仓库早期以 QQ 机器人为主，因此仍保留 `qq-maid-bot` 名称。当前项目正在从 QQ 官方机器人演进为多入口平台型小女仆机器人。
 
-当前稳定版本为 `v0.21.6`，项目处于 `21.x` 版本线；版本线能力与升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)。
+当前稳定版本为 `v0.22.0`，项目处于 `22.x` 版本线；版本线能力与升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)。
 
 使用、安装和配置优先看 [项目 Wiki](https://github.com/kuliantnt/qq-maid-bot/wiki)：从第一次对话、一键安装、Docker / GHCR、配置中心与 `/console/` 首次向导，到 NapCat、`/ops` 运维和 Codex 长任务，都按场景拆开了。仓库内 `docs/` 与各 crate README 更偏开发边界和实现细节。
 
-## 21.x 版本线更新
+## 22.x 版本线更新
+
+- **QQ 语音回复与 Provider 扩展**（v0.22.0）：QQ 官方私聊和群聊支持按会话开启千问 TTS 最终回复；Web 控制台补齐全局 TTS 配置卡片，同时新增 OpenCode Zen / Go Provider、未知 Slash 确定性收口和知识库 embedding 内存限制。
+
+### 上一版（21.x）
+
 - **联网搜索与群聊触发修复**（v0.21.6）：收紧长结果、嵌套调研和空结果的搜索证据语义，补充 `/todo daily status` 帮助，并避免 @全体成员误触发机器人。
 - **QQ 群消息触发修复**（v0.21.5）：修复群聊 @ 机器人识别和 mention 文本污染，兼容 `GROUP_AT_MESSAGE_CREATE`、稳定机器人身份匹配及旧事件字段，同时避免误触发其它机器人。
 - **QQ API v2 消息协议与富媒体上传**（v0.21.4）：对齐图片分片上传、入站消息归一化、稳定群聊 @ 判断和复合消息去重；收紧 ARK、临时上传 URL 与被动回复分段的安全边界。
@@ -36,9 +41,6 @@
 ### 配置方式变化
 
 0.19 及之前需要在 `config/.env` 中手写凭证和开关；0.20 起推荐新部署走 `/console/` 引导；0.21 起 Docker / Release / 源码共用同一配置中心与运维 CLI，旧 `.env` 部署继续可用。
-
-### 上一版（20.x）
-- 安全配置中心与 `/console/`、QQ 语音转写与统一命令前缀、知识库 Agent 化、Tavily 可选搜索、图片生成与多平台发送、Session Dream 续批稳定性。
 
 完整变更与升级说明见 [CHANGELOG.md](./CHANGELOG.md)。
 

--- a/qq-maid-common/Cargo.toml
+++ b/qq-maid-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-common"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 publish = false
 

--- a/qq-maid-core/Cargo.toml
+++ b/qq-maid-core/Cargo.toml
@@ -1,7 +1,7 @@
 # qq-maid-core 项目清单 —— 定义包元信息和依赖项。
 [package]
 name = "qq-maid-core"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 
 # 主运行依赖

--- a/qq-maid-gateway-rs/Cargo.toml
+++ b/qq-maid-gateway-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-gateway-rs"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 publish = false
 

--- a/qq-maid-llm/Cargo.toml
+++ b/qq-maid-llm/Cargo.toml
@@ -1,7 +1,7 @@
 # qq-maid-llm 项目清单 —— 只承载模型调用、Provider 路由和 Web Search 协议能力。
 [package]
 name = "qq-maid-llm"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 publish = false
 

--- a/web-console/dist/styles.css
+++ b/web-console/dist/styles.css
@@ -363,6 +363,7 @@ textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(13, 138
   font-size: .78rem;
   letter-spacing: .06em;
 }
+.config-field-group-hint { margin: 0; padding: 0 .15rem; color: var(--muted); font-size: .78rem; line-height: 1.6; }
 .config-field-group-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .8rem; }
 .config-row {
   display: grid;
@@ -380,6 +381,8 @@ textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(13, 138
 .config-row:focus-within { border-color: #9fd3bd; box-shadow: 0 0 0 3px rgba(13, 138, 95, .08); }
 .config-row-warning { border-color: #e2ad6d; background: #fffaf3; }
 .config-row-warning > strong, .config-row-warning .field-meta { color: var(--warn); }
+.config-row-muted { background: #f7f8f7; opacity: .72; }
+.config-row-muted:focus-within { opacity: 1; }
 .config-row > label:first-child { margin: 0; color: var(--ink); }
 .config-row > input:not([type="checkbox"]) { width: 100%; }
 .config-row .password-field { width: 100%; }

--- a/web-console/dist/views/configuration.js
+++ b/web-console/dist/views/configuration.js
@@ -4,6 +4,13 @@ import { togglePasswordReveal } from "../dom.js";
 import { openCodeProviderChange, readOpenCodeProviders, renderOpenCodeProviders, renderOpenCodeRouteHints, } from "../opencode-providers.js";
 const FIELD_LABELS = {
     "command.prefix": "聊天命令前缀",
+    "delivery.tts.provider": "语音 Provider",
+    "delivery.tts.qwen_api_key": "千问 TTS API Key",
+    "delivery.tts.qwen_base_url": "千问 TTS Base URL",
+    "delivery.tts.qwen_model": "千问 TTS 模型",
+    "delivery.tts.qwen_voice": "千问 TTS 音色",
+    "delivery.tts.request_timeout_seconds": "请求超时（秒）",
+    "delivery.tts.max_text_chars": "最大朗读字符数",
     "provider.openai.base_url": "OpenAI Base URL",
     "provider.openai.api_mode": "OpenAI API 模式",
     "provider.openai.api_key": "OpenAI API Key",
@@ -57,6 +64,11 @@ const FIELD_LABELS = {
 };
 const FIELD_GROUPS = [
     { label: "命令设置", prefix: "command." },
+    {
+        label: "语音回复",
+        prefix: "delivery.tts.",
+        description: "修改后需要重启。Web 控制台只配置全局 TTS 能力；Provider 关闭或千问 API Key 未配置时，/语音 开启会被拒绝。私聊或群聊是否启用仍通过 /语音 开启、/语音 关闭管理。关闭 Provider 不会清除已保存的千问配置，也可以提前填写。",
+    },
     { label: "模型服务", prefix: "provider." },
     { label: "QQ 官方入口", prefix: "platform.qq_official." },
     { label: "OneBot 11 入口", prefix: "platform.onebot11." },
@@ -67,6 +79,32 @@ const FIELD_GROUPS = [
     { label: "Web 控制台", prefix: "console." },
     { label: "基础运行", prefix: "bootstrap." },
 ];
+const TTS_PROVIDER_OPTIONS = [
+    ["disabled", "关闭"],
+    ["qwen", "千问"],
+];
+const TTS_NUMBER_RANGES = {
+    "delivery.tts.request_timeout_seconds": [1, 120],
+    "delivery.tts.max_text_chars": [1, 600],
+};
+export function configFieldLabel(key) {
+    return FIELD_LABELS[key] ?? key;
+}
+export function configFieldGroupLabel(key) {
+    return FIELD_GROUPS.find((group) => key.startsWith(group.prefix))?.label ?? "其他配置";
+}
+/** 未识别的历史 Provider 必须原样保留，避免页面加载或保存时静默改成受支持值。 */
+export function ttsProviderOptions(currentValue) {
+    const current = currentValue === null || currentValue === undefined ? "disabled" : String(currentValue);
+    const options = TTS_PROVIDER_OPTIONS.map(([value, label]) => [value, label]);
+    if (!options.some(([value]) => value === current)) {
+        options.push([current, `${current}（当前自定义值）`]);
+    }
+    return options;
+}
+export function ttsNumberRange(key) {
+    return TTS_NUMBER_RANGES[key] ?? null;
+}
 const AGENT_ROUTE_LABELS = {
     private_main: "私聊主路线",
     group_main: "群聊主路线",
@@ -164,6 +202,7 @@ function render(snapshot) {
     renderSummary(snapshot);
     renderPublicFields(snapshot);
     renderSecretFields(snapshot);
+    bindTtsProviderState();
     renderAgent(snapshot);
     bindRestart(snapshot);
     bindValidation();
@@ -183,9 +222,10 @@ function renderPublicFields(snapshot) {
     appendGroupedFields(target, snapshot.fields.filter((value) => value.sensitivity !== "secret"), (field) => {
         const row = document.createElement("div");
         row.className = "config-row";
+        decorateTtsRow(row, field);
         const label = document.createElement("label");
         label.htmlFor = inputId(field.key);
-        label.textContent = FIELD_LABELS[field.key] ?? field.key;
+        label.textContent = configFieldLabel(field.key);
         label.append(meta(field));
         const input = fieldInput(field);
         row.append(label, input);
@@ -195,7 +235,7 @@ function renderPublicFields(snapshot) {
             row.append(remove);
         }
         return row;
-    });
+    }, true);
     const save = element("save-public-config", HTMLButtonElement);
     save.onclick = () => void savePublicFields();
 }
@@ -205,9 +245,10 @@ function renderSecretFields(snapshot) {
     appendGroupedFields(target, snapshot.fields.filter((value) => value.sensitivity === "secret"), (field) => {
         const row = document.createElement("div");
         row.className = "config-row secret-row";
+        decorateTtsRow(row, field);
         const label = document.createElement("label");
         label.htmlFor = inputId(field.key);
-        label.textContent = FIELD_LABELS[field.key] ?? field.key;
+        label.textContent = configFieldLabel(field.key);
         label.append(meta(field));
         const input = document.createElement("input");
         input.id = inputId(field.key);
@@ -378,19 +419,19 @@ function renderAgent(snapshot) {
     save.disabled = !agent.editable;
     save.onclick = () => void saveAgent();
 }
-function appendGroupedFields(target, fields, row) {
+function appendGroupedFields(target, fields, row, showDescriptions = false) {
     const remaining = new Set(fields);
     for (const group of FIELD_GROUPS) {
         const grouped = fields.filter((field) => field.key.startsWith(group.prefix));
         if (grouped.length === 0)
             continue;
-        target.append(fieldGroup(group.label, grouped.map(row)));
+        target.append(fieldGroup(group.label, grouped.map(row), showDescriptions ? group.description : undefined));
         grouped.forEach((field) => remaining.delete(field));
     }
     if (remaining.size > 0)
         target.append(fieldGroup("其他配置", [...remaining].map(row)));
 }
-function fieldGroup(label, rows) {
+function fieldGroup(label, rows, description) {
     const section = document.createElement("section");
     section.className = "config-field-group";
     const heading = document.createElement("h3");
@@ -398,16 +439,22 @@ function fieldGroup(label, rows) {
     const grid = document.createElement("div");
     grid.className = "config-field-group-grid";
     grid.append(...rows);
-    section.append(heading, grid);
+    section.append(heading);
+    if (description) {
+        const hint = document.createElement("p");
+        hint.className = "config-field-group-hint";
+        hint.textContent = description;
+        section.append(hint);
+    }
+    section.append(grid);
     return section;
 }
-async function savePublicFields() {
-    if (!current)
-        return;
+export function publicConfigurationChanges(fields, values) {
     const changes = [];
-    for (const field of current.fields.filter((value) => value.sensitivity === "public" && value.editable)) {
-        const input = configInput(field.key);
-        const value = inputValue(input, field);
+    for (const field of fields.filter((value) => value.sensitivity === "public" && value.editable)) {
+        if (!values.has(field.key))
+            continue;
+        const value = values.get(field.key);
         const baseline = field.savedValue ?? field.effectiveValue;
         // 未配置的可选字段会显示为空输入框；用户未触碰时不能把空字符串误当成新配置提交。
         if ((baseline === null || baseline === undefined) && isEmptyInputValue(value))
@@ -416,6 +463,21 @@ async function savePublicFields() {
             changes.push({ action: "set", key: field.key, value });
         }
     }
+    return changes;
+}
+async function savePublicFields() {
+    if (!current)
+        return;
+    const values = new Map();
+    for (const field of current.fields.filter((value) => value.sensitivity === "public" && value.editable)) {
+        const input = configInput(field.key);
+        if (!input.checkValidity()) {
+            input.reportValidity();
+            return showResult(`${configFieldLabel(field.key)}不符合页面输入范围，请修改后再保存。`, true);
+        }
+        values.set(field.key, inputValue(input, field));
+    }
+    const changes = publicConfigurationChanges(current.fields, values);
     if (changes.length === 0)
         return showResult("没有需要保存的普通配置。", false);
     await runSave(async () => updateRuntimeConfiguration(current.revision, changes));
@@ -425,20 +487,33 @@ async function removePublicField(key) {
         return;
     await runSave(async () => updateRuntimeConfiguration(current.revision, [{ action: "remove", key }]));
 }
+export function secretConfigurationChanges(fields, values, clearKeys) {
+    const changes = [];
+    for (const field of fields.filter((value) => value.sensitivity === "secret" && value.editable)) {
+        if (clearKeys.has(field.key)) {
+            changes.push({ action: "clear", key: field.key, expected_revision: field.revision ?? "missing" });
+        }
+        else {
+            const value = values.get(field.key) ?? "";
+            if (value.length > 0) {
+                changes.push({ action: "replace", key: field.key, value, expected_revision: field.revision ?? "missing" });
+            }
+        }
+    }
+    return changes;
+}
 async function saveSecrets() {
     if (!current)
         return;
-    const changes = [];
+    const values = new Map();
+    const clearKeys = new Set();
     for (const field of current.fields.filter((value) => value.sensitivity === "secret" && value.editable)) {
-        const input = element(inputId(field.key), HTMLInputElement);
+        values.set(field.key, element(inputId(field.key), HTMLInputElement).value);
         const clear = document.querySelector(`input[data-clear-key="${field.key}"]`);
-        if (clear?.checked) {
-            changes.push({ action: "clear", key: field.key, expected_revision: field.revision ?? "missing" });
-        }
-        else if (input.value.length > 0) {
-            changes.push({ action: "replace", key: field.key, value: input.value, expected_revision: field.revision ?? "missing" });
-        }
+        if (clear?.checked)
+            clearKeys.add(field.key);
     }
+    const changes = secretConfigurationChanges(current.fields, values, clearKeys);
     if (changes.length === 0)
         return showResult("留空不会清除 secret；当前没有显式变更。", false);
     await runSave(async () => updateSecretConfiguration(changes));
@@ -605,6 +680,21 @@ async function runSave(action) {
 }
 function fieldInput(field) {
     const value = field.savedValue ?? field.effectiveValue;
+    if (field.key === "delivery.tts.provider") {
+        const select = document.createElement("select");
+        select.id = inputId(field.key);
+        select.dataset.configKey = field.key;
+        select.disabled = !field.editable;
+        const currentValue = value === null || value === undefined ? "disabled" : String(value);
+        for (const [optionValue, label] of ttsProviderOptions(currentValue)) {
+            const option = document.createElement("option");
+            option.value = optionValue;
+            option.textContent = label;
+            select.append(option);
+        }
+        select.value = currentValue;
+        return select;
+    }
     if (field.key === "command.prefix") {
         const select = document.createElement("select");
         select.id = inputId(field.key);
@@ -639,8 +729,33 @@ function fieldInput(field) {
     else {
         input.type = field.valueType === "integer" ? "number" : "text";
         input.value = Array.isArray(value) ? value.join(", ") : value === null || value === undefined ? "" : String(value);
+        const range = ttsNumberRange(field.key);
+        if (range) {
+            input.min = String(range[0]);
+            input.max = String(range[1]);
+            input.step = "1";
+        }
     }
     return input;
+}
+function decorateTtsRow(row, field) {
+    row.dataset.configFieldKey = field.key;
+    if (field.key.startsWith("delivery.tts.qwen_"))
+        row.dataset.ttsQwenField = "true";
+}
+/** 关闭 Provider 只做视觉提示，字段始终保持可编辑且不会生成清除操作。 */
+function bindTtsProviderState() {
+    const provider = document.getElementById(inputId("delivery.tts.provider"));
+    if (!(provider instanceof HTMLSelectElement))
+        return;
+    const refresh = () => {
+        const disabled = provider.value === "disabled";
+        for (const row of document.querySelectorAll("[data-tts-qwen-field='true']")) {
+            row.classList.toggle("config-row-muted", disabled);
+        }
+    };
+    provider.addEventListener("change", refresh);
+    refresh();
 }
 function inputValue(input, field) {
     if (field.valueType === "boolean")

--- a/web-console/src/styles.css
+++ b/web-console/src/styles.css
@@ -363,6 +363,7 @@ textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(13, 138
   font-size: .78rem;
   letter-spacing: .06em;
 }
+.config-field-group-hint { margin: 0; padding: 0 .15rem; color: var(--muted); font-size: .78rem; line-height: 1.6; }
 .config-field-group-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .8rem; }
 .config-row {
   display: grid;
@@ -380,6 +381,8 @@ textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(13, 138
 .config-row:focus-within { border-color: #9fd3bd; box-shadow: 0 0 0 3px rgba(13, 138, 95, .08); }
 .config-row-warning { border-color: #e2ad6d; background: #fffaf3; }
 .config-row-warning > strong, .config-row-warning .field-meta { color: var(--warn); }
+.config-row-muted { background: #f7f8f7; opacity: .72; }
+.config-row-muted:focus-within { opacity: 1; }
 .config-row > label:first-child { margin: 0; color: var(--ink); }
 .config-row > input:not([type="checkbox"]) { width: 100%; }
 .config-row .password-field { width: 100%; }

--- a/web-console/src/views/configuration.ts
+++ b/web-console/src/views/configuration.ts
@@ -20,6 +20,13 @@ import type { ConfigFieldSnapshot, ConfigurationSnapshot } from "../types.js";
 
 const FIELD_LABELS: Record<string, string> = {
   "command.prefix": "聊天命令前缀",
+  "delivery.tts.provider": "语音 Provider",
+  "delivery.tts.qwen_api_key": "千问 TTS API Key",
+  "delivery.tts.qwen_base_url": "千问 TTS Base URL",
+  "delivery.tts.qwen_model": "千问 TTS 模型",
+  "delivery.tts.qwen_voice": "千问 TTS 音色",
+  "delivery.tts.request_timeout_seconds": "请求超时（秒）",
+  "delivery.tts.max_text_chars": "最大朗读字符数",
   "provider.openai.base_url": "OpenAI Base URL",
   "provider.openai.api_mode": "OpenAI API 模式",
   "provider.openai.api_key": "OpenAI API Key",
@@ -72,8 +79,19 @@ const FIELD_LABELS: Record<string, string> = {
   "bootstrap.ops_config_file": "运维配置文件",
 };
 
-const FIELD_GROUPS = [
+interface FieldGroupDefinition {
+  label: string;
+  prefix: string;
+  description?: string;
+}
+
+const FIELD_GROUPS: readonly FieldGroupDefinition[] = [
   { label: "命令设置", prefix: "command." },
+  {
+    label: "语音回复",
+    prefix: "delivery.tts.",
+    description: "修改后需要重启。Web 控制台只配置全局 TTS 能力；Provider 关闭或千问 API Key 未配置时，/语音 开启会被拒绝。私聊或群聊是否启用仍通过 /语音 开启、/语音 关闭管理。关闭 Provider 不会清除已保存的千问配置，也可以提前填写。",
+  },
   { label: "模型服务", prefix: "provider." },
   { label: "QQ 官方入口", prefix: "platform.qq_official." },
   { label: "OneBot 11 入口", prefix: "platform.onebot11." },
@@ -83,7 +101,39 @@ const FIELD_GROUPS = [
   { label: "天气服务", prefix: "weather." },
   { label: "Web 控制台", prefix: "console." },
   { label: "基础运行", prefix: "bootstrap." },
-] as const;
+];
+
+const TTS_PROVIDER_OPTIONS: ReadonlyArray<readonly [string, string]> = [
+  ["disabled", "关闭"],
+  ["qwen", "千问"],
+];
+
+const TTS_NUMBER_RANGES: Readonly<Record<string, readonly [number, number]>> = {
+  "delivery.tts.request_timeout_seconds": [1, 120],
+  "delivery.tts.max_text_chars": [1, 600],
+};
+
+export function configFieldLabel(key: string): string {
+  return FIELD_LABELS[key] ?? key;
+}
+
+export function configFieldGroupLabel(key: string): string {
+  return FIELD_GROUPS.find((group) => key.startsWith(group.prefix))?.label ?? "其他配置";
+}
+
+/** 未识别的历史 Provider 必须原样保留，避免页面加载或保存时静默改成受支持值。 */
+export function ttsProviderOptions(currentValue: unknown): Array<[string, string]> {
+  const current = currentValue === null || currentValue === undefined ? "disabled" : String(currentValue);
+  const options = TTS_PROVIDER_OPTIONS.map(([value, label]): [string, string] => [value, label]);
+  if (!options.some(([value]) => value === current)) {
+    options.push([current, `${current}（当前自定义值）`]);
+  }
+  return options;
+}
+
+export function ttsNumberRange(key: string): readonly [number, number] | null {
+  return TTS_NUMBER_RANGES[key] ?? null;
+}
 
 const AGENT_ROUTE_LABELS: Record<string, string> = {
   private_main: "私聊主路线",
@@ -208,6 +258,7 @@ function render(snapshot: ConfigurationSnapshot): void {
   renderSummary(snapshot);
   renderPublicFields(snapshot);
   renderSecretFields(snapshot);
+  bindTtsProviderState();
   renderAgent(snapshot);
   bindRestart(snapshot);
   bindValidation();
@@ -236,9 +287,10 @@ function renderPublicFields(snapshot: ConfigurationSnapshot): void {
     (field) => {
     const row = document.createElement("div");
     row.className = "config-row";
+    decorateTtsRow(row, field);
     const label = document.createElement("label");
     label.htmlFor = inputId(field.key);
-    label.textContent = FIELD_LABELS[field.key] ?? field.key;
+    label.textContent = configFieldLabel(field.key);
     label.append(meta(field));
     const input = fieldInput(field);
     row.append(label, input);
@@ -249,6 +301,7 @@ function renderPublicFields(snapshot: ConfigurationSnapshot): void {
     }
       return row;
     },
+    true,
   );
   const save = element("save-public-config", HTMLButtonElement);
   save.onclick = () => void savePublicFields();
@@ -263,9 +316,10 @@ function renderSecretFields(snapshot: ConfigurationSnapshot): void {
     (field) => {
     const row = document.createElement("div");
     row.className = "config-row secret-row";
+    decorateTtsRow(row, field);
     const label = document.createElement("label");
     label.htmlFor = inputId(field.key);
-    label.textContent = FIELD_LABELS[field.key] ?? field.key;
+    label.textContent = configFieldLabel(field.key);
     label.append(meta(field));
     const input = document.createElement("input");
     input.id = inputId(field.key);
@@ -471,18 +525,23 @@ function appendGroupedFields(
   target: HTMLElement,
   fields: ConfigFieldSnapshot[],
   row: (field: ConfigFieldSnapshot) => HTMLElement,
+  showDescriptions = false,
 ): void {
   const remaining = new Set(fields);
   for (const group of FIELD_GROUPS) {
     const grouped = fields.filter((field) => field.key.startsWith(group.prefix));
     if (grouped.length === 0) continue;
-    target.append(fieldGroup(group.label, grouped.map(row)));
+    target.append(fieldGroup(
+      group.label,
+      grouped.map(row),
+      showDescriptions ? group.description : undefined,
+    ));
     grouped.forEach((field) => remaining.delete(field));
   }
   if (remaining.size > 0) target.append(fieldGroup("其他配置", [...remaining].map(row)));
 }
 
-function fieldGroup(label: string, rows: HTMLElement[]): HTMLElement {
+function fieldGroup(label: string, rows: HTMLElement[], description?: string): HTMLElement {
   const section = document.createElement("section");
   section.className = "config-field-group";
   const heading = document.createElement("h3");
@@ -490,16 +549,25 @@ function fieldGroup(label: string, rows: HTMLElement[]): HTMLElement {
   const grid = document.createElement("div");
   grid.className = "config-field-group-grid";
   grid.append(...rows);
-  section.append(heading, grid);
+  section.append(heading);
+  if (description) {
+    const hint = document.createElement("p");
+    hint.className = "config-field-group-hint";
+    hint.textContent = description;
+    section.append(hint);
+  }
+  section.append(grid);
   return section;
 }
 
-async function savePublicFields(): Promise<void> {
-  if (!current) return;
-  const changes: unknown[] = [];
-  for (const field of current.fields.filter((value) => value.sensitivity === "public" && value.editable)) {
-    const input = configInput(field.key);
-    const value = inputValue(input, field);
+export function publicConfigurationChanges(
+  fields: ConfigFieldSnapshot[],
+  values: ReadonlyMap<string, unknown>,
+): Array<Record<string, unknown>> {
+  const changes: Array<Record<string, unknown>> = [];
+  for (const field of fields.filter((value) => value.sensitivity === "public" && value.editable)) {
+    if (!values.has(field.key)) continue;
+    const value = values.get(field.key);
     const baseline = field.savedValue ?? field.effectiveValue;
     // 未配置的可选字段会显示为空输入框；用户未触碰时不能把空字符串误当成新配置提交。
     if ((baseline === null || baseline === undefined) && isEmptyInputValue(value)) continue;
@@ -507,6 +575,21 @@ async function savePublicFields(): Promise<void> {
       changes.push({ action: "set", key: field.key, value });
     }
   }
+  return changes;
+}
+
+async function savePublicFields(): Promise<void> {
+  if (!current) return;
+  const values = new Map<string, unknown>();
+  for (const field of current.fields.filter((value) => value.sensitivity === "public" && value.editable)) {
+    const input = configInput(field.key);
+    if (!input.checkValidity()) {
+      input.reportValidity();
+      return showResult(`${configFieldLabel(field.key)}不符合页面输入范围，请修改后再保存。`, true);
+    }
+    values.set(field.key, inputValue(input, field));
+  }
+  const changes = publicConfigurationChanges(current.fields, values);
   if (changes.length === 0) return showResult("没有需要保存的普通配置。", false);
   await runSave(async () => updateRuntimeConfiguration(current!.revision, changes));
 }
@@ -516,18 +599,35 @@ async function removePublicField(key: string): Promise<void> {
   await runSave(async () => updateRuntimeConfiguration(current!.revision, [{ action: "remove", key }]));
 }
 
-async function saveSecrets(): Promise<void> {
-  if (!current) return;
-  const changes: unknown[] = [];
-  for (const field of current.fields.filter((value) => value.sensitivity === "secret" && value.editable)) {
-    const input = element(inputId(field.key), HTMLInputElement);
-    const clear = document.querySelector<HTMLInputElement>(`input[data-clear-key="${field.key}"]`);
-    if (clear?.checked) {
+export function secretConfigurationChanges(
+  fields: ConfigFieldSnapshot[],
+  values: ReadonlyMap<string, string>,
+  clearKeys: ReadonlySet<string>,
+): Array<Record<string, unknown>> {
+  const changes: Array<Record<string, unknown>> = [];
+  for (const field of fields.filter((value) => value.sensitivity === "secret" && value.editable)) {
+    if (clearKeys.has(field.key)) {
       changes.push({ action: "clear", key: field.key, expected_revision: field.revision ?? "missing" });
-    } else if (input.value.length > 0) {
-      changes.push({ action: "replace", key: field.key, value: input.value, expected_revision: field.revision ?? "missing" });
+    } else {
+      const value = values.get(field.key) ?? "";
+      if (value.length > 0) {
+        changes.push({ action: "replace", key: field.key, value, expected_revision: field.revision ?? "missing" });
+      }
     }
   }
+  return changes;
+}
+
+async function saveSecrets(): Promise<void> {
+  if (!current) return;
+  const values = new Map<string, string>();
+  const clearKeys = new Set<string>();
+  for (const field of current.fields.filter((value) => value.sensitivity === "secret" && value.editable)) {
+    values.set(field.key, element(inputId(field.key), HTMLInputElement).value);
+    const clear = document.querySelector<HTMLInputElement>(`input[data-clear-key="${field.key}"]`);
+    if (clear?.checked) clearKeys.add(field.key);
+  }
+  const changes = secretConfigurationChanges(current.fields, values, clearKeys);
   if (changes.length === 0) return showResult("留空不会清除 secret；当前没有显式变更。", false);
   await runSave(async () => updateSecretConfiguration(changes));
 }
@@ -691,6 +791,21 @@ async function runSave(action: () => Promise<ConfigurationSnapshot>): Promise<vo
 
 function fieldInput(field: ConfigFieldSnapshot): HTMLInputElement | HTMLSelectElement {
   const value = field.savedValue ?? field.effectiveValue;
+  if (field.key === "delivery.tts.provider") {
+    const select = document.createElement("select");
+    select.id = inputId(field.key);
+    select.dataset.configKey = field.key;
+    select.disabled = !field.editable;
+    const currentValue = value === null || value === undefined ? "disabled" : String(value);
+    for (const [optionValue, label] of ttsProviderOptions(currentValue)) {
+      const option = document.createElement("option");
+      option.value = optionValue;
+      option.textContent = label;
+      select.append(option);
+    }
+    select.value = currentValue;
+    return select;
+  }
   if (field.key === "command.prefix") {
     const select = document.createElement("select");
     select.id = inputId(field.key);
@@ -724,8 +839,33 @@ function fieldInput(field: ConfigFieldSnapshot): HTMLInputElement | HTMLSelectEl
   } else {
     input.type = field.valueType === "integer" ? "number" : "text";
     input.value = Array.isArray(value) ? value.join(", ") : value === null || value === undefined ? "" : String(value);
+    const range = ttsNumberRange(field.key);
+    if (range) {
+      input.min = String(range[0]);
+      input.max = String(range[1]);
+      input.step = "1";
+    }
   }
   return input;
+}
+
+function decorateTtsRow(row: HTMLElement, field: ConfigFieldSnapshot): void {
+  row.dataset.configFieldKey = field.key;
+  if (field.key.startsWith("delivery.tts.qwen_")) row.dataset.ttsQwenField = "true";
+}
+
+/** 关闭 Provider 只做视觉提示，字段始终保持可编辑且不会生成清除操作。 */
+function bindTtsProviderState(): void {
+  const provider = document.getElementById(inputId("delivery.tts.provider"));
+  if (!(provider instanceof HTMLSelectElement)) return;
+  const refresh = (): void => {
+    const disabled = provider.value === "disabled";
+    for (const row of document.querySelectorAll<HTMLElement>("[data-tts-qwen-field='true']")) {
+      row.classList.toggle("config-row-muted", disabled);
+    }
+  };
+  provider.addEventListener("change", refresh);
+  refresh();
 }
 
 function inputValue(input: HTMLInputElement | HTMLSelectElement, field: ConfigFieldSnapshot): unknown {

--- a/web-console/tests/tts-configuration.test.mjs
+++ b/web-console/tests/tts-configuration.test.mjs
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  configFieldGroupLabel,
+  configFieldLabel,
+  publicConfigurationChanges,
+  secretConfigurationChanges,
+  ttsNumberRange,
+  ttsProviderOptions,
+} from "../dist/views/configuration.js";
+
+const TTS_KEYS = [
+  "delivery.tts.provider",
+  "delivery.tts.qwen_api_key",
+  "delivery.tts.qwen_base_url",
+  "delivery.tts.qwen_model",
+  "delivery.tts.qwen_voice",
+  "delivery.tts.request_timeout_seconds",
+  "delivery.tts.max_text_chars",
+];
+
+function field(key, savedValue, sensitivity = "public") {
+  return {
+    key,
+    module: "gateway.tts",
+    valueType: typeof savedValue === "number" ? "integer" : "string",
+    source: sensitivity === "secret" ? "encrypted_secret" : "managed_toml",
+    overridden: false,
+    editable: true,
+    configured: savedValue !== null,
+    valid: true,
+    revision: "revision-1",
+    sensitivity,
+    applyMode: "restart",
+    savedValue: sensitivity === "secret" ? null : savedValue,
+    effectiveValue: sensitivity === "secret" ? null : savedValue,
+    runningValue: sensitivity === "secret" ? null : savedValue,
+    pendingRestart: false,
+  };
+}
+
+test("全部 TTS 字段进入语音回复分组并使用专用标签", () => {
+  for (const key of TTS_KEYS) {
+    assert.equal(configFieldGroupLabel(key), "语音回复");
+    assert.notEqual(configFieldLabel(key), key);
+  }
+});
+
+test("TTS Provider 下拉框映射关闭与千问", () => {
+  assert.deepEqual(ttsProviderOptions("qwen"), [
+    ["disabled", "关闭"],
+    ["qwen", "千问"],
+  ]);
+});
+
+test("TTS Provider 下拉框保留未知历史值", () => {
+  const options = ttsProviderOptions("legacy-provider");
+  assert.deepEqual(options.at(-1), ["legacy-provider", "legacy-provider（当前自定义值）"]);
+});
+
+test("TTS 数字字段使用后端约束对应的浏览器范围", () => {
+  assert.deepEqual(ttsNumberRange("delivery.tts.request_timeout_seconds"), [1, 120]);
+  assert.deepEqual(ttsNumberRange("delivery.tts.max_text_chars"), [1, 600]);
+  assert.equal(ttsNumberRange("delivery.tts.qwen_model"), null);
+});
+
+test("切换 disabled 只保存 Provider，不清除或改写 Qwen 配置", () => {
+  const fields = [
+    field("delivery.tts.provider", "qwen"),
+    field("delivery.tts.qwen_base_url", "https://example.test/tts"),
+    field("delivery.tts.qwen_model", "qwen3-tts-flash"),
+    field("delivery.tts.qwen_voice", "Cherry"),
+    field("delivery.tts.request_timeout_seconds", 30),
+    field("delivery.tts.max_text_chars", 600),
+  ];
+  const values = new Map(fields.map((item) => [item.key, item.savedValue]));
+  values.set("delivery.tts.provider", "disabled");
+
+  assert.deepEqual(publicConfigurationChanges(fields, values), [{
+    action: "set",
+    key: "delivery.tts.provider",
+    value: "disabled",
+  }]);
+});
+
+test("千问 API Key 继续使用 secret replace/clear，且留空不修改", () => {
+  const secret = field("delivery.tts.qwen_api_key", null, "secret");
+
+  assert.deepEqual(secretConfigurationChanges([secret], new Map(), new Set()), []);
+  assert.deepEqual(
+    secretConfigurationChanges([secret], new Map([[secret.key, "new-key"]]), new Set()),
+    [{ action: "replace", key: secret.key, value: "new-key", expected_revision: "revision-1" }],
+  );
+  assert.deepEqual(
+    secretConfigurationChanges([secret], new Map([[secret.key, "must-not-win"]]), new Set([secret.key])),
+    [{ action: "clear", key: secret.key, expected_revision: "revision-1" }],
+  );
+  assert.deepEqual(
+    publicConfigurationChanges([secret], new Map([[secret.key, "must-not-enter-runtime.toml"]])),
+    [],
+  );
+});


### PR DESCRIPTION
## 变更说明

- 为 `delivery.tts.*` 增加独立“语音回复”分组和完整中文标签。
- 将 TTS Provider 改为“关闭 / 千问”下拉框，并保留未知历史值。
- 为请求超时和最大朗读字符数增加 `1..120`、`1..600` 浏览器约束。
- 千问 API Key 继续复用加密 secret 的留空不改、replace 与显式 clear 流程。
- Provider 关闭时仅视觉弱化 Qwen 字段，不禁用输入、不清除已保存配置。
- 同步提交 TypeScript 源码、构建产物与 6 项 TTS Web 单元测试。

## 0.22.0 发布内容

汇总 `v0.21.6..master` 已合并的全部 PR：

- #594 社区反馈入口
- #595 未知 Slash 命令确定性收口
- #597 知识库 embedding 批处理内存限制
- #598 OpenCode Zen / Go 配置
- #600 QQ 官方语音回复与会话开关

根包提升到 `0.22.0`，四个内部 crate 分别提升到 `0.1.3`、`0.1.8`、`0.1.17`、`0.1.12`，并同步 Cargo.lock、README 与 CHANGELOG。

## 兼容性与安全

- 不修改 Core/Gateway 的 TTS 投递链路、`/语音` 权限或会话 scope。
- 不新增试听、连接测试、音色枚举或浏览器持久化。
- 无数据库 migration、无必需配置迁移；TTS 仍默认关闭。
- secret 快照不回传真实 Key，也不会写入 runtime.toml。

## 本地验证

- `npm run check`：通过
- `npm test`：21 项通过，0 失败
- `npm run build`：通过（由 npm test 执行）
- `cargo fmt --all -- --check`：通过
- `cargo test -p qq-maid-core config::center::tests --all-features`：43 项通过
- `cargo test -p qq-maid-bot --test config_check --all-features`：3 项通过
- `git diff --cached --check`：通过

按要求停止本地全量 CI；workspace 全特性测试、Clippy 和 release 构建交由 GitHub Actions 执行。

## 真实环境待确认

未使用真实 QQ、千问或 OpenCode 凭证联调。合并发布前仍需在目标环境确认 QQ 可拉取千问签名 WAV URL，以及真实 Provider 调用。