### PR TITLE
fix: 修复 QQ 一级图文引用与 Tool Loop 媒体预算

### DIFF
--- a/qq-maid-gateway-rs/src/gateway/event/content_normalizer.rs
+++ b/qq-maid-gateway-rs/src/gateway/event/content_normalizer.rs
@@ -19,6 +19,7 @@ const MESSAGE_TYPE_ARK: u64 = 3;
 const MESSAGE_TYPE_PARALLEL: u64 = 101;
 const MESSAGE_TYPE_CHAT_HISTORY: u64 = 102;
 const MESSAGE_TYPE_QUOTE: u64 = 103;
+pub(super) const MAX_NORMALIZED_MEDIA_PARTS: usize = 32;
 
 #[derive(Debug, Clone, Copy)]
 struct NormalizerLimits {
@@ -34,7 +35,7 @@ impl Default for NormalizerLimits {
             max_depth: 8,
             max_nodes: 256,
             max_text_chars: 16_000,
-            max_media: 32,
+            max_media: MAX_NORMALIZED_MEDIA_PARTS,
         }
     }
 }

--- a/qq-maid-gateway-rs/src/gateway/event/quoted_payload.rs
+++ b/qq-maid-gateway-rs/src/gateway/event/quoted_payload.rs
@@ -3,7 +3,8 @@
 //! 根据 QQ 最新消息结构文档：
 //! - 顶层 `content` 是当前用户本轮发送的正文。
 //! - `message_type = 103` 时的顶层 `msg_elements` 是本轮直接引用目标的内容元素。
-//! - 元素内部的 `msg_elements` 属于更早的历史引用，只生成固定摘要，不恢复其中媒体。
+//! - 元素内部的 `msg_elements` 属于更早的历史引用，不递归恢复其中正文或媒体。
+//! - QQ 拍平到顶层元素 `content` 的展示文本按普通引用文本保留，不解释其中字段。
 //! - 不再要求元素的 `msg_idx` 必须等于 `ref_msg_idx`（官方事件不保证携带 `msg_idx`）。
 //! - `ref_msg_idx` 仅用于 RefIndex 查询和引用元数据展示。
 
@@ -16,8 +17,6 @@ use crate::gateway::ref_index::qq::{MSG_TYPE_QUOTE, RawMsgElement};
 
 use super::content_normalizer::MAX_NORMALIZED_MEDIA_PARTS;
 use super::{input_parts_from_content_and_attachments, parse_safe_content_parts};
-
-const NESTED_QUOTE_SUMMARY: &str = "历史引用摘要：该消息还引用了更早的消息，历史内容和媒体未展开。";
 
 /// 使用归一化后的当前正文检测并移除 `QuotedMessageContext` 中被污染的引用文字。
 ///
