### PR TITLE
fix: 收紧 TTS 数字输入校验

### DIFF
--- a/web-console/dist/views/configuration.js
+++ b/web-console/dist/views/configuration.js
@@ -105,6 +105,17 @@ export function ttsProviderOptions(currentValue) {
 export function ttsNumberRange(key) {
     return TTS_NUMBER_RANGES[key] ?? null;
 }
+/** TTS 范围字段必须先完整通过整数与边界校验，不能沿用普通整数的宽松 parseInt 语义。 */
+export function parseTtsNumberValue(key, rawValue) {
+    const range = ttsNumberRange(key);
+    if (!range)
+        throw new Error(`${configFieldLabel(key)}没有可用的页面输入范围`);
+    const value = rawValue.trim() === "" ? Number.NaN : Number(rawValue);
+    if (!Number.isFinite(value) || !Number.isInteger(value) || value < range[0] || value > range[1]) {
+        throw new Error(`${configFieldLabel(key)}必须是 ${range[0]} 到 ${range[1]} 之间的整数`);
+    }
+    return value;
+}
 const AGENT_ROUTE_LABELS = {
     private_main: "私聊主路线",
     group_main: "群聊主路线",
@@ -475,7 +486,15 @@ async function savePublicFields() {
             input.reportValidity();
             return showResult(`${configFieldLabel(field.key)}不符合页面输入范围，请修改后再保存。`, true);
         }
-        values.set(field.key, inputValue(input, field));
+        try {
+            const value = ttsNumberRange(field.key)
+                ? parseTtsNumberValue(field.key, input.value)
+                : inputValue(input, field);
+            values.set(field.key, value);
+        }
+        catch (cause) {
+            return showResult(errorMessage(cause), true);
+        }
     }
     const changes = publicConfigurationChanges(current.fields, values);
     if (changes.length === 0)
@@ -734,6 +753,7 @@ function fieldInput(field) {
             input.min = String(range[0]);
             input.max = String(range[1]);
             input.step = "1";
+            input.required = true;
         }
     }
     return input;

--- a/web-console/src/views/configuration.ts
+++ b/web-console/src/views/configuration.ts
@@ -135,6 +135,17 @@ export function ttsNumberRange(key: string): readonly [number, number] | null {
   return TTS_NUMBER_RANGES[key] ?? null;
 }
 
+/** TTS 范围字段必须先完整通过整数与边界校验，不能沿用普通整数的宽松 parseInt 语义。 */
+export function parseTtsNumberValue(key: string, rawValue: string): number {
+  const range = ttsNumberRange(key);
+  if (!range) throw new Error(`${configFieldLabel(key)}没有可用的页面输入范围`);
+  const value = rawValue.trim() === "" ? Number.NaN : Number(rawValue);
+  if (!Number.isFinite(value) || !Number.isInteger(value) || value < range[0] || value > range[1]) {
+    throw new Error(`${configFieldLabel(key)}必须是 ${range[0]} 到 ${range[1]} 之间的整数`);
+  }
+  return value;
+}
+
 const AGENT_ROUTE_LABELS: Record<string, string> = {
   private_main: "私聊主路线",
   group_main: "群聊主路线",
@@ -587,7 +598,14 @@ async function savePublicFields(): Promise<void> {
       input.reportValidity();
       return showResult(`${configFieldLabel(field.key)}不符合页面输入范围，请修改后再保存。`, true);
     }
-    values.set(field.key, inputValue(input, field));
+    try {
+      const value = ttsNumberRange(field.key)
+        ? parseTtsNumberValue(field.key, input.value)
+        : inputValue(input, field);
+      values.set(field.key, value);
+    } catch (cause) {
+      return showResult(errorMessage(cause), true);
+    }
   }
   const changes = publicConfigurationChanges(current.fields, values);
   if (changes.length === 0) return showResult("没有需要保存的普通配置。", false);
@@ -844,6 +862,7 @@ function fieldInput(field: ConfigFieldSnapshot): HTMLInputElement | HTMLSelectEl
       input.min = String(range[0]);
       input.max = String(range[1]);
       input.step = "1";
+      input.required = true;
     }
   }
   return input;

--- a/web-console/tests/tts-configuration.test.mjs
+++ b/web-console/tests/tts-configuration.test.mjs
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   configFieldGroupLabel,
   configFieldLabel,
+  parseTtsNumberValue,
   publicConfigurationChanges,
   secretConfigurationChanges,
   ttsNumberRange,
@@ -63,6 +64,27 @@ test("TTS 数字字段使用后端约束对应的浏览器范围", () => {
   assert.deepEqual(ttsNumberRange("delivery.tts.request_timeout_seconds"), [1, 120]);
   assert.deepEqual(ttsNumberRange("delivery.tts.max_text_chars"), [1, 600]);
   assert.equal(ttsNumberRange("delivery.tts.qwen_model"), null);
+});
+
+test("TTS 数字字段拒绝空值、越界值和小数", () => {
+  for (const [key, invalidValues] of [
+    ["delivery.tts.request_timeout_seconds", ["", "0", "121", "1.5"]],
+    ["delivery.tts.max_text_chars", ["", "0", "601", "1.5"]],
+  ]) {
+    for (const value of invalidValues) {
+      assert.throws(
+        () => parseTtsNumberValue(key, value),
+        /必须是 \d+ 到 \d+ 之间的整数/,
+      );
+    }
+  }
+});
+
+test("TTS 数字字段允许合法边界值", () => {
+  assert.equal(parseTtsNumberValue("delivery.tts.request_timeout_seconds", "1"), 1);
+  assert.equal(parseTtsNumberValue("delivery.tts.request_timeout_seconds", "120"), 120);
+  assert.equal(parseTtsNumberValue("delivery.tts.max_text_chars", "1"), 1);
+  assert.equal(parseTtsNumberValue("delivery.tts.max_text_chars", "600"), 600);
 });
 
 test("切换 disabled 只保存 Provider，不清除或改写 Qwen 配置", () => {


### PR DESCRIPTION
## 修改内容

- 为 `delivery.tts.request_timeout_seconds` 和 `delivery.tts.max_text_chars` 的 number 输入增加必填约束
- 保存前再次校验值为有限整数且处于各自范围内，非法时阻止提交并显示中文错误
- 保持其他普通整数配置的既有解析语义不变
- 同步更新 `src` 与 `dist`

## 根因

两个 TTS number 输入原先只有 `min`、`max` 和 `step`，没有 `required`。输入框清空后，浏览器校验可能通过，后续 `parseInt("")` 产生 `NaN` 并被提交。

## 测试

- `npm run check`
- `npm test`（23/23 通过）
- `npm run build`
- `git diff --check`

测试覆盖空字符串、低于最小值、高于最大值、小数和合法边界值。