### PR TITLE
feat: 统一 Linux/Windows GitHub Release 多代理候选下载与校验

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,33 @@ qbot restart   # 重启服务
 qbot update    # 更新版本
 ```
 
+GitHub 下载不稳定时可设置 `QBOT_GITHUB_PROXY`（单个代理前缀）或
+`QBOT_GITHUB_PROXIES`（空格分隔的多个代理前缀）指向自己信任的加速源；安装器会依次尝试
+官方源和所有代理，任一来源失败自动回退下一来源，并且只有压缩包格式有效且 SHA-256
+校验通过才会继续安装：
+
+```bash
+export QBOT_GITHUB_PROXIES="https://gh-proxy-a.example.com https://gh-proxy-b.example.com"
+qbot install
+```
+
+代理前缀必须是 `https://域名/` 形式的完整前缀，脚本会把它拼接在
+`https://github.com/<仓库>/releases/download/<版本>/<文件>` 前面后再下载。
+
 ### Windows 一键安装
 
 在 PowerShell 中下载安装器：
 
 ```powershell
 $p="$env:TEMP\qbot.ps1"; Invoke-WebRequest https://github.com/kuliantnt/qq-maid-bot/raw/refs/heads/master/scripts/qbot.ps1 -OutFile $p -UseBasicParsing; powershell.exe -NoProfile -ExecutionPolicy Bypass -File $p install
+```
+
+Windows 端支持与 Linux 相同的代理变量（`QBOT_GITHUB_PROXY` / `QBOT_GITHUB_PROXIES`），
+下载失败时同样会自动回退到下一来源并校验 ZIP 与 SHA-256：
+
+```powershell
+$env:QBOT_GITHUB_PROXIES = "https://gh-proxy-a.example.com https://gh-proxy-b.example.com"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$env:TEMP\qbot.ps1" install
 ```
 
 然后编辑配置并启动：

--- a/scripts/qbot.cmd
+++ b/scripts/qbot.cmd
@@ -1,4 +1,12 @@
 @echo off
+rem qq-maid-bot Windows 便捷入口：只负责把参数原样转发给 qbot.ps1，
+rem 所有安装/更新/下载逻辑都在 PowerShell 端实现，本文件不复制任何逻辑。
 setlocal
+if not exist "%~dp0qbot.ps1" (
+    echo qbot.ps1 not found next to qbot.cmd: %~dp0qbot.ps1
+    exit /b 1
+)
+rem %* 完整透传参数；引号保证 qbot.ps1 路径含空格时可用；
+rem 直接以 PowerShell 的退出码返回，保证失败时调用方拿到相同非零值。
 powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0qbot.ps1" %*
 exit /b %errorlevel%

