### PR TITLE
fix: 增强 Web Search 参数错误诊断与 Agent 自纠

### DIFF
--- a/qq-maid-core/src/runtime/tools/search/mod.rs
+++ b/qq-maid-core/src/runtime/tools/search/mod.rs
@@ -597,7 +597,7 @@ fn log_web_search_attempt(
 
 /// 参数校验失败发生在请求构造前，单独记录字段级诊断，避免被上游请求日志的
 /// `duration_ms=0` 和通用 `invalid_arguments` 淹没。这里不记录 query/raw_question
-/// 或完整参数；查询只保留字符数，枚举和数字才允许保留短 safe_value。
+/// 或完整参数；查询只保留字符数，受限参数才允许保留短 safe_value。
 fn log_web_search_argument_error(
     tool: &WebSearchTool,
     context: &ToolContext,
@@ -614,7 +614,7 @@ fn log_web_search_argument_error(
         message = error.message.as_str(),
         value_kind = error.value_kind,
         safe_value = ?error.safe_value,
-        query_chars = error.query_chars.unwrap_or(0),
+        query_chars = ?error.query_chars,
         task_id = context.task_id.as_str(),
         tool_call_id = context.tool_call_id.as_deref().unwrap_or("direct"),
         tool_round = ?context.tool_round,

--- a/qq-maid-core/src/runtime/tools/search/mod.rs
+++ b/qq-maid-core/src/runtime/tools/search/mod.rs
@@ -13,11 +13,6 @@ use tokio::{
     time::{Instant, sleep_until},
 };
 
-#[cfg(test)]
-use qq_maid_common::identity_context::{
-    ConversationKind, ExecutionActorContext, ExecutionConversationContext,
-};
-use qq_maid_common::text::truncate_chars_with_ellipsis_trimmed;
 use qq_maid_llm::{
     tool::{
         DEFAULT_TOOL_OUTPUT_MAX_CHARS, Tool, ToolContext, ToolEffect, ToolMetadata, ToolOutput,
@@ -25,7 +20,7 @@ use qq_maid_llm::{
     },
     web_search::{
         DEFAULT_MAX_RESULTS, DynWebSearchExecutor, WebSearchBackend, WebSearchOutcome,
-        WebSearchRequest, WebSearchSource,
+        WebSearchRequest,
     },
 };
 
@@ -76,7 +71,18 @@ impl Default for WebSearchTimeouts {
 
 pub(crate) mod agent_turn;
 mod ops;
+mod output;
 pub(crate) mod status;
+mod validation;
+
+#[cfg(test)]
+use output::serialized_value_chars;
+use output::{web_search_failure_output, web_search_outcome_has_evidence, web_search_tool_output};
+use validation::{
+    WebSearchArgumentError, WebSearchToolError, normalize_dedup_text, optional_string_field,
+    parse_context_size, parse_max_results, parse_query, parse_time_range, parse_topic,
+    request_from_arguments,
+};
 
 pub(crate) type WebSearchDeltaHandler<'a> = Box<
     dyn FnMut(String) -> Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send>> + Send + 'a,
@@ -151,6 +157,18 @@ impl WebSearchTool {
         self.backend_override
             .map(WebSearchBackend::as_str)
             .unwrap_or("configured_default")
+    }
+
+    fn handle_argument_error(
+        &self,
+        context: &ToolContext,
+        error: WebSearchArgumentError,
+    ) -> Result<ToolOutput, LlmError> {
+        log_web_search_argument_error(self, context, &error);
+        if context.tool_call_id.is_some() {
+            return Ok(ToolOutput::json(error.agent_output(self.backend_label())));
+        }
+        Err(error.into_llm_error())
     }
 
     pub async fn query(&self, req: WebSearchToolRequest) -> Result<WebSearchOutcome, LlmError> {
@@ -393,7 +411,17 @@ impl Tool for WebSearchTool {
     }
 
     fn deduplication_key(&self, arguments: &Value) -> Option<String> {
-        if let Ok(Some(targets)) = ops::parse_research_targets(arguments.get("research_targets")) {
+        if arguments
+            .get("research_targets")
+            .is_some_and(|value| !value.is_null())
+        {
+            let Some(targets) =
+                ops::parse_research_targets(arguments.get("research_targets")).ok()?
+            else {
+                // 研究参数校验失败时不能退回单实体 query 的去重键，否则同一无效
+                // Tool Call 会被当作终态失败缓存，模型就没有机会修正参数。
+                return None;
+            };
             return serde_json::to_string(&json!({
                 "research_targets": targets.iter().map(|target| json!({
                     "entity": normalize_dedup_text(&target.entity),
@@ -440,8 +468,19 @@ impl Tool for WebSearchTool {
         context: ToolContext,
         arguments: Value,
     ) -> Result<ToolOutput, LlmError> {
-        if let Some(targets) = ops::parse_research_targets(arguments.get("research_targets"))? {
-            let output = ops::execute_research(self, &context, &arguments, targets).await?;
+        let research_targets = match ops::parse_research_targets(arguments.get("research_targets"))
+        {
+            Ok(targets) => targets,
+            Err(error) => return self.handle_argument_error(&context, error),
+        };
+        if let Some(targets) = research_targets {
+            let output = match ops::execute_research(self, &context, &arguments, targets).await {
+                Ok(output) => output,
+                Err(WebSearchToolError::Argument(error)) => {
+                    return self.handle_argument_error(&context, error);
+                }
+                Err(WebSearchToolError::Execution(error)) => return Err(error),
+            };
             log_web_search_execution(&context, &arguments, &output.value, true);
             return Ok(output);
         }
@@ -452,10 +491,7 @@ impl Tool for WebSearchTool {
             self.model_override.clone(),
         ) {
             Ok(request) => request,
-            Err(err) => {
-                log_web_search_attempt(self, &context, 1, Duration::ZERO, &Err(err.clone()));
-                return Err(err);
-            }
+            Err(error) => return self.handle_argument_error(&context, error),
         };
         // Issue #361 诊断：联网查询前后只记录尺寸/计数与内存，不记录查询正文。
         // 进程内存采样放进 DEBUG 门控，默认级别不触碰 /proc 读取。
@@ -497,41 +533,6 @@ impl Tool for WebSearchTool {
     }
 }
 
-fn normalize_dedup_text(value: &str) -> String {
-    value
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
-        .to_lowercase()
-}
-
-fn request_from_arguments(
-    context: &ToolContext,
-    arguments: &Value,
-    server_backend_override: Option<WebSearchBackend>,
-    server_model_override: Option<String>,
-) -> Result<WebSearchToolRequest, LlmError> {
-    // 搜索模型路由只允许 `/查` 等服务端直接执行入口注入；模型 Tool Loop 调用
-    // 会带稳定 tool_call_id，此时忽略任何伪造的 model_override 参数。
-    let model_override = server_model_override.or_else(|| {
-        context
-            .tool_call_id
-            .is_none()
-            .then(|| optional_string_field(arguments, "model_override"))
-            .flatten()
-    });
-    Ok(WebSearchToolRequest {
-        query: parse_query(arguments)?,
-        raw_question: optional_string_field(arguments, "raw_question"),
-        max_results: parse_max_results(arguments.get("max_results"))?,
-        context_size: parse_context_size(arguments.get("context_size"))?,
-        topic: parse_topic(arguments.get("topic"))?,
-        time_range: parse_time_range(arguments.get("time_range"))?,
-        backend_override: server_backend_override,
-        model_override,
-    })
-}
-
 fn web_search_timeout_error(phase: &str, message: &str) -> LlmError {
     LlmError::new("timeout", message, format!("web_search_{phase}"))
 }
@@ -547,327 +548,6 @@ fn web_search_request(req: WebSearchToolRequest) -> WebSearchRequest {
         backend_override: req.backend_override,
         model_override: req.model_override,
     }
-}
-
-fn parse_query(arguments: &Value) -> Result<String, LlmError> {
-    let query = arguments
-        .get("query")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| {
-            LlmError::new(
-                "bad_tool_arguments",
-                "web_search requires non-empty query",
-                "tool",
-            )
-        })?;
-    if query.chars().count() > WEB_SEARCH_QUERY_MAX_LENGTH {
-        return Err(LlmError::new(
-            "bad_tool_arguments",
-            "query is too long",
-            "tool",
-        ));
-    }
-    Ok(query.to_owned())
-}
-
-fn parse_max_results(value: Option<&Value>) -> Result<Option<u8>, LlmError> {
-    match value {
-        None | Some(Value::Null) => Ok(None),
-        Some(Value::Number(number)) if !number.is_f64() => match number.as_u64() {
-            Some(value) if (1..=WEB_SEARCH_MAX_RESULTS_LIMIT as u64).contains(&value) => {
-                Ok(Some(value as u8))
-            }
-            _ => reject_invalid_max_results(),
-        },
-        _ => reject_invalid_max_results(),
-    }
-}
-
-fn reject_invalid_max_results() -> Result<Option<u8>, LlmError> {
-    tracing::warn!(
-        tool = WEB_SEARCH_TOOL_NAME,
-        error_code = "bad_tool_arguments",
-        argument = "max_results",
-        "invalid web search max_results argument rejected",
-    );
-    Err(LlmError::new(
-        "bad_tool_arguments",
-        "max_results must be an integer between 1 and 10 or null",
-        "tool",
-    ))
-}
-
-fn parse_context_size(value: Option<&Value>) -> Result<Option<String>, LlmError> {
-    match value {
-        None | Some(Value::Null) => Ok(None),
-        Some(Value::String(text)) => {
-            let text = text.trim();
-            if matches!(text, "low" | "medium" | "high") {
-                Ok(Some(text.to_owned()))
-            } else {
-                reject_invalid_context_size()
-            }
-        }
-        _ => reject_invalid_context_size(),
-    }
-}
-
-fn reject_invalid_context_size() -> Result<Option<String>, LlmError> {
-    tracing::warn!(
-        tool = WEB_SEARCH_TOOL_NAME,
-        error_code = "bad_tool_arguments",
-        argument = "context_size",
-        "invalid web search context_size argument rejected",
-    );
-    Err(LlmError::new(
-        "bad_tool_arguments",
-        "context_size must be low, medium, high, or null",
-        "tool",
-    ))
-}
-
-fn parse_topic(value: Option<&Value>) -> Result<Option<String>, LlmError> {
-    parse_optional_enum(value, "topic", &["general", "news", "finance"])
-}
-
-fn parse_time_range(value: Option<&Value>) -> Result<Option<String>, LlmError> {
-    parse_optional_enum(value, "time_range", &["day", "week", "month", "year"])
-}
-
-fn parse_optional_enum(
-    value: Option<&Value>,
-    name: &str,
-    allowed: &[&str],
-) -> Result<Option<String>, LlmError> {
-    match value {
-        None | Some(Value::Null) => Ok(None),
-        Some(Value::String(text)) => {
-            let text = text.trim().to_ascii_lowercase();
-            if allowed.contains(&text.as_str()) {
-                Ok(Some(text))
-            } else {
-                Err(LlmError::new(
-                    "bad_tool_arguments",
-                    format!("{name} must be one of {} or null", allowed.join(", ")),
-                    "tool",
-                ))
-            }
-        }
-        _ => Err(LlmError::new(
-            "bad_tool_arguments",
-            format!("{name} must be a string or null"),
-            "tool",
-        )),
-    }
-}
-
-fn optional_string_field(arguments: &Value, key: &str) -> Option<String> {
-    match arguments.get(key) {
-        Some(Value::String(value)) => {
-            let value = value.trim();
-            (!value.is_empty()).then(|| value.to_owned())
-        }
-        _ => None,
-    }
-}
-
-fn web_search_tool_output(
-    outcome: &WebSearchOutcome,
-    backend: &str,
-    output_max_chars: usize,
-) -> Value {
-    let result_count = outcome
-        .sources
-        .iter()
-        .filter(|source| web_search_source_has_evidence(source))
-        .count();
-    if !web_search_outcome_has_evidence(outcome) {
-        return json!({
-            "ok": false,
-            "execution_succeeded": true,
-            "backend": backend,
-            "provider": outcome.provider,
-            "answer": "",
-            "sources": [],
-            "result_count": 0,
-            "elapsed_ms": outcome.elapsed_ms,
-            "error": {
-                "code": "empty_result",
-                "stage": "web_search",
-                "message": WEB_SEARCH_EMPTY_RESULT_MODEL_MESSAGE,
-            },
-        });
-    }
-
-    let output = json!({
-        "ok": true,
-        "execution_succeeded": true,
-        "backend": backend,
-        "provider": outcome.provider,
-        "answer": outcome.answer,
-        "sources": outcome.sources.iter().map(web_search_source_json).collect::<Vec<_>>(),
-        "result_count": result_count,
-        "elapsed_ms": outcome.elapsed_ms,
-    });
-    if serialized_value_chars(&output) <= output_max_chars {
-        return output;
-    }
-
-    compact_web_search_tool_output(outcome, backend, result_count, output_max_chars)
-}
-
-/// Tool Registry 对超限输出只能保留通用 preview，搜索投影将因此失去结构化证据。
-/// 搜索领域先压缩重复的来源摘要，并在剩余预算内尽量保留 answer，确保事实卡仍可验真。
-fn compact_web_search_tool_output(
-    outcome: &WebSearchOutcome,
-    backend: &str,
-    result_count: usize,
-    output_max_chars: usize,
-) -> Value {
-    let source_candidates = outcome
-        .sources
-        .iter()
-        .filter(|source| web_search_source_has_evidence(source))
-        .take(WEB_SEARCH_TOOL_SOURCE_LIMIT)
-        .collect::<Vec<_>>();
-    let sources = compact_web_search_sources(
-        outcome,
-        backend,
-        result_count,
-        output_max_chars,
-        &source_candidates,
-    );
-
-    let answer_chars = outcome.answer.trim().chars().collect::<Vec<_>>();
-    let mut low = 0usize;
-    let mut high = answer_chars.len();
-    while low < high {
-        let mid = low + (high - low).div_ceil(2);
-        let answer = answer_chars[..mid].iter().collect::<String>();
-        let candidate =
-            successful_web_search_output(outcome, backend, result_count, &answer, &sources);
-        if serialized_value_chars(&candidate) <= output_max_chars {
-            low = mid;
-        } else {
-            high = mid - 1;
-        }
-    }
-    let answer = answer_chars[..low].iter().collect::<String>();
-    successful_web_search_output(outcome, backend, result_count, &answer, &sources)
-}
-
-fn successful_web_search_output(
-    outcome: &WebSearchOutcome,
-    backend: &str,
-    result_count: usize,
-    answer: &str,
-    sources: &[Value],
-) -> Value {
-    json!({
-        "ok": true,
-        "execution_succeeded": true,
-        "backend": backend,
-        "provider": outcome.provider,
-        "answer": answer,
-        "sources": sources,
-        "result_count": result_count,
-        "elapsed_ms": outcome.elapsed_ms,
-    })
-}
-
-fn compact_web_search_sources(
-    outcome: &WebSearchOutcome,
-    backend: &str,
-    result_count: usize,
-    output_max_chars: usize,
-    candidates: &[&WebSearchSource],
-) -> Vec<Value> {
-    let fits = |sources: &[Value]| {
-        serialized_value_chars(&successful_web_search_output(
-            outcome,
-            backend,
-            result_count,
-            "",
-            sources,
-        )) <= output_max_chars
-    };
-    let with_snippets =
-        compact_web_search_source_jsons(candidates, WEB_SEARCH_TOOL_SOURCE_SNIPPET_MAX_CHARS);
-    if fits(&with_snippets) {
-        return with_snippets;
-    }
-
-    // URL 必须保持完整；预算不足时先压缩摘要，仍放不下才减少来源。
-    let without_snippets = compact_web_search_source_jsons(candidates, 0);
-    if fits(&without_snippets) {
-        return without_snippets;
-    }
-
-    let mut retained = Vec::new();
-    for source in candidates {
-        let mut candidate = retained.clone();
-        candidate.push(*source);
-        if fits(&compact_web_search_source_jsons(&candidate, 0)) {
-            retained = candidate;
-        }
-    }
-    compact_web_search_source_jsons(&retained, 0)
-}
-
-fn compact_web_search_source_jsons(
-    sources: &[&WebSearchSource],
-    snippet_max_chars: usize,
-) -> Vec<Value> {
-    sources
-        .iter()
-        .map(|source| compact_web_search_source_json(source, snippet_max_chars))
-        .collect()
-}
-
-fn compact_web_search_source_json(source: &WebSearchSource, snippet_max_chars: usize) -> Value {
-    let snippet = if snippet_max_chars == 0 {
-        String::new()
-    } else {
-        truncate_chars_with_ellipsis_trimmed(&source.snippet, snippet_max_chars)
-    };
-    json!({
-        "title": truncate_chars_with_ellipsis_trimmed(
-            &source.title,
-            WEB_SEARCH_TOOL_SOURCE_TITLE_MAX_CHARS,
-        ),
-        "url": source.url,
-        "snippet": snippet,
-    })
-}
-
-fn serialized_value_chars(value: &Value) -> usize {
-    serde_json::to_string(value)
-        .map(|serialized| serialized.chars().count())
-        .unwrap_or(usize::MAX)
-}
-
-fn web_search_failure_output(backend: &str, attempts: usize, error: &LlmError) -> Value {
-    json!({
-        "ok": false,
-        "execution_succeeded": false,
-        "backend": backend,
-        "provider": error.upstream_provider().unwrap_or("unknown"),
-        "model": error.upstream_model().unwrap_or("configured_default"),
-        "answer": "",
-        "sources": [],
-        "result_count": 0,
-        "attempts": attempts,
-        "error": {
-            "code": error.code,
-            "message": error.message,
-            "stage": error.stage,
-            "kind": error.error_kind(),
-            "retriable": error.retriable(),
-            "upstream_status": error.upstream_status,
-        },
-    })
 }
 
 fn log_web_search_attempt(
@@ -913,6 +593,33 @@ fn log_web_search_attempt(
             "web search attempt failed"
         ),
     }
+}
+
+/// 参数校验失败发生在请求构造前，单独记录字段级诊断，避免被上游请求日志的
+/// `duration_ms=0` 和通用 `invalid_arguments` 淹没。这里不记录 query/raw_question
+/// 或完整参数；查询只保留字符数，枚举和数字才允许保留短 safe_value。
+fn log_web_search_argument_error(
+    tool: &WebSearchTool,
+    context: &ToolContext,
+    error: &WebSearchArgumentError,
+) {
+    tracing::warn!(
+        tool = WEB_SEARCH_TOOL_NAME,
+        backend = tool.backend_label(),
+        error_code = "invalid_arguments",
+        failure_layer = "tool",
+        duration_ms = 0_u64,
+        argument = error.field.as_str(),
+        reason = error.reason,
+        message = error.message.as_str(),
+        value_kind = error.value_kind,
+        safe_value = ?error.safe_value,
+        query_chars = error.query_chars.unwrap_or(0),
+        task_id = context.task_id.as_str(),
+        tool_call_id = context.tool_call_id.as_deref().unwrap_or("direct"),
+        tool_round = ?context.tool_round,
+        "web search argument validation failed"
+    );
 }
 
 /// 搜索诊断只保留可定位重试的结构化字段；不记录 query、raw_question、聊天历史或上游正文。
@@ -997,24 +704,6 @@ fn log_web_search_execution(
         retry_of = ?context.retry_of,
         "web search tool execution completed"
     );
-}
-
-pub(super) fn web_search_outcome_has_evidence(outcome: &WebSearchOutcome) -> bool {
-    !outcome.answer.trim().is_empty() || outcome.sources.iter().any(web_search_source_has_evidence)
-}
-
-fn web_search_source_has_evidence(source: &WebSearchSource) -> bool {
-    !source.title.trim().is_empty()
-        || !source.url.trim().is_empty()
-        || !source.snippet.trim().is_empty()
-}
-
-fn web_search_source_json(source: &WebSearchSource) -> Value {
-    json!({
-        "title": source.title,
-        "url": source.url,
-        "snippet": source.snippet,
-    })
 }
 
 #[cfg(test)]

--- a/qq-maid-core/src/runtime/tools/search/ops.rs
+++ b/qq-maid-core/src/runtime/tools/search/ops.rs
@@ -17,8 +17,9 @@ use crate::error::LlmError;
 
 use super::{
     WEB_SEARCH_EMPTY_RESULT_MODEL_MESSAGE, WEB_SEARCH_QUERY_MAX_LENGTH, WEB_SEARCH_TOOL_NAME,
-    WebSearchTool, WebSearchToolRequest, optional_string_field, parse_context_size,
-    parse_max_results, parse_time_range, parse_topic, web_search_outcome_has_evidence,
+    WebSearchArgumentError, WebSearchTool, WebSearchToolError, WebSearchToolRequest,
+    optional_string_field, parse_context_size, parse_max_results, parse_time_range, parse_topic,
+    web_search_outcome_has_evidence,
 };
 
 pub(super) const WEB_SEARCH_RESEARCH_MAX_TARGETS: usize = 5;
@@ -40,7 +41,7 @@ pub(super) async fn execute_research(
     context: &ToolContext,
     arguments: &Value,
     targets: Vec<ResearchTarget>,
-) -> Result<ToolOutput, LlmError> {
+) -> Result<ToolOutput, WebSearchToolError> {
     let dimensions = parse_comparison_dimensions(arguments.get("comparison_dimensions"))?;
     let raw_question = optional_string_field(arguments, "raw_question");
     let max_results = parse_max_results(arguments.get("max_results"))?;
@@ -146,7 +147,7 @@ pub(super) async fn execute_research(
 
 pub(super) fn parse_research_targets(
     value: Option<&Value>,
-) -> Result<Option<Vec<ResearchTarget>>, LlmError> {
+) -> Result<Option<Vec<ResearchTarget>>, WebSearchArgumentError> {
     let Some(value) = value else {
         return Ok(None);
     };
@@ -154,19 +155,25 @@ pub(super) fn parse_research_targets(
         return Ok(None);
     }
     let items = value.as_array().ok_or_else(|| {
-        LlmError::new(
-            "bad_tool_arguments",
+        WebSearchArgumentError::new(
+            "research_targets",
+            "invalid_type",
             "research_targets must be an array or null",
-            "tool",
+            Some(value),
+            None,
+            None,
         )
     })?;
     if !(2..=WEB_SEARCH_RESEARCH_MAX_TARGETS).contains(&items.len()) {
-        return Err(LlmError::new(
-            "bad_tool_arguments",
+        return Err(WebSearchArgumentError::new(
+            "research_targets",
+            "out_of_range",
             format!(
                 "research_targets must contain between 2 and {WEB_SEARCH_RESEARCH_MAX_TARGETS} items"
             ),
-            "tool",
+            Some(value),
+            None,
+            None,
         ));
     }
     items
@@ -185,7 +192,9 @@ pub(super) fn parse_research_targets(
         .map(Some)
 }
 
-pub(super) fn parse_comparison_dimensions(value: Option<&Value>) -> Result<Vec<String>, LlmError> {
+pub(super) fn parse_comparison_dimensions(
+    value: Option<&Value>,
+) -> Result<Vec<String>, WebSearchArgumentError> {
     let Some(value) = value else {
         return Ok(Vec::new());
     };
@@ -193,17 +202,23 @@ pub(super) fn parse_comparison_dimensions(value: Option<&Value>) -> Result<Vec<S
         return Ok(Vec::new());
     }
     let items = value.as_array().ok_or_else(|| {
-        LlmError::new(
-            "bad_tool_arguments",
+        WebSearchArgumentError::new(
+            "comparison_dimensions",
+            "invalid_type",
             "comparison_dimensions must be an array or null",
-            "tool",
+            Some(value),
+            None,
+            None,
         )
     })?;
     if items.len() > 8 {
-        return Err(LlmError::new(
-            "bad_tool_arguments",
+        return Err(WebSearchArgumentError::new(
+            "comparison_dimensions",
+            "out_of_range",
             "comparison_dimensions must not contain more than 8 items",
-            "tool",
+            Some(value),
+            None,
+            None,
         ));
     }
     items
@@ -212,34 +227,80 @@ pub(super) fn parse_comparison_dimensions(value: Option<&Value>) -> Result<Vec<S
             let text = item.as_str().map(str::trim).filter(|text| !text.is_empty());
             match text {
                 Some(text) if text.chars().count() <= 80 => Ok(text.to_owned()),
-                _ => Err(LlmError::new(
-                    "bad_tool_arguments",
+                Some(_text) => Err(WebSearchArgumentError::new(
+                    "comparison_dimensions",
+                    "too_long",
                     "comparison dimension must be a non-empty string up to 80 characters",
-                    "tool",
+                    Some(item),
+                    None,
+                    None,
+                )),
+                None => Err(WebSearchArgumentError::new(
+                    "comparison_dimensions",
+                    if item.is_null() || item.as_str().is_some() {
+                        "missing_or_empty"
+                    } else {
+                        "invalid_type"
+                    },
+                    "comparison dimension must be a non-empty string up to 80 characters",
+                    Some(item),
+                    None,
+                    None,
                 )),
             }
         })
         .collect()
 }
 
-fn required_bounded_string(value: &Value, key: &str, max_chars: usize) -> Result<String, LlmError> {
-    let text = value
-        .get(key)
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|text| !text.is_empty())
-        .ok_or_else(|| {
-            LlmError::new(
-                "bad_tool_arguments",
-                format!("research target requires non-empty {key}"),
-                "tool",
-            )
-        })?;
+fn required_bounded_string(
+    value: &Value,
+    key: &str,
+    max_chars: usize,
+) -> Result<String, WebSearchArgumentError> {
+    let field = format!("research_targets.{key}");
+    let Some(raw_value) = value.get(key) else {
+        return Err(WebSearchArgumentError::new(
+            field,
+            "missing_or_empty",
+            format!("research target requires non-empty {key}"),
+            None,
+            None,
+            (key == "query").then_some(0),
+        ));
+    };
+    let Some(text) = raw_value.as_str() else {
+        return Err(WebSearchArgumentError::new(
+            field,
+            if raw_value.is_null() {
+                "missing_or_empty"
+            } else {
+                "invalid_type"
+            },
+            format!("research target requires non-empty {key}"),
+            Some(raw_value),
+            None,
+            None,
+        ));
+    };
+    let text = text.trim();
+    if text.is_empty() {
+        return Err(WebSearchArgumentError::new(
+            field,
+            "missing_or_empty",
+            format!("research target requires non-empty {key}"),
+            Some(raw_value),
+            None,
+            (key == "query").then_some(0),
+        ));
+    }
     if text.chars().count() > max_chars {
-        return Err(LlmError::new(
-            "bad_tool_arguments",
+        return Err(WebSearchArgumentError::new(
+            field,
+            "too_long",
             format!("research target {key} is too long"),
-            "tool",
+            Some(raw_value),
+            None,
+            (key == "query").then_some(text.chars().count()),
         ));
     }
     Ok(text.to_owned())
@@ -249,7 +310,7 @@ fn optional_bounded_string(
     value: &Value,
     key: &str,
     max_chars: usize,
-) -> Result<Option<String>, LlmError> {
+) -> Result<Option<String>, WebSearchArgumentError> {
     let Some(value) = value.get(key) else {
         return Ok(None);
     };
@@ -257,20 +318,26 @@ fn optional_bounded_string(
         return Ok(None);
     }
     let text = value.as_str().map(str::trim).ok_or_else(|| {
-        LlmError::new(
-            "bad_tool_arguments",
+        WebSearchArgumentError::new(
+            format!("research_targets.{key}"),
+            "invalid_type",
             format!("research target {key} must be a string or null"),
-            "tool",
+            Some(value),
+            None,
+            None,
         )
     })?;
     if text.is_empty() {
         return Ok(None);
     }
     if text.chars().count() > max_chars {
-        return Err(LlmError::new(
-            "bad_tool_arguments",
+        return Err(WebSearchArgumentError::new(
+            format!("research_targets.{key}"),
+            "too_long",
             format!("research target {key} is too long"),
-            "tool",
+            Some(value),
+            None,
+            None,
         ));
     }
     Ok(Some(text.to_owned()))

--- a/qq-maid-core/src/runtime/tools/search/output.rs
+++ b/qq-maid-core/src/runtime/tools/search/output.rs
@@ -1,0 +1,227 @@
+//! Web Search Tool 的结构化结果投影与尺寸压缩。
+
+use qq_maid_common::text::truncate_chars_with_ellipsis_trimmed;
+use qq_maid_llm::web_search::{WebSearchOutcome, WebSearchSource};
+use serde_json::{Value, json};
+
+use crate::error::LlmError;
+
+use super::{
+    WEB_SEARCH_EMPTY_RESULT_MODEL_MESSAGE, WEB_SEARCH_TOOL_SOURCE_LIMIT,
+    WEB_SEARCH_TOOL_SOURCE_SNIPPET_MAX_CHARS, WEB_SEARCH_TOOL_SOURCE_TITLE_MAX_CHARS,
+};
+
+pub(super) fn web_search_tool_output(
+    outcome: &WebSearchOutcome,
+    backend: &str,
+    output_max_chars: usize,
+) -> Value {
+    let result_count = outcome
+        .sources
+        .iter()
+        .filter(|source| web_search_source_has_evidence(source))
+        .count();
+    if !web_search_outcome_has_evidence(outcome) {
+        return json!({
+            "ok": false,
+            "execution_succeeded": true,
+            "backend": backend,
+            "provider": outcome.provider,
+            "answer": "",
+            "sources": [],
+            "result_count": 0,
+            "elapsed_ms": outcome.elapsed_ms,
+            "error": {
+                "code": "empty_result",
+                "stage": "web_search",
+                "message": WEB_SEARCH_EMPTY_RESULT_MODEL_MESSAGE,
+            },
+        });
+    }
+
+    let output = json!({
+        "ok": true,
+        "execution_succeeded": true,
+        "backend": backend,
+        "provider": outcome.provider,
+        "answer": outcome.answer,
+        "sources": outcome.sources.iter().map(web_search_source_json).collect::<Vec<_>>(),
+        "result_count": result_count,
+        "elapsed_ms": outcome.elapsed_ms,
+    });
+    if serialized_value_chars(&output) <= output_max_chars {
+        return output;
+    }
+
+    compact_web_search_tool_output(outcome, backend, result_count, output_max_chars)
+}
+
+/// Tool Registry 对超限输出只能保留通用 preview，搜索投影将因此失去结构化证据。
+/// 搜索领域先压缩重复的来源摘要，并在剩余预算内尽量保留 answer，确保事实卡仍可验真。
+fn compact_web_search_tool_output(
+    outcome: &WebSearchOutcome,
+    backend: &str,
+    result_count: usize,
+    output_max_chars: usize,
+) -> Value {
+    let source_candidates = outcome
+        .sources
+        .iter()
+        .filter(|source| web_search_source_has_evidence(source))
+        .take(WEB_SEARCH_TOOL_SOURCE_LIMIT)
+        .collect::<Vec<_>>();
+    let sources = compact_web_search_sources(
+        outcome,
+        backend,
+        result_count,
+        output_max_chars,
+        &source_candidates,
+    );
+
+    let answer_chars = outcome.answer.trim().chars().collect::<Vec<_>>();
+    let mut low = 0usize;
+    let mut high = answer_chars.len();
+    while low < high {
+        let mid = low + (high - low).div_ceil(2);
+        let answer = answer_chars[..mid].iter().collect::<String>();
+        let candidate =
+            successful_web_search_output(outcome, backend, result_count, &answer, &sources);
+        if serialized_value_chars(&candidate) <= output_max_chars {
+            low = mid;
+        } else {
+            high = mid - 1;
+        }
+    }
+    let answer = answer_chars[..low].iter().collect::<String>();
+    successful_web_search_output(outcome, backend, result_count, &answer, &sources)
+}
+
+fn successful_web_search_output(
+    outcome: &WebSearchOutcome,
+    backend: &str,
+    result_count: usize,
+    answer: &str,
+    sources: &[Value],
+) -> Value {
+    json!({
+        "ok": true,
+        "execution_succeeded": true,
+        "backend": backend,
+        "provider": outcome.provider,
+        "answer": answer,
+        "sources": sources,
+        "result_count": result_count,
+        "elapsed_ms": outcome.elapsed_ms,
+    })
+}
+
+fn compact_web_search_sources(
+    outcome: &WebSearchOutcome,
+    backend: &str,
+    result_count: usize,
+    output_max_chars: usize,
+    candidates: &[&WebSearchSource],
+) -> Vec<Value> {
+    let fits = |sources: &[Value]| {
+        serialized_value_chars(&successful_web_search_output(
+            outcome,
+            backend,
+            result_count,
+            "",
+            sources,
+        )) <= output_max_chars
+    };
+    let with_snippets =
+        compact_web_search_source_jsons(candidates, WEB_SEARCH_TOOL_SOURCE_SNIPPET_MAX_CHARS);
+    if fits(&with_snippets) {
+        return with_snippets;
+    }
+
+    // URL 必须保持完整；预算不足时先压缩摘要，仍放不下才减少来源。
+    let without_snippets = compact_web_search_source_jsons(candidates, 0);
+    if fits(&without_snippets) {
+        return without_snippets;
+    }
+
+    let mut retained = Vec::new();
+    for source in candidates {
+        let mut candidate = retained.clone();
+        candidate.push(*source);
+        if fits(&compact_web_search_source_jsons(&candidate, 0)) {
+            retained = candidate;
+        }
+    }
+    compact_web_search_source_jsons(&retained, 0)
+}
+
+fn compact_web_search_source_jsons(
+    sources: &[&WebSearchSource],
+    snippet_max_chars: usize,
+) -> Vec<Value> {
+    sources
+        .iter()
+        .map(|source| compact_web_search_source_json(source, snippet_max_chars))
+        .collect()
+}
+
+fn compact_web_search_source_json(source: &WebSearchSource, snippet_max_chars: usize) -> Value {
+    let snippet = if snippet_max_chars == 0 {
+        String::new()
+    } else {
+        truncate_chars_with_ellipsis_trimmed(&source.snippet, snippet_max_chars)
+    };
+    json!({
+        "title": truncate_chars_with_ellipsis_trimmed(
+            &source.title,
+            WEB_SEARCH_TOOL_SOURCE_TITLE_MAX_CHARS,
+        ),
+        "url": source.url,
+        "snippet": snippet,
+    })
+}
+
+pub(super) fn serialized_value_chars(value: &Value) -> usize {
+    serde_json::to_string(value)
+        .map(|serialized| serialized.chars().count())
+        .unwrap_or(usize::MAX)
+}
+
+pub(super) fn web_search_failure_output(backend: &str, attempts: usize, error: &LlmError) -> Value {
+    json!({
+        "ok": false,
+        "execution_succeeded": false,
+        "backend": backend,
+        "provider": error.upstream_provider().unwrap_or("unknown"),
+        "model": error.upstream_model().unwrap_or("configured_default"),
+        "answer": "",
+        "sources": [],
+        "result_count": 0,
+        "attempts": attempts,
+        "error": {
+            "code": error.code,
+            "message": error.message,
+            "stage": error.stage,
+            "kind": error.error_kind(),
+            "retriable": error.retriable(),
+            "upstream_status": error.upstream_status,
+        },
+    })
+}
+
+pub(super) fn web_search_outcome_has_evidence(outcome: &WebSearchOutcome) -> bool {
+    !outcome.answer.trim().is_empty() || outcome.sources.iter().any(web_search_source_has_evidence)
+}
+
+fn web_search_source_has_evidence(source: &WebSearchSource) -> bool {
+    !source.title.trim().is_empty()
+        || !source.url.trim().is_empty()
+        || !source.snippet.trim().is_empty()
+}
+
+fn web_search_source_json(source: &WebSearchSource) -> Value {
+    json!({
+        "title": source.title,
+        "url": source.url,
+        "snippet": source.snippet,
+    })
+}

--- a/qq-maid-core/src/runtime/tools/search/tests.rs
+++ b/qq-maid-core/src/runtime/tools/search/tests.rs
@@ -794,5 +794,6 @@ async fn web_search_tool_rejects_invalid_options() {
     }
 }
 
+mod agent_loop;
 mod argument_validation;
 mod research;

--- a/qq-maid-core/src/runtime/tools/search/tests.rs
+++ b/qq-maid-core/src/runtime/tools/search/tests.rs
@@ -1,6 +1,4 @@
 use std::{
-    collections::VecDeque,
-    io,
     sync::{
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
@@ -8,195 +6,24 @@ use std::{
     time::Duration,
 };
 
-use async_trait::async_trait;
-
 use qq_maid_llm::{
     tool::{DEFAULT_TOOL_OUTPUT_MAX_CHARS, DEFAULT_TOOL_TIMEOUT, ToolRegistry},
-    web_search::WebSearchExecutor,
+    web_search::{WebSearchExecutor, WebSearchSource},
 };
+use tokio::sync::mpsc;
 
 use super::*;
 
-#[derive(Clone, Default)]
-struct MockWebSearchExecutor {
-    requests: Arc<Mutex<Vec<WebSearchRequest>>>,
-    stream_calls: Arc<AtomicUsize>,
-}
-
-#[async_trait]
-impl WebSearchExecutor for MockWebSearchExecutor {
-    async fn query(&self, req: WebSearchRequest) -> Result<WebSearchOutcome, LlmError> {
-        self.requests.lock().unwrap().push(req.clone());
-        Ok(WebSearchOutcome {
-            answer: format!("answer: {}", req.query),
-            sources: vec![WebSearchSource {
-                title: "source title".to_owned(),
-                url: "https://example.com".to_owned(),
-                snippet: "source snippet".to_owned(),
-            }],
-            provider: "mock-query".to_owned(),
-            elapsed_ms: 12,
-        })
-    }
-
-    async fn query_stream(
-        &self,
-        req: WebSearchRequest,
-        delta_tx: mpsc::Sender<String>,
-    ) -> Result<WebSearchOutcome, LlmError> {
-        self.stream_calls.fetch_add(1, Ordering::SeqCst);
-        let outcome = self.query(req).await?;
-        let _ = delta_tx.send(outcome.answer.clone()).await;
-        Ok(outcome)
-    }
-
-    fn provider_name(&self) -> &'static str {
-        "mock-query"
-    }
-}
-
-struct EmptyWebSearchExecutor;
-
-#[async_trait]
-impl WebSearchExecutor for EmptyWebSearchExecutor {
-    async fn query(&self, _req: WebSearchRequest) -> Result<WebSearchOutcome, LlmError> {
-        Ok(WebSearchOutcome {
-            answer: String::new(),
-            sources: Vec::new(),
-            provider: "tavily".to_owned(),
-            elapsed_ms: 12,
-        })
-    }
-
-    fn provider_name(&self) -> &'static str {
-        "tavily"
-    }
-}
-
-struct FailingWebSearchExecutor;
-
-#[async_trait]
-impl WebSearchExecutor for FailingWebSearchExecutor {
-    async fn query(&self, _req: WebSearchRequest) -> Result<WebSearchOutcome, LlmError> {
-        Err(LlmError::new(
-            "tavily_auth_error",
-            "Tavily rejected the configured API key",
-            "tavily_http",
-        ))
-    }
-
-    fn provider_name(&self) -> &'static str {
-        "tavily"
-    }
-}
-
-struct LargeWebSearchExecutor;
-
-#[derive(Clone)]
-struct ScriptedWebSearchExecutor {
-    outcomes: Arc<Mutex<VecDeque<Result<WebSearchOutcome, LlmError>>>>,
-    calls: Arc<AtomicUsize>,
-}
-
-impl ScriptedWebSearchExecutor {
-    fn failures(errors: Vec<LlmError>) -> Self {
-        Self {
-            outcomes: Arc::new(Mutex::new(errors.into_iter().map(Err).collect())),
-            calls: Arc::new(AtomicUsize::new(0)),
-        }
-    }
-}
-
-#[async_trait]
-impl WebSearchExecutor for ScriptedWebSearchExecutor {
-    async fn query(&self, _req: WebSearchRequest) -> Result<WebSearchOutcome, LlmError> {
-        self.calls.fetch_add(1, Ordering::SeqCst);
-        self.outcomes
-            .lock()
-            .unwrap()
-            .pop_front()
-            .expect("scripted web search outcome")
-    }
-
-    fn provider_name(&self) -> &'static str {
-        "openai_responses"
-    }
-}
-
-#[derive(Clone)]
-struct LogWriter(Arc<Mutex<Vec<u8>>>);
-
-struct LogGuard(Arc<Mutex<Vec<u8>>>);
-
-impl io::Write for LogGuard {
-    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
-        self.0.lock().unwrap().extend_from_slice(bytes);
-        Ok(bytes.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
-impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for LogWriter {
-    type Writer = LogGuard;
-
-    fn make_writer(&'a self) -> Self::Writer {
-        LogGuard(self.0.clone())
-    }
-}
-
-#[async_trait]
-impl WebSearchExecutor for LargeWebSearchExecutor {
-    async fn query(&self, _req: WebSearchRequest) -> Result<WebSearchOutcome, LlmError> {
-        Ok(WebSearchOutcome {
-            answer: "昨日 AI 新闻重点。".repeat(220),
-            sources: (0..8)
-                .map(|index| WebSearchSource {
-                    title: format!("来源 {index} {}", "标题".repeat(80)),
-                    url: format!("https://example.com/news/{index}?query={}", "a".repeat(260)),
-                    snippet: "公开报道摘要。".repeat(180),
-                })
-                .collect(),
-            provider: "tavily".to_owned(),
-            elapsed_ms: 12,
-        })
-    }
-
-    fn provider_name(&self) -> &'static str {
-        "tavily"
-    }
-}
-
-fn test_context() -> ToolContext {
-    ToolContext {
-        task_id: "task-1".to_owned(),
-        actor: ExecutionActorContext {
-            user_id: Some("u1".to_owned()),
-            group_member_role: None,
-        },
-        conversation: ExecutionConversationContext {
-            platform: "test".to_owned(),
-            account_id: None,
-            kind: ConversationKind::Private,
-            target_id: Some("u1".to_owned()),
-            scope_id: "private:u1".to_owned(),
-            interaction_scope_id: "private:u1".to_owned(),
-        },
-        tool_call_id: None,
-        tool_round: None,
-        retry_of: None,
-        execution_deadline: None,
-    }
-}
+mod support;
+use support::*;
 
 #[tokio::test]
 async fn web_search_tool_reuses_query_executor() {
     let executor = MockWebSearchExecutor::default();
     let requests = executor.requests.clone();
     let stream_calls = executor.stream_calls.clone();
-    let tool = WebSearchTool::new(Arc::new(executor));
+    let tool =
+        WebSearchTool::new(Arc::new(executor)).with_backend_override(WebSearchBackend::Tavily);
 
     let output = tool
         .execute(
@@ -222,9 +49,11 @@ async fn web_search_tool_reuses_query_executor() {
     assert_eq!(requests[0].context_size.as_deref(), Some("medium"));
     assert_eq!(requests[0].topic.as_deref(), Some("news"));
     assert_eq!(requests[0].time_range.as_deref(), Some("week"));
+    assert_eq!(requests[0].backend_override, Some(WebSearchBackend::Tavily));
     assert_eq!(requests[0].model_override.as_deref(), Some("gpt-search"));
     assert_eq!(stream_calls.load(Ordering::SeqCst), 1);
     assert_eq!(output.value["ok"], true);
+    assert_eq!(output.value["backend"], "tavily");
     assert_eq!(output.value["result_count"], 1);
     assert_eq!(output.value["answer"], "answer: Rust 新闻");
     assert_eq!(output.value["sources"][0]["url"], "https://example.com");
@@ -888,6 +717,14 @@ async fn web_search_tool_rejects_empty_query_without_calling_executor() {
 
     assert_eq!(err.code, "bad_tool_arguments");
     assert_eq!(requests.lock().unwrap().len(), 0);
+
+    let err = tool
+        .execute(test_context(), json!({"query": null}))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, "bad_tool_arguments");
+    assert_eq!(err.message, "web_search requires non-empty query");
+    assert_eq!(requests.lock().unwrap().len(), 0);
 }
 
 #[tokio::test]
@@ -957,4 +794,5 @@ async fn web_search_tool_rejects_invalid_options() {
     }
 }
 
+mod argument_validation;
 mod research;

--- a/qq-maid-core/src/runtime/tools/search/tests/agent_loop.rs
+++ b/qq-maid-core/src/runtime/tools/search/tests/agent_loop.rs
@@ -1,0 +1,157 @@
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+};
+
+use async_trait::async_trait;
+use qq_maid_llm::{
+    LlmError,
+    agent_loop::{AgentStep, AgentStepSession, AgentToolCall, AgentToolResult, run_agent_loop},
+    tool::ToolRegistry,
+    web_search::{WebSearchBackend, WebSearchRequest},
+};
+use serde_json::Value;
+
+use super::{
+    WEB_SEARCH_TOOL_NAME, WebSearchTool,
+    support::{MockWebSearchExecutor, test_context},
+};
+
+/// 记录每次模型请求收到的工具结果，并在模型请求前观察搜索执行次数。
+///
+/// 该夹具只模拟 Provider 的协议适配层；实际参数校验、ToolRegistry 去重和
+/// Web Search executor 均走生产实现，以覆盖一次完整的 Agent Loop。
+struct RecordingSession {
+    script: VecDeque<AgentStep>,
+    observed_results: Arc<Mutex<Vec<Vec<AgentToolResult>>>>,
+    observed_request_counts: Arc<Mutex<Vec<usize>>>,
+    requests: Arc<Mutex<Vec<WebSearchRequest>>>,
+}
+
+#[async_trait]
+impl AgentStepSession for RecordingSession {
+    fn provider(&self) -> &str {
+        "mock"
+    }
+
+    fn model(&self) -> &str {
+        "mock-model"
+    }
+
+    async fn advance(
+        &mut self,
+        results: &[AgentToolResult],
+        _allow_tool_calls: bool,
+    ) -> Result<AgentStep, LlmError> {
+        self.observed_results.lock().unwrap().push(results.to_vec());
+        self.observed_request_counts
+            .lock()
+            .unwrap()
+            .push(self.requests.lock().unwrap().len());
+        self.script
+            .pop_front()
+            .ok_or_else(|| LlmError::provider("missing scripted Agent step", "test"))
+    }
+}
+
+fn web_search_call(call_id: &str, arguments: &str) -> AgentStep {
+    AgentStep::ToolCalls {
+        calls: vec![AgentToolCall {
+            name: WEB_SEARCH_TOOL_NAME.to_owned(),
+            call_id: call_id.to_owned(),
+            arguments: arguments.to_owned(),
+        }],
+        usage: None,
+    }
+}
+
+fn final_answer(reply: &str) -> AgentStep {
+    AgentStep::FinalAnswer {
+        reply: reply.to_owned(),
+        output_parts: Vec::new(),
+        usage: None,
+    }
+}
+
+#[tokio::test]
+async fn agent_web_search_self_corrects_invalid_topic_before_one_real_call() {
+    let executor = MockWebSearchExecutor::default();
+    let requests = executor.requests.clone();
+    let stream_calls = executor.stream_calls.clone();
+    let tool =
+        WebSearchTool::new(Arc::new(executor)).with_backend_override(WebSearchBackend::Tavily);
+    let registry = ToolRegistry::new().register(tool).unwrap();
+    let observed_results = Arc::new(Mutex::new(Vec::new()));
+    let observed_request_counts = Arc::new(Mutex::new(Vec::new()));
+
+    let session = RecordingSession {
+        script: VecDeque::from([
+            web_search_call(
+                "invalid-topic",
+                r#"{"query":"Rust news","raw_question":"private question","topic":"medical"}"#,
+            ),
+            web_search_call(
+                "corrected-topic",
+                r#"{"query":"Rust news","raw_question":"private question","topic":"general"}"#,
+            ),
+            final_answer("已根据搜索结果整理：Rust news 的公开资料已核实。"),
+        ]),
+        observed_results: observed_results.clone(),
+        observed_request_counts: observed_request_counts.clone(),
+        requests: requests.clone(),
+    };
+
+    let outcome = run_agent_loop(Box::new(session), registry, test_context(), 3, None, None)
+        .await
+        .unwrap();
+
+    let observed_results = observed_results.lock().unwrap();
+    assert_eq!(observed_results.len(), 3);
+    assert!(observed_results[0].is_empty());
+
+    // 第一轮参数错误在第二轮模型请求前已回填；此时 executor 仍未收到任何请求。
+    assert_eq!(observed_results[1].len(), 1);
+    let invalid_output: Value = serde_json::from_str(&observed_results[1][0].output).unwrap();
+    assert_eq!(invalid_output["error"]["argument"], "topic");
+    assert_eq!(invalid_output["error"]["retryable_by_model"], true);
+
+    // 修正后的真实搜索结果继续回填给最终回答轮。
+    assert_eq!(observed_results[2].len(), 1);
+    let success_output: Value = serde_json::from_str(&observed_results[2][0].output).unwrap();
+    assert_eq!(success_output["ok"], true);
+    assert_eq!(success_output["execution_succeeded"], true);
+    assert_eq!(success_output["answer"], "answer: Rust news");
+
+    assert_eq!(
+        *observed_request_counts.lock().unwrap(),
+        vec![0, 0, 1],
+        "invalid arguments must not reach Tavily/mock executor"
+    );
+    let requests = requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].topic.as_deref(), Some("general"));
+    assert_eq!(stream_calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+    assert_eq!(
+        outcome.reply,
+        "已根据搜索结果整理：Rust news 的公开资料已核实。"
+    );
+    assert_eq!(outcome.agent.model_rounds, 3);
+    assert_eq!(outcome.agent.tool_results.len(), 2);
+    assert_eq!(
+        outcome.agent.tool_results[0].output["error"]["argument"],
+        "topic"
+    );
+    assert_eq!(outcome.agent.tool_results[1].output["ok"], true);
+    // Tool Loop 已两次进入 Web Search Tool；第一次在参数边界返回，只有第二次
+    // 越过参数校验后才真正触发 executor。
+    assert_eq!(
+        outcome.agent.executed_tools,
+        [WEB_SEARCH_TOOL_NAME, WEB_SEARCH_TOOL_NAME]
+    );
+    assert_eq!(outcome.agent.tool_attempts[0].retry_of, None);
+    assert_eq!(
+        outcome.agent.tool_attempts[1].retry_of, None,
+        "changed arguments must not be treated as a cached duplicate"
+    );
+}

--- a/qq-maid-core/src/runtime/tools/search/tests/argument_validation.rs
+++ b/qq-maid-core/src/runtime/tools/search/tests/argument_validation.rs
@@ -102,7 +102,7 @@ async fn invalid_argument_log_has_field_diagnostics_without_search_content() {
             json!({
                 "query": "private query content",
                 "raw_question": "private prompt body",
-                "topic": "medical",
+                "topic": "health",
             }),
         )
         .await
@@ -123,7 +123,9 @@ async fn invalid_argument_log_has_field_diagnostics_without_search_content() {
     ] {
         assert!(logs.contains(field), "missing log field {field}: {logs}");
     }
-    assert!(logs.contains("medical"));
+    assert!(logs.contains("safe_value=Some(\"health\")"));
+    assert!(logs.contains("query_chars=None"));
+    assert!(!logs.contains("query_chars=0"));
     assert!(logs.contains("task-argument-diagnostics"));
     assert!(!logs.contains("private query content"));
     assert!(!logs.contains("private prompt body"));

--- a/qq-maid-core/src/runtime/tools/search/tests/argument_validation.rs
+++ b/qq-maid-core/src/runtime/tools/search/tests/argument_validation.rs
@@ -1,0 +1,130 @@
+use super::*;
+
+#[tokio::test]
+async fn agent_web_search_invalid_arguments_are_structured_and_skip_executor() {
+    let executor = MockWebSearchExecutor::default();
+    let requests = executor.requests.clone();
+    let tool =
+        WebSearchTool::new(Arc::new(executor)).with_backend_override(WebSearchBackend::Tavily);
+    let registry = ToolRegistry::new().register(tool).unwrap();
+    let cases = vec![
+        (
+            "topic",
+            json!({"query": "safe query", "topic": "medical"}),
+            "unsupported_value",
+            "string",
+        ),
+        (
+            "time_range",
+            json!({"query": "safe query", "time_range": "all"}),
+            "unsupported_value",
+            "string",
+        ),
+        (
+            "context_size",
+            json!({"query": "safe query", "context_size": "full"}),
+            "unsupported_value",
+            "string",
+        ),
+        (
+            "max_results",
+            json!({"query": "safe query", "max_results": "5"}),
+            "invalid_type",
+            "string",
+        ),
+        (
+            "max_results",
+            json!({"query": "safe query", "max_results": 20}),
+            "out_of_range",
+            "integer",
+        ),
+        ("query", json!({"query": null}), "missing_or_empty", "null"),
+        (
+            "query",
+            json!({"query": "  "}),
+            "missing_or_empty",
+            "string",
+        ),
+        (
+            "query",
+            json!({"query": "q".repeat(WEB_SEARCH_QUERY_MAX_LENGTH + 1)}),
+            "too_long",
+            "string",
+        ),
+    ];
+
+    for (index, (argument, arguments, reason, value_kind)) in cases.into_iter().enumerate() {
+        let mut context = test_context();
+        context.tool_call_id = Some(format!("task-1:invalid-{index}"));
+        context.tool_round = Some(2);
+        let serialized = registry
+            .execute_json(
+                &context,
+                WEB_SEARCH_TOOL_NAME,
+                &serde_json::to_string(&arguments).unwrap(),
+            )
+            .await
+            .unwrap();
+        let output: Value = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(output["ok"], false, "{argument}");
+        assert_eq!(output["execution_succeeded"], false, "{argument}");
+        assert_eq!(output["backend"], "tavily", "{argument}");
+        assert_eq!(output["error"]["code"], "invalid_arguments");
+        assert_eq!(output["error"]["stage"], "tool");
+        assert_eq!(output["error"]["argument"], argument);
+        assert_eq!(output["error"]["reason"], reason);
+        assert_eq!(output["error"]["value_kind"], value_kind);
+        assert_eq!(output["error"]["retryable_by_model"], true);
+    }
+
+    assert!(requests.lock().unwrap().is_empty());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn invalid_argument_log_has_field_diagnostics_without_search_content() {
+    let bytes = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .without_time()
+        .with_ansi(false)
+        .with_writer(LogWriter(bytes.clone()))
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+    let tool = WebSearchTool::new(Arc::new(MockWebSearchExecutor::default()))
+        .with_backend_override(WebSearchBackend::Tavily);
+    let mut context = test_context();
+    context.task_id = "task-argument-diagnostics".to_owned();
+    context.tool_call_id = Some("task-argument-diagnostics:call-1".to_owned());
+    context.tool_round = Some(4);
+
+    let output = tool
+        .execute(
+            context,
+            json!({
+                "query": "private query content",
+                "raw_question": "private prompt body",
+                "topic": "medical",
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(output.value["error"]["argument"], "topic");
+
+    let logs = String::from_utf8(bytes.lock().unwrap().clone()).unwrap();
+    for field in [
+        "tool",
+        "backend",
+        "argument",
+        "reason",
+        "value_kind",
+        "safe_value",
+        "task_id",
+        "tool_call_id",
+        "tool_round",
+    ] {
+        assert!(logs.contains(field), "missing log field {field}: {logs}");
+    }
+    assert!(logs.contains("medical"));
+    assert!(logs.contains("task-argument-diagnostics"));
+    assert!(!logs.contains("private query content"));
+    assert!(!logs.contains("private prompt body"));
+}

--- a/qq-maid-core/src/runtime/tools/search/tests/support.rs
+++ b/qq-maid-core/src/runtime/tools/search/tests/support.rs
@@ -1,0 +1,194 @@
+use std::{
+    collections::VecDeque,
+    io,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+use async_trait::async_trait;
+use qq_maid_common::identity_context::{
+    ConversationKind, ExecutionActorContext, ExecutionConversationContext,
+};
+use qq_maid_llm::{
+    tool::ToolContext,
+    web_search::{WebSearchExecutor, WebSearchOutcome, WebSearchRequest, WebSearchSource},
+};
+use tokio::sync::mpsc;
+
+use crate::error::LlmError;
+
+#[derive(Clone, Default)]
+pub(super) struct MockWebSearchExecutor {
+    pub(super) requests: Arc<Mutex<Vec<WebSearchRequest>>>,
+    pub(super) stream_calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl WebSearchExecutor for MockWebSearchExecutor {
+    async fn query(&self, req: WebSearchRequest) -> Result<WebSearchOutcome, LlmError> {
+        self.requests.lock().unwrap().push(req.clone());
+        Ok(WebSearchOutcome {
+            answer: format!("answer: {}", req.query),
+            sources: vec![WebSearchSource {
+                title: "source title".to_owned(),
+                url: "https://example.com".to_owned(),
+                snippet: "source snippet".to_owned(),
+            }],
+            provider: "mock-query".to_owned(),
+            elapsed_ms: 12,
+        })
+    }
+
+    async fn query_stream(
+        &self,
+        req: WebSearchRequest,
+        delta_tx: mpsc::Sender<String>,
+    ) -> Result<WebSearchOutcome, LlmError> {
+        self.stream_calls.fetch_add(1, Ordering::SeqCst);
+        let outcome = self.query(req).await?;
+        let _ = delta_tx.send(outcome.answer.clone()).await;
+        Ok(outcome)
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "mock-query"
+    }
+}
+
+pub(super) struct EmptyWebSearchExecutor;
+
+#[async_trait]
+impl WebSearchExecutor for EmptyWebSearchExecutor {
+    async fn query(&self, _req: WebSearchRequest) -> Result<WebSearchOutcome, LlmError> {
+        Ok(WebSearchOutcome {
+            answer: String::new(),
+            sources: Vec::new(),
+            provider: "tavily".to_owned(),
+            elapsed_ms: 12,
+        })
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "tavily"
+    }
+}
+
+pub(super) struct FailingWebSearchExecutor;
+
+#[async_trait]
+impl WebSearchExecutor for FailingWebSearchExecutor {
+    async fn query(&self, _req: WebSearchRequest) -> Result<WebSearchOutcome, LlmError> {
+        Err(LlmError::new(
+            "tavily_auth_error",
+            "Tavily rejected the configured API key",
+            "tavily_http",
+        ))
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "tavily"
+    }
+}
+
+pub(super) struct LargeWebSearchExecutor;
+
+#[derive(Clone)]
+pub(super) struct ScriptedWebSearchExecutor {
+    pub(super) outcomes: Arc<Mutex<VecDeque<Result<WebSearchOutcome, LlmError>>>>,
+    pub(super) calls: Arc<AtomicUsize>,
+}
+
+impl ScriptedWebSearchExecutor {
+    pub(super) fn failures(errors: Vec<LlmError>) -> Self {
+        Self {
+            outcomes: Arc::new(Mutex::new(errors.into_iter().map(Err).collect())),
+            calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+#[async_trait]
+impl WebSearchExecutor for ScriptedWebSearchExecutor {
+    async fn query(&self, _req: WebSearchRequest) -> Result<WebSearchOutcome, LlmError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.outcomes
+            .lock()
+            .unwrap()
+            .pop_front()
+            .expect("scripted web search outcome")
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "openai_responses"
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct LogWriter(pub(super) Arc<Mutex<Vec<u8>>>);
+
+pub(super) struct LogGuard(Arc<Mutex<Vec<u8>>>);
+
+impl io::Write for LogGuard {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for LogWriter {
+    type Writer = LogGuard;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        LogGuard(self.0.clone())
+    }
+}
+
+#[async_trait]
+impl WebSearchExecutor for LargeWebSearchExecutor {
+    async fn query(&self, _req: WebSearchRequest) -> Result<WebSearchOutcome, LlmError> {
+        Ok(WebSearchOutcome {
+            answer: "昨日 AI 新闻重点。".repeat(220),
+            sources: (0..8)
+                .map(|index| WebSearchSource {
+                    title: format!("来源 {index} {}", "标题".repeat(80)),
+                    url: format!("https://example.com/news/{index}?query={}", "a".repeat(260)),
+                    snippet: "公开报道摘要。".repeat(180),
+                })
+                .collect(),
+            provider: "tavily".to_owned(),
+            elapsed_ms: 12,
+        })
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "tavily"
+    }
+}
+
+pub(super) fn test_context() -> ToolContext {
+    ToolContext {
+        task_id: "task-1".to_owned(),
+        actor: ExecutionActorContext {
+            user_id: Some("u1".to_owned()),
+            group_member_role: None,
+        },
+        conversation: ExecutionConversationContext {
+            platform: "test".to_owned(),
+            account_id: None,
+            kind: ConversationKind::Private,
+            target_id: Some("u1".to_owned()),
+            scope_id: "private:u1".to_owned(),
+            interaction_scope_id: "private:u1".to_owned(),
+        },
+        tool_call_id: None,
+        tool_round: None,
+        retry_of: None,
+        execution_deadline: None,
+    }
+}

--- a/qq-maid-core/src/runtime/tools/search/validation.rs
+++ b/qq-maid-core/src/runtime/tools/search/validation.rs
@@ -1,0 +1,341 @@
+//! Web Search Tool 参数解析与错误投影。
+//!
+//! 参数错误必须在构造 `WebSearchRequest` 前被识别；该模块只保留字段级、低敏的
+//! 诊断信息，不把 query、raw_question 或完整参数对象带入日志或模型错误。
+
+use serde_json::{Value, json};
+
+use qq_maid_llm::{tool::ToolContext, web_search::WebSearchBackend};
+
+use crate::error::LlmError;
+
+use super::{WEB_SEARCH_MAX_RESULTS_LIMIT, WEB_SEARCH_QUERY_MAX_LENGTH, WebSearchToolRequest};
+
+/// Web Search 参数校验失败时使用的本地结构化错误。
+///
+/// 该错误只保留字段、稳定原因和值类型；`safe_value` 仅允许短的低敏标量，
+/// 查询正文和原始问题始终不进入错误或日志。显式调用最终仍转换为原有
+/// `LlmError`，Agent 调用则把同一份诊断投影为可纠正的 ToolOutput。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct WebSearchArgumentError {
+    pub(super) field: String,
+    pub(super) reason: &'static str,
+    pub(super) message: String,
+    pub(super) value_kind: &'static str,
+    pub(super) safe_value: Option<String>,
+    pub(super) query_chars: Option<usize>,
+}
+
+impl WebSearchArgumentError {
+    pub(super) fn new(
+        field: impl Into<String>,
+        reason: &'static str,
+        message: impl Into<String>,
+        value: Option<&Value>,
+        safe_value: Option<String>,
+        query_chars: Option<usize>,
+    ) -> Self {
+        Self {
+            field: field.into(),
+            message: message.into(),
+            reason,
+            value_kind: argument_value_kind(value),
+            safe_value,
+            query_chars,
+        }
+    }
+
+    pub(super) fn into_llm_error(self) -> LlmError {
+        LlmError::new("bad_tool_arguments", self.message, "tool")
+    }
+
+    pub(super) fn agent_output(&self, backend: &str) -> Value {
+        json!({
+            "ok": false,
+            "execution_succeeded": false,
+            "backend": backend,
+            "answer": "",
+            "sources": [],
+            "result_count": 0,
+            "error": {
+                "code": "invalid_arguments",
+                "stage": "tool",
+                "argument": self.field,
+                "reason": self.reason,
+                "value_kind": self.value_kind,
+                "message": self.message,
+                "kind": "invalid_arguments",
+                "retriable": false,
+                "retryable_by_model": true,
+            },
+        })
+    }
+}
+
+/// 研究模式会在一次 Tool 调用中先校验共享选项，再执行多个搜索请求；保留参数
+/// 错误与运行时 LLM 错误的边界，避免 Agent 把网络失败误判成可纠正参数错误。
+pub(super) enum WebSearchToolError {
+    Argument(WebSearchArgumentError),
+    Execution(LlmError),
+}
+
+impl From<WebSearchArgumentError> for WebSearchToolError {
+    fn from(error: WebSearchArgumentError) -> Self {
+        Self::Argument(error)
+    }
+}
+
+impl From<LlmError> for WebSearchToolError {
+    fn from(error: LlmError) -> Self {
+        Self::Execution(error)
+    }
+}
+
+pub(super) fn request_from_arguments(
+    context: &ToolContext,
+    arguments: &Value,
+    server_backend_override: Option<WebSearchBackend>,
+    server_model_override: Option<String>,
+) -> Result<WebSearchToolRequest, WebSearchArgumentError> {
+    // 搜索模型路由只允许 `/查` 等服务端直接执行入口注入；模型 Tool Loop 调用
+    // 会带稳定 tool_call_id，此时忽略任何伪造的 model_override 参数。
+    let model_override = server_model_override.or_else(|| {
+        context
+            .tool_call_id
+            .is_none()
+            .then(|| optional_string_field(arguments, "model_override"))
+            .flatten()
+    });
+    Ok(WebSearchToolRequest {
+        query: parse_query(arguments)?,
+        raw_question: optional_string_field(arguments, "raw_question"),
+        max_results: parse_max_results(arguments.get("max_results"))?,
+        context_size: parse_context_size(arguments.get("context_size"))?,
+        topic: parse_topic(arguments.get("topic"))?,
+        time_range: parse_time_range(arguments.get("time_range"))?,
+        backend_override: server_backend_override,
+        model_override,
+    })
+}
+
+pub(super) fn parse_query(arguments: &Value) -> Result<String, WebSearchArgumentError> {
+    let Some(value) = arguments.get("query") else {
+        return Err(WebSearchArgumentError::new(
+            "query",
+            "missing_or_empty",
+            "web_search requires non-empty query",
+            None,
+            None,
+            Some(0),
+        ));
+    };
+    let Some(text) = value.as_str() else {
+        return Err(WebSearchArgumentError::new(
+            "query",
+            if value.is_null() {
+                "missing_or_empty"
+            } else {
+                "invalid_type"
+            },
+            "web_search requires non-empty query",
+            Some(value),
+            None,
+            None,
+        ));
+    };
+    let query = text.trim();
+    if query.is_empty() {
+        return Err(WebSearchArgumentError::new(
+            "query",
+            "missing_or_empty",
+            "web_search requires non-empty query",
+            Some(value),
+            None,
+            Some(0),
+        ));
+    }
+    if query.chars().count() > WEB_SEARCH_QUERY_MAX_LENGTH {
+        return Err(WebSearchArgumentError::new(
+            "query",
+            "too_long",
+            "query is too long",
+            Some(value),
+            None,
+            Some(query.chars().count()),
+        ));
+    }
+    Ok(query.to_owned())
+}
+
+pub(super) fn parse_max_results(
+    value: Option<&Value>,
+) -> Result<Option<u8>, WebSearchArgumentError> {
+    match value {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Number(number)) if !number.is_f64() => match number.as_u64() {
+            Some(value) if (1..=WEB_SEARCH_MAX_RESULTS_LIMIT as u64).contains(&value) => {
+                Ok(Some(value as u8))
+            }
+            _ => Err(WebSearchArgumentError::new(
+                "max_results",
+                "out_of_range",
+                "max_results must be an integer between 1 and 10 or null",
+                value,
+                low_sensitivity_safe_value(value),
+                None,
+            )),
+        },
+        Some(value) => Err(WebSearchArgumentError::new(
+            "max_results",
+            "invalid_type",
+            "max_results must be an integer between 1 and 10 or null",
+            Some(value),
+            low_sensitivity_safe_value(Some(value)),
+            None,
+        )),
+    }
+}
+
+pub(super) fn parse_context_size(
+    value: Option<&Value>,
+) -> Result<Option<String>, WebSearchArgumentError> {
+    match value {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(text)) => {
+            let text = text.trim();
+            if matches!(text, "low" | "medium" | "high") {
+                Ok(Some(text.to_owned()))
+            } else {
+                Err(WebSearchArgumentError::new(
+                    "context_size",
+                    "unsupported_value",
+                    "context_size must be low, medium, high, or null",
+                    value,
+                    low_sensitivity_safe_value(value),
+                    None,
+                ))
+            }
+        }
+        Some(value) => Err(WebSearchArgumentError::new(
+            "context_size",
+            "invalid_type",
+            "context_size must be low, medium, high, or null",
+            Some(value),
+            low_sensitivity_safe_value(Some(value)),
+            None,
+        )),
+    }
+}
+
+pub(super) fn parse_topic(value: Option<&Value>) -> Result<Option<String>, WebSearchArgumentError> {
+    parse_optional_enum(value, "topic", &["general", "news", "finance"])
+}
+
+pub(super) fn parse_time_range(
+    value: Option<&Value>,
+) -> Result<Option<String>, WebSearchArgumentError> {
+    parse_optional_enum(value, "time_range", &["day", "week", "month", "year"])
+}
+
+fn parse_optional_enum(
+    value: Option<&Value>,
+    name: &str,
+    allowed: &[&str],
+) -> Result<Option<String>, WebSearchArgumentError> {
+    match value {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(text)) => {
+            let text = text.trim().to_ascii_lowercase();
+            if allowed.contains(&text.as_str()) {
+                Ok(Some(text))
+            } else {
+                Err(WebSearchArgumentError::new(
+                    name,
+                    "unsupported_value",
+                    format!("{name} must be one of {} or null", allowed.join(", ")),
+                    value,
+                    low_sensitivity_safe_value(value),
+                    None,
+                ))
+            }
+        }
+        Some(value) => Err(WebSearchArgumentError::new(
+            name,
+            "invalid_type",
+            format!("{name} must be a string or null"),
+            Some(value),
+            low_sensitivity_safe_value(Some(value)),
+            None,
+        )),
+    }
+}
+
+fn argument_value_kind(value: Option<&Value>) -> &'static str {
+    match value {
+        None => "missing",
+        Some(Value::Null) => "null",
+        Some(Value::Bool(_)) => "boolean",
+        Some(Value::Number(number)) if number.is_i64() || number.is_u64() => "integer",
+        Some(Value::Number(_)) => "number",
+        Some(Value::String(_)) => "string",
+        Some(Value::Array(_)) => "array",
+        Some(Value::Object(_)) => "object",
+    }
+}
+
+/// 仅返回数字或已知短枚举候选，避免把模型偶然放入枚举字段的正文写入日志。
+fn low_sensitivity_safe_value(value: Option<&Value>) -> Option<String> {
+    let text = match value {
+        Some(Value::String(value)) => value.trim().to_owned(),
+        Some(Value::Number(value)) => value.to_string(),
+        _ => return None,
+    };
+    if text.chars().count() > 32
+        || text.is_empty()
+        || !text
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || ".-_+".contains(character))
+    {
+        return None;
+    }
+    if text.chars().all(|character| character.is_ascii_digit()) {
+        return Some(text);
+    }
+    matches!(
+        text.to_ascii_lowercase().as_str(),
+        "low"
+            | "medium"
+            | "high"
+            | "general"
+            | "news"
+            | "finance"
+            | "medical"
+            | "sports"
+            | "day"
+            | "week"
+            | "month"
+            | "year"
+            | "quarter"
+            | "all"
+            | "full"
+    )
+    .then_some(text)
+}
+
+pub(super) fn optional_string_field(arguments: &Value, key: &str) -> Option<String> {
+    match arguments.get(key) {
+        Some(Value::String(value)) => {
+            let value = value.trim();
+            (!value.is_empty()).then(|| value.to_owned())
+        }
+        _ => None,
+    }
+}
+
+pub(super) fn normalize_dedup_text(value: &str) -> String {
+    value
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}

--- a/qq-maid-core/src/runtime/tools/search/validation.rs
+++ b/qq-maid-core/src/runtime/tools/search/validation.rs
@@ -283,7 +283,10 @@ fn argument_value_kind(value: Option<&Value>) -> &'static str {
     }
 }
 
-/// 仅返回数字或已知短枚举候选，避免把模型偶然放入枚举字段的正文写入日志。
+/// 受限参数只保留短、低敏的标量候选，避免把模型偶然放入枚举字段的正文写入日志。
+///
+/// 调用方必须仅限于 `topic`、`time_range`、`context_size`、`max_results` 等受限
+/// 参数；query、raw_question 和研究正文不得复用此投影。
 fn low_sensitivity_safe_value(value: Option<&Value>) -> Option<String> {
     let text = match value {
         Some(Value::String(value)) => value.trim().to_owned(),
@@ -298,28 +301,7 @@ fn low_sensitivity_safe_value(value: Option<&Value>) -> Option<String> {
     {
         return None;
     }
-    if text.chars().all(|character| character.is_ascii_digit()) {
-        return Some(text);
-    }
-    matches!(
-        text.to_ascii_lowercase().as_str(),
-        "low"
-            | "medium"
-            | "high"
-            | "general"
-            | "news"
-            | "finance"
-            | "medical"
-            | "sports"
-            | "day"
-            | "week"
-            | "month"
-            | "year"
-            | "quarter"
-            | "all"
-            | "full"
-    )
-    .then_some(text)
+    Some(text)
 }
 
 pub(super) fn optional_string_field(arguments: &Value, key: &str) -> Option<String> {


### PR DESCRIPTION
## 变更内容

- 修正 Web Search 参数错误日志：非 query 字段不再把未采集的 query 长度写成 `0`，改为保留 `Option` 诊断值。
- 将 `safe_value` 改为受限参数通用的低敏规则：长度不超过 32，只允许 ASCII 字母、数字及 `.-_+`；数组、对象和正文不进入该字段。
- Agent Tool Loop 参数错误继续返回结构化 ToolOutput，保留 `argument=topic` 与 `retryable_by_model=true`，并确保非法参数不会触发 Tavily/mock executor。
- 新增完整 Agent Loop 回归测试，覆盖参数错误回填、自纠、真实搜索执行、成功结果回填和最终回答。
- 保持 Tavily HTTP、认证、代理、超时逻辑及显式 `/查` 错误语义不变。

## 根因

参数校验失败时，日志使用 `unwrap_or(0)` 会把“未采集 query 长度”伪装成长度为 0；原 `safe_value` 还依赖硬编码枚举词表，模型生成 `health`、`science` 等短值时无法提供诊断信息。参数错误若参与终态失败缓存或去重，也可能阻止模型修正下一轮 Tool Call。

## 回归验证

- 第 1 轮模型返回 `topic=medical`：executor 请求计数仍为 0；Tool 结果包含 `error.argument=topic`，并回填给第 2 轮模型。
- 第 2 轮模型修正为 `topic=general`：executor 真实调用 1 次，搜索成功结果回填给第 3 轮。
- 第 3 轮模型基于成功结果正常生成最终回答；非法参数结果未被 terminal failure cache 或错误去重阻止。
- 日志测试验证非法 topic 的 `query_chars=None`、`health` 可作为 `safe_value` 记录，且 query/raw_question 正文不出现在日志中。

## 检查

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p qq-maid-core runtime::tools::search -- --nocapture`（38/38）
- `cargo test --workspace --all-features`（workspace 全部通过）
- `cargo build --workspace --release --all-features`
- `git diff --check`

最新提交：`5362c1b`