### PR TITLE
feat: Todo 管理 API 支持全局管理与真实提醒目标

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -159,7 +159,7 @@ make clean
 Rust HTTP 层只公开外部运维 / 管理能力：
 
 - 始终公开：`GET /healthz`。
-- 仅在 `WEB_CONSOLE_ENABLED=true` 时公开：`GET /console/`、`GET /console/{asset}`、控制台状态/配置接口、`POST /api/v1/markdown/render`，以及受管理员 Session、同源和 CSRF 保护的 Todo 管理 API。Todo 路径、分页、筛选和统一响应约定见 [管理 API 约定](./MANAGEMENT_API.md)。
+- 仅在 `WEB_CONSOLE_ENABLED=true` 时公开：`GET /console/`、`GET /console/{asset}`、控制台状态/配置接口、`POST /api/v1/markdown/render`，以及受管理员 Session、同源和 CSRF 保护的全局 Todo 管理 API。管理员 actor 不参与 Todo owner/scope；目标引用、全局分页、提醒 Outbox 原子写入和统一响应约定见 [管理 API 约定](./MANAGEMENT_API.md)。
 
 旧 HTTP 路由 `/query`、HTTP `/memory`、`/v1/chat` 和内部 respond 主入口不再公开。查询、记忆、待办、会话和 RSS 都通过 `CoreService::respond` 进程内命令流程承载。
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -159,7 +159,7 @@ make clean
 Rust HTTP 层只公开外部运维 / 管理能力：
 
 - 始终公开：`GET /healthz`。
-- 仅在 `WEB_CONSOLE_ENABLED=true` 时公开：`GET /console/`、`GET /console/{asset}`、`GET /api/v1/console/status` 和 `POST /api/v1/markdown/render`；Markdown 预览路由同时处理 CORS preflight。
+- 仅在 `WEB_CONSOLE_ENABLED=true` 时公开：`GET /console/`、`GET /console/{asset}`、控制台状态/配置接口、`POST /api/v1/markdown/render`，以及受管理员 Session、同源和 CSRF 保护的 Todo 管理 API。Todo 路径、分页、筛选和统一响应约定见 [管理 API 约定](./MANAGEMENT_API.md)。
 
 旧 HTTP 路由 `/query`、HTTP `/memory`、`/v1/chat` 和内部 respond 主入口不再公开。查询、记忆、待办、会话和 RSS 都通过 `CoreService::respond` 进程内命令流程承载。
 
@@ -180,7 +180,7 @@ Rust HTTP 层只公开外部运维 / 管理能力：
 - 修改模型协议、Provider 路由、fallback、SSE、usage、健康观测、OpenAI Web Search 传输或 Tool Loop 协议时，优先修改 `qq-maid-llm/`。
 - Gateway 内部继续保持分层边界：`gateway/mod.rs` 负责顶层编排，`gateway/platform/` 负责平台协议到 `InboundMessage` / `CoreRequest` 的映射，`gateway/protocol.rs` 负责 WebSocket 协议与事件分发，`gateway/outbound.rs` 负责出站投递能力和发送状态记录，`respond.rs` 负责 CoreService 进程内桥接；不要把这些职责重新混回单个超长文件。
 - 修改普通聊天、查询命令、记忆、session、待办、会话命令、prompt 或具体业务 Tool 时，优先修改 `qq-maid-core/`。
-- Rust HTTP 层只公开 `GET /healthz`，以及启用控制台时的 `/console/`、静态资源、`/api/v1/console/status` 和 `/api/v1/markdown/render`；不要重新公开 `/query`、HTTP `/memory`、`/v1/chat` 或内部 respond 主入口。
+- Rust HTTP 层只公开 `GET /healthz`，以及启用控制台时的 `/console/`、静态资源、控制台运维接口、`/api/v1/markdown/render` 和受保护的领域管理 API；不要重新公开 `/query`、旧 HTTP `/memory`、`/v1/chat` 或内部 respond 主入口。
 - 通用日期、时间和时区语义优先复用 `qq-maid-common/src/time_context/`；跨 crate 的身份上下文、输入输出结构、Markdown 转换和脱敏也应优先复用 common 现有模块，不要在 Core 或 Gateway 重复实现。
 - Tool Calling 的最终目标参考 Codex 的受控工具调用体验，但本项目必须保持 QQ 场景边界：私聊优先、群聊谨慎、工具白名单、权限校验、超时和输出大小限制不可省略。
 - 自定义业务 Tool 的二开步骤见 [custom-tools.md](./development/custom-tools.md)，包括新增文件、注册、`agent.toml` 白名单和测试要求。

--- a/docs/MANAGEMENT_API.md
+++ b/docs/MANAGEMENT_API.md
@@ -1,0 +1,181 @@
+# 管理 API 约定
+
+本文定义 Web 控制台资源管理接口的公共约定。当前首个资源是 Todo；后续 Memory、知识库等接口复用同一套鉴权、分页、响应和错误基础设施，但必须保留各自的领域 Service、权限和校验逻辑。
+
+## 路由与鉴权
+
+资源管理路由仅在 `WEB_CONSOLE_ENABLED=true` 时注册，统一使用 `/api/v1/console/` 前缀和 `POST`。调用者必须先通过现有部署管理员登录接口取得服务端 Session cookie，并在请求中同时携带登录会话签发的 `x-csrf-token`。浏览器请求还必须通过现有同源校验。
+
+业务请求体不得提供或覆盖 `user_id`、`creator_id`、`owner_id`、`operator_id`、`account_id` 或 `scope_key`。服务端从管理员 Session 生成稳定 API subject，领域 Service 再根据该 subject 判断资源权限。
+
+当前仓库没有“部署管理员与 QQ / OneBot / 微信用户”的可信身份绑定，因此 Todo 管理 API 使用独立的管理员管理作用域，不读取或修改聊天入口 Todo，也不允许通过请求体选择聊天用户。未来若要跨入口管理用户数据，必须先增加显式授权/绑定模型，不能把调用者提交的用户 ID 当作授权事实。
+
+客户端可以传入不超过 128 字符且仅包含字母、数字、`-`、`_`、`.`、`:` 的 `x-request-id`；缺失或非法时由服务端生成 UUID。进入 API Handler 后的成功和错误响应都会回传该 Header，并在 JSON 中包含 `request_id`。
+
+## 统一响应
+
+成功响应：
+
+```json
+{
+  "ok": true,
+  "data": {},
+  "request_id": "2b46a6ac-6b68-4743-b3f1-f980f28a11e0"
+}
+```
+
+错误响应：
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "validation_error",
+    "message": "page must be greater than or equal to 1"
+  },
+  "request_id": "2b46a6ac-6b68-4743-b3f1-f980f28a11e0"
+}
+```
+
+公共错误映射：
+
+| 场景 | HTTP 状态 | `error.code` |
+| --- | ---: | --- |
+| JSON 无法解析或缺少必填字段 | 400 | `invalid_json` |
+| 参数或字段校验失败 | 422 | `validation_error` |
+| 未登录或会话失效 | 401 | `unauthenticated` |
+| Origin、CSRF 或领域权限拒绝 | 403 | 对应安全错误码 / `permission_denied` |
+| 资源不存在或按隐藏策略不可见 | 404 | `not_found` |
+| 状态冲突 | 409 | `conflict` |
+| 领域服务未装配 | 503 | `<domain>_unavailable` |
+| 数据库、通知或其他内部失败 | 500 | `internal_error` |
+
+领域错误先在对应 API adapter 映射为上述 API 错误；领域 Service 不依赖 HTTP 状态码。
+
+## 公共分页
+
+列表请求在顶层复用以下字段：
+
+```json
+{
+  "page": 1,
+  "page_size": 20
+}
+```
+
+- `page` 默认 `1`，从 `1` 开始。
+- `page_size` 默认 `20`，范围为 `1..=100`。
+- 页码乘法和数据库 offset 在公共分页层做溢出校验。
+- 页码超出总页数时返回空 `items`，仍返回真实 `total` 和 `total_pages`。
+
+分页数据结构位于成功响应的 `data`：
+
+```json
+{
+  "items": [],
+  "page": 1,
+  "page_size": 20,
+  "total": 0,
+  "total_pages": 0
+}
+```
+
+`total=0` 时 `total_pages=0`；其余情况按向上取整计算且不使用可能溢出的 `total + page_size - 1`。
+
+## Todo API
+
+五个接口均为 `POST`：
+
+| 路径 | 用途 |
+| --- | --- |
+| `/api/v1/console/todo/create` | 创建 Todo |
+| `/api/v1/console/todo/list` | 分页和组合筛选 |
+| `/api/v1/console/todo/get` | 查询单项 |
+| `/api/v1/console/todo/update` | 部分更新 / 状态转换 |
+| `/api/v1/console/todo/delete` | 按现有物理删除语义删除 |
+
+Todo ID 在响应中使用十进制字符串，输入兼容正整数 JSON number 或十进制字符串。响应 DTO 不包含内部 `user_id`、`scope_key` 和自然语言原文。
+
+### 创建
+
+```json
+{
+  "title": "准备周报",
+  "detail": "整理本周进度",
+  "due_date": "2099-08-01",
+  "due_at": null,
+  "recurrence_kind": "none",
+  "recurrence_interval_days": 0,
+  "recurrence_interval": 0,
+  "recurrence_unit": "day"
+}
+```
+
+仅 `title` 必填且不得为空。日期、时间和重复规则继续由 Todo 领域草稿归一与校验处理；管理 API 不执行 Todo 自然语言时间推断。当前管理身份没有平台投递目标，因此请求 DTO 不开放 `reminder_at` 写入；返回 DTO 保留该字段以兼容 Todo 完整模型。
+
+### 列表与现有筛选
+
+```json
+{
+  "page": 1,
+  "page_size": 20,
+  "status": "pending",
+  "due_date": null,
+  "date_start": "2099-08-01",
+  "date_end": "2099-08-31",
+  "time_filter": null,
+  "keyword": "周报 项目",
+  "recurring": false
+}
+```
+
+筛选直接映射到 Todo 现有 `TodoQuery`：
+
+- `status`：`pending`、`completed`、`all`；默认 `all`。
+- `due_date`：按单日筛选，与日期范围互斥。
+- `date_start` / `date_end`：必须同时传入；`completed` 状态筛完成时间，其余状态筛计划时间。
+- `time_filter`：`overdue` 或 `no_due_date`，与普通日期条件互斥；未显式传 `status` 的 `overdue` 自动使用 `pending`，显式组合其他状态会报参数错误。
+- `keyword`：复用标题、详情和原文的多词 AND 模糊匹配。
+- `recurring`：`true` 仅周期项，`false` 仅一次性项，缺失或 `null` 不限制。
+
+`COUNT(*)` 与当前页查询使用同一个 Todo owner/scope 和同一组筛选条件；分页由 SQLite `LIMIT/OFFSET` 执行，不会先全量加载。排序复用 Todo 现有稳定状态/时间/ID 排序规则。
+
+### 单项、更新和删除
+
+单项和删除请求：
+
+```json
+{
+  "id": "123"
+}
+```
+
+更新使用 Todo 专属部分更新 DTO：
+
+```json
+{
+  "id": "123",
+  "title": "新的标题",
+  "detail": null,
+  "due_date": null,
+  "status": "completed"
+}
+```
+
+- 未传字段保持原值。
+- `detail`、`due_date`、`due_at` 传 `null` 表示显式清空；`title=null` 非法。
+- ID、owner 和 scope 不在更新 DTO 中，不能修改。
+- `status` 使用 Todo 现有完成/恢复规则；周期 Todo 的“完成”仍按现有语义推进下一周期。
+- 已完成 Todo 的普通字段不能直接修改，必须在同一请求或前一请求中恢复为 `pending`。
+- 删除复用 Todo 当前物理删除及提醒取消链路；不存在和不可见资源统一返回 404。
+
+## 后续资源模块
+
+Memory 或知识库 API 可以直接复用 `http/api/common/` 中的：
+
+- `ApiRequestContext` / 管理员身份认证；
+- `PaginationRequest` / `ValidatedPagination` / `PagedResponse<T>`；
+- 成功与错误 envelope、JSON rejection 和请求 ID；
+- 管理员认证错误到 HTTP/API 错误的映射。
+
+新增资源应在 `http/api/<domain>/` 定义自己的 DTO、Handler 和领域错误映射，并调用 `runtime/tools/<domain>/` 的明确门面。不得增加通用 CRUD Service、万能 Patch Map 或任意表 Repository。

--- a/docs/MANAGEMENT_API.md
+++ b/docs/MANAGEMENT_API.md
@@ -1,16 +1,20 @@
 # 管理 API 约定
 
-本文定义 Web 控制台资源管理接口的公共约定。当前首个资源是 Todo；后续 Memory、知识库等接口复用同一套鉴权、分页、响应和错误基础设施，但必须保留各自的领域 Service、权限和校验逻辑。
+本文定义 Web 控制台资源管理接口的公共约定。当前首个资源是 Todo；后续 Memory、知识库等接口复用鉴权、分页、响应和错误基础设施，但必须保留各自的领域权限与数据归属模型。
 
-## 路由与鉴权
+## 路由与公共鉴权
 
-资源管理路由仅在 `WEB_CONSOLE_ENABLED=true` 时注册，统一使用 `/api/v1/console/` 前缀和 `POST`。调用者必须先通过现有部署管理员登录接口取得服务端 Session cookie，并在请求中同时携带登录会话签发的 `x-csrf-token`。浏览器请求还必须通过现有同源校验。
+资源管理路由仅在 `WEB_CONSOLE_ENABLED=true` 时注册，统一使用 `/api/v1/console/` 前缀和 `POST`。调用者必须先通过部署管理员登录取得服务端 Session cookie，并携带同一会话签发的 `x-csrf-token`；浏览器请求还必须通过现有同源校验和管理请求限流。
 
-业务请求体不得提供或覆盖 `user_id`、`creator_id`、`owner_id`、`operator_id`、`account_id` 或 `scope_key`。服务端从管理员 Session 生成稳定 API subject，领域 Service 再根据该 subject 判断资源权限。
-
-当前仓库没有“部署管理员与 QQ / OneBot / 微信用户”的可信身份绑定，因此 Todo 管理 API 使用独立的管理员管理作用域，不读取或修改聊天入口 Todo，也不允许通过请求体选择聊天用户。未来若要跨入口管理用户数据，必须先增加显式授权/绑定模型，不能把调用者提交的用户 ID 当作授权事实。
+`AuthenticatedApiActor` 表示本次操作的管理员调用者，只用于认证、CSRF、Origin、限流、审计和诊断。它不是 Todo owner，不能用于构造 `owner_key` 或 `scope_key`。所有已认证部署管理员当前都具有同一份全局 Todo 管理权限。
 
 客户端可以传入不超过 128 字符且仅包含字母、数字、`-`、`_`、`.`、`:` 的 `x-request-id`；缺失或非法时由服务端生成 UUID。进入 API Handler 后的成功和错误响应都会回传该 Header，并在 JSON 中包含 `request_id`。
+
+## Todo 的真实归属
+
+管理 API 与 QQ、OneBot、微信聊天入口操作同一张 `todos` 表、同一批记录。Todo 继续保存聊天入口生成的真实 `owner_key`、`user_id` 和 conversation `scope_key`，平台、账号、私聊/群聊目标也继续遵循现有稳定 scope 语义。
+
+管理 API 不创建 `console_admin:*` owner，也不使用 `management:console_admin:*` scope。普通聊天 Tool、Slash 命令和 Todo Store 的 owner-scoped 查询入口保持原有校验，不能调用管理专用全局查询。
 
 ## 统一响应
 
@@ -42,15 +46,13 @@
 | 场景 | HTTP 状态 | `error.code` |
 | --- | ---: | --- |
 | JSON 无法解析或缺少必填字段 | 400 | `invalid_json` |
-| 参数或字段校验失败 | 422 | `validation_error` |
+| ID、目标引用、筛选或字段校验失败 | 422 | `validation_error` |
 | 未登录或会话失效 | 401 | `unauthenticated` |
 | Origin、CSRF 或领域权限拒绝 | 403 | 对应安全错误码 / `permission_denied` |
-| 资源不存在或按隐藏策略不可见 | 404 | `not_found` |
-| 状态冲突 | 409 | `conflict` |
+| Todo 不存在 | 404 | `not_found` |
+| 状态或并发版本冲突 | 409 | `conflict` |
 | 领域服务未装配 | 503 | `<domain>_unavailable` |
-| 数据库、通知或其他内部失败 | 500 | `internal_error` |
-
-领域错误先在对应 API adapter 映射为上述 API 错误；领域 Service 不依赖 HTTP 状态码。
+| 数据库、Outbox 或其他内部失败 | 500 | `internal_error` |
 
 ## 公共分页
 
@@ -67,20 +69,9 @@
 - `page_size` 默认 `20`，范围为 `1..=100`。
 - 页码乘法和数据库 offset 在公共分页层做溢出校验。
 - 页码超出总页数时返回空 `items`，仍返回真实 `total` 和 `total_pages`。
+- `total=0` 时 `total_pages=0`；其余情况按向上取整计算。
 
-分页数据结构位于成功响应的 `data`：
-
-```json
-{
-  "items": [],
-  "page": 1,
-  "page_size": 20,
-  "total": 0,
-  "total_pages": 0
-}
-```
-
-`total=0` 时 `total_pages=0`；其余情况按向上取整计算且不使用可能溢出的 `total + page_size - 1`。
+SQLite 使用同一组筛选分别执行 `COUNT(*)` 与带 `LIMIT/OFFSET` 的当前页查询，不会全量加载后在内存切片。排序沿用 Todo 的状态/计划时间/完成时间顺序，并以内部 Todo ID 作为最终稳定次级排序。
 
 ## Todo API
 
@@ -88,22 +79,48 @@
 
 | 路径 | 用途 |
 | --- | --- |
-| `/api/v1/console/todo/create` | 创建 Todo |
-| `/api/v1/console/todo/list` | 分页和组合筛选 |
-| `/api/v1/console/todo/get` | 查询单项 |
-| `/api/v1/console/todo/update` | 部分更新 / 状态转换 |
+| `/api/v1/console/todo/create` | 向经过验证的真实平台目标创建 Todo |
+| `/api/v1/console/todo/list` | 全局分页和组合筛选 |
+| `/api/v1/console/todo/get` | 全局按 ID 查询单项 |
+| `/api/v1/console/todo/update` | 全局部分更新 / 状态转换 |
 | `/api/v1/console/todo/delete` | 按现有物理删除语义删除 |
 
-Todo ID 在响应中使用十进制字符串，输入兼容正整数 JSON number 或十进制字符串。响应 DTO 不包含内部 `user_id`、`scope_key` 和自然语言原文。
+Todo ID 在响应中使用十进制字符串。输入兼容正整数 JSON number 或不带前导零的正整数十进制字符串；`0`、`"0"`、`"000"`、负数、非数字及超出 SQLite `INTEGER` 正数范围的值返回 422，不伪装成 404。
+
+### 目标信息与 `target_ref`
+
+列表、详情、创建和更新响应都包含整理后的 `target`：
+
+```json
+{
+  "target": {
+    "target_ref": "todo_target:v1:...",
+    "platform": "qq_official",
+    "scope_type": "private",
+    "user_id": "...",
+    "group_id": null,
+    "account_id": "...",
+    "reminder_supported": true
+  }
+}
+```
+
+- `target_ref` 是服务端基于真实 owner/scope 生成的版本化稳定引用；客户端应把它视为不透明字符串，不应自行拼接或解析内部 key。
+- 创建时服务端会把引用回查到已有 Todo 目标或已知 Session 目标，并再次校验 owner、conversation scope、平台、账号和目标类型。请求体不能直接提交 `owner_key`、`scope_key`、`group_id` 或 `account_id` 来绕过校验。
+- 对无法完整解析的旧 scope，单项会降级为 `scope_type="unknown"`、`target_ref=null`，并返回受控 `diagnostic`；单条异常记录不会使整个列表失败。
+- 当前五路由协议没有单独的“目标目录”接口。控制台可直接复用列表/详情返回的 `target_ref`；若未来需要为从未出现过 Todo 的会话提供选择器，应增加只读的服务端目标发现接口，而不是允许前端提交内部 key。
 
 ### 创建
 
 ```json
 {
+  "target_ref": "todo_target:v1:...",
   "title": "准备周报",
   "detail": "整理本周进度",
   "due_date": "2099-08-01",
   "due_at": null,
+  "reminder_at": "2099-08-01T09:00:00+08:00",
+  "time_precision": "date_time",
   "recurrence_kind": "none",
   "recurrence_interval_days": 0,
   "recurrence_interval": 0,
@@ -111,9 +128,11 @@ Todo ID 在响应中使用十进制字符串，输入兼容正整数 JSON number
 }
 ```
 
-仅 `title` 必填且不得为空。日期、时间和重复规则继续由 Todo 领域草稿归一与校验处理；管理 API 不执行 Todo 自然语言时间推断。当前管理身份没有平台投递目标，因此请求 DTO 不开放 `reminder_at` 写入；返回 DTO 保留该字段以兼容 Todo 完整模型。
+`target_ref` 和 `title` 必填。管理 API 不执行自然语言时间推断；日期、时间、重复规则和敏感文本处理继续复用 Todo 领域的草稿归一与校验。
 
-### 列表与现有筛选
+创建 Todo 与创建对应 reminder Outbox 记录在同一个 SQLite 事务中提交。目标无效、提醒时间无效、Outbox 写入失败时不会留下 Todo。
+
+### 全局列表与筛选
 
 ```json
 {
@@ -125,20 +144,33 @@ Todo ID 在响应中使用十进制字符串，输入兼容正整数 JSON number
   "date_end": "2099-08-31",
   "time_filter": null,
   "keyword": "周报 项目",
-  "recurring": false
+  "recurring": false,
+  "platform": "onebot",
+  "account_id": "bot-1",
+  "scope_type": "group",
+  "user_id": null,
+  "target_ref": null
 }
 ```
 
-筛选直接映射到 Todo 现有 `TodoQuery`：
+Todo 筛选：
 
 - `status`：`pending`、`completed`、`all`；默认 `all`。
 - `due_date`：按单日筛选，与日期范围互斥。
 - `date_start` / `date_end`：必须同时传入；`completed` 状态筛完成时间，其余状态筛计划时间。
-- `time_filter`：`overdue` 或 `no_due_date`，与普通日期条件互斥；未显式传 `status` 的 `overdue` 自动使用 `pending`，显式组合其他状态会报参数错误。
-- `keyword`：复用标题、详情和原文的多词 AND 模糊匹配。
+- `time_filter`：`overdue` 或 `no_due_date`，与普通日期条件互斥。
+- `keyword`：标题、详情和原文的多词 AND 模糊匹配。
 - `recurring`：`true` 仅周期项，`false` 仅一次性项，缺失或 `null` 不限制。
 
-`COUNT(*)` 与当前页查询使用同一个 Todo owner/scope 和同一组筛选条件；分页由 SQLite `LIMIT/OFFSET` 执行，不会先全量加载。排序复用 Todo 现有稳定状态/时间/ID 排序规则。
+管理目标筛选：
+
+- `platform`：使用稳定 scope 中的实际平台名，例如 `qq_official`、`onebot`、`wechat_service`；QQ 历史 scope 会归入 `qq_official`。
+- `account_id`：按稳定平台账号维度筛选。
+- `scope_type`：`private` 或 `group`。
+- `user_id`：按 Todo 实际归属成员精确筛选。
+- `target_ref`：按服务端已验证的完整 owner/scope 精确筛选。
+
+这些筛选只存在于管理专用全局查询；普通聊天入口仍必须传入当前真实 owner/scope。
 
 ### 单项、更新和删除
 
@@ -158,16 +190,35 @@ Todo ID 在响应中使用十进制字符串，输入兼容正整数 JSON number
   "title": "新的标题",
   "detail": null,
   "due_date": null,
+  "reminder_at": "2099-08-02T09:00:00+08:00",
   "status": "completed"
 }
 ```
 
-- 未传字段保持原值。
-- `detail`、`due_date`、`due_at` 传 `null` 表示显式清空；`title=null` 非法。
-- ID、owner 和 scope 不在更新 DTO 中，不能修改。
-- `status` 使用 Todo 现有完成/恢复规则；周期 Todo 的“完成”仍按现有语义推进下一周期。
-- 已完成 Todo 的普通字段不能直接修改，必须在同一请求或前一请求中恢复为 `pending`。
-- 删除复用 Todo 当前物理删除及提醒取消链路；不存在和不可见资源统一返回 404。
+- 管理 Service 先按 ID 全局读取记录，再使用记录自身的真实 owner/scope 执行写入。
+- 未传字段保持原值；`detail`、`due_date`、`due_at`、`reminder_at` 传 `null` 表示显式清空，`title=null` 非法。
+- 已完成 Todo 的普通字段不能直接修改；同一请求显式恢复为 `pending` 后可以修改。
+- 一次性 Todo 完成后进入 `completed`；周期 Todo 沿用聊天侧“完成本次并推进下一周期”的规则。
+- 删除继续使用物理删除语义，并在同一事务内取消尚未终结的 reminder Outbox。
+
+组合更新在一个 SQLite 事务中完成全局重读、并发快照校验、字段归一、恢复、字段写入、完成/周期推进、旧提醒取消和新提醒写入。能够提前完成的字段、时间和周期计算在写入前完成；任一步失败都会回滚 Todo 和 Outbox，不使用失败后手动改回的补偿逻辑。
+
+## 提醒与平台限制
+
+管理 API 不直接调用平台发送接口，也不新增 Web 专用调度器。带提醒的 Todo 继续走：
+
+```text
+真实 TodoOwner / conversation scope
+→ Todo 与 Notification Outbox 同库事务
+→ Notification Worker
+→ 现有 Push Sink
+→ QQ 官方 / OneBot 11 目标
+```
+
+- QQ 官方私聊、群聊和 OneBot 11 私聊、群聊使用现有主动推送能力；群成员 Todo 继续携带真实 owner 成员 mention。
+- 微信服务号当前不在统一主动 Push Sink 中。微信 Todo 可以通过管理 API 查询、修改或创建，但只要最终 pending Todo 带 `reminder_at`，请求会在写库前返回 422，不创建不可投递提醒。
+- 更新提醒时间会取消旧 pending/retry/sending/failed 任务并写入新的去重事件；已发送历史保留。
+- 完成一次性 Todo 或删除 Todo 会取消旧提醒；完成周期 Todo 会推进时间并写入下一周期提醒。
 
 ## 后续资源模块
 
@@ -178,4 +229,4 @@ Memory 或知识库 API 可以直接复用 `http/api/common/` 中的：
 - 成功与错误 envelope、JSON rejection 和请求 ID；
 - 管理员认证错误到 HTTP/API 错误的映射。
 
-新增资源应在 `http/api/<domain>/` 定义自己的 DTO、Handler 和领域错误映射，并调用 `runtime/tools/<domain>/` 的明确门面。不得增加通用 CRUD Service、万能 Patch Map 或任意表 Repository。
+它们不能照搬 Todo 的 owner 模型。新增资源应在 `http/api/<domain>/` 定义自己的 DTO、Handler、领域 Service、权限和错误映射，并调用 `runtime/tools/<domain>/` 的明确门面；不得增加通用 CRUD Service、万能 Patch Map 或任意表 Repository。

--- a/docs/MANAGEMENT_API.md
+++ b/docs/MANAGEMENT_API.md
@@ -75,12 +75,13 @@ SQLite 使用同一组筛选分别执行 `COUNT(*)` 与带 `LIMIT/OFFSET` 的当
 
 ## Todo API
 
-五个接口均为 `POST`：
+六个接口均为 `POST`：
 
 | 路径 | 用途 |
 | --- | --- |
 | `/api/v1/console/todo/create` | 向经过验证的真实平台目标创建 Todo |
 | `/api/v1/console/todo/list` | 全局分页和组合筛选 |
+| `/api/v1/console/todo/targets` | 分页发现可创建 Todo 的真实会话目标 |
 | `/api/v1/console/todo/get` | 全局按 ID 查询单项 |
 | `/api/v1/console/todo/update` | 全局部分更新 / 状态转换 |
 | `/api/v1/console/todo/delete` | 按现有物理删除语义删除 |
@@ -108,7 +109,8 @@ Todo ID 在响应中使用十进制字符串。输入兼容正整数 JSON number
 - `target_ref` 是服务端基于真实 owner/scope 生成的版本化稳定引用；客户端应把它视为不透明字符串，不应自行拼接或解析内部 key。
 - 创建时服务端会把引用回查到已有 Todo 目标或已知 Session 目标，并再次校验 owner、conversation scope、平台、账号和目标类型。请求体不能直接提交 `owner_key`、`scope_key`、`group_id` 或 `account_id` 来绕过校验。
 - 对无法完整解析的旧 scope，单项会降级为 `scope_type="unknown"`、`target_ref=null`，并返回受控 `diagnostic`；单条异常记录不会使整个列表失败。
-- 当前五路由协议没有单独的“目标目录”接口。控制台可直接复用列表/详情返回的 `target_ref`；若未来需要为从未出现过 Todo 的会话提供选择器，应增加只读的服务端目标发现接口，而不是允许前端提交内部 key。
+- `/api/v1/console/todo/targets` 从已有 Todo 与 Session 的服务端可信身份字段中分页发现目标，因此即使会话从未创建过 Todo，控制台也能先取得 `target_ref` 再创建第一条记录。无法完整恢复真实 owner、成员或 conversation scope 的旧记录不会进入创建目标列表。
+- 目标发现支持 `platform`、`account_id`、`scope_type`、`user_id` 和 `group_id` 精确筛选；响应只包含 `target_ref`、平台/账号、作用域类型、用户/群和 `reminder_supported`，不返回 owner/scope 内部 key。
 
 ### 创建
 