--- a/scripts/qbot.ps1
+++ b/scripts/qbot.ps1
@@ -270,7 +270,8 @@ function Invoke-DownloadFile {
     param([string]$Prefix, [string]$Url, [string]$Destination, [string]$Description)
     # 从单个候选源下载一个文件；网络/HTTP 失败或空文件时返回 $false，由调用方继续尝试下一来源。
     $downloadUrl = Get-DownloadUrl -Prefix $Prefix -RawUrl $Url
-    Write-Output "正在从 $(Get-SourceLabel $Prefix) 下载: $Description"
+    # 状态信息用 Write-Host 输出，避免污染成功流导致链函数布尔返回值被捕获成数组。
+    Write-Host "正在从 $(Get-SourceLabel $Prefix) 下载: $Description"
     Remove-Item -LiteralPath $Destination -Force -ErrorAction SilentlyContinue
     try {
         Invoke-WebRequest -Uri $downloadUrl -OutFile $Destination -UseBasicParsing -TimeoutSec $script:DownloadTimeoutSec
@@ -329,7 +330,7 @@ function Save-ReleaseFromSource {
     )
     # 从单个候选源下载 ZIP 与 .sha256 并当场校验；任一环节失败返回 $false，由调用方回退下一来源。
     $rawUrl = "$($script:ReleasesUrl)/download/$Version/$ArchiveName"
-    Write-Output "尝试下载源: $(Get-SourceLabel $Prefix)"
+    Write-Host "尝试下载源: $(Get-SourceLabel $Prefix)"
 
     if (-not (Invoke-DownloadFile -Prefix $Prefix -Url $rawUrl -Destination $ArchivePath -Description $ArchiveName)) {
         return $false
@@ -347,7 +348,7 @@ function Save-ReleaseFromSource {
         Write-Warning "SHA-256 校验失败，该源内容无效: $($_.Exception.Message)"
         return $false
     }
-    Write-Output "SHA-256 校验通过: $ArchiveName"
+    Write-Host "SHA-256 校验通过: $ArchiveName"
     return $true
 }
 

--- a/scripts/qbot.ps1
+++ b/scripts/qbot.ps1
@@ -304,6 +304,30 @@ function Test-ZipArchive {
     }
 }
 
+function Test-ZipPackageDirectory {
+    param([string]$Archive, [string]$PackageName)
+    # 用 .NET ZipArchive 读取条目，确认 ZIP 包含预期的顶层包目录；
+    # 容器有效但结构损坏（缺少包目录）时返回 $false，由调用方回退下一来源。
+    try {
+        $stream = [IO.File]::OpenRead($Archive)
+        $zip = $null
+        try {
+            $zip = New-Object IO.Compression.ZipArchive($stream, [IO.Compression.ZipArchiveMode]::Read)
+            foreach ($entry in $zip.Entries) {
+                if ($entry.FullName.StartsWith("$PackageName/", [StringComparison]::OrdinalIgnoreCase)) {
+                    return $true
+                }
+            }
+            return $false
+        } finally {
+            if ($null -ne $zip) { $zip.Dispose() }
+            $stream.Dispose()
+        }
+    } catch {
+        return $false
+    }
+}
+
 function Test-ReleaseChecksum {
     param([string]$Archive, [string]$ChecksumFile)
     $checksumText = (Get-Content -LiteralPath $ChecksumFile -Raw).Trim()
@@ -346,6 +370,12 @@ function Save-ReleaseFromSource {
         Test-ReleaseChecksum -Archive $ArchivePath -ChecksumFile $ChecksumPath
     } catch {
         Write-Warning "SHA-256 校验失败，该源内容无效: $($_.Exception.Message)"
+        return $false
+    }
+    # ZIP 深度校验：确认归档包含预期的顶层包目录，使容器有效但结构损坏的来源也能回退下一来源。
+    $packageName = $ArchiveName -replace '\.zip$', ''
+    if (-not (Test-ZipPackageDirectory -Archive $ArchivePath -PackageName $packageName)) {
+        Write-Warning "ZIP 结构无效（缺少预期包目录 $packageName），该源内容不可用: $ArchiveName"
         return $false
     }
     Write-Host "SHA-256 校验通过: $ArchiveName"

--- a/scripts/qbot.ps1
+++ b/scripts/qbot.ps1
@@ -228,17 +228,14 @@ function Get-GitHubProxyPrefixes {
     $null = $seen.Add("")
 
     $single = Get-EnvironmentValue "QBOT_GITHUB_PROXY" ""
-    Write-Host ("[diag] raw single=<" + $single + ">")
     if (-not [string]::IsNullOrWhiteSpace($single)) {
         $normalized = Normalize-ProxyPrefix $single
-        Write-Host ("[diag] normalized single=<" + $normalized + ">")
         if ($null -ne $normalized -and $seen.Add($normalized)) {
             $candidates.Add($normalized) | Out-Null
         }
     }
 
     $multi = Get-EnvironmentValue "QBOT_GITHUB_PROXIES" ""
-    Write-Host ("[diag] raw multi=<" + $multi + ">")
     if (-not [string]::IsNullOrWhiteSpace($multi)) {
         foreach ($entry in ($multi -split '\s+')) {
             if ([string]::IsNullOrWhiteSpace($entry)) {
@@ -250,7 +247,6 @@ function Get-GitHubProxyPrefixes {
             }
         }
     }
-    Write-Host ("[diag] candidates=<" + ($candidates -join ",") + ">")
     return ,$candidates.ToArray()
 }
 
@@ -359,7 +355,10 @@ function Save-ReleaseFromSource {
 function Save-ReleaseChain {
     param([string]$Version, [string]$ArchiveName, [string]$ArchivePath, [string]$ChecksumPath)
     # 依次尝试官方源与全部用户代理源；某来源失败（连接/超时/HTTP/内容无效）时自动回退下一来源。
-    foreach ($prefix in Get-GitHubProxyPrefixes) {
+    # 注意：函数返回的是“单个数组对象”，直接 foreach 命令输出会把整个数组当作一个迭代项，
+    # 导致 [string] 参数把候选数组强制转成带前导空格的字符串；必须先赋值再遍历。
+    $prefixes = Get-GitHubProxyPrefixes
+    foreach ($prefix in $prefixes) {
         if (Save-ReleaseFromSource -Prefix $prefix -Version $Version -ArchiveName $ArchiveName -ArchivePath $ArchivePath -ChecksumPath $ChecksumPath) {
             return $true
         }

--- a/scripts/qbot.ps1
+++ b/scripts/qbot.ps1
@@ -228,14 +228,17 @@ function Get-GitHubProxyPrefixes {
     $null = $seen.Add("")
 
     $single = Get-EnvironmentValue "QBOT_GITHUB_PROXY" ""
+    Write-Host ("[diag] raw single=<" + $single + ">")
     if (-not [string]::IsNullOrWhiteSpace($single)) {
         $normalized = Normalize-ProxyPrefix $single
+        Write-Host ("[diag] normalized single=<" + $normalized + ">")
         if ($null -ne $normalized -and $seen.Add($normalized)) {
             $candidates.Add($normalized) | Out-Null
         }
     }
 
     $multi = Get-EnvironmentValue "QBOT_GITHUB_PROXIES" ""
+    Write-Host ("[diag] raw multi=<" + $multi + ">")
     if (-not [string]::IsNullOrWhiteSpace($multi)) {
         foreach ($entry in ($multi -split '\s+')) {
             if ([string]::IsNullOrWhiteSpace($entry)) {
@@ -247,6 +250,7 @@ function Get-GitHubProxyPrefixes {
             }
         }
     }
+    Write-Host ("[diag] candidates=<" + ($candidates -join ",") + ">")
     return ,$candidates.ToArray()
 }
 

--- a/scripts/qbot.ps1
+++ b/scripts/qbot.ps1
@@ -314,7 +314,8 @@ function Test-ZipPackageDirectory {
         try {
             $zip = New-Object IO.Compression.ZipArchive($stream, [IO.Compression.ZipArchiveMode]::Read)
             foreach ($entry in $zip.Entries) {
-                if ($entry.FullName.StartsWith("$PackageName/", [StringComparison]::OrdinalIgnoreCase)) {
+                if ($entry.FullName.StartsWith("$PackageName/", [StringComparison]::OrdinalIgnoreCase) -or
+                    $entry.FullName.StartsWith("$PackageName\", [StringComparison]::OrdinalIgnoreCase)) {
                     return $true
                 }
             }

--- a/scripts/qbot.ps1
+++ b/scripts/qbot.ps1
@@ -6,6 +6,9 @@ param(
 
 $ErrorActionPreference = "Stop"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+# Test-ZipArchive 需要 System.IO.Compression；Add-Type 在程序集已加载时是幂等操作。
+Add-Type -AssemblyName System.IO.Compression
+Add-Type -AssemblyName System.IO.Compression.FileSystem
 
 function Get-EnvironmentValue {
     param([string]$Name, [string]$DefaultValue)
@@ -72,6 +75,12 @@ $script:InstallerPath = [IO.Path]::GetFullPath($MyInvocation.MyCommand.Path)
 $script:RepoSlug = Get-EnvironmentValue "QBOT_REPO_SLUG" "kuliantnt/qq-maid-bot"
 $script:ReleasesUrl = "https://github.com/$($script:RepoSlug)/releases"
 $script:LatestApiUrl = "https://api.github.com/repos/$($script:RepoSlug)/releases/latest"
+$script:DownloadTimeoutSec = 300
+$timeoutRaw = Get-EnvironmentValue "QBOT_GITHUB_DOWNLOAD_TIMEOUT_SEC" ""
+$timeoutValue = 0
+if (-not [string]::IsNullOrWhiteSpace($timeoutRaw) -and [int]::TryParse($timeoutRaw, [ref]$timeoutValue) -and $timeoutValue -gt 0) {
+    $script:DownloadTimeoutSec = $timeoutValue
+}
 $script:ObsoleteEnvKeys = @(
     "LLM_PROVIDER", "OPENAI_MODEL", "LLM_MODEL", "PRIVATE_LLM_MODEL", "GROUP_LLM_MODEL",
     "OPENAI_SEARCH_MODEL", "PRIVATE_OPENAI_SEARCH_MODEL", "GROUP_OPENAI_SEARCH_MODEL",
@@ -106,7 +115,9 @@ Commands:
 Environment overrides:
   QBOT_APP_DIR            Install directory (default: %USERPROFILE%\qq-maid-bot)
   QBOT_REPO_SLUG          GitHub repository (default: kuliantnt/qq-maid-bot)
-  QBOT_GITHUB_PROXY       Optional trusted download URL prefix
+  QBOT_GITHUB_PROXY       Optional trusted download URL prefix (single proxy)
+  QBOT_GITHUB_PROXIES     Optional whitespace-separated download URL prefixes
+  QBOT_GITHUB_DOWNLOAD_TIMEOUT_SEC  Per-request download timeout (default: 300)
   QBOT_INSTALL_WEB_CONSOLE  Web choice for non-interactive install (true/false)
 "@
 }
@@ -189,36 +200,166 @@ function Resolve-Version {
     return $normalized
 }
 
-function Get-DownloadUrl {
-    param([string]$RawUrl)
-    $prefix = [Environment]::GetEnvironmentVariable("QBOT_GITHUB_PROXY")
-    if ([string]::IsNullOrWhiteSpace($prefix)) {
-        return $RawUrl
+function Normalize-ProxyPrefix {
+    param([AllowEmptyString()][string]$RawValue)
+    # 规范化代理前缀：去首尾空白、去尾部斜杠；只接受 http/https 绝对地址，否则视为无效并返回 $null。
+    if ([string]::IsNullOrWhiteSpace($RawValue)) {
+        return $null
     }
-    return "$($prefix.TrimEnd('/'))/$RawUrl"
+    $value = $RawValue.Trim().TrimEnd('/')
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        return $null
+    }
+    $uri = $null
+    if (-not [Uri]::TryCreate($value, [UriKind]::Absolute, [ref]$uri) -or
+        ($uri.Scheme -ne "http" -and $uri.Scheme -ne "https")) {
+        Write-Warning "忽略无效代理前缀（仅支持 http/https 绝对地址）: $RawValue"
+        return $null
+    }
+    return $value
 }
 
-function Save-ReleaseFile {
-    param([string]$Url, [string]$Destination)
-    $downloadUrl = Get-DownloadUrl $Url
-    Invoke-WebRequest -Uri $downloadUrl -OutFile $Destination -UseBasicParsing
+function Get-GitHubProxyPrefixes {
+    # 候选源顺序：官方直连（空串）→ QBOT_GITHUB_PROXY（单代理）→ QBOT_GITHUB_PROXIES（空格分隔多代理）。
+    # 与 Linux 端 qbot.sh 的 github_accel_prefixes 语义一致：规范化、去重，且不内置任何第三方镜像。
+    $candidates = New-Object System.Collections.Generic.List[string]
+    $seen = New-Object 'System.Collections.Generic.HashSet[string]'
+    $candidates.Add("") | Out-Null
+    $null = $seen.Add("")
+
+    $single = Get-EnvironmentValue "QBOT_GITHUB_PROXY" ""
+    if (-not [string]::IsNullOrWhiteSpace($single)) {
+        $normalized = Normalize-ProxyPrefix $single
+        if ($null -ne $normalized -and $seen.Add($normalized)) {
+            $candidates.Add($normalized) | Out-Null
+        }
+    }
+
+    $multi = Get-EnvironmentValue "QBOT_GITHUB_PROXIES" ""
+    if (-not [string]::IsNullOrWhiteSpace($multi)) {
+        foreach ($entry in ($multi -split '\s+')) {
+            if ([string]::IsNullOrWhiteSpace($entry)) {
+                continue
+            }
+            $normalized = Normalize-ProxyPrefix $entry
+            if ($null -ne $normalized -and $seen.Add($normalized)) {
+                $candidates.Add($normalized) | Out-Null
+            }
+        }
+    }
+    return ,$candidates.ToArray()
+}
+
+function Get-SourceLabel {
+    param([string]$Prefix)
+    if ([string]::IsNullOrWhiteSpace($Prefix)) {
+        return "GitHub 官方源"
+    }
+    return "代理源 $($Prefix.TrimEnd('/'))"
+}
+
+function Get-DownloadUrl {
+    param([string]$Prefix, [string]$RawUrl)
+    if ([string]::IsNullOrWhiteSpace($Prefix)) {
+        return $RawUrl
+    }
+    return "$($Prefix.TrimEnd('/'))/$RawUrl"
+}
+
+function Invoke-DownloadFile {
+    param([string]$Prefix, [string]$Url, [string]$Destination, [string]$Description)
+    # 从单个候选源下载一个文件；网络/HTTP 失败或空文件时返回 $false，由调用方继续尝试下一来源。
+    $downloadUrl = Get-DownloadUrl -Prefix $Prefix -RawUrl $Url
+    Write-Output "正在从 $(Get-SourceLabel $Prefix) 下载: $Description"
+    Remove-Item -LiteralPath $Destination -Force -ErrorAction SilentlyContinue
+    try {
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $Destination -UseBasicParsing -TimeoutSec $script:DownloadTimeoutSec
+    } catch {
+        Write-Warning "下载失败: $Description （$($_.Exception.Message)）"
+        return $false
+    }
     if (-not (Test-Path -LiteralPath $Destination -PathType Leaf) -or
         (Get-Item -LiteralPath $Destination).Length -eq 0) {
-        throw "download returned an empty file: $Url"
+        Write-Warning "下载结果为空文件: $Description"
+        return $false
+    }
+    return $true
+}
+
+function Test-ZipArchive {
+    param([string]$Archive)
+    # 用 .NET ZipArchive 打开验证 ZIP 结构，避免把损坏文件带到后续校验。
+    try {
+        $stream = [IO.File]::OpenRead($Archive)
+        try {
+            $zip = New-Object IO.Compression.ZipArchive($stream, [IO.Compression.ZipArchiveMode]::Read)
+            $zip.Dispose()
+        } finally {
+            $stream.Dispose()
+        }
+        return $true
+    } catch {
+        return $false
     }
 }
 
 function Test-ReleaseChecksum {
     param([string]$Archive, [string]$ChecksumFile)
     $checksumText = (Get-Content -LiteralPath $ChecksumFile -Raw).Trim()
+    if ([string]::IsNullOrWhiteSpace($checksumText)) {
+        throw "SHA-256 校验文件无效（内容为空）: $ChecksumFile"
+    }
     $expected = ($checksumText -split '\s+')[0]
     if ($expected -notmatch '^[0-9a-fA-F]{64}$') {
-        throw "invalid SHA-256 file: $ChecksumFile"
+        throw "SHA-256 校验文件无效: $ChecksumFile"
     }
     $actual = (Get-FileHash -LiteralPath $Archive -Algorithm SHA256).Hash
     if (-not $actual.Equals($expected, [StringComparison]::OrdinalIgnoreCase)) {
-        throw "SHA-256 mismatch for $(Split-Path -Leaf $Archive)"
+        throw "SHA-256 校验失败: $(Split-Path -Leaf $Archive)（期望 $($expected.ToLowerInvariant())，实际 $($actual.ToLowerInvariant())）"
     }
+}
+
+function Save-ReleaseFromSource {
+    param(
+        [string]$Prefix,
+        [string]$Version,
+        [string]$ArchiveName,
+        [string]$ArchivePath,
+        [string]$ChecksumPath
+    )
+    # 从单个候选源下载 ZIP 与 .sha256 并当场校验；任一环节失败返回 $false，由调用方回退下一来源。
+    $rawUrl = "$($script:ReleasesUrl)/download/$Version/$ArchiveName"
+    Write-Output "尝试下载源: $(Get-SourceLabel $Prefix)"
+
+    if (-not (Invoke-DownloadFile -Prefix $Prefix -Url $rawUrl -Destination $ArchivePath -Description $ArchiveName)) {
+        return $false
+    }
+    if (-not (Test-ZipArchive -Archive $ArchivePath)) {
+        Write-Warning "ZIP 格式无效，该源内容不可用: $ArchiveName"
+        return $false
+    }
+    if (-not (Invoke-DownloadFile -Prefix $Prefix -Url "${rawUrl}.sha256" -Destination $ChecksumPath -Description "$ArchiveName.sha256")) {
+        return $false
+    }
+    try {
+        Test-ReleaseChecksum -Archive $ArchivePath -ChecksumFile $ChecksumPath
+    } catch {
+        Write-Warning "SHA-256 校验失败，该源内容无效: $($_.Exception.Message)"
+        return $false
+    }
+    Write-Output "SHA-256 校验通过: $ArchiveName"
+    return $true
+}
+
+function Save-ReleaseChain {
+    param([string]$Version, [string]$ArchiveName, [string]$ArchivePath, [string]$ChecksumPath)
+    # 依次尝试官方源与全部用户代理源；某来源失败（连接/超时/HTTP/内容无效）时自动回退下一来源。
+    foreach ($prefix in Get-GitHubProxyPrefixes) {
+        if (Save-ReleaseFromSource -Prefix $prefix -Version $Version -ArchiveName $ArchiveName -ArchivePath $ArchivePath -ChecksumPath $ChecksumPath) {
+            return $true
+        }
+    }
+    return $false
 }
 
 function Get-LocalVersion {
@@ -331,9 +472,18 @@ function Install-ReleasePayload {
     }
     $installedWrapper = Join-Path $script:AppDir "qbot.cmd"
     if (-not (Test-Path -LiteralPath (Join-Path $ReleaseDir "qbot.cmd") -PathType Leaf)) {
+        # 与 scripts/qbot.cmd 保持一致的轻量入口：只转发参数，不复制下载逻辑。
         Write-Utf8Lines -Path $installedWrapper -Lines @(
             "@echo off",
+            'rem qq-maid-bot Windows 便捷入口：只负责把参数原样转发给 qbot.ps1，',
+            'rem 所有安装/更新/下载逻辑都在 PowerShell 端实现，本文件不复制任何逻辑。',
             "setlocal",
+            'if not exist "%~dp0qbot.ps1" (',
+            "    echo qbot.ps1 not found next to qbot.cmd: %~dp0qbot.ps1",
+            "    exit /b 1",
+            ")",
+            'rem %* 完整透传参数；引号保证 qbot.ps1 路径含空格时可用；',
+            'rem 直接以 PowerShell 的退出码返回，保证失败时调用方拿到相同非零值。',
             'powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%~dp0qbot.ps1" %*',
             "exit /b %errorlevel%"
         )
@@ -539,11 +689,13 @@ function Install-OrUpdate {
     try {
         $archive = Join-Path $tempDir $archiveName
         $checksum = "${archive}.sha256"
-        $rawUrl = "$($script:ReleasesUrl)/download/${version}/${archiveName}"
-        Write-Output "downloading Release: $version (windows-x86_64)"
-        Save-ReleaseFile -Url $rawUrl -Destination $archive
-        Save-ReleaseFile -Url "${rawUrl}.sha256" -Destination $checksum
-        Test-ReleaseChecksum -Archive $archive -ChecksumFile $checksum
+        Write-Output "下载 Release: $version (windows-x86_64)"
+        if (-not (Save-ReleaseChain -Version $version -ArchiveName $archiveName -ArchivePath $archive -ChecksumPath $checksum)) {
+            throw ("所有 GitHub 下载源均失败，已停止安装/更新（未覆盖任何文件）。" +
+                   "请检查网络后重试，或在当前 PowerShell 中设置代理后重试：" + [Environment]::NewLine +
+                   "  `$env:QBOT_GITHUB_PROXY = 'https://你的可信GitHub代理前缀'" + [Environment]::NewLine +
+                   "  或 `$env:QBOT_GITHUB_PROXIES = 'https://代理A https://代理B'")
+        }
         Expand-Archive -LiteralPath $archive -DestinationPath $tempDir -Force
         $releaseDir = Join-Path $tempDir $package
         $agentConfigModule = Join-Path $releaseDir "lib\agent-config.ps1"

--- a/scripts/qbot.sh
+++ b/scripts/qbot.sh
@@ -11,8 +11,6 @@ RELEASES_URL="https://github.com/${REPO_SLUG}/releases"
 API_LATEST_URL="https://api.github.com/repos/${REPO_SLUG}/releases/latest"
 GITHUB_ACCEL_PROXY="${QBOT_GITHUB_PROXY:-${GH_PROXY:-}}"
 GITHUB_ACCEL_PROXIES="${QBOT_GITHUB_PROXIES:-}"
-GITHUB_PROBE_CONNECT_TIMEOUT="${QBOT_GITHUB_PROBE_CONNECT_TIMEOUT:-5}"
-GITHUB_PROBE_MAX_TIME="${QBOT_GITHUB_PROBE_MAX_TIME:-12}"
 GITHUB_DOWNLOAD_CONNECT_TIMEOUT="${QBOT_GITHUB_DOWNLOAD_CONNECT_TIMEOUT:-10}"
 GITHUB_DOWNLOAD_MAX_TIME="${QBOT_GITHUB_DOWNLOAD_MAX_TIME:-300}"
 CURL_PROXY="${QBOT_CURL_PROXY:-}"
@@ -137,7 +135,8 @@ usage() {
 
 目录: ${APP_DIR}
 项目: https://github.com/${REPO_SLUG}
-下载: 默认直连官方 GitHub；如需加速，可用 QBOT_GITHUB_PROXY 或 QBOT_GITHUB_PROXIES 指定可信镜像
+下载: 默认直连官方 GitHub；网络不稳定时可用 QBOT_GITHUB_PROXY（单个代理）或
+      QBOT_GITHUB_PROXIES（空格分隔的多个代理）指定可信前缀；官方源与代理会依次尝试并校验 SHA-256
 自动化: QBOT_INSTALL_WEB_CONSOLE=true|false 可指定非交互安装的 Web 选择
 EOF
 }
@@ -161,17 +160,29 @@ curl_qbot() {
 }
 
 github_accel_prefixes() {
-    echo ""
+    # 候选源顺序：官方直连（空串）→ QBOT_GITHUB_PROXY 单代理 → QBOT_GITHUB_PROXIES 多代理。
+    # 与 PowerShell 端 qbot.ps1 语义一致：按空白切分、去尾部斜杠、仅接受 http/https、
+    # 按序去重；不内置任何用户未显式配置的第三方镜像。
+    printf '\n'
 
     {
-        if [[ -n "${GITHUB_ACCEL_PROXY}" ]]; then
-            echo "${GITHUB_ACCEL_PROXY%/}/"
-        fi
+        printf '%s\n' "${GITHUB_ACCEL_PROXY:-}"
 
-        if [[ -n "${GITHUB_ACCEL_PROXIES}" ]]; then
+        if [[ -n "${GITHUB_ACCEL_PROXIES:-}" ]]; then
             printf '%s\n' ${GITHUB_ACCEL_PROXIES}
         fi
-    } | awk 'NF {sub(/\/?$/, "/", $0); if (!seen[$0]++) print}'
+    } | awk '
+        NF {
+            value = $0
+            gsub(/^[ \t]+|[ \t]+$/, "", value)
+            while (value ~ /\/$/) { sub(/\/$/, "", value) }
+            if (value !~ /^https?:\/\//) {
+                print "忽略无效代理前缀（仅支持 http/https 绝对地址）: " value > "/dev/stderr"
+                next
+            }
+            if (!seen[value]++) print value
+        }
+    '
 }
 
 github_url_for_prefix() {
@@ -179,7 +190,7 @@ github_url_for_prefix() {
     local raw_url="$2"
 
     if [[ -n "${prefix}" ]]; then
-        echo "${prefix%/}/${raw_url}"
+        echo "${prefix}/${raw_url}"
     else
         echo "${raw_url}"
     fi
@@ -189,57 +200,10 @@ github_prefix_label() {
     local prefix="$1"
 
     if [[ -n "${prefix}" ]]; then
-        echo "${prefix%/}/"
+        echo "代理源 ${prefix}"
     else
-        echo "直连 GitHub"
+        echo "GitHub 官方源"
     fi
-}
-
-probe_github_prefix_ms() {
-    local prefix="$1"
-    local raw_url="$2"
-    local url result http_code total
-
-    url="$(github_url_for_prefix "${prefix}" "${raw_url}")"
-    result="$(
-        curl_qbot -L -sS --range 0-0 \
-            --connect-timeout "${GITHUB_PROBE_CONNECT_TIMEOUT}" \
-            --max-time "${GITHUB_PROBE_MAX_TIME}" \
-            -o /dev/null \
-            -w '%{http_code} %{time_total}' \
-            "${url}" 2>/dev/null || true
-    )"
-
-    http_code="${result%% *}"
-    total="${result#* }"
-    if [[ "${http_code}" =~ ^20[0-9]$ || "${http_code}" =~ ^30[0-9]$ ]]; then
-        awk -v sec="${total}" 'BEGIN { printf "%d", sec * 1000 }'
-    else
-        echo 999999
-    fi
-}
-
-sorted_github_sources() {
-    local raw_url="$1"
-    local tmp_file prefix latency order token
-
-    tmp_file="$(mktemp)"
-    order=0
-
-    while IFS= read -r prefix; do
-        latency="$(probe_github_prefix_ms "${prefix}" "${raw_url}")"
-        token="${prefix:-__DIRECT__}"
-        if [[ "${latency}" -lt 999999 ]]; then
-            echo "可用 GitHub 源: $(github_prefix_label "${prefix}") (${latency}ms)" >&2
-        else
-            echo "跳过不可用源: $(github_prefix_label "${prefix}")" >&2
-        fi
-        printf '%s\t%s\t%s\n' "${latency}" "${order}" "${token}" >> "${tmp_file}"
-        order=$((order + 1))
-    done < <(github_accel_prefixes)
-
-    sort -n -k1,1 -k2,2 "${tmp_file}" | awk -F '\t' '$1 < 999999 {print $1 "\t" $3}'
-    rm -f "${tmp_file}"
 }
 
 downloaded_file_is_valid() {
@@ -261,45 +225,49 @@ downloaded_file_is_valid() {
     esac
 }
 
-download_github_file() {
-    local raw_url="$1"
-    local output="$2"
-    local description="$3"
-    local latency prefix_token prefix url
+download_github_file_from_source() {
+    # 从单个候选源下载一个文件；网络/HTTP 失败或内容无效时返回 1，由调用方继续尝试下一来源。
+    local prefix="$1"
+    local raw_url="$2"
+    local output="$3"
+    local description="$4"
+    local url
+
+    url="$(github_url_for_prefix "${prefix}" "${raw_url}")"
+    echo "尝试从 $(github_prefix_label "${prefix}") 下载: ${description}" >&2
 
     rm -f "${output}"
-    echo "测速 GitHub 下载源: ${description}" >&2
-
-    while IFS=$'\t' read -r latency prefix_token; do
-        prefix="${prefix_token}"
-        [[ "${prefix}" == "__DIRECT__" ]] && prefix=""
-        url="$(github_url_for_prefix "${prefix}" "${raw_url}")"
-        echo "尝试下载源: $(github_prefix_label "${prefix}") (${latency}ms)" >&2
-
-        rm -f "${output}"
-        if curl_qbot -fL --retry 2 \
-            --connect-timeout "${GITHUB_DOWNLOAD_CONNECT_TIMEOUT}" \
-            --max-time "${GITHUB_DOWNLOAD_MAX_TIME}" \
-            -o "${output}" "${url}"; then
-            if downloaded_file_is_valid "${output}" "${description}"; then
-                return 0
-            fi
-            echo "下载结果无效，继续尝试下一个源: $(github_prefix_label "${prefix}")" >&2
-        fi
-    done < <(sorted_github_sources "${raw_url}")
-
-    echo "所有 GitHub 下载源失败，最后重试官方直连: ${description}" >&2
-    rm -f "${output}"
-    if curl_qbot -fL --retry 2 \
+    if ! curl_qbot -fL --retry 2 \
         --connect-timeout "${GITHUB_DOWNLOAD_CONNECT_TIMEOUT}" \
         --max-time "${GITHUB_DOWNLOAD_MAX_TIME}" \
-        -o "${output}" "${raw_url}"; then
-        if downloaded_file_is_valid "${output}" "${description}"; then
-            return 0
-        fi
+        -o "${output}" "${url}"; then
+        echo "下载失败（网络或 HTTP 错误）: $(github_prefix_label "${prefix}")" >&2
+        return 1
     fi
+    if ! downloaded_file_is_valid "${output}" "${description}"; then
+        echo "下载内容无效（文件为空或格式损坏）: $(github_prefix_label "${prefix}")" >&2
+        return 1
+    fi
+    return 0
+}
 
-    die "下载失败: ${description}"
+download_release_from_source() {
+    # 从单个候选源下载压缩包与 .sha256 并当场校验；任一环节失败即返回 1，由调用方回退下一来源。
+    local prefix="$1"
+    local version="$2"
+    local target="$3"
+    local tmp_dir="$4"
+    local package="$5"
+    local archive="$6"
+    local raw_url="$7"
+
+    download_github_file_from_source "${prefix}" "${raw_url}" "${tmp_dir}/${archive}" "${archive}" || return 1
+    download_github_file_from_source "${prefix}" "${raw_url}.sha256" "${tmp_dir}/${archive}.sha256" "${archive}.sha256" || return 1
+    if ! (cd "${tmp_dir}" && sha256sum -c "${archive}.sha256" >/dev/null 2>&1); then
+        echo "SHA-256 校验失败，该源内容无效: $(github_prefix_label "${prefix}")" >&2
+        return 1
+    fi
+    return 0
 }
 
 install_deps() {
@@ -1888,10 +1856,24 @@ download_release() {
     local package="qq-maid-bot-${version}-${target}"
     local archive="${package}.tar.gz"
     local raw_url="${RELEASES_URL}/download/${version}/${archive}"
+    local prefix downloaded=0
 
     echo "下载 Release: ${version} (${target})" >&2
-    download_github_file "${raw_url}" "${tmp_dir}/${archive}" "${archive}"
-    download_github_file "${raw_url}.sha256" "${tmp_dir}/${archive}.sha256" "${archive}.sha256"
+
+    # 依次尝试官方源与全部用户代理源；只有压缩包格式有效且最终 SHA-256 校验通过才继续。
+    while IFS= read -r prefix; do
+        if download_release_from_source \
+            "${prefix}" "${version}" "${target}" "${tmp_dir}" "${package}" "${archive}" "${raw_url}"; then
+            downloaded=1
+            break
+        fi
+        echo "该来源不可用，继续尝试下一来源" >&2
+    done < <(github_accel_prefixes)
+
+    if ((downloaded != 1)); then
+        die "Release 下载失败: ${version} (${target})。所有 GitHub 下载源均不可用，已停止安装（未覆盖任何文件）。" \
+            "请检查网络后重试，也可设置 QBOT_GITHUB_PROXY（单个代理前缀）或 QBOT_GITHUB_PROXIES（空格分隔的多个代理前缀）指定可信加速源。"
+    fi
 
     (
         cd "${tmp_dir}"

--- a/scripts/qbot.sh
+++ b/scripts/qbot.sh
@@ -268,11 +268,22 @@ download_release_from_source() {
     local package="$5"
     local archive="$6"
     local raw_url="$7"
+    local listing
 
     download_github_file_from_source "${prefix}" "${raw_url}" "${tmp_dir}/${archive}" "${archive}" || return 1
     download_github_file_from_source "${prefix}" "${raw_url}.sha256" "${tmp_dir}/${archive}.sha256" "${archive}.sha256" || return 1
     if ! (cd "${tmp_dir}" && sha256sum -c "${archive}.sha256" >/dev/null 2>&1); then
         echo "SHA-256 校验失败，该源内容无效: $(github_prefix_label "${prefix}")" >&2
+        return 1
+    fi
+    # 归档深度校验：解压前确认归档可完整读取且包含预期包目录，使 gzip 容器有效但
+    # 内容结构损坏的来源也能在单源成功前回退下一来源（与 Windows 端 ZIP 校验一致）。
+    listing="$(tar -tzf "${tmp_dir}/${archive}" 2>/dev/null)" || {
+        echo "压缩包无法完整读取（结构损坏）: $(github_prefix_label "${prefix}")" >&2
+        return 1
+    }
+    if ! grep -Eq "^${package}($|/)" <<<"${listing}"; then
+        echo "压缩包缺少预期包目录 ${package}，该源内容结构无效: $(github_prefix_label "${prefix}")" >&2
         return 1
     fi
     return 0

--- a/scripts/qbot.sh
+++ b/scripts/qbot.sh
@@ -162,7 +162,7 @@ curl_qbot() {
 github_accel_prefixes() {
     # 候选源顺序：官方直连（空串）→ QBOT_GITHUB_PROXY 单代理 → QBOT_GITHUB_PROXIES 多代理。
     # 与 PowerShell 端 qbot.ps1 语义一致：按空白切分、去尾部斜杠、仅接受 http/https、
-    # 按序去重；不内置任何用户未显式配置的第三方镜像。
+    # 且必须含非空主机部分、按序去重；不内置任何用户未显式配置的第三方镜像。
     printf '\n'
 
     {
@@ -178,6 +178,14 @@ github_accel_prefixes() {
             while (value ~ /\/$/) { sub(/\/$/, "", value) }
             if (value !~ /^https?:\/\//) {
                 print "忽略无效代理前缀（仅支持 http/https 绝对地址）: " value > "/dev/stderr"
+                next
+            }
+            rest = value
+            sub(/^https?:\/\//, "", rest)
+            # 主机部分必须非空：以字母/数字或 IPv6 的 "[" 开头，
+            # 拒绝 http://、http:///path、http://:8080 等无主机名的写法。
+            if (rest !~ /^[A-Za-z0-9]/ && substr(rest, 1, 1) != "[") {
+                print "忽略无效代理前缀（需为含非空主机的 http/https 绝对地址）: " value > "/dev/stderr"
                 next
             }
             if (!seen[value]++) print value

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -34,6 +34,7 @@ DIST_DIR="${DIST_DIR}" BUILD_TARGET="${BUILD_TARGET}" TARGET_TRIPLE="windows-x86
     ARCHIVE_FORMAT="zip" bash "${REPO_DIR}/scripts/package-release.sh" test
 windows_listing="$(unzip -Z1 "${DIST_DIR}/qq-maid-bot-test-windows-x86_64.zip")"
 printf '%s\n' "${windows_listing}" | grep -Fx 'qq-maid-bot-test-windows-x86_64/botctl.cmd' >/dev/null
+printf '%s\n' "${windows_listing}" | grep -Fx 'qq-maid-bot-test-windows-x86_64/qbot.ps1' >/dev/null
 printf '%s\n' "${windows_listing}" | grep -Fx 'qq-maid-bot-test-windows-x86_64/qbot.cmd' >/dev/null
 printf '%s\n' "${windows_listing}" | grep -Fx 'qq-maid-bot-test-windows-x86_64/lib/agent-config.ps1' >/dev/null
 printf '%s\n' "${windows_listing}" | grep -Fx 'qq-maid-bot-test-windows-x86_64/config/.env.example' >/dev/null

--- a/scripts/test-qbot-install.sh
+++ b/scripts/test-qbot-install.sh
@@ -393,14 +393,23 @@ done
 
 # 校验用户 shell、Git 与系统全局配置在测试前后没有变化。
 for snapshot_file in .bashrc .zshrc .profile .gitconfig; do
-    if [[ -f "${HOME}/${snapshot_file}" ]]; then
-        cmp -s "${HOME}/${snapshot_file}" "${config_snapshot}/${snapshot_file}" || {
-            echo "用户配置文件在测试期间被修改: ${HOME}/${snapshot_file}" >&2
+    if [[ -f "${config_snapshot}/${snapshot_file}" ]]; then
+        # 快照时文件存在：结束时必须仍存在且内容一致。
+        if [[ -f "${HOME}/${snapshot_file}" ]]; then
+            cmp -s "${HOME}/${snapshot_file}" "${config_snapshot}/${snapshot_file}" || {
+                echo "用户配置文件在测试期间被修改: ${HOME}/${snapshot_file}" >&2
+                exit 1
+            }
+        else
+            echo "用户配置文件在测试期间被删除: ${HOME}/${snapshot_file}" >&2
             exit 1
-        }
-    elif [[ -f "${config_snapshot}/${snapshot_file}.absent" ]]; then
-        echo "测试期间不应创建用户配置文件: ${HOME}/${snapshot_file}" >&2
-        exit 1
+        fi
+    else
+        # 快照时文件不存在：结束时也不应出现。
+        if [[ -f "${HOME}/${snapshot_file}" ]]; then
+            echo "测试期间不应创建用户配置文件: ${HOME}/${snapshot_file}" >&2
+            exit 1
+        fi
     fi
 done
 git config --global --list > "${config_snapshot}/git-global-config.after" 2>/dev/null || true

--- a/scripts/test-qbot-install.sh
+++ b/scripts/test-qbot-install.sh
@@ -193,6 +193,18 @@ chmod +x "${fixture}/${package}/qq-maid-bot" "${fixture}/${package}/botctl.sh"
     sha256sum "${package}.tar.gz" > "${package}.tar.gz.sha256"
 )
 
+# 结构损坏 mock 产物：gzip 容器有效但内容不是 tar / 顶层目录不是包名，
+# 用于验证“单来源成功前”的归档深度校验能触发回退。
+structure_bad_gzip="${tmp_dir}/structure-bad-gzip.tar.gz"
+awk 'BEGIN { for (i = 0; i < 200; i++) print "not-a-tar-payload-line" }' | gzip -c > "${structure_bad_gzip}"
+structure_wrong_dir="${tmp_dir}/structure-wrong-dir.tar.gz"
+mkdir -p "${tmp_dir}/structure-wrong-dir-fixture/wrong-package-dir"
+printf 'x\n' > "${tmp_dir}/structure-wrong-dir-fixture/wrong-package-dir/file"
+(
+    cd "${tmp_dir}/structure-wrong-dir-fixture"
+    tar -czf "${structure_wrong_dir}" wrong-package-dir
+)
+
 # —— GitHub 下载候选与失败回退回归 ——
 # 用假 curl_qbot 模拟网络：请求 URL 写入日志；按规则返回失败、空文件、损坏压缩包或错误校验和；
 # 正常请求从 fixture 目录取文件，从而在无网络环境验证候选顺序、去重与回退行为。
@@ -201,6 +213,8 @@ MOCK_FAIL_PATTERNS=()
 MOCK_EMPTY_PATTERNS=()
 MOCK_CORRUPT_PATTERNS=()
 MOCK_WRONG_HASH_PATTERNS=()
+MOCK_STRUCTURE_PATTERNS=()
+MOCK_STRUCTURE_ARCHIVE=""
 
 curl_qbot() {
     local url="" out="" arg
@@ -232,6 +246,16 @@ curl_qbot() {
     for pattern in "${MOCK_CORRUPT_PATTERNS[@]}"; do
         if [[ "${url}" == "${pattern}"* ]]; then
             printf 'not-a-gzip\n' > "${out}"
+            return 0
+        fi
+    done
+    for pattern in "${MOCK_STRUCTURE_PATTERNS[@]}"; do
+        if [[ "${url}" == "${pattern}"* ]]; then
+            if [[ "${url}" == *.sha256 ]]; then
+                printf '%s  %s\n' "$(sha256sum "${MOCK_STRUCTURE_ARCHIVE}" | awk '{print $1}')" "${package}.tar.gz" > "${out}"
+            else
+                cp "${MOCK_STRUCTURE_ARCHIVE}" "${out}"
+            fi
             return 0
         fi
     done
@@ -291,6 +315,28 @@ MOCK_CORRUPT_PATTERNS=()
 MOCK_WRONG_HASH_PATTERNS=("https://github.com/kuliantnt")
 download_release v9.9.9 linux-x86_64 "${output}" >/dev/null 2>&1
 
+# 4b) gzip 容器有效但结构损坏（内容非 tar / 顶层目录不是包名）时继续回退下一来源。
+: > "${CURL_LOG}"
+MOCK_CORRUPT_PATTERNS=()
+MOCK_WRONG_HASH_PATTERNS=()
+GITHUB_ACCEL_PROXY="https://proxy-a.example.com"
+GITHUB_ACCEL_PROXIES=""
+
+MOCK_STRUCTURE_PATTERNS=("https://github.com/kuliantnt")
+MOCK_STRUCTURE_ARCHIVE="${structure_bad_gzip}"
+download_release v9.9.9 linux-x86_64 "${output}" >/dev/null 2>&1
+[[ -x "${output}/${package}/qq-maid-bot" ]]
+grep -q '^https://github.com/kuliantnt/qq-maid-bot/releases/download/v9.9.9/qq-maid-bot-v9.9.9-linux-x86_64.tar.gz$' "${CURL_LOG}"
+grep -q '^https://proxy-a.example.com/' "${CURL_LOG}"
+
+MOCK_STRUCTURE_ARCHIVE="${structure_wrong_dir}"
+download_release v9.9.9 linux-x86_64 "${output}" >/dev/null 2>&1
+[[ -x "${output}/${package}/qq-maid-bot" ]]
+grep -q '^https://github.com/kuliantnt/qq-maid-bot/releases/download/v9.9.9/qq-maid-bot-v9.9.9-linux-x86_64.tar.gz$' "${CURL_LOG}"
+grep -q '^https://proxy-a.example.com/' "${CURL_LOG}"
+MOCK_STRUCTURE_PATTERNS=()
+MOCK_STRUCTURE_ARCHIVE=""
+
 # 5) 重复代理（含尾部斜杠差异）不产生重复请求。
 : > "${CURL_LOG}"
 MOCK_WRONG_HASH_PATTERNS=()
@@ -342,6 +388,8 @@ MOCK_FAIL_PATTERNS=()
 MOCK_EMPTY_PATTERNS=()
 MOCK_CORRUPT_PATTERNS=()
 MOCK_WRONG_HASH_PATTERNS=()
+MOCK_STRUCTURE_PATTERNS=()
+MOCK_STRUCTURE_ARCHIVE=""
 GITHUB_ACCEL_PROXY=""
 GITHUB_ACCEL_PROXIES=""
 release_dir="$(download_release v9.9.9 linux-x86_64 "${output}")"

--- a/scripts/test-qbot-install.sh
+++ b/scripts/test-qbot-install.sh
@@ -322,6 +322,13 @@ candidate_list="$(github_accel_prefixes)"
 expected_candidates="$(printf '\n%s\n%s' 'https://proxy-a.example.com' 'https://proxy-b.example.com')"
 [[ "${candidate_list}" == "${expected_candidates}" ]]
 
+# 7a) 代理前缀必须含非空主机部分：纯 scheme、空主机、仅端口等写法都应被忽略。
+GITHUB_ACCEL_PROXY="https://proxy-a.example.com"
+GITHUB_ACCEL_PROXIES="http:// http:///path https://?query http://:8080 https://#frag https://good.example.com"
+candidate_list="$(github_accel_prefixes 2>/dev/null)"
+expected_candidates="$(printf '\n%s\n%s' 'https://proxy-a.example.com' 'https://good.example.com')"
+[[ "${candidate_list}" == "${expected_candidates}" ]]
+
 # 8) QBOT_GITHUB_PROXY / QBOT_GITHUB_PROXIES 环境变量映射到内部候选变量。
 env_mapping="$(QBOT_GITHUB_PROXY='https://env-a.example.com/' QBOT_GITHUB_PROXIES='https://env-b.example.com' bash -c '
     source "$1/scripts/qbot.sh"

--- a/scripts/test-qbot-install.sh
+++ b/scripts/test-qbot-install.sh
@@ -42,6 +42,18 @@ fi
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "${tmp_dir}"' EXIT
 
+# 执行前后用户 shell、Git 与系统全局配置必须保持不变（严禁改 .bashrc/.zshrc/.profile/.gitconfig 等）。
+config_snapshot="${tmp_dir}/config-snapshot"
+mkdir -p "${config_snapshot}"
+for snapshot_file in .bashrc .zshrc .profile .gitconfig; do
+    if [[ -f "${HOME}/${snapshot_file}" ]]; then
+        cp "${HOME}/${snapshot_file}" "${config_snapshot}/${snapshot_file}"
+    else
+        : > "${config_snapshot}/${snapshot_file}.absent"
+    fi
+done
+git config --global --list > "${config_snapshot}/git-global-config" 2>/dev/null || true
+
 APP_DIR="${tmp_dir}/web-choice"
 mkdir -p "${APP_DIR}/config"
 printf '%s\n' 'WEB_CONSOLE_ENABLED=true' > "${APP_DIR}/config/.env"
@@ -181,10 +193,150 @@ chmod +x "${fixture}/${package}/qq-maid-bot" "${fixture}/${package}/botctl.sh"
     sha256sum "${package}.tar.gz" > "${package}.tar.gz.sha256"
 )
 
-download_github_file() {
-    cp "${fixture}/$3" "$2"
+# —— GitHub 下载候选与失败回退回归 ——
+# 用假 curl_qbot 模拟网络：请求 URL 写入日志；按规则返回失败、空文件、损坏压缩包或错误校验和；
+# 正常请求从 fixture 目录取文件，从而在无网络环境验证候选顺序、去重与回退行为。
+CURL_LOG="${tmp_dir}/curl-log"
+MOCK_FAIL_PATTERNS=()
+MOCK_EMPTY_PATTERNS=()
+MOCK_CORRUPT_PATTERNS=()
+MOCK_WRONG_HASH_PATTERNS=()
+
+curl_qbot() {
+    local url="" out="" arg
+    local -a args=("$@")
+    local i
+    for ((i = 0; i < ${#args[@]}; i++)); do
+        arg="${args[$i]}"
+        if [[ "${arg}" == "-o" && $((i + 1)) -le $# ]]; then
+            out="${args[$((i + 1))]}"
+        elif [[ "${arg}" == http* ]]; then
+            url="${arg}"
+        fi
+    done
+    printf '%s\n' "${url}" >> "${CURL_LOG}"
+    local pattern base
+    for pattern in "${MOCK_FAIL_PATTERNS[@]}"; do
+        if [[ "${url}" == "${pattern}"* ]]; then
+            return 1
+        fi
+    done
+    [[ -n "${out}" ]] || return 0
+    base="$(basename -- "${url}")"
+    for pattern in "${MOCK_EMPTY_PATTERNS[@]}"; do
+        if [[ "${url}" == "${pattern}"* ]]; then
+            : > "${out}"
+            return 0
+        fi
+    done
+    for pattern in "${MOCK_CORRUPT_PATTERNS[@]}"; do
+        if [[ "${url}" == "${pattern}"* ]]; then
+            printf 'not-a-gzip\n' > "${out}"
+            return 0
+        fi
+    done
+    for pattern in "${MOCK_WRONG_HASH_PATTERNS[@]}"; do
+        if [[ "${url}" == "${pattern}"* && "${url}" == *.sha256 ]]; then
+            printf '%064d\n' 0 > "${out}"
+            return 0
+        fi
+    done
+    cp "${fixture}/${base}" "${out}"
+    return 0
 }
 
+# 1) 未配置代理时只访问 GitHub 官方源，且安装成功。
+: > "${CURL_LOG}"
+GITHUB_ACCEL_PROXY=""
+GITHUB_ACCEL_PROXIES=""
+download_release v9.9.9 linux-x86_64 "${output}" >/dev/null 2>&1
+[[ -x "${output}/${package}/qq-maid-bot" ]]
+if grep -qv '^https://github.com/kuliantnt/qq-maid-bot/releases/download/v9.9.9/' "${CURL_LOG}"; then
+    echo "未配置代理时访问了非官方源" >&2
+    exit 1
+fi
+
+# 2) 官方源失败时回退到单个代理源。
+: > "${CURL_LOG}"
+MOCK_FAIL_PATTERNS=("https://github.com/kuliantnt")
+GITHUB_ACCEL_PROXY="https://proxy-a.example.com/"
+GITHUB_ACCEL_PROXIES=""
+download_release v9.9.9 linux-x86_64 "${output}" >/dev/null 2>&1
+grep -q '^https://proxy-a.example.com/https://github.com/kuliantnt/qq-maid-bot/releases/download/v9.9.9/qq-maid-bot-v9.9.9-linux-x86_64.tar.gz$' "${CURL_LOG}"
+
+# 3) 第一个代理失败时继续尝试后续代理。
+: > "${CURL_LOG}"
+MOCK_FAIL_PATTERNS=("https://github.com/kuliantnt" "https://proxy-bad.example.com")
+GITHUB_ACCEL_PROXY="https://proxy-bad.example.com"
+GITHUB_ACCEL_PROXIES="https://proxy-good.example.com"
+download_release v9.9.9 linux-x86_64 "${output}" >/dev/null 2>&1
+proxy_bad_first="$(grep -n 'proxy-bad.example.com' "${CURL_LOG}" | head -n 1 | cut -d: -f1)"
+proxy_good_first="$(grep -n 'proxy-good.example.com' "${CURL_LOG}" | head -n 1 | cut -d: -f1)"
+[[ -n "${proxy_bad_first}" && -n "${proxy_good_first}" && "${proxy_bad_first}" -lt "${proxy_good_first}" ]]
+
+# 4) HTTP 成功但文件为空 / 压缩包损坏 / 校验和无效时继续回退。
+: > "${CURL_LOG}"
+MOCK_EMPTY_PATTERNS=("https://github.com/kuliantnt")
+GITHUB_ACCEL_PROXY="https://proxy-a.example.com"
+GITHUB_ACCEL_PROXIES=""
+download_release v9.9.9 linux-x86_64 "${output}" >/dev/null 2>&1
+
+: > "${CURL_LOG}"
+MOCK_EMPTY_PATTERNS=()
+MOCK_CORRUPT_PATTERNS=("https://github.com/kuliantnt")
+download_release v9.9.9 linux-x86_64 "${output}" >/dev/null 2>&1
+
+: > "${CURL_LOG}"
+MOCK_CORRUPT_PATTERNS=()
+MOCK_WRONG_HASH_PATTERNS=("https://github.com/kuliantnt")
+download_release v9.9.9 linux-x86_64 "${output}" >/dev/null 2>&1
+
+# 5) 重复代理（含尾部斜杠差异）不产生重复请求。
+: > "${CURL_LOG}"
+MOCK_WRONG_HASH_PATTERNS=()
+MOCK_FAIL_PATTERNS=("https://github.com/kuliantnt")
+GITHUB_ACCEL_PROXY="https://proxy-a.example.com/"
+GITHUB_ACCEL_PROXIES="https://proxy-a.example.com https://proxy-a.example.com/"
+download_release v9.9.9 linux-x86_64 "${output}" >/dev/null 2>&1
+archive_requests="$(grep -c '^https://proxy-a.example.com/https://github.com/kuliantnt/qq-maid-bot/releases/download/v9.9.9/qq-maid-bot-v9.9.9-linux-x86_64.tar.gz$' "${CURL_LOG}" || true)"
+[[ "${archive_requests}" == "1" ]]
+
+# 6) 所有来源失败时返回非零且不落盘任何程序文件。
+: > "${CURL_LOG}"
+MOCK_FAIL_PATTERNS=("https://github.com/kuliantnt")
+GITHUB_ACCEL_PROXY=""
+GITHUB_ACCEL_PROXIES=""
+fail_output="${tmp_dir}/output-fail"
+set +e
+fail_output_text="$(download_release v9.9.9 linux-x86_64 "${fail_output}" 2>&1)"
+fail_status=$?
+set -e
+[[ "${fail_status}" -ne 0 ]]
+[[ ! -e "${fail_output}/${package}" ]]
+[[ "${fail_output_text}" == *"QBOT_GITHUB_PROXY"* ]]
+
+# 7) 候选列表规范化与去重（与 PowerShell 端语义一致）。
+GITHUB_ACCEL_PROXY="https://proxy-a.example.com/"
+GITHUB_ACCEL_PROXIES="https://proxy-b.example.com https://proxy-a.example.com bad-addr"
+candidate_list="$(github_accel_prefixes)"
+expected_candidates="$(printf '\n%s\n%s' 'https://proxy-a.example.com' 'https://proxy-b.example.com')"
+[[ "${candidate_list}" == "${expected_candidates}" ]]
+
+# 8) QBOT_GITHUB_PROXY / QBOT_GITHUB_PROXIES 环境变量映射到内部候选变量。
+env_mapping="$(QBOT_GITHUB_PROXY='https://env-a.example.com/' QBOT_GITHUB_PROXIES='https://env-b.example.com' bash -c '
+    source "$1/scripts/qbot.sh"
+    printf "%s|%s" "${GITHUB_ACCEL_PROXY}" "${GITHUB_ACCEL_PROXIES}"
+' _ "${REPO_DIR}")"
+# 内部候选变量保留原始值，去尾部斜杠等规范化发生在 github_accel_prefixes（见第 7 项测试）。
+[[ "${env_mapping}" == "https://env-a.example.com/|https://env-b.example.com" ]]
+
+# 恢复正常来源，验证完整安装链路仍然可用。
+MOCK_FAIL_PATTERNS=()
+MOCK_EMPTY_PATTERNS=()
+MOCK_CORRUPT_PATTERNS=()
+MOCK_WRONG_HASH_PATTERNS=()
+GITHUB_ACCEL_PROXY=""
+GITHUB_ACCEL_PROXIES=""
 release_dir="$(download_release v9.9.9 linux-x86_64 "${output}")"
 [[ -x "${release_dir}/qq-maid-bot" ]]
 
@@ -238,5 +390,23 @@ do
         exit 1
     }
 done
+
+# 校验用户 shell、Git 与系统全局配置在测试前后没有变化。
+for snapshot_file in .bashrc .zshrc .profile .gitconfig; do
+    if [[ -f "${HOME}/${snapshot_file}" ]]; then
+        cmp -s "${HOME}/${snapshot_file}" "${config_snapshot}/${snapshot_file}" || {
+            echo "用户配置文件在测试期间被修改: ${HOME}/${snapshot_file}" >&2
+            exit 1
+        }
+    elif [[ -f "${config_snapshot}/${snapshot_file}.absent" ]]; then
+        echo "测试期间不应创建用户配置文件: ${HOME}/${snapshot_file}" >&2
+        exit 1
+    fi
+done
+git config --global --list > "${config_snapshot}/git-global-config.after" 2>/dev/null || true
+cmp -s "${config_snapshot}/git-global-config" "${config_snapshot}/git-global-config.after" || {
+    echo "git 全局配置在测试期间被修改" >&2
+    exit 1
+}
 
 echo "qbot Unix installer regression tests passed"

--- a/scripts/test-windows-qbot.ps1
+++ b/scripts/test-windows-qbot.ps1
@@ -294,8 +294,9 @@ try {
     }
     Set-Content -LiteralPath (Join-Path $mockPackageDir "config\.env.example") -Value "EXAMPLE=1" -Encoding ASCII
     $mockZip = Join-Path $mockServerDir "qq-maid-bot-v9.9.9-windows-x86_64.zip"
-    # 压缩包目录本身，使 ZIP 包含与真实 Release 一致的顶层包目录（结构校验依赖该约定）。
-    Compress-Archive -Path $mockPackageDir -DestinationPath $mockZip -Force
+    # 用 .NET ZipFile 打包，确保 ZIP 顶层是包目录本身（与真实 Release 的 zip -rq 布局一致；
+    # Windows PowerShell 5.1 的 Compress-Archive 直接传目录时不含顶层目录名，不能用于 mock）。
+    [IO.Compression.ZipFile]::CreateFromDirectory($mockPackageDir, $mockZip)
     $mockHash = (Get-FileHash -LiteralPath $mockZip -Algorithm SHA256).Hash.ToLowerInvariant()
     Set-Content -LiteralPath "${mockZip}.sha256" -Value "$mockHash  qq-maid-bot-v9.9.9-windows-x86_64.zip" -Encoding ASCII
     # 结构损坏产物：ZIP 容器有效但缺少预期的顶层包目录，用于验证深度校验回退。

--- a/scripts/test-windows-qbot.ps1
+++ b/scripts/test-windows-qbot.ps1
@@ -9,6 +9,20 @@ $oldServerHost = $env:LLM_SERVER_HOST
 $oldServerPort = $env:LLM_SERVER_PORT
 $oldConsoleEnabled = $env:WEB_CONSOLE_ENABLED
 $oldInstallWeb = $env:QBOT_INSTALL_WEB_CONSOLE
+$oldGitHubProxy = $env:QBOT_GITHUB_PROXY
+$oldGitHubProxies = $env:QBOT_GITHUB_PROXIES
+
+# 执行前后用户/系统环境变量与 git 全局配置必须保持不变（严禁写 User/Machine 作用域）。
+$userProxyBefore = [Environment]::GetEnvironmentVariable("QBOT_GITHUB_PROXY", "User")
+$userProxiesBefore = [Environment]::GetEnvironmentVariable("QBOT_GITHUB_PROXIES", "User")
+$machineProxyBefore = [Environment]::GetEnvironmentVariable("QBOT_GITHUB_PROXY", "Machine")
+$machineProxiesBefore = [Environment]::GetEnvironmentVariable("QBOT_GITHUB_PROXIES", "Machine")
+$gitConfigPath = Join-Path $HOME ".gitconfig"
+$gitConfigBefore = if (Test-Path -LiteralPath $gitConfigPath -PathType Leaf) {
+    (Get-Content -LiteralPath $gitConfigPath -Raw)
+} else {
+    $null
+}
 
 function Assert-True {
     param([bool]$Condition, [string]$Message)
@@ -23,6 +37,8 @@ try {
     $env:LLM_SERVER_HOST = $null
     $env:LLM_SERVER_PORT = $null
     $env:WEB_CONSOLE_ENABLED = $null
+    $env:QBOT_GITHUB_PROXY = $null
+    $env:QBOT_GITHUB_PROXIES = $null
     . (Join-Path $repoDir "scripts\qbot.ps1")
     . (Join-Path $repoDir "scripts\lib\agent-config.ps1")
     $agentConfigMigrationMarker = Join-Path $appDir "config\.agent-config-v0.20.2"
@@ -151,11 +167,9 @@ try {
     Set-Content -LiteralPath (Join-Path $appDir "VERSION") -Value "v0.20.1" -Encoding ASCII
     Set-Content -LiteralPath (Join-Path $appDir "config\agent.toml") -Value "must-survive-full-chain" -Encoding ASCII
     function Resolve-Version { return "v0.20.2" }
-    function Save-ReleaseFile {
-        param([string]$Url, [string]$Destination)
-    }
-    function Test-ReleaseChecksum {
-        param([string]$Archive, [string]$ChecksumFile)
+    function Save-ReleaseChain {
+        param([string]$Version, [string]$ArchiveName, [string]$ArchivePath, [string]$ChecksumPath)
+        return $true
     }
     function Expand-Archive {
         param([string]$LiteralPath, [string]$DestinationPath, [switch]$Force)
@@ -179,8 +193,7 @@ try {
         $failedReplacementError = $_.Exception.Message
     } finally {
         Remove-Item Function:\Resolve-Version -ErrorAction SilentlyContinue
-        Remove-Item Function:\Save-ReleaseFile -ErrorAction SilentlyContinue
-        Remove-Item Function:\Test-ReleaseChecksum -ErrorAction SilentlyContinue
+        Remove-Item Function:\Save-ReleaseChain -ErrorAction SilentlyContinue
         Remove-Item Function:\Expand-Archive -ErrorAction SilentlyContinue
         Remove-Item Function:\Move-Item -ErrorAction SilentlyContinue
         . (Join-Path $repoDir "scripts\qbot.ps1")
@@ -270,6 +283,204 @@ try {
     Set-Content -LiteralPath $checksum -Value "$hash  fixture.zip" -Encoding ASCII
     Test-ReleaseChecksum -Archive $archive -ChecksumFile $checksum
 
+    # —— GitHub 下载候选与失败回退回归 ——
+    # 用 mock 的 Invoke-WebRequest 模拟网络：请求 URL 写入日志；按前缀规则返回失败、
+    # 空文件、损坏 ZIP 或错误校验和；正常请求从 mock-server 目录取 fixture 文件。
+    $mockServerDir = Join-Path $testRoot "mock-server"
+    $mockPackageDir = Join-Path $mockServerDir "qq-maid-bot-v9.9.9-windows-x86_64"
+    New-Item -ItemType Directory -Path (Join-Path $mockPackageDir "config") -Force | Out-Null
+    foreach ($mockFile in @("qq-maid-bot.exe", "README.md", "VERSION")) {
+        Set-Content -LiteralPath (Join-Path $mockPackageDir $mockFile) -Value "release" -Encoding ASCII
+    }
+    Set-Content -LiteralPath (Join-Path $mockPackageDir "config\.env.example") -Value "EXAMPLE=1" -Encoding ASCII
+    $mockZip = Join-Path $mockServerDir "qq-maid-bot-v9.9.9-windows-x86_64.zip"
+    Compress-Archive -Path (Join-Path $mockPackageDir "*") -DestinationPath $mockZip -Force
+    $mockHash = (Get-FileHash -LiteralPath $mockZip -Algorithm SHA256).Hash.ToLowerInvariant()
+    Set-Content -LiteralPath "${mockZip}.sha256" -Value "$mockHash  qq-maid-bot-v9.9.9-windows-x86_64.zip" -Encoding ASCII
+
+    $script:MockRequestLog = New-Object System.Collections.Generic.List[string]
+    $script:MockFailPatterns = New-Object System.Collections.Generic.List[string]
+    $script:MockEmptyPatterns = New-Object System.Collections.Generic.List[string]
+    $script:MockCorruptPatterns = New-Object System.Collections.Generic.List[string]
+    $script:MockWrongHashPatterns = New-Object System.Collections.Generic.List[string]
+
+    function Invoke-WebRequest {
+        param([string]$Uri, [string]$OutFile, [switch]$UseBasicParsing, [int]$TimeoutSec, [string]$ErrorAction)
+        $script:MockRequestLog.Add($Uri) | Out-Null
+        foreach ($pattern in $script:MockFailPatterns) {
+            if ($Uri.StartsWith($pattern, [StringComparison]::OrdinalIgnoreCase)) {
+                throw "simulated HTTP/network failure for $Uri"
+            }
+        }
+        foreach ($pattern in $script:MockEmptyPatterns) {
+            if ($Uri.StartsWith($pattern, [StringComparison]::OrdinalIgnoreCase)) {
+                Set-Content -LiteralPath $OutFile -Value "" -Encoding ASCII
+                return $null
+            }
+        }
+        foreach ($pattern in $script:MockCorruptPatterns) {
+            if ($Uri.StartsWith($pattern, [StringComparison]::OrdinalIgnoreCase)) {
+                Set-Content -LiteralPath $OutFile -Value "not-a-zip" -Encoding ASCII
+                return $null
+            }
+        }
+        foreach ($pattern in $script:MockWrongHashPatterns) {
+            if ($Uri.StartsWith($pattern, [StringComparison]::OrdinalIgnoreCase) -and $Uri.EndsWith(".sha256")) {
+                Set-Content -LiteralPath $OutFile -Value ("0" * 64) -Encoding ASCII
+                return $null
+            }
+        }
+        $fileName = [IO.Path]::GetFileName($Uri)
+        Copy-Item -LiteralPath (Join-Path $mockServerDir $fileName) -Destination $OutFile -Force
+        return $null
+    }
+
+    $officialPrefix = "https://github.com/$($script:RepoSlug)"
+    $archiveName = "qq-maid-bot-v9.9.9-windows-x86_64.zip"
+    $downloadDir = Join-Path $testRoot "download"
+    New-Item -ItemType Directory -Path $downloadDir -Force | Out-Null
+    $archivePath = Join-Path $downloadDir $archiveName
+
+    # 1) 未配置代理时只访问 GitHub 官方源，且下载成功。
+    $script:MockRequestLog.Clear()
+    $script:MockFailPatterns.Clear()
+    $script:MockEmptyPatterns.Clear()
+    $script:MockCorruptPatterns.Clear()
+    $script:MockWrongHashPatterns.Clear()
+    $env:QBOT_GITHUB_PROXY = $null
+    $env:QBOT_GITHUB_PROXIES = $null
+    $prefixes = Get-GitHubProxyPrefixes
+    Assert-True ($prefixes.Count -eq 1 -and $prefixes[0] -eq "") "no proxy should yield only the official source"
+    $ok = Save-ReleaseChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
+    Assert-True $ok "official-only download should succeed"
+    foreach ($requestUrl in $script:MockRequestLog) {
+        Assert-True ($requestUrl.StartsWith("$officialPrefix/releases/download/v9.9.9/", [StringComparison]::OrdinalIgnoreCase)) "no-proxy mode requested a non-official URL: $requestUrl"
+    }
+
+    # 2) 官方源失败时回退到单个代理源。
+    $script:MockRequestLog.Clear()
+    $script:MockFailPatterns.Add($officialPrefix)
+    $env:QBOT_GITHUB_PROXY = "https://proxy-a.example.com/"
+    $env:QBOT_GITHUB_PROXIES = $null
+    $ok = Save-ReleaseChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
+    Assert-True $ok "official failure should fall back to the single proxy"
+    $proxyArchiveUrl = "https://proxy-a.example.com/$officialPrefix/releases/download/v9.9.9/$archiveName"
+    Assert-True ($script:MockRequestLog -contains $proxyArchiveUrl) "proxy URL was not requested after official failure"
+
+    # 3) 第一个代理失败时继续尝试后续代理。
+    $script:MockRequestLog.Clear()
+    $script:MockFailPatterns.Clear()
+    $script:MockFailPatterns.Add($officialPrefix)
+    $script:MockFailPatterns.Add("https://proxy-bad.example.com")
+    $env:QBOT_GITHUB_PROXY = "https://proxy-bad.example.com"
+    $env:QBOT_GITHUB_PROXIES = "https://proxy-good.example.com"
+    $ok = Save-ReleaseChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
+    Assert-True $ok "later proxy should succeed after the first proxy failed"
+    $badIndex = -1
+    $goodIndex = -1
+    for ($i = 0; $i -lt $script:MockRequestLog.Count; $i++) {
+        if ($script:MockRequestLog[$i].StartsWith("https://proxy-bad.example.com/")) { $badIndex = $i; break }
+    }
+    for ($i = 0; $i -lt $script:MockRequestLog.Count; $i++) {
+        if ($script:MockRequestLog[$i].StartsWith("https://proxy-good.example.com/")) { $goodIndex = $i; break }
+    }
+    Assert-True ($badIndex -ge 0 -and $goodIndex -gt $badIndex) "later proxy was not tried after the first proxy failed"
+
+    # 4) HTTP 成功但文件为空 / ZIP 损坏 / checksum 无效时继续回退。
+    $script:MockRequestLog.Clear()
+    $script:MockFailPatterns.Clear()
+    $script:MockEmptyPatterns.Add($officialPrefix)
+    $env:QBOT_GITHUB_PROXY = "https://proxy-a.example.com"
+    $env:QBOT_GITHUB_PROXIES = $null
+    $ok = Save-ReleaseChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
+    Assert-True $ok "empty official file should fall back to proxy"
+
+    $script:MockEmptyPatterns.Clear()
+    $script:MockCorruptPatterns.Add($officialPrefix)
+    $ok = Save-ReleaseChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
+    Assert-True $ok "corrupt official zip should fall back to proxy"
+
+    $script:MockCorruptPatterns.Clear()
+    $script:MockWrongHashPatterns.Add($officialPrefix)
+    $ok = Save-ReleaseChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
+    Assert-True $ok "invalid official checksum should fall back to proxy"
+
+    # 5) 重复代理（含尾部斜杠差异）不产生重复请求。
+    $script:MockRequestLog.Clear()
+    $script:MockWrongHashPatterns.Clear()
+    $script:MockFailPatterns.Add($officialPrefix)
+    $env:QBOT_GITHUB_PROXY = "https://proxy-a.example.com/"
+    $env:QBOT_GITHUB_PROXIES = "https://proxy-a.example.com https://proxy-a.example.com/"
+    $ok = Save-ReleaseChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
+    Assert-True $ok "deduplicated proxy download should succeed"
+    $archiveCount = @($script:MockRequestLog | Where-Object { $_ -eq $proxyArchiveUrl }).Count
+    Assert-True ($archiveCount -eq 1) "duplicate proxies produced duplicate requests"
+
+    # 6) 所有来源失败时返回非零，且不覆盖任何程序文件。
+    $script:MockRequestLog.Clear()
+    $script:MockFailPatterns.Clear()
+    $script:MockFailPatterns.Add($officialPrefix)
+    $env:QBOT_GITHUB_PROXY = $null
+    $env:QBOT_GITHUB_PROXIES = $null
+    $ok = Save-ReleaseChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
+    Assert-True (-not $ok) "all-sources-failed chain should return false"
+    $installFailApp = Join-Path $testRoot "install-fail"
+    New-Item -ItemType Directory -Path (Join-Path $installFailApp "config") -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $installFailApp "VERSION") -Value "v0.0.0-old" -Encoding ASCII
+    $oldScriptAppDir = $script:AppDir
+    $script:AppDir = $installFailApp
+    $installFailError = $null
+    try {
+        Install-OrUpdate -Mode "install" -RequestedVersion "v9.9.9"
+    } catch {
+        $installFailError = $_.Exception.Message
+    } finally {
+        $script:AppDir = $oldScriptAppDir
+    }
+    Assert-True ($null -ne $installFailError) "all-sources-failed install did not return an error"
+    Assert-True ((Get-Content -LiteralPath (Join-Path $installFailApp "VERSION") -Raw).Contains("v0.0.0-old")) "failed install overwrote program files"
+    Assert-True ($installFailError.Contains("QBOT_GITHUB_PROXY")) "all-sources-failed error lacks proxy guidance"
+    Remove-Item Function:\Invoke-WebRequest -ErrorAction SilentlyContinue
+
+    # 7) 候选列表规范化与去重（与 Linux 端语义一致：官方 → 单代理 → 多代理，按序去重）。
+    $env:QBOT_GITHUB_PROXY = "https://proxy-a.example.com/"
+    $env:QBOT_GITHUB_PROXIES = "https://proxy-b.example.com https://proxy-a.example.com bad-addr"
+    $prefixes = Get-GitHubProxyPrefixes
+    Assert-True ($prefixes.Count -eq 3) "expected official plus two deduplicated proxies"
+    Assert-True ($prefixes[0] -eq "" -and $prefixes[1] -eq "https://proxy-a.example.com" -and $prefixes[2] -eq "https://proxy-b.example.com") "proxy prefix order/normalization mismatch"
+    $env:QBOT_GITHUB_PROXY = $null
+    $env:QBOT_GITHUB_PROXIES = $null
+
+    # —— qbot.cmd 参数透传与退出码 ——
+    $cmdDir = Join-Path $testRoot "cmd with spaces"
+    New-Item -ItemType Directory -Path $cmdDir -Force | Out-Null
+    Copy-Item -LiteralPath (Join-Path $repoDir "scripts\qbot.ps1") -Destination (Join-Path $cmdDir "qbot.ps1")
+    Copy-Item -LiteralPath (Join-Path $repoDir "scripts\qbot.cmd") -Destination (Join-Path $cmdDir "qbot.cmd")
+    & cmd.exe /d /c "`"$cmdDir\qbot.cmd`" config set CMD_BINDING_TEST=ok"
+    if ($LASTEXITCODE -ne 0) {
+        throw "qbot.cmd argument pass-through failed"
+    }
+    $values = Read-ConfigValues
+    Assert-True ($values["CMD_BINDING_TEST"] -eq "ok") "qbot.cmd did not forward config arguments"
+    & cmd.exe /d /c "`"$cmdDir\qbot.cmd`" not-a-command"
+    if ($LASTEXITCODE -eq 0) {
+        throw "qbot.cmd swallowed the PowerShell non-zero exit code"
+    }
+
+    # 执行前后用户/系统环境变量与 git 全局配置必须保持不变。
+    $userProxyAfter = [Environment]::GetEnvironmentVariable("QBOT_GITHUB_PROXY", "User")
+    $userProxiesAfter = [Environment]::GetEnvironmentVariable("QBOT_GITHUB_PROXIES", "User")
+    $machineProxyAfter = [Environment]::GetEnvironmentVariable("QBOT_GITHUB_PROXY", "Machine")
+    $machineProxiesAfter = [Environment]::GetEnvironmentVariable("QBOT_GITHUB_PROXIES", "Machine")
+    Assert-True ($userProxyAfter -eq $userProxyBefore -and $userProxiesAfter -eq $userProxiesBefore) "User-scope proxy environment changed during the test"
+    Assert-True ($machineProxyAfter -eq $machineProxyBefore -and $machineProxiesAfter -eq $machineProxiesBefore) "Machine-scope proxy environment changed during the test"
+    $gitConfigAfter = if (Test-Path -LiteralPath $gitConfigPath -PathType Leaf) {
+        (Get-Content -LiteralPath $gitConfigPath -Raw)
+    } else {
+        $null
+    }
+    Assert-True ($gitConfigAfter -eq $gitConfigBefore) "git global config changed during the test"
+
     Write-Output "PowerShell qbot regression tests passed"
 } finally {
     $env:QBOT_APP_DIR = $oldAppDir
@@ -278,5 +489,7 @@ try {
     $env:LLM_SERVER_PORT = $oldServerPort
     $env:WEB_CONSOLE_ENABLED = $oldConsoleEnabled
     $env:QBOT_INSTALL_WEB_CONSOLE = $oldInstallWeb
+    $env:QBOT_GITHUB_PROXY = $oldGitHubProxy
+    $env:QBOT_GITHUB_PROXIES = $oldGitHubProxies
     Remove-Item -LiteralPath $testRoot -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/scripts/test-windows-qbot.ps1
+++ b/scripts/test-windows-qbot.ps1
@@ -294,9 +294,10 @@ try {
     }
     Set-Content -LiteralPath (Join-Path $mockPackageDir "config\.env.example") -Value "EXAMPLE=1" -Encoding ASCII
     $mockZip = Join-Path $mockServerDir "qq-maid-bot-v9.9.9-windows-x86_64.zip"
-    # 用 .NET ZipFile 打包，确保 ZIP 顶层是包目录本身（与真实 Release 的 zip -rq 布局一致；
-    # Windows PowerShell 5.1 的 Compress-Archive 直接传目录时不含顶层目录名，不能用于 mock）。
-    [IO.Compression.ZipFile]::CreateFromDirectory($mockPackageDir, $mockZip)
+    # 用 .NET ZipFile 打包并显式 includeBaseDirectory，确保 ZIP 顶层是包目录本身
+    # （与真实 Release 的 zip -rq 布局一致；Compress-Archive 与默认 2 参 CreateFromDirectory
+    # 都不含顶层目录名，不能用于 mock）。
+    [IO.Compression.ZipFile]::CreateFromDirectory($mockPackageDir, $mockZip, [IO.Compression.CompressionLevel]::Optimal, $true)
     $mockHash = (Get-FileHash -LiteralPath $mockZip -Algorithm SHA256).Hash.ToLowerInvariant()
     Set-Content -LiteralPath "${mockZip}.sha256" -Value "$mockHash  qq-maid-bot-v9.9.9-windows-x86_64.zip" -Encoding ASCII
     # 结构损坏产物：ZIP 容器有效但缺少预期的顶层包目录，用于验证深度校验回退。

--- a/scripts/test-windows-qbot.ps1
+++ b/scripts/test-windows-qbot.ps1
@@ -294,14 +294,24 @@ try {
     }
     Set-Content -LiteralPath (Join-Path $mockPackageDir "config\.env.example") -Value "EXAMPLE=1" -Encoding ASCII
     $mockZip = Join-Path $mockServerDir "qq-maid-bot-v9.9.9-windows-x86_64.zip"
-    Compress-Archive -Path (Join-Path $mockPackageDir "*") -DestinationPath $mockZip -Force
+    # 压缩包目录本身，使 ZIP 包含与真实 Release 一致的顶层包目录（结构校验依赖该约定）。
+    Compress-Archive -Path $mockPackageDir -DestinationPath $mockZip -Force
     $mockHash = (Get-FileHash -LiteralPath $mockZip -Algorithm SHA256).Hash.ToLowerInvariant()
     Set-Content -LiteralPath "${mockZip}.sha256" -Value "$mockHash  qq-maid-bot-v9.9.9-windows-x86_64.zip" -Encoding ASCII
+    # 结构损坏产物：ZIP 容器有效但缺少预期的顶层包目录，用于验证深度校验回退。
+    $mockStructureDir = Join-Path $testRoot "structure-broken"
+    New-Item -ItemType Directory -Path $mockStructureDir -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $mockStructureDir "README.md") -Value "broken" -Encoding ASCII
+    $mockStructureZip = Join-Path $mockServerDir "structure-broken.zip"
+    Compress-Archive -Path (Join-Path $mockStructureDir "*") -DestinationPath $mockStructureZip -Force
+    $mockStructureHash = (Get-FileHash -LiteralPath $mockStructureZip -Algorithm SHA256).Hash.ToLowerInvariant()
+    Set-Content -LiteralPath "${mockStructureZip}.sha256" -Value "$mockStructureHash  qq-maid-bot-v9.9.9-windows-x86_64.zip" -Encoding ASCII
 
     $script:MockRequestLog = New-Object System.Collections.Generic.List[string]
     $script:MockFailPatterns = New-Object System.Collections.Generic.List[string]
     $script:MockEmptyPatterns = New-Object System.Collections.Generic.List[string]
     $script:MockCorruptPatterns = New-Object System.Collections.Generic.List[string]
+    $script:MockStructurePatterns = New-Object System.Collections.Generic.List[string]
     $script:MockWrongHashPatterns = New-Object System.Collections.Generic.List[string]
 
     function Invoke-WebRequest {
@@ -321,6 +331,16 @@ try {
         foreach ($pattern in $script:MockCorruptPatterns) {
             if ($Uri.StartsWith($pattern, [StringComparison]::OrdinalIgnoreCase)) {
                 Set-Content -LiteralPath $OutFile -Value "not-a-zip" -Encoding ASCII
+                return $null
+            }
+        }
+        foreach ($pattern in $script:MockStructurePatterns) {
+            if ($Uri.StartsWith($pattern, [StringComparison]::OrdinalIgnoreCase)) {
+                if ($Uri.EndsWith(".sha256")) {
+                    Copy-Item -LiteralPath "${mockStructureZip}.sha256" -Destination $OutFile -Force
+                } else {
+                    Copy-Item -LiteralPath $mockStructureZip -Destination $OutFile -Force
+                }
                 return $null
             }
         }
@@ -421,6 +441,12 @@ try {
     Assert-True $ok "corrupt official zip should fall back to proxy"
 
     $script:MockCorruptPatterns.Clear()
+    $script:MockStructurePatterns.Add($officialPrefix)
+    $ok = Invoke-TestDownloadChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
+    Assert-True $ok "structure-broken official zip should fall back to proxy"
+    $script:MockStructurePatterns.Clear()
+
+    $script:MockCorruptPatterns.Clear()
     $script:MockWrongHashPatterns.Add($officialPrefix)
     $ok = Invoke-TestDownloadChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
     Assert-True $ok "invalid official checksum should fall back to proxy"
@@ -465,7 +491,7 @@ try {
 
     # 7) 候选列表规范化与去重（与 Linux 端语义一致：官方 → 单代理 → 多代理，按序去重）。
     $env:QBOT_GITHUB_PROXY = "https://proxy-a.example.com/"
-    $env:QBOT_GITHUB_PROXIES = "https://proxy-b.example.com https://proxy-a.example.com bad-addr"
+    $env:QBOT_GITHUB_PROXIES = "https://proxy-b.example.com https://proxy-a.example.com bad-addr http:// http:///path https://?query"
     $prefixes = Get-GitHubProxyPrefixes
     Assert-True ($prefixes.Count -eq 3) "expected official plus two deduplicated proxies"
     Assert-True ($prefixes[0] -eq "" -and $prefixes[1] -eq "https://proxy-a.example.com" -and $prefixes[2] -eq "https://proxy-b.example.com") "proxy prefix order/normalization mismatch"

--- a/scripts/test-windows-qbot.ps1
+++ b/scripts/test-windows-qbot.ps1
@@ -331,8 +331,20 @@ try {
             }
         }
         $fileName = [IO.Path]::GetFileName($Uri)
+        Write-Host ("mock served: " + $Uri)
         Copy-Item -LiteralPath (Join-Path $mockServerDir $fileName) -Destination $OutFile -Force
         return $null
+    }
+
+    function Invoke-TestDownloadChain {
+        # 跑一次真实链路，返回干净的布尔结果，并把诊断信息打到宿主输出（不进成功流）。
+        param([string]$Version, [string]$ArchiveName, [string]$ArchivePath, [string]$ChecksumPath)
+        Write-Host ("mock fail patterns: " + ($script:MockFailPatterns -join " | "))
+        Write-Host ("mock request log: " + ($script:MockRequestLog -join " | "))
+        $result = Save-ReleaseChain -Version $Version -ArchiveName $ArchiveName -ArchivePath $ArchivePath -ChecksumPath $ChecksumPath
+        Write-Host ("chain result: " + $result)
+        Write-Host ("mock request log after: " + ($script:MockRequestLog -join " | "))
+        return $result
     }
 
     $officialPrefix = "https://github.com/$($script:RepoSlug)"
@@ -351,7 +363,7 @@ try {
     $env:QBOT_GITHUB_PROXIES = $null
     $prefixes = Get-GitHubProxyPrefixes
     Assert-True ($prefixes.Count -eq 1 -and $prefixes[0] -eq "") "no proxy should yield only the official source"
-    $ok = Save-ReleaseChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
+    $ok = Invoke-TestDownloadChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
     Assert-True $ok "official-only download should succeed"
     foreach ($requestUrl in $script:MockRequestLog) {
         Assert-True ($requestUrl.StartsWith("$officialPrefix/releases/download/v9.9.9/", [StringComparison]::OrdinalIgnoreCase)) "no-proxy mode requested a non-official URL: $requestUrl"
@@ -362,10 +374,18 @@ try {
     $script:MockFailPatterns.Add($officialPrefix)
     $env:QBOT_GITHUB_PROXY = "https://proxy-a.example.com/"
     $env:QBOT_GITHUB_PROXIES = $null
-    $ok = Save-ReleaseChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
+    $prefixes = Get-GitHubProxyPrefixes
+    Assert-True ($prefixes.Count -eq 2 -and $prefixes[1] -eq "https://proxy-a.example.com") "QBOT_GITHUB_PROXY did not add a proxy candidate"
+    $ok = Invoke-TestDownloadChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
     Assert-True $ok "official failure should fall back to the single proxy"
-    $proxyArchiveUrl = "https://proxy-a.example.com/$officialPrefix/releases/download/v9.9.9/$archiveName"
-    Assert-True ($script:MockRequestLog -contains $proxyArchiveUrl) "proxy URL was not requested after official failure"
+    $proxyRequested = $false
+    foreach ($requestUrl in $script:MockRequestLog) {
+        if ($requestUrl.StartsWith("https://proxy-a.example.com/", [StringComparison]::OrdinalIgnoreCase)) {
+            $proxyRequested = $true
+            break
+        }
+    }
+    Assert-True $proxyRequested "proxy URL was not requested after official failure"
 
     # 3) 第一个代理失败时继续尝试后续代理。
     $script:MockRequestLog.Clear()
@@ -374,7 +394,7 @@ try {
     $script:MockFailPatterns.Add("https://proxy-bad.example.com")
     $env:QBOT_GITHUB_PROXY = "https://proxy-bad.example.com"
     $env:QBOT_GITHUB_PROXIES = "https://proxy-good.example.com"
-    $ok = Save-ReleaseChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
+    $ok = Invoke-TestDownloadChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
     Assert-True $ok "later proxy should succeed after the first proxy failed"
     $badIndex = -1
     $goodIndex = -1
@@ -392,17 +412,17 @@ try {
     $script:MockEmptyPatterns.Add($officialPrefix)
     $env:QBOT_GITHUB_PROXY = "https://proxy-a.example.com"
     $env:QBOT_GITHUB_PROXIES = $null
-    $ok = Save-ReleaseChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
+    $ok = Invoke-TestDownloadChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
     Assert-True $ok "empty official file should fall back to proxy"
 
     $script:MockEmptyPatterns.Clear()
     $script:MockCorruptPatterns.Add($officialPrefix)
-    $ok = Save-ReleaseChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
+    $ok = Invoke-TestDownloadChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
     Assert-True $ok "corrupt official zip should fall back to proxy"
 
     $script:MockCorruptPatterns.Clear()
     $script:MockWrongHashPatterns.Add($officialPrefix)
-    $ok = Save-ReleaseChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
+    $ok = Invoke-TestDownloadChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
     Assert-True $ok "invalid official checksum should fall back to proxy"
 
     # 5) 重复代理（含尾部斜杠差异）不产生重复请求。
@@ -411,9 +431,10 @@ try {
     $script:MockFailPatterns.Add($officialPrefix)
     $env:QBOT_GITHUB_PROXY = "https://proxy-a.example.com/"
     $env:QBOT_GITHUB_PROXIES = "https://proxy-a.example.com https://proxy-a.example.com/"
-    $ok = Save-ReleaseChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
+    $ok = Invoke-TestDownloadChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
     Assert-True $ok "deduplicated proxy download should succeed"
-    $archiveCount = @($script:MockRequestLog | Where-Object { $_ -eq $proxyArchiveUrl }).Count
+    $archiveUrl = "https://proxy-a.example.com/$officialPrefix/releases/download/v9.9.9/$archiveName"
+    $archiveCount = @($script:MockRequestLog | Where-Object { $_ -eq $archiveUrl }).Count
     Assert-True ($archiveCount -eq 1) "duplicate proxies produced duplicate requests"
 
     # 6) 所有来源失败时返回非零，且不覆盖任何程序文件。
@@ -422,7 +443,7 @@ try {
     $script:MockFailPatterns.Add($officialPrefix)
     $env:QBOT_GITHUB_PROXY = $null
     $env:QBOT_GITHUB_PROXIES = $null
-    $ok = Save-ReleaseChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
+    $ok = Invoke-TestDownloadChain -Version "v9.9.9" -ArchiveName $archiveName -ArchivePath $archivePath -ChecksumPath "${archivePath}.sha256"
     Assert-True (-not $ok) "all-sources-failed chain should return false"
     $installFailApp = Join-Path $testRoot "install-fail"
     New-Item -ItemType Directory -Path (Join-Path $installFailApp "config") -Force | Out-Null

--- a/scripts/test-windows-qbot.ps1
+++ b/scripts/test-windows-qbot.ps1
@@ -506,6 +506,10 @@ try {
     Assert-True ($gitConfigAfter -eq $gitConfigBefore) "git global config changed during the test"
 
     Write-Output "PowerShell qbot regression tests passed"
+    # 测试中曾以非零退出运行 cmd.exe（校验 qbot.cmd 退出码透传），
+    # powershell -Command 会沿用最后一条原生命令/LASTEXITCODE 作为进程退出码；
+    # 全部断言通过后显式 exit 0，避免误报失败（断言失败会先抛出，不会走到这里）。
+    exit 0
 } finally {
     $env:QBOT_APP_DIR = $oldAppDir
     $env:LLM_SERVER_URL = $oldServerUrl

--- a/scripts/test-windows-qbot.ps1
+++ b/scripts/test-windows-qbot.ps1
@@ -487,6 +487,9 @@ try {
     if ($LASTEXITCODE -eq 0) {
         throw "qbot.cmd swallowed the PowerShell non-zero exit code"
     }
+    # 上一条 cmd.exe 故意以非零退出；清掉 LASTEXITCODE，避免 powershell -Command
+    # 把“最后一条原生命令”的退出码当成整个测试进程的退出码，误报失败。
+    $LASTEXITCODE = 0
 
     # 执行前后用户/系统环境变量与 git 全局配置必须保持不变。
     $userProxyAfter = [Environment]::GetEnvironmentVariable("QBOT_GITHUB_PROXY", "User")


### PR DESCRIPTION
## 背景

修复 Issue #422：统一 Linux / Windows 的 GitHub Release 下载体验，官方源下载不稳定时可通过用户配置的多个代理候选自动回退，且所有下载均校验内容与 SHA-256。

旧 PR #430 / #433 已关闭，本 PR 从最新 `master` 新建分支 `feat/issue-422-release-download-proxy` 实现。

## 主要修改

- `scripts/qbot.sh`：保留并完善官方源 + 代理候选链路，移除冗余测速排序，改为按序尝试：官方直连 → `QBOT_GITHUB_PROXY`（单代理）→ `QBOT_GITHUB_PROXIES`（空格分隔多代理）；压缩包与 `.sha256` 都走候选链路，仅当压缩包格式有效、归档可完整读取、包含预期包目录且最终 SHA-256 校验通过才继续；任一来源失败自动回退下一来源；全部失败返回非零并给出设置代理的提示。
- `scripts/qbot.ps1`：新增与 Linux 一致的候选生成（`Get-GitHubProxyPrefixes`）、单源下载（`Invoke-DownloadFile`）、ZIP 容器校验（`Test-ZipArchive`）、ZIP 包目录校验（`Test-ZipPackageDirectory`）、SHA-256 校验（`Test-ReleaseChecksum`）与整链回退（`Save-ReleaseChain`）；输出中文状态与错误信息，明确当前尝试的是官方源还是代理源；所有来源失败时停止安装/更新并返回非零。
- `scripts/qbot.cmd`：保持轻量入口，只转发参数给 `qbot.ps1`，补充 `qbot.ps1` 存在性检查；路径含空格可用；以 PowerShell 退出码原样返回。文件内含 UTF-8 中文注释（非纯 ASCII）。
- 代理规范化：去首尾空白、去尾部斜杠、仅接受含非空主机的 http/https 绝对地址（拒绝 `http://`、`http:///path`、`http://:8080` 等无主机名写法）、按序去重；不内置任何用户未显式配置的第三方镜像站。
- 归档深度校验：Linux 在单源成功前执行 `tar -tzf` 并确认归档包含预期包目录；Windows 在单源成功前用 .NET ZipArchive 确认包含预期顶层包目录；容器有效但内容结构损坏的来源也能自动回退下一来源。
- 新增/扩展回归测试：
  - `scripts/test-qbot-install.sh`：未配置代理只访问官方源、官方失败回退代理、首代理失败继续后续代理、空文件/损坏 gzip/错误 checksum/结构损坏（gzip 容器有效但内容非 tar 或缺少包目录）回退、全部失败返回非零且不落盘、重复代理去重、候选规范化、代理前缀无主机名写法被忽略、环境变量映射、测试前后 shell/Git 全局配置不变。
  - `scripts/test-windows-qbot.ps1`：对应 PowerShell 场景（mock `Invoke-WebRequest`）、ZIP 结构损坏回退、无主机名代理前缀被忽略、`qbot.cmd` 参数透传与退出码（含带空格路径）、测试前后 User/Machine 环境变量与 `~/.gitconfig` 不变。
  - `scripts/test-package-release.sh`：补充断言 Windows Release 包同时包含 `qbot.ps1` 与 `qbot.cmd`。
- `README.md`：快速开始补充 `QBOT_GITHUB_PROXY` / `QBOT_GITHUB_PROXIES` 用法说明。

## 已验证

- 本地 Shell 回归：`test-qbot-install.sh`、`test-package-release.sh`、`test-qbot-config.sh`、`test-botctl-guidance.sh`、`test-prepare-project-docs-kb.sh`、`scripts/tests/test-container-release-gate.sh` 通过；`find scripts -name '*.sh' -print0 | xargs -0 bash -n` 全部通过。
- PowerShell 语法与行为已由 GitHub Actions `windows-botctl` job（`test-windows-botctl.sh`、`test-windows-powershell-botctl.ps1`、`test-windows-qbot.ps1`）在本 PR 最新 commit 上全部通过（本地无 Windows/pwsh 环境，以 CI 为准）。

## 风险与说明

- Linux 端移除了原有“测速排序”逻辑，改为按用户配置顺序依次尝试；不预先只选最快代理，任何来源失败都会继续尝试下一来源。
- `qbot.cmd` 使用 `%*` 透传参数，包含 `%` 的参数仍受 cmd 展开限制（与之前一致）。
- `qbot.cmd` 内含 UTF-8 中文注释，在非 UTF-8 代码页的 cmd 窗口中可能显示为乱码，但 `rem` 注释不影响执行逻辑。
- 代理前缀必须是完整的含非空主机的 `https://域名/` 形式，脚本拼接 `https://github.com/<仓库>/releases/download/<版本>/<文件>` 后下载。

Closes #422