@@ -77,7 +76,8 @@ pub(crate) fn strip_contaminated_quote_from_context(
 /// 当 `message_type == 103` 时，按原始顺序解析顶层 `msg_elements` 作为直接引用内容。
 ///
 /// 无论元素是否携带 `msg_idx`，该层的文字和全部附件均组成引用内容；子元素只表示
-/// 更早的历史引用，不递归恢复其 URL、Base64 或媒体对象。
+/// 更早的结构化历史引用，不递归恢复。平台拍平到该层 `content` 的展示文本仍按普通
+/// 引用文本保留，不提取其中的附件描述或临时 URL。
 /// `ref_msg_idx` 不参与元素筛选；调用方自行决定是否用于 RefIndex 查询和元数据展示。
 pub(super) fn parse_quoted_message_elements(
     message_type: Option<u64>,
@@ -137,12 +137,23 @@ fn append_direct_quoted_element_parts(
     input_parts: &mut Vec<MessageInputPart>,
 ) {
     let raw_content = element.content.as_deref().unwrap_or_default();
-    let cleaned_content = strip_qq_image_placeholders(raw_content);
+    // 只有同层确实携带结构化附件时，`[图片]` 才作为附件顺序占位符处理。
+    // 拍平引用展示文本没有结构化附件，必须整体按普通文本保留，不能据此恢复媒体。
+    let has_structured_attachments = !element.attachments.is_empty();
+    let cleaned_content = if has_structured_attachments {
+        strip_qq_image_placeholders(raw_content)
+    } else {
+        raw_content.trim().to_owned()
+    };
     let summary_content = parse_safe_content_parts(&cleaned_content, "qq_official")
         .text
         .trim()
         .to_owned();
-    let protocol_content = raw_content.replace("[图片]", "<img>");
+    let protocol_content = if has_structured_attachments {
+        raw_content.replace("[图片]", "<img>")
+    } else {
+        raw_content.to_owned()
+    };
     let parsed = parse_safe_content_parts(&protocol_content, "qq_official");
     if !summary_content.is_empty() {
         content_fragments.push(summary_content);
@@ -167,15 +178,8 @@ fn append_direct_quoted_element_parts(
         .retain(|part| !matches!(part, MessageInputPart::Text { text, .. } if text.is_empty()));
     input_parts.extend(element_parts);
 
-    if !element.msg_elements.is_empty() {
-        // 内层拍平文本可能包含临时下载 URL、rkey 或 auth_token，因此不提取任何
-        // 子元素字段，只提供固定摘要。第一次视觉分析应由会话历史承接。
-        content_fragments.push(NESTED_QUOTE_SUMMARY.to_owned());
-        input_parts.push(MessageInputPart::Text {
-            text: NESTED_QUOTE_SUMMARY.to_owned(),
-            source: Some(TextSource::Quote),
-        });
-    }
+    // `element.msg_elements` 是更早的结构化引用：不递归访问即可阻止历史媒体恢复。
+    // 若 QQ 已把二次引用展示拍平进本层 `content`，上面的普通文本路径会原样保留它。
 }
 
 fn strip_qq_image_placeholders(value: &str) -> String {

--- a/qq-maid-gateway-rs/src/gateway/event/quoted_payload.rs
+++ b/qq-maid-gateway-rs/src/gateway/event/quoted_payload.rs
@@ -1,18 +1,23 @@
-//! QQ 引用消息 msg_elements 递归解析。
+//! QQ 引用消息直接引用层解析。
 //!
 //! 根据 QQ 最新消息结构文档：
 //! - 顶层 `content` 是当前用户本轮发送的正文。
-//! - `message_type = 103` 时的 `msg_elements` 是引用消息的内容元素，可递归嵌套。
+//! - `message_type = 103` 时的顶层 `msg_elements` 是本轮直接引用目标的内容元素。
+//! - 元素内部的 `msg_elements` 属于更早的历史引用，只生成固定摘要，不恢复其中媒体。
 //! - 不再要求元素的 `msg_idx` 必须等于 `ref_msg_idx`（官方事件不保证携带 `msg_idx`）。
 //! - `ref_msg_idx` 仅用于 RefIndex 查询和引用元数据展示。
 
 use qq_maid_common::input_part::{
     MessageInputPart, QuotedMediaSummary, QuotedMessageContext, TextSource,
 };
+use tracing::debug;
 
 use crate::gateway::ref_index::qq::{MSG_TYPE_QUOTE, RawMsgElement};
 
+use super::content_normalizer::MAX_NORMALIZED_MEDIA_PARTS;
 use super::{input_parts_from_content_and_attachments, parse_safe_content_parts};
+
+const NESTED_QUOTE_SUMMARY: &str = "历史引用摘要：该消息还引用了更早的消息，历史内容和媒体未展开。";
 
 /// 使用归一化后的当前正文检测并移除 `QuotedMessageContext` 中被污染的引用文字。
 ///
@@ -69,9 +74,10 @@ pub(crate) fn strip_contaminated_quote_from_context(
     }
 }
 
-/// 当 `message_type == 103` 时，按原始顺序递归解析全部 `msg_elements` 作为引用内容。
+/// 当 `message_type == 103` 时，按原始顺序解析顶层 `msg_elements` 作为直接引用内容。
 ///
-/// 无论元素是否携带 `msg_idx`，所有文字、附件及嵌套子元素均组成引用内容。
+/// 无论元素是否携带 `msg_idx`，该层的文字和全部附件均组成引用内容；子元素只表示
+/// 更早的历史引用，不递归恢复其 URL、Base64 或媒体对象。
 /// `ref_msg_idx` 不参与元素筛选；调用方自行决定是否用于 RefIndex 查询和元数据展示。
 pub(super) fn parse_quoted_message_elements(
     message_type: Option<u64>,
@@ -85,8 +91,9 @@ pub(super) fn parse_quoted_message_elements(
     let mut input_parts = Vec::new();
 
     for element in msg_elements {
-        append_quoted_element_parts(element, &mut content_fragments, &mut input_parts);
+        append_direct_quoted_element_parts(element, &mut content_fragments, &mut input_parts);
     }
+    retain_direct_quoted_media_with_limit(&mut input_parts);
 
     let content = content_fragments.join("\n");
     let media_summaries = input_parts
@@ -101,36 +108,73 @@ pub(super) fn parse_quoted_message_elements(
     }
 }
 
-fn append_quoted_element_parts(
+fn retain_direct_quoted_media_with_limit(input_parts: &mut Vec<MessageInputPart>) {
+    let mut media_count = 0usize;
+    let original_media_count = input_parts.iter().filter(|part| part.is_non_text()).count();
+    input_parts.retain(|part| {
+        if !part.is_non_text() {
+            return true;
+        }
+        if media_count >= MAX_NORMALIZED_MEDIA_PARTS {
+            return false;
+        }
+        media_count += 1;
+        true
+    });
+    if original_media_count > media_count {
+        debug!(
+            media_count,
+            original_media_count,
+            max_media = MAX_NORMALIZED_MEDIA_PARTS,
+            "QQ direct quote media truncated by normalization limit"
+        );
+    }
+}
+
+fn append_direct_quoted_element_parts(
     element: &RawMsgElement,
     content_fragments: &mut Vec<String>,
     input_parts: &mut Vec<MessageInputPart>,
 ) {
     let raw_content = element.content.as_deref().unwrap_or_default();
     let cleaned_content = strip_qq_image_placeholders(raw_content);
-    let parsed = parse_safe_content_parts(&cleaned_content, "qq_official");
-    let element_content = parsed.text.trim().to_owned();
-    if !element_content.is_empty() {
-        content_fragments.push(element_content.clone());
+    let summary_content = parse_safe_content_parts(&cleaned_content, "qq_official")
+        .text
+        .trim()
+        .to_owned();
+    let protocol_content = raw_content.replace("[图片]", "<img>");
+    let parsed = parse_safe_content_parts(&protocol_content, "qq_official");
+    if !summary_content.is_empty() {
+        content_fragments.push(summary_content);
     }
 
     let mut element_parts = input_parts_from_content_and_attachments(
-        &element_content,
+        &parsed.text,
         parsed.input_parts,
         &element.attachments,
         "qq_official",
         TextSource::Quote,
     );
     for part in &mut element_parts {
-        if let MessageInputPart::Text { source, .. } = part {
+        if let MessageInputPart::Text { text, source } = part {
+            // QQ 会在 `[图片]` 占位符两侧注入展示空格；结构化拆分后清理段落边界，
+            // 避免模型看到仅由平台布局产生的前导/尾随空白。
+            *text = text.trim().to_owned();
             *source = Some(TextSource::Quote);
         }
     }
+    element_parts
+        .retain(|part| !matches!(part, MessageInputPart::Text { text, .. } if text.is_empty()));
     input_parts.extend(element_parts);
 
-    // 递归解析嵌套子元素（图文引用可能含多级嵌套）。
-    for child in &element.msg_elements {
-        append_quoted_element_parts(child, content_fragments, input_parts);
+    if !element.msg_elements.is_empty() {
+        // 内层拍平文本可能包含临时下载 URL、rkey 或 auth_token，因此不提取任何
+        // 子元素字段，只提供固定摘要。第一次视觉分析应由会话历史承接。
+        content_fragments.push(NESTED_QUOTE_SUMMARY.to_owned());
+        input_parts.push(MessageInputPart::Text {
+            text: NESTED_QUOTE_SUMMARY.to_owned(),
+            source: Some(TextSource::Quote),
+        });
     }
 }
 

--- a/qq-maid-gateway-rs/src/gateway/event/quoted_payload.rs
+++ b/qq-maid-gateway-rs/src/gateway/event/quoted_payload.rs
@@ -16,7 +16,10 @@ use tracing::debug;
 use crate::gateway::ref_index::qq::{MSG_TYPE_QUOTE, RawMsgElement};
 
 use super::content_normalizer::MAX_NORMALIZED_MEDIA_PARTS;
-use super::{input_parts_from_content_and_attachments, parse_safe_content_parts};
+use super::{
+    AttachmentKind, attachment_kind, input_parts_from_content_and_attachments,
+    parse_safe_content_parts,
+};
 
 /// 使用归一化后的当前正文检测并移除 `QuotedMessageContext` 中被污染的引用文字。
 ///
@@ -137,35 +140,47 @@ fn append_direct_quoted_element_parts(
     input_parts: &mut Vec<MessageInputPart>,
 ) {
     let raw_content = element.content.as_deref().unwrap_or_default();
-    // 只有同层确实携带结构化附件时，`[图片]` 才作为附件顺序占位符处理。
-    // 拍平引用展示文本没有结构化附件，必须整体按普通文本保留，不能据此恢复媒体。
-    let has_structured_attachments = !element.attachments.is_empty();
-    let cleaned_content = if has_structured_attachments {
-        strip_qq_image_placeholders(raw_content)
+    // 只有同层确实携带结构化图片附件时，`[图片]` 才作为附件顺序占位符处理。
+    // 文件或音频不能打开媒体标记解析，否则拍平文本中的 `[图片]` / `<img>` 会伪造图片。
+    let has_structured_image_attachment = element.attachments.iter().any(|attachment| {
+        attachment_kind(
+            attachment.content_type.as_deref(),
+            attachment.filename.as_deref(),
+        ) == AttachmentKind::Image
+    });
+    let (summary_content, mut element_parts) = if has_structured_image_attachment {
+        let cleaned_content = strip_qq_image_placeholders(raw_content);
+        let summary_content = parse_safe_content_parts(&cleaned_content, "qq_official")
+            .text
+            .trim()
+            .to_owned();
+        let protocol_content = raw_content.replace("[图片]", "<img>");
+        let parsed = parse_safe_content_parts(&protocol_content, "qq_official");
+        let element_parts = input_parts_from_content_and_attachments(
+            &parsed.text,
+            parsed.input_parts,
+            &element.attachments,
+            "qq_official",
+            TextSource::Quote,
+        );
+        (summary_content, element_parts)
     } else {
-        raw_content.trim().to_owned()
+        // 无同层结构化图片时完全绕过 `<img>` 解析器；正文仅做既有的边界空白清理，
+        // 文件、音频等附件仍由统一附件转换逻辑追加为原有类型。
+        let plain_content = raw_content.trim().to_owned();
+        let element_parts = input_parts_from_content_and_attachments(
+            &plain_content,
+            Vec::new(),
+            &element.attachments,
+            "qq_official",
+            TextSource::Quote,
+        );
+        (plain_content, element_parts)
     };
-    let summary_content = parse_safe_content_parts(&cleaned_content, "qq_official")
-        .text
-        .trim()
-        .to_owned();
-    let protocol_content = if has_structured_attachments {
-        raw_content.replace("[图片]", "<img>")
-    } else {
-        raw_content.to_owned()
-    };
-    let parsed = parse_safe_content_parts(&protocol_content, "qq_official");
     if !summary_content.is_empty() {
         content_fragments.push(summary_content);
     }
 
-    let mut element_parts = input_parts_from_content_and_attachments(
-        &parsed.text,
-        parsed.input_parts,
-        &element.attachments,
-        "qq_official",
-        TextSource::Quote,
-    );
     for part in &mut element_parts {
         if let MessageInputPart::Text { text, source } = part {
             // QQ 会在 `[图片]` 占位符两侧注入展示空格；结构化拆分后清理段落边界，

--- a/qq-maid-gateway-rs/src/gateway/event/tests/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/event/tests/mod.rs
@@ -809,7 +809,7 @@ fn msg_elements_are_all_treated_as_quote_content() {
 }
 
 #[test]
-fn nested_quoted_elements_from_single_root_keep_text_and_media_order() {
+fn nested_quoted_elements_from_single_root_only_keep_direct_layer() {
     let envelope = GatewayEnvelope {
         op: 0,
         s: None,
@@ -859,15 +859,18 @@ fn nested_quoted_elements_from_single_root_keep_text_and_media_order() {
             .iter()
             .any(|item| item.filename.as_deref() == Some("current.png"))
     );
-    assert_eq!(reply.content.as_deref(), Some("引用第一段\n引用第二段"));
-    assert_eq!(reply.input_parts[0].text_content(), Some("引用第一段"));
-    assert_eq!(reply.input_parts[1].text_content(), Some("引用第二段"));
     assert_eq!(
-        reply.input_parts[2]
-            .media()
-            .and_then(|media| media.filename.as_deref()),
-        Some("quoted.png")
+        reply.content.as_deref(),
+        Some("引用第一段\n历史引用摘要：该消息还引用了更早的消息，历史内容和媒体未展开。")
     );
+    assert_eq!(reply.input_parts[0].text_content(), Some("引用第一段"));
+    assert!(
+        reply.input_parts[1]
+            .text_content()
+            .is_some_and(|text| text.contains("历史引用摘要"))
+    );
+    assert_eq!(reply.input_parts.len(), 2);
+    assert!(reply.media_summaries.is_empty());
     assert!(!reply.input_parts.iter().any(|part| {
         part.media().and_then(|media| media.filename.as_deref()) == Some("current.png")
     }));
@@ -893,21 +896,21 @@ fn quoted_images_keep_original_order() {
                 "attachments": [
                     {
                         "content_type": "image/png",
-                        "filename": "same.png",
+                        "filename": "first.png",
                         "size": 123,
                         "url": "https://example.test/1.png",
                         "fileid": "file-1"
                     },
                     {
                         "content_type": "image/png",
-                        "filename": "same.png",
+                        "filename": "second.png",
                         "size": 123,
                         "url": "https://example.test/2.png",
                         "fileid": "file-2"
                     },
                     {
                         "content_type": "image/png",
-                        "filename": "same.png",
+                        "filename": "third.png",
                         "size": 123,
                         "url": "https://example.test/3.png",
                         "fileid": "file-3"
@@ -921,6 +924,26 @@ fn quoted_images_keep_original_order() {
     let reply = message.reply.unwrap();
 
     assert_eq!(reply.content.as_deref(), Some("结构化正文"));
+    assert_eq!(reply.input_parts.len(), 4);
+    assert_eq!(
+        reply.input_parts[0]
+            .media()
+            .and_then(|media| media.file_id.as_deref()),
+        Some("file-1")
+    );
+    assert_eq!(
+        reply.input_parts[1]
+            .media()
+            .and_then(|media| media.file_id.as_deref()),
+        Some("file-2")
+    );
+    assert_eq!(
+        reply.input_parts[2]
+            .media()
+            .and_then(|media| media.file_id.as_deref()),
+        Some("file-3")
+    );
+    assert_eq!(reply.input_parts[3].text_content(), Some("结构化正文"));
     let images = reply
         .input_parts
         .iter()

--- a/qq-maid-gateway-rs/src/gateway/event/tests/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/event/tests/mod.rs
@@ -859,17 +859,9 @@ fn nested_quoted_elements_from_single_root_only_keep_direct_layer() {
             .iter()
             .any(|item| item.filename.as_deref() == Some("current.png"))
     );
-    assert_eq!(
-        reply.content.as_deref(),
-        Some("引用第一段\n历史引用摘要：该消息还引用了更早的消息，历史内容和媒体未展开。")
-    );
+    assert_eq!(reply.content.as_deref(), Some("引用第一段"));
     assert_eq!(reply.input_parts[0].text_content(), Some("引用第一段"));
-    assert!(
-        reply.input_parts[1]
-            .text_content()
-            .is_some_and(|text| text.contains("历史引用摘要"))
-    );
-    assert_eq!(reply.input_parts.len(), 2);
+    assert_eq!(reply.input_parts.len(), 1);
     assert!(reply.media_summaries.is_empty());
     assert!(!reply.input_parts.iter().any(|part| {
         part.media().and_then(|media| media.filename.as_deref()) == Some("current.png")

--- a/qq-maid-gateway-rs/src/gateway/event/tests/quote_boundary.rs
+++ b/qq-maid-gateway-rs/src/gateway/event/tests/quote_boundary.rs
@@ -177,7 +177,7 @@ fn missing_ref_msg_idx_keeps_quoted_payload() {
     assert_eq!(reply.input_parts[0].text_content(), Some("引用内容"));
 }
 
-/// 嵌套图文引用：只保留直接层正文和固定历史摘要，不恢复内层媒体。
+/// 嵌套结构化图文引用：只保留直接层正文，不递归恢复内层正文或媒体。
 #[test]
 fn nested_text_image_quote_stops_before_historical_media() {
     let envelope = GatewayEnvelope {
@@ -231,18 +231,10 @@ fn nested_text_image_quote_stops_before_historical_media() {
             .any(|item| item.filename.as_deref() == Some("current.png"))
     );
 
-    // 直接层正文保留，子元素只生成安全摘要；临时 URL 与媒体对象均不恢复。
-    assert_eq!(
-        reply.content.as_deref(),
-        Some("图前文字\n历史引用摘要：该消息还引用了更早的消息，历史内容和媒体未展开。")
-    );
+    // 直接层正文保留，子元素不递归解析；内层结构化媒体不会被恢复。
+    assert_eq!(reply.content.as_deref(), Some("图前文字"));
     assert_eq!(reply.input_parts[0].text_content(), Some("图前文字"));
-    assert!(
-        reply.input_parts[1]
-            .text_content()
-            .is_some_and(|text| text.contains("历史引用摘要"))
-    );
-    assert_eq!(reply.input_parts.len(), 2);
+    assert_eq!(reply.input_parts.len(), 1);
     assert!(reply.media_summaries.is_empty());
     assert!(
         !reply

--- a/qq-maid-gateway-rs/src/gateway/event/tests/quote_boundary.rs
+++ b/qq-maid-gateway-rs/src/gateway/event/tests/quote_boundary.rs
@@ -304,6 +304,99 @@ fn direct_text_and_multiple_images_keep_placeholder_order() {
     assert_eq!(parts[4].text_content(), Some("图后"));
 }
 
+/// 单张结构化图片同样启用占位顺序解析，避免收紧条件后退化为尾部附件。
+#[test]
+fn direct_text_and_single_image_keeps_placeholder_order() {
+    let envelope = GatewayEnvelope {
+        op: 0,
+        s: None,
+        t: Some(EVENT_GROUP_MESSAGE_CREATE.to_owned()),
+        id: None,
+        d: json!({
+            "id": "msg-current",
+            "group_openid": "group-1",
+            "author": {"member_openid": "member-1"},
+            "content": "解释图片",
+            "message_type": 103,
+            "message_scene": {"ext": ["ref_msg_idx=TMP_quoted"]},
+            "msg_elements": [{
+                "content": "图前[图片]图后",
+                "attachments": [{
+                    "content_type": "image/png",
+                    "filename": "quoted.png",
+                    "url": "https://example.test/quoted.png",
+                    "fileid": "file-quoted"
+                }]
+            }]
+        }),
+    };
+
+    let message = parse_group_message(&envelope).unwrap().unwrap();
+    let parts = message.reply.unwrap().input_parts;
+
+    assert_eq!(parts.len(), 3);
+    assert_eq!(parts[0].text_content(), Some("图前"));
+    assert_eq!(
+        parts[1].media().and_then(|media| media.file_id.as_deref()),
+        Some("file-quoted")
+    );
+    assert_eq!(parts[2].text_content(), Some("图后"));
+}
+
+/// 文件或音频附件不代表正文中的 `[图片]` 有对应结构化图片，必须按普通文本保留。
+#[test]
+fn non_image_attachments_do_not_enable_image_placeholder_parsing() {
+    let envelope = GatewayEnvelope {
+        op: 0,
+        s: None,
+        t: Some(EVENT_GROUP_MESSAGE_CREATE.to_owned()),
+        id: None,
+        d: json!({
+            "id": "msg-current",
+            "group_openid": "group-1",
+            "author": {"member_openid": "member-1"},
+            "content": "检查附件",
+            "message_type": 103,
+            "message_scene": {"ext": ["ref_msg_idx=TMP_quoted"]},
+            "msg_elements": [{
+                "content": "原文[图片]结尾",
+                "attachments": [
+                    {
+                        "content_type": "application/pdf",
+                        "filename": "document.pdf",
+                        "url": "https://example.test/document.pdf"
+                    },
+                    {
+                        "content_type": "audio/ogg",
+                        "filename": "voice.ogg",
+                        "url": "https://example.test/voice.ogg"
+                    }
+                ]
+            }]
+        }),
+    };
+
+    let message = parse_group_message(&envelope).unwrap().unwrap();
+    let reply = message.reply.unwrap();
+
+    assert_eq!(reply.content.as_deref(), Some("原文[图片]结尾"));
+    assert_eq!(reply.input_parts[0].text_content(), Some("原文[图片]结尾"));
+    assert_eq!(
+        reply
+            .input_parts
+            .iter()
+            .filter(|part| matches!(part, MessageInputPart::File { .. }))
+            .count(),
+        2
+    );
+    assert!(
+        !reply
+            .input_parts
+            .iter()
+            .any(|part| matches!(part, MessageInputPart::Image { .. }))
+    );
+}
+
 #[test]
 fn direct_quote_media_keeps_existing_normalization_count_limit() {
     let attachments = (0..34)

--- a/qq-maid-gateway-rs/src/gateway/event/tests/quote_boundary.rs
+++ b/qq-maid-gateway-rs/src/gateway/event/tests/quote_boundary.rs
@@ -177,9 +177,9 @@ fn missing_ref_msg_idx_keeps_quoted_payload() {
     assert_eq!(reply.input_parts[0].text_content(), Some("引用内容"));
 }
 
-/// 嵌套图文引用：验证递归顺序和媒体归属。
+/// 嵌套图文引用：只保留直接层正文和固定历史摘要，不恢复内层媒体。
 #[test]
-fn nested_text_image_quote_keeps_order_and_does_not_mix_with_current_attachments() {
+fn nested_text_image_quote_stops_before_historical_media() {
     let envelope = GatewayEnvelope {
         op: 0,
         s: None,
@@ -231,25 +231,126 @@ fn nested_text_image_quote_keeps_order_and_does_not_mix_with_current_attachments
             .any(|item| item.filename.as_deref() == Some("current.png"))
     );
 
-    // 引用内容按递归顺序：图前文字 → 图中图片 → 图后文字。
+    // 直接层正文保留，子元素只生成安全摘要；临时 URL 与媒体对象均不恢复。
     assert_eq!(
         reply.content.as_deref(),
-        Some("图前文字\n图中图片\n图后文字")
+        Some("图前文字\n历史引用摘要：该消息还引用了更早的消息，历史内容和媒体未展开。")
     );
     assert_eq!(reply.input_parts[0].text_content(), Some("图前文字"));
-    assert_eq!(reply.input_parts[1].text_content(), Some("图中图片"));
-    assert_eq!(
-        reply.input_parts[2]
-            .media()
-            .and_then(|media| media.filename.as_deref()),
-        Some("quoted.png")
+    assert!(
+        reply.input_parts[1]
+            .text_content()
+            .is_some_and(|text| text.contains("历史引用摘要"))
     );
-    assert_eq!(reply.input_parts[3].text_content(), Some("图后文字"));
+    assert_eq!(reply.input_parts.len(), 2);
+    assert!(reply.media_summaries.is_empty());
+    assert!(
+        !reply
+            .input_parts
+            .iter()
+            .map(MessageInputPart::fallback_text)
+            .any(|text| text.contains("example.test") || text.contains("quoted.png"))
+    );
 
     // 引用附件不会进入当前消息。
     assert!(!reply.input_parts.iter().any(|part| {
         part.media().and_then(|media| media.filename.as_deref()) == Some("current.png")
     }));
+}
+
+/// QQ 的 `[图片]` 占位与 attachments 一一对应；直接层图文必须按占位顺序进入模型。
+#[test]
+fn direct_text_and_multiple_images_keep_placeholder_order() {
+    let envelope = GatewayEnvelope {
+        op: 0,
+        s: None,
+        t: Some(EVENT_GROUP_MESSAGE_CREATE.to_owned()),
+        id: None,
+        d: json!({
+            "id": "msg-current",
+            "group_openid": "group-1",
+            "author": {"member_openid": "member-1"},
+            "content": "按顺序解释",
+            "message_type": 103,
+            "message_scene": {"ext": ["ref_msg_idx=TMP_quoted"]},
+            "msg_elements": [{
+                "content": "图前[图片]图中[图片]图后",
+                "attachments": [
+                    {
+                        "content_type": "image/png",
+                        "filename": "first.png",
+                        "size": 123,
+                        "url": "https://example.test/1.png",
+                        "fileid": "file-1"
+                    },
+                    {
+                        "content_type": "image/png",
+                        "filename": "second.png",
+                        "size": 123,
+                        "url": "https://example.test/2.png",
+                        "fileid": "file-2"
+                    }
+                ]
+            }]
+        }),
+    };
+
+    let message = parse_group_message(&envelope).unwrap().unwrap();
+    let parts = message.reply.unwrap().input_parts;
+
+    assert_eq!(parts.len(), 5);
+    assert_eq!(parts[0].text_content(), Some("图前"));
+    assert_eq!(
+        parts[1].media().and_then(|media| media.file_id.as_deref()),
+        Some("file-1")
+    );
+    assert_eq!(parts[2].text_content(), Some("图中"));
+    assert_eq!(
+        parts[3].media().and_then(|media| media.file_id.as_deref()),
+        Some("file-2")
+    );
+    assert_eq!(parts[4].text_content(), Some("图后"));
+}
+
+#[test]
+fn direct_quote_media_keeps_existing_normalization_count_limit() {
+    let attachments = (0..34)
+        .map(|index| {
+            json!({
+                "content_type": "image/png",
+                "filename": format!("{index}.png"),
+                "url": format!("https://example.test/{index}.png")
+            })
+        })
+        .collect::<Vec<_>>();
+    let envelope = GatewayEnvelope {
+        op: 0,
+        s: None,
+        t: Some(EVENT_GROUP_MESSAGE_CREATE.to_owned()),
+        id: None,
+        d: json!({
+            "id": "msg-current",
+            "group_openid": "group-1",
+            "author": {"member_openid": "member-1"},
+            "content": "看看这些图",
+            "message_type": 103,
+            "message_scene": {"ext": ["ref_msg_idx=REFIDX_quoted"]},
+            "msg_elements": [{"attachments": attachments}]
+        }),
+    };
+
+    let message = parse_group_message(&envelope).unwrap().unwrap();
+    let reply = message.reply.unwrap();
+
+    assert_eq!(
+        reply
+            .input_parts
+            .iter()
+            .filter(|part| part.is_non_text())
+            .count(),
+        32
+    );
+    assert_eq!(reply.media_summaries.len(), 32);
 }
 
 /// 引用消息中无文字只有附件时，仍保留媒体摘要。

--- a/qq-maid-gateway-rs/src/gateway/media_fetch/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/media_fetch/mod.rs
@@ -151,6 +151,8 @@ pub(crate) async fn fetch_qq_official_quoted_images(
     let Some(reply) = reply else {
         return;
     };
+    // `reply.input_parts` 只承载当前消息的这一条直接引用 payload；在这里创建并销毁
+    // filename 集合，可保证去重不跨当前附件、其他引用、其他消息或 RefIndex 历史。
     deduplicate_quoted_images_by_filename(&mut reply.input_parts);
     let attachments = reply
         .input_parts
@@ -200,10 +202,11 @@ fn deduplicate_quoted_images_by_filename(input_parts: &mut Vec<MessageInputPart>
             .map(str::trim)
             .filter(|value| !value.is_empty())
         else {
+            // filename 缺失时没有经真实事件验证的稳定证据，不做推测性去重。
             return true;
         };
-        // QQ 官方图片文件名实测按内容摘要稳定生成；同一引用内保留首个即可，
-        // 避免相同图片因临时 URL/fileid 不同而重复下载、重复发送给模型。
+        // #578 的真实 QQ 事件表明，同一直接引用中同图重复记录的临时 URL/file_id
+        // 可能不同，但规范化 filename 相同；只保留第一次出现的位置。
         seen.insert(filename.to_ascii_lowercase())
     });
 }

--- a/qq-maid-gateway-rs/src/gateway/media_fetch/tests/quoted.rs
+++ b/qq-maid-gateway-rs/src/gateway/media_fetch/tests/quoted.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[tokio::test]
-async fn quoted_images_with_same_filename_keep_only_first_image() {
+async fn quoted_images_with_same_filename_download_and_send_only_first_image() {
     let app = Router::new()
         .route(
             "/1.png",
@@ -19,7 +19,11 @@ async fn quoted_images_with_same_filename_keep_only_first_image() {
 
     let make_media = |number: u8| MessageMedia {
         mime_type: Some("image/png".to_owned()),
-        filename: Some("same.png".to_owned()),
+        filename: Some(if number == 1 {
+            " Same.PNG ".to_owned()
+        } else {
+            "same.png".to_owned()
+        }),
         size_bytes: Some(3),
         url: Some(format!("http://{addr}/{number}.png")),
         file_id: Some(format!("file-{number}")),
@@ -70,6 +74,183 @@ async fn quoted_images_with_same_filename_keep_only_first_image() {
         b"one"
     );
     assert_eq!(reply.media_summaries.len(), 1);
+}
+
+#[test]
+fn quoted_images_without_filename_are_not_deduplicated() {
+    let mut parts = vec![
+        MessageInputPart::image(MessageMedia {
+            url: Some("https://example.test/first.png".to_owned()),
+            ..Default::default()
+        }),
+        MessageInputPart::image(MessageMedia {
+            url: Some("https://example.test/second.png".to_owned()),
+            ..Default::default()
+        }),
+    ];
+
+    deduplicate_quoted_images_by_filename(&mut parts);
+
+    assert_eq!(parts.len(), 2);
+}
+
+#[tokio::test]
+async fn same_filename_in_different_quoted_payloads_is_not_cross_deduplicated() {
+    let app = Router::new()
+        .route(
+            "/first.png",
+            get(|| async { ([(header::CONTENT_TYPE.as_str(), "image/png")], "first") }),
+        )
+        .route(
+            "/second.png",
+            get(|| async { ([(header::CONTENT_TYPE.as_str(), "image/png")], "second") }),
+        );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let make_reply = |message_id: &str, path: &str| MessageReply {
+        message_id: message_id.to_owned(),
+        ref_msg_idx: Some(message_id.to_owned()),
+        content: None,
+        input_parts: vec![MessageInputPart::image(MessageMedia {
+            mime_type: Some("image/png".to_owned()),
+            filename: Some("same.png".to_owned()),
+            url: Some(format!("http://{addr}/{path}.png")),
+            status: MediaStatus::Available,
+            ..Default::default()
+        })],
+        media_summaries: Vec::new(),
+    };
+    let mut first = make_reply("quoted-first", "first");
+    let mut second = make_reply("quoted-second", "second");
+    let context = MediaFetchContext {
+        platform: "qq_official",
+        app_id: "app".to_owned(),
+        peer_id: "peer".to_owned(),
+        root_dir: std::env::temp_dir().join(format!(
+            "qq-maid-quoted-media-scope-test-{}",
+            MEDIA_FILE_COUNTER.fetch_add(1, Ordering::Relaxed)
+        )),
+        timeout: Duration::from_secs(3),
+        max_bytes: 1024,
+    };
+
+    fetch_qq_official_quoted_images(
+        &qq_maid_common::http_client::client(),
+        &context,
+        "msg-first",
+        Some(&mut first),
+    )
+    .await;
+    fetch_qq_official_quoted_images(
+        &qq_maid_common::http_client::client(),
+        &context,
+        "msg-second",
+        Some(&mut second),
+    )
+    .await;
+
+    let first_media = first.input_parts[0].media().unwrap();
+    let second_media = second.input_parts[0].media().unwrap();
+    assert_eq!(
+        std::fs::read(first_media.local_path.as_ref().unwrap()).unwrap(),
+        b"first"
+    );
+    assert_eq!(
+        std::fs::read(second_media.local_path.as_ref().unwrap()).unwrap(),
+        b"second"
+    );
+}
+
+#[tokio::test]
+async fn current_and_quoted_same_filename_are_not_cross_deduplicated() {
+    let app = Router::new()
+        .route(
+            "/current.png",
+            get(|| async { ([(header::CONTENT_TYPE.as_str(), "image/png")], "current") }),
+        )
+        .route(
+            "/quoted.png",
+            get(|| async { ([(header::CONTENT_TYPE.as_str(), "image/png")], "quoted") }),
+        );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let current_attachment = Attachment {
+        content_type: Some("image/png".to_owned()),
+        filename: Some("same.png".to_owned()),
+        url: Some(format!("http://{addr}/current.png")),
+        size_bytes: None,
+        media_id: None,
+        file_id: Some("current-file".to_owned()),
+        attachment_id: None,
+        asr_refer_text: None,
+        voice_wav_url: None,
+    };
+    let mut current_parts = vec![MessageInputPart::image(MessageMedia {
+        mime_type: current_attachment.content_type.clone(),
+        filename: current_attachment.filename.clone(),
+        url: current_attachment.url.clone(),
+        file_id: current_attachment.file_id.clone(),
+        status: MediaStatus::Available,
+        ..Default::default()
+    })];
+    let mut quoted = MessageReply {
+        message_id: "quoted".to_owned(),
+        ref_msg_idx: Some("quoted".to_owned()),
+        content: None,
+        input_parts: vec![MessageInputPart::image(MessageMedia {
+            mime_type: Some("image/png".to_owned()),
+            filename: Some("same.png".to_owned()),
+            url: Some(format!("http://{addr}/quoted.png")),
+            file_id: Some("quoted-file".to_owned()),
+            status: MediaStatus::Available,
+            ..Default::default()
+        })],
+        media_summaries: Vec::new(),
+    };
+    let context = MediaFetchContext {
+        platform: "qq_official",
+        app_id: "app".to_owned(),
+        peer_id: "peer".to_owned(),
+        root_dir: std::env::temp_dir().join(format!(
+            "qq-maid-current-quoted-scope-test-{}",
+            MEDIA_FILE_COUNTER.fetch_add(1, Ordering::Relaxed)
+        )),
+        timeout: Duration::from_secs(3),
+        max_bytes: 1024,
+    };
+
+    fetch_qq_official_image_attachments(
+        &qq_maid_common::http_client::client(),
+        &context,
+        "msg-current",
+        &mut current_parts,
+        &[current_attachment],
+    )
+    .await;
+    fetch_qq_official_quoted_images(
+        &qq_maid_common::http_client::client(),
+        &context,
+        "msg-current",
+        Some(&mut quoted),
+    )
+    .await;
+
+    let current_media = current_parts[0].media().unwrap();
+    let quoted_media = quoted.input_parts[0].media().unwrap();
+    assert_eq!(
+        std::fs::read(current_media.local_path.as_ref().unwrap()).unwrap(),
+        b"current"
+    );
+    assert_eq!(
+        std::fs::read(quoted_media.local_path.as_ref().unwrap()).unwrap(),
+        b"quoted"
+    );
 }
 
 #[tokio::test]

--- a/qq-maid-gateway-rs/src/gateway/media_fetch/tests/quoted.rs
+++ b/qq-maid-gateway-rs/src/gateway/media_fetch/tests/quoted.rs
@@ -104,6 +104,92 @@ URL:http://{addr}/history.png?rkey=rkey_redacted"
 }
 
 #[tokio::test]
+async fn flattened_quote_img_tag_stays_text_without_media_download_or_data_url() {
+    use crate::gateway::event::{EVENT_GROUP_MESSAGE_CREATE, GatewayEnvelope, parse_group_message};
+
+    let download_count = Arc::new(AtomicUsize::new(0));
+    let handler_count = Arc::clone(&download_count);
+    let app = Router::new().route(
+        "/history.png",
+        get(move || {
+            let handler_count = Arc::clone(&handler_count);
+            async move {
+                handler_count.fetch_add(1, Ordering::Relaxed);
+                ([(header::CONTENT_TYPE.as_str(), "image/png")], "history")
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let flattened = format!(
+        "拍平历史图片：<img src=\"http://{addr}/history.png\">\n\
+[附件1] filename: history.png file_id: file-redacted rkey: rkey-redacted"
+    );
+    let envelope = GatewayEnvelope {
+        op: 0,
+        s: None,
+        t: Some(EVENT_GROUP_MESSAGE_CREATE.to_owned()),
+        id: Some("event-redacted".to_owned()),
+        d: serde_json::json!({
+            "id": "message-redacted",
+            "group_openid": "group-redacted",
+            "author": {"member_openid": "member-redacted"},
+            "content": "继续分析",
+            "message_type": 103,
+            "message_scene": {"ext": ["ref_msg_idx=REFIDX_quote_redacted"]},
+            "msg_elements": [{"content": flattened}]
+        }),
+    };
+
+    let mut message = parse_group_message(&envelope).unwrap().unwrap();
+    let reply = message.reply.as_mut().expect("quoted payload");
+    assert_eq!(reply.content.as_deref(), Some(flattened.as_str()));
+    assert_eq!(reply.input_parts.len(), 1);
+    assert_eq!(
+        reply.input_parts[0].text_content(),
+        Some(flattened.as_str())
+    );
+    assert_eq!(
+        reply
+            .input_parts
+            .iter()
+            .filter(|part| matches!(part, MessageInputPart::Image { .. }))
+            .count(),
+        0
+    );
+
+    let root_dir = std::env::temp_dir().join(format!(
+        "qq-maid-flattened-img-tag-test-{}",
+        MEDIA_FILE_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    let context = MediaFetchContext {
+        platform: "qq_official",
+        app_id: "app-redacted".to_owned(),
+        peer_id: "peer-redacted".to_owned(),
+        root_dir: root_dir.clone(),
+        timeout: Duration::from_secs(1),
+        max_bytes: 1024,
+    };
+    fetch_qq_official_quoted_images(
+        &qq_maid_common::http_client::client(),
+        &context,
+        "message-redacted",
+        Some(reply),
+    )
+    .await;
+
+    assert_eq!(download_count.load(Ordering::Relaxed), 0);
+    assert_eq!(media_file_count(&root_dir), 0);
+    let serialized = serde_json::to_string(&reply.input_parts).unwrap();
+    assert!(serialized.contains("<img src="));
+    assert!(!serialized.contains("data:image"));
+}
+
+#[tokio::test]
 async fn quoted_images_with_same_filename_download_and_send_only_first_image() {
     let app = Router::new()
         .route(

--- a/qq-maid-gateway-rs/src/gateway/media_fetch/tests/quoted.rs
+++ b/qq-maid-gateway-rs/src/gateway/media_fetch/tests/quoted.rs
@@ -1,6 +1,109 @@
 use super::*;
 
 #[tokio::test]
+async fn flattened_secondary_quote_stays_text_without_media_download_or_data_url() {
+    use crate::gateway::event::{EVENT_GROUP_MESSAGE_CREATE, GatewayEnvelope, parse_group_message};
+
+    let download_count = Arc::new(AtomicUsize::new(0));
+    let handler_count = Arc::clone(&download_count);
+    let app = Router::new().route(
+        "/history.png",
+        get(move || {
+            let handler_count = Arc::clone(&handler_count);
+            async move {
+                handler_count.fetch_add(1, Ordering::Relaxed);
+                ([(header::CONTENT_TYPE.as_str(), "image/png")], "history")
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // 脱敏自 QQ 二次引用真实字段形态：历史附件信息已经被平台拍平进 content，
+    // 同时仍可能携带内层结构化 msg_elements。Gateway 只把前者视为普通文本。
+    let flattened = format!(
+        "[关联消息]\n发送者：member_redacted\n[消息内容]\n请看历史图片\n\
+[附件1]\nfilename: history_redacted.png\nfile_id: file_redacted\n\
+URL:http://{addr}/history.png?rkey=rkey_redacted"
+    );
+    let envelope = GatewayEnvelope {
+        op: 0,
+        s: None,
+        t: Some(EVENT_GROUP_MESSAGE_CREATE.to_owned()),
+        id: Some("event-redacted".to_owned()),
+        d: serde_json::json!({
+            "id": "message-redacted",
+            "group_openid": "group-redacted",
+            "author": {"member_openid": "member-redacted"},
+            "content": "继续分析",
+            "message_type": 103,
+            "message_scene": {"ext": [
+                "msg_idx=TMP_current_redacted",
+                "ref_msg_idx=REFIDX_quote_redacted"
+            ]},
+            "msg_elements": [{
+                "content": flattened,
+                "msg_elements": [{
+                    "content": "[图片]",
+                    "attachments": [{
+                        "content_type": "image/png",
+                        "filename": "history_redacted.png",
+                        "fileid": "file_redacted",
+                        "url": format!("http://{addr}/history.png?rkey=rkey_redacted")
+                    }]
+                }]
+            }]
+        }),
+    };
+
+    let mut message = parse_group_message(&envelope).unwrap().unwrap();
+    let reply = message.reply.as_mut().expect("quoted payload");
+    assert_eq!(reply.content.as_deref(), Some(flattened.as_str()));
+    assert_eq!(reply.input_parts.len(), 1);
+    assert_eq!(
+        reply.input_parts[0].text_content(),
+        Some(flattened.as_str())
+    );
+    assert!(reply.input_parts.iter().all(|part| part.media().is_none()));
+    assert!(reply.media_summaries.is_empty());
+
+    let root_dir = std::env::temp_dir().join(format!(
+        "qq-maid-flattened-quote-test-{}",
+        MEDIA_FILE_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    let context = MediaFetchContext {
+        platform: "qq_official",
+        app_id: "app-redacted".to_owned(),
+        peer_id: "peer-redacted".to_owned(),
+        root_dir: root_dir.clone(),
+        timeout: Duration::from_secs(1),
+        max_bytes: 1024,
+    };
+    fetch_qq_official_quoted_images(
+        &qq_maid_common::http_client::client(),
+        &context,
+        "message-redacted",
+        Some(reply),
+    )
+    .await;
+
+    assert_eq!(download_count.load(Ordering::Relaxed), 0);
+    assert_eq!(media_file_count(&root_dir), 0);
+    assert_eq!(
+        reply.input_parts[0].text_content(),
+        Some(flattened.as_str())
+    );
+    let serialized = serde_json::to_string(&reply.input_parts).unwrap();
+    assert!(serialized.contains("filename: history_redacted.png"));
+    assert!(serialized.contains("file_id: file_redacted"));
+    assert!(serialized.contains("rkey=rkey_redacted"));
+    assert!(!serialized.contains("data:image"));
+}
+
+#[tokio::test]
 async fn quoted_images_with_same_filename_download_and_send_only_first_image() {
     let app = Router::new()
         .route(

--- a/qq-maid-gateway-rs/src/gateway/ref_index/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/ref_index/mod.rs
@@ -386,20 +386,63 @@ fn entry_from_inbound(inbound: &InboundMessage) -> RefIndexEntry {
 }
 
 fn effective_index_parts(inbound: &InboundMessage) -> Vec<MessageInputPart> {
-    if !inbound.input_parts.is_empty() {
-        return sanitize_index_parts(inbound.input_parts.clone());
+    let mut parts = if !inbound.input_parts.is_empty() {
+        inbound.input_parts.clone()
+    } else {
+        let mut parts = Vec::new();
+        if !inbound.text.trim().is_empty() {
+            parts.push(MessageInputPart::text(truncate_summary_text(&inbound.text)));
+        }
+        parts.extend(
+            inbound
+                .attachments
+                .iter()
+                .map(|attachment| attachment.to_input_part(inbound.platform)),
+        );
+        parts
+    };
+    if let Some(summary) = indexed_quote_summary(inbound.quoted.as_ref()) {
+        // 只保存当前消息“曾引用历史”的安全摘要，不把 quoted.input_parts 的媒体树
+        // 复制进当前索引项。后续二次引用依赖会话历史中的首次分析结果。
+        parts.push(MessageInputPart::Text {
+            text: summary,
+            source: Some(qq_maid_common::input_part::TextSource::Quote),
+        });
     }
-    let mut parts = Vec::new();
-    if !inbound.text.trim().is_empty() {
-        parts.push(MessageInputPart::text(truncate_summary_text(&inbound.text)));
+    sanitize_index_parts(
+        parts,
+        matches!(inbound.platform, super::platform::Platform::QqOfficial),
+    )
+}
+
+fn indexed_quote_summary(
+    quoted: Option<&qq_maid_common::input_part::QuotedMessageContext>,
+) -> Option<String> {
+    let quoted = quoted?;
+    if !quoted.lookup_found {
+        return Some("历史引用摘要：该消息引用了更早的消息，但历史引用内容不可用。".to_owned());
     }
-    parts.extend(
-        inbound
-            .attachments
+    let text_present = quoted.input_parts.iter().any(|part| {
+        part.text_content()
+            .is_some_and(|text| !text.trim().is_empty())
+    }) || quoted
+        .text_summary
+        .as_deref()
+        .is_some_and(|text| !text.trim().is_empty());
+    let media_count = if quoted.input_parts.is_empty() {
+        quoted.media_summaries.len()
+    } else {
+        quoted
+            .input_parts
             .iter()
-            .map(|attachment| attachment.to_input_part(inbound.platform)),
-    );
-    sanitize_index_parts(parts)
+            .filter(|part| part.is_non_text())
+            .count()
+    };
+    Some(format!(
+        "历史引用摘要：该消息引用了更早的消息（文字={}，媒体数量={}），历史内容和媒体未展开。",
+        if text_present { "有" } else { "无" },
+        media_count
+    ))
 }
 
 fn key_for(
@@ -550,36 +593,43 @@ fn truncate_summary_text(value: &str) -> String {
     output
 }
 
-fn sanitize_index_parts(parts: Vec<MessageInputPart>) -> Vec<MessageInputPart> {
-    parts.into_iter().map(sanitize_index_part).collect()
+fn sanitize_index_parts(
+    parts: Vec<MessageInputPart>,
+    clear_remote_media_urls: bool,
+) -> Vec<MessageInputPart> {
+    parts
+        .into_iter()
+        .map(|part| sanitize_index_part(part, clear_remote_media_urls))
+        .collect()
 }
 
-fn sanitize_index_part(part: MessageInputPart) -> MessageInputPart {
+fn sanitize_index_part(part: MessageInputPart, clear_remote_media_urls: bool) -> MessageInputPart {
     match part {
         MessageInputPart::Text { text, source } => MessageInputPart::Text {
             text: truncate_summary_text(&text),
             source,
         },
         MessageInputPart::Image { media } => MessageInputPart::Image {
-            media: sanitize_index_media(media),
+            media: sanitize_index_media(media, clear_remote_media_urls),
         },
         MessageInputPart::File { media } => MessageInputPart::File {
-            media: sanitize_index_media(media),
+            media: sanitize_index_media(media, clear_remote_media_urls),
         },
         MessageInputPart::Unknown { media, reason } => MessageInputPart::Unknown {
-            media: sanitize_index_media(media),
+            media: sanitize_index_media(media, clear_remote_media_urls),
             reason,
         },
     }
 }
 
-fn sanitize_index_media(mut media: MessageMedia) -> MessageMedia {
-    // ref_index 只保存轻量引用元信息。data URL 可能携带 base64 内容，不能进入内存索引。
-    if media
+fn sanitize_index_media(mut media: MessageMedia, clear_remote_media_urls: bool) -> MessageMedia {
+    // QQ 临时媒体 URL 可能带 rkey/auth_token；下载完成后只保留本地缓存路径。
+    // 其他平台仍保留普通 http(s) 引用，但 data URL 对所有平台都不得进入内存索引。
+    let is_data_url = media
         .url
         .as_deref()
-        .is_some_and(|value| value.trim_start().to_ascii_lowercase().starts_with("data:"))
-    {
+        .is_some_and(|value| value.trim_start().to_ascii_lowercase().starts_with("data:"));
+    if clear_remote_media_urls || is_data_url {
         media.url = None;
         if media
             .local_path

--- a/qq-maid-gateway-rs/src/gateway/ref_index/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/ref_index/mod.rs
@@ -386,7 +386,7 @@ fn entry_from_inbound(inbound: &InboundMessage) -> RefIndexEntry {
 }
 
 fn effective_index_parts(inbound: &InboundMessage) -> Vec<MessageInputPart> {
-    let mut parts = if !inbound.input_parts.is_empty() {
+    let parts = if !inbound.input_parts.is_empty() {
         inbound.input_parts.clone()
     } else {
         let mut parts = Vec::new();
@@ -401,48 +401,12 @@ fn effective_index_parts(inbound: &InboundMessage) -> Vec<MessageInputPart> {
         );
         parts
     };
-    if let Some(summary) = indexed_quote_summary(inbound.quoted.as_ref()) {
-        // 只保存当前消息“曾引用历史”的安全摘要，不把 quoted.input_parts 的媒体树
-        // 复制进当前索引项。后续二次引用依赖会话历史中的首次分析结果。
-        parts.push(MessageInputPart::Text {
-            text: summary,
-            source: Some(qq_maid_common::input_part::TextSource::Quote),
-        });
-    }
+    // RefIndex 只保存当前消息自身的 parts，不复制 quoted 结构，因此不会形成递归
+    // 媒体树。QQ 拍平到当前正文中的展示文本仍由普通 Text part 原样处理。
     sanitize_index_parts(
         parts,
         matches!(inbound.platform, super::platform::Platform::QqOfficial),
     )
-}
-
-fn indexed_quote_summary(
-    quoted: Option<&qq_maid_common::input_part::QuotedMessageContext>,
-) -> Option<String> {
-    let quoted = quoted?;
-    if !quoted.lookup_found {
-        return Some("历史引用摘要：该消息引用了更早的消息，但历史引用内容不可用。".to_owned());
-    }
-    let text_present = quoted.input_parts.iter().any(|part| {
-        part.text_content()
-            .is_some_and(|text| !text.trim().is_empty())
-    }) || quoted
-        .text_summary
-        .as_deref()
-        .is_some_and(|text| !text.trim().is_empty());
-    let media_count = if quoted.input_parts.is_empty() {
-        quoted.media_summaries.len()
-    } else {
-        quoted
-            .input_parts
-            .iter()
-            .filter(|part| part.is_non_text())
-            .count()
-    };
-    Some(format!(
-        "历史引用摘要：该消息引用了更早的消息（文字={}，媒体数量={}），历史内容和媒体未展开。",
-        if text_present { "有" } else { "无" },
-        media_count
-    ))
 }
 
 fn key_for(

--- a/qq-maid-gateway-rs/src/gateway/ref_index/tests/quote_payload.rs
+++ b/qq-maid-gateway-rs/src/gateway/ref_index/tests/quote_payload.rs
@@ -163,3 +163,73 @@ fn missing_ref_msg_idx_with_payload_marks_quoted_payload_without_reference_id() 
     // reference_id 不产生 Some("")。
     assert_eq!(quoted.reference_id, None);
 }
+
+#[test]
+fn second_quote_keeps_current_media_and_safe_summary_without_recursive_media() {
+    let mut store = RefIndex::default();
+    let mut first_quote = group_inbound("gm-first-quote", Some("TMP_first_quote"), "第一次分析");
+    first_quote.input_parts = vec![
+        MessageInputPart::text("第一次分析"),
+        MessageInputPart::image(MessageMedia {
+            mime_type: Some("image/png".to_owned()),
+            filename: Some("current.png".to_owned()),
+            url: Some("https://example.test/current.png?rkey=secret".to_owned()),
+            local_path: Some("/tmp/current.png".to_owned()),
+            status: MediaStatus::Available,
+            ..Default::default()
+        }),
+    ];
+    first_quote.quoted = Some(QuotedMessageContext {
+        ref_msg_idx: Some("REFIDX_history".to_owned()),
+        lookup_found: true,
+        text_summary: Some("历史原文".to_owned()),
+        input_parts: vec![
+            MessageInputPart::text("历史原文"),
+            MessageInputPart::image(MessageMedia {
+                filename: Some("history.png".to_owned()),
+                url: Some(
+                    "https://example.test/history.png?rkey=secret&auth_token=secret".to_owned(),
+                ),
+                local_path: Some("/tmp/history.png".to_owned()),
+                status: MediaStatus::Available,
+                ..Default::default()
+            }),
+        ],
+        ..Default::default()
+    });
+    store.insert_inbound(&first_quote);
+
+    let mut second_quote = group_inbound("gm-second", Some("TMP_second"), "继续");
+    second_quote.quoted = Some(QuotedMessageContext {
+        ref_msg_idx: Some("TMP_first_quote".to_owned()),
+        ..Default::default()
+    });
+    store.enrich_inbound(&mut second_quote);
+
+    let parts = &second_quote.quoted.as_ref().unwrap().input_parts;
+    assert_eq!(parts.len(), 3);
+    assert_eq!(parts[0].text_content(), Some("第一次分析"));
+    let current_media = parts[1].media().expect("current message image");
+    assert_eq!(current_media.filename.as_deref(), Some("current.png"));
+    assert_eq!(
+        current_media.local_path.as_deref(),
+        Some("/tmp/current.png")
+    );
+    assert_eq!(
+        current_media.url, None,
+        "QQ temporary URL must not enter RefIndex"
+    );
+    assert!(
+        parts[2]
+            .text_content()
+            .is_some_and(|text| text.contains("历史引用摘要") && text.contains("媒体数量=1"))
+    );
+    let rendered = parts
+        .iter()
+        .map(MessageInputPart::fallback_text)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(!rendered.contains("history.png"));
+    assert!(!rendered.contains("rkey"));
+    assert!(!rendered.contains("auth_token"));
+}

--- a/qq-maid-gateway-rs/src/gateway/ref_index/tests/quote_payload.rs
+++ b/qq-maid-gateway-rs/src/gateway/ref_index/tests/quote_payload.rs
@@ -165,7 +165,7 @@ fn missing_ref_msg_idx_with_payload_marks_quoted_payload_without_reference_id() 
 }
 
 #[test]
-fn second_quote_keeps_current_media_and_safe_summary_without_recursive_media() {
+fn second_quote_keeps_current_parts_without_recursive_media() {
     let mut store = RefIndex::default();
     let mut first_quote = group_inbound("gm-first-quote", Some("TMP_first_quote"), "第一次分析");
     first_quote.input_parts = vec![
@@ -207,7 +207,7 @@ fn second_quote_keeps_current_media_and_safe_summary_without_recursive_media() {
     store.enrich_inbound(&mut second_quote);
 
     let parts = &second_quote.quoted.as_ref().unwrap().input_parts;
-    assert_eq!(parts.len(), 3);
+    assert_eq!(parts.len(), 2);
     assert_eq!(parts[0].text_content(), Some("第一次分析"));
     let current_media = parts[1].media().expect("current message image");
     assert_eq!(current_media.filename.as_deref(), Some("current.png"));
@@ -219,17 +219,10 @@ fn second_quote_keeps_current_media_and_safe_summary_without_recursive_media() {
         current_media.url, None,
         "QQ temporary URL must not enter RefIndex"
     );
-    assert!(
-        parts[2]
-            .text_content()
-            .is_some_and(|text| text.contains("历史引用摘要") && text.contains("媒体数量=1"))
-    );
     let rendered = parts
         .iter()
         .map(MessageInputPart::fallback_text)
         .collect::<Vec<_>>()
         .join("\n");
     assert!(!rendered.contains("history.png"));
-    assert!(!rendered.contains("rkey"));
-    assert!(!rendered.contains("auth_token"));
 }

--- a/qq-maid-llm/src/context_budget.rs
+++ b/qq-maid-llm/src/context_budget.rs
@@ -10,6 +10,13 @@ use tracing::{debug, warn};
 
 use crate::error::LlmError;
 
+/// 结构化图片在字符预算中的固定估算成本。
+///
+/// Data URL 的 Base64 长度反映传输体积，不等同于模型实际占用的文本 token；图片字节数
+/// 已由 provider 的 `media_max_bytes` 单独限制。这里仍为每张图片保留固定成本，使图片数量
+/// 会进入预算，同时避免把数百 KB 的编码正文误当作用户文本。
+const STRUCTURED_IMAGE_ESTIMATED_CHARS: usize = 1024;
+
 /// 上下文预算配置。
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ContextBudgetConfig {
@@ -307,14 +314,21 @@ pub fn fit_tool_loop_payload(
     config.validate()?;
     let max_input_chars = config.effective_input_limit();
     let estimate = |value: &Value| {
-        let model_context = if value.get("input").is_some() {
-            json!({"input": value.get("input"), "tools": value.get("tools")})
-        } else {
-            json!({"messages": value.get("messages"), "tools": value.get("tools")})
-        };
-        estimated_json_chars(&model_context, stage)
+        tool_loop_budget_estimate(value, stage).map(|estimate| estimate.budgeted_chars)
     };
-    if estimate(&payload)? <= max_input_chars {
+    let initial_estimate = tool_loop_budget_estimate(&payload, stage)?;
+    debug!(
+        stage,
+        raw_model_context_chars = initial_estimate.raw_chars,
+        budgeted_model_context_chars = initial_estimate.budgeted_chars,
+        structured_image_count = initial_estimate.structured_image_count,
+        structured_image_data_chars = initial_estimate.structured_image_data_chars,
+        structured_image_budget_chars = initial_estimate.structured_image_budget_chars,
+        tool_schema_chars = initial_estimate.tool_schema_chars,
+        text_and_protocol_chars = initial_estimate.text_and_protocol_chars,
+        "tool loop context budget estimate"
+    );
+    if initial_estimate.budgeted_chars <= max_input_chars {
         return Ok((payload, false));
     }
 
@@ -364,6 +378,114 @@ pub fn fit_tool_loop_payload(
         "tool loop entered forced finalization budget"
     );
     Ok((payload, true))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ToolLoopBudgetEstimate {
+    raw_chars: usize,
+    budgeted_chars: usize,
+    structured_image_count: usize,
+    structured_image_data_chars: usize,
+    structured_image_budget_chars: usize,
+    tool_schema_chars: usize,
+    text_and_protocol_chars: usize,
+}
+
+fn tool_loop_budget_estimate(
+    payload: &Value,
+    stage: &'static str,
+) -> Result<ToolLoopBudgetEstimate, LlmError> {
+    // 只估算真正进入模型上下文的字段；model、stream、max token 等传输控制字段不计入。
+    let model_context = if payload.get("input").is_some() {
+        json!({"input": payload.get("input"), "tools": payload.get("tools")})
+    } else {
+        json!({"messages": payload.get("messages"), "tools": payload.get("tools")})
+    };
+    let raw_chars = estimated_json_chars(&model_context, stage)?;
+    let tool_schema_chars = payload
+        .get("tools")
+        .map(|tools| estimated_json_chars(tools, stage))
+        .transpose()?
+        .unwrap_or(0);
+    let mut budget_view = model_context;
+    let mut media = StructuredImageBudget::default();
+    mask_structured_image_data_urls(&mut budget_view, &mut media);
+    let budgeted_chars = estimated_json_chars(&budget_view, stage)?;
+    let structured_image_budget_chars =
+        media.count.saturating_mul(STRUCTURED_IMAGE_ESTIMATED_CHARS);
+
+    Ok(ToolLoopBudgetEstimate {
+        raw_chars,
+        budgeted_chars,
+        structured_image_count: media.count,
+        structured_image_data_chars: media.data_url_chars,
+        structured_image_budget_chars,
+        tool_schema_chars,
+        // 这是“文本 + JSON 协议开销”，不会记录或输出任何正文内容。
+        text_and_protocol_chars: raw_chars
+            .saturating_sub(media.data_url_chars)
+            .saturating_sub(tool_schema_chars),
+    })
+}
+
+#[derive(Debug, Default)]
+struct StructuredImageBudget {
+    count: usize,
+    data_url_chars: usize,
+}
+
+fn mask_structured_image_data_urls(value: &mut Value, budget: &mut StructuredImageBudget) {
+    match value {
+        Value::Object(object) => {
+            match object.get("type").and_then(Value::as_str) {
+                // OpenAI Responses：{"type":"input_image","image_url":"data:image/..."}
+                Some("input_image") => {
+                    if let Some(url) = object.get_mut("image_url") {
+                        mask_image_data_url(url, budget);
+                    }
+                }
+                // Chat Completions：
+                // {"type":"image_url","image_url":{"url":"data:image/..."}}
+                Some("image_url") => {
+                    if let Some(url) = object
+                        .get_mut("image_url")
+                        .and_then(Value::as_object_mut)
+                        .and_then(|image_url| image_url.get_mut("url"))
+                    {
+                        mask_image_data_url(url, budget);
+                    }
+                }
+                _ => {}
+            }
+            for child in object.values_mut() {
+                mask_structured_image_data_urls(child, budget);
+            }
+        }
+        Value::Array(items) => {
+            for child in items {
+                mask_structured_image_data_urls(child, budget);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+fn mask_image_data_url(value: &mut Value, budget: &mut StructuredImageBudget) {
+    let Some(url) = value.as_str().filter(|url| is_base64_image_data_url(url)) else {
+        return;
+    };
+    budget.count += 1;
+    budget.data_url_chars = budget.data_url_chars.saturating_add(url.chars().count());
+    // 预算视图只替换估算副本；返回给 provider 的原始 payload 不会被修改。
+    *value = Value::String("i".repeat(STRUCTURED_IMAGE_ESTIMATED_CHARS));
+}
+
+fn is_base64_image_data_url(value: &str) -> bool {
+    let Some((header, _data)) = value.trim().split_once(',') else {
+        return false;
+    };
+    let header = header.to_ascii_lowercase();
+    header.starts_with("data:image/") && header.ends_with(";base64")
 }
 
 fn compact_tool_outputs(
@@ -681,6 +803,101 @@ mod tests {
             );
         }
         serde_json::to_string(&fitted).unwrap();
+    }
+
+    #[test]
+    fn responses_tool_loop_counts_structured_images_without_base64_body() {
+        let first_data_url = format!("data:image/png;base64,{}", "a".repeat(80_000));
+        let second_data_url = format!("data:image/jpeg;base64,{}", "b".repeat(90_000));
+        let payload = json!({
+            "input": [{
+                "type": "message",
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "依次看这两张图"},
+                    {"type": "input_image", "image_url": first_data_url},
+                    {"type": "input_image", "image_url": second_data_url}
+                ]
+            }],
+            "tools": [{"type": "function", "name": "inspect"}]
+        });
+
+        let (fitted, disabled) = fit_tool_loop_payload(config(4_000), payload.clone(), "tool_loop")
+            .expect("structured image data should use the independent media estimate");
+
+        assert!(!disabled);
+        assert_eq!(
+            fitted, payload,
+            "the real provider payload must stay intact"
+        );
+        let estimate = tool_loop_budget_estimate(&fitted, "tool_loop").unwrap();
+        assert_eq!(estimate.structured_image_count, 2);
+        assert!(estimate.structured_image_data_chars > 160_000);
+        assert_eq!(estimate.structured_image_budget_chars, 2_048);
+        assert!(estimate.budgeted_chars < 4_000);
+    }
+
+    #[test]
+    fn chat_tool_loop_counts_structured_images_without_base64_body() {
+        let payload = json!({
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "看图"},
+                    {"type": "image_url", "image_url": {
+                        "url": format!("data:image/webp;base64,{}", "a".repeat(100_000))
+                    }}
+                ]
+            }],
+            "tools": [{"type": "function", "function": {"name": "inspect"}}]
+        });
+
+        let (fitted, disabled) = fit_tool_loop_payload(config(2_500), payload.clone(), "tool_loop")
+            .expect("chat image data should use the same independent media estimate");
+
+        assert!(!disabled);
+        assert_eq!(fitted, payload);
+        let estimate = tool_loop_budget_estimate(&fitted, "tool_loop").unwrap();
+        assert_eq!(estimate.structured_image_count, 1);
+        assert_eq!(estimate.structured_image_budget_chars, 1_024);
+    }
+
+    #[test]
+    fn plain_text_data_url_is_not_exempt_from_tool_loop_budget() {
+        let payload = json!({
+            "input": [{
+                "type": "message",
+                "role": "user",
+                "content": [{
+                    "type": "input_text",
+                    "text": format!("data:image/png;base64,{}", "a".repeat(8_000))
+                }]
+            }],
+            "tools": []
+        });
+
+        let err = fit_tool_loop_payload(config(2_000), payload, "tool_loop").unwrap_err();
+
+        assert_eq!(err.code, "context_budget_exceeded");
+        assert_eq!(err.stage, "tool_loop");
+    }
+
+    #[test]
+    fn unrelated_image_url_field_is_not_exempt_from_tool_loop_budget() {
+        let payload = json!({
+            "messages": [{
+                "role": "user",
+                "content": [{
+                    "type": "text",
+                    "image_url": {"url": format!("data:image/png;base64,{}", "a".repeat(8_000))}
+                }]
+            }],
+            "tools": []
+        });
+
+        let err = fit_tool_loop_payload(config(2_000), payload, "tool_loop").unwrap_err();
+
+        assert_eq!(err.code, "context_budget_exceeded");
     }
 
     struct FailingSerialize;

--- a/qq-maid-llm/src/provider/openai/chat_tool_loop/tests.rs
+++ b/qq-maid-llm/src/provider/openai/chat_tool_loop/tests.rs
@@ -542,6 +542,46 @@ fn tool_loop_budget_ignores_transport_only_payload_fields() {
 }
 
 #[test]
+fn chat_tool_loop_budget_keeps_large_structured_image_payload() {
+    let messages = vec![json!({
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "帮我看看这个"},
+            {"type": "image_url", "image_url": {
+                "url": format!("data:image/jpeg;base64,{}", "a".repeat(100_000))
+            }}
+        ]
+    })];
+    let tools = vec![json!({
+        "type": "function",
+        "function": {
+            "name": "inspect",
+            "parameters": {"type": "object", "properties": {}}
+        },
+    })];
+    let payload =
+        chat_completions_tool_loop_payload(&messages, &tools, "test-model", 1200, true, false);
+
+    let (fitted, disabled) = enforce_tool_loop_budget(
+        Some(ContextBudgetConfig {
+            context_window_chars: 2_500,
+            output_reserve_chars: 200,
+            protected_recent_turns: 0,
+        }),
+        &payload,
+    )
+    .unwrap();
+
+    assert!(!disabled);
+    assert_eq!(fitted, payload);
+    assert!(
+        fitted["messages"][0]["content"][1]["image_url"]["url"]
+            .as_str()
+            .is_some_and(|url| url.len() > 100_000)
+    );
+}
+
+#[test]
 fn payload_disables_tool_calls_explicitly() {
     let payload = chat_completions_tool_loop_payload(
         &[json!({"role": "user", "content": "总结已有结果"})],

--- a/qq-maid-llm/src/provider/openai/tool_loop/tests/payload.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/tests/payload.rs
@@ -148,3 +148,40 @@ fn tool_loop_budget_ignores_transport_only_payload_fields() {
     )
     .unwrap();
 }
+
+#[test]
+fn responses_tool_loop_budget_keeps_large_structured_image_payload() {
+    let data_url = format!("data:image/png;base64,{}", "a".repeat(100_000));
+    let input = vec![json!({
+        "type": "message",
+        "role": "user",
+        "content": [
+            {"type": "input_text", "text": "帮我看看这个"},
+            {"type": "input_image", "image_url": data_url}
+        ],
+    })];
+    let tools = vec![json!({
+        "type": "function",
+        "name": "inspect",
+        "parameters": {"type": "object", "properties": {}},
+    })];
+    let payload = openai_tool_loop_payload(&input, &tools, "gpt-test", 1200, None, true, false);
+
+    let (fitted, disabled) = enforce_tool_loop_budget(
+        Some(ContextBudgetConfig {
+            context_window_chars: 2_500,
+            output_reserve_chars: 200,
+            protected_recent_turns: 0,
+        }),
+        &payload,
+    )
+    .unwrap();
+
+    assert!(!disabled);
+    assert_eq!(fitted, payload);
+    assert!(
+        fitted["input"][0]["content"][1]["image_url"]
+            .as_str()
+            .is_some_and(|url| url.len() > 100_000)
+    );
+}

--- a/qq-maid-llm/src/provider/routing.rs
+++ b/qq-maid-llm/src/provider/routing.rs
@@ -332,11 +332,10 @@ impl LlmProvider for ModelRouteProvider {
                         !diagnostics.side_effecting_tools_started.is_empty()
                             || !diagnostics.tools_with_unknown_result.is_empty()
                     };
-                    // Tool Loop 本地上下文超限不代表 Provider 不可用；在尚未外发
-                    // 内容且未启动副作用时可安全换候选，但绝不重跑已产生副作用的轮次。
-                    let local_budget_fallback = err.code == "context_budget_exceeded";
+                    // 只有可恢复的上游错误才切换候选。本地预算/请求构造错误对等价
+                    // payload 必然重复失败，必须原样返回，不能误报为候选 Provider 不可用。
                     let fallback = index + 1 < candidates.len()
-                        && (should_try_next_model(&err) || local_budget_fallback)
+                        && should_try_next_model(&err)
                         && !visible_delta_sent
                         && !tool_side_effect_started;
                     tracing::warn!(

--- a/qq-maid-llm/src/provider/tests/routing.rs
+++ b/qq-maid-llm/src/provider/tests/routing.rs
@@ -164,6 +164,41 @@ async fn model_route_tool_calling_falls_back_after_eligible_candidate_error() {
 }
 
 #[tokio::test]
+async fn model_route_tool_calling_stops_after_local_budget_error() {
+    let openai = Arc::new(
+        MockProvider::new("openai", Vec::new())
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+            .with_tool_results(vec![Err(LlmError::new(
+                "context_budget_exceeded",
+                "local payload exceeds context budget",
+                "tool_loop",
+            ))]),
+    );
+    let deepseek = Arc::new(
+        MockProvider::new("deepseek", Vec::new())
+            .with_tool_protocol(ToolCallingProtocol::ChatCompletionsToolCalls)
+            .with_tool_results(vec![Ok(outcome("must not run"))]),
+    );
+    let provider = ModelRouteProvider::new(
+        "auto",
+        ModelProvider::OpenAi,
+        ModelRoute::parse_config("openai:gpt-a,deepseek:deepseek-chat", "LLM_MODEL").unwrap(),
+        vec![
+            (ModelProvider::OpenAi, openai.clone()),
+            (ModelProvider::DeepSeek, deepseek.clone()),
+        ],
+    )
+    .unwrap();
+
+    let err = provider.chat_with_tools(tool_request()).await.unwrap_err();
+
+    assert_eq!(err.code, "context_budget_exceeded");
+    assert_eq!(err.stage, "tool_loop");
+    assert_eq!(openai.tool_calls(), 1);
+    assert_eq!(deepseek.tool_calls(), 0);
+}
+
+#[tokio::test]
 async fn tool_candidate_failure_then_timeout_uses_latest_terminal_reason() {
     let (provider, first, second) =
         handle_route_provider(HandleBehavior::Failed, HandleBehavior::Timeout);


### PR DESCRIPTION
Closes #607

## 根因

QQ 一级引用图片下载到本地后会在 OpenAI Provider 组装为 Data URL。Tool Loop 原先按完整 JSON 字符数估算上下文，导致 Base64 传输正文被当作文本预算；同时引用解析会递归进入内层 `msg_elements`，无法稳定区分直接引用与历史引用媒体。

## 修改

- 为 Responses 与 Chat Completions Tool Loop 建立同一套预算视图：
  - 只在 `input_image.image_url` 和 `image_url.image_url.url` 的结构化图片协议字段中遮蔽 Base64。
  - 每张结构化图片按 1024 字符计入独立媒体成本；真实发送 payload 不修改。
  - 普通用户文本中的 Data URL 仍完整计入文本预算。
  - 新增不含正文的安全计数日志：原始上下文、图片编码、图片预算、工具定义、文本与协议开销。
- QQ `message_type=103` 只解析顶层 `msg_elements`：
  - 直接引用层的多段文字与不同 filename 图片按 QQ 占位顺序保留。
  - 子 `msg_elements` 不递归解析，不恢复其中的 URL、Base64 或媒体对象。
  - QQ 拍平到顶层 `msg_elements[].content` 的二次引用展示整体保留为普通文本，不提取 `[消息内容]`、不生成固定摘要，也不解析 `[关联消息]`、`[附件N]`、filename、file_id、rkey 或临时 URL。
  - 延续现有 32 个媒体 part 与 `media_max_bytes` 等限制。
- 保留并收紧 `deduplicate_quoted_images_by_filename`：
  - 仅在一次 `fetch_qq_official_quoted_images` 所持有的单条直接引用 payload 内生效。
  - filename 经 trim + ASCII 小写规范化后相同则保留第一次出现的位置。
  - filename 为空不去重；不按 URL、file_id、大小、尺寸或内容哈希追加推测规则。
  - 去重集合为函数局部状态，不跨当前消息附件、其他引用、其他消息或 RefIndex。
- RefIndex 只保存当前消息自身 parts，不复制 quoted 结构化媒体树；结构化 QQ 临时媒体 URL 不进入索引。拍平引用文本不额外解释或清洗，但不会据此生成图片 part、触发下载或生成 Data URL。
- `context_budget_exceeded@tool_loop` 作为本地永久错误直接返回，不再轮询等价模型候选；Core 继续映射为容量提示，不误报上游不可用。

## 路由与边界

- 直接图片通过当前消息 `input_parts` 进入 Core；一级单图/多图引用通过 `QuotedMessageContext.input_parts` 进入 Core。
- Core 在 `runtime/respond/llm_service/message_parts.rs` 按“引用上下文 → 当前消息”顺序投影；支持视觉时保留图片，否则降级媒体摘要。
- 普通 Chat 继续走所选 Provider 的标准 Responses/Chat Completions payload。
- Tool Loop 根据候选模型协议走 OpenAI Responses `input_image` 或 Chat Completions `image_url`，两者共享本次媒体预算算法。

## 218066 诊断说明

旧日志只有总计 `retained_chars=218066`，没有保存分项，无法从该单值追溯图片编码、文本和工具定义的精确占用。本次新增安全计数日志，可在复现时直接得到：

- `structured_image_data_chars`
- `text_and_protocol_chars`
- `tool_schema_chars`
- `budgeted_model_context_chars`

不会记录图片、聊天正文、URL 或工具参数内容。

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo build --workspace --release --all-features`

覆盖了 Responses/Chat Tool Loop 单图与多图预算、普通文本 Data URL、一级图文顺序、不同 filename 多图、同层规范化 filename 去重、filename 缺失、跨引用/消息隔离、当前附件与引用附件隔离、嵌套结构化媒体停止恢复、拍平引用文本不产生图片/下载/Data URL、RefIndex 不复制 quoted 媒体树及本地预算错误停止候选路由。

## 真机验证

本地未连接真实 QQ 环境。合并前需复测：

1. 手机端发送单图，直接引用并 @机器人发送短文本。
2. 电脑端发送“文字 + 单图”，再直接引用提问。
3. 电脑端发送“文字 + 多张不同 filename 图片”，再直接引用，核对数量与顺序。
4. 构造/观察 QQ 同图重复附件，核对相同 filename 只下载和发送一次。
5. 再次引用一条曾引用图片的消息，确认拍平展示文本仍作为文本存在，但不重新下载、发送或编码内层历史图片。

## 最新提交

- `7866196` `fix: 修正拍平引用文本边界`