@@ -128,7 +130,7 @@ Todo ID 在响应中使用十进制字符串。输入兼容正整数 JSON number
 }
 ```
 
-`target_ref` 和 `title` 必填。管理 API 不执行自然语言时间推断；日期、时间、重复规则和敏感文本处理继续复用 Todo 领域的草稿归一与校验。
+`target_ref` 和 `title` 必填。管理 API 不执行自然语言时间推断；日期、时间、重复规则和敏感文本处理继续复用 Todo 领域的草稿归一与校验。创建请求只要包含非空 `reminder_at`，就必须同时满足“晚于当前时间”和目标平台支持主动提醒，否则返回 422。
 
 创建 Todo 与创建对应 reminder Outbox 记录在同一个 SQLite 事务中提交。目标无效、提醒时间无效、Outbox 写入失败时不会留下 Todo。
 
@@ -197,6 +199,8 @@ Todo 筛选：
 
 - 管理 Service 先按 ID 全局读取记录，再使用记录自身的真实 owner/scope 执行写入。
 - 未传字段保持原值；`detail`、`due_date`、`due_at`、`reminder_at` 传 `null` 表示显式清空，`title=null` 非法。
+- 更新时只有本次请求显式设置的非空 `reminder_at` 才重新校验未来时间和平台能力；显式清空会取消旧未终结 Outbox。未修改提醒字段时允许保留历史值，已经过去的提醒不会重新创建 Outbox，也不会阻止标题、详情或日期更新。
+- 完成 Todo 会取消旧未终结提醒，不因保留的历史 `reminder_at` 已过期而失败；恢复为 `pending` 时沿用领域 Outbox 语义，过期值保留但不重新排程。
 - 已完成 Todo 的普通字段不能直接修改；同一请求显式恢复为 `pending` 后可以修改。
 - 一次性 Todo 完成后进入 `completed`；周期 Todo 沿用聊天侧“完成本次并推进下一周期”的规则。
 - 删除继续使用物理删除语义，并在同一事务内取消尚未终结的 reminder Outbox。

--- a/qq-maid-core/README.md
+++ b/qq-maid-core/README.md
@@ -104,6 +104,8 @@ Todo 提醒当前支持分钟/小时级调度边界：自然语言可以创建�
 
 前端源码和构建说明见 [`../web-console/README.md`](../web-console/README.md)。Rust 直接嵌入已提交的 `web-console/dist/`，普通 Cargo 构建和运行不需要 Node.js。
 
+Todo 管理接口复用同一管理员 Session、同源和 CSRF 安全边界，并统一使用 `/api/v1/console/todo/*` POST 路由。接口、分页、筛选、响应 envelope 和后续 Memory API 的复用边界见 [管理 API 约定](../docs/MANAGEMENT_API.md)。
+
 ## 指令能力
 
 - 会话：`/new`、`/rename`、`/resume`、`/clear`、`/state`、`/compact`、`/help`。`/list` 仅作为 deprecated 兼容别名保留，推荐 `/resume` 或 `/恢复`。

--- a/qq-maid-core/README.md
+++ b/qq-maid-core/README.md
@@ -104,7 +104,7 @@ Todo 提醒当前支持分钟/小时级调度边界：自然语言可以创建�
 
 前端源码和构建说明见 [`../web-console/README.md`](../web-console/README.md)。Rust 直接嵌入已提交的 `web-console/dist/`，普通 Cargo 构建和运行不需要 Node.js。
 
-Todo 管理接口复用同一管理员 Session、同源和 CSRF 安全边界，并统一使用 `/api/v1/console/todo/*` POST 路由。接口、分页、筛选、响应 envelope 和后续 Memory API 的复用边界见 [管理 API 约定](../docs/MANAGEMENT_API.md)。
+Todo 管理接口复用同一管理员 Session、同源和 CSRF 安全边界，并统一使用 `/api/v1/console/todo/*` POST 路由。部署管理员全局管理聊天入口的同一批 Todo；管理员 actor 只用于认证、审计和限流，Todo 仍保留 QQ / OneBot / 微信真实 owner、conversation scope 与提醒目标。目标引用、全局分页、Outbox 原子更新、平台限制和后续 Memory API 的复用边界见 [管理 API 约定](../docs/MANAGEMENT_API.md)。
 
 ## 指令能力
 

--- a/qq-maid-core/src/app/mod.rs
+++ b/qq-maid-core/src/app/mod.rs
@@ -163,6 +163,10 @@ impl LlmRuntime {
             config_center,
             admin_auth,
         )
+        .with_todo_management(crate::runtime::tools::todo::TodoManagementService::new(
+            core_state.stores.todo_store.clone(),
+            core_state.stores.notification_store.clone(),
+        ))
         .with_registered_tools(registered_tools);
         let workers = CoreWorkers::from_runtime_state(&core_state, push_sink)?;
 

--- a/qq-maid-core/src/http/api/common/auth.rs
+++ b/qq-maid-core/src/http/api/common/auth.rs
@@ -1,0 +1,206 @@
+//! 已认证管理 API 调用者上下文。
+
+use axum::http::{HeaderMap, header};
+use uuid::Uuid;
+
+use crate::{
+    http::routes::OpsHttpState,
+    management::{SECURE_SESSION_COOKIE_NAME, SESSION_COOKIE_NAME},
+};
+
+use super::ApiError;
+
+const CSRF_HEADER: &str = "x-csrf-token";
+const REQUEST_ID_HEADER: &str = "x-request-id";
+
+/// 服务端认证后得到的通用 API 身份；领域层仍需自行判断资源权限。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AuthenticatedApiActor {
+    subject: String,
+}
+
+impl AuthenticatedApiActor {
+    /// 不暴露原始 cookie；领域只消费认证系统签发的稳定 subject。
+    pub(crate) fn subject(&self) -> &str {
+        &self.subject
+    }
+}
+
+/// 每个管理 API Handler 复用的身份与诊断上下文。
+#[derive(Debug, Clone)]
+pub(crate) struct ApiRequestContext {
+    pub(crate) actor: AuthenticatedApiActor,
+    pub(crate) request_id: ApiRequestId,
+}
+
+impl ApiRequestContext {
+    /// 所有业务管理接口均为 POST，因此统一要求管理员 Session、同源与 CSRF。
+    pub(crate) fn authenticate(
+        state: &OpsHttpState,
+        headers: &HeaderMap,
+    ) -> Result<Self, ApiError> {
+        let request_id = ApiRequestId::from_headers(headers);
+        authenticate_admin_request(state, headers, true)
+            .map(|authenticated| Self {
+                actor: authenticated.actor,
+                request_id: request_id.clone(),
+            })
+            .map_err(|error| error.with_request_id(request_id))
+    }
+}
+
+/// 配置管理与资源管理 API 共用的完整管理员认证结果。
+pub(crate) struct AuthenticatedAdminRequest {
+    pub(crate) auth: crate::management::AdminAuth,
+    pub(crate) cookie: String,
+    pub(crate) csrf: Option<String>,
+    pub(crate) actor_id: i64,
+    actor: AuthenticatedApiActor,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ApiRequestId(String);
+
+impl ApiRequestId {
+    fn from_headers(headers: &HeaderMap) -> Self {
+        let supplied = headers
+            .get(REQUEST_ID_HEADER)
+            .and_then(|value| value.to_str().ok())
+            .map(str::trim)
+            .filter(|value| {
+                !value.is_empty()
+                    && value.len() <= 128
+                    && value.bytes().all(|byte| {
+                        byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':')
+                    })
+            });
+        Self(
+            supplied
+                .map(str::to_owned)
+                .unwrap_or_else(|| Uuid::new_v4().to_string()),
+        )
+    }
+
+    pub(super) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+pub(crate) fn authenticate_admin_request(
+    state: &OpsHttpState,
+    headers: &HeaderMap,
+    require_csrf: bool,
+) -> Result<AuthenticatedAdminRequest, ApiError> {
+    if !origin_allowed(headers) {
+        return Err(ApiError::forbidden(
+            "origin_denied",
+            "request origin is not allowed",
+        ));
+    }
+    let auth = state.admin_auth.clone().ok_or_else(|| {
+        ApiError::unavailable(
+            "auth_unavailable",
+            "administrator authentication is unavailable",
+        )
+    })?;
+    let cookie = session_cookie(headers, state.config.web_console_secure_cookies)
+        .ok_or_else(|| ApiError::unauthenticated("administrator session is missing"))?;
+    let csrf = csrf_token(headers);
+    if require_csrf && csrf.is_none() {
+        return Err(ApiError::forbidden("csrf_failed", "CSRF token is missing"));
+    }
+    let (admin_id, _) = auth
+        .authorize_admin(
+            &cookie,
+            require_csrf.then_some(csrf.as_deref().unwrap_or_default()),
+        )
+        .map_err(ApiError::from_admin_auth)?;
+    if require_csrf {
+        auth.check_management_rate_limit(admin_id)
+            .map_err(ApiError::from_admin_auth)?;
+    }
+    Ok(AuthenticatedAdminRequest {
+        auth,
+        cookie,
+        csrf,
+        actor_id: admin_id,
+        actor: AuthenticatedApiActor {
+            subject: format!("console_admin:{admin_id}"),
+        },
+    })
+}
+
+pub(crate) fn session_cookie(headers: &HeaderMap, secure: bool) -> Option<String> {
+    let expected = if secure {
+        SECURE_SESSION_COOKIE_NAME
+    } else {
+        SESSION_COOKIE_NAME
+    };
+    headers
+        .get(header::COOKIE)?
+        .to_str()
+        .ok()?
+        .split(';')
+        .filter_map(|item| item.trim().split_once('='))
+        .find_map(|(name, value)| (name == expected).then(|| value.to_owned()))
+}
+
+pub(crate) fn csrf_token(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(CSRF_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+pub(crate) fn origin_allowed(headers: &HeaderMap) -> bool {
+    let Some(origin) = headers
+        .get(header::ORIGIN)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return true;
+    };
+    let Some(host) = headers
+        .get(header::HOST)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return false;
+    };
+    url::Url::parse(origin)
+        .ok()
+        .and_then(|url| {
+            url.host_str()
+                .map(|value| (value.to_owned(), url.port_or_known_default()))
+        })
+        .is_some_and(|(origin_host, origin_port)| {
+            let mut parts = host.rsplitn(2, ':');
+            let port_or_host = parts.next().unwrap_or_default();
+            let maybe_host = parts.next();
+            let (host_name, host_port) = match maybe_host {
+                Some(name) if port_or_host.parse::<u16>().is_ok() => {
+                    (name, port_or_host.parse::<u16>().ok())
+                }
+                _ => (host, None),
+            };
+            origin_host.eq_ignore_ascii_case(host_name)
+                && (host_port.is_none() || host_port == origin_port)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_id_accepts_safe_value_and_replaces_unsafe_value() {
+        let mut headers = HeaderMap::new();
+        headers.insert(REQUEST_ID_HEADER, "req-123".parse().unwrap());
+        assert_eq!(ApiRequestId::from_headers(&headers).as_str(), "req-123");
+
+        headers.insert(REQUEST_ID_HEADER, "unsafe value".parse().unwrap());
+        let generated = ApiRequestId::from_headers(&headers);
+        assert_ne!(generated.as_str(), "unsafe value");
+        assert!(Uuid::parse_str(generated.as_str()).is_ok());
+    }
+}

--- a/qq-maid-core/src/http/api/common/error.rs
+++ b/qq-maid-core/src/http/api/common/error.rs
@@ -1,0 +1,143 @@
+//! 管理 API 的统一 HTTP 错误。
+
+use axum::{
+    Json,
+    http::{HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+};
+use serde::Serialize;
+
+use crate::management::AdminAuthError;
+
+use super::auth::ApiRequestId;
+
+/// API 层错误只负责 HTTP 状态和公开错误文案，不反向进入领域层。
+#[derive(Debug)]
+pub(crate) struct ApiError {
+    status: StatusCode,
+    code: String,
+    message: String,
+    request_id: Option<ApiRequestId>,
+}
+
+#[derive(Serialize)]
+struct ApiErrorEnvelope<'a> {
+    ok: bool,
+    error: ApiErrorBody<'a>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    request_id: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct ApiErrorBody<'a> {
+    code: &'a str,
+    message: &'a str,
+}
+
+impl ApiError {
+    pub(crate) fn new(
+        status: StatusCode,
+        code: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            status,
+            code: code.into(),
+            message: message.into(),
+            request_id: None,
+        }
+    }
+
+    pub(crate) fn invalid_json(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::BAD_REQUEST, "invalid_json", message)
+    }
+
+    pub(crate) fn validation(message: impl Into<String>) -> Self {
+        Self::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "validation_error",
+            message,
+        )
+    }
+
+    pub(crate) fn unauthenticated(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::UNAUTHORIZED, "unauthenticated", message)
+    }
+
+    pub(crate) fn forbidden(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::new(StatusCode::FORBIDDEN, code, message)
+    }
+
+    pub(crate) fn not_found(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::NOT_FOUND, "not_found", message)
+    }
+
+    pub(crate) fn conflict(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::CONFLICT, "conflict", message)
+    }
+
+    pub(crate) fn internal(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::INTERNAL_SERVER_ERROR, "internal_error", message)
+    }
+
+    pub(crate) fn unavailable(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::new(StatusCode::SERVICE_UNAVAILABLE, code, message)
+    }
+
+    pub(crate) fn with_request_id(mut self, request_id: ApiRequestId) -> Self {
+        self.request_id = Some(request_id);
+        self
+    }
+
+    pub(crate) fn from_admin_auth(error: AdminAuthError) -> Self {
+        let status = match error.code() {
+            "unauthenticated" | "invalid_credentials" => StatusCode::UNAUTHORIZED,
+            "csrf_failed" | "invalid_bootstrap_token" | "already_initialized" => {
+                StatusCode::FORBIDDEN
+            }
+            "rate_limited" => StatusCode::TOO_MANY_REQUESTS,
+            "not_initialized" => StatusCode::CONFLICT,
+            "session_capacity_reached" => StatusCode::SERVICE_UNAVAILABLE,
+            "validation_error" | "invalid_bootstrap_token_format" => StatusCode::BAD_REQUEST,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        Self::new(status, error.code(), error.message())
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let request_id = self.request_id.as_ref().map(ApiRequestId::as_str);
+        let mut response = (
+            self.status,
+            Json(ApiErrorEnvelope {
+                ok: false,
+                error: ApiErrorBody {
+                    code: &self.code,
+                    message: &self.message,
+                },
+                request_id,
+            }),
+        )
+            .into_response();
+        if let Some(request_id) = request_id
+            && let Ok(value) = HeaderValue::from_str(request_id)
+        {
+            response.headers_mut().insert("x-request-id", value);
+        }
+        response
+    }
+}
+
+/// 旧控制台接口复用统一错误结构，但保持原有无 request_id 响应兼容性。
+pub(crate) fn error_response(
+    status: StatusCode,
+    code: impl Into<String>,
+    message: impl Into<String>,
+) -> Response {
+    ApiError::new(status, code, message).into_response()
+}
+
+pub(crate) fn auth_error_response(error: AdminAuthError) -> Response {
+    ApiError::from_admin_auth(error).into_response()
+}

--- a/qq-maid-core/src/http/api/common/mod.rs
+++ b/qq-maid-core/src/http/api/common/mod.rs
@@ -1,0 +1,13 @@
+//! 管理 API 共用的 HTTP 基础设施。
+
+mod auth;
+mod error;
+mod pagination;
+mod response;
+
+pub(crate) use auth::{
+    ApiRequestContext, authenticate_admin_request, csrf_token, origin_allowed, session_cookie,
+};
+pub(crate) use error::{ApiError, auth_error_response, error_response};
+pub(crate) use pagination::{PagedResponse, PaginationRequest, ValidatedPagination};
+pub(crate) use response::{json_payload, respond, respond_error};

--- a/qq-maid-core/src/http/api/common/pagination.rs
+++ b/qq-maid-core/src/http/api/common/pagination.rs
@@ -1,0 +1,159 @@
+//! 管理 API 共用分页请求与响应。
+
+use serde::{Deserialize, Serialize};
+
+use super::ApiError;
+
+pub(crate) const DEFAULT_PAGE: u64 = 1;
+pub(crate) const DEFAULT_PAGE_SIZE: u64 = 20;
+pub(crate) const MAX_PAGE_SIZE: u64 = 100;
+
+#[derive(Debug, Clone, Deserialize, Default, PartialEq, Eq)]
+pub(crate) struct PaginationRequest {
+    pub(crate) page: Option<u64>,
+    pub(crate) page_size: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ValidatedPagination {
+    page: u64,
+    page_size: u64,
+    offset: u64,
+}
+
+impl PaginationRequest {
+    pub(crate) fn validate(self) -> Result<ValidatedPagination, ApiError> {
+        let page = self.page.unwrap_or(DEFAULT_PAGE);
+        let page_size = self.page_size.unwrap_or(DEFAULT_PAGE_SIZE);
+        if page == 0 {
+            return Err(ApiError::validation(
+                "page must be greater than or equal to 1",
+            ));
+        }
+        if page_size == 0 {
+            return Err(ApiError::validation(
+                "page_size must be greater than or equal to 1",
+            ));
+        }
+        if page_size > MAX_PAGE_SIZE {
+            return Err(ApiError::validation(format!(
+                "page_size must not exceed {MAX_PAGE_SIZE}"
+            )));
+        }
+        let offset = page
+            .checked_sub(1)
+            .and_then(|value| value.checked_mul(page_size))
+            .filter(|value| *value <= i64::MAX as u64)
+            .ok_or_else(|| ApiError::validation("pagination offset is too large"))?;
+        Ok(ValidatedPagination {
+            page,
+            page_size,
+            offset,
+        })
+    }
+}
+
+impl ValidatedPagination {
+    pub(crate) fn page(self) -> u64 {
+        self.page
+    }
+
+    pub(crate) fn page_size(self) -> u64 {
+        self.page_size
+    }
+
+    pub(crate) fn offset(self) -> u64 {
+        self.offset
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct PagedResponse<T> {
+    pub(crate) items: Vec<T>,
+    pub(crate) page: u64,
+    pub(crate) page_size: u64,
+    pub(crate) total: u64,
+    pub(crate) total_pages: u64,
+}
+
+impl<T> PagedResponse<T> {
+    pub(crate) fn new(items: Vec<T>, pagination: ValidatedPagination, total: u64) -> Self {
+        let page_size = pagination.page_size;
+        let total_pages = if total == 0 {
+            0
+        } else {
+            total / page_size + u64::from(!total.is_multiple_of(page_size))
+        };
+        Self {
+            items,
+            page: pagination.page(),
+            page_size,
+            total,
+            total_pages,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pagination_uses_defaults_and_accepts_custom_values() {
+        let default = PaginationRequest::default().validate().unwrap();
+        assert_eq!(default.page(), 1);
+        assert_eq!(default.page_size(), 20);
+        assert_eq!(default.offset(), 0);
+
+        let custom = PaginationRequest {
+            page: Some(3),
+            page_size: Some(7),
+        }
+        .validate()
+        .unwrap();
+        assert_eq!(custom.page(), 3);
+        assert_eq!(custom.page_size(), 7);
+        assert_eq!(custom.offset(), 14);
+    }
+
+    #[test]
+    fn pagination_rejects_zero_and_oversized_values() {
+        assert!(
+            PaginationRequest {
+                page: Some(0),
+                page_size: None,
+            }
+            .validate()
+            .is_err()
+        );
+        assert!(
+            PaginationRequest {
+                page: None,
+                page_size: Some(0),
+            }
+            .validate()
+            .is_err()
+        );
+        assert!(
+            PaginationRequest {
+                page: None,
+                page_size: Some(MAX_PAGE_SIZE + 1),
+            }
+            .validate()
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn paged_response_calculates_zero_and_partial_pages_without_overflow() {
+        let pagination = PaginationRequest::default().validate().unwrap();
+        let empty = PagedResponse::<()>::new(Vec::new(), pagination, 0);
+        assert_eq!(empty.total_pages, 0);
+
+        let partial = PagedResponse::<()>::new(Vec::new(), pagination, 21);
+        assert_eq!(partial.total_pages, 2);
+
+        let maximum = PagedResponse::<()>::new(Vec::new(), pagination, u64::MAX);
+        assert_eq!(maximum.total_pages, u64::MAX / 20 + 1);
+    }
+}

--- a/qq-maid-core/src/http/api/common/response.rs
+++ b/qq-maid-core/src/http/api/common/response.rs
@@ -1,0 +1,63 @@
+//! 管理 API 的统一成功响应和 JSON rejection 映射。
+
+use axum::{
+    Json,
+    extract::rejection::JsonRejection,
+    http::{HeaderMap, HeaderValue},
+    response::{IntoResponse, Response},
+};
+use serde::{Serialize, de::DeserializeOwned};
+
+use crate::http::{console_routes::with_console_cors, routes::OpsHttpState};
+
+use super::{ApiError, ApiRequestContext};
+
+#[derive(Serialize)]
+struct ApiSuccessEnvelope<'a, T> {
+    ok: bool,
+    data: T,
+    request_id: &'a str,
+}
+
+pub(crate) fn json_payload<T: DeserializeOwned>(
+    payload: Result<Json<T>, JsonRejection>,
+    context: &ApiRequestContext,
+) -> Result<T, ApiError> {
+    payload.map(|Json(value)| value).map_err(|error| {
+        ApiError::invalid_json(error.body_text()).with_request_id(context.request_id.clone())
+    })
+}
+
+pub(crate) fn respond<T: Serialize>(
+    state: &OpsHttpState,
+    headers: &HeaderMap,
+    context: &ApiRequestContext,
+    result: Result<T, ApiError>,
+) -> Response {
+    let response = match result {
+        Ok(data) => {
+            let mut response = Json(ApiSuccessEnvelope {
+                ok: true,
+                data,
+                request_id: context.request_id.as_str(),
+            })
+            .into_response();
+            if let Ok(value) = HeaderValue::from_str(context.request_id.as_str()) {
+                response.headers_mut().insert("x-request-id", value);
+            }
+            response
+        }
+        Err(error) => error
+            .with_request_id(context.request_id.clone())
+            .into_response(),
+    };
+    with_console_cors(response, state, headers)
+}
+
+pub(crate) fn respond_error(
+    state: &OpsHttpState,
+    headers: &HeaderMap,
+    error: ApiError,
+) -> Response {
+    with_console_cors(error.into_response(), state, headers)
+}

--- a/qq-maid-core/src/http/api/mod.rs
+++ b/qq-maid-core/src/http/api/mod.rs
@@ -1,4 +1,10 @@
 //! Web 控制台 API 模块。
+//!
+//! `common` 只承载鉴权、分页、响应 envelope 和 HTTP 错误等 Web API 基础设施；
+//! Todo、后续 Memory 等资源仍各自维护领域 DTO、权限规则和业务服务。
+
+pub(crate) mod common;
+pub(crate) mod todo;
 
 use axum::{
     Json,

--- a/qq-maid-core/src/http/api/todo/dto.rs
+++ b/qq-maid-core/src/http/api/todo/dto.rs
@@ -6,9 +6,9 @@ use serde_json::Value;
 
 use crate::runtime::tools::todo::{
     TodoEditPatch, TodoItemDraft, TodoListDateFilter, TodoManagementItem, TodoManagementListFilter,
-    TodoQuery, TodoQueryStatus, TodoQueryTimeFilter, TodoRecurrenceKind, TodoRecurrenceUnit,
-    TodoStatus, TodoTimePrecision, management_group_scope_type, management_private_scope_type,
-    resolve_todo_list_date_filter,
+    TodoManagementTarget, TodoManagementTargetListFilter, TodoQuery, TodoQueryStatus,
+    TodoQueryTimeFilter, TodoRecurrenceKind, TodoRecurrenceUnit, TodoStatus, TodoTimePrecision,
+    management_group_scope_type, management_private_scope_type, resolve_todo_list_date_filter,
 };
 
 use super::super::common::{ApiError, PaginationRequest, ValidatedPagination};
@@ -193,6 +193,38 @@ impl ListTodoRequest {
     }
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ListTodoTargetsRequest {
+    /// 目标发现与资源列表共用顶层分页协议和上限。
+    #[serde(flatten)]
+    pub pagination: PaginationRequest,
+    pub platform: Option<String>,
+    pub account_id: Option<String>,
+    pub scope_type: Option<TodoTargetScopeType>,
+    pub user_id: Option<String>,
+    pub group_id: Option<String>,
+}
+
+impl ListTodoTargetsRequest {
+    pub(super) fn pagination(&self) -> Result<ValidatedPagination, ApiError> {
+        self.pagination.clone().validate()
+    }
+
+    pub(super) fn into_filter(self) -> Result<TodoManagementTargetListFilter, ApiError> {
+        Ok(TodoManagementTargetListFilter {
+            platform: optional_segment(self.platform, "platform", 64)?,
+            account_id: optional_segment(self.account_id, "account_id", 128)?,
+            scope_type: self.scope_type.map(|scope_type| match scope_type {
+                TodoTargetScopeType::Private => management_private_scope_type(),
+                TodoTargetScopeType::Group => management_group_scope_type(),
+            }),
+            user_id: optional_text(self.user_id, "user_id", 256)?,
+            group_id: optional_text(self.group_id, "group_id", 256)?,
+        })
+    }
+}
+
 fn time_filter_from_date(filter: TodoListDateFilter) -> TodoQueryTimeFilter {
     TodoQueryTimeFilter::DateRange {
         start: filter.start,
@@ -366,6 +398,35 @@ pub(super) struct TodoTargetDto {
     reminder_supported: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     diagnostic: Option<String>,
+}
+
+/// 创建目标发现只返回客户端选择目标所需的公开字段；内部 key 和诊断信息不出域。
+#[derive(Debug, Serialize)]
+pub(super) struct TodoTargetDiscoveryDto {
+    target_ref: String,
+    platform: String,
+    account_id: Option<String>,
+    scope_type: String,
+    user_id: Option<String>,
+    group_id: Option<String>,
+    reminder_supported: bool,
+}
+
+impl TodoTargetDiscoveryDto {
+    pub(super) fn try_from_target(value: TodoManagementTarget) -> Result<Self, ApiError> {
+        let target_ref = value.target_ref.ok_or_else(|| {
+            ApiError::internal("target candidate cannot be restored to a public reference")
+        })?;
+        Ok(Self {
+            target_ref,
+            platform: value.platform,
+            account_id: value.account_id,
+            scope_type: value.scope_type,
+            user_id: value.user_id,
+            group_id: value.group_id,
+            reminder_supported: value.reminder_supported,
+        })
+    }
 }
 
 impl From<TodoManagementItem> for TodoDto {

--- a/qq-maid-core/src/http/api/todo/dto.rs
+++ b/qq-maid-core/src/http/api/todo/dto.rs
@@ -2,10 +2,12 @@
 
 use chrono::NaiveDate;
 use serde::{Deserialize, Deserializer, Serialize, de::DeserializeOwned};
+use serde_json::Value;
 
 use crate::runtime::tools::todo::{
-    TodoEditPatch, TodoItem, TodoItemDraft, TodoListDateFilter, TodoQuery, TodoQueryStatus,
-    TodoQueryTimeFilter, TodoRecurrenceKind, TodoRecurrenceUnit, TodoStatus, TodoTimePrecision,
+    TodoEditPatch, TodoItemDraft, TodoListDateFilter, TodoManagementItem, TodoManagementListFilter,
+    TodoQuery, TodoQueryStatus, TodoQueryTimeFilter, TodoRecurrenceKind, TodoRecurrenceUnit,
+    TodoStatus, TodoTimePrecision, management_group_scope_type, management_private_scope_type,
     resolve_todo_list_date_filter,
 };
 
@@ -14,10 +16,13 @@ use super::super::common::{ApiError, PaginationRequest, ValidatedPagination};
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct CreateTodoRequest {
+    pub target_ref: String,
     pub title: String,
     pub detail: Option<String>,
     pub due_date: Option<String>,
     pub due_at: Option<String>,
+    pub reminder_at: Option<String>,
+    pub time_precision: Option<TodoTimePrecision>,
     pub recurrence_kind: Option<TodoRecurrenceKind>,
     pub recurrence_interval_days: Option<u32>,
     pub recurrence_interval: Option<u32>,
@@ -25,22 +30,27 @@ pub(super) struct CreateTodoRequest {
 }
 
 impl CreateTodoRequest {
-    pub(super) fn into_draft(self) -> Result<TodoItemDraft, ApiError> {
+    pub(super) fn into_parts(self) -> Result<(String, TodoItemDraft), ApiError> {
         validate_optional_date(self.due_date.as_deref())?;
         validate_optional_datetime(self.due_at.as_deref())?;
-        Ok(TodoItemDraft {
-            title: self.title,
-            detail: self.detail,
-            raw_text: None,
-            due_date: self.due_date,
-            due_at: self.due_at,
-            reminder_at: None,
-            time_precision: TodoTimePrecision::None,
-            recurrence_kind: self.recurrence_kind.unwrap_or_default(),
-            recurrence_interval_days: self.recurrence_interval_days.unwrap_or_default(),
-            recurrence_interval: self.recurrence_interval.unwrap_or_default(),
-            recurrence_unit: self.recurrence_unit.unwrap_or_default(),
-        })
+        validate_optional_datetime(self.reminder_at.as_deref())?;
+        let target_ref = required_text(self.target_ref, "target_ref", 96)?;
+        Ok((
+            target_ref,
+            TodoItemDraft {
+                title: self.title,
+                detail: self.detail,
+                raw_text: None,
+                due_date: self.due_date,
+                due_at: self.due_at,
+                reminder_at: self.reminder_at,
+                time_precision: self.time_precision.unwrap_or_default(),
+                recurrence_kind: self.recurrence_kind.unwrap_or_default(),
+                recurrence_interval_days: self.recurrence_interval_days.unwrap_or_default(),
+                recurrence_interval: self.recurrence_interval.unwrap_or_default(),
+                recurrence_unit: self.recurrence_unit.unwrap_or_default(),
+            },
+        ))
     }
 }
 
@@ -78,6 +88,14 @@ pub(super) enum TodoTimeFilterRequest {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum TodoTargetScopeType {
+    Private,
+    Group,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(super) struct ListTodoRequest {
     /// 使用 flatten 保持 `{page, page_size}` 顶层协议，同时复用公共分页 DTO。
     #[serde(flatten)]
@@ -89,6 +107,11 @@ pub(super) struct ListTodoRequest {
     pub time_filter: Option<TodoTimeFilterRequest>,
     pub keyword: Option<String>,
     pub recurring: Option<bool>,
+    pub platform: Option<String>,
+    pub account_id: Option<String>,
+    pub scope_type: Option<TodoTargetScopeType>,
+    pub user_id: Option<String>,
+    pub target_ref: Option<String>,
 }
 
 impl ListTodoRequest {
@@ -96,7 +119,20 @@ impl ListTodoRequest {
         self.pagination.clone().validate()
     }
 
-    pub(super) fn into_query(self, pagination: ValidatedPagination) -> Result<TodoQuery, ApiError> {
+    pub(super) fn into_parts(
+        self,
+        pagination: ValidatedPagination,
+    ) -> Result<(TodoQuery, TodoManagementListFilter), ApiError> {
+        let target_filter = TodoManagementListFilter {
+            platform: optional_segment(self.platform, "platform", 64)?,
+            account_id: optional_segment(self.account_id, "account_id", 128)?,
+            scope_type: self.scope_type.map(|scope_type| match scope_type {
+                TodoTargetScopeType::Private => management_private_scope_type(),
+                TodoTargetScopeType::Group => management_group_scope_type(),
+            }),
+            user_id: optional_text(self.user_id, "user_id", 256)?,
+            target_ref: optional_text(self.target_ref, "target_ref", 96)?,
+        };
         let status = self.status.unwrap_or(TodoListStatus::All);
         let due_date = self.due_date.as_deref().map(parse_date).transpose()?;
         let date_range = match (self.date_start.as_deref(), self.date_end.as_deref()) {
@@ -143,14 +179,17 @@ impl ListTodoRequest {
             .map_err(|_| ApiError::validation("page_size is too large"))?;
         let offset = usize::try_from(pagination.offset())
             .map_err(|_| ApiError::validation("pagination offset is too large"))?;
-        Ok(TodoQuery {
-            status: query_status,
-            time,
-            keyword,
-            recurring: self.recurring,
-            limit,
-            offset,
-        })
+        Ok((
+            TodoQuery {
+                status: query_status,
+                time,
+                keyword,
+                recurring: self.recurring,
+                limit,
+                offset,
+            },
+            target_filter,
+        ))
     }
 }
 
@@ -163,22 +202,29 @@ fn time_filter_from_date(filter: TodoListDateFilter) -> TodoQueryTimeFilter {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(untagged)]
-pub(super) enum TodoId {
-    String(String),
-    Number(i64),
-}
+pub(super) struct TodoId(Value);
 
 impl TodoId {
     pub(super) fn into_string(self) -> Result<String, ApiError> {
-        let value = match self {
-            Self::String(value) => value.trim().to_owned(),
-            Self::Number(value) if value > 0 => value.to_string(),
-            Self::Number(_) => return Err(ApiError::validation("id must be a positive integer")),
+        let value = match self.0 {
+            Value::String(value) => {
+                let value = value.trim();
+                if value.is_empty()
+                    || value.starts_with('0')
+                    || !value.bytes().all(|byte| byte.is_ascii_digit())
+                    || value.parse::<i64>().ok().filter(|id| *id > 0).is_none()
+                {
+                    return Err(ApiError::validation("id must be a positive integer"));
+                }
+                value.to_owned()
+            }
+            Value::Number(value) => value
+                .as_u64()
+                .filter(|id| *id > 0 && *id <= i64::MAX as u64)
+                .map(|id| id.to_string())
+                .ok_or_else(|| ApiError::validation("id must be a positive integer"))?,
+            _ => return Err(ApiError::validation("id must be a positive integer")),
         };
-        if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
-            return Err(ApiError::validation("id must be a positive integer"));
-        }
         Ok(value)
     }
 }
@@ -224,7 +270,10 @@ pub(super) struct UpdateTodoRequest {
     pub due_date: PatchField<String>,
     #[serde(default)]
     pub due_at: PatchField<String>,
+    #[serde(default)]
+    pub reminder_at: PatchField<String>,
     pub status: Option<TodoStatus>,
+    pub time_precision: Option<TodoTimePrecision>,
     pub recurrence_kind: Option<TodoRecurrenceKind>,
     pub recurrence_interval_days: Option<u32>,
     pub recurrence_interval: Option<u32>,
@@ -244,10 +293,14 @@ impl UpdateTodoRequest {
         let detail = nullable_patch(self.detail);
         let due_date = nullable_patch(self.due_date);
         let due_at = nullable_patch(self.due_at);
+        let reminder_at = nullable_patch(self.reminder_at);
         if let Some(value) = due_date.as_deref().filter(|value| !value.is_empty()) {
             validate_optional_date(Some(value))?;
         }
         if let Some(value) = due_at.as_deref().filter(|value| !value.is_empty()) {
+            validate_optional_datetime(Some(value))?;
+        }
+        if let Some(value) = reminder_at.as_deref().filter(|value| !value.is_empty()) {
             validate_optional_datetime(Some(value))?;
         }
         let update = crate::runtime::tools::todo::TodoManagementUpdate {
@@ -256,11 +309,12 @@ impl UpdateTodoRequest {
                 detail,
                 due_date,
                 due_at,
+                reminder_at,
+                time_precision: self.time_precision,
                 recurrence_kind: self.recurrence_kind,
                 recurrence_interval_days: self.recurrence_interval_days,
                 recurrence_interval: self.recurrence_interval,
                 recurrence_unit: self.recurrence_unit,
-                ..Default::default()
             },
             status: self.status,
         };
@@ -298,10 +352,25 @@ pub(super) struct TodoDto {
     created_at: String,
     updated_at: String,
     completed_at: Option<String>,
+    target: TodoTargetDto,
 }
 
-impl From<TodoItem> for TodoDto {
-    fn from(item: TodoItem) -> Self {
+#[derive(Debug, Serialize)]
+pub(super) struct TodoTargetDto {
+    target_ref: Option<String>,
+    platform: String,
+    scope_type: String,
+    user_id: Option<String>,
+    group_id: Option<String>,
+    account_id: Option<String>,
+    reminder_supported: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    diagnostic: Option<String>,
+}
+
+impl From<TodoManagementItem> for TodoDto {
+    fn from(value: TodoManagementItem) -> Self {
+        let item = value.item;
         Self {
             id: item.id,
             title: item.title,
@@ -318,6 +387,16 @@ impl From<TodoItem> for TodoDto {
             created_at: item.created_at,
             updated_at: item.updated_at,
             completed_at: item.completed_at,
+            target: TodoTargetDto {
+                target_ref: value.target.target_ref,
+                platform: value.target.platform,
+                scope_type: value.target.scope_type,
+                user_id: value.target.user_id,
+                group_id: value.target.group_id,
+                account_id: value.target.account_id,
+                reminder_supported: value.target.reminder_supported,
+                diagnostic: value.target.diagnostic,
+            },
         }
     }
 }
@@ -349,4 +428,47 @@ fn validate_optional_datetime(value: Option<&str>) -> Result<(), ApiError> {
         ));
     }
     Ok(())
+}
+
+fn required_text(value: String, field: &str, max_len: usize) -> Result<String, ApiError> {
+    optional_text(Some(value), field, max_len)?
+        .ok_or_else(|| ApiError::validation(format!("{field} is required")))
+}
+
+fn optional_text(
+    value: Option<String>,
+    field: &str,
+    max_len: usize,
+) -> Result<Option<String>, ApiError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let value = value.trim();
+    if value.is_empty() {
+        return Ok(None);
+    }
+    if value.chars().count() > max_len {
+        return Err(ApiError::validation(format!(
+            "{field} must not exceed {max_len} characters"
+        )));
+    }
+    Ok(Some(value.to_owned()))
+}
+
+fn optional_segment(
+    value: Option<String>,
+    field: &str,
+    max_len: usize,
+) -> Result<Option<String>, ApiError> {
+    let value = optional_text(value, field, max_len)?;
+    if value.as_deref().is_some_and(|value| {
+        !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    }) {
+        return Err(ApiError::validation(format!(
+            "{field} contains invalid characters"
+        )));
+    }
+    Ok(value)
 }

--- a/qq-maid-core/src/http/api/todo/dto.rs
+++ b/qq-maid-core/src/http/api/todo/dto.rs
@@ -1,0 +1,352 @@
+//! Todo 管理 API 的领域 DTO。
+
+use chrono::NaiveDate;
+use serde::{Deserialize, Deserializer, Serialize, de::DeserializeOwned};
+
+use crate::runtime::tools::todo::{
+    TodoEditPatch, TodoItem, TodoItemDraft, TodoListDateFilter, TodoQuery, TodoQueryStatus,
+    TodoQueryTimeFilter, TodoRecurrenceKind, TodoRecurrenceUnit, TodoStatus, TodoTimePrecision,
+    resolve_todo_list_date_filter,
+};
+
+use super::super::common::{ApiError, PaginationRequest, ValidatedPagination};
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct CreateTodoRequest {
+    pub title: String,
+    pub detail: Option<String>,
+    pub due_date: Option<String>,
+    pub due_at: Option<String>,
+    pub recurrence_kind: Option<TodoRecurrenceKind>,
+    pub recurrence_interval_days: Option<u32>,
+    pub recurrence_interval: Option<u32>,
+    pub recurrence_unit: Option<TodoRecurrenceUnit>,
+}
+
+impl CreateTodoRequest {
+    pub(super) fn into_draft(self) -> Result<TodoItemDraft, ApiError> {
+        validate_optional_date(self.due_date.as_deref())?;
+        validate_optional_datetime(self.due_at.as_deref())?;
+        Ok(TodoItemDraft {
+            title: self.title,
+            detail: self.detail,
+            raw_text: None,
+            due_date: self.due_date,
+            due_at: self.due_at,
+            reminder_at: None,
+            time_precision: TodoTimePrecision::None,
+            recurrence_kind: self.recurrence_kind.unwrap_or_default(),
+            recurrence_interval_days: self.recurrence_interval_days.unwrap_or_default(),
+            recurrence_interval: self.recurrence_interval.unwrap_or_default(),
+            recurrence_unit: self.recurrence_unit.unwrap_or_default(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum TodoListStatus {
+    Pending,
+    Completed,
+    All,
+}
+
+impl TodoListStatus {
+    fn query_status(self) -> TodoQueryStatus {
+        match self {
+            Self::Pending => TodoQueryStatus::Pending,
+            Self::Completed => TodoQueryStatus::Completed,
+            Self::All => TodoQueryStatus::All,
+        }
+    }
+
+    fn storage_status(self) -> Option<TodoStatus> {
+        match self {
+            Self::Pending => Some(TodoStatus::Pending),
+            Self::Completed => Some(TodoStatus::Completed),
+            Self::All => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum TodoTimeFilterRequest {
+    Overdue,
+    NoDueDate,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ListTodoRequest {
+    /// 使用 flatten 保持 `{page, page_size}` 顶层协议，同时复用公共分页 DTO。
+    #[serde(flatten)]
+    pub pagination: PaginationRequest,
+    pub status: Option<TodoListStatus>,
+    pub due_date: Option<String>,
+    pub date_start: Option<String>,
+    pub date_end: Option<String>,
+    pub time_filter: Option<TodoTimeFilterRequest>,
+    pub keyword: Option<String>,
+    pub recurring: Option<bool>,
+}
+
+impl ListTodoRequest {
+    pub(super) fn pagination(&self) -> Result<ValidatedPagination, ApiError> {
+        self.pagination.clone().validate()
+    }
+
+    pub(super) fn into_query(self, pagination: ValidatedPagination) -> Result<TodoQuery, ApiError> {
+        let status = self.status.unwrap_or(TodoListStatus::All);
+        let due_date = self.due_date.as_deref().map(parse_date).transpose()?;
+        let date_range = match (self.date_start.as_deref(), self.date_end.as_deref()) {
+            (None, None) => None,
+            (Some(start), Some(end)) => Some((parse_date(start)?, parse_date(end)?)),
+            _ => {
+                return Err(ApiError::validation(
+                    "date_start and date_end must be provided together",
+                ));
+            }
+        };
+        if due_date.is_some() && date_range.is_some() {
+            return Err(ApiError::validation(
+                "due_date cannot be combined with date_start/date_end",
+            ));
+        }
+        if self.time_filter.is_some() && (due_date.is_some() || date_range.is_some()) {
+            return Err(ApiError::validation(
+                "time_filter cannot be combined with date filters",
+            ));
+        }
+        let date_filter =
+            resolve_todo_list_date_filter(status.storage_status(), due_date, date_range)
+                .map_err(|error| ApiError::validation(error.message()))?;
+        let query_status = match (self.status, self.time_filter) {
+            (None, Some(TodoTimeFilterRequest::Overdue)) => TodoQueryStatus::Pending,
+            _ => status.query_status(),
+        };
+        let time = match self.time_filter {
+            Some(TodoTimeFilterRequest::Overdue) => Some(TodoQueryTimeFilter::Overdue {
+                now: qq_maid_common::time_context::parse_local_datetime_for_comparison(
+                    qq_maid_common::time_context::request_time_context().current_time(),
+                )
+                .expect("request time context must contain a valid local datetime"),
+            }),
+            Some(TodoTimeFilterRequest::NoDueDate) => Some(TodoQueryTimeFilter::NoDueDate),
+            None => date_filter.map(time_filter_from_date),
+        };
+        let keyword = self
+            .keyword
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty());
+        let limit = usize::try_from(pagination.page_size())
+            .map_err(|_| ApiError::validation("page_size is too large"))?;
+        let offset = usize::try_from(pagination.offset())
+            .map_err(|_| ApiError::validation("pagination offset is too large"))?;
+        Ok(TodoQuery {
+            status: query_status,
+            time,
+            keyword,
+            recurring: self.recurring,
+            limit,
+            offset,
+        })
+    }
+}
+
+fn time_filter_from_date(filter: TodoListDateFilter) -> TodoQueryTimeFilter {
+    TodoQueryTimeFilter::DateRange {
+        start: filter.start,
+        end: filter.end,
+        field: filter.field,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(super) enum TodoId {
+    String(String),
+    Number(i64),
+}
+
+impl TodoId {
+    pub(super) fn into_string(self) -> Result<String, ApiError> {
+        let value = match self {
+            Self::String(value) => value.trim().to_owned(),
+            Self::Number(value) if value > 0 => value.to_string(),
+            Self::Number(_) => return Err(ApiError::validation("id must be a positive integer")),
+        };
+        if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+            return Err(ApiError::validation("id must be a positive integer"));
+        }
+        Ok(value)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct GetTodoRequest {
+    pub id: TodoId,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct DeleteTodoRequest {
+    pub id: TodoId,
+}
+
+#[derive(Debug, Default)]
+pub(super) enum PatchField<T> {
+    #[default]
+    Missing,
+    Null,
+    Value(T),
+}
+
+impl<'de, T: DeserializeOwned> Deserialize<'de> for PatchField<T> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Option::<T>::deserialize(deserializer).map(|value| match value {
+            Some(value) => Self::Value(value),
+            None => Self::Null,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct UpdateTodoRequest {
+    pub id: TodoId,
+    #[serde(default)]
+    pub title: PatchField<String>,
+    #[serde(default)]
+    pub detail: PatchField<String>,
+    #[serde(default)]
+    pub due_date: PatchField<String>,
+    #[serde(default)]
+    pub due_at: PatchField<String>,
+    pub status: Option<TodoStatus>,
+    pub recurrence_kind: Option<TodoRecurrenceKind>,
+    pub recurrence_interval_days: Option<u32>,
+    pub recurrence_interval: Option<u32>,
+    pub recurrence_unit: Option<TodoRecurrenceUnit>,
+}
+
+impl UpdateTodoRequest {
+    pub(super) fn into_parts(
+        self,
+    ) -> Result<(String, crate::runtime::tools::todo::TodoManagementUpdate), ApiError> {
+        let id = self.id.into_string()?;
+        let title = match self.title {
+            PatchField::Missing => None,
+            PatchField::Null => return Err(ApiError::validation("title cannot be null")),
+            PatchField::Value(value) => Some(value),
+        };
+        let detail = nullable_patch(self.detail);
+        let due_date = nullable_patch(self.due_date);
+        let due_at = nullable_patch(self.due_at);
+        if let Some(value) = due_date.as_deref().filter(|value| !value.is_empty()) {
+            validate_optional_date(Some(value))?;
+        }
+        if let Some(value) = due_at.as_deref().filter(|value| !value.is_empty()) {
+            validate_optional_datetime(Some(value))?;
+        }
+        let update = crate::runtime::tools::todo::TodoManagementUpdate {
+            fields: TodoEditPatch {
+                title,
+                detail,
+                due_date,
+                due_at,
+                recurrence_kind: self.recurrence_kind,
+                recurrence_interval_days: self.recurrence_interval_days,
+                recurrence_interval: self.recurrence_interval,
+                recurrence_unit: self.recurrence_unit,
+                ..Default::default()
+            },
+            status: self.status,
+        };
+        if !update.has_field_changes() && update.status.is_none() {
+            return Err(ApiError::validation(
+                "at least one updatable field must be provided",
+            ));
+        }
+        Ok((id, update))
+    }
+}
+
+fn nullable_patch(field: PatchField<String>) -> Option<String> {
+    match field {
+        PatchField::Missing => None,
+        PatchField::Null => Some(String::new()),
+        PatchField::Value(value) => Some(value),
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct TodoDto {
+    id: String,
+    title: String,
+    detail: Option<String>,
+    due_date: Option<String>,
+    due_at: Option<String>,
+    reminder_at: Option<String>,
+    time_precision: TodoTimePrecision,
+    recurrence_kind: TodoRecurrenceKind,
+    recurrence_interval_days: u32,
+    recurrence_interval: u32,
+    recurrence_unit: TodoRecurrenceUnit,
+    status: TodoStatus,
+    created_at: String,
+    updated_at: String,
+    completed_at: Option<String>,
+}
+
+impl From<TodoItem> for TodoDto {
+    fn from(item: TodoItem) -> Self {
+        Self {
+            id: item.id,
+            title: item.title,
+            detail: item.detail,
+            due_date: item.due_date,
+            due_at: item.due_at,
+            reminder_at: item.reminder_at,
+            time_precision: item.time_precision,
+            recurrence_kind: item.recurrence_kind,
+            recurrence_interval_days: item.recurrence_interval_days,
+            recurrence_interval: item.recurrence_interval,
+            recurrence_unit: item.recurrence_unit,
+            status: item.status,
+            created_at: item.created_at,
+            updated_at: item.updated_at,
+            completed_at: item.completed_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct DeleteTodoResponse {
+    pub id: String,
+    pub deleted: bool,
+}
+
+fn parse_date(value: &str) -> Result<NaiveDate, ApiError> {
+    NaiveDate::parse_from_str(value.trim(), "%Y-%m-%d")
+        .map_err(|_| ApiError::validation("date must use YYYY-MM-DD format"))
+}
+
+fn validate_optional_date(value: Option<&str>) -> Result<(), ApiError> {
+    if let Some(value) = value {
+        parse_date(value)?;
+    }
+    Ok(())
+}
+
+fn validate_optional_datetime(value: Option<&str>) -> Result<(), ApiError> {
+    if let Some(value) = value
+        && qq_maid_common::time_context::parse_local_datetime_for_comparison(value).is_none()
+    {
+        return Err(ApiError::validation(
+            "datetime must be RFC3339 or YYYY-MM-DD HH:MM:SS",
+        ));
+    }
+    Ok(())
+}

--- a/qq-maid-core/src/http/api/todo/handlers.rs
+++ b/qq-maid-core/src/http/api/todo/handlers.rs
@@ -19,7 +19,7 @@ use crate::{
 
 use super::dto::{
     CreateTodoRequest, DeleteTodoRequest, DeleteTodoResponse, GetTodoRequest, ListTodoRequest,
-    TodoDto, UpdateTodoRequest,
+    ListTodoTargetsRequest, TodoDto, TodoTargetDiscoveryDto, UpdateTodoRequest,
 };
 
 pub(super) async fn create(
@@ -75,6 +75,43 @@ pub(super) async fn list(
             pagination,
             total,
         ))
+    })();
+    respond(&state, &headers, &context, result)
+}
+
+pub(super) async fn targets(
+    State(state): State<OpsHttpState>,
+    headers: HeaderMap,
+    payload: Result<Json<ListTodoTargetsRequest>, JsonRejection>,
+) -> Response {
+    let context = match ApiRequestContext::authenticate(&state, &headers) {
+        Ok(context) => context,
+        Err(error) => return respond_error(&state, &headers, error),
+    };
+    tracing::debug!(
+        actor = context.actor.subject(),
+        action = "targets",
+        "Todo 管理请求已认证"
+    );
+    let result = (|| {
+        let request = json_payload(payload, &context)?;
+        let pagination = request.pagination()?;
+        let filter = request.into_filter()?;
+        let limit = usize::try_from(pagination.page_size())
+            .map_err(|_| ApiError::validation("page_size is too large"))?;
+        let offset = usize::try_from(pagination.offset())
+            .map_err(|_| ApiError::validation("pagination offset is too large"))?;
+        let page = service(&state)?
+            .targets(filter, limit, offset)
+            .map_err(map_todo_error)?;
+        let items = page
+            .items
+            .into_iter()
+            .map(TodoTargetDiscoveryDto::try_from_target)
+            .collect::<Result<Vec<_>, _>>()?;
+        let total = u64::try_from(page.total_count)
+            .map_err(|_| ApiError::internal("todo target count overflow"))?;
+        Ok(PagedResponse::new(items, pagination, total))
     })();
     respond(&state, &headers, &context, result)
 }

--- a/qq-maid-core/src/http/api/todo/handlers.rs
+++ b/qq-maid-core/src/http/api/todo/handlers.rs
@@ -1,0 +1,151 @@
+//! Todo 管理 API Handler；只负责认证、DTO 映射和领域错误到 API 错误的转换。
+
+use axum::{
+    Json,
+    extract::{State, rejection::JsonRejection},
+    http::HeaderMap,
+    response::Response,
+};
+
+use crate::{
+    http::{
+        api::common::{
+            ApiError, ApiRequestContext, PagedResponse, json_payload, respond, respond_error,
+        },
+        routes::OpsHttpState,
+    },
+    runtime::tools::todo::TodoManagementError,
+};
+
+use super::dto::{
+    CreateTodoRequest, DeleteTodoRequest, DeleteTodoResponse, GetTodoRequest, ListTodoRequest,
+    TodoDto, UpdateTodoRequest,
+};
+
+pub(super) async fn create(
+    State(state): State<OpsHttpState>,
+    headers: HeaderMap,
+    payload: Result<Json<CreateTodoRequest>, JsonRejection>,
+) -> Response {
+    let context = match ApiRequestContext::authenticate(&state, &headers) {
+        Ok(context) => context,
+        Err(error) => return respond_error(&state, &headers, error),
+    };
+    let result = (|| {
+        let request = json_payload(payload, &context)?;
+        let draft = request.into_draft()?;
+        service(&state)?
+            .create(context.actor.subject(), draft)
+            .map(TodoDto::from)
+            .map_err(map_todo_error)
+    })();
+    respond(&state, &headers, &context, result)
+}
+
+pub(super) async fn list(
+    State(state): State<OpsHttpState>,
+    headers: HeaderMap,
+    payload: Result<Json<ListTodoRequest>, JsonRejection>,
+) -> Response {
+    let context = match ApiRequestContext::authenticate(&state, &headers) {
+        Ok(context) => context,
+        Err(error) => return respond_error(&state, &headers, error),
+    };
+    let result = (|| {
+        let request = json_payload(payload, &context)?;
+        let pagination = request.pagination()?;
+        let query = request.into_query(pagination)?;
+        let page = service(&state)?
+            .list(context.actor.subject(), &query)
+            .map_err(map_todo_error)?;
+        let total = u64::try_from(page.total_count)
+            .map_err(|_| ApiError::internal("todo count overflow"))?;
+        Ok(PagedResponse::new(
+            page.items.into_iter().map(TodoDto::from).collect(),
+            pagination,
+            total,
+        ))
+    })();
+    respond(&state, &headers, &context, result)
+}
+
+pub(super) async fn get(
+    State(state): State<OpsHttpState>,
+    headers: HeaderMap,
+    payload: Result<Json<GetTodoRequest>, JsonRejection>,
+) -> Response {
+    let context = match ApiRequestContext::authenticate(&state, &headers) {
+        Ok(context) => context,
+        Err(error) => return respond_error(&state, &headers, error),
+    };
+    let result = (|| {
+        let request = json_payload(payload, &context)?;
+        let id = request.id.into_string()?;
+        service(&state)?
+            .get(context.actor.subject(), &id)
+            .map(TodoDto::from)
+            .map_err(map_todo_error)
+    })();
+    respond(&state, &headers, &context, result)
+}
+
+pub(super) async fn update(
+    State(state): State<OpsHttpState>,
+    headers: HeaderMap,
+    payload: Result<Json<UpdateTodoRequest>, JsonRejection>,
+) -> Response {
+    let context = match ApiRequestContext::authenticate(&state, &headers) {
+        Ok(context) => context,
+        Err(error) => return respond_error(&state, &headers, error),
+    };
+    let result = (|| {
+        let request = json_payload(payload, &context)?;
+        let (id, update) = request.into_parts()?;
+        service(&state)?
+            .update(context.actor.subject(), &id, update)
+            .map(TodoDto::from)
+            .map_err(map_todo_error)
+    })();
+    respond(&state, &headers, &context, result)
+}
+
+pub(super) async fn delete(
+    State(state): State<OpsHttpState>,
+    headers: HeaderMap,
+    payload: Result<Json<DeleteTodoRequest>, JsonRejection>,
+) -> Response {
+    let context = match ApiRequestContext::authenticate(&state, &headers) {
+        Ok(context) => context,
+        Err(error) => return respond_error(&state, &headers, error),
+    };
+    let result = (|| {
+        let request = json_payload(payload, &context)?;
+        let id = request.id.into_string()?;
+        service(&state)?
+            .delete(context.actor.subject(), &id)
+            .map_err(map_todo_error)?;
+        Ok(DeleteTodoResponse { id, deleted: true })
+    })();
+    respond(&state, &headers, &context, result)
+}
+
+fn service(
+    state: &OpsHttpState,
+) -> Result<&crate::runtime::tools::todo::TodoManagementService, ApiError> {
+    state.todo_management.as_ref().ok_or_else(|| {
+        ApiError::unavailable("todo_unavailable", "todo management service is unavailable")
+    })
+}
+
+fn map_todo_error(error: TodoManagementError) -> ApiError {
+    match error.code() {
+        "bad_request" => ApiError::validation(error.message()),
+        "not_found" => ApiError::not_found("todo not found"),
+        "permission_denied" => ApiError::forbidden("permission_denied", error.message()),
+        "conflict" => ApiError::conflict(error.message()),
+        _ => {
+            tracing::error!(code = error.code(), "todo management operation failed");
+            ApiError::internal("todo service failed")
+        }
+    }
+}

--- a/qq-maid-core/src/http/api/todo/handlers.rs
+++ b/qq-maid-core/src/http/api/todo/handlers.rs
@@ -31,11 +31,16 @@ pub(super) async fn create(
         Ok(context) => context,
         Err(error) => return respond_error(&state, &headers, error),
     };
+    tracing::debug!(
+        actor = context.actor.subject(),
+        action = "create",
+        "Todo 管理请求已认证"
+    );
     let result = (|| {
         let request = json_payload(payload, &context)?;
-        let draft = request.into_draft()?;
+        let (target_ref, draft) = request.into_parts()?;
         service(&state)?
-            .create(context.actor.subject(), draft)
+            .create(&target_ref, draft)
             .map(TodoDto::from)
             .map_err(map_todo_error)
     })();
@@ -51,12 +56,17 @@ pub(super) async fn list(
         Ok(context) => context,
         Err(error) => return respond_error(&state, &headers, error),
     };
+    tracing::debug!(
+        actor = context.actor.subject(),
+        action = "list",
+        "Todo 管理请求已认证"
+    );
     let result = (|| {
         let request = json_payload(payload, &context)?;
         let pagination = request.pagination()?;
-        let query = request.into_query(pagination)?;
+        let (query, filter) = request.into_parts(pagination)?;
         let page = service(&state)?
-            .list(context.actor.subject(), &query)
+            .list(&query, filter)
             .map_err(map_todo_error)?;
         let total = u64::try_from(page.total_count)
             .map_err(|_| ApiError::internal("todo count overflow"))?;
@@ -78,11 +88,16 @@ pub(super) async fn get(
         Ok(context) => context,
         Err(error) => return respond_error(&state, &headers, error),
     };
+    tracing::debug!(
+        actor = context.actor.subject(),
+        action = "get",
+        "Todo 管理请求已认证"
+    );
     let result = (|| {
         let request = json_payload(payload, &context)?;
         let id = request.id.into_string()?;
         service(&state)?
-            .get(context.actor.subject(), &id)
+            .get(&id)
             .map(TodoDto::from)
             .map_err(map_todo_error)
     })();
@@ -98,11 +113,16 @@ pub(super) async fn update(
         Ok(context) => context,
         Err(error) => return respond_error(&state, &headers, error),
     };
+    tracing::debug!(
+        actor = context.actor.subject(),
+        action = "update",
+        "Todo 管理请求已认证"
+    );
     let result = (|| {
         let request = json_payload(payload, &context)?;
         let (id, update) = request.into_parts()?;
         service(&state)?
-            .update(context.actor.subject(), &id, update)
+            .update(&id, update)
             .map(TodoDto::from)
             .map_err(map_todo_error)
     })();
@@ -118,12 +138,15 @@ pub(super) async fn delete(
         Ok(context) => context,
         Err(error) => return respond_error(&state, &headers, error),
     };
+    tracing::debug!(
+        actor = context.actor.subject(),
+        action = "delete",
+        "Todo 管理请求已认证"
+    );
     let result = (|| {
         let request = json_payload(payload, &context)?;
         let id = request.id.into_string()?;
-        service(&state)?
-            .delete(context.actor.subject(), &id)
-            .map_err(map_todo_error)?;
+        service(&state)?.delete(&id).map_err(map_todo_error)?;
         Ok(DeleteTodoResponse { id, deleted: true })
     })();
     respond(&state, &headers, &context, result)

--- a/qq-maid-core/src/http/api/todo/mod.rs
+++ b/qq-maid-core/src/http/api/todo/mod.rs
@@ -11,6 +11,7 @@ pub(crate) fn router() -> Router<OpsHttpState> {
     Router::new()
         .route("/api/v1/console/todo/create", post(handlers::create))
         .route("/api/v1/console/todo/list", post(handlers::list))
+        .route("/api/v1/console/todo/targets", post(handlers::targets))
         .route("/api/v1/console/todo/get", post(handlers::get))
         .route("/api/v1/console/todo/update", post(handlers::update))
         .route("/api/v1/console/todo/delete", post(handlers::delete))

--- a/qq-maid-core/src/http/api/todo/mod.rs
+++ b/qq-maid-core/src/http/api/todo/mod.rs
@@ -1,0 +1,21 @@
+//! Todo 管理 API 路由。
+
+mod dto;
+mod handlers;
+
+use axum::{Router, extract::DefaultBodyLimit, routing::post};
+
+use crate::http::routes::OpsHttpState;
+
+pub(crate) fn router() -> Router<OpsHttpState> {
+    Router::new()
+        .route("/api/v1/console/todo/create", post(handlers::create))
+        .route("/api/v1/console/todo/list", post(handlers::list))
+        .route("/api/v1/console/todo/get", post(handlers::get))
+        .route("/api/v1/console/todo/update", post(handlers::update))
+        .route("/api/v1/console/todo/delete", post(handlers::delete))
+        .layer(DefaultBodyLimit::max(64 * 1024))
+}
+
+#[cfg(test)]
+mod tests;

--- a/qq-maid-core/src/http/api/todo/tests.rs
+++ b/qq-maid-core/src/http/api/todo/tests.rs
@@ -1,0 +1,447 @@
+//! Todo 管理 API 集成测试。
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use http_body_util::BodyExt;
+use qq_maid_llm::provider::{
+    ChatOutcome, LlmProvider,
+    status::{UpstreamStatus, observe_provider},
+    types::{ChatRequest, TokenUsage},
+};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use crate::{
+    error::LlmError,
+    http::routes::{OpsHttpConfig, OpsHttpState, build_router},
+    management::{AdminAuth, SESSION_COOKIE_NAME},
+    runtime::tools::todo::{TodoManagementService, TodoStore},
+    storage::{APP_MIGRATIONS, database::SqliteDatabase, notification::NotificationOutboxStore},
+    util::metrics::LlmMetrics,
+};
+
+#[derive(Clone)]
+struct MockProvider;
+
+#[async_trait]
+impl LlmProvider for MockProvider {
+    async fn chat(&self, _req: ChatRequest) -> Result<ChatOutcome, LlmError> {
+        Ok(ChatOutcome {
+            reply: String::new(),
+            output_parts: Vec::new(),
+            metrics: LlmMetrics {
+                provider: "mock".to_owned(),
+                model: "mock".to_owned(),
+                stream: false,
+                ttfe_ms: None,
+                ttft_ms: None,
+                total_latency_ms: 0,
+            },
+            usage: Some(TokenUsage {
+                input_tokens: None,
+                cached_input_tokens: None,
+                output_tokens: None,
+                total_tokens: None,
+            }),
+            fallback_used: false,
+            agent: Default::default(),
+        })
+    }
+
+    fn name(&self) -> &str {
+        "mock"
+    }
+
+    fn model(&self) -> &str {
+        "mock"
+    }
+
+    fn stream_enabled(&self) -> bool {
+        false
+    }
+}
+
+struct TestApi {
+    state: OpsHttpState,
+    cookie: String,
+    csrf: String,
+}
+
+impl TestApi {
+    fn new() -> Self {
+        let (database, directory) =
+            SqliteDatabase::open_temp_directory("todo-management-api", APP_MIGRATIONS).unwrap();
+        let token_file = directory.join("config/secrets/bootstrap.token");
+        let auth = AdminAuth::open(database.clone(), token_file.clone()).unwrap();
+        let token = std::fs::read_to_string(token_file)
+            .unwrap()
+            .trim()
+            .splitn(3, ':')
+            .nth(2)
+            .unwrap()
+            .to_owned();
+        let preauth = auth.issue_preauth().unwrap();
+        let issued = auth
+            .initialize(
+                &preauth.cookie_value,
+                &preauth.session.csrf_token,
+                &token,
+                "admin",
+                "correct horse battery staple",
+            )
+            .unwrap();
+        let upstream = UpstreamStatus::default();
+        let mut state = OpsHttpState::from_parts(
+            OpsHttpConfig {
+                web_console_enabled: true,
+                web_console_allowed_origins: Vec::new(),
+                web_console_trusted_proxy_ips: Vec::new(),
+                web_console_secure_cookies: false,
+            },
+            observe_provider(Arc::new(MockProvider), upstream.clone()),
+            upstream,
+        );
+        state.admin_auth = Some(auth);
+        state = state.with_todo_management(TodoManagementService::new(
+            TodoStore::new(database.clone()),
+            NotificationOutboxStore::new(database),
+        ));
+        Self {
+            state,
+            cookie: issued.cookie_value,
+            csrf: issued.session.csrf_token,
+        }
+    }
+
+    async fn post(&self, path: &str, body: Value) -> (StatusCode, Value) {
+        self.request("POST", path, Some(body), true).await
+    }
+
+    async fn request(
+        &self,
+        method: &str,
+        path: &str,
+        body: Option<Value>,
+        authenticated: bool,
+    ) -> (StatusCode, Value) {
+        let mut builder = Request::builder()
+            .method(method)
+            .uri(path)
+            .header("content-type", "application/json")
+            .header("host", "localhost")
+            .header("x-request-id", "todo-api-test");
+        if authenticated {
+            builder = builder
+                .header("cookie", format!("{}={}", SESSION_COOKIE_NAME, self.cookie))
+                .header("x-csrf-token", &self.csrf);
+        }
+        let body = body
+            .map(|value| Body::from(value.to_string()))
+            .unwrap_or_else(Body::empty);
+        let response = build_router(self.state.clone())
+            .oneshot(builder.body(body).unwrap())
+            .await
+            .unwrap();
+        let status = response.status();
+        // 路由方法不匹配时由 Axum 在进入 API Handler 前直接生成 405，没有请求上下文。
+        if status != StatusCode::METHOD_NOT_ALLOWED {
+            assert_eq!(
+                response
+                    .headers()
+                    .get("x-request-id")
+                    .and_then(|value| value.to_str().ok()),
+                Some("todo-api-test")
+            );
+        }
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let json = serde_json::from_slice(&bytes).unwrap_or_else(|_| json!({}));
+        (status, json)
+    }
+
+    async fn create(&self, title: &str, extra: Value) -> Value {
+        let mut body = json!({"title": title});
+        body.as_object_mut()
+            .unwrap()
+            .extend(extra.as_object().cloned().unwrap_or_default());
+        let (status, response) = self.post("/api/v1/console/todo/create", body).await;
+        assert_eq!(status, StatusCode::OK, "{response}");
+        response["data"].clone()
+    }
+}
+
+#[tokio::test]
+async fn todo_api_requires_authentication_and_only_registers_post() {
+    let api = TestApi::new();
+    let (status, body) = api
+        .request(
+            "POST",
+            "/api/v1/console/todo/create",
+            Some(json!({"title": "未认证"})),
+            false,
+        )
+        .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(body["ok"], false);
+    assert_eq!(body["error"]["code"], "unauthenticated");
+
+    let (status, _) = api
+        .request("GET", "/api/v1/console/todo/list", None, true)
+        .await;
+    assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
+}
+
+#[tokio::test]
+async fn todo_create_validates_json_and_empty_title() {
+    let api = TestApi::new();
+    let created = api
+        .create(
+            "准备周报",
+            json!({"detail": "整理本周进度", "due_date": "2099-08-01"}),
+        )
+        .await;
+    assert_eq!(created["title"], "准备周报");
+    assert_eq!(created["detail"], "整理本周进度");
+    assert_eq!(created["status"], "pending");
+    assert!(created.get("user_id").is_none());
+    assert!(created.get("scope_key").is_none());
+
+    let (status, body) = api
+        .post("/api/v1/console/todo/create", json!({"title": "  "}))
+        .await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(body["error"]["code"], "validation_error");
+
+    let (status, body) = api
+        .post("/api/v1/console/todo/create", json!({"detail": "缺标题"}))
+        .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["error"]["code"], "invalid_json");
+
+    let (status, _) = api
+        .post(
+            "/api/v1/console/todo/create",
+            json!({"title": "日期错误", "due_date": "2099-99-99"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn todo_list_paginates_in_repository_with_stable_order_and_total() {
+    let api = TestApi::new();
+    for index in 1..=25 {
+        api.create(&format!("第 {index} 项"), json!({})).await;
+    }
+
+    let (status, default_page) = api.post("/api/v1/console/todo/list", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(default_page["data"]["page"], 1);
+    assert_eq!(default_page["data"]["page_size"], 20);
+    assert_eq!(default_page["data"]["total"], 25);
+    assert_eq!(default_page["data"]["total_pages"], 2);
+    assert_eq!(default_page["data"]["items"].as_array().unwrap().len(), 20);
+
+    let (_, first) = api
+        .post(
+            "/api/v1/console/todo/list",
+            json!({"page": 1, "page_size": 10}),
+        )
+        .await;
+    let (_, first_again) = api
+        .post(
+            "/api/v1/console/todo/list",
+            json!({"page": 1, "page_size": 10}),
+        )
+        .await;
+    assert_eq!(first["data"]["items"], first_again["data"]["items"]);
+    assert_eq!(first["data"]["total_pages"], 3);
+
+    let (_, last) = api
+        .post(
+            "/api/v1/console/todo/list",
+            json!({"page": 3, "page_size": 10}),
+        )
+        .await;
+    assert_eq!(last["data"]["items"].as_array().unwrap().len(), 5);
+
+    let (_, beyond) = api
+        .post(
+            "/api/v1/console/todo/list",
+            json!({"page": 4, "page_size": 10}),
+        )
+        .await;
+    assert!(beyond["data"]["items"].as_array().unwrap().is_empty());
+    assert_eq!(beyond["data"]["total"], 25);
+
+    let (_, management_max) = api
+        .post(
+            "/api/v1/console/todo/list",
+            json!({"page": 1, "page_size": 100}),
+        )
+        .await;
+    assert_eq!(
+        management_max["data"]["items"].as_array().unwrap().len(),
+        25
+    );
+}
+
+#[tokio::test]
+async fn todo_list_reuses_existing_status_keyword_recurrence_and_time_filters() {
+    let api = TestApi::new();
+    let completed = api
+        .create("项目 Alpha 周报", json!({"due_date": "2099-08-01"}))
+        .await;
+    api.create("项目 Beta 无日期", json!({})).await;
+    api.create(
+        "周期巡检",
+        json!({"due_date": "2099-08-02", "recurrence_kind": "daily"}),
+    )
+    .await;
+    let (status, _) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({"id": completed["id"], "status": "completed"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (_, completed_page) = api
+        .post("/api/v1/console/todo/list", json!({"status": "completed"}))
+        .await;
+    assert_eq!(completed_page["data"]["total"], 1);
+    assert_eq!(
+        completed_page["data"]["items"][0]["title"],
+        "项目 Alpha 周报"
+    );
+
+    let (_, keyword_page) = api
+        .post(
+            "/api/v1/console/todo/list",
+            json!({"status": "all", "keyword": "项目 Beta"}),
+        )
+        .await;
+    assert_eq!(keyword_page["data"]["total"], 1);
+
+    let (_, recurring_page) = api
+        .post("/api/v1/console/todo/list", json!({"recurring": true}))
+        .await;
+    assert_eq!(recurring_page["data"]["total"], 1);
+    assert_eq!(recurring_page["data"]["items"][0]["title"], "周期巡检");
+
+    let (_, no_due_page) = api
+        .post(
+            "/api/v1/console/todo/list",
+            json!({"status": "pending", "time_filter": "no_due_date"}),
+        )
+        .await;
+    assert_eq!(no_due_page["data"]["total"], 1);
+    assert_eq!(no_due_page["data"]["items"][0]["title"], "项目 Beta 无日期");
+
+    let (_, date_page) = api
+        .post(
+            "/api/v1/console/todo/list",
+            json!({
+                "status": "pending",
+                "date_start": "2099-08-02",
+                "date_end": "2099-08-02"
+            }),
+        )
+        .await;
+    assert_eq!(date_page["data"]["total"], 1);
+}
+
+#[tokio::test]
+async fn todo_get_update_and_delete_follow_domain_semantics() {
+    let api = TestApi::new();
+    let created = api
+        .create(
+            "初始标题",
+            json!({"detail": "待清空", "due_date": "2099-08-01"}),
+        )
+        .await;
+    let id = created["id"].clone();
+
+    let (status, fetched) = api
+        .post("/api/v1/console/todo/get", json!({"id": id}))
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(fetched["data"]["title"], "初始标题");
+
+    let (status, updated) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({
+                "id": id,
+                "title": "更新标题",
+                "detail": null,
+                "due_date": null,
+                "status": "completed"
+            }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{updated}");
+    assert_eq!(updated["data"]["title"], "更新标题");
+    assert_eq!(updated["data"]["detail"], Value::Null);
+    assert_eq!(updated["data"]["due_date"], Value::Null);
+    assert_eq!(updated["data"]["status"], "completed");
+
+    let (status, conflict) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({"id": id, "title": "不能直接编辑终态"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(conflict["error"]["code"], "conflict");
+
+    let (status, restored) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({"id": id, "status": "pending", "detail": "恢复后编辑"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(restored["data"]["detail"], "恢复后编辑");
+    assert_eq!(restored["data"]["status"], "pending");
+
+    let (status, deleted) = api
+        .post("/api/v1/console/todo/delete", json!({"id": id}))
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(deleted["data"]["deleted"], true);
+
+    for path in ["get", "update", "delete"] {
+        let payload = if path == "update" {
+            json!({"id": id, "title": "不存在"})
+        } else {
+            json!({"id": id})
+        };
+        let (status, body) = api
+            .post(&format!("/api/v1/console/todo/{path}"), payload)
+            .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body["error"]["code"], "not_found");
+    }
+}
+
+#[tokio::test]
+async fn todo_list_rejects_invalid_pagination_and_filter_combinations() {
+    let api = TestApi::new();
+    for payload in [
+        json!({"page": 0}),
+        json!({"page_size": 0}),
+        json!({"page_size": 101}),
+        json!({"date_start": "2099-01-01"}),
+        json!({"due_date": "2099-01-01", "time_filter": "no_due_date"}),
+        json!({"status": "all", "time_filter": "overdue"}),
+    ] {
+        let (status, body) = api.post("/api/v1/console/todo/list", payload).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "{body}");
+        assert_eq!(body["error"]["code"], "validation_error");
+    }
+}

--- a/qq-maid-core/src/http/api/todo/tests.rs
+++ b/qq-maid-core/src/http/api/todo/tests.rs
@@ -19,9 +19,20 @@ use tower::ServiceExt;
 use crate::{
     error::LlmError,
     http::routes::{OpsHttpConfig, OpsHttpState, build_router},
+    identity::conversation_scope_key,
     management::{AdminAuth, SESSION_COOKIE_NAME},
-    runtime::tools::todo::{TodoManagementService, TodoStore},
-    storage::{APP_MIGRATIONS, database::SqliteDatabase, notification::NotificationOutboxStore},
+    runtime::{
+        session::{SessionMeta, SessionStore},
+        tools::todo::{
+            TodoItemDraft, TodoManagementService, TodoRecurrenceKind, TodoRecurrenceUnit,
+            TodoStore, TodoTimePrecision,
+        },
+    },
+    storage::{
+        APP_MIGRATIONS,
+        database::SqliteDatabase,
+        notification::{NotificationOutboxStore, NotificationStatus},
+    },
     util::metrics::LlmMetrics,
 };
 
@@ -70,6 +81,11 @@ struct TestApi {
     state: OpsHttpState,
     cookie: String,
     csrf: String,
+    other_cookie: String,
+    other_csrf: String,
+    target_ref: String,
+    todo_store: TodoStore,
+    notification_store: NotificationOutboxStore,
 }
 
 impl TestApi {
@@ -106,20 +122,79 @@ impl TestApi {
             observe_provider(Arc::new(MockProvider), upstream.clone()),
             upstream,
         );
-        state.admin_auth = Some(auth);
-        state = state.with_todo_management(TodoManagementService::new(
-            TodoStore::new(database.clone()),
-            NotificationOutboxStore::new(database),
-        ));
+        state.admin_auth = Some(auth.clone());
+        let todo_store = TodoStore::new(database.clone());
+        let notification_store = NotificationOutboxStore::new(database.clone());
+        let default_scope = conversation_scope_key(
+            "qq_official",
+            Some("app-default"),
+            "private",
+            "user-default",
+        );
+        SessionStore::new(database.clone())
+            .get_or_create_active(&SessionMeta::new_with_account(
+                default_scope.clone(),
+                Some("user-default".to_owned()),
+                None,
+                None,
+                None,
+                "qq_official",
+                Some("app-default".to_owned()),
+            ))
+            .unwrap();
+        let default_owner = TodoStore::owner(Some("user-default"), &default_scope);
+        let anchor = todo_store
+            .create(&default_owner, todo_draft("目标锚点"))
+            .unwrap();
+        let service = TodoManagementService::new(todo_store.clone(), notification_store.clone());
+        let target_ref = service.get(&anchor.id).unwrap().target.target_ref.unwrap();
+        todo_store
+            .delete_by_ids(&default_owner, &[anchor.id])
+            .unwrap();
+        database
+            .connection()
+            .unwrap()
+            .execute(
+                "INSERT INTO console_admins (username, password_hash, disabled, created_at)
+                 SELECT 'admin2', password_hash, 0, created_at
+                 FROM console_admins WHERE username = 'admin'",
+                [],
+            )
+            .unwrap();
+        let other_preauth = auth.issue_preauth().unwrap();
+        let other_issued = auth
+            .login(
+                &other_preauth.cookie_value,
+                &other_preauth.session.csrf_token,
+                "admin2",
+                "correct horse battery staple",
+            )
+            .unwrap();
+        state = state.with_todo_management(service);
         Self {
             state,
             cookie: issued.cookie_value,
             csrf: issued.session.csrf_token,
+            other_cookie: other_issued.cookie_value,
+            other_csrf: other_issued.session.csrf_token,
+            target_ref,
+            todo_store,
+            notification_store,
         }
     }
 
     async fn post(&self, path: &str, body: Value) -> (StatusCode, Value) {
         self.request("POST", path, Some(body), true).await
+    }
+
+    async fn post_as_other(&self, path: &str, body: Value) -> (StatusCode, Value) {
+        self.request_with_credentials(
+            "POST",
+            path,
+            Some(body),
+            Some((&self.other_cookie, &self.other_csrf)),
+        )
+        .await
     }
 
     async fn request(
@@ -129,16 +204,28 @@ impl TestApi {
         body: Option<Value>,
         authenticated: bool,
     ) -> (StatusCode, Value) {
+        let credentials = authenticated.then_some((self.cookie.as_str(), self.csrf.as_str()));
+        self.request_with_credentials(method, path, body, credentials)
+            .await
+    }
+
+    async fn request_with_credentials(
+        &self,
+        method: &str,
+        path: &str,
+        body: Option<Value>,
+        credentials: Option<(&str, &str)>,
+    ) -> (StatusCode, Value) {
         let mut builder = Request::builder()
             .method(method)
             .uri(path)
             .header("content-type", "application/json")
             .header("host", "localhost")
             .header("x-request-id", "todo-api-test");
-        if authenticated {
+        if let Some((cookie, csrf)) = credentials {
             builder = builder
-                .header("cookie", format!("{}={}", SESSION_COOKIE_NAME, self.cookie))
-                .header("x-csrf-token", &self.csrf);
+                .header("cookie", format!("{SESSION_COOKIE_NAME}={cookie}"))
+                .header("x-csrf-token", csrf);
         }
         let body = body
             .map(|value| Body::from(value.to_string()))
@@ -164,13 +251,59 @@ impl TestApi {
     }
 
     async fn create(&self, title: &str, extra: Value) -> Value {
-        let mut body = json!({"title": title});
+        let mut body = json!({"target_ref": self.target_ref, "title": title});
         body.as_object_mut()
             .unwrap()
             .extend(extra.as_object().cloned().unwrap_or_default());
         let (status, response) = self.post("/api/v1/console/todo/create", body).await;
         assert_eq!(status, StatusCode::OK, "{response}");
         response["data"].clone()
+    }
+
+    fn seed_todo(
+        &self,
+        platform: &str,
+        account_id: &str,
+        scope_type: &str,
+        target_id: &str,
+        user_id: &str,
+        title: &str,
+    ) -> (
+        crate::runtime::tools::todo::TodoOwner,
+        crate::runtime::tools::todo::TodoItem,
+    ) {
+        let scope = conversation_scope_key(platform, Some(account_id), scope_type, target_id);
+        let owner = TodoStore::owner(Some(user_id), &scope);
+        let item = self.todo_store.create(&owner, todo_draft(title)).unwrap();
+        (owner, item)
+    }
+
+    fn target_ref_for_item(&self, id: &str) -> String {
+        self.state
+            .todo_management
+            .as_ref()
+            .unwrap()
+            .get(id)
+            .unwrap()
+            .target
+            .target_ref
+            .unwrap()
+    }
+}
+
+fn todo_draft(title: &str) -> TodoItemDraft {
+    TodoItemDraft {
+        title: title.to_owned(),
+        detail: None,
+        raw_text: None,
+        due_date: None,
+        due_at: None,
+        reminder_at: None,
+        time_precision: TodoTimePrecision::None,
+        recurrence_kind: TodoRecurrenceKind::None,
+        recurrence_interval_days: 0,
+        recurrence_interval: 0,
+        recurrence_unit: TodoRecurrenceUnit::Day,
     }
 }
 
@@ -209,9 +342,15 @@ async fn todo_create_validates_json_and_empty_title() {
     assert_eq!(created["status"], "pending");
     assert!(created.get("user_id").is_none());
     assert!(created.get("scope_key").is_none());
+    assert_eq!(created["target"]["platform"], "qq_official");
+    assert_eq!(created["target"]["scope_type"], "private");
+    assert_eq!(created["target"]["user_id"], "user-default");
 
     let (status, body) = api
-        .post("/api/v1/console/todo/create", json!({"title": "  "}))
+        .post(
+            "/api/v1/console/todo/create",
+            json!({"target_ref": api.target_ref, "title": "  "}),
+        )
         .await;
     assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
     assert_eq!(body["error"]["code"], "validation_error");
@@ -225,7 +364,7 @@ async fn todo_create_validates_json_and_empty_title() {
     let (status, _) = api
         .post(
             "/api/v1/console/todo/create",
-            json!({"title": "日期错误", "due_date": "2099-99-99"}),
+            json!({"target_ref": api.target_ref, "title": "日期错误", "due_date": "2099-99-99"}),
         )
         .await;
     assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
@@ -444,4 +583,399 @@ async fn todo_list_rejects_invalid_pagination_and_filter_combinations() {
         assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "{body}");
         assert_eq!(body["error"]["code"], "validation_error");
     }
+}
+
+#[tokio::test]
+async fn global_management_is_shared_by_admins_and_preserves_chat_owner_scope() {
+    let api = TestApi::new();
+    let (qq_owner, qq) = api.seed_todo(
+        "qq_official",
+        "app-1",
+        "private",
+        "qq-user",
+        "qq-user",
+        "QQ 待办",
+    );
+    let (onebot_owner, onebot) = api.seed_todo(
+        "onebot",
+        "bot-1",
+        "group",
+        "group-1",
+        "member-1",
+        "OneBot 待办",
+    );
+    let (wechat_owner, wechat) = api.seed_todo(
+        "wechat_service",
+        "wx-1",
+        "private",
+        "wx-user",
+        "wx-user",
+        "微信待办",
+    );
+
+    let (status, first_admin) = api
+        .post(
+            "/api/v1/console/todo/list",
+            json!({"status": "all", "page_size": 100}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(first_admin["data"]["total"], 3);
+    let (status, second_admin) = api
+        .post_as_other(
+            "/api/v1/console/todo/list",
+            json!({"status": "all", "page_size": 100}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(second_admin["data"]["items"], first_admin["data"]["items"]);
+
+    let (status, updated) = api
+        .post_as_other(
+            "/api/v1/console/todo/update",
+            json!({"id": qq.id, "title": "管理员已修改 QQ 待办"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{updated}");
+    assert_eq!(
+        api.todo_store
+            .get_by_id(&qq_owner, &qq.id)
+            .unwrap()
+            .unwrap()
+            .title,
+        "管理员已修改 QQ 待办"
+    );
+
+    let (status, updated) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({"id": onebot.id, "title": "管理员已修改 OneBot 待办"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{updated}");
+    assert_eq!(
+        api.todo_store
+            .get_by_id(&onebot_owner, &onebot.id)
+            .unwrap()
+            .unwrap()
+            .title,
+        "管理员已修改 OneBot 待办"
+    );
+
+    let (status, updated) = api
+        .post_as_other(
+            "/api/v1/console/todo/update",
+            json!({"id": wechat.id, "title": "管理员已修改微信待办"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{updated}");
+    assert_eq!(
+        api.todo_store
+            .get_by_id(&wechat_owner, &wechat.id)
+            .unwrap()
+            .unwrap()
+            .title,
+        "管理员已修改微信待办"
+    );
+
+    // 普通聊天使用的 owner-scoped Store 入口仍只能看到当前真实 owner 的记录。
+    assert_eq!(api.todo_store.list_all(&qq_owner).unwrap().len(), 1);
+    assert_eq!(api.todo_store.list_all(&onebot_owner).unwrap().len(), 1);
+    assert_eq!(api.todo_store.list_all(&wechat_owner).unwrap().len(), 1);
+
+    let (status, filtered) = api
+        .post(
+            "/api/v1/console/todo/list",
+            json!({"platform": "onebot", "scope_type": "group"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(filtered["data"]["total"], 1);
+    assert_eq!(filtered["data"]["items"][0]["id"], onebot.id);
+
+    let (status, _) = api
+        .post_as_other("/api/v1/console/todo/delete", json!({"id": onebot.id}))
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        api.todo_store
+            .get_by_id(&onebot_owner, &onebot.id)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn create_uses_verified_private_or_group_target_and_rejects_unsupported_reminder() {
+    let api = TestApi::new();
+    let (private_owner, private_anchor) = api.seed_todo(
+        "qq_official",
+        "app-2",
+        "private",
+        "private-2",
+        "private-2",
+        "私聊锚点",
+    );
+    let private_ref = api.target_ref_for_item(&private_anchor.id);
+    let (status, private_created) = api
+        .post(
+            "/api/v1/console/todo/create",
+            json!({"target_ref": private_ref, "title": "API 私聊待办"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{private_created}");
+    assert_eq!(private_created["data"]["target"]["scope_type"], "private");
+    assert!(
+        api.todo_store
+            .list_all(&private_owner)
+            .unwrap()
+            .iter()
+            .any(|item| item.title == "API 私聊待办")
+    );
+
+    let (group_owner, group_anchor) = api.seed_todo(
+        "onebot",
+        "bot-2",
+        "group",
+        "group-2",
+        "member-2",
+        "群聊锚点",
+    );
+    let group_ref = api.target_ref_for_item(&group_anchor.id);
+    let (status, group_created) = api
+        .post(
+            "/api/v1/console/todo/create",
+            json!({
+                "target_ref": group_ref,
+                "title": "API 群聊提醒",
+                "reminder_at": "2099-08-01T09:00:00+08:00"
+            }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{group_created}");
+    assert_eq!(group_created["data"]["target"]["platform"], "onebot");
+    assert!(
+        api.todo_store
+            .list_all(&group_owner)
+            .unwrap()
+            .iter()
+            .any(|item| item.title == "API 群聊提醒")
+    );
+    let tasks = api.notification_store.list_all_for_test().unwrap();
+    let group_task = tasks
+        .iter()
+        .find(|task| task.source_id == group_created["data"]["id"].as_str().unwrap())
+        .unwrap();
+    assert_eq!(group_task.target.platform, "onebot11");
+    assert_eq!(group_task.target.target_id, "group-2");
+
+    let (_, wechat_anchor) = api.seed_todo(
+        "wechat_service",
+        "wx-2",
+        "private",
+        "wx-user-2",
+        "wx-user-2",
+        "微信锚点",
+    );
+    let wechat_ref = api.target_ref_for_item(&wechat_anchor.id);
+    let (status, rejected) = api
+        .post(
+            "/api/v1/console/todo/create",
+            json!({
+                "target_ref": wechat_ref,
+                "title": "不可投递提醒",
+                "reminder_at": "2099-08-01T10:00:00+08:00"
+            }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(rejected["error"]["code"], "validation_error");
+    let (_, absent) = api
+        .post(
+            "/api/v1/console/todo/list",
+            json!({"keyword": "不可投递提醒"}),
+        )
+        .await;
+    assert_eq!(absent["data"]["total"], 0);
+}
+
+#[tokio::test]
+async fn reminder_update_replaces_outbox_and_delete_cancels_it() {
+    let api = TestApi::new();
+    let (_, item) = api.seed_todo(
+        "qq_official",
+        "app-3",
+        "private",
+        "user-3",
+        "user-3",
+        "提醒待办",
+    );
+    let (status, first) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({"id": item.id, "reminder_at": "2099-08-01T09:00:00+08:00"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{first}");
+    let (status, second) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({"id": item.id, "reminder_at": "2099-08-01T10:00:00+08:00"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{second}");
+    let tasks = api.notification_store.list_all_for_test().unwrap();
+    assert_eq!(tasks.len(), 2);
+    assert_eq!(tasks[0].status, NotificationStatus::Cancelled);
+    assert_eq!(tasks[1].status, NotificationStatus::Pending);
+    assert_eq!(tasks[1].scheduled_at, "2099-08-01T10:00:00+08:00");
+
+    let (status, _) = api
+        .post("/api/v1/console/todo/delete", json!({"id": item.id}))
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    let tasks = api.notification_store.list_all_for_test().unwrap();
+    assert_eq!(tasks[1].status, NotificationStatus::Cancelled);
+}
+
+#[tokio::test]
+async fn recurring_completion_advances_atomically_and_reschedules_reminder() {
+    let api = TestApi::new();
+    let scope = conversation_scope_key(
+        "qq_official",
+        Some("app-recurring"),
+        "private",
+        "recurring-user",
+    );
+    let owner = TodoStore::owner(Some("recurring-user"), &scope);
+    let mut draft = todo_draft("周期提醒");
+    draft.due_date = Some("2099-08-01".to_owned());
+    draft.reminder_at = Some("2099-08-01T09:00:00+08:00".to_owned());
+    draft.recurrence_kind = TodoRecurrenceKind::Daily;
+    draft.recurrence_interval_days = 1;
+    let item = api.todo_store.create(&owner, draft).unwrap();
+
+    let (status, completed) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({"id": item.id, "title": "周期提醒已更新", "status": "completed"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{completed}");
+    assert_eq!(completed["data"]["status"], "pending");
+    assert_eq!(completed["data"]["title"], "周期提醒已更新");
+    assert_ne!(completed["data"]["reminder_at"], item.reminder_at.unwrap());
+    let stored = api.todo_store.get_by_id(&owner, &item.id).unwrap().unwrap();
+    assert_eq!(
+        stored.status,
+        crate::runtime::tools::todo::TodoStatus::Pending
+    );
+    assert_eq!(stored.title, "周期提醒已更新");
+    assert_eq!(api.notification_store.list_all_for_test().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn invalid_target_atomic_restore_patch_and_invalid_ids_leave_data_unchanged() {
+    let api = TestApi::new();
+    let created = api.create("原子恢复", json!({})).await;
+    api.post(
+        "/api/v1/console/todo/update",
+        json!({"id": created["id"], "status": "completed"}),
+    )
+    .await;
+    let (status, invalid_patch) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({"id": created["id"], "status": "pending", "title": "   "}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(invalid_patch["error"]["code"], "validation_error");
+    let (_, unchanged) = api
+        .post("/api/v1/console/todo/get", json!({"id": created["id"]}))
+        .await;
+    assert_eq!(unchanged["data"]["status"], "completed");
+    assert_eq!(unchanged["data"]["title"], "原子恢复");
+
+    let (status, invalid_target) = api
+        .post(
+            "/api/v1/console/todo/create",
+            json!({"target_ref": "todo_target:v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "title": "幽灵 Todo"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(invalid_target["error"]["code"], "validation_error");
+
+    let legacy_owner = TodoStore::owner(Some("legacy-user"), "mystery:legacy-scope");
+    api.todo_store
+        .create(&legacy_owner, todo_draft("异常旧作用域"))
+        .unwrap();
+    let (status, degraded) = api
+        .post(
+            "/api/v1/console/todo/list",
+            json!({"keyword": "异常旧作用域"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        degraded["data"]["items"][0]["target"]["scope_type"],
+        "unknown"
+    );
+    assert_eq!(
+        degraded["data"]["items"][0]["target"]["target_ref"],
+        Value::Null
+    );
+    assert_eq!(
+        degraded["data"]["items"][0]["target"]["diagnostic"],
+        "unrecognized_scope"
+    );
+
+    for id in [
+        json!("0"),
+        json!("000"),
+        json!("abc"),
+        json!(-1),
+        json!(9223372036854775808_u64),
+        json!("9223372036854775808"),
+    ] {
+        let (status, body) = api
+            .post("/api/v1/console/todo/get", json!({"id": id}))
+            .await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "{body}");
+        assert_eq!(body["error"]["code"], "validation_error");
+    }
+}
+
+#[tokio::test]
+async fn todo_api_still_rejects_missing_csrf_and_cross_origin_requests() {
+    let api = TestApi::new();
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/console/todo/list")
+        .header("content-type", "application/json")
+        .header("host", "localhost")
+        .header("cookie", format!("{}={}", SESSION_COOKIE_NAME, api.cookie))
+        .body(Body::from("{}"))
+        .unwrap();
+    let response = build_router(api.state.clone())
+        .oneshot(request)
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/console/todo/list")
+        .header("content-type", "application/json")
+        .header("host", "localhost")
+        .header("origin", "https://evil.example")
+        .header("cookie", format!("{}={}", SESSION_COOKIE_NAME, api.cookie))
+        .header("x-csrf-token", api.csrf)
+        .body(Body::from("{}"))
+        .unwrap();
+    let response = build_router(api.state.clone())
+        .oneshot(request)
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }

--- a/qq-maid-core/src/http/api/todo/tests/mod.rs
+++ b/qq-maid-core/src/http/api/todo/tests/mod.rs
@@ -1,5 +1,8 @@
 //! Todo 管理 API 集成测试。
 
+mod reminders;
+mod targets;
+
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -19,7 +22,7 @@ use tower::ServiceExt;
 use crate::{
     error::LlmError,
     http::routes::{OpsHttpConfig, OpsHttpState, build_router},
-    identity::conversation_scope_key,
+    identity::{conversation_scope_key, interaction_scope_key},
     management::{AdminAuth, SESSION_COOKIE_NAME},
     runtime::{
         session::{SessionMeta, SessionStore},
@@ -84,6 +87,7 @@ struct TestApi {
     other_cookie: String,
     other_csrf: String,
     target_ref: String,
+    database: SqliteDatabase,
     todo_store: TodoStore,
     notification_store: NotificationOutboxStore,
 }
@@ -178,6 +182,7 @@ impl TestApi {
             other_cookie: other_issued.cookie_value,
             other_csrf: other_issued.session.csrf_token,
             target_ref,
+            database,
             todo_store,
             notification_store,
         }
@@ -288,6 +293,47 @@ impl TestApi {
             .target
             .target_ref
             .unwrap()
+    }
+
+    fn seed_session_target(
+        &self,
+        platform: &str,
+        account_id: &str,
+        scope_type: &str,
+        target_id: &str,
+        user_id: &str,
+    ) -> String {
+        let conversation =
+            conversation_scope_key(platform, Some(account_id), scope_type, target_id);
+        let session_scope = if scope_type == "group" {
+            interaction_scope_key(Some(user_id), &conversation)
+        } else {
+            conversation.clone()
+        };
+        SessionStore::new(self.database.clone())
+            .get_or_create_active(&SessionMeta::new_with_account(
+                session_scope,
+                Some(user_id.to_owned()),
+                (scope_type == "group").then(|| target_id.to_owned()),
+                None,
+                None,
+                platform,
+                Some(account_id.to_owned()),
+            ))
+            .unwrap();
+        conversation
+    }
+
+    fn replace_reminder_at(&self, id: &str, reminder_at: &str) {
+        let id = id.parse::<i64>().unwrap();
+        self.database
+            .connection()
+            .unwrap()
+            .execute(
+                "UPDATE todos SET reminder_at = ?2 WHERE id = ?1",
+                rusqlite::params![id, reminder_at],
+            )
+            .unwrap();
     }
 }
 
@@ -706,175 +752,6 @@ async fn global_management_is_shared_by_admins_and_preserves_chat_owner_scope() 
 }
 
 #[tokio::test]
-async fn create_uses_verified_private_or_group_target_and_rejects_unsupported_reminder() {
-    let api = TestApi::new();
-    let (private_owner, private_anchor) = api.seed_todo(
-        "qq_official",
-        "app-2",
-        "private",
-        "private-2",
-        "private-2",
-        "私聊锚点",
-    );
-    let private_ref = api.target_ref_for_item(&private_anchor.id);
-    let (status, private_created) = api
-        .post(
-            "/api/v1/console/todo/create",
-            json!({"target_ref": private_ref, "title": "API 私聊待办"}),
-        )
-        .await;
-    assert_eq!(status, StatusCode::OK, "{private_created}");
-    assert_eq!(private_created["data"]["target"]["scope_type"], "private");
-    assert!(
-        api.todo_store
-            .list_all(&private_owner)
-            .unwrap()
-            .iter()
-            .any(|item| item.title == "API 私聊待办")
-    );
-
-    let (group_owner, group_anchor) = api.seed_todo(
-        "onebot",
-        "bot-2",
-        "group",
-        "group-2",
-        "member-2",
-        "群聊锚点",
-    );
-    let group_ref = api.target_ref_for_item(&group_anchor.id);
-    let (status, group_created) = api
-        .post(
-            "/api/v1/console/todo/create",
-            json!({
-                "target_ref": group_ref,
-                "title": "API 群聊提醒",
-                "reminder_at": "2099-08-01T09:00:00+08:00"
-            }),
-        )
-        .await;
-    assert_eq!(status, StatusCode::OK, "{group_created}");
-    assert_eq!(group_created["data"]["target"]["platform"], "onebot");
-    assert!(
-        api.todo_store
-            .list_all(&group_owner)
-            .unwrap()
-            .iter()
-            .any(|item| item.title == "API 群聊提醒")
-    );
-    let tasks = api.notification_store.list_all_for_test().unwrap();
-    let group_task = tasks
-        .iter()
-        .find(|task| task.source_id == group_created["data"]["id"].as_str().unwrap())
-        .unwrap();
-    assert_eq!(group_task.target.platform, "onebot11");
-    assert_eq!(group_task.target.target_id, "group-2");
-
-    let (_, wechat_anchor) = api.seed_todo(
-        "wechat_service",
-        "wx-2",
-        "private",
-        "wx-user-2",
-        "wx-user-2",
-        "微信锚点",
-    );
-    let wechat_ref = api.target_ref_for_item(&wechat_anchor.id);
-    let (status, rejected) = api
-        .post(
-            "/api/v1/console/todo/create",
-            json!({
-                "target_ref": wechat_ref,
-                "title": "不可投递提醒",
-                "reminder_at": "2099-08-01T10:00:00+08:00"
-            }),
-        )
-        .await;
-    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
-    assert_eq!(rejected["error"]["code"], "validation_error");
-    let (_, absent) = api
-        .post(
-            "/api/v1/console/todo/list",
-            json!({"keyword": "不可投递提醒"}),
-        )
-        .await;
-    assert_eq!(absent["data"]["total"], 0);
-}
-
-#[tokio::test]
-async fn reminder_update_replaces_outbox_and_delete_cancels_it() {
-    let api = TestApi::new();
-    let (_, item) = api.seed_todo(
-        "qq_official",
-        "app-3",
-        "private",
-        "user-3",
-        "user-3",
-        "提醒待办",
-    );
-    let (status, first) = api
-        .post(
-            "/api/v1/console/todo/update",
-            json!({"id": item.id, "reminder_at": "2099-08-01T09:00:00+08:00"}),
-        )
-        .await;
-    assert_eq!(status, StatusCode::OK, "{first}");
-    let (status, second) = api
-        .post(
-            "/api/v1/console/todo/update",
-            json!({"id": item.id, "reminder_at": "2099-08-01T10:00:00+08:00"}),
-        )
-        .await;
-    assert_eq!(status, StatusCode::OK, "{second}");
-    let tasks = api.notification_store.list_all_for_test().unwrap();
-    assert_eq!(tasks.len(), 2);
-    assert_eq!(tasks[0].status, NotificationStatus::Cancelled);
-    assert_eq!(tasks[1].status, NotificationStatus::Pending);
-    assert_eq!(tasks[1].scheduled_at, "2099-08-01T10:00:00+08:00");
-
-    let (status, _) = api
-        .post("/api/v1/console/todo/delete", json!({"id": item.id}))
-        .await;
-    assert_eq!(status, StatusCode::OK);
-    let tasks = api.notification_store.list_all_for_test().unwrap();
-    assert_eq!(tasks[1].status, NotificationStatus::Cancelled);
-}
-
-#[tokio::test]
-async fn recurring_completion_advances_atomically_and_reschedules_reminder() {
-    let api = TestApi::new();
-    let scope = conversation_scope_key(
-        "qq_official",
-        Some("app-recurring"),
-        "private",
-        "recurring-user",
-    );
-    let owner = TodoStore::owner(Some("recurring-user"), &scope);
-    let mut draft = todo_draft("周期提醒");
-    draft.due_date = Some("2099-08-01".to_owned());
-    draft.reminder_at = Some("2099-08-01T09:00:00+08:00".to_owned());
-    draft.recurrence_kind = TodoRecurrenceKind::Daily;
-    draft.recurrence_interval_days = 1;
-    let item = api.todo_store.create(&owner, draft).unwrap();
-
-    let (status, completed) = api
-        .post(
-            "/api/v1/console/todo/update",
-            json!({"id": item.id, "title": "周期提醒已更新", "status": "completed"}),
-        )
-        .await;
-    assert_eq!(status, StatusCode::OK, "{completed}");
-    assert_eq!(completed["data"]["status"], "pending");
-    assert_eq!(completed["data"]["title"], "周期提醒已更新");
-    assert_ne!(completed["data"]["reminder_at"], item.reminder_at.unwrap());
-    let stored = api.todo_store.get_by_id(&owner, &item.id).unwrap().unwrap();
-    assert_eq!(
-        stored.status,
-        crate::runtime::tools::todo::TodoStatus::Pending
-    );
-    assert_eq!(stored.title, "周期提醒已更新");
-    assert_eq!(api.notification_store.list_all_for_test().unwrap().len(), 1);
-}
-
-#[tokio::test]
 async fn invalid_target_atomic_restore_patch_and_invalid_ids_leave_data_unchanged() {
     let api = TestApi::new();
     let created = api.create("原子恢复", json!({})).await;
@@ -929,6 +806,14 @@ async fn invalid_target_atomic_restore_patch_and_invalid_ids_leave_data_unchange
         degraded["data"]["items"][0]["target"]["diagnostic"],
         "unrecognized_scope"
     );
+    let (status, undiscoverable) = api
+        .post(
+            "/api/v1/console/todo/targets",
+            json!({"user_id": "legacy-user"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{undiscoverable}");
+    assert_eq!(undiscoverable["data"]["total"], 0);
 
     for id in [
         json!("0"),

--- a/qq-maid-core/src/http/api/todo/tests/reminders.rs
+++ b/qq-maid-core/src/http/api/todo/tests/reminders.rs
@@ -1,0 +1,336 @@
+//! Todo reminder 与 Notification Outbox 管理语义测试。
+
+use super::*;
+
+#[tokio::test]
+async fn create_uses_verified_private_or_group_target_and_rejects_unsupported_reminder() {
+    let api = TestApi::new();
+    let (status, past) = api
+        .post(
+            "/api/v1/console/todo/create",
+            json!({
+                "target_ref": api.target_ref,
+                "title": "过去时间不能创建",
+                "reminder_at": "2000-01-01T09:00:00+08:00"
+            }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "{past}");
+    let (_, absent) = api
+        .post(
+            "/api/v1/console/todo/list",
+            json!({"keyword": "过去时间不能创建"}),
+        )
+        .await;
+    assert_eq!(absent["data"]["total"], 0);
+
+    let (private_owner, private_anchor) = api.seed_todo(
+        "qq_official",
+        "app-2",
+        "private",
+        "private-2",
+        "private-2",
+        "私聊锚点",
+    );
+    let private_ref = api.target_ref_for_item(&private_anchor.id);
+    let (status, private_created) = api
+        .post(
+            "/api/v1/console/todo/create",
+            json!({"target_ref": private_ref, "title": "API 私聊待办"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{private_created}");
+    assert_eq!(private_created["data"]["target"]["scope_type"], "private");
+    assert!(
+        api.todo_store
+            .list_all(&private_owner)
+            .unwrap()
+            .iter()
+            .any(|item| item.title == "API 私聊待办")
+    );
+
+    let (group_owner, group_anchor) = api.seed_todo(
+        "onebot",
+        "bot-2",
+        "group",
+        "group-2",
+        "member-2",
+        "群聊锚点",
+    );
+    let group_ref = api.target_ref_for_item(&group_anchor.id);
+    let (status, group_created) = api
+        .post(
+            "/api/v1/console/todo/create",
+            json!({
+                "target_ref": group_ref,
+                "title": "API 群聊提醒",
+                "reminder_at": "2099-08-01T09:00:00+08:00"
+            }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{group_created}");
+    assert_eq!(group_created["data"]["target"]["platform"], "onebot");
+    assert!(
+        api.todo_store
+            .list_all(&group_owner)
+            .unwrap()
+            .iter()
+            .any(|item| item.title == "API 群聊提醒")
+    );
+    let tasks = api.notification_store.list_all_for_test().unwrap();
+    let group_task = tasks
+        .iter()
+        .find(|task| task.source_id == group_created["data"]["id"].as_str().unwrap())
+        .unwrap();
+    assert_eq!(group_task.target.platform, "onebot11");
+    assert_eq!(group_task.target.target_id, "group-2");
+
+    let (_, wechat_anchor) = api.seed_todo(
+        "wechat_service",
+        "wx-2",
+        "private",
+        "wx-user-2",
+        "wx-user-2",
+        "微信锚点",
+    );
+    let wechat_ref = api.target_ref_for_item(&wechat_anchor.id);
+    let (status, rejected) = api
+        .post(
+            "/api/v1/console/todo/create",
+            json!({
+                "target_ref": wechat_ref,
+                "title": "不可投递提醒",
+                "reminder_at": "2099-08-01T10:00:00+08:00"
+            }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(rejected["error"]["code"], "validation_error");
+    let (_, absent) = api
+        .post(
+            "/api/v1/console/todo/list",
+            json!({"keyword": "不可投递提醒"}),
+        )
+        .await;
+    assert_eq!(absent["data"]["total"], 0);
+}
+
+#[tokio::test]
+async fn reminder_update_replaces_outbox_and_delete_cancels_it() {
+    let api = TestApi::new();
+    let (_, item) = api.seed_todo(
+        "qq_official",
+        "app-3",
+        "private",
+        "user-3",
+        "user-3",
+        "提醒待办",
+    );
+    let (status, first) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({"id": item.id, "reminder_at": "2099-08-01T09:00:00+08:00"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{first}");
+    let (status, second) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({"id": item.id, "reminder_at": "2099-08-01T10:00:00+08:00"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{second}");
+    let tasks = api.notification_store.list_all_for_test().unwrap();
+    assert_eq!(tasks.len(), 2);
+    assert_eq!(tasks[0].status, NotificationStatus::Cancelled);
+    assert_eq!(tasks[1].status, NotificationStatus::Pending);
+    assert_eq!(tasks[1].scheduled_at, "2099-08-01T10:00:00+08:00");
+
+    let (status, _) = api
+        .post("/api/v1/console/todo/delete", json!({"id": item.id}))
+        .await;
+    assert_eq!(status, StatusCode::OK);
+    let tasks = api.notification_store.list_all_for_test().unwrap();
+    assert_eq!(tasks[1].status, NotificationStatus::Cancelled);
+}
+
+#[tokio::test]
+async fn inherited_past_reminder_allows_unrelated_update_but_explicit_past_value_is_rejected() {
+    let api = TestApi::new();
+    let (owner, item) = api.seed_todo(
+        "qq_official",
+        "app-past",
+        "private",
+        "past-user",
+        "past-user",
+        "已发送的一次性提醒",
+    );
+    let (status, scheduled) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({"id": item.id, "reminder_at": "2099-08-01T09:00:00+08:00"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{scheduled}");
+    let task = api.notification_store.list_all_for_test().unwrap()[0].clone();
+    api.notification_store
+        .claim_for_test(task.id, "management-test-worker")
+        .unwrap();
+    api.notification_store
+        .mark_sent(task.id, "management-test-worker", task.delivered_parts)
+        .unwrap();
+    api.replace_reminder_at(&item.id, "2000-01-01T09:00:00+08:00");
+
+    let (status, renamed) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({"id": item.id, "title": "仅修改标题成功"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{renamed}");
+    assert_eq!(renamed["data"]["title"], "仅修改标题成功");
+    assert_eq!(renamed["data"]["reminder_at"], "2000-01-01T09:00:00+08:00");
+    let tasks = api.notification_store.list_all_for_test().unwrap();
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].status, NotificationStatus::Sent);
+
+    let (status, rejected) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({"id": item.id, "reminder_at": "2001-01-01T09:00:00+08:00"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "{rejected}");
+    assert_eq!(rejected["error"]["code"], "validation_error");
+    let unchanged = api.todo_store.get_by_id(&owner, &item.id).unwrap().unwrap();
+    assert_eq!(unchanged.title, "仅修改标题成功");
+    assert_eq!(
+        unchanged.reminder_at.as_deref(),
+        Some("2000-01-01T09:00:00+08:00")
+    );
+
+    let (status, rejected_completion) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({
+                "id": item.id,
+                "reminder_at": "2002-01-01T09:00:00+08:00",
+                "status": "completed"
+            }),
+        )
+        .await;
+    assert_eq!(
+        status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "{rejected_completion}"
+    );
+    assert_eq!(
+        api.todo_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        crate::runtime::tools::todo::TodoStatus::Pending
+    );
+
+    let (status, cleared) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({"id": item.id, "reminder_at": null}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{cleared}");
+    assert_eq!(cleared["data"]["reminder_at"], Value::Null);
+    assert_eq!(api.notification_store.list_all_for_test().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn completing_and_restoring_todo_with_past_reminder_is_atomic_and_does_not_reschedule() {
+    let api = TestApi::new();
+    let (owner, item) = api.seed_todo(
+        "qq_official",
+        "app-past-state",
+        "private",
+        "past-state-user",
+        "past-state-user",
+        "过期提醒状态转换",
+    );
+    let (status, scheduled) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({"id": item.id, "reminder_at": "2099-08-01T09:00:00+08:00"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{scheduled}");
+    api.replace_reminder_at(&item.id, "2000-01-01T09:00:00+08:00");
+
+    let (status, completed) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({"id": item.id, "status": "completed"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{completed}");
+    assert_eq!(completed["data"]["status"], "completed");
+    assert_eq!(
+        completed["data"]["reminder_at"],
+        "2000-01-01T09:00:00+08:00"
+    );
+    let tasks = api.notification_store.list_all_for_test().unwrap();
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].status, NotificationStatus::Cancelled);
+
+    let (status, restored) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({"id": item.id, "status": "pending"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{restored}");
+    assert_eq!(restored["data"]["status"], "pending");
+    assert_eq!(restored["data"]["reminder_at"], "2000-01-01T09:00:00+08:00");
+    let stored = api.todo_store.get_by_id(&owner, &item.id).unwrap().unwrap();
+    assert_eq!(
+        stored.status,
+        crate::runtime::tools::todo::TodoStatus::Pending
+    );
+    let tasks = api.notification_store.list_all_for_test().unwrap();
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].status, NotificationStatus::Cancelled);
+}
+
+#[tokio::test]
+async fn recurring_completion_advances_atomically_and_reschedules_reminder() {
+    let api = TestApi::new();
+    let scope = conversation_scope_key(
+        "qq_official",
+        Some("app-recurring"),
+        "private",
+        "recurring-user",
+    );
+    let owner = TodoStore::owner(Some("recurring-user"), &scope);
+    let mut draft = todo_draft("周期提醒");
+    draft.due_date = Some("2099-08-01".to_owned());
+    draft.reminder_at = Some("2099-08-01T09:00:00+08:00".to_owned());
+    draft.recurrence_kind = TodoRecurrenceKind::Daily;
+    draft.recurrence_interval_days = 1;
+    let item = api.todo_store.create(&owner, draft).unwrap();
+
+    let (status, completed) = api
+        .post(
+            "/api/v1/console/todo/update",
+            json!({"id": item.id, "title": "周期提醒已更新", "status": "completed"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{completed}");
+    assert_eq!(completed["data"]["status"], "pending");
+    assert_eq!(completed["data"]["title"], "周期提醒已更新");
+    assert_ne!(completed["data"]["reminder_at"], item.reminder_at.unwrap());
+    let stored = api.todo_store.get_by_id(&owner, &item.id).unwrap().unwrap();
+    assert_eq!(
+        stored.status,
+        crate::runtime::tools::todo::TodoStatus::Pending
+    );
+    assert_eq!(stored.title, "周期提醒已更新");
+    assert_eq!(api.notification_store.list_all_for_test().unwrap().len(), 1);
+}

--- a/qq-maid-core/src/http/api/todo/tests/targets.rs
+++ b/qq-maid-core/src/http/api/todo/tests/targets.rs
@@ -1,0 +1,210 @@
+//! Todo 创建目标发现接口测试。
+
+use super::*;
+
+#[tokio::test]
+async fn todo_targets_discovers_session_only_private_target_and_creates_first_todo() {
+    let api = TestApi::new();
+    assert!(
+        api.todo_store
+            .list_all(&TodoStore::owner(
+                Some("user-default"),
+                &conversation_scope_key(
+                    "qq_official",
+                    Some("app-default"),
+                    "private",
+                    "user-default"
+                )
+            ))
+            .unwrap()
+            .is_empty()
+    );
+
+    let (status, targets) = api
+        .post(
+            "/api/v1/console/todo/targets",
+            json!({"platform": "qq_official", "user_id": "user-default"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{targets}");
+    assert_eq!(targets["data"]["total"], 1);
+    let target = &targets["data"]["items"][0];
+    assert_eq!(target["platform"], "qq_official");
+    assert_eq!(target["account_id"], "app-default");
+    assert_eq!(target["scope_type"], "private");
+    assert_eq!(target["user_id"], "user-default");
+    assert_eq!(target["group_id"], Value::Null);
+    assert_eq!(target["reminder_supported"], true);
+    assert!(
+        target["target_ref"]
+            .as_str()
+            .unwrap()
+            .starts_with("todo_target:v1:")
+    );
+    assert!(target.get("owner_key").is_none());
+    assert!(target.get("scope_key").is_none());
+
+    let (status, created) = api
+        .post(
+            "/api/v1/console/todo/create",
+            json!({
+                "target_ref": target["target_ref"],
+                "title": "Session 的第一条 Todo"
+            }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{created}");
+    assert_eq!(created["data"]["title"], "Session 的第一条 Todo");
+
+    // 同一 owner/scope 同时来自 Session 和 Todo 时仍只返回一个真实目标。
+    let (_, deduplicated) = api
+        .post(
+            "/api/v1/console/todo/targets",
+            json!({"platform": "qq_official", "user_id": "user-default"}),
+        )
+        .await;
+    assert_eq!(deduplicated["data"]["total"], 1);
+}
+
+#[tokio::test]
+async fn todo_targets_restore_group_member_and_report_unsupported_platform() {
+    let api = TestApi::new();
+    let group_scope = api.seed_session_target(
+        "onebot",
+        "bot-targets",
+        "group",
+        "group-targets",
+        "member-targets",
+    );
+    api.seed_session_target(
+        "wechat_service",
+        "wx-targets",
+        "private",
+        "wx-target-user",
+        "wx-target-user",
+    );
+
+    let (status, group_targets) = api
+        .post(
+            "/api/v1/console/todo/targets",
+            json!({
+                "platform": "onebot",
+                "account_id": "bot-targets",
+                "scope_type": "group",
+                "group_id": "group-targets"
+            }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{group_targets}");
+    assert_eq!(group_targets["data"]["total"], 1);
+    let group = &group_targets["data"]["items"][0];
+    assert_eq!(group["user_id"], "member-targets");
+    assert_eq!(group["group_id"], "group-targets");
+    assert_eq!(group["account_id"], "bot-targets");
+    assert_eq!(group["reminder_supported"], true);
+
+    let (status, created) = api
+        .post(
+            "/api/v1/console/todo/create",
+            json!({"target_ref": group["target_ref"], "title": "群成员第一条 Todo"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{created}");
+    let group_owner = TodoStore::owner(Some("member-targets"), &group_scope);
+    assert_eq!(api.todo_store.list_all(&group_owner).unwrap().len(), 1);
+
+    let (status, wechat_targets) = api
+        .post(
+            "/api/v1/console/todo/targets",
+            json!({"platform": "wechat_service", "account_id": "wx-targets"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{wechat_targets}");
+    assert_eq!(wechat_targets["data"]["total"], 1);
+    assert_eq!(
+        wechat_targets["data"]["items"][0]["reminder_supported"],
+        false
+    );
+}
+
+#[tokio::test]
+async fn todo_targets_support_pagination_filters_authentication_and_csrf() {
+    let api = TestApi::new();
+    for index in 1..=5 {
+        let user_id = format!("page-target-{index}");
+        api.seed_session_target("onebot", "bot-page", "private", &user_id, &user_id);
+    }
+
+    let (status, first) = api
+        .post(
+            "/api/v1/console/todo/targets",
+            json!({
+                "platform": "onebot",
+                "account_id": "bot-page",
+                "scope_type": "private",
+                "page": 1,
+                "page_size": 2
+            }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{first}");
+    assert_eq!(first["data"]["total"], 5);
+    assert_eq!(first["data"]["total_pages"], 3);
+    assert_eq!(first["data"]["items"].as_array().unwrap().len(), 2);
+    let (status, second) = api
+        .post(
+            "/api/v1/console/todo/targets",
+            json!({
+                "platform": "onebot",
+                "account_id": "bot-page",
+                "scope_type": "private",
+                "page": 2,
+                "page_size": 2
+            }),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{second}");
+    assert_ne!(first["data"]["items"], second["data"]["items"]);
+
+    let (status, filtered) = api
+        .post(
+            "/api/v1/console/todo/targets",
+            json!({"platform": "onebot", "user_id": "page-target-3"}),
+        )
+        .await;
+    assert_eq!(status, StatusCode::OK, "{filtered}");
+    assert_eq!(filtered["data"]["total"], 1);
+
+    for payload in [json!({"page": 0}), json!({"page_size": 101})] {
+        let (status, body) = api.post("/api/v1/console/todo/targets", payload).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "{body}");
+    }
+
+    let (status, unauthenticated) = api
+        .request(
+            "POST",
+            "/api/v1/console/todo/targets",
+            Some(json!({})),
+            false,
+        )
+        .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED, "{unauthenticated}");
+    let (status, _) = api
+        .request("GET", "/api/v1/console/todo/targets", None, true)
+        .await;
+    assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/console/todo/targets")
+        .header("content-type", "application/json")
+        .header("host", "localhost")
+        .header("cookie", format!("{}={}", SESSION_COOKIE_NAME, api.cookie))
+        .body(Body::from("{}"))
+        .unwrap();
+    let response = build_router(api.state.clone())
+        .oneshot(request)
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}

--- a/qq-maid-core/src/http/management/auth_routes.rs
+++ b/qq-maid-core/src/http/management/auth_routes.rs
@@ -12,14 +12,19 @@ use serde_json::json;
 use std::{convert::Infallible, net::SocketAddr};
 
 use crate::management::{
-    AdminAuthError, PREAUTH_COOKIE_NAME, SECURE_PREAUTH_COOKIE_NAME, SECURE_SESSION_COOKIE_NAME,
+    PREAUTH_COOKIE_NAME, SECURE_PREAUTH_COOKIE_NAME, SECURE_SESSION_COOKIE_NAME,
     SESSION_COOKIE_NAME,
 };
 
-use super::{admin_context, api_error, respond};
-use crate::http::routes::OpsHttpState;
+use super::{admin_context, respond};
+use crate::http::{
+    api::common::{
+        auth_error_response as auth_error, csrf_token, error_response as api_error, origin_allowed,
+        session_cookie,
+    },
+    routes::OpsHttpState,
+};
 
-const CSRF_HEADER: &str = "x-csrf-token";
 const COOKIE_MAX_AGE_SECONDS: i64 = 12 * 60 * 60;
 
 struct OptionalPeer(Option<SocketAddr>);
@@ -536,40 +541,6 @@ async fn auth_logout(State(state): State<OpsHttpState>, headers: HeaderMap) -> R
     respond(&state, &headers, response)
 }
 
-pub(super) fn origin_allowed(headers: &HeaderMap) -> bool {
-    let Some(origin) = headers
-        .get(header::ORIGIN)
-        .and_then(|value| value.to_str().ok())
-    else {
-        return true;
-    };
-    let Some(host) = headers
-        .get(header::HOST)
-        .and_then(|value| value.to_str().ok())
-    else {
-        return false;
-    };
-    url::Url::parse(origin)
-        .ok()
-        .and_then(|url| {
-            url.host_str()
-                .map(|value| (value.to_owned(), url.port_or_known_default()))
-        })
-        .is_some_and(|(origin_host, origin_port)| {
-            let mut parts = host.rsplitn(2, ':');
-            let port_or_host = parts.next().unwrap_or_default();
-            let maybe_host = parts.next();
-            let (host_name, host_port) = match maybe_host {
-                Some(name) if port_or_host.parse::<u16>().is_ok() => {
-                    (name, port_or_host.parse::<u16>().ok())
-                }
-                _ => (host, None),
-            };
-            origin_host.eq_ignore_ascii_case(host_name)
-                && (host_port.is_none() || host_port == origin_port)
-        })
-}
-
 fn preauth_request_allowed(headers: &HeaderMap) -> bool {
     if !origin_allowed(headers) {
         return false;
@@ -608,17 +579,6 @@ fn cookie_value(headers: &HeaderMap, name: &str) -> Option<String> {
         .find_map(|(candidate, value)| (candidate == name).then(|| value.to_owned()))
 }
 
-pub(super) fn session_cookie(headers: &HeaderMap, secure: bool) -> Option<String> {
-    cookie_value(
-        headers,
-        if secure {
-            SECURE_SESSION_COOKIE_NAME
-        } else {
-            SESSION_COOKIE_NAME
-        },
-    )
-}
-
 fn preauth_cookie(headers: &HeaderMap, secure: bool) -> Option<String> {
     cookie_value(
         headers,
@@ -628,13 +588,6 @@ fn preauth_cookie(headers: &HeaderMap, secure: bool) -> Option<String> {
             PREAUTH_COOKIE_NAME
         },
     )
-}
-
-pub(super) fn csrf_token(headers: &HeaderMap) -> Option<String> {
-    headers
-        .get(CSRF_HEADER)
-        .and_then(|value| value.to_str().ok())
-        .map(str::to_owned)
 }
 
 fn set_cookie(response: &mut Response, name: &str, value: &str, max_age: i64, secure: bool) {
@@ -690,17 +643,4 @@ fn clear_preauth_cookie(response: &mut Response, secure: bool) {
         },
         secure,
     );
-}
-
-pub(super) fn auth_error(error: AdminAuthError) -> Response {
-    let status = match error.code() {
-        "unauthenticated" | "invalid_credentials" => StatusCode::UNAUTHORIZED,
-        "csrf_failed" | "invalid_bootstrap_token" | "already_initialized" => StatusCode::FORBIDDEN,
-        "rate_limited" => StatusCode::TOO_MANY_REQUESTS,
-        "not_initialized" => StatusCode::CONFLICT,
-        "session_capacity_reached" => StatusCode::SERVICE_UNAVAILABLE,
-        "validation_error" | "invalid_bootstrap_token_format" => StatusCode::BAD_REQUEST,
-        _ => StatusCode::INTERNAL_SERVER_ERROR,
-    };
-    api_error(status, error.code(), error.message())
 }

--- a/qq-maid-core/src/http/management/mod.rs
+++ b/qq-maid-core/src/http/management/mod.rs
@@ -26,11 +26,13 @@ use crate::config::{
     },
 };
 
-use super::{console_routes::with_console_cors, routes::OpsHttpState};
+use super::{
+    api::common::{authenticate_admin_request, error_response as api_error},
+    console_routes::with_console_cors,
+    routes::OpsHttpState,
+};
 
 mod auth_routes;
-
-use auth_routes::{auth_error, csrf_token, origin_allowed, session_cookie};
 
 pub(super) type BoxedResponse = Box<Response>;
 
@@ -855,47 +857,14 @@ fn admin_context(
     headers: &HeaderMap,
     require_csrf: bool,
 ) -> Result<(crate::management::AdminAuth, String, Option<String>, i64), BoxedResponse> {
-    if !origin_allowed(headers) {
-        return Err(Box::new(api_error(
-            StatusCode::FORBIDDEN,
-            "origin_denied",
-            "request origin is not allowed",
-        )));
-    }
-    let auth = state.admin_auth.clone().ok_or_else(|| {
-        Box::new(api_error(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "auth_unavailable",
-            "administrator authentication is unavailable",
-        ))
-    })?;
-    let cookie =
-        session_cookie(headers, state.config.web_console_secure_cookies).ok_or_else(|| {
-            Box::new(api_error(
-                StatusCode::UNAUTHORIZED,
-                "unauthenticated",
-                "administrator session is missing",
-            ))
-        })?;
-    let csrf = csrf_token(headers);
-    if require_csrf && csrf.is_none() {
-        return Err(Box::new(api_error(
-            StatusCode::FORBIDDEN,
-            "csrf_failed",
-            "CSRF token is missing",
-        )));
-    }
-    let (id, _) = auth
-        .authorize_admin(
-            &cookie,
-            require_csrf.then_some(csrf.as_deref().unwrap_or_default()),
-        )
-        .map_err(|error| Box::new(auth_error(error)))?;
-    if require_csrf {
-        auth.check_management_rate_limit(id)
-            .map_err(|error| Box::new(auth_error(error)))?;
-    }
-    Ok((auth, cookie, csrf, id))
+    let authenticated = authenticate_admin_request(state, headers, require_csrf)
+        .map_err(|error| Box::new(error.into_response()))?;
+    Ok((
+        authenticated.auth,
+        authenticated.cookie,
+        authenticated.csrf,
+        authenticated.actor_id,
+    ))
 }
 
 fn agent_change(change: AgentChangeRequest) -> Result<AgentConfigChange, BoxedResponse> {
@@ -1063,17 +1032,6 @@ fn config_error(error: ConfigCenterError) -> Response {
         _ => StatusCode::INTERNAL_SERVER_ERROR,
     };
     api_error(status, error.code(), error.message())
-}
-
-fn api_error(status: StatusCode, code: &str, message: &str) -> Response {
-    (
-        status,
-        Json(json!({
-            "ok": false,
-            "error": {"code": code, "message": message},
-        })),
-    )
-        .into_response()
 }
 
 fn respond(state: &OpsHttpState, headers: &HeaderMap, response: Response) -> Response {

--- a/qq-maid-core/src/http/router_builder.rs
+++ b/qq-maid-core/src/http/router_builder.rs
@@ -6,6 +6,7 @@ use axum::{
 };
 
 use super::{
+    api::todo,
     console_routes::{
         console_asset, console_configuration, console_index, console_status, healthz,
         markdown_render, markdown_render_preflight,
@@ -28,6 +29,7 @@ pub fn build_router(state: OpsHttpState) -> Router {
                 "/api/v1/markdown/render",
                 post(markdown_render).options(markdown_render_preflight),
             )
+            .merge(todo::router())
             .merge(management_router())
     } else {
         router

--- a/qq-maid-core/src/http/routes.rs
+++ b/qq-maid-core/src/http/routes.rs
@@ -17,6 +17,7 @@ use crate::{
         DynConsoleStatusSource, EmptyConsoleStatusSource,
     },
     management::AdminAuth,
+    runtime::tools::todo::TodoManagementService,
 };
 
 pub use super::router_builder::build_router;
@@ -56,6 +57,8 @@ pub struct OpsHttpState {
     pub config_center: Option<ConfigCenter>,
     /// 配置 WebUI 与后续 Memory WebUI 统一复用的部署管理员安全边界。
     pub admin_auth: Option<AdminAuth>,
+    /// Todo 管理领域门面；Handler 不直接持有数据库或通知 Store。
+    pub(crate) todo_management: Option<TodoManagementService>,
     /// 当前进程真实注册的 Tool 元数据，供 WebUI 动态展示白名单选项。
     pub registered_tools: Arc<Vec<ConsoleToolMetadata>>,
     /// 仅复用部署目录中的受控 botctl 脚本，不直接操作 systemd 或 Docker。
@@ -67,6 +70,11 @@ pub struct OpsHttpState {
 impl OpsHttpState {
     pub fn with_registered_tools(mut self, tools: Vec<ConsoleToolMetadata>) -> Self {
         self.registered_tools = Arc::new(tools);
+        self
+    }
+
+    pub(crate) fn with_todo_management(mut self, service: TodoManagementService) -> Self {
+        self.todo_management = Some(service);
         self
     }
 
@@ -92,6 +100,7 @@ impl OpsHttpState {
             console_status_source: Arc::new(EmptyConsoleStatusSource),
             config_center: None,
             admin_auth: None,
+            todo_management: None,
             registered_tools: Arc::new(Vec::new()),
             restart_controller: ConsoleRestartController::default(),
             setup_required: false,
@@ -133,6 +142,7 @@ impl OpsHttpState {
             console_status_source,
             config_center,
             admin_auth,
+            todo_management: None,
             registered_tools: Arc::new(Vec::new()),
             restart_controller: ConsoleRestartController::from_current_dir(),
             setup_required: false,
@@ -153,6 +163,7 @@ impl OpsHttpState {
             console_status_source: Arc::new(EmptyConsoleStatusSource),
             config_center: Some(config_center),
             admin_auth,
+            todo_management: None,
             registered_tools: Arc::new(Vec::new()),
             restart_controller: ConsoleRestartController::from_current_dir(),
             setup_required: true,

--- a/qq-maid-core/src/runtime/respond/tests/chat/mod.rs
+++ b/qq-maid-core/src/runtime/respond/tests/chat/mod.rs
@@ -481,6 +481,31 @@ async fn group_tool_loop_exposes_rss_management_but_not_todo_when_enabled() {
 }
 
 #[tokio::test]
+async fn ordinary_chat_tool_loop_cannot_access_todo_management_target_discovery() {
+    let inspector = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    service
+        .respond(private_message("查看普通聊天工具边界"))
+        .await
+        .unwrap();
+    let tool_request = inspector.tool_requests().remove(0);
+    assert!(
+        tool_request
+            .tools
+            .metadata()
+            .iter()
+            .all(|metadata| metadata.name != "list_todo_targets")
+    );
+    let error = tool_request
+        .tools
+        .execute_json(&tool_request.tool_context, "list_todo_targets", r#"{}"#)
+        .await
+        .unwrap_err();
+    assert_eq!(error.code, "tool_not_found");
+}
+
+#[tokio::test]
 async fn private_natural_search_requests_wait_for_structured_tool_status() {
     let provider = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let service = test_service_with_provider_and_tool_calling(provider, true);

--- a/qq-maid-core/src/runtime/tools/todo/management.rs
+++ b/qq-maid-core/src/runtime/tools/todo/management.rs
@@ -1,0 +1,351 @@
+//! Todo 管理 API 使用的领域门面。
+//!
+//! 本模块只复用 Todo 现有草稿归一、状态转换、提醒同步和 Repository；它不理解
+//! HTTP 状态码、cookie、JSON envelope，也不抽象其他领域的 CRUD。
+
+use crate::storage::notification::NotificationOutboxStore;
+
+use super::{
+    TodoEditPatch, TodoError, TodoItem, TodoItemDraft, TodoOwner, TodoQuery, TodoQueryPage,
+    TodoStatus, TodoStore, cancel_reminder_task, edit_patch, sync_reminder_task,
+};
+
+const MANAGEMENT_SCOPE_PREFIX: &str = "management:";
+
+#[derive(Debug, Clone)]
+pub(crate) struct TodoManagementUpdate {
+    pub(crate) fields: TodoEditPatch,
+    pub(crate) status: Option<TodoStatus>,
+}
+
+impl TodoManagementUpdate {
+    pub(crate) fn has_field_changes(&self) -> bool {
+        let fields = &self.fields;
+        fields.title.is_some()
+            || fields.detail.is_some()
+            || fields.due_date.is_some()
+            || fields.due_at.is_some()
+            || fields.reminder_at.is_some()
+            || fields.time_precision.is_some()
+            || fields.recurrence_kind.is_some()
+            || fields.recurrence_interval_days.is_some()
+            || fields.recurrence_interval.is_some()
+            || fields.recurrence_unit.is_some()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum TodoManagementError {
+    Domain(TodoError),
+    NotFound,
+    Conflict(String),
+    Notification(String),
+    InvalidActor,
+}
+
+impl TodoManagementError {
+    pub(crate) fn code(&self) -> &str {
+        match self {
+            Self::Domain(error) => error.code(),
+            Self::NotFound => "not_found",
+            Self::Conflict(_) => "conflict",
+            Self::Notification(_) => "notification_error",
+            Self::InvalidActor => "permission_denied",
+        }
+    }
+
+    pub(crate) fn message(&self) -> &str {
+        match self {
+            Self::Domain(error) => error.message(),
+            Self::NotFound => "todo not found",
+            Self::Conflict(message) | Self::Notification(message) => message,
+            Self::InvalidActor => "authenticated API actor is invalid",
+        }
+    }
+}
+
+impl From<TodoError> for TodoManagementError {
+    fn from(value: TodoError) -> Self {
+        Self::Domain(value)
+    }
+}
+
+/// Todo 管理场景的领域 Service；未来 Memory API 应实现自己的独立 Service。
+#[derive(Clone)]
+pub(crate) struct TodoManagementService {
+    store: TodoStore,
+    notification_store: NotificationOutboxStore,
+}
+
+impl TodoManagementService {
+    pub(crate) fn new(store: TodoStore, notification_store: NotificationOutboxStore) -> Self {
+        Self {
+            store,
+            notification_store,
+        }
+    }
+
+    pub(crate) fn create(
+        &self,
+        actor_subject: &str,
+        draft: TodoItemDraft,
+    ) -> Result<TodoItem, TodoManagementError> {
+        let owner = owner_for_actor(actor_subject)?;
+        let item = self.store.create(&owner, draft)?;
+        self.sync_reminder(&owner, &item)?;
+        Ok(item)
+    }
+
+    pub(crate) fn list(
+        &self,
+        actor_subject: &str,
+        query: &TodoQuery,
+    ) -> Result<TodoQueryPage, TodoManagementError> {
+        let owner = owner_for_actor(actor_subject)?;
+        self.store
+            .query_todos_for_management(&owner, query)
+            .map_err(Into::into)
+    }
+
+    pub(crate) fn get(
+        &self,
+        actor_subject: &str,
+        id: &str,
+    ) -> Result<TodoItem, TodoManagementError> {
+        let owner = owner_for_actor(actor_subject)?;
+        self.get_for_owner(&owner, id)
+    }
+
+    pub(crate) fn update(
+        &self,
+        actor_subject: &str,
+        id: &str,
+        update: TodoManagementUpdate,
+    ) -> Result<TodoItem, TodoManagementError> {
+        let owner = owner_for_actor(actor_subject)?;
+        let current = self.get_for_owner(&owner, id)?;
+        let has_fields = update.has_field_changes();
+
+        let mut item = match (&current.status, &update.status) {
+            (TodoStatus::Completed, Some(TodoStatus::Pending)) => {
+                let outcome = self
+                    .store
+                    .restore_completed_by_ids(&owner, &[id.to_owned()])?;
+                outcome.restored.into_iter().next().ok_or_else(|| {
+                    TodoManagementError::Conflict("todo status changed".to_owned())
+                })?
+            }
+            (TodoStatus::Pending, Some(TodoStatus::Completed)) => current.clone(),
+            (TodoStatus::Completed, _) if has_fields => {
+                return Err(TodoManagementError::Conflict(
+                    "completed todo fields cannot be edited before restoring it".to_owned(),
+                ));
+            }
+            _ => current.clone(),
+        };
+
+        if has_fields {
+            let raw_text = item.raw_text.clone().unwrap_or_else(|| item.title.clone());
+            let draft = edit_patch::apply_to_draft(
+                TodoItemDraft::from_item(&item, &raw_text),
+                &update.fields,
+                &raw_text,
+            );
+            item = self.store.edit(&owner, id, draft)?;
+        }
+
+        if matches!(current.status, TodoStatus::Pending)
+            && matches!(update.status, Some(TodoStatus::Completed))
+        {
+            let outcome = self
+                .store
+                .complete_by_ids_with_recurrence(&owner, &[id.to_owned()])?;
+            if outcome.completed.is_empty() && outcome.advanced.is_empty() {
+                return Err(TodoManagementError::Conflict(
+                    "todo status changed".to_owned(),
+                ));
+            }
+            item = self.get_for_owner(&owner, id)?;
+        }
+
+        self.sync_reminder(&owner, &item)?;
+        Ok(item)
+    }
+
+    pub(crate) fn delete(&self, actor_subject: &str, id: &str) -> Result<(), TodoManagementError> {
+        let owner = owner_for_actor(actor_subject)?;
+        let item = self.get_for_owner(&owner, id)?;
+        let outcome = self.store.delete_by_ids(&owner, &[id.to_owned()])?;
+        if outcome.deleted_count == 0 {
+            return Err(TodoManagementError::NotFound);
+        }
+        cancel_reminder_task(&self.notification_store, &item)
+            .map_err(TodoManagementError::Notification)
+    }
+
+    fn get_for_owner(&self, owner: &TodoOwner, id: &str) -> Result<TodoItem, TodoManagementError> {
+        self.store
+            .get_by_id(owner, id)?
+            .ok_or(TodoManagementError::NotFound)
+    }
+
+    fn sync_reminder(&self, owner: &TodoOwner, item: &TodoItem) -> Result<(), TodoManagementError> {
+        if item.reminder_at.is_none() {
+            return cancel_reminder_task(&self.notification_store, item)
+                .map_err(TodoManagementError::Notification);
+        }
+        sync_reminder_task(&self.notification_store, owner, item)
+            .map_err(TodoManagementError::Notification)
+    }
+}
+
+fn owner_for_actor(actor_subject: &str) -> Result<TodoOwner, TodoManagementError> {
+    let actor_subject = actor_subject.trim();
+    if actor_subject.is_empty() || actor_subject.len() > 128 {
+        return Err(TodoManagementError::InvalidActor);
+    }
+    // 管理 API Todo 与聊天入口 Todo 使用不同 conversation scope；认证 subject 既决定
+    // owner 又参与 scope，未来即使出现多个管理员也不会越权读取彼此的数据。
+    Ok(TodoStore::owner(
+        Some(actor_subject),
+        &format!("{MANAGEMENT_SCOPE_PREFIX}{actor_subject}"),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        runtime::tools::todo::{
+            TodoRecurrenceKind, TodoRecurrenceUnit, TodoTimePrecision, storage::TODO_MIGRATIONS,
+        },
+        storage::{
+            database::SqliteDatabase,
+            notification::{NOTIFICATION_MIGRATIONS, NotificationOutboxStore},
+        },
+    };
+
+    fn service() -> TodoManagementService {
+        let mut migrations = TODO_MIGRATIONS.to_vec();
+        migrations.extend_from_slice(NOTIFICATION_MIGRATIONS);
+        let database = SqliteDatabase::open_temp("todo-management-service", &migrations).unwrap();
+        TodoManagementService::new(
+            TodoStore::new(database.clone()),
+            NotificationOutboxStore::new(database),
+        )
+    }
+
+    fn draft(title: &str) -> TodoItemDraft {
+        TodoItemDraft {
+            title: title.to_owned(),
+            detail: None,
+            raw_text: None,
+            due_date: None,
+            due_at: None,
+            reminder_at: None,
+            time_precision: TodoTimePrecision::None,
+            recurrence_kind: TodoRecurrenceKind::None,
+            recurrence_interval_days: 0,
+            recurrence_interval: 0,
+            recurrence_unit: TodoRecurrenceUnit::Day,
+        }
+    }
+
+    #[test]
+    fn management_service_isolates_actors_and_supports_crud() {
+        let service = service();
+        let created = service
+            .create("console_admin:1", draft("原始标题"))
+            .unwrap();
+        assert!(matches!(
+            service.get("console_admin:2", &created.id),
+            Err(TodoManagementError::NotFound)
+        ));
+        let other_page = service
+            .list(
+                "console_admin:2",
+                &TodoQuery {
+                    status: crate::runtime::tools::todo::TodoQueryStatus::All,
+                    ..TodoQuery::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(other_page.total_count, 0);
+        assert!(matches!(
+            service.update(
+                "console_admin:2",
+                &created.id,
+                TodoManagementUpdate {
+                    fields: TodoEditPatch {
+                        title: Some("越权更新".to_owned()),
+                        ..Default::default()
+                    },
+                    status: None,
+                }
+            ),
+            Err(TodoManagementError::NotFound)
+        ));
+        assert!(matches!(
+            service.delete("console_admin:2", &created.id),
+            Err(TodoManagementError::NotFound)
+        ));
+
+        let updated = service
+            .update(
+                "console_admin:1",
+                &created.id,
+                TodoManagementUpdate {
+                    fields: TodoEditPatch {
+                        title: Some("更新标题".to_owned()),
+                        detail: Some("详情".to_owned()),
+                        ..Default::default()
+                    },
+                    status: None,
+                },
+            )
+            .unwrap();
+        assert_eq!(updated.title, "更新标题");
+        assert_eq!(updated.detail.as_deref(), Some("详情"));
+
+        service.delete("console_admin:1", &created.id).unwrap();
+        assert!(matches!(
+            service.get("console_admin:1", &created.id),
+            Err(TodoManagementError::NotFound)
+        ));
+    }
+
+    #[test]
+    fn management_update_clears_nullable_fields_and_uses_status_transitions() {
+        let service = service();
+        let mut initial = draft("待办");
+        initial.detail = Some("将清空".to_owned());
+        let created = service.create("console_admin:1", initial).unwrap();
+        let completed = service
+            .update(
+                "console_admin:1",
+                &created.id,
+                TodoManagementUpdate {
+                    fields: TodoEditPatch {
+                        detail: Some(String::new()),
+                        ..Default::default()
+                    },
+                    status: Some(TodoStatus::Completed),
+                },
+            )
+            .unwrap();
+        assert_eq!(completed.detail, None);
+        assert_eq!(completed.status, TodoStatus::Completed);
+
+        let restored = service
+            .update(
+                "console_admin:1",
+                &created.id,
+                TodoManagementUpdate {
+                    fields: TodoEditPatch::default(),
+                    status: Some(TodoStatus::Pending),
+                },
+            )
+            .unwrap();
+        assert_eq!(restored.status, TodoStatus::Pending);
+    }
+}

--- a/qq-maid-core/src/runtime/tools/todo/management.rs
+++ b/qq-maid-core/src/runtime/tools/todo/management.rs
@@ -20,11 +20,13 @@ use super::{
     reminder::{prepare_reminder_upsert, validate_draft_reminder},
     storage::{
         TodoManagementPage, TodoManagementRecord, TodoManagementScopeType,
-        TodoManagementTargetFilter, advance_after_completion, is_recurring, normalize_draft,
+        TodoManagementTargetCandidateFilter, TodoManagementTargetFilter, advance_after_completion,
+        is_recurring, normalize_draft,
     },
 };
 
 const TARGET_REF_PREFIX: &str = "todo_target:v1:";
+const TARGET_RESOLUTION_PAGE_SIZE: usize = 100;
 
 #[derive(Debug, Clone)]
 pub(crate) struct TodoManagementUpdate {
@@ -57,6 +59,15 @@ pub(crate) struct TodoManagementListFilter {
     pub(crate) target_ref: Option<String>,
 }
 
+#[derive(Debug, Clone, Default)]
+pub(crate) struct TodoManagementTargetListFilter {
+    pub(crate) platform: Option<String>,
+    pub(crate) account_id: Option<String>,
+    pub(crate) scope_type: Option<TodoManagementScopeType>,
+    pub(crate) user_id: Option<String>,
+    pub(crate) group_id: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct TodoManagementTarget {
     pub(crate) target_ref: Option<String>,
@@ -78,6 +89,12 @@ pub(crate) struct TodoManagementItem {
 #[derive(Debug, Clone)]
 pub(crate) struct TodoManagementListPage {
     pub(crate) items: Vec<TodoManagementItem>,
+    pub(crate) total_count: usize,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TodoManagementTargetListPage {
+    pub(crate) items: Vec<TodoManagementTarget>,
     pub(crate) total_count: usize,
 }
 
@@ -146,8 +163,7 @@ impl TodoManagementService {
         self.ensure_shared_database()?;
         let owner = self.resolve_target_ref(target_ref)?;
         let draft = normalize_draft(draft)?;
-        let preview = record_from_draft(&owner, "preview", &draft, TodoStatus::Pending);
-        self.validate_pending_reminder(&preview)?;
+        self.validate_reminder(&owner, &draft)?;
         let created = self
             .store
             .create_todo_for_management(&owner, draft, reminder_upsert)?;
@@ -182,6 +198,38 @@ impl TodoManagementService {
         Ok(self.present(record))
     }
 
+    /// 分页发现服务端已知且能完整恢复的创建目标，不暴露内部 owner/scope。
+    pub(crate) fn targets(
+        &self,
+        filter: TodoManagementTargetListFilter,
+        limit: usize,
+        offset: usize,
+    ) -> Result<TodoManagementTargetListPage, TodoManagementError> {
+        let page = self.store.management_target_candidates_page(
+            &TodoManagementTargetCandidateFilter {
+                platform: filter.platform,
+                account_id: filter.account_id,
+                scope_type: filter.scope_type,
+                user_id: filter.user_id,
+                group_id: filter.group_id,
+            },
+            limit,
+            offset,
+        )?;
+        let items = page
+            .items
+            .into_iter()
+            .filter_map(|owner| {
+                let target = target_from_owner(&owner);
+                target.target_ref.is_some().then_some(target)
+            })
+            .collect();
+        Ok(TodoManagementTargetListPage {
+            items,
+            total_count: page.total_count,
+        })
+    }
+
     pub(crate) fn update(
         &self,
         id: &str,
@@ -192,16 +240,22 @@ impl TodoManagementService {
         if !update.has_field_changes() && update.status.as_ref() == Some(&current.item.status) {
             return Ok(self.present(current));
         }
-        let (draft, final_status) = plan_update(&current, &update)?;
-        let preview = record_from_draft(
-            &current.owner,
-            &current.item.id,
-            &draft,
-            final_status.clone(),
-        );
-        if final_status == TodoStatus::Pending {
-            self.validate_pending_reminder(&preview)?;
+        if let Some(reminder_at) = update
+            .fields
+            .reminder_at
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            // 显式新值始终按请求值校验，即使同一请求还会完成 Todo 或推进周期；
+            // 不能让状态转换掩盖“用户本次提交了过去时间”。
+            let mut reminder_draft = TodoItemDraft::from_item(
+                &current.item,
+                current.item.raw_text.clone().unwrap_or_default(),
+            );
+            reminder_draft.reminder_at = Some(reminder_at.to_owned());
+            self.validate_reminder(&current.owner, &reminder_draft)?;
         }
+        let (draft, final_status) = plan_update(&current, &update)?;
         let updated =
             self.store
                 .update_todo_for_management(&current, draft, final_status, |record| {
@@ -225,15 +279,28 @@ impl TodoManagementService {
 
     fn resolve_target_ref(&self, target_ref: &str) -> Result<TodoOwner, TodoManagementError> {
         validate_target_ref_format(target_ref)?;
-        let candidates = self.store.management_target_candidates()?;
-        let owner = candidates
-            .into_iter()
-            .find(|owner| target_ref_for(owner) == target_ref)
-            .ok_or_else(|| {
-                TodoManagementError::InvalidTarget(
+        let mut offset = 0;
+        let owner = loop {
+            let page = self.store.management_target_candidates_page(
+                &TodoManagementTargetCandidateFilter::default(),
+                TARGET_RESOLUTION_PAGE_SIZE,
+                offset,
+            )?;
+            if let Some(owner) = page
+                .items
+                .iter()
+                .find(|owner| target_ref_for(owner) == target_ref)
+                .cloned()
+            {
+                break owner;
+            }
+            offset = offset.saturating_add(page.limit);
+            if offset >= page.total_count || page.items.is_empty() {
+                return Err(TodoManagementError::InvalidTarget(
                     "target_ref is unknown or no longer references a known conversation".to_owned(),
-                )
-            })?;
+                ));
+            }
+        };
         let target = target_from_owner(&owner);
         if target.target_ref.as_deref() != Some(target_ref) {
             return Err(TodoManagementError::InvalidTarget(
@@ -243,19 +310,16 @@ impl TodoManagementService {
         Ok(owner)
     }
 
-    fn validate_pending_reminder(
+    fn validate_reminder(
         &self,
-        record: &TodoManagementRecord,
+        owner: &TodoOwner,
+        draft: &TodoItemDraft,
     ) -> Result<(), TodoManagementError> {
-        if record.item.reminder_at.is_none() {
+        if draft.reminder_at.is_none() {
             return Ok(());
         }
-        validate_draft_reminder(&TodoItemDraft::from_item(
-            &record.item,
-            record.item.raw_text.clone().unwrap_or_default(),
-        ))
-        .map_err(TodoManagementError::InvalidTarget)?;
-        let target = target_from_owner(&record.owner);
+        validate_draft_reminder(draft).map_err(TodoManagementError::InvalidTarget)?;
+        let target = target_from_owner(owner);
         if target.target_ref.is_none() {
             return Err(TodoManagementError::InvalidTarget(
                 "todo target cannot be restored from its owner/scope".to_owned(),

--- a/qq-maid-core/src/runtime/tools/todo/management.rs
+++ b/qq-maid-core/src/runtime/tools/todo/management.rs
@@ -1,16 +1,30 @@
 //! Todo 管理 API 使用的领域门面。
 //!
-//! 本模块只复用 Todo 现有草稿归一、状态转换、提醒同步和 Repository；它不理解
-//! HTTP 状态码、cookie、JSON envelope，也不抽象其他领域的 CRUD。
+//! 管理员 actor 只在 HTTP 公共层完成认证、审计和限流；本模块始终从 Todo 记录或
+//! 服务端已知目标恢复真实 owner/scope，不把管理员身份写入 Todo。
 
-use crate::storage::notification::NotificationOutboxStore;
+use qq_maid_common::time_context::request_time_context;
+use sha2::{Digest, Sha256};
 
-use super::{
-    TodoEditPatch, TodoError, TodoItem, TodoItemDraft, TodoOwner, TodoQuery, TodoQueryPage,
-    TodoStatus, TodoStore, cancel_reminder_task, edit_patch, sync_reminder_task,
+use crate::{
+    identity::{
+        group_raw_target_from_scope_key, parse_stable_scope_key, private_raw_target_from_scope_key,
+    },
+    runtime::push::{ONEBOT11_PLATFORM, QQ_OFFICIAL_PLATFORM},
+    storage::notification::NotificationOutboxStore,
 };
 
-const MANAGEMENT_SCOPE_PREFIX: &str = "management:";
+use super::{
+    TodoEditPatch, TodoError, TodoItem, TodoItemDraft, TodoOwner, TodoQuery, TodoStatus, TodoStore,
+    edit_patch,
+    reminder::{prepare_reminder_upsert, validate_draft_reminder},
+    storage::{
+        TodoManagementPage, TodoManagementRecord, TodoManagementScopeType,
+        TodoManagementTargetFilter, advance_after_completion, is_recurring, normalize_draft,
+    },
+};
+
+const TARGET_REF_PREFIX: &str = "todo_target:v1:";
 
 #[derive(Debug, Clone)]
 pub(crate) struct TodoManagementUpdate {
@@ -34,13 +48,46 @@ impl TodoManagementUpdate {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+pub(crate) struct TodoManagementListFilter {
+    pub(crate) platform: Option<String>,
+    pub(crate) account_id: Option<String>,
+    pub(crate) scope_type: Option<TodoManagementScopeType>,
+    pub(crate) user_id: Option<String>,
+    pub(crate) target_ref: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TodoManagementTarget {
+    pub(crate) target_ref: Option<String>,
+    pub(crate) platform: String,
+    pub(crate) scope_type: String,
+    pub(crate) user_id: Option<String>,
+    pub(crate) group_id: Option<String>,
+    pub(crate) account_id: Option<String>,
+    pub(crate) reminder_supported: bool,
+    pub(crate) diagnostic: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TodoManagementItem {
+    pub(crate) item: TodoItem,
+    pub(crate) target: TodoManagementTarget,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TodoManagementListPage {
+    pub(crate) items: Vec<TodoManagementItem>,
+    pub(crate) total_count: usize,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum TodoManagementError {
     Domain(TodoError),
     NotFound,
     Conflict(String),
+    InvalidTarget(String),
     Notification(String),
-    InvalidActor,
 }
 
 impl TodoManagementError {
@@ -49,8 +96,8 @@ impl TodoManagementError {
             Self::Domain(error) => error.code(),
             Self::NotFound => "not_found",
             Self::Conflict(_) => "conflict",
+            Self::InvalidTarget(_) => "bad_request",
             Self::Notification(_) => "notification_error",
-            Self::InvalidActor => "permission_denied",
         }
     }
 
@@ -58,19 +105,25 @@ impl TodoManagementError {
         match self {
             Self::Domain(error) => error.message(),
             Self::NotFound => "todo not found",
-            Self::Conflict(message) | Self::Notification(message) => message,
-            Self::InvalidActor => "authenticated API actor is invalid",
+            Self::Conflict(message)
+            | Self::InvalidTarget(message)
+            | Self::Notification(message) => message,
         }
     }
 }
 
 impl From<TodoError> for TodoManagementError {
     fn from(value: TodoError) -> Self {
-        Self::Domain(value)
+        match value.code() {
+            "not_found" => Self::NotFound,
+            "conflict" => Self::Conflict(value.message().to_owned()),
+            "notification_error" => Self::Notification(value.message().to_owned()),
+            _ => Self::Domain(value),
+        }
     }
 }
 
-/// Todo 管理场景的领域 Service；未来 Memory API 应实现自己的独立 Service。
+/// Todo 管理场景的领域 Service；未来 Memory API 应实现自己的独立权限模型。
 #[derive(Clone)]
 pub(crate) struct TodoManagementService {
     store: TodoStore,
@@ -87,151 +140,376 @@ impl TodoManagementService {
 
     pub(crate) fn create(
         &self,
-        actor_subject: &str,
+        target_ref: &str,
         draft: TodoItemDraft,
-    ) -> Result<TodoItem, TodoManagementError> {
-        let owner = owner_for_actor(actor_subject)?;
-        let item = self.store.create(&owner, draft)?;
-        self.sync_reminder(&owner, &item)?;
-        Ok(item)
+    ) -> Result<TodoManagementItem, TodoManagementError> {
+        self.ensure_shared_database()?;
+        let owner = self.resolve_target_ref(target_ref)?;
+        let draft = normalize_draft(draft)?;
+        let preview = record_from_draft(&owner, "preview", &draft, TodoStatus::Pending);
+        self.validate_pending_reminder(&preview)?;
+        let created = self
+            .store
+            .create_todo_for_management(&owner, draft, reminder_upsert)?;
+        Ok(self.present(created))
     }
 
     pub(crate) fn list(
         &self,
-        actor_subject: &str,
         query: &TodoQuery,
-    ) -> Result<TodoQueryPage, TodoManagementError> {
-        let owner = owner_for_actor(actor_subject)?;
-        self.store
-            .query_todos_for_management(&owner, query)
-            .map_err(Into::into)
+        filter: TodoManagementListFilter,
+    ) -> Result<TodoManagementListPage, TodoManagementError> {
+        let target = filter
+            .target_ref
+            .as_deref()
+            .map(|target_ref| self.resolve_target_ref(target_ref))
+            .transpose()?;
+        let page = self.store.query_todos_for_management(
+            query,
+            &TodoManagementTargetFilter {
+                platform: filter.platform,
+                account_id: filter.account_id,
+                scope_type: filter.scope_type,
+                user_id: filter.user_id,
+                target,
+            },
+        )?;
+        Ok(self.present_page(page))
     }
 
-    pub(crate) fn get(
-        &self,
-        actor_subject: &str,
-        id: &str,
-    ) -> Result<TodoItem, TodoManagementError> {
-        let owner = owner_for_actor(actor_subject)?;
-        self.get_for_owner(&owner, id)
+    pub(crate) fn get(&self, id: &str) -> Result<TodoManagementItem, TodoManagementError> {
+        let record = self.get_record(id)?;
+        Ok(self.present(record))
     }
 
     pub(crate) fn update(
         &self,
-        actor_subject: &str,
         id: &str,
         update: TodoManagementUpdate,
-    ) -> Result<TodoItem, TodoManagementError> {
-        let owner = owner_for_actor(actor_subject)?;
-        let current = self.get_for_owner(&owner, id)?;
-        let has_fields = update.has_field_changes();
-
-        let mut item = match (&current.status, &update.status) {
-            (TodoStatus::Completed, Some(TodoStatus::Pending)) => {
-                let outcome = self
-                    .store
-                    .restore_completed_by_ids(&owner, &[id.to_owned()])?;
-                outcome.restored.into_iter().next().ok_or_else(|| {
-                    TodoManagementError::Conflict("todo status changed".to_owned())
-                })?
-            }
-            (TodoStatus::Pending, Some(TodoStatus::Completed)) => current.clone(),
-            (TodoStatus::Completed, _) if has_fields => {
-                return Err(TodoManagementError::Conflict(
-                    "completed todo fields cannot be edited before restoring it".to_owned(),
-                ));
-            }
-            _ => current.clone(),
-        };
-
-        if has_fields {
-            let raw_text = item.raw_text.clone().unwrap_or_else(|| item.title.clone());
-            let draft = edit_patch::apply_to_draft(
-                TodoItemDraft::from_item(&item, &raw_text),
-                &update.fields,
-                &raw_text,
-            );
-            item = self.store.edit(&owner, id, draft)?;
+    ) -> Result<TodoManagementItem, TodoManagementError> {
+        self.ensure_shared_database()?;
+        let current = self.get_record(id)?;
+        if !update.has_field_changes() && update.status.as_ref() == Some(&current.item.status) {
+            return Ok(self.present(current));
         }
-
-        if matches!(current.status, TodoStatus::Pending)
-            && matches!(update.status, Some(TodoStatus::Completed))
-        {
-            let outcome = self
-                .store
-                .complete_by_ids_with_recurrence(&owner, &[id.to_owned()])?;
-            if outcome.completed.is_empty() && outcome.advanced.is_empty() {
-                return Err(TodoManagementError::Conflict(
-                    "todo status changed".to_owned(),
-                ));
-            }
-            item = self.get_for_owner(&owner, id)?;
+        let (draft, final_status) = plan_update(&current, &update)?;
+        let preview = record_from_draft(
+            &current.owner,
+            &current.item.id,
+            &draft,
+            final_status.clone(),
+        );
+        if final_status == TodoStatus::Pending {
+            self.validate_pending_reminder(&preview)?;
         }
-
-        self.sync_reminder(&owner, &item)?;
-        Ok(item)
+        let updated =
+            self.store
+                .update_todo_for_management(&current, draft, final_status, |record| {
+                    reminder_upsert(record)
+                })?;
+        Ok(self.present(updated))
     }
 
-    pub(crate) fn delete(&self, actor_subject: &str, id: &str) -> Result<(), TodoManagementError> {
-        let owner = owner_for_actor(actor_subject)?;
-        let item = self.get_for_owner(&owner, id)?;
-        let outcome = self.store.delete_by_ids(&owner, &[id.to_owned()])?;
-        if outcome.deleted_count == 0 {
-            return Err(TodoManagementError::NotFound);
-        }
-        cancel_reminder_task(&self.notification_store, &item)
-            .map_err(TodoManagementError::Notification)
+    pub(crate) fn delete(&self, id: &str) -> Result<(), TodoManagementError> {
+        self.ensure_shared_database()?;
+        let current = self.get_record(id)?;
+        self.store.delete_todo_for_management(&current)?;
+        Ok(())
     }
 
-    fn get_for_owner(&self, owner: &TodoOwner, id: &str) -> Result<TodoItem, TodoManagementError> {
+    fn get_record(&self, id: &str) -> Result<TodoManagementRecord, TodoManagementError> {
         self.store
-            .get_by_id(owner, id)?
+            .get_todo_for_management(id)?
             .ok_or(TodoManagementError::NotFound)
     }
 
-    fn sync_reminder(&self, owner: &TodoOwner, item: &TodoItem) -> Result<(), TodoManagementError> {
-        if item.reminder_at.is_none() {
-            return cancel_reminder_task(&self.notification_store, item)
-                .map_err(TodoManagementError::Notification);
+    fn resolve_target_ref(&self, target_ref: &str) -> Result<TodoOwner, TodoManagementError> {
+        validate_target_ref_format(target_ref)?;
+        let candidates = self.store.management_target_candidates()?;
+        let owner = candidates
+            .into_iter()
+            .find(|owner| target_ref_for(owner) == target_ref)
+            .ok_or_else(|| {
+                TodoManagementError::InvalidTarget(
+                    "target_ref is unknown or no longer references a known conversation".to_owned(),
+                )
+            })?;
+        let target = target_from_owner(&owner);
+        if target.target_ref.as_deref() != Some(target_ref) {
+            return Err(TodoManagementError::InvalidTarget(
+                "target_ref does not identify a complete platform target".to_owned(),
+            ));
         }
-        sync_reminder_task(&self.notification_store, owner, item)
-            .map_err(TodoManagementError::Notification)
+        Ok(owner)
+    }
+
+    fn validate_pending_reminder(
+        &self,
+        record: &TodoManagementRecord,
+    ) -> Result<(), TodoManagementError> {
+        if record.item.reminder_at.is_none() {
+            return Ok(());
+        }
+        validate_draft_reminder(&TodoItemDraft::from_item(
+            &record.item,
+            record.item.raw_text.clone().unwrap_or_default(),
+        ))
+        .map_err(TodoManagementError::InvalidTarget)?;
+        let target = target_from_owner(&record.owner);
+        if target.target_ref.is_none() {
+            return Err(TodoManagementError::InvalidTarget(
+                "todo target cannot be restored from its owner/scope".to_owned(),
+            ));
+        }
+        if !target.reminder_supported {
+            return Err(TodoManagementError::InvalidTarget(format!(
+                "platform `{}` does not support proactive Todo reminders",
+                target.platform
+            )));
+        }
+        Ok(())
+    }
+
+    fn ensure_shared_database(&self) -> Result<(), TodoManagementError> {
+        if self.store.database_path() == self.notification_store.database_path() {
+            Ok(())
+        } else {
+            Err(TodoManagementError::Notification(
+                "Todo and Notification Outbox must use the same SQLite database".to_owned(),
+            ))
+        }
+    }
+
+    fn present(&self, record: TodoManagementRecord) -> TodoManagementItem {
+        TodoManagementItem {
+            target: target_from_owner(&record.owner),
+            item: record.item,
+        }
+    }
+
+    fn present_page(&self, page: TodoManagementPage) -> TodoManagementListPage {
+        TodoManagementListPage {
+            items: page
+                .items
+                .into_iter()
+                .map(|record| self.present(record))
+                .collect(),
+            total_count: page.total_count,
+        }
     }
 }
 
-fn owner_for_actor(actor_subject: &str) -> Result<TodoOwner, TodoManagementError> {
-    let actor_subject = actor_subject.trim();
-    if actor_subject.is_empty() || actor_subject.len() > 128 {
-        return Err(TodoManagementError::InvalidActor);
+fn plan_update(
+    current: &TodoManagementRecord,
+    update: &TodoManagementUpdate,
+) -> Result<(TodoItemDraft, TodoStatus), TodoManagementError> {
+    let has_fields = update.has_field_changes();
+    if current.item.status == TodoStatus::Completed
+        && has_fields
+        && update.status != Some(TodoStatus::Pending)
+    {
+        return Err(TodoManagementError::Conflict(
+            "completed todo fields cannot be edited before restoring it".to_owned(),
+        ));
     }
-    // 管理 API Todo 与聊天入口 Todo 使用不同 conversation scope；认证 subject 既决定
-    // owner 又参与 scope，未来即使出现多个管理员也不会越权读取彼此的数据。
-    Ok(TodoStore::owner(
-        Some(actor_subject),
-        &format!("{MANAGEMENT_SCOPE_PREFIX}{actor_subject}"),
-    ))
+
+    let raw_text = current
+        .item
+        .raw_text
+        .clone()
+        .unwrap_or_else(|| current.item.title.clone());
+    let base = TodoItemDraft::from_item(&current.item, &raw_text);
+    let mut draft = if has_fields {
+        edit_patch::apply_to_draft(base, &update.fields, &raw_text)
+    } else {
+        base
+    };
+    draft = normalize_draft(draft)?;
+
+    let requested_status = update
+        .status
+        .clone()
+        .unwrap_or_else(|| current.item.status.clone());
+    if current.item.status == TodoStatus::Pending && requested_status == TodoStatus::Completed {
+        let pending = record_from_draft(
+            &current.owner,
+            &current.item.id,
+            &draft,
+            TodoStatus::Pending,
+        );
+        if is_recurring(&pending.item) {
+            draft = normalize_draft(advance_after_completion(&pending.item)?)?;
+            return Ok((draft, TodoStatus::Pending));
+        }
+    }
+    Ok((draft, requested_status))
+}
+
+fn record_from_draft(
+    owner: &TodoOwner,
+    id: &str,
+    draft: &TodoItemDraft,
+    status: TodoStatus,
+) -> TodoManagementRecord {
+    let now = request_time_context().current_time().to_owned();
+    TodoManagementRecord {
+        owner: owner.clone(),
+        item: TodoItem {
+            id: id.to_owned(),
+            user_id: owner.user_id.clone(),
+            scope_key: owner.scope_key.clone(),
+            title: draft.title.clone(),
+            detail: draft.detail.clone(),
+            raw_text: draft.raw_text.clone(),
+            due_date: draft.due_date.clone(),
+            due_at: draft.due_at.clone(),
+            reminder_at: draft.reminder_at.clone(),
+            time_precision: draft.time_precision,
+            recurrence_kind: draft.recurrence_kind.clone(),
+            recurrence_interval_days: draft.recurrence_interval_days,
+            recurrence_interval: draft.recurrence_interval,
+            recurrence_unit: draft.recurrence_unit,
+            status,
+            created_at: now.clone(),
+            updated_at: now,
+            completed_at: None,
+        },
+    }
+}
+
+fn reminder_upsert(
+    record: &TodoManagementRecord,
+) -> Result<Option<crate::storage::notification::NotificationUpsert>, TodoError> {
+    prepare_reminder_upsert(&record.owner, &record.item).map_err(TodoError::notification)
+}
+
+fn target_from_owner(owner: &TodoOwner) -> TodoManagementTarget {
+    if TodoStore::owner(owner.user_id.as_deref(), &owner.scope_key).key != owner.key {
+        return unknown_target(owner, "owner_scope_mismatch");
+    }
+    let (platform, account_id) = parse_stable_scope_key(&owner.scope_key)
+        .map(|parsed| {
+            (
+                parsed.platform.to_owned(),
+                (parsed.account_id != "-").then(|| parsed.account_id.to_owned()),
+            )
+        })
+        .unwrap_or_else(|| (QQ_OFFICIAL_PLATFORM.to_owned(), None));
+
+    if let Some(group_id) = group_raw_target_from_scope_key(&owner.scope_key) {
+        return known_target(owner, platform, account_id, "group", None, Some(group_id));
+    }
+    if let Some(private_id) = private_raw_target_from_scope_key(&owner.scope_key) {
+        let user_id = owner.user_id.clone();
+        if user_id.as_deref().map(str::trim) != Some(private_id.as_str()) {
+            return unknown_target(owner, "private_owner_target_mismatch");
+        }
+        return known_target(owner, platform, account_id, "private", user_id, None);
+    }
+    unknown_target(owner, "unrecognized_scope")
+}
+
+fn known_target(
+    owner: &TodoOwner,
+    platform: String,
+    account_id: Option<String>,
+    scope_type: &str,
+    user_id: Option<String>,
+    group_id: Option<String>,
+) -> TodoManagementTarget {
+    let reminder_supported = match platform.as_str() {
+        QQ_OFFICIAL_PLATFORM => true,
+        "onebot" | ONEBOT11_PLATFORM => account_id.is_some(),
+        _ => false,
+    };
+    TodoManagementTarget {
+        target_ref: Some(target_ref_for(owner)),
+        platform,
+        scope_type: scope_type.to_owned(),
+        user_id: user_id.or_else(|| owner.user_id.clone()),
+        group_id,
+        account_id,
+        reminder_supported,
+        diagnostic: None,
+    }
+}
+
+fn unknown_target(owner: &TodoOwner, diagnostic: &str) -> TodoManagementTarget {
+    TodoManagementTarget {
+        target_ref: None,
+        platform: parse_stable_scope_key(&owner.scope_key)
+            .map(|parsed| parsed.platform.to_owned())
+            .unwrap_or_else(|| "unknown".to_owned()),
+        scope_type: "unknown".to_owned(),
+        user_id: owner.user_id.clone(),
+        group_id: None,
+        account_id: None,
+        reminder_supported: false,
+        diagnostic: Some(diagnostic.to_owned()),
+    }
+}
+
+fn target_ref_for(owner: &TodoOwner) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"qq-maid-todo-target-v1\0");
+    digest.update(owner.key.as_bytes());
+    digest.update(b"\0");
+    digest.update(owner.user_id.as_deref().unwrap_or_default().as_bytes());
+    digest.update(b"\0");
+    digest.update(owner.scope_key.as_bytes());
+    let bytes = digest.finalize();
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(encoded, "{byte:02x}");
+    }
+    format!("{TARGET_REF_PREFIX}{encoded}")
+}
+
+fn validate_target_ref_format(target_ref: &str) -> Result<(), TodoManagementError> {
+    let digest = target_ref
+        .trim()
+        .strip_prefix(TARGET_REF_PREFIX)
+        .filter(|value| {
+            value.len() == 64
+                && value
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        });
+    if digest.is_none() {
+        return Err(TodoManagementError::InvalidTarget(
+            "target_ref format is invalid".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn management_private_scope_type() -> TodoManagementScopeType {
+    TodoManagementScopeType::Private
+}
+
+pub(crate) fn management_group_scope_type() -> TodoManagementScopeType {
+    TodoManagementScopeType::Group
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        runtime::tools::todo::{
-            TodoRecurrenceKind, TodoRecurrenceUnit, TodoTimePrecision, storage::TODO_MIGRATIONS,
-        },
-        storage::{
-            database::SqliteDatabase,
-            notification::{NOTIFICATION_MIGRATIONS, NotificationOutboxStore},
-        },
+        identity::conversation_scope_key,
+        runtime::tools::todo::{TodoRecurrenceKind, TodoRecurrenceUnit, TodoTimePrecision},
+        storage::{APP_MIGRATIONS, database::SqliteDatabase},
     };
 
-    fn service() -> TodoManagementService {
-        let mut migrations = TODO_MIGRATIONS.to_vec();
-        migrations.extend_from_slice(NOTIFICATION_MIGRATIONS);
-        let database = SqliteDatabase::open_temp("todo-management-service", &migrations).unwrap();
-        TodoManagementService::new(
-            TodoStore::new(database.clone()),
-            NotificationOutboxStore::new(database),
+    fn service() -> (TodoManagementService, TodoStore, NotificationOutboxStore) {
+        let database =
+            SqliteDatabase::open_temp("todo-management-service", APP_MIGRATIONS).unwrap();
+        let store = TodoStore::new(database.clone());
+        let notifications = NotificationOutboxStore::new(database);
+        (
+            TodoManagementService::new(store.clone(), notifications.clone()),
+            store,
+            notifications,
         )
     }
 
@@ -252,100 +530,99 @@ mod tests {
     }
 
     #[test]
-    fn management_service_isolates_actors_and_supports_crud() {
-        let service = service();
-        let created = service
-            .create("console_admin:1", draft("原始标题"))
-            .unwrap();
-        assert!(matches!(
-            service.get("console_admin:2", &created.id),
-            Err(TodoManagementError::NotFound)
-        ));
-        let other_page = service
+    fn management_service_reads_and_updates_global_real_owner() {
+        let (service, store, _) = service();
+        let scope = conversation_scope_key("qq_official", Some("app-1"), "private", "u1");
+        let owner = TodoStore::owner(Some("u1"), &scope);
+        let created = store.create(&owner, draft("原始标题")).unwrap();
+
+        let listed = service
             .list(
-                "console_admin:2",
                 &TodoQuery {
-                    status: crate::runtime::tools::todo::TodoQueryStatus::All,
+                    status: super::super::TodoQueryStatus::All,
                     ..TodoQuery::default()
                 },
+                TodoManagementListFilter::default(),
             )
             .unwrap();
-        assert_eq!(other_page.total_count, 0);
-        assert!(matches!(
-            service.update(
-                "console_admin:2",
-                &created.id,
-                TodoManagementUpdate {
-                    fields: TodoEditPatch {
-                        title: Some("越权更新".to_owned()),
-                        ..Default::default()
-                    },
-                    status: None,
-                }
-            ),
-            Err(TodoManagementError::NotFound)
-        ));
-        assert!(matches!(
-            service.delete("console_admin:2", &created.id),
-            Err(TodoManagementError::NotFound)
-        ));
+        assert_eq!(listed.total_count, 1);
+        assert_eq!(listed.items[0].item.id, created.id);
 
         let updated = service
             .update(
-                "console_admin:1",
                 &created.id,
                 TodoManagementUpdate {
                     fields: TodoEditPatch {
                         title: Some("更新标题".to_owned()),
-                        detail: Some("详情".to_owned()),
                         ..Default::default()
                     },
                     status: None,
                 },
             )
             .unwrap();
-        assert_eq!(updated.title, "更新标题");
-        assert_eq!(updated.detail.as_deref(), Some("详情"));
-
-        service.delete("console_admin:1", &created.id).unwrap();
-        assert!(matches!(
-            service.get("console_admin:1", &created.id),
-            Err(TodoManagementError::NotFound)
-        ));
+        assert_eq!(updated.item.title, "更新标题");
+        assert_eq!(
+            store.get_by_id(&owner, &created.id).unwrap().unwrap().title,
+            "更新标题"
+        );
     }
 
     #[test]
-    fn management_update_clears_nullable_fields_and_uses_status_transitions() {
-        let service = service();
-        let mut initial = draft("待办");
-        initial.detail = Some("将清空".to_owned());
-        let created = service.create("console_admin:1", initial).unwrap();
-        let completed = service
-            .update(
-                "console_admin:1",
-                &created.id,
-                TodoManagementUpdate {
-                    fields: TodoEditPatch {
-                        detail: Some(String::new()),
-                        ..Default::default()
-                    },
-                    status: Some(TodoStatus::Completed),
-                },
-            )
-            .unwrap();
-        assert_eq!(completed.detail, None);
-        assert_eq!(completed.status, TodoStatus::Completed);
+    fn invalid_patch_after_restore_does_not_partially_change_completed_todo() {
+        let (service, store, _) = service();
+        let scope = conversation_scope_key("qq_official", Some("app-1"), "private", "u1");
+        let owner = TodoStore::owner(Some("u1"), &scope);
+        let created = store.create(&owner, draft("原始标题")).unwrap();
+        store.complete(&owner, &created.id).unwrap();
 
-        let restored = service
-            .update(
-                "console_admin:1",
-                &created.id,
-                TodoManagementUpdate {
-                    fields: TodoEditPatch::default(),
-                    status: Some(TodoStatus::Pending),
+        let result = service.update(
+            &created.id,
+            TodoManagementUpdate {
+                fields: TodoEditPatch {
+                    title: Some("   ".to_owned()),
+                    ..Default::default()
                 },
-            )
+                status: Some(TodoStatus::Pending),
+            },
+        );
+        assert!(matches!(result, Err(TodoManagementError::Domain(_))));
+        let unchanged = store.get_by_id(&owner, &created.id).unwrap().unwrap();
+        assert_eq!(unchanged.status, TodoStatus::Completed);
+        assert_eq!(unchanged.title, "原始标题");
+    }
+
+    #[test]
+    fn notification_failure_rolls_back_todo_update() {
+        let database =
+            SqliteDatabase::open_temp("todo-management-rollback", APP_MIGRATIONS).unwrap();
+        let store = TodoStore::new(database.clone());
+        let service = TodoManagementService::new(
+            store.clone(),
+            NotificationOutboxStore::new(database.clone()),
+        );
+        let scope = conversation_scope_key("qq_official", Some("app-1"), "private", "u1");
+        let owner = TodoStore::owner(Some("u1"), &scope);
+        let created = store.create(&owner, draft("原始标题")).unwrap();
+        database
+            .connection()
+            .unwrap()
+            .execute("DROP TABLE notification_outbox", [])
             .unwrap();
-        assert_eq!(restored.status, TodoStatus::Pending);
+
+        let result = service.update(
+            &created.id,
+            TodoManagementUpdate {
+                fields: TodoEditPatch {
+                    title: Some("不应落库".to_owned()),
+                    ..Default::default()
+                },
+                status: None,
+            },
+        );
+        assert!(matches!(result, Err(TodoManagementError::Notification(_))));
+        assert_eq!(
+            store.get_by_id(&owner, &created.id).unwrap().unwrap().title,
+            "原始标题"
+        );
     }
 }

--- a/qq-maid-core/src/runtime/tools/todo/mod.rs
+++ b/qq-maid-core/src/runtime/tools/todo/mod.rs
@@ -66,7 +66,8 @@ pub(crate) use get::GetTodoTool;
 pub(crate) use list::ListTodoTool;
 pub(crate) use management::{
     TodoManagementError, TodoManagementItem, TodoManagementListFilter, TodoManagementService,
-    TodoManagementUpdate, management_group_scope_type, management_private_scope_type,
+    TodoManagementTarget, TodoManagementTargetListFilter, TodoManagementUpdate,
+    management_group_scope_type, management_private_scope_type,
 };
 pub(crate) use merge::MergeTodoTool;
 pub(crate) use pending::{

--- a/qq-maid-core/src/runtime/tools/todo/mod.rs
+++ b/qq-maid-core/src/runtime/tools/todo/mod.rs
@@ -21,6 +21,7 @@ mod freshness;
 pub(crate) mod group_admin;
 pub(crate) mod interaction_state;
 mod json;
+pub(crate) mod management;
 pub(crate) mod ops;
 pub(crate) mod pending;
 pub(crate) mod query_filter;
@@ -63,6 +64,7 @@ pub use edit_patch::TodoEditPatch;
 pub(crate) use freshness::valid_last_visible_todo_query;
 pub(crate) use get::GetTodoTool;
 pub(crate) use list::ListTodoTool;
+pub(crate) use management::{TodoManagementError, TodoManagementService, TodoManagementUpdate};
 pub(crate) use merge::MergeTodoTool;
 pub(crate) use pending::{
     ClarificationCandidate, PendingTodoClarification, TODO_PENDING_DOMAIN, TodoPendingPayload,

--- a/qq-maid-core/src/runtime/tools/todo/mod.rs
+++ b/qq-maid-core/src/runtime/tools/todo/mod.rs
@@ -64,7 +64,10 @@ pub use edit_patch::TodoEditPatch;
 pub(crate) use freshness::valid_last_visible_todo_query;
 pub(crate) use get::GetTodoTool;
 pub(crate) use list::ListTodoTool;
-pub(crate) use management::{TodoManagementError, TodoManagementService, TodoManagementUpdate};
+pub(crate) use management::{
+    TodoManagementError, TodoManagementItem, TodoManagementListFilter, TodoManagementService,
+    TodoManagementUpdate, management_group_scope_type, management_private_scope_type,
+};
 pub(crate) use merge::MergeTodoTool;
 pub(crate) use pending::{
     ClarificationCandidate, PendingTodoClarification, TODO_PENDING_DOMAIN, TodoPendingPayload,

--- a/qq-maid-core/src/runtime/tools/todo/reminder.rs
+++ b/qq-maid-core/src/runtime/tools/todo/reminder.rs
@@ -96,14 +96,34 @@ pub fn sync_reminder_task(
     owner: &TodoOwner,
     item: &TodoItem,
 ) -> Result<(), String> {
-    let Some(reminder_at) = item.reminder_at.as_deref() else {
-        cancel_reminder_task(store, item)?;
+    let request = prepare_reminder_upsert(owner, item)?;
+    // 无提醒或已经完成的 Todo 只取消旧任务；不能因为记录还保留 reminder_at
+    // 就把 completed Todo 重新排入 Outbox。
+    cancel_reminder_task(store, item)?;
+    let Some(request) = request else {
         return Ok(());
+    };
+    store
+        .upsert(request)
+        .map(|_| ())
+        .map_err(|err| err.message().to_owned())
+}
+
+/// 纯构造 Todo reminder 的 Outbox 快照，供管理更新与 Todo 写入共用事务。
+/// 返回 `None` 表示最终状态不应再投递；本函数本身不写数据库。
+pub(crate) fn prepare_reminder_upsert(
+    owner: &TodoOwner,
+    item: &TodoItem,
+) -> Result<Option<NotificationUpsert>, String> {
+    if item.status != super::TodoStatus::Pending {
+        return Ok(None);
+    }
+    let Some(reminder_at) = item.reminder_at.as_deref() else {
+        return Ok(None);
     };
     let scheduled_at = parse_reminder_at(reminder_at)?;
     if scheduled_at <= Utc::now().with_timezone(&shanghai_offset()) {
-        cancel_reminder_task(store, item)?;
-        return Ok(());
+        return Ok(None);
     }
     let target = push_target_from_scope(&owner.scope_key)
         .ok_or_else(|| "当前会话没有可用的提醒推送目标。".to_owned())?;
@@ -115,32 +135,26 @@ pub fn sync_reminder_task(
         item,
         Some("todo_reminder"),
     );
-    // 单次提醒重排时，新时间会生成新 dedupe_key；先取消旧的未发送任务，
-    // 避免未来时间 A 改到 B 后两个 pending/retry 提醒都发出。sent 记录由存储层保留。
-    cancel_reminder_task(store, item)?;
     let message = render_todo_reminder(item);
     let mentions = todo_reminder_mentions(&target, owner);
-    store
-        .upsert(NotificationUpsert {
-            source_type: TODO_REMINDER_SOURCE.to_owned(),
-            source_id: item.id.clone(),
-            dedupe_key: reminder_dedupe_key(item, &scheduled_at),
-            target,
-            channel: "qq".to_owned(),
-            kind: TODO_REMINDER_KIND.to_owned(),
-            payload: json!({
-                "message_type": "markdown",
-                "text": message.markdown,
-                "fallback_text": message.text,
-                "mentions": mentions,
-                "visible_entity_snapshot": visible_entity_snapshot,
-            }),
-            scheduled_at: scheduled_at.to_rfc3339(),
-            max_attempts: 5,
-            reactivate_cancelled: true,
-        })
-        .map(|_| ())
-        .map_err(|err| err.message().to_owned())
+    Ok(Some(NotificationUpsert {
+        source_type: TODO_REMINDER_SOURCE.to_owned(),
+        source_id: item.id.clone(),
+        dedupe_key: reminder_dedupe_key(item, &scheduled_at),
+        target,
+        channel: "qq".to_owned(),
+        kind: TODO_REMINDER_KIND.to_owned(),
+        payload: json!({
+            "message_type": "markdown",
+            "text": message.markdown,
+            "fallback_text": message.text,
+            "mentions": mentions,
+            "visible_entity_snapshot": visible_entity_snapshot,
+        }),
+        scheduled_at: scheduled_at.to_rfc3339(),
+        max_attempts: 5,
+        reactivate_cancelled: true,
+    }))
 }
 
 fn todo_reminder_mentions(target: &PushTarget, owner: &TodoOwner) -> Vec<PushMention> {

--- a/qq-maid-core/src/runtime/tools/todo/storage/management.rs
+++ b/qq-maid-core/src/runtime/tools/todo/storage/management.rs
@@ -1,0 +1,280 @@
+//! 部署管理员 Todo 场景的专用持久化入口。
+//!
+//! 普通聊天仍只能调用 owner-scoped Repository 方法；本模块只向 Todo 管理 Service
+//! 暴露全局读取，以及 Todo 与 Notification Outbox 的同库事务写入。
+
+use std::collections::BTreeMap;
+
+use rusqlite::{Connection, OptionalExtension, params};
+
+use crate::{
+    identity::{group_raw_target_from_scope_key, private_raw_target_from_scope_key},
+    runtime::tools::todo::reminder::TODO_REMINDER_SOURCE,
+    storage::{
+        notification::{NotificationUpsert, cancel_by_source_on_connection, upsert_on_connection},
+        session::now_iso_cn,
+    },
+};
+
+use super::{
+    TodoError, TodoItemDraft, TodoManagementRecord, TodoOwner, TodoStatus, TodoStore,
+    id::{clean_todo_id, parse_todo_db_id},
+    normalize::normalize_draft,
+    query::todo_item_from_row,
+    write::insert_todo_unlocked,
+};
+
+const MANAGEMENT_SELECT: &str = "id, user_id, scope_key, title, detail, raw_text,
+    due_date, due_at, reminder_at, time_precision, recurrence_kind,
+    recurrence_interval_days, recurrence_interval, recurrence_unit, status,
+    created_at, updated_at, completed_at, owner_key";
+
+impl TodoStore {
+    /// 按内部 ID 全局读取 Todo，仅供已通过部署管理员鉴权的领域 Service。
+    pub(crate) fn get_todo_for_management(
+        &self,
+        id: &str,
+    ) -> Result<Option<TodoManagementRecord>, TodoError> {
+        let Some(id) = parse_todo_db_id(&clean_todo_id(id)) else {
+            return Ok(None);
+        };
+        let conn = self.connection()?;
+        get_management_record_unlocked(&conn, id)
+    }
+
+    /// 返回服务端已经见过的真实 Todo 目标。Todo 记录是事实来源；Session 只补充
+    /// 已发生过聊天但尚无 Todo 的私聊或群成员交互目标。
+    pub(crate) fn management_target_candidates(&self) -> Result<Vec<TodoOwner>, TodoError> {
+        let conn = self.connection()?;
+        let mut targets = BTreeMap::<(String, Option<String>, String), TodoOwner>::new();
+        {
+            let mut stmt = conn
+                .prepare("SELECT DISTINCT owner_key, user_id, scope_key FROM todos")
+                .map_err(TodoError::from_sql)?;
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok(TodoOwner {
+                        key: row.get(0)?,
+                        user_id: row.get(1)?,
+                        scope_key: row.get(2)?,
+                    })
+                })
+                .map_err(TodoError::from_sql)?;
+            for target in rows {
+                insert_target(&mut targets, target.map_err(TodoError::from_sql)?);
+            }
+        }
+
+        let mut stmt = conn
+            .prepare("SELECT DISTINCT scope_key, user_id, group_id FROM sessions")
+            .map_err(TodoError::from_sql)?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                ))
+            })
+            .map_err(TodoError::from_sql)?;
+        for row in rows {
+            let (session_scope, user_id, group_id) = row.map_err(TodoError::from_sql)?;
+            if let Some(target) = target_from_session(&session_scope, user_id, group_id) {
+                insert_target(&mut targets, target);
+            }
+        }
+        Ok(targets.into_values().collect())
+    }
+
+    /// 管理创建与 reminder Outbox 在同一个事务内提交。
+    pub(crate) fn create_todo_for_management<F>(
+        &self,
+        owner: &TodoOwner,
+        draft: TodoItemDraft,
+        notification: F,
+    ) -> Result<TodoManagementRecord, TodoError>
+    where
+        F: FnOnce(&TodoManagementRecord) -> Result<Option<NotificationUpsert>, TodoError>,
+    {
+        let draft = normalize_draft(draft)?;
+        let mut conn = self.connection()?;
+        let tx = conn.transaction().map_err(TodoError::from_sql)?;
+        let item = insert_todo_unlocked(&tx, owner, draft, &now_iso_cn())?;
+        let record = TodoManagementRecord {
+            owner: owner.clone(),
+            item,
+        };
+        if let Some(request) = notification(&record)? {
+            upsert_on_connection(&tx, &request).map_err(notification_error)?;
+        }
+        tx.commit().map_err(TodoError::from_sql)?;
+        Ok(record)
+    }
+
+    /// 把字段、状态/周期推进和 reminder Outbox 一次性写入同一个 SQLite 事务。
+    /// `expected` 是 Service 在完成所有前置校验时读取的快照；事务内若发现并发变化，
+    /// 返回 conflict，不用旧计划覆盖聊天入口刚写入的新状态。
+    pub(crate) fn update_todo_for_management<F>(
+        &self,
+        expected: &TodoManagementRecord,
+        draft: TodoItemDraft,
+        final_status: TodoStatus,
+        notification: F,
+    ) -> Result<TodoManagementRecord, TodoError>
+    where
+        F: FnOnce(&TodoManagementRecord) -> Result<Option<NotificationUpsert>, TodoError>,
+    {
+        let draft = normalize_draft(draft)?;
+        let id = parse_todo_db_id(&expected.item.id)
+            .ok_or_else(|| TodoError::bad_request("invalid todo id"))?;
+        let mut conn = self.connection()?;
+        let tx = conn.transaction().map_err(TodoError::from_sql)?;
+        let current = get_management_record_unlocked(&tx, id)?
+            .ok_or_else(|| TodoError::not_found("todo not found"))?;
+        if current != *expected {
+            return Err(TodoError::conflict("todo changed during management update"));
+        }
+        let now = now_iso_cn();
+        let completed_at = matches!(final_status, TodoStatus::Completed).then_some(now.as_str());
+        tx.execute(
+            "UPDATE todos
+             SET title = ?4,
+                 detail = ?5,
+                 raw_text = ?6,
+                 due_date = ?7,
+                 due_at = ?8,
+                 reminder_at = ?9,
+                 time_precision = ?10,
+                 recurrence_kind = ?11,
+                 recurrence_interval_days = ?12,
+                 recurrence_interval = ?13,
+                 recurrence_unit = ?14,
+                 status = ?15,
+                 completed = ?16,
+                 updated_at = ?17,
+                 completed_at = ?18
+             WHERE id = ?1 AND owner_key = ?2 AND scope_key = ?3",
+            params![
+                id,
+                expected.owner.key.as_str(),
+                expected.owner.scope_key.as_str(),
+                draft.title,
+                draft.detail,
+                draft.raw_text,
+                draft.due_date,
+                draft.due_at,
+                draft.reminder_at,
+                draft.time_precision.as_str(),
+                draft.recurrence_kind.as_str(),
+                i64::from(draft.recurrence_interval_days),
+                i64::from(draft.recurrence_interval),
+                draft.recurrence_unit.as_str(),
+                final_status.as_str(),
+                i64::from(matches!(final_status, TodoStatus::Completed)),
+                now,
+                completed_at,
+            ],
+        )
+        .map_err(TodoError::from_sql)?;
+        let updated = get_management_record_unlocked(&tx, id)?
+            .ok_or_else(|| TodoError::io("todo disappeared after management update"))?;
+        cancel_by_source_on_connection(&tx, TODO_REMINDER_SOURCE, &updated.item.id)
+            .map_err(notification_error)?;
+        if let Some(request) = notification(&updated)? {
+            upsert_on_connection(&tx, &request).map_err(notification_error)?;
+        }
+        tx.commit().map_err(TodoError::from_sql)?;
+        Ok(updated)
+    }
+
+    /// 管理删除仍使用真实 owner/scope，并与 reminder 取消原子提交。
+    pub(crate) fn delete_todo_for_management(
+        &self,
+        expected: &TodoManagementRecord,
+    ) -> Result<(), TodoError> {
+        let id = parse_todo_db_id(&expected.item.id)
+            .ok_or_else(|| TodoError::bad_request("invalid todo id"))?;
+        let mut conn = self.connection()?;
+        let tx = conn.transaction().map_err(TodoError::from_sql)?;
+        let current = get_management_record_unlocked(&tx, id)?
+            .ok_or_else(|| TodoError::not_found("todo not found"))?;
+        if current != *expected {
+            return Err(TodoError::conflict("todo changed during management delete"));
+        }
+        cancel_by_source_on_connection(&tx, TODO_REMINDER_SOURCE, &current.item.id)
+            .map_err(notification_error)?;
+        let deleted = tx
+            .execute(
+                "DELETE FROM todos WHERE id = ?1 AND owner_key = ?2 AND scope_key = ?3",
+                params![
+                    id,
+                    current.owner.key.as_str(),
+                    current.owner.scope_key.as_str()
+                ],
+            )
+            .map_err(TodoError::from_sql)?;
+        if deleted != 1 {
+            return Err(TodoError::conflict("todo changed during management delete"));
+        }
+        tx.commit().map_err(TodoError::from_sql)
+    }
+}
+
+fn get_management_record_unlocked(
+    conn: &Connection,
+    id: i64,
+) -> Result<Option<TodoManagementRecord>, TodoError> {
+    conn.query_row(
+        &format!("SELECT {MANAGEMENT_SELECT} FROM todos WHERE id = ?1"),
+        [id],
+        |row| {
+            let item = todo_item_from_row(row)?;
+            Ok(TodoManagementRecord {
+                owner: TodoOwner {
+                    key: row.get(18)?,
+                    user_id: item.user_id.clone(),
+                    scope_key: item.scope_key.clone(),
+                },
+                item,
+            })
+        },
+    )
+    .optional()
+    .map_err(TodoError::from_sql)
+}
+
+fn target_from_session(
+    session_scope: &str,
+    user_id: Option<String>,
+    group_id: Option<String>,
+) -> Option<TodoOwner> {
+    let user_id = user_id.filter(|value| !value.trim().is_empty())?;
+    if private_raw_target_from_scope_key(session_scope).is_some() {
+        return Some(TodoStore::owner(Some(&user_id), session_scope));
+    }
+    let actor_suffix = format!(":actor:{user_id}");
+    let conversation_scope = session_scope.strip_suffix(&actor_suffix)?;
+    let raw_group = group_raw_target_from_scope_key(conversation_scope)?;
+    if group_id.as_deref().map(str::trim) != Some(raw_group.as_str()) {
+        return None;
+    }
+    let owner = TodoStore::owner(Some(&user_id), conversation_scope);
+    (owner.key == session_scope).then_some(owner)
+}
+
+fn insert_target(
+    targets: &mut BTreeMap<(String, Option<String>, String), TodoOwner>,
+    target: TodoOwner,
+) {
+    targets
+        .entry((
+            target.key.clone(),
+            target.user_id.clone(),
+            target.scope_key.clone(),
+        ))
+        .or_insert(target);
+}
+
+fn notification_error(error: crate::storage::notification::NotificationError) -> TodoError {
+    TodoError::notification(error.message())
+}

--- a/qq-maid-core/src/runtime/tools/todo/storage/management.rs
+++ b/qq-maid-core/src/runtime/tools/todo/storage/management.rs
@@ -3,12 +3,9 @@
 //! 普通聊天仍只能调用 owner-scoped Repository 方法；本模块只向 Todo 管理 Service
 //! 暴露全局读取，以及 Todo 与 Notification Outbox 的同库事务写入。
 
-use std::collections::BTreeMap;
-
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, params, params_from_iter, types::Value as SqlValue};
 
 use crate::{
-    identity::{group_raw_target_from_scope_key, private_raw_target_from_scope_key},
     runtime::tools::todo::reminder::TODO_REMINDER_SOURCE,
     storage::{
         notification::{NotificationUpsert, cancel_by_source_on_connection, upsert_on_connection},
@@ -17,7 +14,9 @@ use crate::{
 };
 
 use super::{
-    TodoError, TodoItemDraft, TodoManagementRecord, TodoOwner, TodoStatus, TodoStore,
+    TodoError, TodoItemDraft, TodoManagementRecord, TodoManagementScopeType,
+    TodoManagementTargetCandidateFilter, TodoManagementTargetCandidatePage, TodoOwner, TodoStatus,
+    TodoStore,
     id::{clean_todo_id, parse_todo_db_id},
     normalize::normalize_draft,
     query::todo_item_from_row,
@@ -28,6 +27,110 @@ const MANAGEMENT_SELECT: &str = "id, user_id, scope_key, title, detail, raw_text
     due_date, due_at, reminder_at, time_precision, recurrence_kind,
     recurrence_interval_days, recurrence_interval, recurrence_unit, status,
     created_at, updated_at, completed_at, owner_key";
+
+const MANAGEMENT_TARGET_QUERY_MAX_LIMIT: usize = 100;
+
+/// 先把 Todo 事实记录和可完整恢复的 Session 规整成相同的真实 owner/scope 行。
+/// Session 的群聊候选只接受 actor interaction session；共享 conversation session
+/// 不能可靠代表具体成员，不能据此为某个成员创建 Todo。
+const MANAGEMENT_TARGET_CANDIDATES_CTE: &str = r#"
+WITH session_group_candidates(session_scope, user_id, group_id) AS (
+    SELECT TRIM(scope_key), TRIM(user_id), TRIM(group_id)
+    FROM sessions
+    WHERE NULLIF(TRIM(user_id), '') IS NOT NULL
+      AND NULLIF(TRIM(group_id), '') IS NOT NULL
+      AND SUBSTR(
+            TRIM(scope_key),
+            -LENGTH(':actor:' || TRIM(user_id))
+          ) = ':actor:' || TRIM(user_id)
+),
+raw_candidates(owner_key, user_id, scope_key) AS (
+    SELECT owner_key, NULLIF(TRIM(user_id), ''), TRIM(scope_key)
+    FROM todos
+
+    UNION
+
+    SELECT
+        CASE
+            WHEN TRIM(scope_key) GLOB 'platform:?*:account:?*:private:?*'
+                THEN TRIM(scope_key) || ':actor:' || TRIM(user_id)
+            ELSE TRIM(user_id)
+        END,
+        TRIM(user_id),
+        TRIM(scope_key)
+    FROM sessions
+    WHERE NULLIF(TRIM(user_id), '') IS NOT NULL
+      AND (
+            (
+                TRIM(scope_key) GLOB 'platform:?*:account:?*:private:?*'
+                AND SUBSTR(
+                        TRIM(scope_key),
+                        -(LENGTH(TRIM(user_id)) + LENGTH(':private:'))
+                    ) = ':private:' || TRIM(user_id)
+            )
+            OR TRIM(scope_key) = 'private:' || TRIM(user_id)
+          )
+
+    UNION
+
+    SELECT
+        session_scope,
+        user_id,
+        SUBSTR(
+            session_scope,
+            1,
+            LENGTH(session_scope) - LENGTH(':actor:' || user_id)
+        )
+    FROM session_group_candidates
+    WHERE (
+            SUBSTR(
+                session_scope,
+                1,
+                LENGTH(session_scope) - LENGTH(':actor:' || user_id)
+            ) = 'group:' || group_id
+          )
+       OR (
+            SUBSTR(
+                session_scope,
+                1,
+                LENGTH(session_scope) - LENGTH(':actor:' || user_id)
+            ) GLOB 'platform:?*:account:?*:group:?*'
+            AND SUBSTR(
+                    SUBSTR(
+                        session_scope,
+                        1,
+                        LENGTH(session_scope) - LENGTH(':actor:' || user_id)
+                    ),
+                    -(LENGTH(group_id) + LENGTH(':group:'))
+                ) = ':group:' || group_id
+          )
+),
+candidates(owner_key, user_id, scope_key) AS (
+    SELECT DISTINCT owner_key, user_id, scope_key
+    FROM raw_candidates
+    WHERE NULLIF(TRIM(owner_key), '') IS NOT NULL
+      AND NULLIF(TRIM(scope_key), '') IS NOT NULL
+      AND owner_key = CASE
+            WHEN user_id IS NULL THEN scope_key
+            WHEN scope_key GLOB 'platform:?*:account:?*:*:?*'
+                THEN scope_key || ':actor:' || user_id
+            ELSE user_id
+          END
+      AND (
+            (
+                scope_key GLOB 'platform:?*:account:?*:private:?*'
+                AND user_id IS NOT NULL
+                AND SUBSTR(
+                        scope_key,
+                        -(LENGTH(user_id) + LENGTH(':private:'))
+                    ) = ':private:' || user_id
+            )
+            OR scope_key = 'private:' || user_id
+            OR scope_key GLOB 'platform:?*:account:?*:group:?*'
+            OR scope_key GLOB 'group:?*'
+          )
+)
+"#;
 
 impl TodoStore {
     /// 按内部 ID 全局读取 Todo，仅供已通过部署管理员鉴权的领域 Service。
@@ -42,48 +145,60 @@ impl TodoStore {
         get_management_record_unlocked(&conn, id)
     }
 
-    /// 返回服务端已经见过的真实 Todo 目标。Todo 记录是事实来源；Session 只补充
-    /// 已发生过聊天但尚无 Todo 的私聊或群成员交互目标。
-    pub(crate) fn management_target_candidates(&self) -> Result<Vec<TodoOwner>, TodoError> {
+    /// 分页返回服务端已经见过的真实 Todo 目标。Todo 记录是事实来源；Session
+    /// 只补充已发生过聊天但尚无 Todo 的私聊或群成员交互目标。
+    pub(crate) fn management_target_candidates_page(
+        &self,
+        filter: &TodoManagementTargetCandidateFilter,
+        limit: usize,
+        offset: usize,
+    ) -> Result<TodoManagementTargetCandidatePage, TodoError> {
+        if limit == 0 {
+            return Err(TodoError::bad_request(
+                "target page size must be greater than 0",
+            ));
+        }
         let conn = self.connection()?;
-        let mut targets = BTreeMap::<(String, Option<String>, String), TodoOwner>::new();
-        {
-            let mut stmt = conn
-                .prepare("SELECT DISTINCT owner_key, user_id, scope_key FROM todos")
-                .map_err(TodoError::from_sql)?;
-            let rows = stmt
-                .query_map([], |row| {
-                    Ok(TodoOwner {
-                        key: row.get(0)?,
-                        user_id: row.get(1)?,
-                        scope_key: row.get(2)?,
-                    })
-                })
-                .map_err(TodoError::from_sql)?;
-            for target in rows {
-                insert_target(&mut targets, target.map_err(TodoError::from_sql)?);
-            }
-        }
-
-        let mut stmt = conn
-            .prepare("SELECT DISTINCT scope_key, user_id, group_id FROM sessions")
-            .map_err(TodoError::from_sql)?;
-        let rows = stmt
-            .query_map([], |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, Option<String>>(1)?,
-                    row.get::<_, Option<String>>(2)?,
-                ))
+        let (where_sql, params) = management_target_where(filter);
+        let count_sql = format!(
+            "{MANAGEMENT_TARGET_CANDIDATES_CTE}\nSELECT COUNT(*) FROM candidates WHERE {where_sql}"
+        );
+        let total_count = conn
+            .query_row(&count_sql, params_from_iter(params.iter()), |row| {
+                row.get::<_, i64>(0)
             })
+            .map_err(TodoError::from_sql)?
+            .try_into()
+            .map_err(|_| TodoError::data("target candidate count overflow"))?;
+
+        let limit = limit.min(MANAGEMENT_TARGET_QUERY_MAX_LIMIT);
+        let page_sql = format!(
+            "{MANAGEMENT_TARGET_CANDIDATES_CTE}
+             SELECT owner_key, user_id, scope_key
+             FROM candidates
+             WHERE {where_sql}
+             ORDER BY scope_key ASC, user_id ASC, owner_key ASC
+             LIMIT {limit} OFFSET {offset}"
+        );
+        let mut stmt = conn.prepare(&page_sql).map_err(TodoError::from_sql)?;
+        let items = stmt
+            .query_map(params_from_iter(params.iter()), |row| {
+                Ok(TodoOwner {
+                    key: row.get(0)?,
+                    user_id: row.get(1)?,
+                    scope_key: row.get(2)?,
+                })
+            })
+            .map_err(TodoError::from_sql)?
+            .collect::<Result<Vec<_>, _>>()
             .map_err(TodoError::from_sql)?;
-        for row in rows {
-            let (session_scope, user_id, group_id) = row.map_err(TodoError::from_sql)?;
-            if let Some(target) = target_from_session(&session_scope, user_id, group_id) {
-                insert_target(&mut targets, target);
-            }
-        }
-        Ok(targets.into_values().collect())
+
+        Ok(TodoManagementTargetCandidatePage {
+            items,
+            total_count,
+            limit,
+            offset,
+        })
     }
 
     /// 管理创建与 reminder Outbox 在同一个事务内提交。
@@ -243,36 +358,56 @@ fn get_management_record_unlocked(
     .map_err(TodoError::from_sql)
 }
 
-fn target_from_session(
-    session_scope: &str,
-    user_id: Option<String>,
-    group_id: Option<String>,
-) -> Option<TodoOwner> {
-    let user_id = user_id.filter(|value| !value.trim().is_empty())?;
-    if private_raw_target_from_scope_key(session_scope).is_some() {
-        return Some(TodoStore::owner(Some(&user_id), session_scope));
+fn management_target_where(
+    filter: &TodoManagementTargetCandidateFilter,
+) -> (String, Vec<SqlValue>) {
+    let mut clauses = vec!["1 = 1".to_owned()];
+    let mut params = Vec::new();
+    if let Some(platform) = &filter.platform {
+        let stable_prefix = format!("platform:{}:account:%", escape_like(platform));
+        if platform == "qq_official" {
+            clauses.push(
+                "(scope_key LIKE ? ESCAPE '\\' OR scope_key LIKE 'private:%' OR scope_key LIKE 'group:%')"
+                    .to_owned(),
+            );
+        } else {
+            clauses.push("scope_key LIKE ? ESCAPE '\\'".to_owned());
+        }
+        params.push(SqlValue::Text(stable_prefix));
     }
-    let actor_suffix = format!(":actor:{user_id}");
-    let conversation_scope = session_scope.strip_suffix(&actor_suffix)?;
-    let raw_group = group_raw_target_from_scope_key(conversation_scope)?;
-    if group_id.as_deref().map(str::trim) != Some(raw_group.as_str()) {
-        return None;
+    if let Some(account_id) = &filter.account_id {
+        clauses.push("scope_key LIKE ? ESCAPE '\\'".to_owned());
+        params.push(SqlValue::Text(format!(
+            "platform:%:account:{}:%",
+            escape_like(account_id)
+        )));
     }
-    let owner = TodoStore::owner(Some(&user_id), conversation_scope);
-    (owner.key == session_scope).then_some(owner)
+    if let Some(scope_type) = filter.scope_type {
+        let (stable_type, legacy_type) = match scope_type {
+            TodoManagementScopeType::Private => ("private", "private:%"),
+            TodoManagementScopeType::Group => ("group", "group:%"),
+        };
+        clauses.push(format!(
+            "(scope_key LIKE 'platform:%:account:%:{stable_type}:%' OR scope_key LIKE '{legacy_type}')"
+        ));
+    }
+    if let Some(user_id) = &filter.user_id {
+        clauses.push("user_id = ?".to_owned());
+        params.push(SqlValue::Text(user_id.clone()));
+    }
+    if let Some(group_id) = &filter.group_id {
+        clauses.push("(scope_key = ? OR scope_key LIKE ? ESCAPE '\\')".to_owned());
+        params.push(SqlValue::Text(format!("group:{group_id}")));
+        params.push(SqlValue::Text(format!("%:group:{}", escape_like(group_id))));
+    }
+    (clauses.join(" AND "), params)
 }
 
-fn insert_target(
-    targets: &mut BTreeMap<(String, Option<String>, String), TodoOwner>,
-    target: TodoOwner,
-) {
-    targets
-        .entry((
-            target.key.clone(),
-            target.user_id.clone(),
-            target.scope_key.clone(),
-        ))
-        .or_insert(target);
+fn escape_like(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
 }
 
 fn notification_error(error: crate::storage::notification::NotificationError) -> TodoError {

--- a/qq-maid-core/src/runtime/tools/todo/storage/mod.rs
+++ b/qq-maid-core/src/runtime/tools/todo/storage/mod.rs
@@ -19,6 +19,7 @@ use crate::{
 // 拆分出的纯 helper 子模块：均不改变 schema 与对外 API。
 mod delete;
 mod id;
+mod management;
 mod normalize;
 mod query;
 mod query_model;
@@ -55,7 +56,7 @@ mod group_admin_tests;
 use self::id::{
     clean_todo_id, parse_required_todo_db_id, parse_todo_db_id, private_target_from_scope_key,
 };
-use normalize::normalize_draft;
+pub(crate) use normalize::normalize_draft;
 #[cfg(test)]
 use query::query_private_pending_owner_scopes;
 use query::{
@@ -70,10 +71,16 @@ use sort::{
 };
 use write::{complete_pending_unlocked, insert_todo_unlocked, update_pending_todo_unlocked};
 
+pub(crate) use recurrence::{advance_after_completion, is_recurring};
+
 impl TodoStore {
     /// 创建一个新的 TodoStore，复用应用级 SQLite 句柄。
     pub fn new(database: SqliteDatabase) -> Self {
         Self { database }
+    }
+
+    pub(crate) fn database_path(&self) -> &std::path::Path {
+        self.database.path()
     }
 
     /// 构造所有者标识。

--- a/qq-maid-core/src/runtime/tools/todo/storage/normalize.rs
+++ b/qq-maid-core/src/runtime/tools/todo/storage/normalize.rs
@@ -16,7 +16,7 @@ use super::{
 use crate::storage::session::redact_sensitive_text;
 
 /// 规范化待办草稿：校验必填字段、脱敏敏感文本、截断超长文本。
-pub(super) fn normalize_draft(mut draft: TodoItemDraft) -> Result<TodoItemDraft, TodoError> {
+pub(crate) fn normalize_draft(mut draft: TodoItemDraft) -> Result<TodoItemDraft, TodoError> {
     let title = clean_optional(&draft.title)
         .ok_or_else(|| TodoError::bad_request("todo title is required"))?;
     draft.title = truncate_chars(&redact_sensitive_text(title), 120);

--- a/qq-maid-core/src/runtime/tools/todo/storage/query_model.rs
+++ b/qq-maid-core/src/runtime/tools/todo/storage/query_model.rs
@@ -6,8 +6,10 @@
 use rusqlite::{params_from_iter, types::Value as SqlValue};
 
 use super::{
-    TODO_QUERY_MAX_LIMIT, TodoError, TodoListDateField, TodoQuery, TodoQueryPage, TodoQueryStatus,
-    TodoQueryTimeFilter, TodoRecurrenceKind, TodoStatus, TodoStore, query::todo_item_from_row,
+    TODO_QUERY_MAX_LIMIT, TodoError, TodoListDateField, TodoManagementPage, TodoManagementRecord,
+    TodoManagementScopeType, TodoManagementTargetFilter, TodoOwner, TodoQuery, TodoQueryPage,
+    TodoQueryStatus, TodoQueryTimeFilter, TodoRecurrenceKind, TodoStatus, TodoStore,
+    query::todo_item_from_row,
 };
 
 const TODO_MANAGEMENT_QUERY_MAX_LIMIT: usize = 100;
@@ -27,14 +29,54 @@ impl TodoStore {
         self.query_todos_with_max_limit(owner, query, TODO_QUERY_MAX_LIMIT)
     }
 
-    /// 管理 API 复用同一套 Todo 查询条件，但允许使用通用 API 的 100 条分页上限。
-    /// Tool/Slash 的 20 条展示边界保持不变，避免扩大模型上下文。
+    /// 管理 API 独立执行全局查询，不复用任何管理员 actor 作为 Todo owner。
+    /// Tool/Slash 仍走上面的 owner-scoped 入口，20 条展示边界保持不变。
     pub(crate) fn query_todos_for_management(
         &self,
-        owner: &super::TodoOwner,
         query: &TodoQuery,
-    ) -> Result<TodoQueryPage, TodoError> {
-        self.query_todos_with_max_limit(owner, query, TODO_MANAGEMENT_QUERY_MAX_LIMIT)
+        target_filter: &TodoManagementTargetFilter,
+    ) -> Result<TodoManagementPage, TodoError> {
+        validate_todo_query(query)?;
+        let conn = self.connection()?;
+        let (where_sql, params) = build_management_where(query, target_filter);
+        let count_sql = format!("SELECT COUNT(*) FROM todos WHERE {where_sql}");
+        let total_count = conn
+            .query_row(&count_sql, params_from_iter(params.iter()), |row| {
+                row.get::<_, i64>(0)
+            })
+            .map_err(TodoError::from_sql)?
+            .try_into()
+            .map_err(|_| TodoError::data("todo count overflow"))?;
+
+        let limit = query.limit.min(TODO_MANAGEMENT_QUERY_MAX_LIMIT);
+        let order_sql = order_by_sql(query.status);
+        let page_sql = format!(
+            "SELECT {SELECT_COLUMNS}, owner_key FROM todos WHERE {where_sql} {order_sql} LIMIT {limit} OFFSET {}",
+            query.offset
+        );
+        let mut stmt = conn.prepare(&page_sql).map_err(TodoError::from_sql)?;
+        let items = stmt
+            .query_map(params_from_iter(params.iter()), |row| {
+                let item = todo_item_from_row(row)?;
+                Ok(TodoManagementRecord {
+                    owner: TodoOwner {
+                        key: row.get(18)?,
+                        user_id: item.user_id.clone(),
+                        scope_key: item.scope_key.clone(),
+                    },
+                    item,
+                })
+            })
+            .map_err(TodoError::from_sql)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(TodoError::from_sql)?;
+
+        Ok(TodoManagementPage {
+            items,
+            total_count,
+            limit,
+            offset: query.offset,
+        })
     }
 
     fn query_todos_with_max_limit(
@@ -103,6 +145,65 @@ fn build_where(owner: &super::TodoOwner, query: &TodoQuery) -> (String, Vec<SqlV
         SqlValue::Text(owner.key.clone()),
         SqlValue::Text(owner.scope_key.clone()),
     ];
+    append_query_filters(&mut clauses, &mut params, query);
+    (clauses.join(" AND "), params)
+}
+
+fn build_management_where(
+    query: &TodoQuery,
+    filter: &TodoManagementTargetFilter,
+) -> (String, Vec<SqlValue>) {
+    let mut clauses = vec!["1 = 1".to_owned()];
+    let mut params = Vec::new();
+    if let Some(target) = &filter.target {
+        clauses.push("owner_key = ?".to_owned());
+        clauses.push("scope_key = ?".to_owned());
+        params.push(SqlValue::Text(target.key.clone()));
+        params.push(SqlValue::Text(target.scope_key.clone()));
+    }
+    if let Some(user_id) = &filter.user_id {
+        clauses.push("user_id = ?".to_owned());
+        params.push(SqlValue::Text(user_id.clone()));
+    }
+    if let Some(platform) = &filter.platform {
+        let stable_prefix = format!("platform:{}:account:%", escape_like(platform));
+        if platform == "qq_official" {
+            clauses.push(
+                "(scope_key LIKE ? ESCAPE '\\' OR scope_key LIKE 'private:%' OR scope_key LIKE 'group:%' OR scope_key LIKE 'service_account:%')"
+                    .to_owned(),
+            );
+        } else {
+            clauses.push("scope_key LIKE ? ESCAPE '\\'".to_owned());
+        }
+        params.push(SqlValue::Text(stable_prefix));
+    }
+    if let Some(account_id) = &filter.account_id {
+        clauses.push("scope_key LIKE ? ESCAPE '\\'".to_owned());
+        params.push(SqlValue::Text(format!(
+            "platform:%:account:{}:%",
+            escape_like(account_id)
+        )));
+    }
+    if let Some(scope_type) = filter.scope_type {
+        let target_type = match scope_type {
+            TodoManagementScopeType::Private => "private",
+            TodoManagementScopeType::Group => "group",
+        };
+        let legacy_clause = match scope_type {
+            TodoManagementScopeType::Private => {
+                "scope_key LIKE 'private:%' OR scope_key LIKE 'service_account:%'"
+            }
+            TodoManagementScopeType::Group => "scope_key LIKE 'group:%'",
+        };
+        clauses.push(format!(
+            "(scope_key LIKE 'platform:%:account:%:{target_type}:%' OR {legacy_clause})"
+        ));
+    }
+    append_query_filters(&mut clauses, &mut params, query);
+    (clauses.join(" AND "), params)
+}
+
+fn append_query_filters(clauses: &mut Vec<String>, params: &mut Vec<SqlValue>, query: &TodoQuery) {
     match query.status {
         TodoQueryStatus::Pending => {
             clauses.push("status = ?".to_owned());
@@ -115,7 +216,7 @@ fn build_where(owner: &super::TodoOwner, query: &TodoQuery) -> (String, Vec<SqlV
         TodoQueryStatus::All => {}
     }
     if let Some(time) = &query.time {
-        append_time_filter(&mut clauses, &mut params, time);
+        append_time_filter(clauses, params, time);
     }
     if let Some(recurring) = query.recurring {
         clauses.push(if recurring {
@@ -142,7 +243,6 @@ fn build_where(owner: &super::TodoOwner, query: &TodoQuery) -> (String, Vec<SqlV
             )));
         }
     }
-    (clauses.join(" AND "), params)
 }
 
 fn append_time_filter(

--- a/qq-maid-core/src/runtime/tools/todo/storage/query_model.rs
+++ b/qq-maid-core/src/runtime/tools/todo/storage/query_model.rs
@@ -10,6 +10,8 @@ use super::{
     TodoQueryTimeFilter, TodoRecurrenceKind, TodoStatus, TodoStore, query::todo_item_from_row,
 };
 
+const TODO_MANAGEMENT_QUERY_MAX_LIMIT: usize = 100;
+
 const SELECT_COLUMNS: &str = "id, user_id, scope_key, title, detail, raw_text,
     due_date, due_at, reminder_at, time_precision, recurrence_kind,
     recurrence_interval_days, recurrence_interval, recurrence_unit, status,
@@ -21,6 +23,25 @@ impl TodoStore {
         &self,
         owner: &super::TodoOwner,
         query: &TodoQuery,
+    ) -> Result<TodoQueryPage, TodoError> {
+        self.query_todos_with_max_limit(owner, query, TODO_QUERY_MAX_LIMIT)
+    }
+
+    /// 管理 API 复用同一套 Todo 查询条件，但允许使用通用 API 的 100 条分页上限。
+    /// Tool/Slash 的 20 条展示边界保持不变，避免扩大模型上下文。
+    pub(crate) fn query_todos_for_management(
+        &self,
+        owner: &super::TodoOwner,
+        query: &TodoQuery,
+    ) -> Result<TodoQueryPage, TodoError> {
+        self.query_todos_with_max_limit(owner, query, TODO_MANAGEMENT_QUERY_MAX_LIMIT)
+    }
+
+    fn query_todos_with_max_limit(
+        &self,
+        owner: &super::TodoOwner,
+        query: &TodoQuery,
+        max_limit: usize,
     ) -> Result<TodoQueryPage, TodoError> {
         validate_todo_query(query)?;
         let conn = self.connection()?;
@@ -34,7 +55,7 @@ impl TodoStore {
             .try_into()
             .map_err(|_| TodoError::data("todo count overflow"))?;
 
-        let limit = query.limit.min(TODO_QUERY_MAX_LIMIT);
+        let limit = query.limit.min(max_limit);
         let order_sql = order_by_sql(query.status);
         let page_sql = format!(
             "SELECT {SELECT_COLUMNS} FROM todos WHERE {where_sql} {order_sql} LIMIT {limit} OFFSET {}",

--- a/qq-maid-core/src/runtime/tools/todo/storage/types.rs
+++ b/qq-maid-core/src/runtime/tools/todo/storage/types.rs
@@ -256,6 +256,26 @@ pub(crate) struct TodoManagementPage {
     pub offset: usize,
 }
 
+/// 管理控制台发现可创建 Todo 的真实会话目标时使用的筛选。
+///
+/// 这些字段只参与服务端可信候选查询；HTTP 层不能提交 owner_key / scope_key。
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct TodoManagementTargetCandidateFilter {
+    pub platform: Option<String>,
+    pub account_id: Option<String>,
+    pub scope_type: Option<TodoManagementScopeType>,
+    pub user_id: Option<String>,
+    pub group_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TodoManagementTargetCandidatePage {
+    pub items: Vec<TodoOwner>,
+    pub total_count: usize,
+    pub limit: usize,
+    pub offset: usize,
+}
+
 /// 根据查询状态和参数决定时间范围筛哪个业务字段。
 pub fn resolve_todo_list_date_filter(
     status: Option<TodoStatus>,

--- a/qq-maid-core/src/runtime/tools/todo/storage/types.rs
+++ b/qq-maid-core/src/runtime/tools/todo/storage/types.rs
@@ -224,6 +224,38 @@ pub struct TodoQueryPage {
     pub offset: usize,
 }
 
+/// 部署管理员全局查询使用的目标范围；普通聊天查询不会消费这些字段。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TodoManagementScopeType {
+    Private,
+    Group,
+}
+
+/// 管理查询的身份筛选。`target` 只能来自服务端解析并回查成功的 target_ref，
+/// HTTP 请求不能直接拼接 owner_key / scope_key。
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct TodoManagementTargetFilter {
+    pub platform: Option<String>,
+    pub account_id: Option<String>,
+    pub scope_type: Option<TodoManagementScopeType>,
+    pub user_id: Option<String>,
+    pub target: Option<TodoOwner>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TodoManagementRecord {
+    pub owner: TodoOwner,
+    pub item: TodoItem,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TodoManagementPage {
+    pub items: Vec<TodoManagementRecord>,
+    pub total_count: usize,
+    pub limit: usize,
+    pub offset: usize,
+}
+
 /// 根据查询状态和参数决定时间范围筛哪个业务字段。
 pub fn resolve_todo_list_date_filter(
     status: Option<TodoStatus>,
@@ -375,6 +407,20 @@ impl TodoError {
     pub(super) fn not_found(message: impl Into<String>) -> Self {
         Self {
             code: "not_found",
+            message: message.into(),
+        }
+    }
+
+    pub(super) fn conflict(message: impl Into<String>) -> Self {
+        Self {
+            code: "conflict",
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn notification(message: impl Into<String>) -> Self {
+        Self {
+            code: "notification_error",
             message: message.into(),
         }
     }

--- a/qq-maid-core/src/storage/notification.rs
+++ b/qq-maid-core/src/storage/notification.rs
@@ -157,6 +157,10 @@ impl NotificationOutboxStore {
         self.database.clone()
     }
 
+    pub(crate) fn database_path(&self) -> &std::path::Path {
+        self.database.path()
+    }
+
     /// 创建或更新同一个去重键下尚未终结的任务。
     ///
     /// 已发送任务不会被重开，避免业务层重复提交导致同一事件再次推送；若业务确实需要
@@ -167,131 +171,9 @@ impl NotificationOutboxStore {
         &self,
         request: NotificationUpsert,
     ) -> Result<NotificationTask, NotificationError> {
-        validate_upsert(&request)?;
-        let payload_json = serde_json::to_string(&request.payload)
-            .map_err(|err| NotificationError::bad_request(format!("invalid payload: {err}")))?;
-        let now = now_iso_cn();
         {
             let conn = self.connection()?;
-            conn.execute(
-                "INSERT INTO notification_outbox (
-                    source_type, source_id, dedupe_key, platform, account_id, target_type, target_id,
-                    channel, kind, payload_json, scheduled_at, status, attempts, max_attempts,
-                    next_attempt_at, locked_by, locked_at, sent_at, last_error,
-                    created_at, updated_at, cancelled_at
-                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, 0, ?13, NULL, NULL, NULL, NULL, NULL, ?14, ?14, NULL)
-                 ON CONFLICT(dedupe_key) DO UPDATE SET
-                    source_type = CASE
-                        WHEN notification_outbox.status = 'sending' THEN notification_outbox.source_type
-                        ELSE excluded.source_type
-                    END,
-                    source_id = CASE
-                        WHEN notification_outbox.status = 'sending' THEN notification_outbox.source_id
-                        ELSE excluded.source_id
-                    END,
-                    platform = CASE
-                        WHEN notification_outbox.status = 'sending' THEN notification_outbox.platform
-                        ELSE excluded.platform
-                    END,
-                    account_id = CASE
-                        WHEN notification_outbox.status = 'sending' THEN notification_outbox.account_id
-                        ELSE excluded.account_id
-                    END,
-                    target_type = CASE
-                        WHEN notification_outbox.status = 'sending' THEN notification_outbox.target_type
-                        ELSE excluded.target_type
-                    END,
-                    target_id = CASE
-                        WHEN notification_outbox.status = 'sending' THEN notification_outbox.target_id
-                        ELSE excluded.target_id
-                    END,
-                    channel = CASE
-                        WHEN notification_outbox.status = 'sending' THEN notification_outbox.channel
-                        ELSE excluded.channel
-                    END,
-                    kind = CASE
-                        WHEN notification_outbox.status = 'sending' THEN notification_outbox.kind
-                        ELSE excluded.kind
-                    END,
-                    payload_json = CASE
-                        WHEN notification_outbox.status = 'sending' THEN notification_outbox.payload_json
-                        ELSE excluded.payload_json
-                    END,
-                    scheduled_at = CASE
-                        WHEN notification_outbox.status = 'sending' THEN notification_outbox.scheduled_at
-                        ELSE excluded.scheduled_at
-                    END,
-                    status = CASE
-                        WHEN notification_outbox.status = 'sent' THEN notification_outbox.status
-                        WHEN notification_outbox.status = 'sending' THEN notification_outbox.status
-                        WHEN notification_outbox.status = 'cancelled' AND ?15 = 0 THEN notification_outbox.status
-                        ELSE 'pending'
-                    END,
-                    attempts = CASE
-                        WHEN notification_outbox.status = 'sent' THEN notification_outbox.attempts
-                        WHEN notification_outbox.status = 'sending' THEN notification_outbox.attempts
-                        WHEN notification_outbox.status = 'cancelled' AND ?15 = 0 THEN notification_outbox.attempts
-                        ELSE 0
-                    END,
-                    delivered_parts = CASE
-                        WHEN notification_outbox.status = 'sending'
-                            THEN notification_outbox.delivered_parts
-                        WHEN notification_outbox.status IN ('pending', 'retry')
-                            AND notification_outbox.platform = excluded.platform
-                            AND notification_outbox.account_id IS excluded.account_id
-                            AND notification_outbox.target_type = excluded.target_type
-                            AND notification_outbox.target_id = excluded.target_id
-                            AND notification_outbox.channel = excluded.channel
-                            AND notification_outbox.kind = excluded.kind
-                            AND notification_outbox.payload_json = excluded.payload_json
-                            THEN notification_outbox.delivered_parts
-                        ELSE 0
-                    END,
-                    max_attempts = CASE
-                        WHEN notification_outbox.status = 'sending' THEN notification_outbox.max_attempts
-                        ELSE excluded.max_attempts
-                    END,
-                    next_attempt_at = CASE
-                        WHEN notification_outbox.status = 'sending' THEN notification_outbox.next_attempt_at
-                        ELSE NULL
-                    END,
-                    locked_by = CASE
-                        WHEN notification_outbox.status = 'sending' THEN notification_outbox.locked_by
-                        ELSE NULL
-                    END,
-                    locked_at = CASE
-                        WHEN notification_outbox.status = 'sending' THEN notification_outbox.locked_at
-                        ELSE NULL
-                    END,
-                    last_error = CASE
-                        WHEN notification_outbox.status = 'sending' THEN notification_outbox.last_error
-                        ELSE NULL
-                    END,
-                    updated_at = excluded.updated_at,
-                    cancelled_at = CASE
-                        WHEN notification_outbox.status = 'cancelled' AND ?15 <> 0 THEN NULL
-                        ELSE notification_outbox.cancelled_at
-                    END
-                 WHERE notification_outbox.status <> 'sent'",
-                params![
-                    request.source_type,
-                    request.source_id,
-                    request.dedupe_key,
-                    request.target.platform,
-                    request.target.account_id,
-                    request.target.target_type.as_str(),
-                    request.target.target_id,
-                    request.channel,
-                    request.kind,
-                    payload_json,
-                    request.scheduled_at,
-                    NotificationStatus::Pending.as_str(),
-                    i64::from(request.max_attempts),
-                    now,
-                    if request.reactivate_cancelled { 1 } else { 0 },
-                ],
-            )
-            .map_err(NotificationError::from_sql)?;
+            upsert_on_connection(&conn, &request)?;
         }
         self.get_by_dedupe_key(&request.dedupe_key)?
             .ok_or_else(|| NotificationError::io("notification disappeared after upsert"))
@@ -303,25 +185,7 @@ impl NotificationOutboxStore {
         source_id: &str,
     ) -> Result<usize, NotificationError> {
         let conn = self.connection()?;
-        let now = now_iso_cn();
-        conn.execute(
-            "UPDATE notification_outbox
-             SET status = ?3,
-                 updated_at = ?4,
-                 cancelled_at = ?4,
-                 locked_by = NULL,
-                 locked_at = NULL
-             WHERE source_type = ?1
-               AND source_id = ?2
-               AND status IN ('pending', 'retry', 'sending', 'failed')",
-            params![
-                source_type,
-                source_id,
-                NotificationStatus::Cancelled.as_str(),
-                now,
-            ],
-        )
-        .map_err(NotificationError::from_sql)
+        cancel_by_source_on_connection(&conn, source_type, source_id)
     }
 
     /// 取消某类业务来源仍未终结的全部通知。用于业务明确无法跨进程恢复时清理旧快照；
@@ -599,6 +463,164 @@ impl NotificationOutboxStore {
             .connection()
             .map_err(NotificationError::from_database)
     }
+}
+
+/// 让需要跨领域原子写入的业务在自己的 SQLite 事务中复用同一套 Outbox 语义。
+/// 调用方只能传入已经由领域层构造并校验的通知快照，不能自行复制 SQL。
+pub(crate) fn upsert_on_connection(
+    conn: &Connection,
+    request: &NotificationUpsert,
+) -> Result<(), NotificationError> {
+    validate_upsert(request)?;
+    let payload_json = serde_json::to_string(&request.payload)
+        .map_err(|err| NotificationError::bad_request(format!("invalid payload: {err}")))?;
+    let now = now_iso_cn();
+    conn.execute(
+        "INSERT INTO notification_outbox (
+            source_type, source_id, dedupe_key, platform, account_id, target_type, target_id,
+            channel, kind, payload_json, scheduled_at, status, attempts, max_attempts,
+            next_attempt_at, locked_by, locked_at, sent_at, last_error,
+            created_at, updated_at, cancelled_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, 0, ?13, NULL, NULL, NULL, NULL, NULL, ?14, ?14, NULL)
+         ON CONFLICT(dedupe_key) DO UPDATE SET
+            source_type = CASE
+                WHEN notification_outbox.status = 'sending' THEN notification_outbox.source_type
+                ELSE excluded.source_type
+            END,
+            source_id = CASE
+                WHEN notification_outbox.status = 'sending' THEN notification_outbox.source_id
+                ELSE excluded.source_id
+            END,
+            platform = CASE
+                WHEN notification_outbox.status = 'sending' THEN notification_outbox.platform
+                ELSE excluded.platform
+            END,
+            account_id = CASE
+                WHEN notification_outbox.status = 'sending' THEN notification_outbox.account_id
+                ELSE excluded.account_id
+            END,
+            target_type = CASE
+                WHEN notification_outbox.status = 'sending' THEN notification_outbox.target_type
+                ELSE excluded.target_type
+            END,
+            target_id = CASE
+                WHEN notification_outbox.status = 'sending' THEN notification_outbox.target_id
+                ELSE excluded.target_id
+            END,
+            channel = CASE
+                WHEN notification_outbox.status = 'sending' THEN notification_outbox.channel
+                ELSE excluded.channel
+            END,
+            kind = CASE
+                WHEN notification_outbox.status = 'sending' THEN notification_outbox.kind
+                ELSE excluded.kind
+            END,
+            payload_json = CASE
+                WHEN notification_outbox.status = 'sending' THEN notification_outbox.payload_json
+                ELSE excluded.payload_json
+            END,
+            scheduled_at = CASE
+                WHEN notification_outbox.status = 'sending' THEN notification_outbox.scheduled_at
+                ELSE excluded.scheduled_at
+            END,
+            status = CASE
+                WHEN notification_outbox.status = 'sent' THEN notification_outbox.status
+                WHEN notification_outbox.status = 'sending' THEN notification_outbox.status
+                WHEN notification_outbox.status = 'cancelled' AND ?15 = 0 THEN notification_outbox.status
+                ELSE 'pending'
+            END,
+            attempts = CASE
+                WHEN notification_outbox.status = 'sent' THEN notification_outbox.attempts
+                WHEN notification_outbox.status = 'sending' THEN notification_outbox.attempts
+                WHEN notification_outbox.status = 'cancelled' AND ?15 = 0 THEN notification_outbox.attempts
+                ELSE 0
+            END,
+            delivered_parts = CASE
+                WHEN notification_outbox.status = 'sending'
+                    THEN notification_outbox.delivered_parts
+                WHEN notification_outbox.status IN ('pending', 'retry')
+                    AND notification_outbox.platform = excluded.platform
+                    AND notification_outbox.account_id IS excluded.account_id
+                    AND notification_outbox.target_type = excluded.target_type
+                    AND notification_outbox.target_id = excluded.target_id
+                    AND notification_outbox.channel = excluded.channel
+                    AND notification_outbox.kind = excluded.kind
+                    AND notification_outbox.payload_json = excluded.payload_json
+                    THEN notification_outbox.delivered_parts
+                ELSE 0
+            END,
+            max_attempts = CASE
+                WHEN notification_outbox.status = 'sending' THEN notification_outbox.max_attempts
+                ELSE excluded.max_attempts
+            END,
+            next_attempt_at = CASE
+                WHEN notification_outbox.status = 'sending' THEN notification_outbox.next_attempt_at
+                ELSE NULL
+            END,
+            locked_by = CASE
+                WHEN notification_outbox.status = 'sending' THEN notification_outbox.locked_by
+                ELSE NULL
+            END,
+            locked_at = CASE
+                WHEN notification_outbox.status = 'sending' THEN notification_outbox.locked_at
+                ELSE NULL
+            END,
+            last_error = CASE
+                WHEN notification_outbox.status = 'sending' THEN notification_outbox.last_error
+                ELSE NULL
+            END,
+            updated_at = excluded.updated_at,
+            cancelled_at = CASE
+                WHEN notification_outbox.status = 'cancelled' AND ?15 <> 0 THEN NULL
+                ELSE notification_outbox.cancelled_at
+            END
+         WHERE notification_outbox.status <> 'sent'",
+        params![
+            request.source_type.as_str(),
+            request.source_id.as_str(),
+            request.dedupe_key.as_str(),
+            request.target.platform.as_str(),
+            request.target.account_id.as_deref(),
+            request.target.target_type.as_str(),
+            request.target.target_id.as_str(),
+            request.channel.as_str(),
+            request.kind.as_str(),
+            payload_json,
+            request.scheduled_at.as_str(),
+            NotificationStatus::Pending.as_str(),
+            i64::from(request.max_attempts),
+            now,
+            if request.reactivate_cancelled { 1 } else { 0 },
+        ],
+    )
+    .map(|_| ())
+    .map_err(NotificationError::from_sql)
+}
+
+pub(crate) fn cancel_by_source_on_connection(
+    conn: &Connection,
+    source_type: &str,
+    source_id: &str,
+) -> Result<usize, NotificationError> {
+    let now = now_iso_cn();
+    conn.execute(
+        "UPDATE notification_outbox
+         SET status = ?3,
+             updated_at = ?4,
+             cancelled_at = ?4,
+             locked_by = NULL,
+             locked_at = NULL
+         WHERE source_type = ?1
+           AND source_id = ?2
+           AND status IN ('pending', 'retry', 'sending', 'failed')",
+        params![
+            source_type,
+            source_id,
+            NotificationStatus::Cancelled.as_str(),
+            now,
+        ],
+    )
+    .map_err(NotificationError::from_sql)
 }
 
 fn write_outcome(changed: usize) -> NotificationWriteOutcome {


### PR DESCRIPTION
## 变更内容

- 保留现有管理员 Session、Origin、CSRF、限流、请求 ID、分页和统一响应基础设施；`AuthenticatedApiActor` 只用于认证、审计与诊断，不参与 Todo owner/scope 构造。
- 删除 `console_admin:*` owner、`management:console_admin:*` scope 及管理员隔离语义。所有部署管理员查看和管理同一批 QQ、OneBot、微信真实 Todo。
- 新增管理专用全局 Store 查询：列表通过同一组筛选分别执行 SQLite `COUNT(*)` 和 `LIMIT/OFFSET`，按 ID 全局读取后恢复记录自身的真实 owner/scope；普通聊天的 owner-scoped 查询保持不变。
- 创建请求必填服务端生成的不透明 `target_ref`。服务端只从可信 Todo/Session 候选回查并验证平台、账号、用户/群和 owner/scope，不接受客户端提交内部 `owner_key` / `scope_key`。
- Todo 响应增加脱敏 `target` 信息；旧数据无法解析时按单条记录安全降级为 `scope_type=unknown`，不会拖垮全局列表。
- 创建、组合更新、周期推进、提醒替换/取消和删除复用现有 Notification Outbox 与 Push Sink；Todo 和 Outbox 在同一 SQLite 事务中提交，失败整体回滚。
- Todo ID 统一接受正整数 JSON number 或无前导零的正整数十进制字符串，非法值返回 422。
- 更新管理 API、Core README 和开发文档，明确后续 Memory API 只复用公共 Web API 基础设施，不照搬 Todo 所有权模型。

## Reminder 更新语义修复

根因是管理 `update` 在合并补丁与历史记录后，只要最终状态为 `pending` 就无条件执行“提醒必须晚于当前时间”校验，无法区分本次新设提醒与已发送后保留的历史 `reminder_at`。领域层 `prepare_reminder_upsert` 对过期提醒的既有语义是返回 `None`、不再排程，因此管理前置校验比领域语义更严格，导致仅修改标题/详情也返回 422。

修复后的规则：

- 创建时，非空 `reminder_at` 必须晚于当前时间，并且真实目标平台必须支持主动提醒。
- 更新时，本次显式设置的新非空 reminder 必须校验未来时间和平台能力；即使同一请求还会完成 Todo，也不能用状态转换绕过过去时间校验。
- 显式清空 reminder 允许执行，并在同一事务内取消旧未终结 Outbox。
- 未修改 reminder 时允许继承历史值；过期历史值继续保留在 Todo 和响应中，但不重新创建 Outbox，也不阻止标题、详情或日期更新。
- 完成 Todo 会取消旧未终结提醒，不校验继承的历史 reminder 是否过期；恢复为 `pending` 时沿用领域语义，过期值保留但不重新排程。

## 目标发现接口

新增统一 POST 路由：

```text
POST /api/v1/console/todo/targets
```

- 复用管理员 Session、Origin、CSRF、限流、请求 ID、统一 envelope 和公共分页协议。
- 数据来自服务端可信的 Todo/Session 目标候选，通过 SQLite `COUNT(*)` 与 `LIMIT/OFFSET` 分页，不全量加载 Session 后在内存切片。
- 支持 `platform`、`account_id`、`scope_type`、`user_id`、`group_id` 精确筛选。
- 返回 `target_ref`、`platform`、`account_id`、`scope_type`、`user_id`、`group_id`、`reminder_supported`。
- 不返回 owner/scope 内部 key、Cookie、Token 等敏感字段；同一真实 owner/scope 去重，无法完整恢复的旧目标不作为可创建目标返回。
- Session 已存在但尚无 Todo 时，网页端可先发现 `target_ref`，再用它创建第一条 Todo；目标发现未注册为普通聊天 Tool。

## 提醒与平台边界

- QQ 官方和 OneBot 11 私聊/群聊继续走现有主动推送链路。
- 微信服务号目前不在统一主动 Push Sink 中；普通 Todo 可管理，目标发现返回 `reminder_supported=false`，显式创建/更新 reminder 会在写库前返回 422。
- 未执行真实 QQ / OneBot / 微信登录与真机推送烟测；本 PR 不以自动化测试替代真实平台结论。

## 测试覆盖

- 一次性提醒已发送且 `reminder_at` 已过去时，仅修改标题成功且不新建 Outbox。
- 显式设置过去 reminder（包括同时完成 Todo）返回 422，Todo 保持不变；显式清空成功。
- 带过去 reminder 的完成、恢复和未终结 Outbox 取消保持原子语义。
- Session-only 私聊目标可发现并创建第一条 Todo；群目标恢复正确成员 owner 和群 target；微信目标报告不支持提醒。
- 目标分页、平台/账号/作用域/用户/群筛选、去重、鉴权、CSRF、请求 ID，以及普通聊天 Tool Registry 隔离。
- 多管理员共享全局数据、非法目标/ID、Outbox 失败回滚、周期推进和 owner-scoped 普通聊天边界。
- Todo API 测试拆为 `tests/mod.rs`、`tests/reminders.rs` 和 `tests/targets.rs`，单文件均保持在 1000 行以内。

## 本地验证

- `cargo test -p qq-maid-core --all-features`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace --release --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`

以上本地检查均通过。
