### PR TITLE
fix: 支持待办仅设置截止日期

### DIFF
--- a/web-console/dist/index.html
+++ b/web-console/dist/index.html
@@ -245,7 +245,12 @@
           </div>
           <label>标题<input id="todo-create-title" name="title" required maxlength="500" placeholder="例如：整理部署日志"></label>
           <label>目标<select id="todo-create-target" name="target_ref" required><option value="">加载目标中…</option></select></label>
-          <label>截止日期与时间<input id="todo-create-deadline" name="deadline" type="datetime-local"></label>
+          <label>截止日期与时间
+            <span class="todo-create-deadline-fields">
+              <input id="todo-create-due-date" name="due_date" type="date" aria-label="截止日期">
+              <input id="todo-create-due-time" name="due_time" type="time" aria-label="截止时间（可选）">
+            </span>
+          </label>
           <label>提醒时间<input id="todo-create-reminder-at" name="reminder_at" type="datetime-local"></label>
           <label>重复类型<select id="todo-create-recurrence-kind"><option value="none">不重复</option><option value="every_n_days">间隔重复</option></select></label>
           <label>重复间隔<input id="todo-create-recurrence-interval" type="number" min="1" placeholder="可选"></label>

--- a/web-console/dist/styles.css
+++ b/web-console/dist/styles.css
@@ -515,11 +515,14 @@ textarea { width: 100%; min-height: 25rem; flex: 1; resize: vertical; padding: v
 .todo-create-heading button { padding: .2rem .5rem; line-height: 1; }
 .todo-create-form label { display: grid; gap: .25rem; margin: 0; color: var(--muted); font-size: .7rem; font-weight: 700; }
 .todo-create-form label.todo-create-detail { grid-column: 1 / -1; }
+.todo-create-deadline-fields { display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr); gap: .4rem; }
+.todo-create-deadline-fields input { min-width: 0; width: 100%; }
 .todo-create-form .error { grid-column: 1 / -1; margin: 0; min-height: 1.1rem; }
 .todo-create-form > button[type="submit"] { grid-column: 1 / -1; justify-self: end; min-width: 8rem; }
 @media (max-width: 767px) {
   .todo-create-dialog .todo-create-form { grid-template-columns: 1fr; }
   .todo-create-form label.todo-create-detail { grid-column: auto; }
+  .todo-create-deadline-fields { grid-template-columns: 1fr; }
   .todo-create-form .error { grid-column: auto; }
   .todo-create-form > button[type="submit"] { grid-column: auto; width: 100%; }
 }

--- a/web-console/dist/views/todo/todo-form.js
+++ b/web-console/dist/views/todo/todo-form.js
@@ -14,6 +14,14 @@ export function todoDeadlineFields(value) {
     }
     return { dueDate, dueAt: deadline, timePrecision: "date_time" };
 }
