### PR TITLE
fix: 区分 LLM 与搜索请求超时

### DIFF
--- a/qq-maid-core/src/service/errors.rs
+++ b/qq-maid-core/src/service/errors.rs
@@ -106,9 +106,15 @@ impl CoreRespondFailure {
             ("timeout", _) => CoreFailureKind::LlmTimeout,
             (_, "query" | "search" | "web_search") => CoreFailureKind::SearchFailed,
             ("context_budget_exceeded", _) => CoreFailureKind::ContextBudgetExceeded,
-            ("provider_error" | "http_error" | "upstream_unavailable" | "rate_limited", _) => {
-                CoreFailureKind::LlmFailed
-            }
+            (
+                "provider_error"
+                | "http_error"
+                | "network_error"
+                | "authentication_failed"
+                | "upstream_unavailable"
+                | "rate_limited",
+                _,
+            ) => CoreFailureKind::LlmFailed,
             _ => CoreFailureKind::Internal,
         };
         Self {
@@ -131,7 +137,7 @@ fn user_visible_failure_message(kind: CoreFailureKind) -> String {
     match kind {
         CoreFailureKind::SearchTimeout => "联网查询超时了，请稍后再试。",
         CoreFailureKind::SearchFailed => "联网查询暂时不可用，请稍后再试。",
-        CoreFailureKind::LlmTimeout => "LLM 服务处理超时，请稍后再试。",
+        CoreFailureKind::LlmTimeout => "LLM 请求超时，请稍后重试。",
         CoreFailureKind::LlmFailed => "上游服务暂时不可用，请稍后再试。",
         CoreFailureKind::ContextBudgetExceeded => {
             "本次查阅的资料较多，已超出当前对话可处理范围，请缩小查询范围后重试。"
@@ -180,6 +186,7 @@ pub(crate) fn warn_core_error(scope_key: &str, err: &LlmError) {
     warn!(
         scope_key,
         error_code = err.code,
+        error_kind = err.kind().as_str(),
         error_stage = err.stage,
         error_message = %safe_error_message(err),
         agent_stop_reason = agent
@@ -197,11 +204,24 @@ pub(crate) fn warn_core_error(scope_key: &str, err: &LlmError) {
     );
 }
 
-pub(crate) fn error_core_error(scope_key: &str, err: &LlmError) {
+pub(crate) fn error_core_error(
+    scope_key: &str,
+    err: &LlmError,
+    provider: &str,
+    model: &str,
+    stream: bool,
+    timeout_seconds: u64,
+) {
     error!(
         scope_key,
+        provider,
+        model,
+        stream,
         error_code = err.code,
+        error_kind = err.kind().as_str(),
         error_stage = err.stage,
+        timeout_stage = err.stage,
+        timeout_seconds,
         error_message = %safe_error_message(err),
         "core respond request timed out"
     );
@@ -226,7 +246,13 @@ mod tests {
 
     #[test]
     fn agent_provider_failures_keep_original_classification() {
-        for code in ["provider_error", "rate_limited", "upstream_unavailable"] {
+        for code in [
+            "provider_error",
+            "network_error",
+            "authentication_failed",
+            "rate_limited",
+            "upstream_unavailable",
+        ] {
             let failure = CoreRespondFailure::from_llm_error(&agent_error(
                 code,
                 "provider",
@@ -263,6 +289,15 @@ mod tests {
         ));
         assert_eq!(max_rounds.kind, CoreFailureKind::Internal);
         assert!(!max_rounds.retryable);
+    }
+
+    #[test]
+    fn exhausted_llm_timeout_has_explicit_user_message() {
+        let failure = CoreRespondFailure::from_llm_error(&LlmError::timeout("stream_read"));
+
+        assert_eq!(failure.kind, CoreFailureKind::LlmTimeout);
+        assert!(failure.message.contains("超时"));
+        assert!(!failure.message.contains("不可用"));
     }
 
     #[test]

--- a/qq-maid-core/src/service/handle.rs
+++ b/qq-maid-core/src/service/handle.rs
@@ -168,7 +168,14 @@ impl CoreService for CoreHandle {
                 }
                 Err(_) => {
                     let err = LlmError::timeout("stream_init");
-                    error_core_error(&scope_key, &err);
+                    error_core_error(
+                        &scope_key,
+                        &err,
+                        state.provider.name(),
+                        state.provider.model(),
+                        state.provider.stream_enabled(),
+                        state.config.request_timeout_seconds,
+                    );
                     let _metrics = recorder.fail(
                         state.provider.name(),
                         state.provider.model(),
@@ -206,7 +213,14 @@ impl CoreService for CoreHandle {
             }
             Err(_) => {
                 let err = LlmError::timeout("request");
-                error_core_error(&scope_key, &err);
+                error_core_error(
+                    &scope_key,
+                    &err,
+                    state.provider.name(),
+                    state.provider.model(),
+                    state.provider.stream_enabled(),
+                    state.config.request_timeout_seconds,
+                );
                 let _metrics = recorder.fail(
                     state.provider.name(),
                     state.provider.model(),

--- a/qq-maid-gateway-rs/src/gateway/onebot11/dispatch/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/onebot11/dispatch/mod.rs
@@ -28,7 +28,7 @@ use crate::{
 use super::{OneBotSendError, OneBotSendResult, OneBotSender};
 
 const STREAM_FAILED_TEXT: &str = "处理失败，请稍后再试。";
-const STREAM_TIMEOUT_TEXT: &str = "LLM 服务处理超时，请稍后再试";
+const STREAM_TIMEOUT_TEXT: &str = "LLM 请求超时，请稍后重试。";
 const STREAM_CANCELLED_TEXT: &str = "本次处理已取消，请重新发送消息。";
 
 type EventFuture<'a> = Pin<Box<dyn Future<Output = Option<CoreResponseEvent>> + Send + 'a>>;
@@ -925,7 +925,7 @@ mod tests {
                     "respond",
                     "timed out",
                 ))),
-                "LLM 服务处理超时，请稍后再试",
+                "LLM 请求超时，请稍后重试。",
             ),
             (
                 Ok(OneBotCoreTransport::Stream(Box::new(FakeStream {

--- a/qq-maid-gateway-rs/src/gateway/qq_official/group/tests.rs
+++ b/qq-maid-gateway-rs/src/gateway/qq_official/group/tests.rs
@@ -16,7 +16,7 @@ fn local_group_hints_use_configured_bot_display_name() {
 async fn group_stream_timeout_sends_core_safe_failure_text() {
     let stream = FakeGroupEventStream::new([CoreResponseEvent::Failed(CoreRespondFailure {
         kind: CoreFailureKind::LlmTimeout,
-        message: "LLM 服务处理超时，请稍后再试。".to_owned(),
+        message: "LLM 请求超时，请稍后重试。".to_owned(),
         retryable: true,
         agent: None,
     })]);
@@ -39,7 +39,7 @@ async fn group_stream_timeout_sends_core_safe_failure_text() {
                 group_openid: "group-1".to_owned(),
                 msg_id: Some("group-msg-1".to_owned()),
             },
-            "LLM 服务处理超时，请稍后再试。".to_owned(),
+            "LLM 请求超时，请稍后重试。".to_owned(),
         )]
     );
     assert!(cache.lock().unwrap().contains("failure-message-id"));

--- a/qq-maid-gateway-rs/src/gateway/stream/tests/mod.rs
+++ b/qq-maid-gateway-rs/src/gateway/stream/tests/mod.rs
@@ -924,7 +924,7 @@ async fn pending_core_failure_sends_safe_ordinary_failure_reply() {
 async fn stream_timeout_failure_stops_typing_with_timeout_reason() {
     let events = FakeEventStream::new([CoreResponseEvent::Failed(CoreRespondFailure {
         kind: CoreFailureKind::LlmTimeout,
-        message: "LLM 服务处理超时，请稍后再试。".to_owned(),
+        message: "LLM 请求超时，请稍后重试。".to_owned(),
         retryable: true,
         agent: None,
     })]);
@@ -958,7 +958,7 @@ async fn stream_timeout_failure_stops_typing_with_timeout_reason() {
     assert_eq!(
         sender.calls(),
         vec![FakeCall::Text {
-            content: "LLM 服务处理超时，请稍后再试。".to_owned(),
+            content: "LLM 请求超时，请稍后重试。".to_owned(),
             msg_id: Some("msg-1".to_owned()),
         }]
     );
@@ -970,7 +970,7 @@ async fn active_core_failure_finalizes_stream_without_ordinary_failure_reply() {
         CoreResponseEvent::TextDelta("已发送".to_owned()),
         CoreResponseEvent::Failed(CoreRespondFailure {
             kind: CoreFailureKind::LlmTimeout,
-            message: "LLM 服务处理超时，请稍后再试。".to_owned(),
+            message: "LLM 请求超时，请稍后重试。".to_owned(),
             retryable: true,
             agent: None,
         }),

--- a/qq-maid-gateway-rs/src/respond.rs
+++ b/qq-maid-gateway-rs/src/respond.rs
@@ -730,7 +730,7 @@ fn respond_error_info_to_qq_text(code: &str, stage: &str, message: &str) -> Stri
     let stage = stage.trim();
     let safe_message = sanitize_visible_error_message(message);
     match code {
-        "timeout" => "LLM 服务处理超时，请稍后再试".to_owned(),
+        "timeout" => "LLM 请求超时，请稍后重试。".to_owned(),
         "config" => "LLM 服务配置未完成，请联系维护者处理".to_owned(),
         "safety_blocked" => {
             "这条消息触发了上游安全拦截，我没法按原样继续。可以换个说法再试。".to_owned()
@@ -745,7 +745,12 @@ fn respond_error_info_to_qq_text(code: &str, stage: &str, message: &str) -> Stri
             .map(|message| format!("没有找到相关结果：{message}"))
             .unwrap_or_else(|| "没有找到相关结果，请换个说法再试".to_owned()),
         "io_error" => "服务存储暂时不可用，请稍后再试".to_owned(),
-        "provider_error" | "http_error" => "上游服务暂时不可用，请稍后再试".to_owned(),
+        "authentication_failed" => "LLM 服务鉴权失败，请联系维护者处理。".to_owned(),
+        "rate_limited" => "LLM 请求受到限流，请稍后重试。".to_owned(),
+        "network_error" | "http_error" => "LLM 网络连接失败，请稍后重试。".to_owned(),
+        "upstream_unavailable" | "provider_error" => {
+            "上游服务暂时不可用，请稍后再试".to_owned()
+        }
         _ => safe_message
             .map(|message| format!("处理失败：{message}"))
             .unwrap_or_else(|| format!("处理失败（阶段：{stage}，错误码：{code}）")),
@@ -1502,6 +1507,19 @@ mod tests {
 
         assert_eq!(text, "请求格式有误，请调整后再试");
         assert!(!text.contains("sk-secret"));
+    }
+
+    #[test]
+    fn timeout_error_is_not_rendered_as_service_unavailable() {
+        let text = respond_error_to_qq_text(&RespondError::Core(CoreError::new(
+            "timeout",
+            "stream_read",
+            "internal timeout detail",
+        )));
+
+        assert_eq!(text, "LLM 请求超时，请稍后重试。");
+        assert!(text.contains("超时"));
+        assert!(!text.contains("不可用"));
     }
 
     /// 群聊寻址前缀下的污染检测：raw.content 包含 @机器人 前缀，

--- a/qq-maid-llm/src/error.rs
+++ b/qq-maid-llm/src/error.rs
@@ -1,6 +1,8 @@
 //! 应用错误类型。定义 `LlmError` 主错误结构体及其便捷构造方法，
 //! 以及序列化友好的 `ErrorInfo` 表示。
 
+use std::{error::Error as StdError, io};
+
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -21,6 +23,35 @@ pub struct ErrorInfo {
     pub message: String,
     /// 错误发生的阶段
     pub stage: String,
+}
+
+/// LLM 调用失败的稳定分类。
+///
+/// Provider 可以保留自己的错误码与阶段，但路由、日志和用户提示应优先消费这一层，
+/// 避免把客户端超时、连接失败和上游 5xx 都压成同一个“服务不可用”。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LlmErrorKind {
+    Timeout,
+    Authentication,
+    RateLimit,
+    UpstreamUnavailable,
+    Network,
+    InvalidRequest,
+    Other,
+}
+
+impl LlmErrorKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Timeout => "timeout",
+            Self::Authentication => "authentication",
+            Self::RateLimit => "rate_limit",
+            Self::UpstreamUnavailable => "upstream_unavailable",
+            Self::Network => "network",
+            Self::InvalidRequest => "invalid_request",
+            Self::Other => "other",
+        }
+    }
 }
 
 /// 应用主错误类型，携带代码、消息和阶段信息。
@@ -66,6 +97,79 @@ impl LlmError {
     /// 创建超时类错误。
     pub fn timeout(stage: impl Into<String>) -> Self {
         Self::new("timeout", "LLM request timed out", stage)
+    }
+
+    /// 从带 source chain 的底层错误创建 LLM 错误。
+    ///
+    /// 结构化的 reqwest / io 超时优先于 fallback；无法识别时才采用调用点给出的
+    /// fallback。消息保留错误链供脱敏日志排障，用户侧不得直接展示该消息。
+    pub fn from_error_source(
+        error: &(dyn StdError + 'static),
+        fallback: LlmErrorKind,
+        stage: impl Into<String>,
+        context: impl AsRef<str>,
+    ) -> Self {
+        let detected = classify_error_source(error);
+        let kind = if detected == LlmErrorKind::Other {
+            fallback
+        } else {
+            detected
+        };
+        Self::from_kind(
+            kind,
+            format!("{}: {}", context.as_ref(), error_chain_message(error)),
+            stage,
+        )
+    }
+
+    /// 映射读取非流式响应正文时的 reqwest 错误：超时/断链属于传输阶段，纯 JSON
+    /// 解码失败仍属于上游响应协议错误。
+    pub fn from_response_source(
+        error: &(dyn StdError + 'static),
+        context: impl AsRef<str>,
+    ) -> Self {
+        let detected = classify_error_source(error);
+        let stage = if matches!(detected, LlmErrorKind::Timeout | LlmErrorKind::Network) {
+            "response_read"
+        } else {
+            "json"
+        };
+        Self::from_error_source(error, LlmErrorKind::Other, stage, context)
+    }
+
+    /// 按稳定分类构造错误，同时保留项目既有错误码以兼容调用方。
+    pub fn from_kind(
+        kind: LlmErrorKind,
+        message: impl Into<String>,
+        stage: impl Into<String>,
+    ) -> Self {
+        let code = match kind {
+            LlmErrorKind::Timeout => "timeout",
+            LlmErrorKind::Authentication => "authentication_failed",
+            LlmErrorKind::RateLimit => "rate_limited",
+            LlmErrorKind::UpstreamUnavailable => "upstream_unavailable",
+            LlmErrorKind::Network => "network_error",
+            LlmErrorKind::InvalidRequest => "bad_request",
+            LlmErrorKind::Other => "provider_error",
+        };
+        Self::new(code, message, stage)
+    }
+
+    /// 根据真实上游 HTTP 状态建立错误分类；调用方仍可在此之前处理安全拦截等
+    /// 协议特例，但不得从响应正文反向猜测状态。
+    pub fn from_upstream_status(
+        status: u16,
+        message: impl Into<String>,
+        stage: impl Into<String>,
+    ) -> Self {
+        let kind = match status {
+            401 | 403 => LlmErrorKind::Authentication,
+            429 => LlmErrorKind::RateLimit,
+            500..=599 => LlmErrorKind::UpstreamUnavailable,
+            400..=499 => LlmErrorKind::InvalidRequest,
+            _ => LlmErrorKind::Other,
+        };
+        Self::from_kind(kind, message, stage).with_upstream_status(status)
     }
 
     /// 创建供应商接口类错误。
@@ -125,6 +229,30 @@ impl LlmError {
             .map(|context| context.model.as_str())
     }
 
+    /// 返回跨 Provider 统一的错误分类。
+    pub fn kind(&self) -> LlmErrorKind {
+        match self.upstream_status {
+            Some(401 | 403) => return LlmErrorKind::Authentication,
+            Some(429) => return LlmErrorKind::RateLimit,
+            Some(500..=599) => return LlmErrorKind::UpstreamUnavailable,
+            Some(400..=499) => return LlmErrorKind::InvalidRequest,
+            _ => {}
+        }
+        match self.code.as_str() {
+            "timeout" => LlmErrorKind::Timeout,
+            "authentication_failed" | "tavily_auth_error" | "permission_denied" => {
+                LlmErrorKind::Authentication
+            }
+            "rate_limited" | "quota_exhausted" => LlmErrorKind::RateLimit,
+            "upstream_unavailable" => LlmErrorKind::UpstreamUnavailable,
+            "http_error" | "network_error" => LlmErrorKind::Network,
+            "bad_tool_arguments" | "bad_request" | "invalid_request" | "upstream_bad_request" => {
+                LlmErrorKind::InvalidRequest
+            }
+            _ => LlmErrorKind::Other,
+        }
+    }
+
     /// 将历史错误码归一为稳定的联网/工具故障分类。
     pub fn error_kind(&self) -> &'static str {
         match self.upstream_status {
@@ -169,9 +297,161 @@ impl LlmError {
     }
 }
 
+/// 沿错误 source chain 识别结构化超时与传输错误，不依赖错误文本。
+pub fn classify_error_source(error: &(dyn StdError + 'static)) -> LlmErrorKind {
+    let mut current = Some(error);
+    while let Some(source) = current {
+        if let Some(error) = source.downcast_ref::<reqwest::Error>() {
+            if error.is_timeout() {
+                return LlmErrorKind::Timeout;
+            }
+            if let Some(status) = error.status() {
+                return match status.as_u16() {
+                    401 | 403 => LlmErrorKind::Authentication,
+                    429 => LlmErrorKind::RateLimit,
+                    500..=599 => LlmErrorKind::UpstreamUnavailable,
+                    400..=499 => LlmErrorKind::InvalidRequest,
+                    _ => LlmErrorKind::Other,
+                };
+            }
+            if error.is_connect() || error.is_request() || error.is_body() {
+                return LlmErrorKind::Network;
+            }
+        }
+        if let Some(error) = source.downcast_ref::<io::Error>() {
+            match error.kind() {
+                io::ErrorKind::TimedOut => return LlmErrorKind::Timeout,
+                io::ErrorKind::ConnectionRefused
+                | io::ErrorKind::ConnectionReset
+                | io::ErrorKind::ConnectionAborted
+                | io::ErrorKind::NotConnected
+                | io::ErrorKind::AddrInUse
+                | io::ErrorKind::AddrNotAvailable
+                | io::ErrorKind::BrokenPipe
+                | io::ErrorKind::UnexpectedEof => return LlmErrorKind::Network,
+                _ => {}
+            }
+        }
+        current = source.source();
+    }
+    LlmErrorKind::Other
+}
+
+fn error_chain_message(error: &(dyn StdError + 'static)) -> String {
+    let mut messages = Vec::new();
+    let mut current = Some(error);
+    while let Some(source) = current {
+        messages.push(source.to_string());
+        current = source.source();
+    }
+    messages.join(": caused by: ")
+}
+
 /// 自动将 LlmError 转换为 ErrorInfo。
 impl From<LlmError> for ErrorInfo {
     fn from(value: LlmError) -> Self {
         value.as_info()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[derive(Debug, Error)]
+    #[error("middle transport wrapper")]
+    struct MiddleError(#[source] reqwest::Error);
+
+    #[derive(Debug, Error)]
+    #[error("outer provider wrapper")]
+    struct OuterError(#[source] MiddleError);
+
+    async fn structured_reqwest_timeout() -> reqwest::Error {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.unwrap();
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        });
+        qq_maid_common::http_client::try_builder()
+            .unwrap()
+            .timeout(Duration::from_millis(20))
+            .build()
+            .unwrap()
+            .get(format!("http://{addr}/slow"))
+            .send()
+            .await
+            .unwrap_err()
+    }
+
+    #[tokio::test]
+    async fn structured_http_timeout_maps_to_timeout() {
+        let source = structured_reqwest_timeout().await;
+        assert!(source.is_timeout());
+
+        let error = LlmError::from_error_source(
+            &source,
+            LlmErrorKind::Network,
+            "http_request_timeout",
+            "test request failed",
+        );
+
+        assert_eq!(error.kind(), LlmErrorKind::Timeout);
+        assert_eq!(error.code, "timeout");
+        assert_eq!(error.stage, "http_request_timeout");
+    }
+
+    #[tokio::test]
+    async fn wrapped_source_chain_still_detects_reqwest_timeout() {
+        let wrapped = OuterError(MiddleError(structured_reqwest_timeout().await));
+
+        assert_eq!(classify_error_source(&wrapped), LlmErrorKind::Timeout);
+        let error = LlmError::from_error_source(
+            &wrapped,
+            LlmErrorKind::Other,
+            "response_read",
+            "wrapped request failed",
+        );
+        assert_eq!(error.code, "timeout");
+        assert!(error.message.contains("middle transport wrapper"));
+    }
+
+    #[tokio::test]
+    async fn connection_failure_is_network_not_timeout() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let source = qq_maid_common::http_client::client()
+            .get(format!("http://{addr}/unavailable"))
+            .send()
+            .await
+            .unwrap_err();
+
+        let error = LlmError::from_error_source(
+            &source,
+            LlmErrorKind::Network,
+            "http_request",
+            "test request failed",
+        );
+        assert_eq!(error.kind(), LlmErrorKind::Network);
+        assert_eq!(error.code, "network_error");
+        assert_ne!(error.kind(), LlmErrorKind::Timeout);
+    }
+
+    #[test]
+    fn upstream_statuses_have_distinct_categories() {
+        let cases = [
+            (401, LlmErrorKind::Authentication),
+            (429, LlmErrorKind::RateLimit),
+            (503, LlmErrorKind::UpstreamUnavailable),
+            (400, LlmErrorKind::InvalidRequest),
+        ];
+        for (status, expected) in cases {
+            let error = LlmError::from_upstream_status(status, "upstream failed", "http");
+            assert_eq!(error.kind(), expected, "status={status}");
+            assert_ne!(error.kind(), LlmErrorKind::Timeout, "status={status}");
+        }
     }
 }

--- a/qq-maid-llm/src/lib.rs
+++ b/qq-maid-llm/src/lib.rs
@@ -15,5 +15,5 @@ pub mod sse;
 pub mod tool;
 pub mod web_search;
 
-pub use error::{ErrorInfo, LlmError};
+pub use error::{ErrorInfo, LlmError, LlmErrorKind};
 pub use service::LlmService;

--- a/qq-maid-llm/src/provider/openai/chat/mod.rs
+++ b/qq-maid-llm/src/provider/openai/chat/mod.rs
@@ -10,11 +10,11 @@ use reqwest::{
     header::{HeaderName, HeaderValue},
 };
 use serde_json::{Value, json};
-use std::{collections::VecDeque, path::Path};
+use std::{collections::VecDeque, path::Path, time::Instant};
 
 use crate::{
     config::HttpAuthConfig,
-    error::LlmError,
+    error::{LlmError, LlmErrorKind},
     metrics::MetricsRecorder,
     provider::{
         ChatOutcome, LlmStream, LlmStreamEvent, collect_llm_stream,
@@ -395,6 +395,8 @@ pub(crate) fn file_unsupported_error() -> LlmError {
 
 pub(super) async fn send_chat_completions_request(
     client: &ChatCompletionsClient,
+    provider: &str,
+    model: &str,
     payload: &Value,
     stream: bool,
 ) -> Result<reqwest::Response, LlmError> {
@@ -424,17 +426,30 @@ pub(super) async fn send_chat_completions_request(
     if stream {
         request = request.header(header::ACCEPT, "text/event-stream");
     }
+    let started = Instant::now();
     let response = request.send().await.map_err(|err| {
-        if err.is_timeout() {
-            LlmError::timeout("http")
+        let stage = if err.is_timeout() {
+            "http_request_timeout"
         } else {
-            let context = if stream {
-                "Chat Completions stream request failed"
-            } else {
-                "Chat Completions request failed"
-            };
-            LlmError::http(format!("{context}: {err}"))
-        }
+            "http_request"
+        };
+        let context = if stream {
+            "Chat Completions stream request failed"
+        } else {
+            "Chat Completions request failed"
+        };
+        let mapped = LlmError::from_error_source(&err, LlmErrorKind::Network, stage, context);
+        tracing::warn!(
+            provider,
+            model,
+            stream,
+            timeout_stage = mapped.stage.as_str(),
+            elapsed_ms = started.elapsed().as_millis(),
+            error_kind = mapped.kind().as_str(),
+            error = %err,
+            "LLM Chat Completions transport failed"
+        );
+        mapped
     })?;
     let status = response.status();
     if !status.is_success() {
@@ -459,13 +474,7 @@ async fn chat_status_error(status: StatusCode, response: reqwest::Response) -> L
     if is_prompt_blocked_error(&detail) {
         return LlmError::new("safety_blocked", message, "http");
     }
-    match status.as_u16() {
-        401 | 403 => LlmError::config(message),
-        400 | 404 | 422 => LlmError::new("bad_request", message, "http"),
-        429 => LlmError::new("rate_limited", message, "http"),
-        500..=599 => LlmError::new("upstream_unavailable", message, "http"),
-        _ => LlmError::http(message),
-    }
+    LlmError::from_upstream_status(status.as_u16(), message, "http")
 }
 
 fn truncate_error_detail(value: &str, limit: usize) -> String {
@@ -496,9 +505,9 @@ pub(crate) async fn non_stream_completion(
     let recorder = MetricsRecorder::start();
     let payload =
         chat_completions_payload(messages, model, media_max_bytes, max_output_tokens, false)?;
-    let response = send_chat_completions_request(client, &payload, false).await?;
+    let response = send_chat_completions_request(client, provider, model, &payload, false).await?;
     let body: Value = response.json().await.map_err(|err| {
-        LlmError::provider(format!("invalid Chat Completions JSON: {err}"), "json")
+        LlmError::from_response_source(&err, "failed to read Chat Completions JSON")
     })?;
     let reply = extract_chat_completion_text(&body).ok_or_else(|| {
         LlmError::provider("Chat Completions returned empty text output", "provider")
@@ -549,7 +558,7 @@ pub(crate) async fn chat_completions_stream(
     let recorder = MetricsRecorder::start();
     let payload =
         chat_completions_payload(messages, _model, media_max_bytes, max_output_tokens, true)?;
-    let response = send_chat_completions_request(client, &payload, true).await?;
+    let response = send_chat_completions_request(client, _provider, _model, &payload, true).await?;
     let frame_buffer = Vec::new();
     let answer = String::new();
     let final_message = String::new();
@@ -745,7 +754,8 @@ async fn next_chat_stream_event(
             }
             Err(err) => {
                 return Some(Err(stream_transport_error(
-                    format!("Chat Completions stream failed: {err}"),
+                    err,
+                    "Chat Completions stream failed",
                     &state.answer,
                 )));
             }

--- a/qq-maid-llm/src/provider/openai/chat_tool_loop/mod.rs
+++ b/qq-maid-llm/src/provider/openai/chat_tool_loop/mod.rs
@@ -105,12 +105,16 @@ impl AgentStepSession for ChatCompletionsAgentSession {
             false,
         );
         let (payload, tools_disabled) = enforce_tool_loop_budget(self.context_budget, payload)?;
-        let response = send_chat_completions_request(&self.client, &payload, false).await?;
+        let response = send_chat_completions_request(
+            &self.client,
+            &self.provider,
+            &self.model,
+            &payload,
+            false,
+        )
+        .await?;
         let body: Value = response.json().await.map_err(|err| {
-            LlmError::provider(
-                format!("invalid Chat Completions tool loop JSON: {err}"),
-                "json",
-            )
+            LlmError::from_response_source(&err, "failed to read Chat Completions tool loop JSON")
         })?;
         let step_usage = extract_chat_completion_usage(&body);
         let tool_rounds = extract_tool_call_rounds(&body)?;
@@ -176,7 +180,14 @@ impl AgentStepSession for ChatCompletionsAgentSession {
             true,
         );
         let (payload, tools_disabled) = enforce_tool_loop_budget(self.context_budget, payload)?;
-        let response = send_chat_completions_request(&self.client, &payload, true).await?;
+        let response = send_chat_completions_request(
+            &self.client,
+            &self.provider,
+            &self.model,
+            &payload,
+            true,
+        )
+        .await?;
         let step = collect_chat_completions_tool_loop_stream(
             response,
             &mut messages,
@@ -390,7 +401,8 @@ async fn collect_chat_completions_tool_loop_stream(
             Ok(None) => break,
             Err(err) => {
                 return Err(stream_transport_error(
-                    format!("Chat Completions tool loop stream failed: {err}"),
+                    err,
+                    "Chat Completions tool loop stream failed",
                     &answer,
                 ));
             }

--- a/qq-maid-llm/src/provider/openai/configured.rs
+++ b/qq-maid-llm/src/provider/openai/configured.rs
@@ -768,7 +768,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn configured_responses_maps_upstream_401_to_provider_unavailable() {
+    async fn configured_responses_keeps_upstream_401_as_authentication() {
         let (base_url, state) = spawn_mock(vec![MockReply {
             status: StatusCode::UNAUTHORIZED,
             content_type: "application/json",
@@ -790,8 +790,9 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert_eq!(error.code, "provider_error");
-        assert_eq!(error.stage, "provider_unavailable");
+        assert_eq!(error.code, "authentication_failed");
+        assert_eq!(error.kind(), crate::error::LlmErrorKind::Authentication);
+        assert_eq!(error.upstream_status, Some(401));
         assert!(error.message.contains("HTTP 401"));
         assert_eq!(state.lock().await.requests.len(), 1);
     }

--- a/qq-maid-llm/src/provider/openai/fallback.rs
+++ b/qq-maid-llm/src/provider/openai/fallback.rs
@@ -33,10 +33,10 @@ pub(crate) fn should_retry_non_stream_after_stream_error(err: &LlmError) -> bool
 /// 当 Responses 主链路失败时，是否允许降级到 Chat Completions。
 /// 认证/授权拒绝对同一 Provider 的另一端点同样无效，应直接交给跨 Provider 候选链。
 pub(crate) fn should_fallback_to_chat_after_responses_error(err: &LlmError) -> bool {
-    if err.upstream_status == Some(400) {
-        // Responses 端点的协议/模型兼容错误仍按既有行为尝试 Chat Completions；
-        // 本地 bad_request 没有 upstream_status，不会因此产生额外请求。
-        return true;
+    if let Some(status) = err.upstream_status {
+        // 只有真实上游返回的端点/协议兼容状态才允许切换端点；本地 bad_request
+        // 没有 upstream_status，认证、限流和服务端错误也不应重复请求同一 Provider。
+        return matches!(status, 400 | 404 | 422);
     }
     matches!(
         err.code.as_str(),
@@ -105,19 +105,46 @@ mod tests {
     }
 
     #[test]
-    fn responses_errors_trigger_chat_fallback_only_for_upstream_failures() {
-        assert!(should_fallback_to_chat_after_responses_error(
-            &LlmError::http("OpenAI chat returned HTTP 400")
-        ));
-        assert!(should_fallback_to_chat_after_responses_error(
-            &LlmError::provider("invalid OpenAI chat stream JSON", "sse")
-        ));
+    fn responses_incompatible_upstream_statuses_trigger_chat_fallback() {
+        for status in [400, 404, 422] {
+            let error =
+                LlmError::from_upstream_status(status, "incompatible Responses API", "http");
+            assert!(
+                should_fallback_to_chat_after_responses_error(&error),
+                "status={status}"
+            );
+        }
+    }
+
+    #[test]
+    fn local_bad_request_does_not_trigger_chat_fallback() {
         assert!(!should_fallback_to_chat_after_responses_error(
             &LlmError::new(
                 "bad_request",
                 "messages must contain non-empty content",
                 "request"
             )
+        ));
+    }
+
+    #[test]
+    fn authentication_statuses_do_not_trigger_chat_fallback() {
+        for status in [401, 403] {
+            let error = LlmError::from_upstream_status(status, "authentication rejected", "http");
+            assert!(
+                !should_fallback_to_chat_after_responses_error(&error),
+                "status={status}"
+            );
+        }
+    }
+
+    #[test]
+    fn responses_protocol_errors_without_http_status_can_trigger_chat_fallback() {
+        assert!(should_fallback_to_chat_after_responses_error(
+            &LlmError::http("OpenAI Responses transport failed")
+        ));
+        assert!(should_fallback_to_chat_after_responses_error(
+            &LlmError::provider("invalid OpenAI chat stream JSON", "sse")
         ));
         assert!(!should_fallback_to_chat_after_responses_error(
             &LlmError::config("OPENAI_API_KEY is required")

--- a/qq-maid-llm/src/provider/openai/fallback.rs
+++ b/qq-maid-llm/src/provider/openai/fallback.rs
@@ -14,22 +14,36 @@ pub(crate) fn should_retry_non_stream_after_empty_stream(outcome: &ChatOutcome) 
 pub(crate) fn should_retry_non_stream_after_stream_error(err: &LlmError) -> bool {
     matches!(
         err.code.as_str(),
-        "provider_error" | "http_error" | "timeout"
+        "provider_error" | "http_error" | "network_error" | "timeout"
     ) && matches!(
         err.stage.as_str(),
-        "provider" | "stream" | "http" | "sse" | "stream_after_delta"
+        "provider"
+            | "stream"
+            | "http"
+            | "http_request"
+            | "http_request_timeout"
+            | "response_read"
+            | "stream_read"
+            | "stream_read_after_delta"
+            | "sse"
+            | "stream_after_delta"
     )
 }
 
 /// 当 Responses 主链路失败时，是否允许降级到 Chat Completions。
 /// 认证/授权拒绝对同一 Provider 的另一端点同样无效，应直接交给跨 Provider 候选链。
 pub(crate) fn should_fallback_to_chat_after_responses_error(err: &LlmError) -> bool {
+    if err.upstream_status == Some(400) {
+        // Responses 端点的协议/模型兼容错误仍按既有行为尝试 Chat Completions；
+        // 本地 bad_request 没有 upstream_status，不会因此产生额外请求。
+        return true;
+    }
     matches!(
         err.code.as_str(),
-        "provider_error" | "http_error" | "timeout"
+        "provider_error" | "http_error" | "network_error" | "timeout"
     ) && !matches!(
         err.stage.as_str(),
-        "stream_after_delta" | "provider_unavailable"
+        "stream_after_delta" | "stream_read_after_delta" | "provider_unavailable"
     )
 }
 

--- a/qq-maid-llm/src/provider/openai/mod.rs
+++ b/qq-maid-llm/src/provider/openai/mod.rs
@@ -840,6 +840,94 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn openai_chat_falls_back_after_responses_incompatible_status() {
+        for responses_status in [
+            AxumStatusCode::NOT_FOUND,
+            AxumStatusCode::UNPROCESSABLE_ENTITY,
+        ] {
+            let (base_url, state) = spawn_mock_openai(MockOpenAiState {
+                responses_status,
+                responses_body: serde_json::json!({"error": {"message": "Responses API is incompatible"}}),
+                chat_body: mock_chat_response("chat fallback ok"),
+                responses_calls: 0,
+                chat_calls: 0,
+                chat_requests: Vec::new(),
+            })
+            .await;
+            let http_client = qq_maid_common::http_client::client();
+            let chat_client =
+                ChatCompletionsClient::new("test-key", Some(&base_url), http_client.clone());
+
+            let outcome = openai_chat_with_chat_fallback(OpenAiChatFallbackRequest {
+                api_mode: OpenAiApiMode::Auto,
+                stream: false,
+                responses_client: &http_client,
+                chat_client: &chat_client,
+                api_key: "test-key",
+                base_url: Some(&base_url),
+                responses_auth: None,
+                provider: "openai",
+                model: "gpt-5.5",
+                media_max_bytes: 10 * 1024 * 1024,
+                max_output_tokens: 1200,
+                reasoning_effort: None,
+                messages: &[ChatMessage::user("hi")],
+                image_generation_enabled: false,
+            })
+            .await
+            .unwrap();
+
+            assert_eq!(outcome.reply, "chat fallback ok");
+            let state = state.lock().await;
+            assert_eq!(state.responses_calls, 1, "status={responses_status}");
+            assert_eq!(state.chat_calls, 1, "status={responses_status}");
+        }
+    }
+
+    #[tokio::test]
+    async fn openai_chat_does_not_fallback_after_responses_authentication_status() {
+        for responses_status in [AxumStatusCode::UNAUTHORIZED, AxumStatusCode::FORBIDDEN] {
+            let (base_url, state) = spawn_mock_openai(MockOpenAiState {
+                responses_status,
+                responses_body: serde_json::json!({"error": {"message": "authentication rejected"}}),
+                chat_body: mock_chat_response("must not run"),
+                responses_calls: 0,
+                chat_calls: 0,
+                chat_requests: Vec::new(),
+            })
+            .await;
+            let http_client = qq_maid_common::http_client::client();
+            let chat_client =
+                ChatCompletionsClient::new("test-key", Some(&base_url), http_client.clone());
+
+            let error = openai_chat_with_chat_fallback(OpenAiChatFallbackRequest {
+                api_mode: OpenAiApiMode::Auto,
+                stream: false,
+                responses_client: &http_client,
+                chat_client: &chat_client,
+                api_key: "test-key",
+                base_url: Some(&base_url),
+                responses_auth: None,
+                provider: "openai",
+                model: "gpt-5.5",
+                media_max_bytes: 10 * 1024 * 1024,
+                max_output_tokens: 1200,
+                reasoning_effort: None,
+                messages: &[ChatMessage::user("hi")],
+                image_generation_enabled: false,
+            })
+            .await
+            .unwrap_err();
+
+            assert_eq!(error.code, "authentication_failed");
+            assert_eq!(error.upstream_status, Some(responses_status.as_u16()));
+            let state = state.lock().await;
+            assert_eq!(state.responses_calls, 1, "status={responses_status}");
+            assert_eq!(state.chat_calls, 0, "status={responses_status}");
+        }
+    }
+
+    #[tokio::test]
     async fn openai_chat_only_uses_chat_completions_without_responses() {
         let (base_url, state) = spawn_mock_openai(MockOpenAiState {
             responses_status: AxumStatusCode::INTERNAL_SERVER_ERROR,

--- a/qq-maid-llm/src/provider/openai/mod.rs
+++ b/qq-maid-llm/src/provider/openai/mod.rs
@@ -55,7 +55,9 @@ pub(crate) use chat_tool_loop::{
 };
 pub(crate) use configured::ConfiguredResponsesProvider;
 pub(crate) use stream::is_openai_responses_done_sentinel;
-pub(crate) use transport::{openai_responses_url, send_openai_responses_request};
+pub(crate) use transport::{
+    ResponsesTransportContext, openai_responses_url, send_openai_responses_request,
+};
 
 struct OpenAiChatFallbackRequest<'a> {
     api_mode: OpenAiApiMode,

--- a/qq-maid-llm/src/provider/openai/responses.rs
+++ b/qq-maid-llm/src/provider/openai/responses.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 
 use super::{
+    ResponsesTransportContext,
     extract::{
         extract_response_output_parts, extract_response_output_text, extract_response_usage,
     },
@@ -103,17 +104,19 @@ pub(crate) async fn openai_responses_non_stream_chat(
         req.client,
         req.api_key,
         req.base_url,
-        req.provider,
         req.auth,
         &payload,
-        false,
+        ResponsesTransportContext {
+            provider: req.provider,
+            model: req.model,
+            stream: false,
+        },
     )
     .await?;
 
-    let body: Value = response
-        .json()
-        .await
-        .map_err(|err| LlmError::provider(format!("invalid OpenAI chat JSON: {err}"), "json"))?;
+    let body: Value = response.json().await.map_err(|err| {
+        LlmError::from_response_source(&err, "failed to read OpenAI Responses JSON")
+    })?;
     let output_parts = extract_response_output_parts(&body);
     let reply = extract_response_output_text(&body).unwrap_or_default();
     if reply.trim().is_empty() && output_parts.is_empty() {
@@ -160,10 +163,13 @@ pub(crate) async fn openai_responses_chat_stream(
         req.client,
         req.api_key,
         req.base_url,
-        req.provider,
         req.auth,
         &payload,
-        true,
+        ResponsesTransportContext {
+            provider: req.provider,
+            model: req.model,
+            stream: true,
+        },
     )
     .await?;
 
@@ -346,7 +352,8 @@ async fn next_responses_stream_event(
             }
             Err(err) => {
                 return Some(Err(stream_transport_error(
-                    format!("OpenAI chat stream failed: {err}"),
+                    err,
+                    "OpenAI chat stream failed",
                     &state.answer,
                 )));
             }
@@ -363,13 +370,17 @@ pub(crate) fn incomplete_stream_eof_error(message: &str, answer: &str) -> LlmErr
     LlmError::provider(message, stage)
 }
 
-pub(crate) fn stream_transport_error(message: String, answer: &str) -> LlmError {
+pub(crate) fn stream_transport_error(
+    error: reqwest::Error,
+    context: &str,
+    answer: &str,
+) -> LlmError {
     let stage = if answer.trim().is_empty() {
-        "http"
+        "stream_read"
     } else {
-        "stream_after_delta"
+        "stream_read_after_delta"
     };
-    LlmError::new("http_error", message, stage)
+    LlmError::from_error_source(&error, crate::error::LlmErrorKind::Network, stage, context)
 }
 
 #[cfg(test)]
@@ -443,6 +454,24 @@ mod tests {
 
     async fn spawn_never_closing_completed_response() -> String {
         let app = Router::new().route("/v1/responses", post(never_closing_completed_handler));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}/v1")
+    }
+
+    async fn stalled_stream_handler() -> Response<Body> {
+        let body = Body::from_stream(stream::pending::<Result<Bytes, Infallible>>());
+        Response::builder()
+            .header(header::CONTENT_TYPE, "text/event-stream")
+            .body(body)
+            .unwrap()
+    }
+
+    async fn spawn_stalled_stream_response() -> String {
+        let app = Router::new().route("/v1/responses", post(stalled_stream_handler));
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move {
@@ -532,6 +561,24 @@ mod tests {
         .unwrap();
 
         assert_eq!(outcome.reply, "prompt completion");
+    }
+
+    #[tokio::test]
+    async fn responses_stream_read_timeout_keeps_timeout_classification() {
+        let base_url = spawn_stalled_stream_response().await;
+        let client = qq_maid_common::http_client::try_builder()
+            .unwrap()
+            .timeout(Duration::from_millis(30))
+            .build()
+            .unwrap();
+        let messages = [ChatMessage::user("hi")];
+        let req = stream_req(&client, &base_url, &messages);
+
+        let error = openai_responses_stream_chat(&req).await.unwrap_err();
+
+        assert_eq!(error.code, "timeout");
+        assert_eq!(error.kind(), crate::error::LlmErrorKind::Timeout);
+        assert_eq!(error.stage, "stream_read");
     }
 
     #[tokio::test]

--- a/qq-maid-llm/src/provider/openai/tool_loop/session.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/session.rs
@@ -29,6 +29,7 @@ use super::{
     streaming::collect_responses_tool_loop_stream,
 };
 use crate::provider::openai::{
+    ResponsesTransportContext,
     extract::{
         extract_response_output_parts, extract_response_output_text, extract_response_usage,
     },
@@ -213,14 +214,17 @@ impl AgentStepSession for ResponsesAgentSession {
             &self.client,
             &self.api_key,
             self.base_url.as_deref(),
-            &self.provider,
             self.auth.as_ref(),
             &payload,
-            false,
+            ResponsesTransportContext {
+                provider: &self.provider,
+                model: &self.model,
+                stream: false,
+            },
         )
         .await?;
         let body: Value = response.json().await.map_err(|err| {
-            LlmError::provider(format!("invalid OpenAI tool loop JSON: {err}"), "json")
+            LlmError::from_response_source(&err, "failed to read OpenAI tool loop JSON")
         })?;
         let step_usage = extract_response_usage(&body);
         let calls = extract_function_calls(&body)?;
@@ -295,10 +299,13 @@ impl AgentStepSession for ResponsesAgentSession {
             &self.client,
             &self.api_key,
             self.base_url.as_deref(),
-            &self.provider,
             self.auth.as_ref(),
             &payload,
-            true,
+            ResponsesTransportContext {
+                provider: &self.provider,
+                model: &self.model,
+                stream: true,
+            },
         )
         .await?;
         let step = collect_responses_tool_loop_stream(

--- a/qq-maid-llm/src/provider/openai/tool_loop/streaming.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/streaming.rs
@@ -162,7 +162,8 @@ pub(super) async fn collect_responses_tool_loop_stream(
             Err(err) => {
                 set_streaming_fallback_reason(&diagnostics, "http_sse_parse_error");
                 return Err(stream_transport_error(
-                    format!("OpenAI tool loop stream failed: {err}"),
+                    err,
+                    "OpenAI tool loop stream failed",
                     &answer,
                 ));
             }

--- a/qq-maid-llm/src/provider/openai/transport.rs
+++ b/qq-maid-llm/src/provider/openai/transport.rs
@@ -3,13 +3,25 @@
 //! Responses 主链路只关心“发什么 payload”和“如何解析返回值”；真正的 URL 拼接、
 //! Accept 头、HTTP 错误文本裁剪统一放在这里，避免调用点重复处理 transport 细节。
 
+use std::time::Instant;
+
 use reqwest::{StatusCode, header};
 use serde_json::Value;
 
-use crate::{config::HttpAuthConfig, error::LlmError};
+use crate::{
+    config::HttpAuthConfig,
+    error::{LlmError, LlmErrorKind},
+};
 
 /// OpenAI API 默认基础地址。
 const OPENAI_DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
+
+/// 单次 Responses 传输的低敏观测上下文。
+pub(crate) struct ResponsesTransportContext<'a> {
+    pub(crate) provider: &'a str,
+    pub(crate) model: &'a str,
+    pub(crate) stream: bool,
+}
 
 /// 构造 OpenAI Responses API 完整 URL。
 pub(crate) fn openai_responses_url(base_url: Option<&str>) -> String {
@@ -25,11 +37,15 @@ pub(crate) async fn send_openai_responses_request(
     client: &reqwest::Client,
     api_key: &str,
     base_url: Option<&str>,
-    provider: &str,
     auth: Option<&HttpAuthConfig>,
     payload: &Value,
-    stream: bool,
+    transport: ResponsesTransportContext<'_>,
 ) -> Result<reqwest::Response, LlmError> {
+    let ResponsesTransportContext {
+        provider,
+        model,
+        stream,
+    } = transport;
     let request = client.post(openai_responses_url(base_url));
     let mut request = match auth {
         Some(auth) => {
@@ -52,13 +68,31 @@ pub(crate) async fn send_openai_responses_request(
     if stream {
         request = request.header(header::ACCEPT, "text/event-stream");
     }
+    let started = Instant::now();
     let response = request.send().await.map_err(|err| {
-        if err.is_timeout() {
-            LlmError::timeout("http")
+        let stage = if err.is_timeout() {
+            "http_request_timeout"
         } else {
-            let context = if stream { "stream request" } else { "request" };
-            LlmError::http(format!("{provider} Responses {context} failed: {err}"))
-        }
+            "http_request"
+        };
+        let context = if stream { "stream request" } else { "request" };
+        let mapped = LlmError::from_error_source(
+            &err,
+            LlmErrorKind::Network,
+            stage,
+            format!("{provider} Responses {context} failed"),
+        );
+        tracing::warn!(
+            provider,
+            model,
+            stream,
+            timeout_stage = mapped.stage.as_str(),
+            elapsed_ms = started.elapsed().as_millis(),
+            error_kind = mapped.kind().as_str(),
+            error = %err,
+            "LLM Responses transport failed"
+        );
+        mapped
     })?;
 
     let status = response.status();
@@ -84,17 +118,9 @@ async fn responses_status_error(
             detail
         )
     };
-    let error = match status.as_u16() {
-        // 请求已经通过本地凭证预检并真正到达上游，此时的认证/授权拒绝只说明当前
-        // Provider 不可用。不要再标成 config，否则会阻断跨 Provider 候选降级；
-        // 缺失 API Key 等本地错误仍由 Provider 构造和启动预检返回 config。
-        400 => LlmError::http(message),
-        401 | 403 => LlmError::provider(message, "provider_unavailable"),
-        429 => LlmError::new("rate_limited", message, "http"),
-        500..=599 => LlmError::new("upstream_unavailable", message, "http"),
-        _ => LlmError::http(message),
-    };
-    error.with_upstream_status(status.as_u16())
+    // 缺失 API Key 等本地错误仍由 Provider 构造阶段返回 config；已经到达上游的
+    // 401/403 保留 Authentication 分类，同时由候选路由继续执行既有 fallback。
+    LlmError::from_upstream_status(status.as_u16(), message, "http")
 }
 
 fn truncate_error_detail(value: &str, limit: usize) -> String {

--- a/qq-maid-llm/src/provider/openai_compatible.rs
+++ b/qq-maid-llm/src/provider/openai_compatible.rs
@@ -5,15 +5,12 @@
 
 use std::time::Duration;
 
-use async_trait::async_trait;
-use futures::StreamExt;
-
 use crate::{
-    agent_loop::{AgentSessionRequest, AgentStep, AgentStepSession, AgentToolResult},
+    agent_loop::{AgentSessionRequest, AgentStepSession},
     config::OpenAiCompatibleProviderConfig,
     error::LlmError,
     provider::{
-        ChatOutcome, LlmProvider, LlmStream, LlmStreamEvent, ToolCallingProtocol,
+        ChatOutcome, LlmProvider, LlmStream, ToolCallingProtocol,
         openai::{
             ChatCompletionsClient, begin_chat_completions_session, chat_completions_stream,
             chat_completions_with_stream_fallback, provider_chat_completions_tool_calling_protocol,
@@ -22,6 +19,7 @@ use crate::{
         types::{ChatRequest, ModelId, ModelProvider},
     },
 };
+use async_trait::async_trait;
 
 /// 配置驱动的 OpenAI-compatible provider。
 pub struct OpenAiCompatibleProvider {
@@ -116,7 +114,6 @@ impl LlmProvider for OpenAiCompatibleProvider {
             &req.messages,
         )
         .await
-        .map_err(map_auth_error_to_unavailable)
     }
 
     async fn stream_chat(&self, req: ChatRequest) -> Result<LlmStream, LlmError> {
@@ -131,8 +128,7 @@ impl LlmProvider for OpenAiCompatibleProvider {
                 req.max_output_tokens.unwrap_or(self.max_output_tokens),
                 &req.messages,
             )
-            .await
-            .map_err(map_auth_error_to_unavailable)?;
+            .await?;
             return Ok(outcome_to_stream(outcome));
         }
         let stream = chat_completions_stream(
@@ -144,9 +140,8 @@ impl LlmProvider for OpenAiCompatibleProvider {
             &req.messages,
             true,
         )
-        .await
-        .map_err(map_auth_error_to_unavailable)?;
-        Ok(map_stream_errors(stream))
+        .await?;
+        Ok(stream)
     }
 
     async fn begin_agent_session(
@@ -167,12 +162,11 @@ impl LlmProvider for OpenAiCompatibleProvider {
             req.chat.max_output_tokens.unwrap_or(self.max_output_tokens),
             |value, _| self.effective_model(value),
         )
-        .await
-        .map_err(map_auth_error_to_unavailable)?
+        .await?
         else {
             return Ok(None);
         };
-        Ok(Some(Box::new(AuthMappingAgentSession { inner: session })))
+        Ok(Some(session))
     }
 
     fn tool_calling_protocol(&self, model: Option<&str>) -> Option<ToolCallingProtocol> {
@@ -198,47 +192,6 @@ impl LlmProvider for OpenAiCompatibleProvider {
     fn stream_enabled(&self) -> bool {
         self.stream
     }
-}
-
-struct AuthMappingAgentSession {
-    inner: Box<dyn AgentStepSession + Send>,
-}
-
-#[async_trait]
-impl AgentStepSession for AuthMappingAgentSession {
-    fn provider(&self) -> &str {
-        self.inner.provider()
-    }
-
-    fn model(&self) -> &str {
-        self.inner.model()
-    }
-
-    async fn advance(
-        &mut self,
-        results: &[AgentToolResult],
-        allow_tool_calls: bool,
-    ) -> Result<AgentStep, LlmError> {
-        self.inner
-            .advance(results, allow_tool_calls)
-            .await
-            .map_err(map_auth_error_to_unavailable)
-    }
-}
-
-fn map_stream_errors(stream: LlmStream) -> LlmStream {
-    Box::pin(stream.map(|event: Result<LlmStreamEvent, LlmError>| {
-        event.map_err(map_auth_error_to_unavailable)
-    }))
-}
-
-fn map_auth_error_to_unavailable(err: LlmError) -> LlmError {
-    if err.code == "config"
-        && (err.message.contains("HTTP 401") || err.message.contains("HTTP 403"))
-    {
-        return LlmError::provider(err.message, "provider_unavailable");
-    }
-    err
 }
 
 #[cfg(test)]
@@ -618,7 +571,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn custom_provider_maps_auth_failure_to_candidate_unavailable() {
+    async fn custom_provider_keeps_auth_failure_classification() {
         let (base_url, _state) = spawn_mock_chat(StatusCode::UNAUTHORIZED).await;
         let provider = OpenAiCompatibleProvider::new(
             &mimo_config(base_url),
@@ -643,8 +596,9 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert_eq!(err.code, "provider_error");
-        assert_eq!(err.stage, "provider_unavailable");
+        assert_eq!(err.code, "authentication_failed");
+        assert_eq!(err.kind(), crate::error::LlmErrorKind::Authentication);
+        assert_eq!(err.upstream_status, Some(401));
         assert!(err.message.contains("HTTP 401"));
     }
 

--- a/qq-maid-llm/src/provider/route_error.rs
+++ b/qq-maid-llm/src/provider/route_error.rs
@@ -56,6 +56,8 @@ pub(crate) fn should_try_next_model(err: &LlmError) -> bool {
         "timeout"
             | "provider_error"
             | "http_error"
+            | "network_error"
+            | "authentication_failed"
             | "rate_limited"
             | "upstream_unavailable"
             | "unsupported_input_part"
@@ -86,7 +88,8 @@ pub(crate) fn unavailable_provider_error(
 pub(crate) fn model_error_kind(err: &LlmError) -> &'static str {
     match err.code.as_str() {
         "timeout" => "timeout",
-        "http_error" => "http_error",
+        "http_error" | "network_error" => "network",
+        "authentication_failed" => "authentication",
         "provider_error" if matches!(err.stage.as_str(), "stream" | "sse") => "stream_error",
         "provider_error" if err.stage == "json" => "invalid_response",
         "provider_error" if err.stage == "provider_unavailable" => "provider_unavailable",
@@ -114,7 +117,10 @@ pub(crate) fn model_task_name(req: &ChatRequest) -> &str {
 ///
 /// 文案格式与原实现保持一致：`#<index> <provider>:<model> -> <code>@<stage>`，
 /// 用 `; ` 分隔，便于在调用方日志中一次性看到整条链的失败原因。
-pub(crate) fn aggregate_route_error(task: &str, failures: Vec<ModelAttemptFailure>) -> LlmError {
+pub(crate) fn aggregate_route_error(
+    task: &str,
+    mut failures: Vec<ModelAttemptFailure>,
+) -> LlmError {
     if failures
         .iter()
         .all(|failure| failure.error.code == "unsupported_input_part")
@@ -136,7 +142,7 @@ pub(crate) fn aggregate_route_error(task: &str, failures: Vec<ModelAttemptFailur
             .error;
     }
     let details = failures
-        .into_iter()
+        .iter()
         .map(|failure| {
             format!(
                 "#{} {}:{} -> {}@{}",
@@ -149,8 +155,17 @@ pub(crate) fn aggregate_route_error(task: &str, failures: Vec<ModelAttemptFailur
         })
         .collect::<Vec<_>>()
         .join("; ");
-    LlmError::provider(
-        format!("all model candidates failed for task `{task}`: {details}"),
-        "provider_route",
-    )
+    let Some(mut terminal) = failures.pop().map(|failure| failure.error) else {
+        return LlmError::provider(
+            format!("model route for task `{task}` had no candidates"),
+            "provider_route",
+        );
+    };
+    // 候选明细用于日志排障，但最终错误码、阶段、HTTP 状态和 Agent diagnostics
+    // 必须保留最后一次真实失败，尤其不能把重试耗尽的 timeout 改写成 provider_error。
+    terminal.message = format!(
+        "all model candidates failed for task `{task}`: {details}; terminal error: {}",
+        terminal.message
+    );
+    terminal
 }

--- a/qq-maid-llm/src/provider/route_error.rs
+++ b/qq-maid-llm/src/provider/route_error.rs
@@ -51,6 +51,11 @@ impl ModelAttemptFailure {
 /// 这里只接收上游传输、限流、超时、空响应和 provider 协议类失败；配置错误、
 /// 本地请求构造错误和业务参数错误会直接返回，避免把本地问题放大成多次计费请求。
 pub(crate) fn should_try_next_model(err: &LlmError) -> bool {
+    if matches!(err.upstream_status, Some(404 | 422)) {
+        // Responses 端点不存在或拒绝其协议载荷时，当前 Provider 可能没有可用链路，
+        // 但结构化状态可证明这不是本地参数错误，因此允许继续候选链。
+        return true;
+    }
     matches!(
         err.code.as_str(),
         "timeout"

--- a/qq-maid-llm/src/provider/tests/routing.rs
+++ b/qq-maid-llm/src/provider/tests/routing.rs
@@ -634,11 +634,36 @@ async fn model_route_provider_aggregates_all_candidate_failures() {
     let err = provider.chat(request()).await.unwrap_err();
 
     assert_eq!(err.code, "provider_error");
-    assert_eq!(err.stage, "provider_route");
+    assert_eq!(err.stage, "provider");
     assert!(err.message.contains("#0 openai:gpt-a -> timeout@provider"));
     assert!(
         err.message
             .contains("#1 deepseek:deepseek-chat -> provider_error@provider")
+    );
+    assert_eq!(openai.calls(), 1);
+    assert_eq!(deepseek.calls(), 1);
+}
+
+#[tokio::test]
+async fn model_route_timeout_exhaustion_keeps_terminal_timeout() {
+    let (provider, openai, deepseek) = route_provider(
+        "openai:gpt-a,deepseek:deepseek-chat",
+        vec![Err(LlmError::timeout("http_request_timeout"))],
+        vec![Err(LlmError::timeout("stream_read"))],
+    );
+
+    let err = provider.chat(request()).await.unwrap_err();
+
+    assert_eq!(err.code, "timeout");
+    assert_eq!(err.kind(), crate::error::LlmErrorKind::Timeout);
+    assert_eq!(err.stage, "stream_read");
+    assert!(
+        err.message
+            .contains("#0 openai:gpt-a -> timeout@http_request_timeout")
+    );
+    assert!(
+        err.message
+            .contains("#1 deepseek:deepseek-chat -> timeout@stream_read")
     );
     assert_eq!(openai.calls(), 1);
     assert_eq!(deepseek.calls(), 1);

--- a/qq-maid-llm/src/provider/tests/routing.rs
+++ b/qq-maid-llm/src/provider/tests/routing.rs
@@ -17,6 +17,13 @@ fn provider_errors_are_fallback_eligible() {
         "bad local request",
         "request"
     )));
+    for status in [404, 422] {
+        assert!(should_try_next_model(&LlmError::from_upstream_status(
+            status,
+            "Responses API is incompatible",
+            "http"
+        )));
+    }
 }
 
 #[tokio::test]
@@ -478,6 +485,28 @@ async fn model_route_provider_falls_back_on_eligible_error() {
         deepseek.requests()[0].model.as_deref(),
         Some("deepseek:deepseek-chat")
     );
+}
+
+#[tokio::test]
+async fn model_route_provider_tries_next_candidate_after_responses_incompatible_status() {
+    for status in [404, 422] {
+        let (provider, openai, deepseek) = route_provider(
+            "openai:gpt-a,deepseek:deepseek-chat",
+            vec![Err(LlmError::from_upstream_status(
+                status,
+                "Responses API is incompatible",
+                "http",
+            ))],
+            vec![Ok(outcome("fallback"))],
+        );
+
+        let result = provider.chat(request()).await.unwrap();
+
+        assert_eq!(result.reply, "fallback", "status={status}");
+        assert!(result.fallback_used, "status={status}");
+        assert_eq!(openai.calls(), 1, "status={status}");
+        assert_eq!(deepseek.calls(), 1, "status={status}");
+    }
 }
 
 #[tokio::test]

--- a/qq-maid-llm/src/web_search/gemini.rs
+++ b/qq-maid-llm/src/web_search/gemini.rs
@@ -6,7 +6,7 @@ use serde_json::{Value, json};
 
 use crate::{
     config::LlmConfig,
-    error::LlmError,
+    error::{LlmError, LlmErrorKind},
     metrics::duration_ms,
     provider::types::{ModelId, ModelProvider},
 };
@@ -98,11 +98,28 @@ impl WebSearchExecutor for GeminiWebSearchExecutor {
             .send()
             .await
             .map_err(|err| {
-                if err.is_timeout() {
-                    LlmError::timeout("http")
+                let stage = if err.is_timeout() {
+                    "http_request_timeout"
                 } else {
-                    LlmError::http(format!("Gemini web query request failed: {err}"))
-                }
+                    "http_request"
+                };
+                let mapped = LlmError::from_error_source(
+                    &err,
+                    LlmErrorKind::Network,
+                    stage,
+                    "Gemini web query request failed",
+                );
+                tracing::warn!(
+                    provider = "gemini",
+                    model,
+                    stream = false,
+                    timeout_stage = mapped.stage.as_str(),
+                    elapsed_ms = started.elapsed().as_millis(),
+                    error_kind = mapped.kind().as_str(),
+                    error = %err,
+                    "Gemini web search transport failed"
+                );
+                mapped
             })?;
 
         let status = response.status();
@@ -111,7 +128,7 @@ impl WebSearchExecutor for GeminiWebSearchExecutor {
         }
 
         let body: Value = response.json().await.map_err(|err| {
-            LlmError::provider(format!("invalid Gemini query JSON: {err}"), "json")
+            LlmError::from_response_source(&err, "failed to read Gemini web query JSON")
         })?;
         let answer = extract_gemini_output_text(&body).ok_or_else(|| {
             LlmError::provider("Gemini web query returned empty text output", "provider")
@@ -237,15 +254,7 @@ async fn gemini_status_error(status: StatusCode, response: reqwest::Response) ->
             status.as_u16()
         )
     };
-    let error = match status.as_u16() {
-        400 => LlmError::new("upstream_bad_request", message, "http"),
-        401 => LlmError::new("authentication_failed", message, "http"),
-        403 => LlmError::new("permission_denied", message, "http"),
-        429 => LlmError::new("rate_limited", message, "http"),
-        500..=599 => LlmError::new("upstream_unavailable", message, "http"),
-        _ => LlmError::http(message),
-    };
-    error.with_upstream_status(status.as_u16())
+    LlmError::from_upstream_status(status.as_u16(), message, "http")
 }
 
 fn extract_gemini_output_text(body: &Value) -> Option<String> {

--- a/qq-maid-llm/src/web_search/openai/mod.rs
+++ b/qq-maid-llm/src/web_search/openai/mod.rs
@@ -6,10 +6,11 @@ use tokio::sync::mpsc;
 
 use crate::{
     config::{HttpAuthConfig, LlmConfig, OpenAiResponsesProviderConfig},
-    error::LlmError,
+    error::{LlmError, LlmErrorKind},
     metrics::duration_ms,
     provider::openai::{
-        is_openai_responses_done_sentinel, openai_responses_url, send_openai_responses_request,
+        ResponsesTransportContext, is_openai_responses_done_sentinel, openai_responses_url,
+        send_openai_responses_request,
     },
     sse::{SseFrame, parse_sse_frame, take_sse_frame},
 };
@@ -165,17 +166,24 @@ impl WebSearchExecutor for ResponsesWebSearchExecutor {
             &self.client,
             &self.api_key,
             self.base_url.as_deref(),
-            &self.provider,
             self.auth.as_ref(),
             &payload,
-            false,
+            ResponsesTransportContext {
+                provider: &self.provider,
+                model,
+                stream: false,
+            },
         )
         .await
         .map_err(|err| err.with_upstream_context(self.provider.clone(), model.to_owned()))?;
 
-        let body: Value = response.json().await.map_err(|err| {
-            LlmError::provider(format!("invalid Responses web search JSON: {err}"), "json")
-        })?;
+        let body: Value = response
+            .json()
+            .await
+            .map_err(|err| {
+                LlmError::from_response_source(&err, "failed to read Responses web search JSON")
+            })
+            .map_err(|err| err.with_upstream_context(self.provider.clone(), model.to_owned()))?;
         let answer = extract_output_text(&body).ok_or_else(|| {
             LlmError::provider(
                 "Responses web search returned empty text output",
@@ -224,10 +232,13 @@ impl WebSearchExecutor for ResponsesWebSearchExecutor {
             &self.client,
             &self.api_key,
             self.base_url.as_deref(),
-            &self.provider,
             self.auth.as_ref(),
             &payload,
-            true,
+            ResponsesTransportContext {
+                provider: &self.provider,
+                model,
+                stream: true,
+            },
         )
         .await
         .map_err(|err| err.with_upstream_context(self.provider.clone(), model.to_owned()))?;
@@ -239,7 +250,8 @@ impl WebSearchExecutor for ResponsesWebSearchExecutor {
         while let Some(chunk) = response
             .chunk()
             .await
-            .map_err(|err| web_search_stream_transport_error(err, &answer))?
+            .map_err(|err| web_search_stream_transport_error(err, &answer))
+            .map_err(|err| err.with_upstream_context(self.provider.clone(), model.to_owned()))?
         {
             frame_buffer.extend_from_slice(&chunk);
             while let Some(frame) = take_sse_frame(&mut frame_buffer) {
@@ -452,14 +464,15 @@ fn web_search_incomplete_eof_error(answer: &str) -> LlmError {
 
 fn web_search_stream_transport_error(err: reqwest::Error, answer: &str) -> LlmError {
     let stage = if answer.trim().is_empty() {
-        "http"
+        "web_search_stream_read"
     } else {
-        "stream_after_delta"
+        "web_search_stream_read_after_delta"
     };
-    LlmError::new(
-        "http_error",
-        format!("Responses web search stream failed: {err}"),
+    LlmError::from_error_source(
+        &err,
+        LlmErrorKind::Network,
         stage,
+        "Responses web search stream failed",
     )
 }
 
@@ -595,13 +608,14 @@ mod tests {
     use super::*;
     use axum::{
         Router,
-        body::Body,
+        body::{Body, Bytes},
         extract::State,
-        http::{StatusCode, header},
+        http::{Response, StatusCode, header},
         response::IntoResponse,
         routing::post,
     };
-    use std::sync::Arc;
+    use futures::stream;
+    use std::{convert::Infallible, sync::Arc, time::Duration};
     use tokio::{net::TcpListener, sync::Mutex};
 
     #[test]
@@ -718,6 +732,24 @@ mod tests {
         (format!("http://{addr}/v1"), state)
     }
 
+    async fn stalled_search_stream_handler() -> Response<Body> {
+        let body = Body::from_stream(stream::pending::<Result<Bytes, Infallible>>());
+        Response::builder()
+            .header(header::CONTENT_TYPE, "text/event-stream")
+            .body(body)
+            .unwrap()
+    }
+
+    async fn spawn_stalled_search_stream() -> String {
+        let app = Router::new().route("/v1/responses", post(stalled_search_stream_handler));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}/v1")
+    }
+
     #[tokio::test]
     async fn configured_responses_query_stream_emits_deltas_and_accepts_done_sentinel() {
         let body = concat!(
@@ -762,6 +794,49 @@ mod tests {
         assert_eq!(outcome.answer, "你好");
         assert_eq!(outcome.provider, "xai");
         assert_eq!(state.lock().await.requests[0]["stream"], true);
+    }
+
+    #[tokio::test]
+    async fn responses_search_stream_read_timeout_stays_timeout() {
+        let base_url = spawn_stalled_search_stream().await;
+        let client = qq_maid_common::http_client::try_builder()
+            .unwrap()
+            .timeout(Duration::from_millis(30))
+            .build()
+            .unwrap();
+        let executor = ResponsesWebSearchExecutor {
+            client,
+            api_key: "test-key".to_owned(),
+            base_url: Some(base_url),
+            auth: None,
+            provider: "openai".to_owned(),
+            search_model: "gpt-search".to_owned(),
+            search_context_size_supported: true,
+        };
+        let (delta_tx, _delta_rx) = mpsc::channel(1);
+
+        let error = executor
+            .query_stream(
+                WebSearchRequest {
+                    query: "测试".to_owned(),
+                    raw_question: None,
+                    max_results: None,
+                    context_size: None,
+                    topic: None,
+                    time_range: None,
+                    backend_override: None,
+                    model_override: None,
+                },
+                delta_tx,
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code, "timeout");
+        assert_eq!(error.kind(), LlmErrorKind::Timeout);
+        assert_eq!(error.stage, "web_search_stream_read");
+        assert_eq!(error.upstream_provider(), Some("openai"));
+        assert_eq!(error.upstream_model(), Some("gpt-search"));
     }
 
     #[tokio::test]

--- a/qq-maid-llm/src/web_search/tavily.rs
+++ b/qq-maid-llm/src/web_search/tavily.rs
@@ -113,15 +113,17 @@ impl WebSearchExecutor for TavilyWebSearchExecutor {
         }
 
         let body: TavilySearchResponse = response.json().await.map_err(|err| {
-            if err.is_timeout() {
-                LlmError::new(
-                    "timeout",
-                    "Tavily response body exceeded the configured total timeout",
-                    "tavily_total",
-                )
+            let stage = if err.is_timeout() {
+                "tavily_total"
             } else {
-                LlmError::provider(format!("invalid Tavily search JSON: {err}"), "tavily_json")
-            }
+                "tavily_json"
+            };
+            LlmError::from_error_source(
+                &err,
+                crate::error::LlmErrorKind::Other,
+                stage,
+                "failed to read Tavily search JSON",
+            )
         })?;
         let sources = tavily_sources(body.results, usize::from(payload.max_results));
         if sources.is_empty() {
@@ -379,21 +381,19 @@ fn truncate_chars(value: &str, limit: usize) -> String {
 }
 
 fn tavily_transport_error(err: reqwest::Error) -> LlmError {
-    if err.is_timeout() && err.is_connect() {
-        LlmError::new(
-            "timeout",
-            "Tavily connection exceeded the configured timeout",
-            "tavily_connect",
-        )
+    let stage = if err.is_timeout() && err.is_connect() {
+        "tavily_connect"
     } else if err.is_timeout() {
-        LlmError::new(
-            "timeout",
-            "Tavily request exceeded the configured total timeout",
-            "tavily_total",
-        )
+        "tavily_total"
     } else {
-        LlmError::http(format!("Tavily search request failed: {err}"))
-    }
+        "tavily_request"
+    };
+    LlmError::from_error_source(
+        &err,
+        crate::error::LlmErrorKind::Network,
+        stage,
+        "Tavily search request failed",
+    )
 }
 
 async fn tavily_status_error(status: StatusCode, response: reqwest::Response) -> LlmError {


### PR DESCRIPTION
## 变更

- 新增统一的 LLM 错误分类，区分 Timeout、Authentication、RateLimit、UpstreamUnavailable、Network、InvalidRequest 和 Other
- 沿 reqwest / io 错误 source chain 识别结构化超时，覆盖请求、首包/响应读取、SSE 流式读取和项目总超时
- 修复模型候选全部失败后将真实 timeout 聚合成 provider_error 的问题
- 同步修复 OpenAI Responses、Chat Completions、OpenAI Compatible、Gemini Search、OpenAI Search 与 Tavily Search 链路
- LLM 最终超时提示调整为“LLM 请求超时，请稍后重试。”
- 日志补充 provider、model、流式标记、超时阶段、等待时间、分类及底层错误链

## 根因

Provider 传输层虽然能识别部分 reqwest 超时，但模型路由在候选全部失败后会统一重建为 `provider_error@provider_route`，丢失终态 timeout 分类。部分流式响应和非流式 JSON 读取错误也会被转换为通用 HTTP/Provider 错误，最终在用户侧显示为“服务不可用”。

## 行为影响

- 中间候选超时后成功时仍正常返回，不发送错误
- fallback 和自动重试行为保持不变
- 全部候选因超时失败时最终保留 Timeout
- HTTP 503、连接失败、鉴权失败和限流不会被误报为超时
- 用户提示不暴露上游响应、内部 URL、密钥或错误堆栈

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo build --workspace --release --all-features`
- `git diff --check`

真实 Provider 调用未执行；超时路径通过本地延迟 HTTP/SSE 服务和连接失败场景验证。