+/** 创建表单把同一字段组内的日期与可选时间合成统一截止值。 */
+export function todoDeadlineFromParts(dateValue, timeValue) {
+    const dueDate = dateValue.trim();
+    const dueTime = timeValue.trim();
+    if (!dueDate)
+        return todoDeadlineFields(null);
+    return todoDeadlineFields(dueTime ? `${dueDate}T${dueTime}` : dueDate);
+}
 export async function submitTodo(form, dialog) {
     const title = valueOf("todo-create-title").trim();
     const targetRef = valueOf("todo-create-target");
@@ -26,10 +34,17 @@ export async function submitTodo(form, dialog) {
             error.textContent = "标题和目标不能为空";
         return showResult("标题和目标不能为空", true);
     }
+    const dueDate = valueOf("todo-create-due-date");
+    const dueTime = valueOf("todo-create-due-time");
+    if (!dueDate && dueTime) {
+        if (error)
+            error.textContent = "设置截止时间前请先选择截止日期";
+        return showResult("设置截止时间前请先选择截止日期", true);
+    }
     const button = form.querySelector("button[type=submit]");
     if (button)
         button.disabled = true;
-    const deadline = todoDeadlineFields(valueOf("todo-create-deadline"));
+    const deadline = todoDeadlineFromParts(dueDate, dueTime);
     const reminderAt = valueOf("todo-create-reminder-at") || null;
     try {
         await createTodo({

--- a/web-console/src/index.html
+++ b/web-console/src/index.html
@@ -245,7 +245,12 @@
           </div>
           <label>标题<input id="todo-create-title" name="title" required maxlength="500" placeholder="例如：整理部署日志"></label>
           <label>目标<select id="todo-create-target" name="target_ref" required><option value="">加载目标中…</option></select></label>
-          <label>截止日期与时间<input id="todo-create-deadline" name="deadline" type="datetime-local"></label>
+          <label>截止日期与时间
+            <span class="todo-create-deadline-fields">
+              <input id="todo-create-due-date" name="due_date" type="date" aria-label="截止日期">
+              <input id="todo-create-due-time" name="due_time" type="time" aria-label="截止时间（可选）">
+            </span>
+          </label>
           <label>提醒时间<input id="todo-create-reminder-at" name="reminder_at" type="datetime-local"></label>
           <label>重复类型<select id="todo-create-recurrence-kind"><option value="none">不重复</option><option value="every_n_days">间隔重复</option></select></label>
           <label>重复间隔<input id="todo-create-recurrence-interval" type="number" min="1" placeholder="可选"></label>

--- a/web-console/src/styles.css
+++ b/web-console/src/styles.css
@@ -515,11 +515,14 @@ textarea { width: 100%; min-height: 25rem; flex: 1; resize: vertical; padding: v
 .todo-create-heading button { padding: .2rem .5rem; line-height: 1; }
 .todo-create-form label { display: grid; gap: .25rem; margin: 0; color: var(--muted); font-size: .7rem; font-weight: 700; }
 .todo-create-form label.todo-create-detail { grid-column: 1 / -1; }
+.todo-create-deadline-fields { display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr); gap: .4rem; }
+.todo-create-deadline-fields input { min-width: 0; width: 100%; }
 .todo-create-form .error { grid-column: 1 / -1; margin: 0; min-height: 1.1rem; }
 .todo-create-form > button[type="submit"] { grid-column: 1 / -1; justify-self: end; min-width: 8rem; }
 @media (max-width: 767px) {
   .todo-create-dialog .todo-create-form { grid-template-columns: 1fr; }
   .todo-create-form label.todo-create-detail { grid-column: auto; }
+  .todo-create-deadline-fields { grid-template-columns: 1fr; }
   .todo-create-form .error { grid-column: auto; }
   .todo-create-form > button[type="submit"] { grid-column: auto; width: 100%; }
 }

--- a/web-console/src/views/todo/todo-form.ts
+++ b/web-console/src/views/todo/todo-form.ts
@@ -21,6 +21,14 @@ export function todoDeadlineFields(value: string | null): TodoDeadlineFields {
   return { dueDate, dueAt: deadline, timePrecision: "date_time" };
 }
 
+/** 创建表单把同一字段组内的日期与可选时间合成统一截止值。 */
+export function todoDeadlineFromParts(dateValue: string, timeValue: string): TodoDeadlineFields {
+  const dueDate = dateValue.trim();
+  const dueTime = timeValue.trim();
+  if (!dueDate) return todoDeadlineFields(null);
+  return todoDeadlineFields(dueTime ? `${dueDate}T${dueTime}` : dueDate);
+}
+
 export async function submitTodo(form: HTMLFormElement, dialog: HTMLDialogElement): Promise<void> {
   const title = valueOf("todo-create-title").trim();
   const targetRef = valueOf("todo-create-target");
@@ -32,9 +40,15 @@ export async function submitTodo(form: HTMLFormElement, dialog: HTMLDialogElemen
     if (error) error.textContent = "标题和目标不能为空";
     return showResult("标题和目标不能为空", true);
   }
+  const dueDate = valueOf("todo-create-due-date");
+  const dueTime = valueOf("todo-create-due-time");
+  if (!dueDate && dueTime) {
+    if (error) error.textContent = "设置截止时间前请先选择截止日期";
+    return showResult("设置截止时间前请先选择截止日期", true);
+  }
   const button = form.querySelector<HTMLButtonElement>("button[type=submit]");
   if (button) button.disabled = true;
-  const deadline = todoDeadlineFields(valueOf("todo-create-deadline"));
+  const deadline = todoDeadlineFromParts(dueDate, dueTime);
   const reminderAt = valueOf("todo-create-reminder-at") || null;
   try {
     await createTodo({

--- a/web-console/tests/todo.test.mjs
+++ b/web-console/tests/todo.test.mjs
@@ -11,7 +11,7 @@ import {
   pageAfterDelete,
 } from "../dist/views/todo/todo-paging.js";
 import { filterResetDefaults, loadTodoForEdit } from "../dist/views/todo/todo.js";
-import { todoDeadlineFields } from "../dist/views/todo/todo-form.js";
+import { todoDeadlineFields, todoDeadlineFromParts } from "../dist/views/todo/todo-form.js";
 
 function targetOption(targetRef, overrides = {}) {
   return {
@@ -166,10 +166,25 @@ test("单个截止日期时间同步生成一致的后端日期、时间和精�
   });
 });
 
-test("创建表单只保留一个截止日期与时间控件", async () => {
+test("创建表单的可选时间支持仅日期与日期时间两种语义", () => {
+  assert.deepEqual(todoDeadlineFromParts("2026-08-01", ""), {
+    dueDate: "2026-08-01",
+    dueAt: null,
+    timePrecision: "date",
+  });
+  assert.deepEqual(todoDeadlineFromParts("2026-08-01", "10:30"), {
+    dueDate: "2026-08-01",
+    dueAt: "2026-08-01T10:30",
+    timePrecision: "date_time",
+  });
+});
+
+test("创建表单把截止日期与可选时间收拢在同一字段组", async () => {
   const html = await readFile(new URL("../dist/index.html", import.meta.url), "utf8");
-  assert.match(html, /截止日期与时间<input id="todo-create-deadline"[^>]*type="datetime-local">/);
-  assert.doesNotMatch(html, /todo-create-due-date|todo-create-due-at|todo-create-time-precision/);
+  assert.match(html, /todo-create-deadline-fields/);
+  assert.match(html, /id="todo-create-due-date"[^>]*type="date"/);
+  assert.match(html, /id="todo-create-due-time"[^>]*type="time"/);
+  assert.doesNotMatch(html, /todo-create-due-at|todo-create-time-precision/);
 });
 
 test("Todo 卡片操作按钮顺序：删除恒为最后，且查看/编辑已接线", async () => {


### PR DESCRIPTION
## 修改内容

- 将 Todo 创建表单的截止设置收拢为同一字段组：日期 + 可选时间
- 只填写日期时仅提交 `due_date`，同时填写时间时再生成一致的 `due_at`
- 自动推导 `time_precision`，并拒绝仅填写时间而没有日期的输入
- 同步桌面端与移动端布局及构建产物

## 原因与影响

原实现使用单个 `datetime-local` 控件，浏览器要求日期和时间同时存在，导致无法创建“仅截止到某日”的 Todo。调整后保留统一的视觉分组，同时恢复仅日期语义，并避免 `due_date` 与 `due_at` 不一致。

## 验证

- `npm test`（包含 `npm run build`，108 项测试通过）
- `npm run check`
- `git diff --check`