### PR TITLE
feat(web-console): 知识库管理页面（#643）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ data/
 # 真实环境变量文件可能残留在旧模块或误运行子目录，显式兜底避免迁移期误提交。
 **/.env
 config/.env
+config/agent.toml
+config/runtime.toml
+config/ops.toml
+config/secrets/
 config/world.md
 config/context_modules.toml
 config/prompts/*.md

--- a/docs/API_CONTRACTS.md
+++ b/docs/API_CONTRACTS.md
@@ -24,8 +24,16 @@
 | POST | `/api/v1/console/configuration/validate` | 本地配置预检 | admin + CSRF |
 | POST | `/api/v1/console/restart` | 提交受控重启 | admin + CSRF |
 | POST | `/api/v1/markdown/render` | 服务端 Markdown 安全预览 | 只读 |
+| POST | `/api/v1/console/knowledge/files/capabilities` | 读取知识库文件能力和限制 | admin + CSRF |
+| POST | `/api/v1/console/knowledge/files/list` | 分页查询知识库文件 | admin + CSRF |
+| POST | `/api/v1/console/knowledge/files/upload` | 上传托管知识库文件 | admin + CSRF |
+| POST | `/api/v1/console/knowledge/files/get/{file_id}` | 下载原始知识库文件 | admin，成功返回 raw Blob |
+| POST | `/api/v1/console/knowledge/files/delete` | 删除托管文件及其派生数据 | admin + CSRF |
+| POST | `/api/v1/console/knowledge/files/retry` | 重新处理失败的托管文件 | admin + CSRF |
 
 `status` 页面数据是安全摘要，不包含 token、secret、API key、cookie、authorization 或绝对敏感路径。配置 snapshot 对 secret 只返回配置状态，不返回原文。配置写入使用 revision，发生冲突时必须刷新并由用户重新确认，不得覆盖未知修改。
+
+知识库 JSON 接口使用统一的 `{ok,data,request_id}` 包络；`get/{file_id}` 成功时返回原始文件字节，错误仍使用 JSON 包络。所有会改变状态的接口必须携带 CSRF；错误保留 HTTP `status`、服务端 `code` 和安全 `message`。
 
 配置交互的完整状态协议见 [`INTERACTION_CONTRACTS.md`](./INTERACTION_CONTRACTS.md)。特别约束：runtime 和 agent 使用 expected revision；secret 每项 replace/clear 使用自己的 expected revision；空 secret 不产生请求；409 或 `config_conflict` 不得自动重试；成功必须以服务端返回的 snapshot 为准。
 

--- a/qq-maid-core/src/http/console_routes.rs
+++ b/qq-maid-core/src/http/console_routes.rs
@@ -211,6 +211,41 @@ const CONSOLE_ASSETS: &[(&str, &str, &str)] = &[
         "text/javascript; charset=utf-8",
     ),
     (
+        "views/knowledge/knowledge-actions.js",
+        include_str!("../../../web-console/dist/views/knowledge/knowledge-actions.js"),
+        "text/javascript; charset=utf-8",
+    ),
+    (
+        "views/knowledge/knowledge-list.js",
+        include_str!("../../../web-console/dist/views/knowledge/knowledge-list.js"),
+        "text/javascript; charset=utf-8",
+    ),
+    (
+        "views/knowledge/knowledge-paging.js",
+        include_str!("../../../web-console/dist/views/knowledge/knowledge-paging.js"),
+        "text/javascript; charset=utf-8",
+    ),
+    (
+        "views/knowledge/knowledge-polling.js",
+        include_str!("../../../web-console/dist/views/knowledge/knowledge-polling.js"),
+        "text/javascript; charset=utf-8",
+    ),
+    (
+        "views/knowledge/knowledge-status.js",
+        include_str!("../../../web-console/dist/views/knowledge/knowledge-status.js"),
+        "text/javascript; charset=utf-8",
+    ),
+    (
+        "views/knowledge/knowledge-upload.js",
+        include_str!("../../../web-console/dist/views/knowledge/knowledge-upload.js"),
+        "text/javascript; charset=utf-8",
+    ),
+    (
+        "views/knowledge/knowledge.js",
+        include_str!("../../../web-console/dist/views/knowledge/knowledge.js"),
+        "text/javascript; charset=utf-8",
+    ),
+    (
         "views/dashboard.js",
         include_str!("../../../web-console/dist/views/dashboard.js"),
         "text/javascript; charset=utf-8",

--- a/web-console/DESIGN.md
+++ b/web-console/DESIGN.md
@@ -99,6 +99,7 @@
 - **Overview signal board**：`StatusCard` 作为唯一视觉焦点；`MetricCard` 组成紧凑指标 rail；Provider 与 upstream 作为 edge readout。数据模块可 hover 提升 2px，表示可扫描的交互层次。
 - **Platform identity / capability matrix**：平台状态使用动态 table body 保持 API 兼容，桌面端以身份行呈现，窄屏转为逐行 card；能力矩阵保留方向与能力语义，但视觉上与平台状态分离。
 - **Storage resource list**：`#storage-body` 保持 table renderer 和移动 card fallback；路径使用 mono metadata，状态与 schema/migration 作为同一资源行的健康信号。
+- **Knowledge file management**：知识库文件管理负责查看、上传、下载、删除和重试。`pending`（等待处理）与 `processing`（处理中）使用警告菱形，`ready`（已完成）使用成功方形，`failed`（处理失败）使用错误三角形，四者均保留文字；managed 文件可操作，directory 来源只读。仅在页面可见且存在非终态行时轮询，页面隐藏即暂停，全部终态即停止。删除使用原生 dialog，不允许背板关闭，取消为初始焦点，关闭后焦点回收至触发按钮。窄屏以逐行 card 替代表格；所有操作、状态和反馈满足 WCAG 2.2 AA，`prefers-reduced-motion: reduce` 下关闭处理状态的非必要动效。
 - **Configuration workbench**：顶部为校验、摘要和重启后的控制 strip；主体按模型与供应商、模型路由、联网与工具、记忆与知识库、回复与语音、平台接入、待办与通知、系统与安全切换。runtime、Secret、Agent 与 Interface 仍是内部保存来源，但不作为用户主导航；单次只显示当前业务域的配置卡片。
 - **MarkdownEditor**：左侧编辑、右侧后端清理预览。安全预览标签与“后端清理结果”始终可见，编辑器获得主导宽度。
 

--- a/web-console/README.md
+++ b/web-console/README.md
@@ -72,4 +72,4 @@ git diff --exit-code -- web-console/dist
 | [INTERACTION_CONTRACTS.md](../docs/INTERACTION_CONTRACTS.md) | 配置保存、修改、冲突、密钥和重启交互协议 |
 | [ADDING_A_PAGE.md](ADDING_A_PAGE.md) | 新增页面、组件、主题和 API 消费者的步骤 |
 
-当前顶层信息架构包含 Overview、Platforms、Todo、Configuration、Storage、Tools。Configuration 在原页面内按模型与供应商、模型路由、联网与工具、记忆与知识库、回复与语音、平台接入、待办与通知、系统与安全组织；runtime、Secret 和 Agent 只是保存边界，不再作为用户的主导航结构。
+当前顶层信息架构包含 Overview、Platforms、Todo、知识库、Configuration、Storage、Tools。知识库页面管理托管文件的查看、上传、下载、删除和失败重试；目录来源文件只读。Configuration 在原页面内按模型与供应商、模型路由、联网与工具、记忆与知识库、回复与语音、平台接入、待办与通知、系统与安全组织；runtime、Secret 和 Agent 只是保存边界，不再作为用户的主导航结构。

--- a/web-console/dist/api-routes.js
+++ b/web-console/dist/api-routes.js
@@ -38,6 +38,14 @@ export const USER_DATA_ROUTES = {
     filesDelete: "/api/v1/console/files/delete",
     filesGet: (fileId) => `/api/v1/console/files/get/${fileId}`,
 };
+export const KNOWLEDGE_ROUTES = {
+    capabilities: "/api/v1/console/knowledge/files/capabilities",
+    list: "/api/v1/console/knowledge/files/list",
+    upload: "/api/v1/console/knowledge/files/upload",
+    delete: "/api/v1/console/knowledge/files/delete",
+    retry: "/api/v1/console/knowledge/files/retry",
+    get: (fileId) => `/api/v1/console/knowledge/files/get/${fileId}`,
+};
 export const STATUS_ROUTE = "/api/v1/console/status";
 export const RESTART_ROUTE = "/api/v1/console/restart";
 export const MARKDOWN_RENDER_ROUTE = "/api/v1/markdown/render";

--- a/web-console/dist/api.js
+++ b/web-console/dist/api.js
@@ -1,4 +1,4 @@
-import { AUTH_ROUTES, CONFIGURATION_ROUTES, MARKDOWN_RENDER_ROUTE, RESTART_ROUTE, STATUS_ROUTE, TODO_ROUTES, USER_DATA_ROUTES, } from "./api-routes.js";
+import { AUTH_ROUTES, CONFIGURATION_ROUTES, MARKDOWN_RENDER_ROUTE, KNOWLEDGE_ROUTES, RESTART_ROUTE, STATUS_ROUTE, TODO_ROUTES, USER_DATA_ROUTES, } from "./api-routes.js";
 export class ConsoleApiError extends Error {
     code;
     status;
@@ -136,6 +136,76 @@ export async function readUserFile(file) {
 export async function deleteUserFile(fileId) {
     await mutatingJson(USER_DATA_ROUTES.filesDelete, "POST", { file_id: fileId });
 }
+export async function fetchKnowledgeCapabilities() {
+    const payload = record(await mutatingJson(KNOWLEDGE_ROUTES.capabilities, "POST", {}));
+    const data = record(payload.data);
+    return {
+        supported_extensions: array(data.supported_extensions).map((value) => requiredString(value, "supported_extensions")),
+        max_file_bytes: requiredFiniteNumber(data.max_file_bytes, "max_file_bytes"),
+        max_filename_chars: requiredFiniteNumber(data.max_filename_chars, "max_filename_chars"),
+    };
+}
+export async function listKnowledgeFiles(params) {
+    const payload = record(await mutatingJson(KNOWLEDGE_ROUTES.list, "POST", {
+        page: params.page,
+        page_size: params.page_size,
+        search: params.search,
+        ...(params.status === "all" ? {} : { status: params.status }),
+        sort: params.sort,
+        order: params.order,
+    }));
+    return parseKnowledgeFilePage(payload.data);
+}
+export async function uploadKnowledgeFile(file) {
+    const form = new FormData();
+    form.append("file", file);
+    const response = await fetch(KNOWLEDGE_ROUTES.upload, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { Accept: "application/json", "X-CSRF-Token": csrfToken },
+        body: form,
+    });
+    if (!response.ok)
+        throw await responseError(response);
+    return parseKnowledgeFileItem(record(await response.json()).data);
+}
+export async function downloadKnowledgeFile(item) {
+    if (item.file_id === null)
+        throw new ConsoleApiError("知识库文件缺少标识", "invalid_response");
+    const response = await fetch(KNOWLEDGE_ROUTES.get(item.file_id), {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "X-CSRF-Token": csrfToken },
+    });
+    if (!response.ok)
+        throw await responseError(response);
+    return {
+        blob: await response.blob(),
+        filename: filenameFromContentDisposition(response.headers.get("Content-Disposition")) ?? item.filename,
+    };
+}
+export function filenameFromContentDisposition(value) {
+    if (value === null)
+        return null;
+    const encoded = /(?:^|;)\s*filename\*=UTF-8''([^;]+)/i.exec(value);
+    if (encoded?.[1] !== undefined) {
+        try {
+            return decodeURIComponent(encoded[1]);
+        }
+        catch {
+            return null;
+        }
+    }
+    const plain = /(?:^|;)\s*filename="([^"]+)"/i.exec(value);
+    return plain?.[1] ?? null;
+}
+export async function deleteKnowledgeFile(fileId) {
+    await mutatingJson(KNOWLEDGE_ROUTES.delete, "POST", { file_id: fileId });
+}
+export async function retryKnowledgeFile(fileId) {
+    const payload = record(await mutatingJson(KNOWLEDGE_ROUTES.retry, "POST", { file_id: fileId }));
+    return parseKnowledgeFileItem(payload.data);
+}
 export async function fetchConfiguration() {
     const payload = record(await fetchJson(CONFIGURATION_ROUTES.get, {
         headers: { Accept: "application/json" },
@@ -230,6 +300,45 @@ function parseTodoPage(value) {
         pageSize: finiteNumber(data.page_size) ?? 50,
         total: finiteNumber(data.total) ?? 0,
         totalPages: finiteNumber(data.total_pages) ?? 1,
+    };
+}
+function parseKnowledgeFilePage(value) {
+    const data = record(value);
+    return {
+        items: array(data.items).map(parseKnowledgeFileItem),
+        page: finiteNumber(data.page) ?? 1,
+        page_size: finiteNumber(data.page_size) ?? 20,
+        total: finiteNumber(data.total) ?? 0,
+        total_pages: finiteNumber(data.total_pages) ?? 1,
+    };
+}
+export function parseKnowledgeFileItem(value) {
+    const item = record(value);
+    const source = item.source;
+    const status = item.status;
+    if (source !== "managed" && source !== "directory")
+        throw new ConsoleApiError("知识库文件来源无效", "invalid_response");
+    if (status !== "pending" && status !== "processing" && status !== "ready" && status !== "failed") {
+        throw new ConsoleApiError("知识库文件状态无效", "invalid_response");
+    }
+    return {
+        file_id: nullableString(item.file_id),
+        filename: requiredString(item.filename, "filename"),
+        content_type: requiredString(item.content_type, "content_type"),
+        size: finiteNumber(item.size),
+        source: source,
+        source_label: requiredString(item.source_label, "source_label"),
+        status: status,
+        uploaded_at: nullableString(item.uploaded_at),
+        processing_started_at: nullableString(item.processing_started_at),
+        processed_at: nullableString(item.processed_at),
+        updated_at: requiredString(item.updated_at, "updated_at"),
+        error_code: nullableString(item.error_code),
+        error_summary: nullableString(item.error_summary),
+        chunk_count: finiteNumber(item.chunk_count),
+        embedding_count: finiteNumber(item.embedding_count),
+        downloadable: requiredBoolean(item.downloadable, "downloadable"),
+        download_url: nullableString(item.download_url),
     };
 }
 function parseUserPreferences(value) {
@@ -359,6 +468,18 @@ async function mutatingJson(input, method, body, allowEmpty = false) {
         throw new ConsoleApiError(message, code, response.status);
     }
     return await response.json();
+}
+async function responseError(response) {
+    let code = "request_failed";
+    let message = `管理接口请求失败（HTTP ${response.status}）`;
+    try {
+        const payload = record(await response.json());
+        const error = record(payload.error);
+        code = string(error.code, code);
+        message = string(error.message, message);
+    }
+    catch { /* 保留稳定错误。 */ }
+    return new ConsoleApiError(message, code, response.status);
 }
 function parseRuntime(value) {
     const item = record(value);
@@ -536,6 +657,23 @@ function array(value) {
 }
 function string(value, fallback) {
     return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+function requiredString(value, field) {
+    if (typeof value !== "string" || value.length === 0) {
+        throw new ConsoleApiError(`管理接口返回了无效 ${field}`, "invalid_response");
+    }
+    return value;
+}
+function requiredBoolean(value, field) {
+    if (typeof value !== "boolean")
+        throw new ConsoleApiError(`管理接口返回了无效 ${field}`, "invalid_response");
+    return value;
+}
+function requiredFiniteNumber(value, field) {
+    const number = finiteNumber(value);
+    if (number === null)
+        throw new ConsoleApiError(`管理接口返回了无效 ${field}`, "invalid_response");
+    return number;
 }
 function nullableString(value) {
     return typeof value === "string" && value.length > 0 ? value : null;

--- a/web-console/dist/app.js
+++ b/web-console/dist/app.js
@@ -8,6 +8,7 @@ import { initializeConfiguration } from "./views/configuration/configuration.js"
 import { createThemeController } from "./theme.js";
 import { bindConsoleNavigation } from "./console-shell.js";
 import { initializeTodo } from "./views/todo/todo.js";
+import { initializeKnowledge } from "./views/knowledge/knowledge.js";
 import { createBackgroundController, installBackgroundConsoleUnlock, unlockPreferencePatch } from "./background.js";
 import { cacheFileBlob, clearFileBlobCache, deleteCachedFileBlob, readCachedFileBlob } from "./file-cache.js";
 let localStorage = null;
@@ -218,6 +219,7 @@ async function showConsole(username) {
     await Promise.all([refreshStatus(), hydrateUserData()]);
     await refreshConfiguration();
     await initializeTodo();
+    await initializeKnowledge();
 }
 async function hydrateUserData() {
     try {

--- a/web-console/dist/app.js
+++ b/web-console/dist/app.js
@@ -8,7 +8,7 @@ import { initializeConfiguration } from "./views/configuration/configuration.js"
 import { createThemeController } from "./theme.js";
 import { bindConsoleNavigation } from "./console-shell.js";
 import { initializeTodo } from "./views/todo/todo.js";
-import { initializeKnowledge } from "./views/knowledge/knowledge.js";
+import { disposeKnowledge, initializeKnowledge } from "./views/knowledge/knowledge.js";
 import { createBackgroundController, installBackgroundConsoleUnlock, unlockPreferencePatch } from "./background.js";
 import { cacheFileBlob, clearFileBlobCache, deleteCachedFileBlob, readCachedFileBlob } from "./file-cache.js";
 let localStorage = null;
@@ -290,6 +290,7 @@ async function logout() {
         await logoutAdmin();
     }
     finally {
+        disposeKnowledge();
         backgroundController.dispose();
         void clearFileBlobCache();
         userDataController = null;

--- a/web-console/dist/console-shell.js
+++ b/web-console/dist/console-shell.js
@@ -1,10 +1,11 @@
-export const CONSOLE_PAGE_IDS = ["overview", "platforms", "configuration", "storage", "todo", "tools"];
+export const CONSOLE_PAGE_IDS = ["overview", "platforms", "configuration", "storage", "todo", "knowledge", "tools"];
 export const CONSOLE_PAGES = [
     { id: "overview", label: "总览", icon: "overview", targetId: "dashboard" },
     { id: "platforms", label: "平台", icon: "platforms", targetId: "platforms" },
     { id: "configuration", label: "配置", icon: "configuration", targetId: "configuration" },
     { id: "storage", label: "存储", icon: "storage", targetId: "storage" },
     { id: "todo", label: "Todo", icon: "todo", targetId: "todo" },
+    { id: "knowledge", label: "知识库", icon: "knowledge", targetId: "knowledge" },
     { id: "tools", label: "工具", icon: "tools", targetId: "markdown" },
 ];
 export const CONSOLE_EXTENSION_SLOTS = ["memory", "logs", "debug", "attachments"];
@@ -14,6 +15,7 @@ const ICONS = {
     configuration: { label: "配置", paths: ["M12 8.5a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7Z", "M12 2v3", "M12 19v3", "M2 12h3", "M19 12h3", "m4.93 4.93 2.12-2.12", "m16.95 7.05 2.12-2.12", "m4.93 7.07 2.12 2.12", "m16.95 16.95 2.12 2.12"] },
     storage: { label: "存储", paths: ["M4 6.5C4 5.12 7.58 4 12 4s8 1.12 8 2.5S16.42 9 12 9 4 7.88 4 6.5Z", "M4 6.5v5C4 12.88 7.58 14 12 14s8-1.12 8-2.5v-5", "M4 11.5v6C4 18.88 7.58 20 12 20s8-1.12 8-2.5v-6"] },
     todo: { label: "Todo", paths: ["M5 6h14", "M5 12h14", "M5 18h9", "M3 6h.01", "M3 12h.01", "M3 18h.01"] },
+    knowledge: { label: "知识库", paths: ["M4 5a2 2 0 0 1 2-2h9l5 5v11a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V5Z", "M14 3v5h5", "M8 12h8", "M8 16h5"] },
     tools: { label: "工具", paths: ["m14.7 6.3 3-3 3 3-3 3", "m17.7 3.3-7.1 7.1", "M5 20h4l8.7-8.7-4-4L5 16v4Z"] },
 };
 export function pageForTarget(targetId) {
@@ -29,8 +31,10 @@ export function pageForTarget(targetId) {
             return CONSOLE_PAGES[3];
         case "todo":
             return CONSOLE_PAGES[4];
-        case "markdown":
+        case "knowledge":
             return CONSOLE_PAGES[5];
+        case "markdown":
+            return CONSOLE_PAGES[6];
         default:
             return undefined;
     }

--- a/web-console/dist/index.html
+++ b/web-console/dist/index.html
@@ -237,6 +237,38 @@
         </section>
       </div>
 
+      <!-- 知识库页面用于查看、筛选和上传由后端处理的知识库文件。 -->
+      <div class="console-page" data-console-page="knowledge" hidden>
+        <header class="product-page-heading">
+          <div>
+            <p class="eyebrow">KNOWLEDGE / FILES</p>
+            <h2>知识库管理</h2>
+            <p class="product-page-lede">查看、筛选和上传知识库文件，处理状态与文件信息均来自管理 API。</p>
+          </div>
+          <div class="knowledge-page-actions">
+            <button id="knowledge-upload-open" type="button">上传文件</button>
+          </div>
+        </header>
+        <section class="panel knowledge-panel" aria-labelledby="knowledge-heading">
+          <header class="section-heading">
+            <div>
+              <h2 id="knowledge-heading">知识库文件</h2>
+            </div>
+            <span class="section-meta">文件 · 处理状态</span>
+          </header>
+          <div class="knowledge-toolbar">
+            <label class="knowledge-search">搜索文件名<input id="knowledge-search" type="search" placeholder="搜索文件名"></label>
+            <label>状态<select id="knowledge-status-filter"><option value="all">全部</option><option value="pending">等待处理</option><option value="processing">处理中</option><option value="ready">已完成</option><option value="failed">处理失败</option></select></label>
+            <button id="knowledge-filter-submit" type="button">应用筛选</button>
+            <button id="knowledge-filter-reset" type="button" class="secondary">重置</button>
+            <button id="knowledge-refresh" type="button" class="secondary">刷新</button>
+          </div>
+          <p id="knowledge-result" class="status-message" role="status" aria-live="polite"></p>
+          <div id="knowledge-list" class="knowledge-list" aria-live="polite"><p class="hint">正在加载知识库…</p></div>
+          <div id="knowledge-pagination" class="knowledge-pagination"></div>
+        </section>
+      </div>
+
       <dialog id="todo-create-dialog" class="todo-create-dialog">
         <form id="todo-create-form" class="todo-create-form" method="dialog">
           <div class="todo-create-heading">

--- a/web-console/dist/styles.css
+++ b/web-console/dist/styles.css
@@ -384,19 +384,21 @@ textarea { width: 100%; min-height: 25rem; flex: 1; resize: vertical; padding: v
 }
 
 @media (max-width: 700px) {
-  .platform-table-wrap, .capability-table-wrap, .storage-table-wrap { overflow: visible; }
+  .platform-table-wrap, .capability-table-wrap, .storage-table-wrap, .knowledge-list { overflow: visible; }
   .platform-table-wrap table, .capability-table-wrap table, .storage-table-wrap table,
   .platform-table-wrap thead, .capability-table-wrap thead, .storage-table-wrap thead,
   .platform-table-wrap tbody, .capability-table-wrap tbody, .storage-table-wrap tbody,
   .platform-table-wrap tr, .capability-table-wrap tr, .storage-table-wrap tr,
   .platform-table-wrap th, .capability-table-wrap th, .storage-table-wrap th,
-  .platform-table-wrap td, .capability-table-wrap td, .storage-table-wrap td { display: block; }
-  .platform-table-wrap thead, .capability-table-wrap thead, .storage-table-wrap thead { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap; }
+  .platform-table-wrap td, .capability-table-wrap td, .storage-table-wrap td,
+  .knowledge-table, .knowledge-table thead, .knowledge-table tbody, .knowledge-table tr, .knowledge-table th, .knowledge-table td { display: block; }
+  .platform-table-wrap thead, .capability-table-wrap thead, .storage-table-wrap thead, .knowledge-table thead { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap; }
   .platform-table-wrap tbody, .capability-table-wrap tbody, .storage-table-wrap tbody { padding: .25rem; }
-  .platform-table-wrap tr, .capability-table-wrap tr, .storage-table-wrap tr { margin-bottom: .55rem; padding: .65rem; border: 1px solid var(--console-line); background: var(--console-glass-muted); }
-  .platform-table-wrap td, .capability-table-wrap td, .storage-table-wrap td { display: grid; grid-template-columns: minmax(6.5rem, 34%) minmax(0, 1fr); gap: .7rem; padding: .45rem 0; border: 0; border-bottom: 1px solid var(--console-line); background: transparent; font-size: .76rem; }
-  .platform-table-wrap td:last-child, .capability-table-wrap td:last-child, .storage-table-wrap td:last-child { border-bottom: 0; }
-  .platform-table-wrap td::before, .capability-table-wrap td::before, .storage-table-wrap td::before { color: var(--muted); font-size: .62rem; font-weight: 800; letter-spacing: .05em; text-transform: uppercase; }
+  .knowledge-table tbody { padding: .25rem; }
+  .platform-table-wrap tr, .capability-table-wrap tr, .storage-table-wrap tr, .knowledge-table tr { margin-bottom: .55rem; padding: .65rem; border: 1px solid var(--console-line); background: var(--console-glass-muted); }
+  .platform-table-wrap td, .capability-table-wrap td, .storage-table-wrap td, .knowledge-table td { display: grid; grid-template-columns: minmax(6.5rem, 34%) minmax(0, 1fr); gap: .7rem; padding: .45rem 0; border: 0; border-bottom: 1px solid var(--console-line); background: transparent; font-size: .76rem; }
+  .platform-table-wrap td:last-child, .capability-table-wrap td:last-child, .storage-table-wrap td:last-child, .knowledge-table td:last-child { border-bottom: 0; }
+  .platform-table-wrap td::before, .capability-table-wrap td::before, .storage-table-wrap td::before, .knowledge-table td::before { color: var(--muted); font-size: .62rem; font-weight: 800; letter-spacing: .05em; text-transform: uppercase; }
   .platform-table-wrap td:nth-child(1)::before, .capability-table-wrap td:nth-child(1)::before { content: "平台"; }
   .platform-table-wrap td:nth-child(2)::before { content: "已配置"; }
   .platform-table-wrap td:nth-child(3)::before { content: "已启用"; }
@@ -419,6 +421,15 @@ textarea { width: 100%; min-height: 25rem; flex: 1; resize: vertical; padding: v
   .storage-table-wrap td:nth-child(6)::before { content: "可写"; }
   .storage-table-wrap td:nth-child(7)::before { content: "错误"; }
   .storage-table-wrap td:nth-child(8)::before { content: "Schema"; }
+  .knowledge-table td:nth-child(1)::before { content: "文件名"; }
+  .knowledge-table td:nth-child(2)::before { content: "类型"; }
+  .knowledge-table td:nth-child(3)::before { content: "大小"; }
+  .knowledge-table td:nth-child(4)::before { content: "上传时间"; }
+  .knowledge-table td:nth-child(5)::before { content: "最近处理"; }
+  .knowledge-table td:nth-child(6)::before { content: "状态"; }
+  .knowledge-table td:nth-child(7)::before { content: "失败原因"; }
+  .knowledge-table td:nth-child(8)::before { content: "操作"; }
+  .knowledge-actions { flex-wrap: wrap; }
 }
 
 @media (max-width: 520px) {
@@ -495,6 +506,33 @@ textarea { width: 100%; min-height: 25rem; flex: 1; resize: vertical; padding: v
   .route-template-row { grid-template-columns: 1fr; }
   .model-route-field-group .config-field-group-grid { grid-template-columns: minmax(0, 1fr); }
   .model-route-add-row { flex-direction: column; align-items: stretch; }
+}
+
+/* ---- 知识库页面：文件处理状态与管理列表 ---- */
+.knowledge-toolbar { display: flex; flex-wrap: wrap; align-items: end; gap: .6rem; margin-bottom: .5rem; }
+.knowledge-toolbar label { display: grid; gap: .2rem; margin: 0; color: var(--muted); font-size: .7rem; font-weight: 700; }
+.knowledge-search input { width: 100%; }
+.knowledge-list { min-width: 0; }
+.knowledge-table { width: 100%; }
+.knowledge-table td:nth-child(1), .knowledge-table td:nth-child(7) { overflow-wrap: anywhere; }
+.knowledge-table td:nth-child(6), .knowledge-table td:nth-child(8) { white-space: nowrap; }
+.knowledge-source-badge { display: inline-flex; align-items: center; width: fit-content; padding: .2rem .4rem; border: 1px solid var(--console-line); border-radius: var(--console-radius); color: var(--accent-strong); background: var(--accent-soft); font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: .6rem; font-weight: 800; letter-spacing: .04em; }
+.knowledge-status { display: inline-flex; align-items: center; gap: .4rem; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: .68rem; font-weight: 800; letter-spacing: .04em; }
+.knowledge-status-dot { display: inline-block; width: .55rem; height: .55rem; flex: 0 0 .55rem; border: 1px solid currentColor; background: currentColor; }
+.knowledge-status--pending, .knowledge-status--processing { color: var(--console-status-warn); }
+.knowledge-status--pending .knowledge-status-dot, .knowledge-status--processing .knowledge-status-dot { transform: rotate(45deg) scale(.82); }
+.knowledge-status--ready { color: var(--console-status-good); }
+.knowledge-status--failed { color: var(--console-status-error); }
+.knowledge-status--failed .knowledge-status-dot { border: 0; clip-path: polygon(50% 0, 100% 100%, 0 100%); }
+.knowledge-status--processing .knowledge-status-dot { animation: knowledge-processing-pulse 1.5s ease-in-out infinite; }
+.knowledge-error-summary { max-width: 14rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.knowledge-actions { white-space: nowrap; }
+.knowledge-action { padding: .35rem .55rem; }
+.knowledge-action--danger { color: var(--console-error); }
+.knowledge-pagination { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: .7rem; margin-top: var(--console-space-5); color: var(--muted); font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: .72rem; }
+@keyframes knowledge-processing-pulse { 0%, 100% { opacity: 1; } 50% { opacity: .45; } }
+@media (prefers-reduced-motion: reduce) {
+  .knowledge-status--processing .knowledge-status-dot { animation: none; }
 }
 
 /* ---- Todo 页面：常用筛选 + 高级筛选折叠 ---- */

--- a/web-console/dist/styles.css
+++ b/web-console/dist/styles.css
@@ -437,8 +437,9 @@ textarea { width: 100%; min-height: 25rem; flex: 1; resize: vertical; padding: v
   .topbar { align-items: flex-start; padding-block: .7rem; }
   .topbar .security-note { display: none; }
   .refresh-box { width: 100%; }
-  .bottom-nav { bottom: calc(.75rem + env(safe-area-inset-bottom)); max-width: calc(100% - 1rem); }
-  .bottom-nav-link { flex-basis: 3.6rem; font-size: .6rem; }
+  .bottom-nav { bottom: calc(.75rem + env(safe-area-inset-bottom)); width: calc(100% - 1rem); max-width: 410px; }
+  .bottom-nav-list { width: 100%; }
+  .bottom-nav-link { flex: 1 1 0; min-width: 0; font-size: .6rem; }
   .console-content > .error, .console-content > .console-page { width: calc(100% - 1rem); }
   .overview-heading, .product-page-heading { flex-direction: column; gap: var(--console-space-3); padding-inline: 0; }
   .overview-heading-meta { justify-items: start; }

--- a/web-console/dist/views/knowledge/knowledge-actions.js
+++ b/web-console/dist/views/knowledge/knowledge-actions.js
@@ -1,4 +1,11 @@
 import { ConsoleApiError } from "../../api.js";
+let deleteDialog = null;
+let deleteDialogTitle = null;
+let deleteDialogMessage = null;
+let deleteDialogCancel = null;
+let deleteDialogConfirm = null;
+let deleteOpener = null;
+let deleteFileId = null;
 export function triggerBrowserDownload(blob, filename) {
     if (typeof URL === "undefined" || typeof document === "undefined" || document.body === null)
         return;
@@ -68,44 +75,24 @@ function openDeleteDialog(item, deps, active) {
     const opener = actionButton(item.file_id, "删除");
     if (opener === null || active.has(opener))
         return;
-    const dialog = document.createElement("dialog");
-    dialog.setAttribute("role", "alertdialog");
-    dialog.setAttribute("aria-modal", "true");
-    const title = document.createElement("h2");
-    title.id = "knowledge-delete-title";
-    title.textContent = `删除文件：${item.filename}`;
-    const message = document.createElement("p");
-    message.id = "knowledge-delete-message";
-    message.textContent = "删除后，该文件及对应的知识库解析和索引数据将被移除，且无法继续被检索。此操作不可恢复。";
-    dialog.setAttribute("aria-labelledby", title.id);
-    dialog.setAttribute("aria-describedby", message.id);
-    const cancel = document.createElement("button");
-    cancel.type = "button";
-    cancel.textContent = "取消";
-    const confirm = document.createElement("button");
-    confirm.type = "button";
-    confirm.className = "danger";
-    confirm.textContent = "删除";
-    dialog.append(title, message, cancel, confirm);
-    if (document.body)
-        document.body.append(dialog);
-    // 对话框无论取消、成功还是冲突都归还焦点，键盘用户能回到触发删除的那一行。
-    const close = () => {
-        if (typeof dialog.close === "function")
-            dialog.close();
-        else
-            dialog.removeAttribute("open");
-        opener.focus();
-    };
-    cancel.onclick = close;
-    dialog.addEventListener("click", (event) => { if (event.target !== dialog)
-        return; });
-    confirm.onclick = () => void confirmDelete(fileId, confirm, close, deps, active);
+    const dialog = ensureDeleteDialog();
+    deleteOpener = opener;
+    deleteFileId = fileId;
+    if (deleteDialogTitle)
+        deleteDialogTitle.textContent = `删除文件：${item.filename}`;
+    if (deleteDialogMessage)
+        deleteDialogMessage.textContent = "删除后，该文件及对应的知识库解析和索引数据将被移除，且无法继续被检索。此操作不可恢复。";
+    const close = () => closeDeleteDialog(opener, fileId);
+    if (deleteDialogCancel)
+        deleteDialogCancel.onclick = close;
+    const confirmButton = deleteDialogConfirm;
+    if (confirmButton)
+        confirmButton.onclick = () => void confirmDelete(fileId, confirmButton, close, deps, active);
+    deleteDialogCancel?.focus();
     if (typeof dialog.showModal === "function")
         dialog.showModal();
     else
         dialog.setAttribute("open", "");
-    cancel.focus();
 }
 async function confirmDelete(fileId, button, close, deps, active) {
     // 确认按钮也单独加锁，避免删除请求尚未完成时重复提交同一文件。
@@ -127,6 +114,65 @@ async function confirmDelete(fileId, button, close, deps, active) {
         active.delete(button);
         button.disabled = false;
     }
+}
+function ensureDeleteDialog() {
+    if (deleteDialog !== null && document.querySelector('[role="alertdialog"]') === deleteDialog)
+        return deleteDialog;
+    const dialog = document.createElement("dialog");
+    dialog.setAttribute("role", "alertdialog");
+    dialog.setAttribute("aria-modal", "true");
+    const title = document.createElement("h2");
+    title.id = "knowledge-delete-title";
+    const message = document.createElement("p");
+    message.id = "knowledge-delete-message";
+    const cancel = document.createElement("button");
+    cancel.type = "button";
+    cancel.textContent = "取消";
+    const confirm = document.createElement("button");
+    confirm.type = "button";
+    confirm.className = "danger";
+    confirm.textContent = "删除";
+    dialog.setAttribute("aria-labelledby", title.id);
+    dialog.setAttribute("aria-describedby", message.id);
+    dialog.append(title, message, cancel, confirm);
+    document.body?.append(dialog);
+    deleteDialog = dialog;
+    deleteDialogTitle = title;
+    deleteDialogMessage = message;
+    deleteDialogCancel = cancel;
+    deleteDialogConfirm = confirm;
+    dialog.addEventListener("cancel", () => {
+        if (deleteOpener !== null && deleteFileId !== null)
+            closeDeleteDialog(deleteOpener, deleteFileId);
+    });
+    return dialog;
+}
+function closeDeleteDialog(opener, fileId) {
+    if (deleteDialog === null)
+        return;
+    if (typeof deleteDialog.close === "function")
+        deleteDialog.close();
+    else
+        deleteDialog.removeAttribute("open");
+    restoreFocus(opener, fileId);
+}
+function restoreFocus(opener, fileId) {
+    if (opener.isConnected !== false) {
+        opener.focus();
+        return;
+    }
+    const rowButton = actionButton(fileId, "删除") ?? actionButton(fileId, "重新处理") ?? actionButton(fileId, "下载");
+    if (rowButton !== null && rowButton.isConnected !== false) {
+        rowButton.focus();
+        return;
+    }
+    const list = document.getElementById("knowledge-list");
+    if (list instanceof HTMLElement) {
+        list.tabIndex = -1;
+        list.focus();
+        return;
+    }
+    document.getElementById("knowledge-upload-open")?.focus();
 }
 function actionButton(fileId, label) {
     const buttons = document.querySelectorAll("button[data-file-id]");

--- a/web-console/dist/views/knowledge/knowledge-actions.js
+++ b/web-console/dist/views/knowledge/knowledge-actions.js
@@ -1,11 +1,16 @@
 import { ConsoleApiError } from "../../api.js";
 export function triggerBrowserDownload(blob, filename) {
+    if (typeof URL === "undefined" || typeof document === "undefined" || document.body === null)
+        return;
     const href = URL.createObjectURL(blob);
     const anchor = document.createElement("a");
     anchor.href = href;
     anchor.download = filename;
+    anchor.style.display = "none";
+    document.body.append(anchor);
     anchor.click();
-    URL.revokeObjectURL(href);
+    anchor.remove();
+    window.setTimeout(() => URL.revokeObjectURL(href), 60_000);
 }
 export function createKnowledgeActionHandlers(deps) {
     // 操作锁按按钮实例隔离，避免重复点击同一行，同时不阻塞其他文件的独立操作。

--- a/web-console/dist/views/knowledge/knowledge-actions.js
+++ b/web-console/dist/views/knowledge/knowledge-actions.js
@@ -8,6 +8,7 @@ export function triggerBrowserDownload(blob, filename) {
     URL.revokeObjectURL(href);
 }
 export function createKnowledgeActionHandlers(deps) {
+    // 操作锁按按钮实例隔离，避免重复点击同一行，同时不阻塞其他文件的独立操作。
     const activeButtons = new WeakSet();
     return {
         onDownload: (item) => void download(item, deps, activeButtons),
@@ -83,6 +84,7 @@ function openDeleteDialog(item, deps, active) {
     dialog.append(title, message, cancel, confirm);
     if (document.body)
         document.body.append(dialog);
+    // 对话框无论取消、成功还是冲突都归还焦点，键盘用户能回到触发删除的那一行。
     const close = () => {
         if (typeof dialog.close === "function")
             dialog.close();
@@ -101,6 +103,7 @@ function openDeleteDialog(item, deps, active) {
     cancel.focus();
 }
 async function confirmDelete(fileId, button, close, deps, active) {
+    // 确认按钮也单独加锁，避免删除请求尚未完成时重复提交同一文件。
     if (active.has(button))
         return;
     active.add(button);

--- a/web-console/dist/views/knowledge/knowledge-actions.js
+++ b/web-console/dist/views/knowledge/knowledge-actions.js
@@ -1,0 +1,133 @@
+import { ConsoleApiError } from "../../api.js";
+export function triggerBrowserDownload(blob, filename) {
+    const href = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = href;
+    anchor.download = filename;
+    anchor.click();
+    URL.revokeObjectURL(href);
+}
+export function createKnowledgeActionHandlers(deps) {
+    const activeButtons = new WeakSet();
+    return {
+        onDownload: (item) => void download(item, deps, activeButtons),
+        onDelete: (item) => openDeleteDialog(item, deps, activeButtons),
+        onRetry: (item) => void retry(item, deps, activeButtons),
+    };
+}
+async function download(item, deps, active) {
+    if (!item.downloadable || item.source !== "managed" || item.file_id === null)
+        return;
+    const button = actionButton(item.file_id, "下载");
+    if (button === null || active.has(button))
+        return;
+    active.add(button);
+    button.disabled = true;
+    try {
+        const result = await deps.download(item);
+        deps.triggerDownload(result.blob, result.filename);
+    }
+    catch (cause) {
+        deps.setStatus(safeMessage(cause));
+    }
+    finally {
+        active.delete(button);
+        button.disabled = false;
+    }
+}
+async function retry(item, deps, active) {
+    if (item.status !== "failed" || item.source !== "managed" || item.file_id === null)
+        return;
+    const button = actionButton(item.file_id, "重新处理");
+    if (button === null || active.has(button))
+        return;
+    active.add(button);
+    button.disabled = true;
+    try {
+        await deps.retryFile(item.file_id);
+        deps.refresh("retry");
+    }
+    catch (cause) {
+        deps.setStatus(safeMessage(cause));
+    }
+    finally {
+        active.delete(button);
+        button.disabled = false;
+    }
+}
+function openDeleteDialog(item, deps, active) {
+    if (item.source !== "managed" || item.file_id === null || item.status === "processing")
+        return;
+    const fileId = item.file_id;
+    const opener = actionButton(item.file_id, "删除");
+    if (opener === null || active.has(opener))
+        return;
+    const dialog = document.createElement("dialog");
+    dialog.setAttribute("role", "alertdialog");
+    dialog.setAttribute("aria-modal", "true");
+    const title = document.createElement("h2");
+    title.id = "knowledge-delete-title";
+    title.textContent = `删除文件：${item.filename}`;
+    const message = document.createElement("p");
+    message.id = "knowledge-delete-message";
+    message.textContent = "删除后，该文件及对应的知识库解析和索引数据将被移除，且无法继续被检索。此操作不可恢复。";
+    dialog.setAttribute("aria-labelledby", title.id);
+    dialog.setAttribute("aria-describedby", message.id);
+    const cancel = document.createElement("button");
+    cancel.type = "button";
+    cancel.textContent = "取消";
+    const confirm = document.createElement("button");
+    confirm.type = "button";
+    confirm.className = "danger";
+    confirm.textContent = "删除";
+    dialog.append(title, message, cancel, confirm);
+    if (document.body)
+        document.body.append(dialog);
+    const close = () => {
+        if (typeof dialog.close === "function")
+            dialog.close();
+        else
+            dialog.removeAttribute("open");
+        opener.focus();
+    };
+    cancel.onclick = close;
+    dialog.addEventListener("click", (event) => { if (event.target !== dialog)
+        return; });
+    confirm.onclick = () => void confirmDelete(fileId, confirm, close, deps, active);
+    if (typeof dialog.showModal === "function")
+        dialog.showModal();
+    else
+        dialog.setAttribute("open", "");
+    cancel.focus();
+}
+async function confirmDelete(fileId, button, close, deps, active) {
+    if (active.has(button))
+        return;
+    active.add(button);
+    button.disabled = true;
+    try {
+        await deps.deleteFile(fileId);
+        close();
+        deps.refresh("delete");
+        deps.setStatus("文件已删除");
+    }
+    catch (cause) {
+        close();
+        deps.setStatus(cause instanceof ConsoleApiError && cause.status === 409 ? "文件正在处理中，暂不能删除" : safeMessage(cause));
+    }
+    finally {
+        active.delete(button);
+        button.disabled = false;
+    }
+}
+function actionButton(fileId, label) {
+    const buttons = document.querySelectorAll("button[data-file-id]");
+    for (const button of buttons) {
+        if (button instanceof HTMLButtonElement && button.dataset.fileId === fileId && button.textContent === label)
+            return button;
+    }
+    return null;
+}
+function safeMessage(cause) {
+    return cause instanceof Error ? cause.message : "操作失败，请稍后重试";
+}

--- a/web-console/dist/views/knowledge/knowledge-list.js
+++ b/web-console/dist/views/knowledge/knowledge-list.js
@@ -1,0 +1,87 @@
+import { formatBytes, formatDateTime, renderKnowledgeStatus } from "./knowledge-status.js";
+const HEADERS = ["文件名", "类型", "大小", "上传时间", "最近处理", "状态", "失败原因", "操作"];
+export function renderKnowledgeList(target, items, callbacks) {
+    const table = document.createElement("table");
+    table.className = "knowledge-table";
+    const head = document.createElement("thead");
+    const headRow = document.createElement("tr");
+    for (const label of HEADERS) {
+        const cell = document.createElement("th");
+        cell.textContent = label;
+        headRow.append(cell);
+    }
+    head.append(headRow);
+    const body = document.createElement("tbody");
+    for (const item of items)
+        body.append(knowledgeRow(item, callbacks));
+    table.append(head, body);
+    target.replaceChildren(table);
+}
+export function renderKnowledgeEmpty(target) {
+    const hint = document.createElement("p");
+    hint.className = "hint";
+    hint.textContent = "暂无知识库文件";
+    target.replaceChildren(hint);
+}
+function knowledgeRow(item, callbacks) {
+    const row = document.createElement("tr");
+    const filename = document.createElement("td");
+    filename.textContent = item.filename;
+    const badge = document.createElement("span");
+    badge.className = "knowledge-source-badge";
+    badge.textContent = item.source === "managed" ? "托管" : "目录";
+    filename.append(document.createTextNode(" "), badge);
+    row.append(filename, textCell(shortContentType(item.content_type)), textCell(formatBytes(item.size)));
+    row.append(textCell(formatDateTime(item.uploaded_at)), textCell(formatDateTime(latestProcessingTime(item))));
+    const status = document.createElement("td");
+    renderKnowledgeStatus(status, item);
+    row.append(status, errorCell(item.error_summary), actionsCell(item, callbacks));
+    return row;
+}
+function textCell(value) {
+    const cell = document.createElement("td");
+    cell.textContent = value;
+    return cell;
+}
+function errorCell(error) {
+    const cell = textCell(error || "—");
+    cell.className = "knowledge-error-summary";
+    if (error)
+        cell.title = error;
+    return cell;
+}
+function actionsCell(item, callbacks) {
+    const cell = document.createElement("td");
+    cell.className = "knowledge-actions";
+    if (item.source === "directory") {
+        cell.textContent = "—";
+        return cell;
+    }
+    if (item.downloadable)
+        cell.append(actionButton("下载", item, "knowledge-action secondary", callbacks.onDownload));
+    if (item.status === "failed")
+        cell.append(actionButton("重新处理", item, "knowledge-action secondary", callbacks.onRetry));
+    if (item.status !== "processing")
+        cell.append(actionButton("删除", item, "knowledge-action knowledge-action--danger danger", callbacks.onDelete));
+    return cell;
+}
+function actionButton(label, item, className, callback) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = className;
+    button.textContent = label;
+    if (item.file_id !== null)
+        button.dataset.fileId = item.file_id;
+    button.onclick = () => callback?.(item);
+    return button;
+}
+function shortContentType(contentType) {
+    return contentType.startsWith(".") ? contentType.slice(1) : contentType;
+}
+function latestProcessingTime(item) {
+    if (item.processing_started_at === null)
+        return item.processed_at;
+    if (item.processed_at === null)
+        return item.processing_started_at;
+    return item.processing_started_at > item.processed_at ? item.processing_started_at : item.processed_at;
+}

--- a/web-console/dist/views/knowledge/knowledge-list.js
+++ b/web-console/dist/views/knowledge/knowledge-list.js
@@ -34,7 +34,9 @@ function knowledgeRow(item, callbacks) {
     row.append(filename, textCell(shortContentType(item.content_type)), textCell(formatBytes(item.size)));
     row.append(textCell(formatDateTime(item.uploaded_at)), textCell(formatDateTime(latestProcessingTime(item))));
     const status = document.createElement("td");
-    renderKnowledgeStatus(status, item);
+    const statusBadge = document.createElement("span");
+    renderKnowledgeStatus(statusBadge, item);
+    status.append(statusBadge);
     row.append(status, errorCell(item.error_summary), actionsCell(item, callbacks));
     return row;
 }

--- a/web-console/dist/views/knowledge/knowledge-paging.js
+++ b/web-console/dist/views/knowledge/knowledge-paging.js
@@ -1,0 +1,17 @@
+export function initialKnowledgePager() {
+    return { page: 1, totalPages: 0, loadedCount: 0, hasMore: false };
+}
+export function appendKnowledgePage(pager, page) {
+    return {
+        page: page.page,
+        totalPages: page.total_pages,
+        loadedCount: pager.loadedCount + page.items.length,
+        hasMore: page.page < page.total_pages,
+    };
+}
+export function hasMoreKnowledgePages(pager) {
+    return pager.hasMore;
+}
+export function pageAfterKnowledgeDelete(pager, deletedCount) {
+    return { ...pager, loadedCount: Math.max(0, pager.loadedCount - deletedCount) };
+}

--- a/web-console/dist/views/knowledge/knowledge-polling.js
+++ b/web-console/dist/views/knowledge/knowledge-polling.js
@@ -1,0 +1,87 @@
+const POLL_INTERVAL_MS = 5_000;
+const MAX_CONSECUTIVE_FAILURES = 3;
+export class KnowledgePollingController {
+    deps;
+    timerId = null;
+    params = null;
+    items = [];
+    failures = 0;
+    generation = 0;
+    constructor(deps) {
+        this.deps = deps;
+    }
+    start(params) {
+        this.params = { ...params };
+        this.failures = 0;
+        this.resetTimer();
+    }
+    stop() {
+        this.generation += 1;
+        if (this.timerId !== null)
+            this.deps.clearTimeout(this.timerId);
+        this.timerId = null;
+    }
+    setPages(items) {
+        this.items = [...items];
+    }
+    hasActive() {
+        return this.items.some((item) => item.status === "pending" || item.status === "processing");
+    }
+    notifyChange() {
+        this.resetTimer();
+    }
+    resetTimer() {
+        this.stop();
+        if (this.params !== null && this.hasActive())
+            this.schedule();
+    }
+    schedule() {
+        this.timerId = this.deps.setTimeout(() => void this.tick(), POLL_INTERVAL_MS);
+    }
+    async tick() {
+        this.timerId = null;
+        if (!this.hasActive() || this.params === null)
+            return;
+        if (!this.deps.isVisible()) {
+            this.schedule();
+            return;
+        }
+        const generation = ++this.generation;
+        try {
+            const page = await this.deps.fetchPage(this.params);
+            if (generation !== this.generation)
+                return;
+            this.reportTerminalTransitions(page.items);
+            this.items = [...page.items];
+            this.failures = 0;
+            this.deps.onUpdate(page);
+            if (this.hasActive())
+                this.schedule();
+        }
+        catch (cause) {
+            if (generation !== this.generation)
+                return;
+            this.failures += 1;
+            this.deps.onTransientError("状态刷新失败");
+            if (this.failures >= MAX_CONSECUTIVE_FAILURES) {
+                this.stop();
+                this.deps.onTransientError("状态刷新多次失败，请手动刷新");
+            }
+            else {
+                this.schedule();
+            }
+        }
+    }
+    reportTerminalTransitions(nextItems) {
+        const previous = new Map(this.items.map((item) => [item.file_id, item.status]));
+        for (const item of nextItems) {
+            const status = previous.get(item.file_id);
+            if ((status === "pending" || status === "processing") && item.status === "ready") {
+                this.deps.onTerminalTransition("文件处理完成");
+            }
+            if ((status === "pending" || status === "processing") && item.status === "failed") {
+                this.deps.onTerminalTransition("文件处理失败");
+            }
+        }
+    }
+}

--- a/web-console/dist/views/knowledge/knowledge-polling.js
+++ b/web-console/dist/views/knowledge/knowledge-polling.js
@@ -15,6 +15,10 @@ export class KnowledgePollingController {
         this.failures = 0;
         this.resetTimer();
     }
+    updateParams(params) {
+        this.params = { ...params };
+        this.resetTimer();
+    }
     stop() {
         this.generation += 1;
         if (this.timerId !== null)

--- a/web-console/dist/views/knowledge/knowledge-polling.js
+++ b/web-console/dist/views/knowledge/knowledge-polling.js
@@ -52,13 +52,19 @@ export class KnowledgePollingController {
         }
         const generation = ++this.generation;
         try {
-            const page = await this.deps.fetchPage(this.params);
+            const pages = await this.deps.fetchPages(this.params, this.pageCount());
             if (generation !== this.generation)
                 return;
-            this.reportTerminalTransitions(page.items);
-            this.items = [...page.items];
+            if (pages.length === 0) {
+                if (this.hasActive())
+                    this.schedule();
+                return;
+            }
+            const nextItems = pages.flatMap((page) => page.items);
+            this.reportTerminalTransitions(nextItems);
+            this.items = nextItems;
             this.failures = 0;
-            this.deps.onUpdate(page);
+            this.deps.onUpdate(pages);
             if (this.hasActive())
                 this.schedule();
         }
@@ -75,6 +81,9 @@ export class KnowledgePollingController {
                 this.schedule();
             }
         }
+    }
+    pageCount() {
+        return Math.max(1, this.params?.page ?? 1);
     }
     reportTerminalTransitions(nextItems) {
         const previous = new Map(this.items.map((item) => [item.file_id, item.status]));

--- a/web-console/dist/views/knowledge/knowledge-status.js
+++ b/web-console/dist/views/knowledge/knowledge-status.js
@@ -1,0 +1,32 @@
+export function knowledgeStatusMeta(status) {
+    switch (status) {
+        case "pending": return { label: "等待处理", className: "knowledge-status--pending" };
+        case "processing": return { label: "处理中", className: "knowledge-status--processing" };
+        case "ready": return { label: "已完成", className: "knowledge-status--ready" };
+        case "failed": return { label: "处理失败", className: "knowledge-status--failed" };
+    }
+}
+export function renderKnowledgeStatus(target, item) {
+    const meta = knowledgeStatusMeta(item.status);
+    target.className = `knowledge-status ${meta.className}`;
+    target.replaceChildren();
+    const dot = document.createElement("span");
+    dot.className = "knowledge-status-dot";
+    dot.setAttribute("aria-hidden", "true");
+    target.append(dot, document.createTextNode(meta.label));
+}
+export function formatBytes(size) {
+    if (size === null || size === 0)
+        return "—";
+    if (size < 1024)
+        return `${size} B`;
+    if (size < 1024 * 1024)
+        return `${formatDecimal(size / 1024)} KB`;
+    return `${formatDecimal(size / (1024 * 1024))} MB`;
+}
+export function formatDateTime(value) {
+    return value ? value.replace("T", " ").slice(0, 16) : "—";
+}
+function formatDecimal(value) {
+    return Number(value.toFixed(1)).toString();
+}

--- a/web-console/dist/views/knowledge/knowledge-upload.js
+++ b/web-console/dist/views/knowledge/knowledge-upload.js
@@ -1,12 +1,19 @@
 import { ConsoleApiError } from "../../api.js";
 import { requiredElement } from "../../dom.js";
+export function formatFileSizeLimit(bytes) {
+    if (bytes >= 1024 * 1024)
+        return `${Number((bytes / (1024 * 1024)).toFixed(1))} MB`;
+    if (bytes >= 1024)
+        return `${Number((bytes / 1024).toFixed(1))} KB`;
+    return `${bytes} B`;
+}
 export function validateKnowledgeFile(file, capabilities) {
     const extensions = capabilities.supported_extensions.map((extension) => extension.toLowerCase());
     if (!extensions.some((extension) => file.name.toLowerCase().endsWith(extension))) {
         return { ok: false, reason: `仅支持 ${capabilities.supported_extensions.join(" / ")} 文件` };
     }
     if (file.size > capabilities.max_file_bytes) {
-        return { ok: false, reason: `文件大小超过上限（${capabilities.max_file_bytes / 1024 / 1024} MB）` };
+        return { ok: false, reason: `文件大小超过上限（${formatFileSizeLimit(capabilities.max_file_bytes)}）` };
     }
     if (file.name.length > capabilities.max_filename_chars)
         return { ok: false, reason: "文件名过长" };

--- a/web-console/dist/views/knowledge/knowledge-upload.js
+++ b/web-console/dist/views/knowledge/knowledge-upload.js
@@ -37,8 +37,11 @@ async function uploadSelectedFile(input, button, deps) {
     const capabilities = deps.getCapabilities();
     if (capabilities !== null) {
         const validation = validateKnowledgeFile(file, capabilities);
-        if (!validation.ok)
-            deps.setStatus(`警告：${validation.reason}，服务端可能拒绝`);
+        if (!validation.ok) {
+            deps.setStatus(`上传已阻止：${validation.reason}`);
+            input.value = "";
+            return;
+        }
     }
     button.disabled = true;
     deps.setStatus("上传中…");

--- a/web-console/dist/views/knowledge/knowledge-upload.js
+++ b/web-console/dist/views/knowledge/knowledge-upload.js
@@ -1,0 +1,50 @@
+import { ConsoleApiError } from "../../api.js";
+import { requiredElement } from "../../dom.js";
+export function validateKnowledgeFile(file, capabilities) {
+    const extensions = capabilities.supported_extensions.map((extension) => extension.toLowerCase());
+    if (!extensions.some((extension) => file.name.toLowerCase().endsWith(extension))) {
+        return { ok: false, reason: `仅支持 ${capabilities.supported_extensions.join(" / ")} 文件` };
+    }
+    if (file.size > capabilities.max_file_bytes) {
+        return { ok: false, reason: `文件大小超过上限（${capabilities.max_file_bytes / 1024 / 1024} MB）` };
+    }
+    if (file.name.length > capabilities.max_filename_chars)
+        return { ok: false, reason: "文件名过长" };
+    return { ok: true, file };
+}
+export function installKnowledgeUpload(deps) {
+    const button = requiredElement(deps.buttonId, HTMLButtonElement);
+    const input = document.createElement("input");
+    input.id = deps.inputId;
+    input.type = "file";
+    input.hidden = true;
+    input.accept = deps.getCapabilities()?.supported_extensions.join(",") ?? "";
+    document.body.append(input);
+    button.onclick = () => input.click();
+    input.addEventListener("change", () => { void uploadSelectedFile(input, button, deps); });
+}
+async function uploadSelectedFile(input, button, deps) {
+    const file = input.files?.[0];
+    if (file === undefined)
+        return;
+    const capabilities = deps.getCapabilities();
+    if (capabilities !== null) {
+        const validation = validateKnowledgeFile(file, capabilities);
+        if (!validation.ok)
+            deps.setStatus(`警告：${validation.reason}，服务端可能拒绝`);
+    }
+    button.disabled = true;
+    deps.setStatus("上传中…");
+    try {
+        await deps.upload(file);
+        deps.setStatus("文件已上传，正在等待处理");
+        deps.onUploaded();
+    }
+    catch (cause) {
+        deps.setStatus(cause instanceof ConsoleApiError ? `${cause.message}（${cause.code}）` : "文件上传失败");
+    }
+    finally {
+        button.disabled = false;
+        input.value = "";
+    }
+}

--- a/web-console/dist/views/knowledge/knowledge.js
+++ b/web-console/dist/views/knowledge/knowledge.js
@@ -7,18 +7,42 @@ import { KnowledgePollingController } from "./knowledge-polling.js";
 import { installKnowledgeUpload } from "./knowledge-upload.js";
 let capabilities = null;
 let pager = initialKnowledgePager();
-let loadedItems = [];
-let currentParams = defaultKnowledgeParams();
+let loadedPages = 0;
+let itemsByPage = new Map();
+let allItems = [];
+let filterParams = defaultKnowledgeParams();
 let uploadFlowInstalled = false;
+let loadMoreInFlight = false;
+let requestGeneration = 0;
+let knowledgeInitialized = false;
+let controlsBound = false;
+let documentListenersBound = false;
+const onVisibilityChange = () => {
+    if (document.visibilityState !== "hidden" && polling.hasActive())
+        polling.notifyChange();
+};
+const onPageHide = () => polling.stop();
 const polling = new KnowledgePollingController({
     isVisible: () => typeof document === "undefined" || document.visibilityState !== "hidden",
     setTimeout: (fn, ms) => window.setTimeout(fn, ms),
     clearTimeout: (id) => window.clearTimeout(id),
-    fetchPage: (params) => listKnowledgeFiles({ ...params, page: 1 }),
-    onUpdate: (page) => {
-        currentParams = { ...currentParams, page: page.page };
-        pager = appendKnowledgePage(initialKnowledgePager(), page);
-        loadedItems = [...page.items];
+    fetchPages: (params, pageCount) => {
+        const generation = ++requestGeneration;
+        return Promise.all(Array.from({ length: pageCount }, (_, index) => listKnowledgeFiles({ ...params, page: index + 1 }))).then((pages) => {
+            if (generation !== requestGeneration || !paramsMatch({ ...params, page: 1 }, { ...filterParams, page: 1 }))
+                return [];
+            return pages;
+        });
+    },
+    onUpdate: (pages) => {
+        if (pages.length === 0)
+            return;
+        for (const page of pages)
+            itemsByPage.set(page.page, [...page.items]);
+        const lastPage = pages[pages.length - 1];
+        if (lastPage === undefined)
+            return;
+        rebuildLoadedState(lastPage);
         renderKnowledgeContent();
     },
     onTransientError: (message) => setText("knowledge-result", message),
@@ -31,10 +55,14 @@ const actions = createKnowledgeActionHandlers({
     deleteFile: deleteKnowledgeFile,
     retryFile: retryKnowledgeFile,
     refresh: (reason) => void refreshKnowledgeList(reason),
-    getItems: () => loadedItems,
+    getItems: () => allItems,
 });
 export async function initializeKnowledge() {
+    if (knowledgeInitialized)
+        return;
+    knowledgeInitialized = true;
     bindKnowledgeControls();
+    bindDocumentListeners();
     try {
         capabilities = await fetchKnowledgeCapabilities();
     }
@@ -42,57 +70,79 @@ export async function initializeKnowledge() {
         showKnowledgeError(cause, "知识库能力加载失败");
     }
     if (!uploadFlowInstalled) {
-        installKnowledgeUpload({
-            inputId: "knowledge-upload-input",
-            buttonId: "knowledge-upload-open",
-            setStatus: (text) => setText("knowledge-result", text),
-            getCapabilities: getKnowledgeCapabilities,
-            upload: uploadKnowledgeFile,
-            onUploaded: () => void refreshKnowledgeList("upload"),
-        });
+        installKnowledgeUpload({ inputId: "knowledge-upload-input", buttonId: "knowledge-upload-open", setStatus: (text) => setText("knowledge-result", text), getCapabilities: getKnowledgeCapabilities, upload: uploadKnowledgeFile, onUploaded: () => void refreshKnowledgeList("upload") });
         uploadFlowInstalled = true;
     }
     await refreshKnowledgeList("refresh");
-    polling.start(currentParams);
+    polling.start({ ...filterParams, page: loadedPages || 1 });
+}
+export function disposeKnowledge() {
+    polling.stop();
+    requestGeneration += 1;
+    if (documentListenersBound && typeof document !== "undefined" && typeof document.removeEventListener === "function")
+        document.removeEventListener("visibilitychange", onVisibilityChange);
+    if (documentListenersBound && typeof window !== "undefined" && typeof window.removeEventListener === "function")
+        window.removeEventListener("pagehide", onPageHide);
+    documentListenersBound = false;
+    const input = typeof document === "undefined" ? null : document.getElementById("knowledge-upload-input");
+    if (input && typeof input.remove === "function")
+        input.remove();
+    capabilities = null;
+    pager = initialKnowledgePager();
+    loadedPages = 0;
+    itemsByPage.clear();
+    allItems = [];
+    filterParams = defaultKnowledgeParams();
+    uploadFlowInstalled = false;
+    knowledgeInitialized = false;
+    controlsBound = false;
+    loadMoreInFlight = false;
     if (typeof document !== "undefined") {
-        document.addEventListener("visibilitychange", () => {
-            if (document.visibilityState !== "hidden" && polling.hasActive())
-                polling.notifyChange();
-        });
-    }
-    if (typeof window !== "undefined" && typeof window.addEventListener === "function") {
-        window.addEventListener("pagehide", () => polling.stop());
+        document.getElementById("knowledge-list")?.replaceChildren();
+        document.getElementById("knowledge-pagination")?.replaceChildren();
+        if (document.getElementById("knowledge-result"))
+            setText("knowledge-result", "");
     }
 }
 export function getKnowledgeCapabilities() {
     return capabilities;
 }
 export async function refreshKnowledgeList(reason) {
-    // 各入口共用此刷新边界：筛选和手动刷新从第一页替换，其余操作保留当前筛选条件。
+    const generation = ++requestGeneration;
     const reset = reason === "refresh" || reason === "filter";
     if (reset) {
-        currentParams = { ...currentParams, page: 1 };
+        itemsByPage.clear();
+        loadedPages = 0;
+        allItems = [];
         pager = initialKnowledgePager();
-        loadedItems = [];
     }
-    if (loadedItems.length === 0)
+    if (allItems.length === 0)
         renderKnowledgeLoading();
+    const params = { ...filterParams, page: 1 };
     try {
-        const page = await listKnowledgeFiles({ ...currentParams, page: 1 });
-        currentParams = { ...currentParams, page: page.page };
-        pager = appendKnowledgePage(initialKnowledgePager(), page);
-        loadedItems = [...page.items];
-        // 筛选成功后立即替换轮询参数，防止旧条件的异步结果覆盖当前视图。
-        polling.updateParams(currentParams);
-        polling.setPages(loadedItems);
-        polling.notifyChange();
+        const page = await listKnowledgeFiles(params);
+        if (generation !== requestGeneration || !paramsMatch(params, { ...filterParams, page: 1 }))
+            return;
+        itemsByPage.set(1, [...page.items]);
+        loadedPages = reset ? 1 : Math.max(loadedPages, 1);
+        rebuildLoadedState(page);
+        polling.updateParams({ ...filterParams, page: loadedPages });
+        polling.setPages(allItems);
         renderKnowledgeContent();
+        polling.notifyChange();
     }
     catch (cause) {
+        if (generation !== requestGeneration)
+            return;
         showKnowledgeError(cause, "知识库列表加载失败");
+        if (allItems.length === 0)
+            renderKnowledgeLoadError();
     }
 }
 function bindKnowledgeControls() {
+    if (controlsBound)
+        return;
+    controlsBound = true;
     const search = requiredElement("knowledge-search", HTMLInputElement);
     const status = requiredElement("knowledge-status-filter", HTMLSelectElement);
     const submit = requiredElement("knowledge-filter-submit", HTMLButtonElement);
@@ -107,22 +157,52 @@ function bindKnowledgeControls() {
         apply();
     } });
 }
+function bindDocumentListeners() {
+    if (documentListenersBound)
+        return;
+    documentListenersBound = true;
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    if (typeof window.addEventListener === "function")
+        window.addEventListener("pagehide", onPageHide);
+}
 function syncKnowledgeFilters(search, status) {
-    currentParams = { ...currentParams, page: 1, search: search.value.trim(), status: knowledgeStatusValue(status.value) };
+    requestGeneration += 1;
+    filterParams = { ...filterParams, search: search.value.trim(), status: knowledgeStatusValue(status.value) };
+}
+function rebuildLoadedState(lastPage) {
+    pager = appendKnowledgePage({ ...pager, loadedCount: 0 }, lastPage);
+    pager = { ...pager, page: loadedPages, loadedCount: allPageItems().length, hasMore: loadedPages < lastPage.total_pages };
+    allItems = allPageItems();
+}
+function allPageItems() {
+    return Array.from({ length: loadedPages }, (_, index) => itemsByPage.get(index + 1) ?? []).flat();
+}
+function paramsMatch(left, right) {
+    return left.page_size === right.page_size && left.search === right.search && left.status === right.status && left.sort === right.sort && left.order === right.order;
 }
 function renderKnowledgeLoading() {
-    const target = requiredElement("knowledge-list", HTMLElement);
     const hint = document.createElement("p");
     hint.className = "hint";
     hint.textContent = "正在加载知识库…";
-    target.replaceChildren(hint);
+    requiredElement("knowledge-list", HTMLElement).replaceChildren(hint);
+}
+function renderKnowledgeLoadError() {
+    const target = requiredElement("knowledge-list", HTMLElement);
+    const hint = document.createElement("p");
+    hint.className = "hint";
+    hint.textContent = "知识库列表加载失败";
+    const retry = document.createElement("button");
+    retry.type = "button";
+    retry.textContent = "重试";
+    retry.onclick = () => void refreshKnowledgeList("refresh");
+    target.replaceChildren(hint, retry);
 }
 function renderKnowledgeContent() {
     const target = requiredElement("knowledge-list", HTMLElement);
-    if (loadedItems.length === 0)
+    if (allItems.length === 0)
         renderKnowledgeEmpty(target);
     else
-        renderKnowledgeList(target, loadedItems, actions);
+        renderKnowledgeList(target, allItems, actions);
     renderKnowledgePagination();
 }
 function renderKnowledgePagination() {
@@ -133,33 +213,52 @@ function renderKnowledgePagination() {
     const button = document.createElement("button");
     button.type = "button";
     button.className = "secondary";
-    button.textContent = "加载更多";
+    button.textContent = loadMoreInFlight ? "加载中…" : "加载更多";
+    button.disabled = loadMoreInFlight;
     button.onclick = () => void loadMoreKnowledgeFiles();
     target.append(button);
 }
 async function loadMoreKnowledgeFiles() {
-    if (!hasMoreKnowledgePages(pager))
+    if (loadMoreInFlight || !hasMoreKnowledgePages(pager))
         return;
+    const previous = { loadedPages, pager: { ...pager }, allItems: [...allItems] };
+    const generation = ++requestGeneration;
+    const pageNumber = loadedPages + 1;
+    const params = { ...filterParams, page: pageNumber };
+    loadMoreInFlight = true;
+    renderKnowledgePagination();
     try {
-        currentParams = { ...currentParams, page: currentParams.page + 1 };
-        const page = await listKnowledgeFiles(currentParams);
-        pager = appendKnowledgePage(pager, page);
-        loadedItems = [...loadedItems, ...page.items];
-        // 分页也保持控制器快照与页面条件一致；轮询请求仍固定拉取第一页的状态。
-        polling.updateParams(currentParams);
-        polling.setPages(loadedItems);
-        polling.notifyChange();
+        const page = await listKnowledgeFiles(params);
+        if (generation !== requestGeneration || !paramsMatch(params, { ...filterParams, page: pageNumber }))
+            return;
+        itemsByPage.set(pageNumber, [...page.items]);
+        loadedPages = pageNumber;
+        rebuildLoadedState(page);
+        polling.updateParams({ ...filterParams, page: loadedPages });
+        polling.setPages(allItems);
         renderKnowledgeContent();
+        polling.notifyChange();
     }
     catch (cause) {
-        showKnowledgeError(cause, "知识库列表加载失败");
+        if (generation === requestGeneration) {
+            loadedPages = previous.loadedPages;
+            pager = previous.pager;
+            allItems = previous.allItems;
+            showKnowledgeError(cause, "知识库列表加载失败");
+            renderKnowledgeContent();
+        }
+    }
+    finally {
+        loadMoreInFlight = false;
+        if (generation === requestGeneration)
+            renderKnowledgePagination();
     }
 }
 function showKnowledgeError(cause, fallback) {
     setText("knowledge-result", cause instanceof Error ? cause.message : fallback);
 }
 function defaultKnowledgeParams() {
-    return { page: 1, page_size: 20, search: "", status: "all", sort: "updated_at", order: "desc" };
+    return { page_size: 20, search: "", status: "all", sort: "updated_at", order: "desc" };
 }
 function knowledgeStatusValue(value) {
     switch (value) {

--- a/web-console/dist/views/knowledge/knowledge.js
+++ b/web-console/dist/views/knowledge/knowledge.js
@@ -68,6 +68,7 @@ export function getKnowledgeCapabilities() {
     return capabilities;
 }
 export async function refreshKnowledgeList(reason) {
+    // 各入口共用此刷新边界：筛选和手动刷新从第一页替换，其余操作保留当前筛选条件。
     const reset = reason === "refresh" || reason === "filter";
     if (reset) {
         currentParams = { ...currentParams, page: 1 };
@@ -81,6 +82,8 @@ export async function refreshKnowledgeList(reason) {
         currentParams = { ...currentParams, page: page.page };
         pager = appendKnowledgePage(initialKnowledgePager(), page);
         loadedItems = [...page.items];
+        // 筛选成功后立即替换轮询参数，防止旧条件的异步结果覆盖当前视图。
+        polling.updateParams(currentParams);
         polling.setPages(loadedItems);
         polling.notifyChange();
         renderKnowledgeContent();
@@ -142,6 +145,8 @@ async function loadMoreKnowledgeFiles() {
         const page = await listKnowledgeFiles(currentParams);
         pager = appendKnowledgePage(pager, page);
         loadedItems = [...loadedItems, ...page.items];
+        // 分页也保持控制器快照与页面条件一致；轮询请求仍固定拉取第一页的状态。
+        polling.updateParams(currentParams);
         polling.setPages(loadedItems);
         polling.notifyChange();
         renderKnowledgeContent();

--- a/web-console/dist/views/knowledge/knowledge.js
+++ b/web-console/dist/views/knowledge/knowledge.js
@@ -22,6 +22,15 @@ const onVisibilityChange = () => {
         polling.notifyChange();
 };
 const onPageHide = () => polling.stop();
+const onSearchKeydown = (event) => {
+    if (event.key === "Enter") {
+        event.preventDefault();
+        const search = requiredElement("knowledge-search", HTMLInputElement);
+        const status = requiredElement("knowledge-status-filter", HTMLSelectElement);
+        syncKnowledgeFilters(search, status);
+        void refreshKnowledgeList("filter");
+    }
+};
 const polling = new KnowledgePollingController({
     isVisible: () => typeof document === "undefined" || document.visibilityState !== "hidden",
     setTimeout: (fn, ms) => window.setTimeout(fn, ms),
@@ -83,6 +92,9 @@ export function disposeKnowledge() {
         document.removeEventListener("visibilitychange", onVisibilityChange);
     if (documentListenersBound && typeof window !== "undefined" && typeof window.removeEventListener === "function")
         window.removeEventListener("pagehide", onPageHide);
+    const search = typeof document === "undefined" ? null : document.getElementById("knowledge-search");
+    if (typeof HTMLInputElement !== "undefined" && search instanceof HTMLInputElement)
+        search.removeEventListener("keydown", onSearchKeydown);
     documentListenersBound = false;
     const input = typeof document === "undefined" ? null : document.getElementById("knowledge-upload-input");
     if (input && typeof input.remove === "function")
@@ -152,10 +164,7 @@ function bindKnowledgeControls() {
     submit.onclick = apply;
     reset.onclick = () => { search.value = ""; status.value = "all"; syncKnowledgeFilters(search, status); void refreshKnowledgeList("filter"); };
     refresh.onclick = () => void refreshKnowledgeList("refresh");
-    search.addEventListener("keydown", (event) => { if (event.key === "Enter") {
-        event.preventDefault();
-        apply();
-    } });
+    search.addEventListener("keydown", onSearchKeydown);
 }
 function bindDocumentListeners() {
     if (documentListenersBound)

--- a/web-console/dist/views/knowledge/knowledge.js
+++ b/web-console/dist/views/knowledge/knowledge.js
@@ -1,3 +1,121 @@
+import { fetchKnowledgeCapabilities, listKnowledgeFiles } from "../../api.js";
+import { requiredElement, setText } from "../../dom.js";
+import { renderKnowledgeEmpty, renderKnowledgeList } from "./knowledge-list.js";
+import { appendKnowledgePage, hasMoreKnowledgePages, initialKnowledgePager } from "./knowledge-paging.js";
+let capabilities = null;
+let pager = initialKnowledgePager();
+let loadedItems = [];
+let currentParams = defaultKnowledgeParams();
+let uploadHandler = null;
 export async function initializeKnowledge() {
-    /* Todo 4 实现页面控制器 */
+    bindKnowledgeControls();
+    try {
+        capabilities = await fetchKnowledgeCapabilities();
+    }
+    catch (cause) {
+        showKnowledgeError(cause, "知识库能力加载失败");
+    }
+    await refreshKnowledgeList("refresh");
+}
+export function setKnowledgeUploadHandler(handler) {
+    uploadHandler = handler;
+}
+export function getKnowledgeCapabilities() {
+    return capabilities;
+}
+export async function refreshKnowledgeList(reason) {
+    const reset = reason === "refresh" || reason === "filter";
+    if (reset) {
+        currentParams = { ...currentParams, page: 1 };
+        pager = initialKnowledgePager();
+        loadedItems = [];
+    }
+    if (loadedItems.length === 0)
+        renderKnowledgeLoading();
+    try {
+        const page = await listKnowledgeFiles({ ...currentParams, page: 1 });
+        currentParams = { ...currentParams, page: page.page };
+        pager = appendKnowledgePage(initialKnowledgePager(), page);
+        loadedItems = [...page.items];
+        renderKnowledgeContent();
+    }
+    catch (cause) {
+        showKnowledgeError(cause, "知识库列表加载失败");
+    }
+}
+function bindKnowledgeControls() {
+    const search = requiredElement("knowledge-search", HTMLInputElement);
+    const status = requiredElement("knowledge-status-filter", HTMLSelectElement);
+    const submit = requiredElement("knowledge-filter-submit", HTMLButtonElement);
+    const reset = requiredElement("knowledge-filter-reset", HTMLButtonElement);
+    const refresh = requiredElement("knowledge-refresh", HTMLButtonElement);
+    const upload = requiredElement("knowledge-upload-open", HTMLButtonElement);
+    const apply = () => { syncKnowledgeFilters(search, status); void refreshKnowledgeList("filter"); };
+    submit.onclick = apply;
+    reset.onclick = () => { search.value = ""; status.value = "all"; syncKnowledgeFilters(search, status); void refreshKnowledgeList("filter"); };
+    refresh.onclick = () => void refreshKnowledgeList("refresh");
+    upload.onclick = () => uploadHandler?.();
+    search.addEventListener("keydown", (event) => { if (event.key === "Enter") {
+        event.preventDefault();
+        apply();
+    } });
+}
+function syncKnowledgeFilters(search, status) {
+    currentParams = { ...currentParams, page: 1, search: search.value.trim(), status: knowledgeStatusValue(status.value) };
+}
+function renderKnowledgeLoading() {
+    const target = requiredElement("knowledge-list", HTMLElement);
+    const hint = document.createElement("p");
+    hint.className = "hint";
+    hint.textContent = "正在加载知识库…";
+    target.replaceChildren(hint);
+}
+function renderKnowledgeContent() {
+    const target = requiredElement("knowledge-list", HTMLElement);
+    if (loadedItems.length === 0)
+        renderKnowledgeEmpty(target);
+    else
+        renderKnowledgeList(target, loadedItems, {});
+    renderKnowledgePagination();
+}
+function renderKnowledgePagination() {
+    const target = requiredElement("knowledge-pagination", HTMLElement);
+    target.replaceChildren();
+    if (!hasMoreKnowledgePages(pager))
+        return;
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "secondary";
+    button.textContent = "加载更多";
+    button.onclick = () => void loadMoreKnowledgeFiles();
+    target.append(button);
+}
+async function loadMoreKnowledgeFiles() {
+    if (!hasMoreKnowledgePages(pager))
+        return;
+    try {
+        currentParams = { ...currentParams, page: currentParams.page + 1 };
+        const page = await listKnowledgeFiles(currentParams);
+        pager = appendKnowledgePage(pager, page);
+        loadedItems = [...loadedItems, ...page.items];
+        renderKnowledgeContent();
+    }
+    catch (cause) {
+        showKnowledgeError(cause, "知识库列表加载失败");
+    }
+}
+function showKnowledgeError(cause, fallback) {
+    setText("knowledge-result", cause instanceof Error ? cause.message : fallback);
+}
+function defaultKnowledgeParams() {
+    return { page: 1, page_size: 20, search: "", status: "all", sort: "updated_at", order: "desc" };
+}
+function knowledgeStatusValue(value) {
+    switch (value) {
+        case "pending":
+        case "processing":
+        case "ready":
+        case "failed": return value;
+        default: return "all";
+    }
 }

--- a/web-console/dist/views/knowledge/knowledge.js
+++ b/web-console/dist/views/knowledge/knowledge.js
@@ -1,0 +1,3 @@
+export async function initializeKnowledge() {
+    /* Todo 4 实现页面控制器 */
+}

--- a/web-console/dist/views/knowledge/knowledge.js
+++ b/web-console/dist/views/knowledge/knowledge.js
@@ -1,12 +1,38 @@
-import { fetchKnowledgeCapabilities, listKnowledgeFiles } from "../../api.js";
+import { deleteKnowledgeFile, downloadKnowledgeFile, fetchKnowledgeCapabilities, listKnowledgeFiles, retryKnowledgeFile, uploadKnowledgeFile } from "../../api.js";
 import { requiredElement, setText } from "../../dom.js";
 import { renderKnowledgeEmpty, renderKnowledgeList } from "./knowledge-list.js";
+import { createKnowledgeActionHandlers, triggerBrowserDownload } from "./knowledge-actions.js";
 import { appendKnowledgePage, hasMoreKnowledgePages, initialKnowledgePager } from "./knowledge-paging.js";
+import { KnowledgePollingController } from "./knowledge-polling.js";
+import { installKnowledgeUpload } from "./knowledge-upload.js";
 let capabilities = null;
 let pager = initialKnowledgePager();
 let loadedItems = [];
 let currentParams = defaultKnowledgeParams();
-let uploadHandler = null;
+let uploadFlowInstalled = false;
+const polling = new KnowledgePollingController({
+    isVisible: () => typeof document === "undefined" || document.visibilityState !== "hidden",
+    setTimeout: (fn, ms) => window.setTimeout(fn, ms),
+    clearTimeout: (id) => window.clearTimeout(id),
+    fetchPage: (params) => listKnowledgeFiles({ ...params, page: 1 }),
+    onUpdate: (page) => {
+        currentParams = { ...currentParams, page: page.page };
+        pager = appendKnowledgePage(initialKnowledgePager(), page);
+        loadedItems = [...page.items];
+        renderKnowledgeContent();
+    },
+    onTransientError: (message) => setText("knowledge-result", message),
+    onTerminalTransition: (message) => setText("knowledge-result", message),
+});
+const actions = createKnowledgeActionHandlers({
+    setStatus: (text) => setText("knowledge-result", text),
+    download: downloadKnowledgeFile,
+    triggerDownload: triggerBrowserDownload,
+    deleteFile: deleteKnowledgeFile,
+    retryFile: retryKnowledgeFile,
+    refresh: (reason) => void refreshKnowledgeList(reason),
+    getItems: () => loadedItems,
+});
 export async function initializeKnowledge() {
     bindKnowledgeControls();
     try {
@@ -15,10 +41,28 @@ export async function initializeKnowledge() {
     catch (cause) {
         showKnowledgeError(cause, "知识库能力加载失败");
     }
+    if (!uploadFlowInstalled) {
+        installKnowledgeUpload({
+            inputId: "knowledge-upload-input",
+            buttonId: "knowledge-upload-open",
+            setStatus: (text) => setText("knowledge-result", text),
+            getCapabilities: getKnowledgeCapabilities,
+            upload: uploadKnowledgeFile,
+            onUploaded: () => void refreshKnowledgeList("upload"),
+        });
+        uploadFlowInstalled = true;
+    }
     await refreshKnowledgeList("refresh");
-}
-export function setKnowledgeUploadHandler(handler) {
-    uploadHandler = handler;
+    polling.start(currentParams);
+    if (typeof document !== "undefined") {
+        document.addEventListener("visibilitychange", () => {
+            if (document.visibilityState !== "hidden" && polling.hasActive())
+                polling.notifyChange();
+        });
+    }
+    if (typeof window !== "undefined" && typeof window.addEventListener === "function") {
+        window.addEventListener("pagehide", () => polling.stop());
+    }
 }
 export function getKnowledgeCapabilities() {
     return capabilities;
@@ -37,6 +81,8 @@ export async function refreshKnowledgeList(reason) {
         currentParams = { ...currentParams, page: page.page };
         pager = appendKnowledgePage(initialKnowledgePager(), page);
         loadedItems = [...page.items];
+        polling.setPages(loadedItems);
+        polling.notifyChange();
         renderKnowledgeContent();
     }
     catch (cause) {
@@ -49,12 +95,10 @@ function bindKnowledgeControls() {
     const submit = requiredElement("knowledge-filter-submit", HTMLButtonElement);
     const reset = requiredElement("knowledge-filter-reset", HTMLButtonElement);
     const refresh = requiredElement("knowledge-refresh", HTMLButtonElement);
-    const upload = requiredElement("knowledge-upload-open", HTMLButtonElement);
     const apply = () => { syncKnowledgeFilters(search, status); void refreshKnowledgeList("filter"); };
     submit.onclick = apply;
     reset.onclick = () => { search.value = ""; status.value = "all"; syncKnowledgeFilters(search, status); void refreshKnowledgeList("filter"); };
     refresh.onclick = () => void refreshKnowledgeList("refresh");
-    upload.onclick = () => uploadHandler?.();
     search.addEventListener("keydown", (event) => { if (event.key === "Enter") {
         event.preventDefault();
         apply();
@@ -75,7 +119,7 @@ function renderKnowledgeContent() {
     if (loadedItems.length === 0)
         renderKnowledgeEmpty(target);
     else
-        renderKnowledgeList(target, loadedItems, {});
+        renderKnowledgeList(target, loadedItems, actions);
     renderKnowledgePagination();
 }
 function renderKnowledgePagination() {
@@ -98,6 +142,8 @@ async function loadMoreKnowledgeFiles() {
         const page = await listKnowledgeFiles(currentParams);
         pager = appendKnowledgePage(pager, page);
         loadedItems = [...loadedItems, ...page.items];
+        polling.setPages(loadedItems);
+        polling.notifyChange();
         renderKnowledgeContent();
     }
     catch (cause) {

--- a/web-console/src/api-routes.ts
+++ b/web-console/src/api-routes.ts
@@ -43,6 +43,15 @@ export const USER_DATA_ROUTES = {
   filesGet: (fileId: string): string => `/api/v1/console/files/get/${fileId}`,
 } as const;
 
+export const KNOWLEDGE_ROUTES = {
+  capabilities: "/api/v1/console/knowledge/files/capabilities",
+  list: "/api/v1/console/knowledge/files/list",
+  upload: "/api/v1/console/knowledge/files/upload",
+  delete: "/api/v1/console/knowledge/files/delete",
+  retry: "/api/v1/console/knowledge/files/retry",
+  get: (fileId: string): string => `/api/v1/console/knowledge/files/get/${fileId}`,
+} as const;
+
 export const STATUS_ROUTE = "/api/v1/console/status";
 export const RESTART_ROUTE = "/api/v1/console/restart";
 export const MARKDOWN_RENDER_ROUTE = "/api/v1/markdown/render";

--- a/web-console/src/api.ts
+++ b/web-console/src/api.ts
@@ -2,6 +2,7 @@ import {
   AUTH_ROUTES,
   CONFIGURATION_ROUTES,
   MARKDOWN_RENDER_ROUTE,
+  KNOWLEDGE_ROUTES,
   RESTART_ROUTE,
   STATUS_ROUTE,
   TODO_ROUTES,
@@ -23,6 +24,12 @@ import type {
   BootstrapStatus,
   ConfigurationSnapshot,
   ConfigFieldSnapshot,
+  KnowledgeFileCapabilities,
+  KnowledgeFileItem,
+  KnowledgeFileListParams,
+  KnowledgeFilePage,
+  KnowledgeFileSource,
+  KnowledgeFileStatus,
   RegisteredTool,
   TodoItem,
   TodoPage,
@@ -196,6 +203,78 @@ export async function deleteUserFile(fileId: string): Promise<void> {
   await mutatingJson(USER_DATA_ROUTES.filesDelete, "POST", { file_id: fileId });
 }
 
+export async function fetchKnowledgeCapabilities(): Promise<KnowledgeFileCapabilities> {
+  const payload = record(await mutatingJson(KNOWLEDGE_ROUTES.capabilities, "POST", {}));
+  const data = record(payload.data);
+  return {
+    supported_extensions: array(data.supported_extensions).map((value) => requiredString(value, "supported_extensions")),
+    max_file_bytes: requiredFiniteNumber(data.max_file_bytes, "max_file_bytes"),
+    max_filename_chars: requiredFiniteNumber(data.max_filename_chars, "max_filename_chars"),
+  };
+}
+
+export async function listKnowledgeFiles(params: KnowledgeFileListParams): Promise<KnowledgeFilePage> {
+  const payload = record(await mutatingJson(KNOWLEDGE_ROUTES.list, "POST", {
+    page: params.page,
+    page_size: params.page_size,
+    search: params.search,
+    ...(params.status === "all" ? {} : { status: params.status }),
+    sort: params.sort,
+    order: params.order,
+  }));
+  return parseKnowledgeFilePage(payload.data);
+}
+
+export async function uploadKnowledgeFile(file: File): Promise<KnowledgeFileItem> {
+  const form = new FormData();
+  form.append("file", file);
+  const response = await fetch(KNOWLEDGE_ROUTES.upload, {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { Accept: "application/json", "X-CSRF-Token": csrfToken },
+    body: form,
+  });
+  if (!response.ok) throw await responseError(response);
+  return parseKnowledgeFileItem(record(await response.json() as unknown).data);
+}
+
+export async function downloadKnowledgeFile(item: Pick<KnowledgeFileItem, "file_id" | "filename">): Promise<{ blob: Blob; filename: string }> {
+  if (item.file_id === null) throw new ConsoleApiError("知识库文件缺少标识", "invalid_response");
+  const response = await fetch(KNOWLEDGE_ROUTES.get(item.file_id), {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "X-CSRF-Token": csrfToken },
+  });
+  if (!response.ok) throw await responseError(response);
+  return {
+    blob: await response.blob(),
+    filename: filenameFromContentDisposition(response.headers.get("Content-Disposition")) ?? item.filename,
+  };
+}
+
+export function filenameFromContentDisposition(value: string | null): string | null {
+  if (value === null) return null;
+  const encoded = /(?:^|;)\s*filename\*=UTF-8''([^;]+)/i.exec(value);
+  if (encoded?.[1] !== undefined) {
+    try {
+      return decodeURIComponent(encoded[1]);
+    } catch {
+      return null;
+    }
+  }
+  const plain = /(?:^|;)\s*filename="([^"]+)"/i.exec(value);
+  return plain?.[1] ?? null;
+}
+
+export async function deleteKnowledgeFile(fileId: string): Promise<void> {
+  await mutatingJson(KNOWLEDGE_ROUTES.delete, "POST", { file_id: fileId });
+}
+
+export async function retryKnowledgeFile(fileId: string): Promise<KnowledgeFileItem> {
+  const payload = record(await mutatingJson(KNOWLEDGE_ROUTES.retry, "POST", { file_id: fileId }));
+  return parseKnowledgeFileItem(payload.data);
+}
+
 export async function fetchConfiguration(): Promise<ConfigurationSnapshot> {
   const payload = record(await fetchJson(CONFIGURATION_ROUTES.get, {
     headers: { Accept: "application/json" },
@@ -304,6 +383,46 @@ function parseTodoPage(value: unknown): TodoPage {
     pageSize: finiteNumber(data.page_size) ?? 50,
     total: finiteNumber(data.total) ?? 0,
     totalPages: finiteNumber(data.total_pages) ?? 1,
+  };
+}
+
+function parseKnowledgeFilePage(value: unknown): KnowledgeFilePage {
+  const data = record(value);
+  return {
+    items: array(data.items).map(parseKnowledgeFileItem),
+    page: finiteNumber(data.page) ?? 1,
+    page_size: finiteNumber(data.page_size) ?? 20,
+    total: finiteNumber(data.total) ?? 0,
+    total_pages: finiteNumber(data.total_pages) ?? 1,
+  };
+}
+
+export function parseKnowledgeFileItem(value: unknown): KnowledgeFileItem {
+  const item = record(value);
+  const source = item.source;
+  const status = item.status;
+  if (source !== "managed" && source !== "directory") throw new ConsoleApiError("知识库文件来源无效", "invalid_response");
+  if (status !== "pending" && status !== "processing" && status !== "ready" && status !== "failed") {
+    throw new ConsoleApiError("知识库文件状态无效", "invalid_response");
+  }
+  return {
+    file_id: nullableString(item.file_id),
+    filename: requiredString(item.filename, "filename"),
+    content_type: requiredString(item.content_type, "content_type"),
+    size: finiteNumber(item.size),
+    source: source satisfies KnowledgeFileSource,
+    source_label: requiredString(item.source_label, "source_label"),
+    status: status satisfies KnowledgeFileStatus,
+    uploaded_at: nullableString(item.uploaded_at),
+    processing_started_at: nullableString(item.processing_started_at),
+    processed_at: nullableString(item.processed_at),
+    updated_at: requiredString(item.updated_at, "updated_at"),
+    error_code: nullableString(item.error_code),
+    error_summary: nullableString(item.error_summary),
+    chunk_count: finiteNumber(item.chunk_count),
+    embedding_count: finiteNumber(item.embedding_count),
+    downloadable: requiredBoolean(item.downloadable, "downloadable"),
+    download_url: nullableString(item.download_url),
   };
 }
 
@@ -435,6 +554,18 @@ async function mutatingJson(input: string, method: string, body?: unknown, allow
     throw new ConsoleApiError(message, code, response.status);
   }
   return await response.json() as unknown;
+}
+
+async function responseError(response: Response): Promise<ConsoleApiError> {
+  let code = "request_failed";
+  let message = `管理接口请求失败（HTTP ${response.status}）`;
+  try {
+    const payload = record(await response.json() as unknown);
+    const error = record(payload.error);
+    code = string(error.code, code);
+    message = string(error.message, message);
+  } catch { /* 保留稳定错误。 */ }
+  return new ConsoleApiError(message, code, response.status);
 }
 
 function parseRuntime(value: unknown): RuntimeStatus {
@@ -628,6 +759,24 @@ function array(value: unknown): unknown[] {
 
 function string(value: unknown, fallback: string): string {
   return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new ConsoleApiError(`管理接口返回了无效 ${field}`, "invalid_response");
+  }
+  return value;
+}
+
+function requiredBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== "boolean") throw new ConsoleApiError(`管理接口返回了无效 ${field}`, "invalid_response");
+  return value;
+}
+
+function requiredFiniteNumber(value: unknown, field: string): number {
+  const number = finiteNumber(value);
+  if (number === null) throw new ConsoleApiError(`管理接口返回了无效 ${field}`, "invalid_response");
+  return number;
 }
 
 function nullableString(value: unknown): string | null {

--- a/web-console/src/console-shell.ts
+++ b/web-console/src/console-shell.ts
@@ -1,8 +1,8 @@
 import type { BackgroundController } from "./background.js";
 
-export const CONSOLE_PAGE_IDS = ["overview", "platforms", "configuration", "storage", "todo", "tools"] as const;
+export const CONSOLE_PAGE_IDS = ["overview", "platforms", "configuration", "storage", "todo", "knowledge", "tools"] as const;
 export type ConsolePageId = (typeof CONSOLE_PAGE_IDS)[number];
-export type ConsoleIconName = "overview" | "platforms" | "configuration" | "storage" | "todo" | "tools";
+export type ConsoleIconName = "overview" | "platforms" | "configuration" | "storage" | "todo" | "knowledge" | "tools";
 export type ConsoleExtensionSlot = "memory" | "logs" | "debug" | "attachments";
 
 export type ConsolePage = {
@@ -18,6 +18,7 @@ export const CONSOLE_PAGES: readonly ConsolePage[] = [
   { id: "configuration", label: "配置", icon: "configuration", targetId: "configuration" },
   { id: "storage", label: "存储", icon: "storage", targetId: "storage" },
   { id: "todo", label: "Todo", icon: "todo", targetId: "todo" },
+  { id: "knowledge", label: "知识库", icon: "knowledge", targetId: "knowledge" },
   { id: "tools", label: "工具", icon: "tools", targetId: "markdown" },
 ] as const;
 
@@ -34,6 +35,7 @@ const ICONS: Readonly<Record<ConsoleIconName, IconDefinition>> = {
   configuration: { label: "配置", paths: ["M12 8.5a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7Z", "M12 2v3", "M12 19v3", "M2 12h3", "M19 12h3", "m4.93 4.93 2.12-2.12", "m16.95 7.05 2.12-2.12", "m4.93 7.07 2.12 2.12", "m16.95 16.95 2.12 2.12"] },
   storage: { label: "存储", paths: ["M4 6.5C4 5.12 7.58 4 12 4s8 1.12 8 2.5S16.42 9 12 9 4 7.88 4 6.5Z", "M4 6.5v5C4 12.88 7.58 14 12 14s8-1.12 8-2.5v-5", "M4 11.5v6C4 18.88 7.58 20 12 20s8-1.12 8-2.5v-6"] },
   todo: { label: "Todo", paths: ["M5 6h14", "M5 12h14", "M5 18h9", "M3 6h.01", "M3 12h.01", "M3 18h.01"] },
+  knowledge: { label: "知识库", paths: ["M4 5a2 2 0 0 1 2-2h9l5 5v11a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V5Z", "M14 3v5h5", "M8 12h8", "M8 16h5"] },
   tools: { label: "工具", paths: ["m14.7 6.3 3-3 3 3-3 3", "m17.7 3.3-7.1 7.1", "M5 20h4l8.7-8.7-4-4L5 16v4Z"] },
 };
 
@@ -50,8 +52,10 @@ export function pageForTarget(targetId: string): ConsolePage | undefined {
       return CONSOLE_PAGES[3];
     case "todo":
       return CONSOLE_PAGES[4];
-    case "markdown":
+    case "knowledge":
       return CONSOLE_PAGES[5];
+    case "markdown":
+      return CONSOLE_PAGES[6];
     default:
       return undefined;
   }

--- a/web-console/src/index.html
+++ b/web-console/src/index.html
@@ -237,6 +237,38 @@
         </section>
       </div>
 
+      <!-- 知识库页面用于查看、筛选和上传由后端处理的知识库文件。 -->
+      <div class="console-page" data-console-page="knowledge" hidden>
+        <header class="product-page-heading">
+          <div>
+            <p class="eyebrow">KNOWLEDGE / FILES</p>
+            <h2>知识库管理</h2>
+            <p class="product-page-lede">查看、筛选和上传知识库文件，处理状态与文件信息均来自管理 API。</p>
+          </div>
+          <div class="knowledge-page-actions">
+            <button id="knowledge-upload-open" type="button">上传文件</button>
+          </div>
+        </header>
+        <section class="panel knowledge-panel" aria-labelledby="knowledge-heading">
+          <header class="section-heading">
+            <div>
+              <h2 id="knowledge-heading">知识库文件</h2>
+            </div>
+            <span class="section-meta">文件 · 处理状态</span>
+          </header>
+          <div class="knowledge-toolbar">
+            <label class="knowledge-search">搜索文件名<input id="knowledge-search" type="search" placeholder="搜索文件名"></label>
+            <label>状态<select id="knowledge-status-filter"><option value="all">全部</option><option value="pending">等待处理</option><option value="processing">处理中</option><option value="ready">已完成</option><option value="failed">处理失败</option></select></label>
+            <button id="knowledge-filter-submit" type="button">应用筛选</button>
+            <button id="knowledge-filter-reset" type="button" class="secondary">重置</button>
+            <button id="knowledge-refresh" type="button" class="secondary">刷新</button>
+          </div>
+          <p id="knowledge-result" class="status-message" role="status" aria-live="polite"></p>
+          <div id="knowledge-list" class="knowledge-list" aria-live="polite"><p class="hint">正在加载知识库…</p></div>
+          <div id="knowledge-pagination" class="knowledge-pagination"></div>
+        </section>
+      </div>
+
       <dialog id="todo-create-dialog" class="todo-create-dialog">
         <form id="todo-create-form" class="todo-create-form" method="dialog">
           <div class="todo-create-heading">

--- a/web-console/src/main.ts
+++ b/web-console/src/main.ts
@@ -26,7 +26,7 @@ import type { BootstrapStatus } from "./types.js";
 import { createThemeController } from "./theme.js";
 import { bindConsoleNavigation } from "./console-shell.js";
 import { initializeTodo } from "./views/todo/todo.js";
-import { initializeKnowledge } from "./views/knowledge/knowledge.js";
+import { disposeKnowledge, initializeKnowledge } from "./views/knowledge/knowledge.js";
 import { createBackgroundController, installBackgroundConsoleUnlock, unlockPreferencePatch, type BackgroundFile } from "./background.js";
 import { cacheFileBlob, clearFileBlobCache, deleteCachedFileBlob, readCachedFileBlob } from "./file-cache.js";
 
@@ -309,6 +309,7 @@ async function logout(): Promise<void> {
   try {
     await logoutAdmin();
   } finally {
+    disposeKnowledge();
     backgroundController.dispose();
     void clearFileBlobCache();
     userDataController = null;

--- a/web-console/src/main.ts
+++ b/web-console/src/main.ts
@@ -26,6 +26,7 @@ import type { BootstrapStatus } from "./types.js";
 import { createThemeController } from "./theme.js";
 import { bindConsoleNavigation } from "./console-shell.js";
 import { initializeTodo } from "./views/todo/todo.js";
+import { initializeKnowledge } from "./views/knowledge/knowledge.js";
 import { createBackgroundController, installBackgroundConsoleUnlock, unlockPreferencePatch, type BackgroundFile } from "./background.js";
 import { cacheFileBlob, clearFileBlobCache, deleteCachedFileBlob, readCachedFileBlob } from "./file-cache.js";
 
@@ -238,6 +239,7 @@ async function showConsole(username: string): Promise<void> {
   await Promise.all([refreshStatus(), hydrateUserData()]);
   await refreshConfiguration();
   await initializeTodo();
+  await initializeKnowledge();
 }
 
 async function hydrateUserData(): Promise<void> {

--- a/web-console/src/styles.css
+++ b/web-console/src/styles.css
@@ -384,19 +384,21 @@ textarea { width: 100%; min-height: 25rem; flex: 1; resize: vertical; padding: v
 }
 
 @media (max-width: 700px) {
-  .platform-table-wrap, .capability-table-wrap, .storage-table-wrap { overflow: visible; }
+  .platform-table-wrap, .capability-table-wrap, .storage-table-wrap, .knowledge-list { overflow: visible; }
   .platform-table-wrap table, .capability-table-wrap table, .storage-table-wrap table,
   .platform-table-wrap thead, .capability-table-wrap thead, .storage-table-wrap thead,
   .platform-table-wrap tbody, .capability-table-wrap tbody, .storage-table-wrap tbody,
   .platform-table-wrap tr, .capability-table-wrap tr, .storage-table-wrap tr,
   .platform-table-wrap th, .capability-table-wrap th, .storage-table-wrap th,
-  .platform-table-wrap td, .capability-table-wrap td, .storage-table-wrap td { display: block; }
-  .platform-table-wrap thead, .capability-table-wrap thead, .storage-table-wrap thead { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap; }
+  .platform-table-wrap td, .capability-table-wrap td, .storage-table-wrap td,
+  .knowledge-table, .knowledge-table thead, .knowledge-table tbody, .knowledge-table tr, .knowledge-table th, .knowledge-table td { display: block; }
+  .platform-table-wrap thead, .capability-table-wrap thead, .storage-table-wrap thead, .knowledge-table thead { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap; }
   .platform-table-wrap tbody, .capability-table-wrap tbody, .storage-table-wrap tbody { padding: .25rem; }
-  .platform-table-wrap tr, .capability-table-wrap tr, .storage-table-wrap tr { margin-bottom: .55rem; padding: .65rem; border: 1px solid var(--console-line); background: var(--console-glass-muted); }
-  .platform-table-wrap td, .capability-table-wrap td, .storage-table-wrap td { display: grid; grid-template-columns: minmax(6.5rem, 34%) minmax(0, 1fr); gap: .7rem; padding: .45rem 0; border: 0; border-bottom: 1px solid var(--console-line); background: transparent; font-size: .76rem; }
-  .platform-table-wrap td:last-child, .capability-table-wrap td:last-child, .storage-table-wrap td:last-child { border-bottom: 0; }
-  .platform-table-wrap td::before, .capability-table-wrap td::before, .storage-table-wrap td::before { color: var(--muted); font-size: .62rem; font-weight: 800; letter-spacing: .05em; text-transform: uppercase; }
+  .knowledge-table tbody { padding: .25rem; }
+  .platform-table-wrap tr, .capability-table-wrap tr, .storage-table-wrap tr, .knowledge-table tr { margin-bottom: .55rem; padding: .65rem; border: 1px solid var(--console-line); background: var(--console-glass-muted); }
+  .platform-table-wrap td, .capability-table-wrap td, .storage-table-wrap td, .knowledge-table td { display: grid; grid-template-columns: minmax(6.5rem, 34%) minmax(0, 1fr); gap: .7rem; padding: .45rem 0; border: 0; border-bottom: 1px solid var(--console-line); background: transparent; font-size: .76rem; }
+  .platform-table-wrap td:last-child, .capability-table-wrap td:last-child, .storage-table-wrap td:last-child, .knowledge-table td:last-child { border-bottom: 0; }
+  .platform-table-wrap td::before, .capability-table-wrap td::before, .storage-table-wrap td::before, .knowledge-table td::before { color: var(--muted); font-size: .62rem; font-weight: 800; letter-spacing: .05em; text-transform: uppercase; }
   .platform-table-wrap td:nth-child(1)::before, .capability-table-wrap td:nth-child(1)::before { content: "平台"; }
   .platform-table-wrap td:nth-child(2)::before { content: "已配置"; }
   .platform-table-wrap td:nth-child(3)::before { content: "已启用"; }
@@ -419,6 +421,15 @@ textarea { width: 100%; min-height: 25rem; flex: 1; resize: vertical; padding: v
   .storage-table-wrap td:nth-child(6)::before { content: "可写"; }
   .storage-table-wrap td:nth-child(7)::before { content: "错误"; }
   .storage-table-wrap td:nth-child(8)::before { content: "Schema"; }
+  .knowledge-table td:nth-child(1)::before { content: "文件名"; }
+  .knowledge-table td:nth-child(2)::before { content: "类型"; }
+  .knowledge-table td:nth-child(3)::before { content: "大小"; }
+  .knowledge-table td:nth-child(4)::before { content: "上传时间"; }
+  .knowledge-table td:nth-child(5)::before { content: "最近处理"; }
+  .knowledge-table td:nth-child(6)::before { content: "状态"; }
+  .knowledge-table td:nth-child(7)::before { content: "失败原因"; }
+  .knowledge-table td:nth-child(8)::before { content: "操作"; }
+  .knowledge-actions { flex-wrap: wrap; }
 }
 
 @media (max-width: 520px) {
@@ -495,6 +506,33 @@ textarea { width: 100%; min-height: 25rem; flex: 1; resize: vertical; padding: v
   .route-template-row { grid-template-columns: 1fr; }
   .model-route-field-group .config-field-group-grid { grid-template-columns: minmax(0, 1fr); }
   .model-route-add-row { flex-direction: column; align-items: stretch; }
+}
+
+/* ---- 知识库页面：文件处理状态与管理列表 ---- */
+.knowledge-toolbar { display: flex; flex-wrap: wrap; align-items: end; gap: .6rem; margin-bottom: .5rem; }
+.knowledge-toolbar label { display: grid; gap: .2rem; margin: 0; color: var(--muted); font-size: .7rem; font-weight: 700; }
+.knowledge-search input { width: 100%; }
+.knowledge-list { min-width: 0; }
+.knowledge-table { width: 100%; }
+.knowledge-table td:nth-child(1), .knowledge-table td:nth-child(7) { overflow-wrap: anywhere; }
+.knowledge-table td:nth-child(6), .knowledge-table td:nth-child(8) { white-space: nowrap; }
+.knowledge-source-badge { display: inline-flex; align-items: center; width: fit-content; padding: .2rem .4rem; border: 1px solid var(--console-line); border-radius: var(--console-radius); color: var(--accent-strong); background: var(--accent-soft); font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: .6rem; font-weight: 800; letter-spacing: .04em; }
+.knowledge-status { display: inline-flex; align-items: center; gap: .4rem; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: .68rem; font-weight: 800; letter-spacing: .04em; }
+.knowledge-status-dot { display: inline-block; width: .55rem; height: .55rem; flex: 0 0 .55rem; border: 1px solid currentColor; background: currentColor; }
+.knowledge-status--pending, .knowledge-status--processing { color: var(--console-status-warn); }
+.knowledge-status--pending .knowledge-status-dot, .knowledge-status--processing .knowledge-status-dot { transform: rotate(45deg) scale(.82); }
+.knowledge-status--ready { color: var(--console-status-good); }
+.knowledge-status--failed { color: var(--console-status-error); }
+.knowledge-status--failed .knowledge-status-dot { border: 0; clip-path: polygon(50% 0, 100% 100%, 0 100%); }
+.knowledge-status--processing .knowledge-status-dot { animation: knowledge-processing-pulse 1.5s ease-in-out infinite; }
+.knowledge-error-summary { max-width: 14rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.knowledge-actions { white-space: nowrap; }
+.knowledge-action { padding: .35rem .55rem; }
+.knowledge-action--danger { color: var(--console-error); }
+.knowledge-pagination { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: .7rem; margin-top: var(--console-space-5); color: var(--muted); font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: .72rem; }
+@keyframes knowledge-processing-pulse { 0%, 100% { opacity: 1; } 50% { opacity: .45; } }
+@media (prefers-reduced-motion: reduce) {
+  .knowledge-status--processing .knowledge-status-dot { animation: none; }
 }
 
 /* ---- Todo 页面：常用筛选 + 高级筛选折叠 ---- */

--- a/web-console/src/styles.css
+++ b/web-console/src/styles.css
@@ -437,8 +437,9 @@ textarea { width: 100%; min-height: 25rem; flex: 1; resize: vertical; padding: v
   .topbar { align-items: flex-start; padding-block: .7rem; }
   .topbar .security-note { display: none; }
   .refresh-box { width: 100%; }
-  .bottom-nav { bottom: calc(.75rem + env(safe-area-inset-bottom)); max-width: calc(100% - 1rem); }
-  .bottom-nav-link { flex-basis: 3.6rem; font-size: .6rem; }
+  .bottom-nav { bottom: calc(.75rem + env(safe-area-inset-bottom)); width: calc(100% - 1rem); max-width: 410px; }
+  .bottom-nav-list { width: 100%; }
+  .bottom-nav-link { flex: 1 1 0; min-width: 0; font-size: .6rem; }
   .console-content > .error, .console-content > .console-page { width: calc(100% - 1rem); }
   .overview-heading, .product-page-heading { flex-direction: column; gap: var(--console-space-3); padding-inline: 0; }
   .overview-heading-meta { justify-items: start; }

--- a/web-console/src/types.ts
+++ b/web-console/src/types.ts
@@ -236,3 +236,50 @@ export interface TodoTargetPage {
   total: number;
   totalPages: number;
 }
+
+export type KnowledgeFileStatus = "pending" | "processing" | "ready" | "failed";
+
+export type KnowledgeFileSource = "managed" | "directory";
+
+export interface KnowledgeFileItem {
+  readonly file_id: string | null;
+  readonly filename: string;
+  readonly content_type: string;
+  readonly size: number | null;
+  readonly source: KnowledgeFileSource;
+  readonly source_label: string;
+  readonly status: KnowledgeFileStatus;
+  readonly uploaded_at: string | null;
+  readonly processing_started_at: string | null;
+  readonly processed_at: string | null;
+  readonly updated_at: string;
+  readonly error_code: string | null;
+  readonly error_summary: string | null;
+  readonly chunk_count: number | null;
+  readonly embedding_count: number | null;
+  readonly downloadable: boolean;
+  readonly download_url: string | null;
+}
+
+export interface KnowledgeFilePage {
+  items: KnowledgeFileItem[];
+  page: number;
+  page_size: number;
+  total: number;
+  total_pages: number;
+}
+
+export interface KnowledgeFileCapabilities {
+  supported_extensions: string[];
+  max_file_bytes: number;
+  max_filename_chars: number;
+}
+
+export interface KnowledgeFileListParams {
+  page: number;
+  page_size: number;
+  search: string;
+  status: KnowledgeFileStatus | "all";
+  sort: "uploaded_at" | "updated_at";
+  order: "asc" | "desc";
+}

--- a/web-console/src/views/knowledge/knowledge-actions.ts
+++ b/web-console/src/views/knowledge/knowledge-actions.ts
@@ -1,0 +1,138 @@
+import { ConsoleApiError } from "../../api.js";
+import type { KnowledgeFileItem } from "../../types.js";
+
+type KnowledgeActionDeps = {
+  readonly setStatus: (text: string) => void;
+  readonly download: (item: KnowledgeFileItem) => Promise<{ blob: Blob; filename: string }>;
+  readonly triggerDownload: (blob: Blob, filename: string) => void;
+  readonly deleteFile: (fileId: string) => Promise<void>;
+  readonly retryFile: (fileId: string) => Promise<KnowledgeFileItem>;
+  readonly refresh: (reason: "delete" | "retry") => void;
+  readonly getItems: () => readonly KnowledgeFileItem[];
+};
+
+type KnowledgeActionHandlers = {
+  readonly onDownload: (item: KnowledgeFileItem) => void;
+  readonly onDelete: (item: KnowledgeFileItem) => void;
+  readonly onRetry: (item: KnowledgeFileItem) => void;
+};
+
+export function triggerBrowserDownload(blob: Blob, filename: string): void {
+  const href = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = href;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(href);
+}
+
+export function createKnowledgeActionHandlers(deps: KnowledgeActionDeps): KnowledgeActionHandlers {
+  const activeButtons = new WeakSet<HTMLButtonElement>();
+  return {
+    onDownload: (item) => void download(item, deps, activeButtons),
+    onDelete: (item) => openDeleteDialog(item, deps, activeButtons),
+    onRetry: (item) => void retry(item, deps, activeButtons),
+  };
+}
+
+async function download(item: KnowledgeFileItem, deps: KnowledgeActionDeps, active: WeakSet<HTMLButtonElement>): Promise<void> {
+  if (!item.downloadable || item.source !== "managed" || item.file_id === null) return;
+  const button = actionButton(item.file_id, "下载");
+  if (button === null || active.has(button)) return;
+  active.add(button);
+  button.disabled = true;
+  try {
+    const result = await deps.download(item);
+    deps.triggerDownload(result.blob, result.filename);
+  } catch (cause) {
+    deps.setStatus(safeMessage(cause));
+  } finally {
+    active.delete(button);
+    button.disabled = false;
+  }
+}
+
+async function retry(item: KnowledgeFileItem, deps: KnowledgeActionDeps, active: WeakSet<HTMLButtonElement>): Promise<void> {
+  if (item.status !== "failed" || item.source !== "managed" || item.file_id === null) return;
+  const button = actionButton(item.file_id, "重新处理");
+  if (button === null || active.has(button)) return;
+  active.add(button);
+  button.disabled = true;
+  try {
+    await deps.retryFile(item.file_id);
+    deps.refresh("retry");
+  } catch (cause) {
+    deps.setStatus(safeMessage(cause));
+  } finally {
+    active.delete(button);
+    button.disabled = false;
+  }
+}
+
+function openDeleteDialog(item: KnowledgeFileItem, deps: KnowledgeActionDeps, active: WeakSet<HTMLButtonElement>): void {
+  if (item.source !== "managed" || item.file_id === null || item.status === "processing") return;
+  const fileId = item.file_id;
+  const opener = actionButton(item.file_id, "删除");
+  if (opener === null || active.has(opener)) return;
+  const dialog = document.createElement("dialog");
+  dialog.setAttribute("role", "alertdialog");
+  dialog.setAttribute("aria-modal", "true");
+  const title = document.createElement("h2");
+  title.id = "knowledge-delete-title";
+  title.textContent = `删除文件：${item.filename}`;
+  const message = document.createElement("p");
+  message.id = "knowledge-delete-message";
+  message.textContent = "删除后，该文件及对应的知识库解析和索引数据将被移除，且无法继续被检索。此操作不可恢复。";
+  dialog.setAttribute("aria-labelledby", title.id);
+  dialog.setAttribute("aria-describedby", message.id);
+  const cancel = document.createElement("button");
+  cancel.type = "button";
+  cancel.textContent = "取消";
+  const confirm = document.createElement("button");
+  confirm.type = "button";
+  confirm.className = "danger";
+  confirm.textContent = "删除";
+  dialog.append(title, message, cancel, confirm);
+  if (document.body) document.body.append(dialog);
+  const close = () => {
+    if (typeof dialog.close === "function") dialog.close();
+    else dialog.removeAttribute("open");
+    opener.focus();
+  };
+  cancel.onclick = close;
+  dialog.addEventListener("click", (event) => { if (event.target !== dialog) return; });
+  confirm.onclick = () => void confirmDelete(fileId, confirm, close, deps, active);
+  if (typeof dialog.showModal === "function") dialog.showModal();
+  else dialog.setAttribute("open", "");
+  cancel.focus();
+}
+
+async function confirmDelete(fileId: string, button: HTMLButtonElement, close: () => void, deps: KnowledgeActionDeps, active: WeakSet<HTMLButtonElement>): Promise<void> {
+  if (active.has(button)) return;
+  active.add(button);
+  button.disabled = true;
+  try {
+    await deps.deleteFile(fileId);
+    close();
+    deps.refresh("delete");
+    deps.setStatus("文件已删除");
+  } catch (cause) {
+    close();
+    deps.setStatus(cause instanceof ConsoleApiError && cause.status === 409 ? "文件正在处理中，暂不能删除" : safeMessage(cause));
+  } finally {
+    active.delete(button);
+    button.disabled = false;
+  }
+}
+
+function actionButton(fileId: string, label: string): HTMLButtonElement | null {
+  const buttons = document.querySelectorAll("button[data-file-id]");
+  for (const button of buttons) {
+    if (button instanceof HTMLButtonElement && button.dataset.fileId === fileId && button.textContent === label) return button;
+  }
+  return null;
+}
+
+function safeMessage(cause: unknown): string {
+  return cause instanceof Error ? cause.message : "操作失败，请稍后重试";
+}

--- a/web-console/src/views/knowledge/knowledge-actions.ts
+++ b/web-console/src/views/knowledge/knowledge-actions.ts
@@ -1,6 +1,7 @@
 import { ConsoleApiError } from "../../api.js";
 import type { KnowledgeFileItem } from "../../types.js";
 
+/** 知识库行操作集中处理下载、重试和删除，避免展示层绕过文件状态与权限边界。 */
 type KnowledgeActionDeps = {
   readonly setStatus: (text: string) => void;
   readonly download: (item: KnowledgeFileItem) => Promise<{ blob: Blob; filename: string }>;
@@ -27,6 +28,7 @@ export function triggerBrowserDownload(blob: Blob, filename: string): void {
 }
 
 export function createKnowledgeActionHandlers(deps: KnowledgeActionDeps): KnowledgeActionHandlers {
+  // 操作锁按按钮实例隔离，避免重复点击同一行，同时不阻塞其他文件的独立操作。
   const activeButtons = new WeakSet<HTMLButtonElement>();
   return {
     onDownload: (item) => void download(item, deps, activeButtons),
@@ -94,6 +96,7 @@ function openDeleteDialog(item: KnowledgeFileItem, deps: KnowledgeActionDeps, ac
   confirm.textContent = "删除";
   dialog.append(title, message, cancel, confirm);
   if (document.body) document.body.append(dialog);
+  // 对话框无论取消、成功还是冲突都归还焦点，键盘用户能回到触发删除的那一行。
   const close = () => {
     if (typeof dialog.close === "function") dialog.close();
     else dialog.removeAttribute("open");
@@ -108,6 +111,7 @@ function openDeleteDialog(item: KnowledgeFileItem, deps: KnowledgeActionDeps, ac
 }
 
 async function confirmDelete(fileId: string, button: HTMLButtonElement, close: () => void, deps: KnowledgeActionDeps, active: WeakSet<HTMLButtonElement>): Promise<void> {
+  // 确认按钮也单独加锁，避免删除请求尚未完成时重复提交同一文件。
   if (active.has(button)) return;
   active.add(button);
   button.disabled = true;

--- a/web-console/src/views/knowledge/knowledge-actions.ts
+++ b/web-console/src/views/knowledge/knowledge-actions.ts
@@ -19,12 +19,16 @@ type KnowledgeActionHandlers = {
 };
 
 export function triggerBrowserDownload(blob: Blob, filename: string): void {
+  if (typeof URL === "undefined" || typeof document === "undefined" || document.body === null) return;
   const href = URL.createObjectURL(blob);
   const anchor = document.createElement("a");
   anchor.href = href;
   anchor.download = filename;
+  anchor.style.display = "none";
+  document.body.append(anchor);
   anchor.click();
-  URL.revokeObjectURL(href);
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(href), 60_000);
 }
 
 export function createKnowledgeActionHandlers(deps: KnowledgeActionDeps): KnowledgeActionHandlers {

--- a/web-console/src/views/knowledge/knowledge-actions.ts
+++ b/web-console/src/views/knowledge/knowledge-actions.ts
@@ -18,6 +18,14 @@ type KnowledgeActionHandlers = {
   readonly onRetry: (item: KnowledgeFileItem) => void;
 };
 
+let deleteDialog: HTMLDialogElement | null = null;
+let deleteDialogTitle: HTMLElement | null = null;
+let deleteDialogMessage: HTMLElement | null = null;
+let deleteDialogCancel: HTMLButtonElement | null = null;
+let deleteDialogConfirm: HTMLButtonElement | null = null;
+let deleteOpener: HTMLButtonElement | null = null;
+let deleteFileId: string | null = null;
+
 export function triggerBrowserDownload(blob: Blob, filename: string): void {
   if (typeof URL === "undefined" || typeof document === "undefined" || document.body === null) return;
   const href = URL.createObjectURL(blob);
@@ -80,38 +88,18 @@ function openDeleteDialog(item: KnowledgeFileItem, deps: KnowledgeActionDeps, ac
   const fileId = item.file_id;
   const opener = actionButton(item.file_id, "删除");
   if (opener === null || active.has(opener)) return;
-  const dialog = document.createElement("dialog");
-  dialog.setAttribute("role", "alertdialog");
-  dialog.setAttribute("aria-modal", "true");
-  const title = document.createElement("h2");
-  title.id = "knowledge-delete-title";
-  title.textContent = `删除文件：${item.filename}`;
-  const message = document.createElement("p");
-  message.id = "knowledge-delete-message";
-  message.textContent = "删除后，该文件及对应的知识库解析和索引数据将被移除，且无法继续被检索。此操作不可恢复。";
-  dialog.setAttribute("aria-labelledby", title.id);
-  dialog.setAttribute("aria-describedby", message.id);
-  const cancel = document.createElement("button");
-  cancel.type = "button";
-  cancel.textContent = "取消";
-  const confirm = document.createElement("button");
-  confirm.type = "button";
-  confirm.className = "danger";
-  confirm.textContent = "删除";
-  dialog.append(title, message, cancel, confirm);
-  if (document.body) document.body.append(dialog);
-  // 对话框无论取消、成功还是冲突都归还焦点，键盘用户能回到触发删除的那一行。
-  const close = () => {
-    if (typeof dialog.close === "function") dialog.close();
-    else dialog.removeAttribute("open");
-    opener.focus();
-  };
-  cancel.onclick = close;
-  dialog.addEventListener("click", (event) => { if (event.target !== dialog) return; });
-  confirm.onclick = () => void confirmDelete(fileId, confirm, close, deps, active);
+  const dialog = ensureDeleteDialog();
+  deleteOpener = opener;
+  deleteFileId = fileId;
+  if (deleteDialogTitle) deleteDialogTitle.textContent = `删除文件：${item.filename}`;
+  if (deleteDialogMessage) deleteDialogMessage.textContent = "删除后，该文件及对应的知识库解析和索引数据将被移除，且无法继续被检索。此操作不可恢复。";
+  const close = () => closeDeleteDialog(opener, fileId);
+  if (deleteDialogCancel) deleteDialogCancel.onclick = close;
+  const confirmButton = deleteDialogConfirm;
+  if (confirmButton) confirmButton.onclick = () => void confirmDelete(fileId, confirmButton, close, deps, active);
+  deleteDialogCancel?.focus();
   if (typeof dialog.showModal === "function") dialog.showModal();
   else dialog.setAttribute("open", "");
-  cancel.focus();
 }
 
 async function confirmDelete(fileId: string, button: HTMLButtonElement, close: () => void, deps: KnowledgeActionDeps, active: WeakSet<HTMLButtonElement>): Promise<void> {
@@ -131,6 +119,63 @@ async function confirmDelete(fileId: string, button: HTMLButtonElement, close: (
     active.delete(button);
     button.disabled = false;
   }
+}
+
+function ensureDeleteDialog(): HTMLDialogElement {
+  if (deleteDialog !== null && document.querySelector('[role="alertdialog"]') === deleteDialog) return deleteDialog;
+  const dialog = document.createElement("dialog") as HTMLDialogElement;
+  dialog.setAttribute("role", "alertdialog");
+  dialog.setAttribute("aria-modal", "true");
+  const title = document.createElement("h2");
+  title.id = "knowledge-delete-title";
+  const message = document.createElement("p");
+  message.id = "knowledge-delete-message";
+  const cancel = document.createElement("button");
+  cancel.type = "button";
+  cancel.textContent = "取消";
+  const confirm = document.createElement("button");
+  confirm.type = "button";
+  confirm.className = "danger";
+  confirm.textContent = "删除";
+  dialog.setAttribute("aria-labelledby", title.id);
+  dialog.setAttribute("aria-describedby", message.id);
+  dialog.append(title, message, cancel, confirm);
+  document.body?.append(dialog);
+  deleteDialog = dialog;
+  deleteDialogTitle = title;
+  deleteDialogMessage = message;
+  deleteDialogCancel = cancel;
+  deleteDialogConfirm = confirm;
+  dialog.addEventListener("cancel", () => {
+    if (deleteOpener !== null && deleteFileId !== null) closeDeleteDialog(deleteOpener, deleteFileId);
+  });
+  return dialog;
+}
+
+function closeDeleteDialog(opener: HTMLButtonElement, fileId: string): void {
+  if (deleteDialog === null) return;
+  if (typeof deleteDialog.close === "function") deleteDialog.close();
+  else deleteDialog.removeAttribute("open");
+  restoreFocus(opener, fileId);
+}
+
+function restoreFocus(opener: HTMLButtonElement, fileId: string): void {
+  if (opener.isConnected !== false) {
+    opener.focus();
+    return;
+  }
+  const rowButton = actionButton(fileId, "删除") ?? actionButton(fileId, "重新处理") ?? actionButton(fileId, "下载");
+  if (rowButton !== null && rowButton.isConnected !== false) {
+    rowButton.focus();
+    return;
+  }
+  const list = document.getElementById("knowledge-list");
+  if (list instanceof HTMLElement) {
+    list.tabIndex = -1;
+    list.focus();
+    return;
+  }
+  document.getElementById("knowledge-upload-open")?.focus();
 }
 
 function actionButton(fileId: string, label: string): HTMLButtonElement | null {

--- a/web-console/src/views/knowledge/knowledge-list.ts
+++ b/web-console/src/views/knowledge/knowledge-list.ts
@@ -1,0 +1,96 @@
+import { formatBytes, formatDateTime, renderKnowledgeStatus } from "./knowledge-status.js";
+import type { KnowledgeFileItem } from "../../types.js";
+
+export type KnowledgeListCallbacks = {
+  onDownload?: (item: KnowledgeFileItem) => void;
+  onDelete?: (item: KnowledgeFileItem) => void;
+  onRetry?: (item: KnowledgeFileItem) => void;
+};
+
+const HEADERS = ["文件名", "类型", "大小", "上传时间", "最近处理", "状态", "失败原因", "操作"] as const;
+
+export function renderKnowledgeList(target: HTMLElement, items: readonly KnowledgeFileItem[], callbacks: KnowledgeListCallbacks): void {
+  const table = document.createElement("table");
+  table.className = "knowledge-table";
+  const head = document.createElement("thead");
+  const headRow = document.createElement("tr");
+  for (const label of HEADERS) {
+    const cell = document.createElement("th");
+    cell.textContent = label;
+    headRow.append(cell);
+  }
+  head.append(headRow);
+  const body = document.createElement("tbody");
+  for (const item of items) body.append(knowledgeRow(item, callbacks));
+  table.append(head, body);
+  target.replaceChildren(table);
+}
+
+export function renderKnowledgeEmpty(target: HTMLElement): void {
+  const hint = document.createElement("p");
+  hint.className = "hint";
+  hint.textContent = "暂无知识库文件";
+  target.replaceChildren(hint);
+}
+
+function knowledgeRow(item: KnowledgeFileItem, callbacks: KnowledgeListCallbacks): HTMLTableRowElement {
+  const row = document.createElement("tr");
+  const filename = document.createElement("td");
+  filename.textContent = item.filename;
+  const badge = document.createElement("span");
+  badge.className = "knowledge-source-badge";
+  badge.textContent = item.source === "managed" ? "托管" : "目录";
+  filename.append(document.createTextNode(" "), badge);
+  row.append(filename, textCell(shortContentType(item.content_type)), textCell(formatBytes(item.size)));
+  row.append(textCell(formatDateTime(item.uploaded_at)), textCell(formatDateTime(latestProcessingTime(item))));
+  const status = document.createElement("td");
+  renderKnowledgeStatus(status, item);
+  row.append(status, errorCell(item.error_summary), actionsCell(item, callbacks));
+  return row;
+}
+
+function textCell(value: string): HTMLTableCellElement {
+  const cell = document.createElement("td");
+  cell.textContent = value;
+  return cell;
+}
+
+function errorCell(error: string | null | undefined): HTMLTableCellElement {
+  const cell = textCell(error || "—");
+  cell.className = "knowledge-error-summary";
+  if (error) cell.title = error;
+  return cell;
+}
+
+function actionsCell(item: KnowledgeFileItem, callbacks: KnowledgeListCallbacks): HTMLTableCellElement {
+  const cell = document.createElement("td");
+  cell.className = "knowledge-actions";
+  if (item.source === "directory") {
+    cell.textContent = "—";
+    return cell;
+  }
+  if (item.downloadable) cell.append(actionButton("下载", item, "knowledge-action secondary", callbacks.onDownload));
+  if (item.status === "failed") cell.append(actionButton("重新处理", item, "knowledge-action secondary", callbacks.onRetry));
+  if (item.status !== "processing") cell.append(actionButton("删除", item, "knowledge-action knowledge-action--danger danger", callbacks.onDelete));
+  return cell;
+}
+
+function actionButton(label: string, item: KnowledgeFileItem, className: string, callback: ((item: KnowledgeFileItem) => void) | undefined): HTMLButtonElement {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = className;
+  button.textContent = label;
+  if (item.file_id !== null) button.dataset.fileId = item.file_id;
+  button.onclick = () => callback?.(item);
+  return button;
+}
+
+function shortContentType(contentType: string): string {
+  return contentType.startsWith(".") ? contentType.slice(1) : contentType;
+}
+
+function latestProcessingTime(item: KnowledgeFileItem): string | null {
+  if (item.processing_started_at === null) return item.processed_at;
+  if (item.processed_at === null) return item.processing_started_at;
+  return item.processing_started_at > item.processed_at ? item.processing_started_at : item.processed_at;
+}

--- a/web-console/src/views/knowledge/knowledge-list.ts
+++ b/web-console/src/views/knowledge/knowledge-list.ts
@@ -44,7 +44,9 @@ function knowledgeRow(item: KnowledgeFileItem, callbacks: KnowledgeListCallbacks
   row.append(filename, textCell(shortContentType(item.content_type)), textCell(formatBytes(item.size)));
   row.append(textCell(formatDateTime(item.uploaded_at)), textCell(formatDateTime(latestProcessingTime(item))));
   const status = document.createElement("td");
-  renderKnowledgeStatus(status, item);
+  const statusBadge = document.createElement("span");
+  renderKnowledgeStatus(statusBadge, item);
+  status.append(statusBadge);
   row.append(status, errorCell(item.error_summary), actionsCell(item, callbacks));
   return row;
 }

--- a/web-console/src/views/knowledge/knowledge-paging.ts
+++ b/web-console/src/views/knowledge/knowledge-paging.ts
@@ -1,0 +1,29 @@
+import type { KnowledgeFilePage } from "../../types.js";
+
+export type KnowledgePager = {
+  page: number;
+  totalPages: number;
+  loadedCount: number;
+  hasMore: boolean;
+};
+
+export function initialKnowledgePager(): KnowledgePager {
+  return { page: 1, totalPages: 0, loadedCount: 0, hasMore: false };
+}
+
+export function appendKnowledgePage(pager: KnowledgePager, page: KnowledgeFilePage): KnowledgePager {
+  return {
+    page: page.page,
+    totalPages: page.total_pages,
+    loadedCount: pager.loadedCount + page.items.length,
+    hasMore: page.page < page.total_pages,
+  };
+}
+
+export function hasMoreKnowledgePages(pager: KnowledgePager): boolean {
+  return pager.hasMore;
+}
+
+export function pageAfterKnowledgeDelete(pager: KnowledgePager, deletedCount: number): KnowledgePager {
+  return { ...pager, loadedCount: Math.max(0, pager.loadedCount - deletedCount) };
+}

--- a/web-console/src/views/knowledge/knowledge-polling.ts
+++ b/web-console/src/views/knowledge/knowledge-polling.ts
@@ -4,8 +4,8 @@ export type KnowledgePollingDeps = {
   readonly isVisible: () => boolean;
   readonly setTimeout: (fn: () => void, ms: number) => number;
   readonly clearTimeout: (id: number) => void;
-  readonly fetchPage: (params: KnowledgeFileListParams) => Promise<KnowledgeFilePage>;
-  readonly onUpdate: (page: KnowledgeFilePage) => void;
+  readonly fetchPages: (params: KnowledgeFileListParams, pageCount: number) => Promise<KnowledgeFilePage[]>;
+  readonly onUpdate: (pages: KnowledgeFilePage[]) => void;
   readonly onTransientError: (message: string) => void;
   readonly onTerminalTransition: (message: string) => void;
 };
@@ -69,12 +69,17 @@ export class KnowledgePollingController {
     }
     const generation = ++this.generation;
     try {
-      const page = await this.deps.fetchPage(this.params);
+      const pages = await this.deps.fetchPages(this.params, this.pageCount());
       if (generation !== this.generation) return;
-      this.reportTerminalTransitions(page.items);
-      this.items = [...page.items];
+      if (pages.length === 0) {
+        if (this.hasActive()) this.schedule();
+        return;
+      }
+      const nextItems = pages.flatMap((page) => page.items);
+      this.reportTerminalTransitions(nextItems);
+      this.items = nextItems;
       this.failures = 0;
-      this.deps.onUpdate(page);
+      this.deps.onUpdate(pages);
       if (this.hasActive()) this.schedule();
     } catch (cause) {
       if (generation !== this.generation) return;
@@ -87,6 +92,10 @@ export class KnowledgePollingController {
         this.schedule();
       }
     }
+  }
+
+  private pageCount(): number {
+    return Math.max(1, this.params?.page ?? 1);
   }
 
   private reportTerminalTransitions(nextItems: readonly KnowledgeFileItem[]): void {

--- a/web-console/src/views/knowledge/knowledge-polling.ts
+++ b/web-console/src/views/knowledge/knowledge-polling.ts
@@ -1,0 +1,99 @@
+import type { KnowledgeFileItem, KnowledgeFileListParams, KnowledgeFilePage } from "../../types.js";
+
+export type KnowledgePollingDeps = {
+  readonly isVisible: () => boolean;
+  readonly setTimeout: (fn: () => void, ms: number) => number;
+  readonly clearTimeout: (id: number) => void;
+  readonly fetchPage: (params: KnowledgeFileListParams) => Promise<KnowledgeFilePage>;
+  readonly onUpdate: (page: KnowledgeFilePage) => void;
+  readonly onTransientError: (message: string) => void;
+  readonly onTerminalTransition: (message: string) => void;
+};
+
+const POLL_INTERVAL_MS = 5_000;
+const MAX_CONSECUTIVE_FAILURES = 3;
+
+export class KnowledgePollingController {
+  private timerId: number | null = null;
+  private params: KnowledgeFileListParams | null = null;
+  private items: readonly KnowledgeFileItem[] = [];
+  private failures = 0;
+  private generation = 0;
+
+  constructor(private readonly deps: KnowledgePollingDeps) {}
+
+  start(params: KnowledgeFileListParams): void {
+    this.params = { ...params };
+    this.failures = 0;
+    this.resetTimer();
+  }
+
+  stop(): void {
+    this.generation += 1;
+    if (this.timerId !== null) this.deps.clearTimeout(this.timerId);
+    this.timerId = null;
+  }
+
+  setPages(items: readonly KnowledgeFileItem[]): void {
+    this.items = [...items];
+  }
+
+  hasActive(): boolean {
+    return this.items.some((item) => item.status === "pending" || item.status === "processing");
+  }
+
+  notifyChange(): void {
+    this.resetTimer();
+  }
+
+  private resetTimer(): void {
+    this.stop();
+    if (this.params !== null && this.hasActive()) this.schedule();
+  }
+
+  private schedule(): void {
+    this.timerId = this.deps.setTimeout(() => void this.tick(), POLL_INTERVAL_MS);
+  }
+
+  private async tick(): Promise<void> {
+    this.timerId = null;
+    if (!this.hasActive() || this.params === null) return;
+    if (!this.deps.isVisible()) {
+      this.schedule();
+      return;
+    }
+    const generation = ++this.generation;
+    try {
+      const page = await this.deps.fetchPage(this.params);
+      if (generation !== this.generation) return;
+      this.reportTerminalTransitions(page.items);
+      this.items = [...page.items];
+      this.failures = 0;
+      this.deps.onUpdate(page);
+      if (this.hasActive()) this.schedule();
+    } catch (cause) {
+      if (generation !== this.generation) return;
+      this.failures += 1;
+      this.deps.onTransientError("状态刷新失败");
+      if (this.failures >= MAX_CONSECUTIVE_FAILURES) {
+        this.stop();
+        this.deps.onTransientError("状态刷新多次失败，请手动刷新");
+      } else {
+        this.schedule();
+      }
+    }
+  }
+
+  private reportTerminalTransitions(nextItems: readonly KnowledgeFileItem[]): void {
+    const previous = new Map(this.items.map((item) => [item.file_id, item.status]));
+    for (const item of nextItems) {
+      const status = previous.get(item.file_id);
+      if ((status === "pending" || status === "processing") && item.status === "ready") {
+        this.deps.onTerminalTransition("文件处理完成");
+      }
+      if ((status === "pending" || status === "processing") && item.status === "failed") {
+        this.deps.onTerminalTransition("文件处理失败");
+      }
+    }
+  }
+}

--- a/web-console/src/views/knowledge/knowledge-polling.ts
+++ b/web-console/src/views/knowledge/knowledge-polling.ts
@@ -28,6 +28,11 @@ export class KnowledgePollingController {
     this.resetTimer();
   }
 
+  updateParams(params: KnowledgeFileListParams): void {
+    this.params = { ...params };
+    this.resetTimer();
+  }
+
   stop(): void {
     this.generation += 1;
     if (this.timerId !== null) this.deps.clearTimeout(this.timerId);

--- a/web-console/src/views/knowledge/knowledge-status.ts
+++ b/web-console/src/views/knowledge/knowledge-status.ts
@@ -1,0 +1,35 @@
+import type { KnowledgeFileItem, KnowledgeFileStatus } from "../../types.js";
+
+export function knowledgeStatusMeta(status: KnowledgeFileStatus): { label: string; className: string } {
+  switch (status) {
+    case "pending": return { label: "等待处理", className: "knowledge-status--pending" };
+    case "processing": return { label: "处理中", className: "knowledge-status--processing" };
+    case "ready": return { label: "已完成", className: "knowledge-status--ready" };
+    case "failed": return { label: "处理失败", className: "knowledge-status--failed" };
+  }
+}
+
+export function renderKnowledgeStatus(target: HTMLElement, item: KnowledgeFileItem): void {
+  const meta = knowledgeStatusMeta(item.status);
+  target.className = `knowledge-status ${meta.className}`;
+  target.replaceChildren();
+  const dot = document.createElement("span");
+  dot.className = "knowledge-status-dot";
+  dot.setAttribute("aria-hidden", "true");
+  target.append(dot, document.createTextNode(meta.label));
+}
+
+export function formatBytes(size: number | null): string {
+  if (size === null || size === 0) return "—";
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${formatDecimal(size / 1024)} KB`;
+  return `${formatDecimal(size / (1024 * 1024))} MB`;
+}
+
+export function formatDateTime(value: string | null): string {
+  return value ? value.replace("T", " ").slice(0, 16) : "—";
+}
+
+function formatDecimal(value: number): string {
+  return Number(value.toFixed(1)).toString();
+}

--- a/web-console/src/views/knowledge/knowledge-upload.ts
+++ b/web-console/src/views/knowledge/knowledge-upload.ts
@@ -1,0 +1,64 @@
+import { ConsoleApiError } from "../../api.js";
+import { requiredElement } from "../../dom.js";
+import type { KnowledgeFileCapabilities, KnowledgeFileItem } from "../../types.js";
+
+export type UploadValidation = { ok: true; file: File } | { ok: false; reason: string };
+
+type KnowledgeUploadDependencies = {
+  readonly inputId: string;
+  readonly buttonId: string;
+  readonly setStatus: (text: string) => void;
+  readonly getCapabilities: () => KnowledgeFileCapabilities | null;
+  readonly upload: (file: File) => Promise<KnowledgeFileItem>;
+  readonly onUploaded: () => void;
+};
+
+export function validateKnowledgeFile(file: File, capabilities: KnowledgeFileCapabilities): UploadValidation {
+  const extensions = capabilities.supported_extensions.map((extension) => extension.toLowerCase());
+  if (!extensions.some((extension) => file.name.toLowerCase().endsWith(extension))) {
+    return { ok: false, reason: `仅支持 ${capabilities.supported_extensions.join(" / ")} 文件` };
+  }
+  if (file.size > capabilities.max_file_bytes) {
+    return { ok: false, reason: `文件大小超过上限（${capabilities.max_file_bytes / 1024 / 1024} MB）` };
+  }
+  if (file.name.length > capabilities.max_filename_chars) return { ok: false, reason: "文件名过长" };
+  return { ok: true, file };
+}
+
+export function installKnowledgeUpload(deps: KnowledgeUploadDependencies): void {
+  const button = requiredElement(deps.buttonId, HTMLButtonElement);
+  const input = document.createElement("input");
+  input.id = deps.inputId;
+  input.type = "file";
+  input.hidden = true;
+  input.accept = deps.getCapabilities()?.supported_extensions.join(",") ?? "";
+  document.body.append(input);
+  button.onclick = () => input.click();
+  input.addEventListener("change", () => { void uploadSelectedFile(input, button, deps); });
+}
+
+async function uploadSelectedFile(
+  input: HTMLInputElement,
+  button: HTMLButtonElement,
+  deps: KnowledgeUploadDependencies,
+): Promise<void> {
+  const file = input.files?.[0];
+  if (file === undefined) return;
+  const capabilities = deps.getCapabilities();
+  if (capabilities !== null) {
+    const validation = validateKnowledgeFile(file, capabilities);
+    if (!validation.ok) deps.setStatus(`警告：${validation.reason}，服务端可能拒绝`);
+  }
+  button.disabled = true;
+  deps.setStatus("上传中…");
+  try {
+    await deps.upload(file);
+    deps.setStatus("文件已上传，正在等待处理");
+    deps.onUploaded();
+  } catch (cause) {
+    deps.setStatus(cause instanceof ConsoleApiError ? `${cause.message}（${cause.code}）` : "文件上传失败");
+  } finally {
+    button.disabled = false;
+    input.value = "";
+  }
+}

--- a/web-console/src/views/knowledge/knowledge-upload.ts
+++ b/web-console/src/views/knowledge/knowledge-upload.ts
@@ -4,6 +4,12 @@ import type { KnowledgeFileCapabilities, KnowledgeFileItem } from "../../types.j
 
 export type UploadValidation = { ok: true; file: File } | { ok: false; reason: string };
 
+export function formatFileSizeLimit(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${Number((bytes / (1024 * 1024)).toFixed(1))} MB`;
+  if (bytes >= 1024) return `${Number((bytes / 1024).toFixed(1))} KB`;
+  return `${bytes} B`;
+}
+
 type KnowledgeUploadDependencies = {
   readonly inputId: string;
   readonly buttonId: string;
@@ -19,7 +25,7 @@ export function validateKnowledgeFile(file: File, capabilities: KnowledgeFileCap
     return { ok: false, reason: `仅支持 ${capabilities.supported_extensions.join(" / ")} 文件` };
   }
   if (file.size > capabilities.max_file_bytes) {
-    return { ok: false, reason: `文件大小超过上限（${capabilities.max_file_bytes / 1024 / 1024} MB）` };
+    return { ok: false, reason: `文件大小超过上限（${formatFileSizeLimit(capabilities.max_file_bytes)}）` };
   }
   if (file.name.length > capabilities.max_filename_chars) return { ok: false, reason: "文件名过长" };
   return { ok: true, file };

--- a/web-console/src/views/knowledge/knowledge-upload.ts
+++ b/web-console/src/views/knowledge/knowledge-upload.ts
@@ -53,7 +53,11 @@ async function uploadSelectedFile(
   const capabilities = deps.getCapabilities();
   if (capabilities !== null) {
     const validation = validateKnowledgeFile(file, capabilities);
-    if (!validation.ok) deps.setStatus(`警告：${validation.reason}，服务端可能拒绝`);
+    if (!validation.ok) {
+      deps.setStatus(`上传已阻止：${validation.reason}`);
+      input.value = "";
+      return;
+    }
   }
   button.disabled = true;
   deps.setStatus("上传中…");

--- a/web-console/src/views/knowledge/knowledge.ts
+++ b/web-console/src/views/knowledge/knowledge.ts
@@ -8,6 +8,7 @@ import type { KnowledgeFileCapabilities, KnowledgeFileItem, KnowledgeFileListPar
 import type { KnowledgePager } from "./knowledge-paging.js";
 import { installKnowledgeUpload } from "./knowledge-upload.js";
 
+/** 知识库页面负责筛选、分页和文件操作编排，轮询只消费这里维护的当前列表状态。 */
 type KnowledgeRefreshReason = "refresh" | "upload" | "retry" | "delete" | "filter";
 
 let capabilities: KnowledgeFileCapabilities | null = null;
@@ -76,6 +77,7 @@ export function getKnowledgeCapabilities(): KnowledgeFileCapabilities | null {
 }
 
 export async function refreshKnowledgeList(reason: KnowledgeRefreshReason): Promise<void> {
+  // 各入口共用此刷新边界：筛选和手动刷新从第一页替换，其余操作保留当前筛选条件。
   const reset = reason === "refresh" || reason === "filter";
   if (reset) {
     currentParams = { ...currentParams, page: 1 };
@@ -88,6 +90,8 @@ export async function refreshKnowledgeList(reason: KnowledgeRefreshReason): Prom
     currentParams = { ...currentParams, page: page.page };
     pager = appendKnowledgePage(initialKnowledgePager(), page);
     loadedItems = [...page.items];
+    // 筛选成功后立即替换轮询参数，防止旧条件的异步结果覆盖当前视图。
+    polling.updateParams(currentParams);
     polling.setPages(loadedItems);
     polling.notifyChange();
     renderKnowledgeContent();
@@ -147,6 +151,8 @@ async function loadMoreKnowledgeFiles(): Promise<void> {
     const page = await listKnowledgeFiles(currentParams);
     pager = appendKnowledgePage(pager, page);
     loadedItems = [...loadedItems, ...page.items];
+    // 分页也保持控制器快照与页面条件一致；轮询请求仍固定拉取第一页的状态。
+    polling.updateParams(currentParams);
     polling.setPages(loadedItems);
     polling.notifyChange();
     renderKnowledgeContent();

--- a/web-console/src/views/knowledge/knowledge.ts
+++ b/web-console/src/views/knowledge/knowledge.ts
@@ -2,30 +2,49 @@ import { deleteKnowledgeFile, downloadKnowledgeFile, fetchKnowledgeCapabilities,
 import { requiredElement, setText } from "../../dom.js";
 import { renderKnowledgeEmpty, renderKnowledgeList } from "./knowledge-list.js";
 import { createKnowledgeActionHandlers, triggerBrowserDownload } from "./knowledge-actions.js";
-import { appendKnowledgePage, hasMoreKnowledgePages, initialKnowledgePager } from "./knowledge-paging.js";
+import { appendKnowledgePage, hasMoreKnowledgePages, initialKnowledgePager, type KnowledgePager } from "./knowledge-paging.js";
 import { KnowledgePollingController } from "./knowledge-polling.js";
-import type { KnowledgeFileCapabilities, KnowledgeFileItem, KnowledgeFileListParams } from "../../types.js";
-import type { KnowledgePager } from "./knowledge-paging.js";
+import type { KnowledgeFileCapabilities, KnowledgeFileItem, KnowledgeFileListParams, KnowledgeFilePage } from "../../types.js";
 import { installKnowledgeUpload } from "./knowledge-upload.js";
 
-/** 知识库页面负责筛选、分页和文件操作编排，轮询只消费这里维护的当前列表状态。 */
 type KnowledgeRefreshReason = "refresh" | "upload" | "retry" | "delete" | "filter";
+type KnowledgeFilterParams = Omit<KnowledgeFileListParams, "page">;
 
 let capabilities: KnowledgeFileCapabilities | null = null;
 let pager: KnowledgePager = initialKnowledgePager();
-let loadedItems: KnowledgeFileItem[] = [];
-let currentParams: KnowledgeFileListParams = defaultKnowledgeParams();
+let loadedPages = 0;
+let itemsByPage = new Map<number, KnowledgeFileItem[]>();
+let allItems: KnowledgeFileItem[] = [];
+let filterParams: KnowledgeFilterParams = defaultKnowledgeParams();
 let uploadFlowInstalled = false;
+let loadMoreInFlight = false;
+let requestGeneration = 0;
+let knowledgeInitialized = false;
+let controlsBound = false;
+let documentListenersBound = false;
+
+const onVisibilityChange = () => {
+  if (document.visibilityState !== "hidden" && polling.hasActive()) polling.notifyChange();
+};
+const onPageHide = () => polling.stop();
 
 const polling = new KnowledgePollingController({
   isVisible: () => typeof document === "undefined" || document.visibilityState !== "hidden",
   setTimeout: (fn, ms) => window.setTimeout(fn, ms),
   clearTimeout: (id) => window.clearTimeout(id),
-  fetchPage: (params) => listKnowledgeFiles({ ...params, page: 1 }),
-  onUpdate: (page) => {
-    currentParams = { ...currentParams, page: page.page };
-    pager = appendKnowledgePage(initialKnowledgePager(), page);
-    loadedItems = [...page.items];
+  fetchPages: (params, pageCount) => {
+    const generation = ++requestGeneration;
+    return Promise.all(Array.from({ length: pageCount }, (_, index) => listKnowledgeFiles({ ...params, page: index + 1 }))).then((pages) => {
+      if (generation !== requestGeneration || !paramsMatch({ ...params, page: 1 }, { ...filterParams, page: 1 })) return [];
+      return pages;
+    });
+  },
+  onUpdate: (pages) => {
+    if (pages.length === 0) return;
+    for (const page of pages) itemsByPage.set(page.page, [...page.items]);
+    const lastPage = pages[pages.length - 1];
+    if (lastPage === undefined) return;
+    rebuildLoadedState(lastPage);
     renderKnowledgeContent();
   },
   onTransientError: (message) => setText("knowledge-result", message),
@@ -39,36 +58,49 @@ const actions = createKnowledgeActionHandlers({
   deleteFile: deleteKnowledgeFile,
   retryFile: retryKnowledgeFile,
   refresh: (reason) => void refreshKnowledgeList(reason),
-  getItems: () => loadedItems,
+  getItems: () => allItems,
 });
 
 export async function initializeKnowledge(): Promise<void> {
+  if (knowledgeInitialized) return;
+  knowledgeInitialized = true;
   bindKnowledgeControls();
+  bindDocumentListeners();
   try {
     capabilities = await fetchKnowledgeCapabilities();
   } catch (cause) {
     showKnowledgeError(cause, "知识库能力加载失败");
   }
   if (!uploadFlowInstalled) {
-    installKnowledgeUpload({
-      inputId: "knowledge-upload-input",
-      buttonId: "knowledge-upload-open",
-      setStatus: (text) => setText("knowledge-result", text),
-      getCapabilities: getKnowledgeCapabilities,
-      upload: uploadKnowledgeFile,
-      onUploaded: () => void refreshKnowledgeList("upload"),
-    });
+    installKnowledgeUpload({ inputId: "knowledge-upload-input", buttonId: "knowledge-upload-open", setStatus: (text) => setText("knowledge-result", text), getCapabilities: getKnowledgeCapabilities, upload: uploadKnowledgeFile, onUploaded: () => void refreshKnowledgeList("upload") });
     uploadFlowInstalled = true;
   }
   await refreshKnowledgeList("refresh");
-  polling.start(currentParams);
+  polling.start({ ...filterParams, page: loadedPages || 1 });
+}
+
+export function disposeKnowledge(): void {
+  polling.stop();
+  requestGeneration += 1;
+  if (documentListenersBound && typeof document !== "undefined" && typeof document.removeEventListener === "function") document.removeEventListener("visibilitychange", onVisibilityChange);
+  if (documentListenersBound && typeof window !== "undefined" && typeof window.removeEventListener === "function") window.removeEventListener("pagehide", onPageHide);
+  documentListenersBound = false;
+  const input = typeof document === "undefined" ? null : document.getElementById("knowledge-upload-input");
+  if (input && typeof input.remove === "function") input.remove();
+  capabilities = null;
+  pager = initialKnowledgePager();
+  loadedPages = 0;
+  itemsByPage.clear();
+  allItems = [];
+  filterParams = defaultKnowledgeParams();
+  uploadFlowInstalled = false;
+  knowledgeInitialized = false;
+  controlsBound = false;
+  loadMoreInFlight = false;
   if (typeof document !== "undefined") {
-    document.addEventListener("visibilitychange", () => {
-      if (document.visibilityState !== "hidden" && polling.hasActive()) polling.notifyChange();
-    });
-  }
-  if (typeof window !== "undefined" && typeof window.addEventListener === "function") {
-    window.addEventListener("pagehide", () => polling.stop());
+    document.getElementById("knowledge-list")?.replaceChildren();
+    document.getElementById("knowledge-pagination")?.replaceChildren();
+    if (document.getElementById("knowledge-result")) setText("knowledge-result", "");
   }
 }
 
@@ -77,30 +109,36 @@ export function getKnowledgeCapabilities(): KnowledgeFileCapabilities | null {
 }
 
 export async function refreshKnowledgeList(reason: KnowledgeRefreshReason): Promise<void> {
-  // 各入口共用此刷新边界：筛选和手动刷新从第一页替换，其余操作保留当前筛选条件。
+  const generation = ++requestGeneration;
   const reset = reason === "refresh" || reason === "filter";
   if (reset) {
-    currentParams = { ...currentParams, page: 1 };
+    itemsByPage.clear();
+    loadedPages = 0;
+    allItems = [];
     pager = initialKnowledgePager();
-    loadedItems = [];
   }
-  if (loadedItems.length === 0) renderKnowledgeLoading();
+  if (allItems.length === 0) renderKnowledgeLoading();
+  const params = { ...filterParams, page: 1 };
   try {
-    const page = await listKnowledgeFiles({ ...currentParams, page: 1 });
-    currentParams = { ...currentParams, page: page.page };
-    pager = appendKnowledgePage(initialKnowledgePager(), page);
-    loadedItems = [...page.items];
-    // 筛选成功后立即替换轮询参数，防止旧条件的异步结果覆盖当前视图。
-    polling.updateParams(currentParams);
-    polling.setPages(loadedItems);
-    polling.notifyChange();
+    const page = await listKnowledgeFiles(params);
+    if (generation !== requestGeneration || !paramsMatch(params, { ...filterParams, page: 1 })) return;
+    itemsByPage.set(1, [...page.items]);
+    loadedPages = reset ? 1 : Math.max(loadedPages, 1);
+    rebuildLoadedState(page);
+    polling.updateParams({ ...filterParams, page: loadedPages });
+    polling.setPages(allItems);
     renderKnowledgeContent();
+    polling.notifyChange();
   } catch (cause) {
+    if (generation !== requestGeneration) return;
     showKnowledgeError(cause, "知识库列表加载失败");
+    if (allItems.length === 0) renderKnowledgeLoadError();
   }
 }
 
 function bindKnowledgeControls(): void {
+  if (controlsBound) return;
+  controlsBound = true;
   const search = requiredElement("knowledge-search", HTMLInputElement);
   const status = requiredElement("knowledge-status-filter", HTMLSelectElement);
   const submit = requiredElement("knowledge-filter-submit", HTMLButtonElement);
@@ -113,22 +151,55 @@ function bindKnowledgeControls(): void {
   search.addEventListener("keydown", (event) => { if (event.key === "Enter") { event.preventDefault(); apply(); } });
 }
 
+function bindDocumentListeners(): void {
+  if (documentListenersBound) return;
+  documentListenersBound = true;
+  document.addEventListener("visibilitychange", onVisibilityChange);
+  if (typeof window.addEventListener === "function") window.addEventListener("pagehide", onPageHide);
+}
+
 function syncKnowledgeFilters(search: HTMLInputElement, status: HTMLSelectElement): void {
-  currentParams = { ...currentParams, page: 1, search: search.value.trim(), status: knowledgeStatusValue(status.value) };
+  requestGeneration += 1;
+  filterParams = { ...filterParams, search: search.value.trim(), status: knowledgeStatusValue(status.value) };
+}
+
+function rebuildLoadedState(lastPage: KnowledgeFilePage): void {
+  pager = appendKnowledgePage({ ...pager, loadedCount: 0 }, lastPage);
+  pager = { ...pager, page: loadedPages, loadedCount: allPageItems().length, hasMore: loadedPages < lastPage.total_pages };
+  allItems = allPageItems();
+}
+
+function allPageItems(): KnowledgeFileItem[] {
+  return Array.from({ length: loadedPages }, (_, index) => itemsByPage.get(index + 1) ?? []).flat();
+}
+
+function paramsMatch(left: KnowledgeFileListParams, right: KnowledgeFileListParams): boolean {
+  return left.page_size === right.page_size && left.search === right.search && left.status === right.status && left.sort === right.sort && left.order === right.order;
 }
 
 function renderKnowledgeLoading(): void {
-  const target = requiredElement("knowledge-list", HTMLElement);
   const hint = document.createElement("p");
   hint.className = "hint";
   hint.textContent = "正在加载知识库…";
-  target.replaceChildren(hint);
+  requiredElement("knowledge-list", HTMLElement).replaceChildren(hint);
+}
+
+function renderKnowledgeLoadError(): void {
+  const target = requiredElement("knowledge-list", HTMLElement);
+  const hint = document.createElement("p");
+  hint.className = "hint";
+  hint.textContent = "知识库列表加载失败";
+  const retry = document.createElement("button");
+  retry.type = "button";
+  retry.textContent = "重试";
+  retry.onclick = () => void refreshKnowledgeList("refresh");
+  target.replaceChildren(hint, retry);
 }
 
 function renderKnowledgeContent(): void {
   const target = requiredElement("knowledge-list", HTMLElement);
-  if (loadedItems.length === 0) renderKnowledgeEmpty(target);
-  else renderKnowledgeList(target, loadedItems, actions);
+  if (allItems.length === 0) renderKnowledgeEmpty(target);
+  else renderKnowledgeList(target, allItems, actions);
   renderKnowledgePagination();
 }
 
@@ -139,25 +210,41 @@ function renderKnowledgePagination(): void {
   const button = document.createElement("button");
   button.type = "button";
   button.className = "secondary";
-  button.textContent = "加载更多";
+  button.textContent = loadMoreInFlight ? "加载中…" : "加载更多";
+  button.disabled = loadMoreInFlight;
   button.onclick = () => void loadMoreKnowledgeFiles();
   target.append(button);
 }
 
 async function loadMoreKnowledgeFiles(): Promise<void> {
-  if (!hasMoreKnowledgePages(pager)) return;
+  if (loadMoreInFlight || !hasMoreKnowledgePages(pager)) return;
+  const previous = { loadedPages, pager: { ...pager }, allItems: [...allItems] };
+  const generation = ++requestGeneration;
+  const pageNumber = loadedPages + 1;
+  const params = { ...filterParams, page: pageNumber };
+  loadMoreInFlight = true;
+  renderKnowledgePagination();
   try {
-    currentParams = { ...currentParams, page: currentParams.page + 1 };
-    const page = await listKnowledgeFiles(currentParams);
-    pager = appendKnowledgePage(pager, page);
-    loadedItems = [...loadedItems, ...page.items];
-    // 分页也保持控制器快照与页面条件一致；轮询请求仍固定拉取第一页的状态。
-    polling.updateParams(currentParams);
-    polling.setPages(loadedItems);
-    polling.notifyChange();
+    const page = await listKnowledgeFiles(params);
+    if (generation !== requestGeneration || !paramsMatch(params, { ...filterParams, page: pageNumber })) return;
+    itemsByPage.set(pageNumber, [...page.items]);
+    loadedPages = pageNumber;
+    rebuildLoadedState(page);
+    polling.updateParams({ ...filterParams, page: loadedPages });
+    polling.setPages(allItems);
     renderKnowledgeContent();
+    polling.notifyChange();
   } catch (cause) {
-    showKnowledgeError(cause, "知识库列表加载失败");
+    if (generation === requestGeneration) {
+      loadedPages = previous.loadedPages;
+      pager = previous.pager;
+      allItems = previous.allItems;
+      showKnowledgeError(cause, "知识库列表加载失败");
+      renderKnowledgeContent();
+    }
+  } finally {
+    loadMoreInFlight = false;
+    if (generation === requestGeneration) renderKnowledgePagination();
   }
 }
 
@@ -165,8 +252,8 @@ function showKnowledgeError(cause: unknown, fallback: string): void {
   setText("knowledge-result", cause instanceof Error ? cause.message : fallback);
 }
 
-function defaultKnowledgeParams(): KnowledgeFileListParams {
-  return { page: 1, page_size: 20, search: "", status: "all", sort: "updated_at", order: "desc" };
+function defaultKnowledgeParams(): KnowledgeFilterParams {
+  return { page_size: 20, search: "", status: "all", sort: "updated_at", order: "desc" };
 }
 
 function knowledgeStatusValue(value: string): KnowledgeFileListParams["status"] {

--- a/web-console/src/views/knowledge/knowledge.ts
+++ b/web-console/src/views/knowledge/knowledge.ts
@@ -1,0 +1,3 @@
+export async function initializeKnowledge(): Promise<void> {
+  /* Todo 4 实现页面控制器 */
+}

--- a/web-console/src/views/knowledge/knowledge.ts
+++ b/web-console/src/views/knowledge/knowledge.ts
@@ -1,3 +1,128 @@
+import { fetchKnowledgeCapabilities, listKnowledgeFiles } from "../../api.js";
+import { requiredElement, setText } from "../../dom.js";
+import { renderKnowledgeEmpty, renderKnowledgeList } from "./knowledge-list.js";
+import { appendKnowledgePage, hasMoreKnowledgePages, initialKnowledgePager } from "./knowledge-paging.js";
+import type { KnowledgeFileCapabilities, KnowledgeFileItem, KnowledgeFileListParams } from "../../types.js";
+import type { KnowledgePager } from "./knowledge-paging.js";
+
+type KnowledgeRefreshReason = "refresh" | "upload" | "retry" | "delete" | "filter";
+
+let capabilities: KnowledgeFileCapabilities | null = null;
+let pager: KnowledgePager = initialKnowledgePager();
+let loadedItems: KnowledgeFileItem[] = [];
+let currentParams: KnowledgeFileListParams = defaultKnowledgeParams();
+let uploadHandler: (() => void) | null = null;
+
 export async function initializeKnowledge(): Promise<void> {
-  /* Todo 4 实现页面控制器 */
+  bindKnowledgeControls();
+  try {
+    capabilities = await fetchKnowledgeCapabilities();
+  } catch (cause) {
+    showKnowledgeError(cause, "知识库能力加载失败");
+  }
+  await refreshKnowledgeList("refresh");
+}
+
+export function setKnowledgeUploadHandler(handler: () => void): void {
+  uploadHandler = handler;
+}
+
+export function getKnowledgeCapabilities(): KnowledgeFileCapabilities | null {
+  return capabilities;
+}
+
+export async function refreshKnowledgeList(reason: KnowledgeRefreshReason): Promise<void> {
+  const reset = reason === "refresh" || reason === "filter";
+  if (reset) {
+    currentParams = { ...currentParams, page: 1 };
+    pager = initialKnowledgePager();
+    loadedItems = [];
+  }
+  if (loadedItems.length === 0) renderKnowledgeLoading();
+  try {
+    const page = await listKnowledgeFiles({ ...currentParams, page: 1 });
+    currentParams = { ...currentParams, page: page.page };
+    pager = appendKnowledgePage(initialKnowledgePager(), page);
+    loadedItems = [...page.items];
+    renderKnowledgeContent();
+  } catch (cause) {
+    showKnowledgeError(cause, "知识库列表加载失败");
+  }
+}
+
+function bindKnowledgeControls(): void {
+  const search = requiredElement("knowledge-search", HTMLInputElement);
+  const status = requiredElement("knowledge-status-filter", HTMLSelectElement);
+  const submit = requiredElement("knowledge-filter-submit", HTMLButtonElement);
+  const reset = requiredElement("knowledge-filter-reset", HTMLButtonElement);
+  const refresh = requiredElement("knowledge-refresh", HTMLButtonElement);
+  const upload = requiredElement("knowledge-upload-open", HTMLButtonElement);
+  const apply = () => { syncKnowledgeFilters(search, status); void refreshKnowledgeList("filter"); };
+  submit.onclick = apply;
+  reset.onclick = () => { search.value = ""; status.value = "all"; syncKnowledgeFilters(search, status); void refreshKnowledgeList("filter"); };
+  refresh.onclick = () => void refreshKnowledgeList("refresh");
+  upload.onclick = () => uploadHandler?.();
+  search.addEventListener("keydown", (event) => { if (event.key === "Enter") { event.preventDefault(); apply(); } });
+}
+
+function syncKnowledgeFilters(search: HTMLInputElement, status: HTMLSelectElement): void {
+  currentParams = { ...currentParams, page: 1, search: search.value.trim(), status: knowledgeStatusValue(status.value) };
+}
+
+function renderKnowledgeLoading(): void {
+  const target = requiredElement("knowledge-list", HTMLElement);
+  const hint = document.createElement("p");
+  hint.className = "hint";
+  hint.textContent = "正在加载知识库…";
+  target.replaceChildren(hint);
+}
+
+function renderKnowledgeContent(): void {
+  const target = requiredElement("knowledge-list", HTMLElement);
+  if (loadedItems.length === 0) renderKnowledgeEmpty(target);
+  else renderKnowledgeList(target, loadedItems, {});
+  renderKnowledgePagination();
+}
+
+function renderKnowledgePagination(): void {
+  const target = requiredElement("knowledge-pagination", HTMLElement);
+  target.replaceChildren();
+  if (!hasMoreKnowledgePages(pager)) return;
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "secondary";
+  button.textContent = "加载更多";
+  button.onclick = () => void loadMoreKnowledgeFiles();
+  target.append(button);
+}
+
+async function loadMoreKnowledgeFiles(): Promise<void> {
+  if (!hasMoreKnowledgePages(pager)) return;
+  try {
+    currentParams = { ...currentParams, page: currentParams.page + 1 };
+    const page = await listKnowledgeFiles(currentParams);
+    pager = appendKnowledgePage(pager, page);
+    loadedItems = [...loadedItems, ...page.items];
+    renderKnowledgeContent();
+  } catch (cause) {
+    showKnowledgeError(cause, "知识库列表加载失败");
+  }
+}
+
+function showKnowledgeError(cause: unknown, fallback: string): void {
+  setText("knowledge-result", cause instanceof Error ? cause.message : fallback);
+}
+
+function defaultKnowledgeParams(): KnowledgeFileListParams {
+  return { page: 1, page_size: 20, search: "", status: "all", sort: "updated_at", order: "desc" };
+}
+
+function knowledgeStatusValue(value: string): KnowledgeFileListParams["status"] {
+  switch (value) {
+    case "pending":
+    case "processing":
+    case "ready":
+    case "failed": return value;
+    default: return "all";
+  }
 }

--- a/web-console/src/views/knowledge/knowledge.ts
+++ b/web-console/src/views/knowledge/knowledge.ts
@@ -1,9 +1,12 @@
-import { fetchKnowledgeCapabilities, listKnowledgeFiles } from "../../api.js";
+import { deleteKnowledgeFile, downloadKnowledgeFile, fetchKnowledgeCapabilities, listKnowledgeFiles, retryKnowledgeFile, uploadKnowledgeFile } from "../../api.js";
 import { requiredElement, setText } from "../../dom.js";
 import { renderKnowledgeEmpty, renderKnowledgeList } from "./knowledge-list.js";
+import { createKnowledgeActionHandlers, triggerBrowserDownload } from "./knowledge-actions.js";
 import { appendKnowledgePage, hasMoreKnowledgePages, initialKnowledgePager } from "./knowledge-paging.js";
+import { KnowledgePollingController } from "./knowledge-polling.js";
 import type { KnowledgeFileCapabilities, KnowledgeFileItem, KnowledgeFileListParams } from "../../types.js";
 import type { KnowledgePager } from "./knowledge-paging.js";
+import { installKnowledgeUpload } from "./knowledge-upload.js";
 
 type KnowledgeRefreshReason = "refresh" | "upload" | "retry" | "delete" | "filter";
 
@@ -11,7 +14,32 @@ let capabilities: KnowledgeFileCapabilities | null = null;
 let pager: KnowledgePager = initialKnowledgePager();
 let loadedItems: KnowledgeFileItem[] = [];
 let currentParams: KnowledgeFileListParams = defaultKnowledgeParams();
-let uploadHandler: (() => void) | null = null;
+let uploadFlowInstalled = false;
+
+const polling = new KnowledgePollingController({
+  isVisible: () => typeof document === "undefined" || document.visibilityState !== "hidden",
+  setTimeout: (fn, ms) => window.setTimeout(fn, ms),
+  clearTimeout: (id) => window.clearTimeout(id),
+  fetchPage: (params) => listKnowledgeFiles({ ...params, page: 1 }),
+  onUpdate: (page) => {
+    currentParams = { ...currentParams, page: page.page };
+    pager = appendKnowledgePage(initialKnowledgePager(), page);
+    loadedItems = [...page.items];
+    renderKnowledgeContent();
+  },
+  onTransientError: (message) => setText("knowledge-result", message),
+  onTerminalTransition: (message) => setText("knowledge-result", message),
+});
+
+const actions = createKnowledgeActionHandlers({
+  setStatus: (text) => setText("knowledge-result", text),
+  download: downloadKnowledgeFile,
+  triggerDownload: triggerBrowserDownload,
+  deleteFile: deleteKnowledgeFile,
+  retryFile: retryKnowledgeFile,
+  refresh: (reason) => void refreshKnowledgeList(reason),
+  getItems: () => loadedItems,
+});
 
 export async function initializeKnowledge(): Promise<void> {
   bindKnowledgeControls();
@@ -20,11 +48,27 @@ export async function initializeKnowledge(): Promise<void> {
   } catch (cause) {
     showKnowledgeError(cause, "知识库能力加载失败");
   }
+  if (!uploadFlowInstalled) {
+    installKnowledgeUpload({
+      inputId: "knowledge-upload-input",
+      buttonId: "knowledge-upload-open",
+      setStatus: (text) => setText("knowledge-result", text),
+      getCapabilities: getKnowledgeCapabilities,
+      upload: uploadKnowledgeFile,
+      onUploaded: () => void refreshKnowledgeList("upload"),
+    });
+    uploadFlowInstalled = true;
+  }
   await refreshKnowledgeList("refresh");
-}
-
-export function setKnowledgeUploadHandler(handler: () => void): void {
-  uploadHandler = handler;
+  polling.start(currentParams);
+  if (typeof document !== "undefined") {
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState !== "hidden" && polling.hasActive()) polling.notifyChange();
+    });
+  }
+  if (typeof window !== "undefined" && typeof window.addEventListener === "function") {
+    window.addEventListener("pagehide", () => polling.stop());
+  }
 }
 
 export function getKnowledgeCapabilities(): KnowledgeFileCapabilities | null {
@@ -44,6 +88,8 @@ export async function refreshKnowledgeList(reason: KnowledgeRefreshReason): Prom
     currentParams = { ...currentParams, page: page.page };
     pager = appendKnowledgePage(initialKnowledgePager(), page);
     loadedItems = [...page.items];
+    polling.setPages(loadedItems);
+    polling.notifyChange();
     renderKnowledgeContent();
   } catch (cause) {
     showKnowledgeError(cause, "知识库列表加载失败");
@@ -56,12 +102,10 @@ function bindKnowledgeControls(): void {
   const submit = requiredElement("knowledge-filter-submit", HTMLButtonElement);
   const reset = requiredElement("knowledge-filter-reset", HTMLButtonElement);
   const refresh = requiredElement("knowledge-refresh", HTMLButtonElement);
-  const upload = requiredElement("knowledge-upload-open", HTMLButtonElement);
   const apply = () => { syncKnowledgeFilters(search, status); void refreshKnowledgeList("filter"); };
   submit.onclick = apply;
   reset.onclick = () => { search.value = ""; status.value = "all"; syncKnowledgeFilters(search, status); void refreshKnowledgeList("filter"); };
   refresh.onclick = () => void refreshKnowledgeList("refresh");
-  upload.onclick = () => uploadHandler?.();
   search.addEventListener("keydown", (event) => { if (event.key === "Enter") { event.preventDefault(); apply(); } });
 }
 
@@ -80,7 +124,7 @@ function renderKnowledgeLoading(): void {
 function renderKnowledgeContent(): void {
   const target = requiredElement("knowledge-list", HTMLElement);
   if (loadedItems.length === 0) renderKnowledgeEmpty(target);
-  else renderKnowledgeList(target, loadedItems, {});
+  else renderKnowledgeList(target, loadedItems, actions);
   renderKnowledgePagination();
 }
 
@@ -103,6 +147,8 @@ async function loadMoreKnowledgeFiles(): Promise<void> {
     const page = await listKnowledgeFiles(currentParams);
     pager = appendKnowledgePage(pager, page);
     loadedItems = [...loadedItems, ...page.items];
+    polling.setPages(loadedItems);
+    polling.notifyChange();
     renderKnowledgeContent();
   } catch (cause) {
     showKnowledgeError(cause, "知识库列表加载失败");

--- a/web-console/src/views/knowledge/knowledge.ts
+++ b/web-console/src/views/knowledge/knowledge.ts
@@ -27,6 +27,15 @@ const onVisibilityChange = () => {
   if (document.visibilityState !== "hidden" && polling.hasActive()) polling.notifyChange();
 };
 const onPageHide = () => polling.stop();
+const onSearchKeydown = (event: KeyboardEvent) => {
+  if (event.key === "Enter") {
+    event.preventDefault();
+    const search = requiredElement("knowledge-search", HTMLInputElement);
+    const status = requiredElement("knowledge-status-filter", HTMLSelectElement);
+    syncKnowledgeFilters(search, status);
+    void refreshKnowledgeList("filter");
+  }
+};
 
 const polling = new KnowledgePollingController({
   isVisible: () => typeof document === "undefined" || document.visibilityState !== "hidden",
@@ -84,6 +93,8 @@ export function disposeKnowledge(): void {
   requestGeneration += 1;
   if (documentListenersBound && typeof document !== "undefined" && typeof document.removeEventListener === "function") document.removeEventListener("visibilitychange", onVisibilityChange);
   if (documentListenersBound && typeof window !== "undefined" && typeof window.removeEventListener === "function") window.removeEventListener("pagehide", onPageHide);
+  const search = typeof document === "undefined" ? null : document.getElementById("knowledge-search");
+  if (typeof HTMLInputElement !== "undefined" && search instanceof HTMLInputElement) search.removeEventListener("keydown", onSearchKeydown);
   documentListenersBound = false;
   const input = typeof document === "undefined" ? null : document.getElementById("knowledge-upload-input");
   if (input && typeof input.remove === "function") input.remove();
@@ -148,7 +159,7 @@ function bindKnowledgeControls(): void {
   submit.onclick = apply;
   reset.onclick = () => { search.value = ""; status.value = "all"; syncKnowledgeFilters(search, status); void refreshKnowledgeList("filter"); };
   refresh.onclick = () => void refreshKnowledgeList("refresh");
-  search.addEventListener("keydown", (event) => { if (event.key === "Enter") { event.preventDefault(); apply(); } });
+  search.addEventListener("keydown", onSearchKeydown);
 }
 
 function bindDocumentListeners(): void {

--- a/web-console/tests/console-shell.test.mjs
+++ b/web-console/tests/console-shell.test.mjs
@@ -278,6 +278,12 @@ test("prefers-reduced-motion 下不播放动画但完整同步状态", async () 
 test("pageForTarget 映射保持正确", () => {
   assert.equal(pageForTarget("dashboard")?.id, "overview");
   assert.equal(pageForTarget("capabilities")?.id, "platforms");
+  assert.deepEqual(pageForTarget("knowledge"), {
+    id: "knowledge",
+    label: "知识库",
+    icon: "knowledge",
+    targetId: "knowledge",
+  });
   assert.equal(pageForTarget("markdown")?.id, "tools");
   assert.equal(pageForTarget("unknown"), undefined);
 });

--- a/web-console/tests/knowledge-actions.test.mjs
+++ b/web-console/tests/knowledge-actions.test.mjs
@@ -1,0 +1,119 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { ConsoleApiError } from "../dist/api.js";
+import { createKnowledgeActionHandlers } from "../dist/views/knowledge/knowledge-actions.js";
+import { createFakeDom, installDomGlobals } from "./helpers/fake-dom.mjs";
+
+function item(overrides = {}) {
+  return { file_id: "file-1", filename: "guide.md", source: "managed", status: "ready", downloadable: true, ...overrides };
+}
+
+function setup() {
+  installDomGlobals(createFakeDom());
+  const statuses = [];
+  const refreshes = [];
+  const handlers = createKnowledgeActionHandlers({
+    setStatus: (text) => statuses.push(text),
+    download: async () => ({ blob: new Blob(["guide"]), filename: "guide.md" }),
+    triggerDownload: () => undefined,
+    deleteFile: async () => undefined,
+    retryFile: async () => item({ status: "pending" }),
+    refresh: (reason) => refreshes.push(reason),
+    getItems: () => [],
+  });
+  return { handlers, statuses, refreshes };
+}
+
+function button(fileId, label) {
+  const value = document.createElement("button");
+  value.dataset.fileId = fileId;
+  value.textContent = label;
+  return value;
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+test("download guards unavailable rows and disables its own button while running", async () => {
+  const { handlers } = setup();
+  let resolveDownload;
+  let downloads = 0;
+  const controlled = createKnowledgeActionHandlers({
+    setStatus: () => undefined,
+    download: () => new Promise((resolve) => { downloads += 1; resolveDownload = resolve; }),
+    triggerDownload: () => undefined,
+    deleteFile: async () => undefined,
+    retryFile: async () => item(),
+    refresh: () => undefined,
+    getItems: () => [],
+  });
+  const downloadButton = button("file-1", "下载");
+  controlled.onDownload(item());
+  controlled.onDownload(item());
+  assert.equal(downloadButton.disabled, true);
+  assert.equal(downloads, 1);
+  resolveDownload({ blob: new Blob(["x"]), filename: "guide.md" });
+  await flush();
+  assert.equal(downloadButton.disabled, false);
+  handlers.onDownload(item({ source: "directory" }));
+  handlers.onDownload(item({ downloadable: false }));
+});
+
+test("retry only submits failed managed files and refreshes after success", async () => {
+  const { handlers, refreshes } = setup();
+  button("file-1", "重新处理");
+  handlers.onRetry(item({ status: "failed" }));
+  await flush();
+  assert.deepEqual(refreshes, ["retry"]);
+  handlers.onRetry(item());
+  await flush();
+  assert.deepEqual(refreshes, ["retry"]);
+});
+
+test("delete dialog has safe focus, confirmation guard, and conflict feedback", async () => {
+  const { handlers, statuses, refreshes } = setup();
+  const opener = button("file-1", "删除");
+  let resolveDelete;
+  const controlled = createKnowledgeActionHandlers({
+    setStatus: (text) => statuses.push(text),
+    download: async () => ({ blob: new Blob(), filename: "guide.md" }),
+    triggerDownload: () => undefined,
+    deleteFile: () => new Promise((resolve) => { resolveDelete = resolve; }),
+    retryFile: async () => item(),
+    refresh: (reason) => refreshes.push(reason),
+    getItems: () => [],
+  });
+  controlled.onDelete(item());
+  const dialog = document.querySelector('[role="alertdialog"]');
+  assert.equal(dialog.getAttribute("aria-modal"), "true");
+  assert.match(dialog.children[0].textContent, /guide\.md/);
+  assert.match(dialog.children[1].textContent, /无法继续被检索/);
+  const cancel = dialog.children[2];
+  const confirm = dialog.children[3];
+  assert.equal(cancel.focused, true);
+  dialog.listeners.get("click")[0]({ target: dialog });
+  assert.equal(dialog.getAttribute("open"), "");
+  confirm.onclick();
+  confirm.onclick();
+  assert.equal(confirm.disabled, true);
+  resolveDelete();
+  await flush();
+  assert.deepEqual(refreshes, ["delete"]);
+  assert.equal(statuses.at(-1), "文件已删除");
+  assert.equal(opener.focused, true);
+
+  const conflict = setup();
+  const conflictOpener = button("file-1", "删除");
+  const conflictHandlers = createKnowledgeActionHandlers({
+    setStatus: (text) => conflict.statuses.push(text),
+    download: async () => ({ blob: new Blob(), filename: "guide.md" }), triggerDownload: () => undefined,
+    deleteFile: async () => { throw new ConsoleApiError("冲突", "conflict", 409); }, retryFile: async () => item(),
+    refresh: () => undefined, getItems: () => [],
+  });
+  conflictHandlers.onDelete(item());
+  document.querySelector('[role="alertdialog"]').children[3].onclick();
+  await flush();
+  assert.equal(conflict.statuses.at(-1), "文件正在处理中，暂不能删除");
+  assert.equal(conflictOpener.focused, true);
+  conflictHandlers.onDelete(item({ status: "processing" }));
+});

--- a/web-console/tests/knowledge-actions.test.mjs
+++ b/web-console/tests/knowledge-actions.test.mjs
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { ConsoleApiError } from "../dist/api.js";
-import { createKnowledgeActionHandlers } from "../dist/views/knowledge/knowledge-actions.js";
+import { createKnowledgeActionHandlers, triggerBrowserDownload } from "../dist/views/knowledge/knowledge-actions.js";
 import { createFakeDom, installDomGlobals } from "./helpers/fake-dom.mjs";
 
 function item(overrides = {}) {
@@ -33,6 +33,65 @@ function button(fileId, label) {
 }
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+test("browser download attaches the anchor and defers blob URL revocation", () => {
+  const previousDocument = globalThis.document;
+  const previousUrl = globalThis.URL;
+  const previousWindow = globalThis.window;
+  const href = "blob:test-download";
+  const revoked = [];
+  const timers = [];
+  const body = {
+    children: [],
+    append(anchor) {
+      this.children.push(anchor);
+      anchor.parentNode = this;
+    },
+    removeChild(anchor) {
+      this.children.splice(this.children.indexOf(anchor), 1);
+      anchor.parentNode = null;
+    },
+  };
+  const anchor = {
+    style: {},
+    href: "",
+    download: "",
+    parentNode: null,
+    click() {
+      assert.equal(this.parentNode, body);
+      assert.equal(revoked.length, 0);
+    },
+    remove() {
+      this.parentNode.removeChild(this);
+    },
+  };
+  globalThis.document = { body, createElement: () => anchor };
+  globalThis.URL = {
+    createObjectURL: (blob) => {
+      assert.ok(blob instanceof Blob);
+      return href;
+    },
+    revokeObjectURL: (value) => revoked.push(value),
+  };
+  globalThis.window = { setTimeout: (callback, delay) => timers.push({ callback, delay }) };
+
+  try {
+    triggerBrowserDownload(new Blob(["guide"]), "guide.md");
+    assert.equal(anchor.download, "guide.md");
+    assert.equal(anchor.href, href);
+    assert.equal(anchor.style.display, "none");
+    assert.equal(body.children.length, 0);
+    assert.deepEqual(revoked, []);
+    assert.equal(timers.length, 1);
+    assert.equal(timers[0].delay, 60_000);
+    timers[0].callback();
+    assert.deepEqual(revoked, [href]);
+  } finally {
+    globalThis.document = previousDocument;
+    globalThis.URL = previousUrl;
+    globalThis.window = previousWindow;
+  }
+});
 
 test("download guards unavailable rows and disables its own button while running", async () => {
   const { handlers } = setup();

--- a/web-console/tests/knowledge-actions.test.mjs
+++ b/web-console/tests/knowledge-actions.test.mjs
@@ -11,6 +11,7 @@ function item(overrides = {}) {
 
 function setup() {
   installDomGlobals(createFakeDom());
+  document.body = document.createElement("div");
   const statuses = [];
   const refreshes = [];
   const handlers = createKnowledgeActionHandlers({
@@ -29,6 +30,7 @@ function button(fileId, label) {
   const value = document.createElement("button");
   value.dataset.fileId = fileId;
   value.textContent = label;
+  document.body?.append(value);
   return value;
 }
 
@@ -150,7 +152,6 @@ test("delete dialog has safe focus, confirmation guard, and conflict feedback", 
   const cancel = dialog.children[2];
   const confirm = dialog.children[3];
   assert.equal(cancel.focused, true);
-  dialog.listeners.get("click")[0]({ target: dialog });
   assert.equal(dialog.getAttribute("open"), "");
   confirm.onclick();
   confirm.onclick();
@@ -175,4 +176,18 @@ test("delete dialog has safe focus, confirmation guard, and conflict feedback", 
   assert.equal(conflict.statuses.at(-1), "文件正在处理中，暂不能删除");
   assert.equal(conflictOpener.focused, true);
   conflictHandlers.onDelete(item({ status: "processing" }));
+});
+
+test("delete dialog is a singleton and Escape restores the opener focus", () => {
+  const { handlers } = setup();
+  const first = button("file-a", "删除");
+  handlers.onDelete(item({ file_id: "file-a", filename: "a.md" }));
+  const dialog = document.querySelector('[role="alertdialog"]');
+  handlers.onDelete(item({ file_id: "file-a", filename: "b.md" }));
+  assert.equal(document.querySelectorAll("#knowledge-delete-title").length, 1);
+  assert.equal(document.querySelectorAll("#knowledge-delete-message").length, 1);
+  assert.equal(document.querySelectorAll('[role="alertdialog"]').length, 1);
+  dialog.listeners.get("cancel")[0]({});
+  assert.equal(dialog.getAttribute("open"), null);
+  assert.equal(first.focused, true);
 });

--- a/web-console/tests/knowledge-api.test.mjs
+++ b/web-console/tests/knowledge-api.test.mjs
@@ -1,0 +1,190 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ConsoleApiError,
+  deleteKnowledgeFile,
+  downloadKnowledgeFile,
+  fetchKnowledgeCapabilities,
+  filenameFromContentDisposition,
+  listKnowledgeFiles,
+  parseKnowledgeFileItem,
+  retryKnowledgeFile,
+  setCsrfToken,
+  uploadKnowledgeFile,
+} from "../dist/api.js";
+
+function knowledgeItem(overrides = {}) {
+  return {
+    file_id: "file-1",
+    filename: "a.md",
+    content_type: "text/markdown",
+    size: 12,
+    source: "managed",
+    source_label: "托管",
+    status: "ready",
+    uploaded_at: "2026-01-01T00:00:00Z",
+    processing_started_at: "2026-01-01T00:00:01Z",
+    processed_at: "2026-01-01T00:00:02Z",
+    updated_at: "2026-01-01T00:00:02Z",
+    error_code: null,
+    error_summary: null,
+    chunk_count: 1,
+    embedding_count: 1,
+    downloadable: true,
+    download_url: "/download/file-1",
+    ...overrides,
+  };
+}
+
+function envelope(data) {
+  return { ok: true, data, request_id: "test-request" };
+}
+
+function errorEnvelope(code, message) {
+  return { ok: false, error: { code, message }, request_id: "test-request" };
+}
+
+function jsonResponse(data, status = 200, headers = {}) {
+  return new Response(JSON.stringify(data), { status, headers: { "Content-Type": "application/json", ...headers } });
+}
+
+async function withFetchMock(handler, fn) {
+  const previousFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (input, init = {}) => {
+    calls.push({ input: String(input), init });
+    return handler(input, init);
+  };
+  try {
+    await fn(calls);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+}
+
+function listParams(status = "all") {
+  return { page: 2, page_size: 20, search: "guide", status, sort: "updated_at", order: "desc" };
+}
+
+test("知识库 capabilities 成功解析服务端限制", async () => {
+  await withFetchMock(async () => jsonResponse(envelope({
+    supported_extensions: [".md", ".markdown"], max_file_bytes: 1024, max_filename_chars: 64,
+  })), async () => {
+    const result = await fetchKnowledgeCapabilities();
+    assert.deepEqual(result, { supported_extensions: [".md", ".markdown"], max_file_bytes: 1024, max_filename_chars: 64 });
+  });
+});
+
+test("知识库列表解析分页和缺失的可空字段", async () => {
+  const { file_id, size, uploaded_at, processing_started_at, processed_at, error_code, error_summary, chunk_count, embedding_count, download_url, ...itemWithoutNullableFields } = knowledgeItem();
+  await withFetchMock(async () => jsonResponse(envelope({
+    items: [itemWithoutNullableFields],
+    page: 2, page_size: 20, total: 1, total_pages: 0,
+  })), async () => {
+    const result = await listKnowledgeFiles(listParams());
+    assert.equal(result.page, 2);
+    assert.equal(result.page_size, 20);
+    assert.equal(result.total, 1);
+    assert.equal(result.total_pages, 0);
+    assert.deepEqual(result.items[0], knowledgeItem({ file_id: null, size: null, uploaded_at: null, processing_started_at: null, processed_at: null, error_code: null, error_summary: null, chunk_count: null, embedding_count: null, download_url: null }));
+  });
+});
+
+test("知识库列表仅在具体状态时发送 status", async () => {
+  await withFetchMock(async () => jsonResponse(envelope({ items: [], page: 1, page_size: 20, total: 0, total_pages: 0 })), async (calls) => {
+    await listKnowledgeFiles({ ...listParams(), page: 1 });
+    await listKnowledgeFiles({ ...listParams("failed"), page: 1 });
+    assert.deepEqual(JSON.parse(String(calls[0].init.body)), { page: 1, page_size: 20, search: "guide", sort: "updated_at", order: "desc" });
+    assert.deepEqual(JSON.parse(String(calls[1].init.body)), { page: 1, page_size: 20, search: "guide", status: "failed", sort: "updated_at", order: "desc" });
+  });
+});
+
+test("上传知识库文件使用受 CSRF 保护的 multipart 请求并返回 pending 项", async () => {
+  setCsrfToken("csrf-test");
+  await withFetchMock(async () => jsonResponse(envelope(knowledgeItem({ status: "pending" }))), async (calls) => {
+    const result = await uploadKnowledgeFile(new File(["# guide"], "guide.md", { type: "text/markdown" }));
+    assert.equal(result.status, "pending");
+    assert.equal(calls[0].init.method, "POST");
+    assert.equal(calls[0].init.credentials, "same-origin");
+    assert.equal(calls[0].init.headers["X-CSRF-Token"], "csrf-test");
+    assert.equal(calls[0].init.body.get("file").name, "guide.md");
+  });
+});
+
+test("上传知识库文件保留 413 服务端错误状态和代码", async () => {
+  await withFetchMock(async () => jsonResponse(errorEnvelope("knowledge_file_too_large", "文件过大"), 413), async () => {
+    await assert.rejects(uploadKnowledgeFile(new File(["x"], "large.md")), (error) => (
+      error instanceof ConsoleApiError && error.status === 413 && error.code === "knowledge_file_too_large"
+    ));
+  });
+});
+
+test("下载知识库文件使用受保护 POST 并优先使用 UTF-8 文件名", async () => {
+  setCsrfToken("csrf-test");
+  await withFetchMock(async () => new Response("document", {
+    status: 200,
+    headers: { "Content-Disposition": "attachment; filename=\"a.md\"; filename*=UTF-8''%E6%B5%8B%E8%AF%95.md" },
+  }), async (calls) => {
+    const result = await downloadKnowledgeFile({ file_id: "file-1", filename: "fallback.md" });
+    assert.equal(result.blob instanceof Blob, true);
+    assert.equal(result.filename, "测试.md");
+    assert.equal(calls[0].init.method, "POST");
+    assert.equal(calls[0].init.credentials, "same-origin");
+    assert.equal(calls[0].init.headers["X-CSRF-Token"], "csrf-test");
+  });
+});
+
+test("下载缺少 Content-Disposition 时回退 API 项文件名", async () => {
+  await withFetchMock(async () => new Response("document", { status: 200 }), async () => {
+    const result = await downloadKnowledgeFile({ file_id: "file-1", filename: "fallback.md" });
+    assert.equal(result.filename, "fallback.md");
+  });
+});
+
+test("删除知识库文件支持成功和 409 冲突错误", async () => {
+  await withFetchMock(async () => jsonResponse(envelope({})), async () => {
+    await deleteKnowledgeFile("file-1");
+  });
+  await withFetchMock(async () => jsonResponse(errorEnvelope("conflict", "文件正在处理中"), 409), async () => {
+    await assert.rejects(deleteKnowledgeFile("file-1"), (error) => (
+      error instanceof ConsoleApiError && error.status === 409 && error.code === "conflict"
+    ));
+  });
+});
+
+test("重新处理知识库文件返回 pending 并保留 404 错误", async () => {
+  await withFetchMock(async () => jsonResponse(envelope(knowledgeItem({ status: "pending" }))), async () => {
+    assert.equal((await retryKnowledgeFile("file-1")).status, "pending");
+  });
+  await withFetchMock(async () => jsonResponse(errorEnvelope("not_found", "文件不存在"), 404), async () => {
+    await assert.rejects(retryKnowledgeFile("file-1"), (error) => (
+      error instanceof ConsoleApiError && error.status === 404 && error.code === "not_found"
+    ));
+  });
+});
+
+test("认证和权限错误保留安全信息而不泄漏原始响应", async () => {
+  for (const [status, code, message] of [[401, "unauthorized", "请先登录"], [403, "forbidden", "权限不足"]]) {
+    await withFetchMock(async () => jsonResponse(errorEnvelope(code, message), status), async () => {
+      await assert.rejects(fetchKnowledgeCapabilities(), (error) => (
+        error instanceof ConsoleApiError
+        && error.status === status
+        && error.code === code
+        && error.message === message
+        && !error.message.includes("request_id")
+      ));
+    });
+  }
+});
+
+test("知识库 parser 拒绝缺失必填字段和未知状态", () => {
+  assert.throws(() => parseKnowledgeFileItem(knowledgeItem({ filename: "" })), (error) => error instanceof ConsoleApiError && error.code === "invalid_response");
+  assert.throws(() => parseKnowledgeFileItem(knowledgeItem({ status: "bogus" })), (error) => error instanceof ConsoleApiError && error.code === "invalid_response");
+});
+
+test("Content-Disposition 文件名解析覆盖空值、ASCII 和 UTF-8", () => {
+  assert.equal(filenameFromContentDisposition(null), null);
+  assert.equal(filenameFromContentDisposition("attachment; filename=\"a.md\""), "a.md");
+  assert.equal(filenameFromContentDisposition("attachment; filename*=UTF-8''%E6%B5%8B%E8%AF%95.md"), "测试.md");
+});

--- a/web-console/tests/knowledge-polling.test.mjs
+++ b/web-console/tests/knowledge-polling.test.mjs
@@ -21,8 +21,8 @@ function pollingFixture(overrides = {}) {
     isVisible: () => true,
     setTimeout: (fn) => { const id = nextId++; timers.set(id, fn); return id; },
     clearTimeout: (id) => timers.delete(id),
-    fetchPage: async () => page([item("pending")]),
-    onUpdate: (value) => updates.push(value),
+    fetchPages: async () => [page([item("pending")])],
+    onUpdate: (value) => updates.push(value[0]),
     onTransientError: (message) => errors.push(message),
     onTerminalTransition: (message) => transitions.push(message),
     ...overrides,
@@ -44,10 +44,10 @@ test("polling fetches active pages and ignores stale responses", async () => {
   let resolveSecond;
   let calls = 0;
   const fixture = pollingFixture({
-    fetchPage: () => new Promise((resolve) => {
+    fetchPages: () => new Promise((resolve) => {
       calls += 1;
-      if (calls === 1) resolveFirst = resolve;
-      else resolveSecond = resolve;
+      if (calls === 1) resolveFirst = (value) => resolve([value]);
+      else resolveSecond = (value) => resolve([value]);
     }),
   });
   fixture.controller.setPages([item("pending")]);
@@ -65,7 +65,7 @@ test("polling fetches active pages and ignores stale responses", async () => {
 
 test("polling skips hidden pages and stops after terminal result", async () => {
   let fetches = 0;
-  const fixture = pollingFixture({ isVisible: () => false, fetchPage: async () => { fetches += 1; return page([item("ready")]); } });
+   const fixture = pollingFixture({ isVisible: () => false, fetchPages: async () => { fetches += 1; return [page([item("ready")])]; } });
   fixture.controller.setPages([item("pending")]);
   fixture.controller.start({ page: 1, page_size: 20, search: "", status: "all", sort: "updated_at", order: "desc" });
   await runTimer(fixture.timers);
@@ -73,7 +73,7 @@ test("polling skips hidden pages and stops after terminal result", async () => {
   assert.equal(fixture.timers.size, 1);
   fixture.controller.stop();
   fixture.controller.setPages([item("pending")]);
-  const terminal = pollingFixture({ fetchPage: async () => page([item("ready")]) });
+  const terminal = pollingFixture({ fetchPages: async () => [page([item("ready")])] });
   terminal.controller.setPages([item("pending")]);
   terminal.controller.start({ page: 1, page_size: 20, search: "", status: "all", sort: "updated_at", order: "desc" });
   await runTimer(terminal.timers);
@@ -81,7 +81,7 @@ test("polling skips hidden pages and stops after terminal result", async () => {
 });
 
 test("polling stops after three failures and reports terminal transitions", async () => {
-  const fixture = pollingFixture({ fetchPage: async () => { throw new Error("offline"); } });
+  const fixture = pollingFixture({ fetchPages: async () => { throw new Error("offline"); } });
   fixture.controller.setPages([item("pending")]);
   fixture.controller.start({ page: 1, page_size: 20, search: "", status: "all", sort: "updated_at", order: "desc" });
   await runTimer(fixture.timers);
@@ -90,7 +90,7 @@ test("polling stops after three failures and reports terminal transitions", asyn
   assert.deepEqual(fixture.errors, ["状态刷新失败", "状态刷新失败", "状态刷新失败", "状态刷新多次失败，请手动刷新"]);
   assert.equal(fixture.timers.size, 0);
 
-  const transitions = pollingFixture({ fetchPage: async () => page([item("ready"), item("failed", "file-2")]) });
+  const transitions = pollingFixture({ fetchPages: async () => [page([item("ready"), item("failed", "file-2")])] });
   transitions.controller.setPages([item("pending"), item("processing", "file-2")]);
   transitions.controller.start({ page: 1, page_size: 20, search: "", status: "all", sort: "updated_at", order: "desc" });
   await runTimer(transitions.timers);
@@ -110,9 +110,9 @@ test("notifyChange clears the prior poll timer", () => {
 test("updateParams replaces the next polling request and resets its timer", async () => {
   const requests = [];
   const fixture = pollingFixture({
-    fetchPage: async (params) => {
+    fetchPages: async (params) => {
       requests.push(params);
-      return page([item("pending")]);
+      return [page([item("pending")])];
     },
   });
   const initialParams = { page: 1, page_size: 20, search: "", status: "all", sort: "updated_at", order: "desc" };
@@ -127,4 +127,17 @@ test("updateParams replaces the next polling request and resets its timer", asyn
   assert.equal(fixture.timers.size, 1);
   await runTimer(fixture.timers);
   assert.deepEqual(requests, [filteredParams]);
+});
+
+test("polling continues when a later loaded page is still processing", async () => {
+  const fixture = pollingFixture({
+    fetchPages: async () => [
+      page([item("ready", "page-1")]),
+      page([item("processing", "page-2")]),
+    ],
+  });
+  fixture.controller.setPages([item("ready", "page-1"), item("processing", "page-2")]);
+  fixture.controller.start({ page: 2, page_size: 20, search: "", status: "all", sort: "updated_at", order: "desc" });
+  await runTimer(fixture.timers);
+  assert.equal(fixture.timers.size, 1);
 });

--- a/web-console/tests/knowledge-polling.test.mjs
+++ b/web-console/tests/knowledge-polling.test.mjs
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { KnowledgePollingController } from "../dist/views/knowledge/knowledge-polling.js";
+
+function item(status, fileId = "file-1") {
+  return { file_id: fileId, status };
+}
+
+function page(items) {
+  return { items, page: 1, page_size: 20, total: items.length, total_pages: 1 };
+}
+
+function pollingFixture(overrides = {}) {
+  const timers = new Map();
+  let nextId = 1;
+  const updates = [];
+  const errors = [];
+  const transitions = [];
+  const deps = {
+    isVisible: () => true,
+    setTimeout: (fn) => { const id = nextId++; timers.set(id, fn); return id; },
+    clearTimeout: (id) => timers.delete(id),
+    fetchPage: async () => page([item("pending")]),
+    onUpdate: (value) => updates.push(value),
+    onTransientError: (message) => errors.push(message),
+    onTerminalTransition: (message) => transitions.push(message),
+    ...overrides,
+  };
+  const controller = new KnowledgePollingController(deps);
+  return { controller, timers, updates, errors, transitions };
+}
+
+async function runTimer(timers) {
+  const entry = timers.entries().next().value;
+  assert.ok(entry, "expected a scheduled poll");
+  timers.delete(entry[0]);
+  entry[1]();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test("polling fetches active pages and ignores stale responses", async () => {
+  let resolveFirst;
+  let resolveSecond;
+  let calls = 0;
+  const fixture = pollingFixture({
+    fetchPage: () => new Promise((resolve) => {
+      calls += 1;
+      if (calls === 1) resolveFirst = resolve;
+      else resolveSecond = resolve;
+    }),
+  });
+  fixture.controller.setPages([item("pending")]);
+  fixture.controller.start({ page: 1, page_size: 20, search: "", status: "all", sort: "updated_at", order: "desc" });
+  await runTimer(fixture.timers);
+  fixture.controller.notifyChange();
+  await runTimer(fixture.timers);
+  resolveSecond(page([item("ready")]));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  resolveFirst(page([item("failed")]));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(fixture.updates.length, 1);
+  assert.equal(fixture.updates[0].items[0].status, "ready");
+});
+
+test("polling skips hidden pages and stops after terminal result", async () => {
+  let fetches = 0;
+  const fixture = pollingFixture({ isVisible: () => false, fetchPage: async () => { fetches += 1; return page([item("ready")]); } });
+  fixture.controller.setPages([item("pending")]);
+  fixture.controller.start({ page: 1, page_size: 20, search: "", status: "all", sort: "updated_at", order: "desc" });
+  await runTimer(fixture.timers);
+  assert.equal(fetches, 0);
+  assert.equal(fixture.timers.size, 1);
+  fixture.controller.stop();
+  fixture.controller.setPages([item("pending")]);
+  const terminal = pollingFixture({ fetchPage: async () => page([item("ready")]) });
+  terminal.controller.setPages([item("pending")]);
+  terminal.controller.start({ page: 1, page_size: 20, search: "", status: "all", sort: "updated_at", order: "desc" });
+  await runTimer(terminal.timers);
+  assert.equal(terminal.timers.size, 0);
+});
+
+test("polling stops after three failures and reports terminal transitions", async () => {
+  const fixture = pollingFixture({ fetchPage: async () => { throw new Error("offline"); } });
+  fixture.controller.setPages([item("pending")]);
+  fixture.controller.start({ page: 1, page_size: 20, search: "", status: "all", sort: "updated_at", order: "desc" });
+  await runTimer(fixture.timers);
+  await runTimer(fixture.timers);
+  await runTimer(fixture.timers);
+  assert.deepEqual(fixture.errors, ["状态刷新失败", "状态刷新失败", "状态刷新失败", "状态刷新多次失败，请手动刷新"]);
+  assert.equal(fixture.timers.size, 0);
+
+  const transitions = pollingFixture({ fetchPage: async () => page([item("ready"), item("failed", "file-2")]) });
+  transitions.controller.setPages([item("pending"), item("processing", "file-2")]);
+  transitions.controller.start({ page: 1, page_size: 20, search: "", status: "all", sort: "updated_at", order: "desc" });
+  await runTimer(transitions.timers);
+  assert.deepEqual(transitions.transitions, ["文件处理完成", "文件处理失败"]);
+});
+
+test("notifyChange clears the prior poll timer", () => {
+  const fixture = pollingFixture();
+  fixture.controller.setPages([item("pending")]);
+  fixture.controller.start({ page: 1, page_size: 20, search: "", status: "all", sort: "updated_at", order: "desc" });
+  const first = [...fixture.timers.keys()][0];
+  fixture.controller.notifyChange();
+  assert.equal(fixture.timers.has(first), false);
+  assert.equal(fixture.timers.size, 1);
+});

--- a/web-console/tests/knowledge-polling.test.mjs
+++ b/web-console/tests/knowledge-polling.test.mjs
@@ -106,3 +106,25 @@ test("notifyChange clears the prior poll timer", () => {
   assert.equal(fixture.timers.has(first), false);
   assert.equal(fixture.timers.size, 1);
 });
+
+test("updateParams replaces the next polling request and resets its timer", async () => {
+  const requests = [];
+  const fixture = pollingFixture({
+    fetchPage: async (params) => {
+      requests.push(params);
+      return page([item("pending")]);
+    },
+  });
+  const initialParams = { page: 1, page_size: 20, search: "", status: "all", sort: "updated_at", order: "desc" };
+  const filteredParams = { ...initialParams, search: "失败文件", status: "failed" };
+  fixture.controller.setPages([item("pending")]);
+  fixture.controller.start(initialParams);
+  const initialTimer = [...fixture.timers.keys()][0];
+
+  fixture.controller.updateParams(filteredParams);
+
+  assert.equal(fixture.timers.has(initialTimer), false);
+  assert.equal(fixture.timers.size, 1);
+  await runTimer(fixture.timers);
+  assert.deepEqual(requests, [filteredParams]);
+});

--- a/web-console/tests/knowledge.test.mjs
+++ b/web-console/tests/knowledge.test.mjs
@@ -1,0 +1,148 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { formatBytes, formatDateTime, knowledgeStatusMeta } from "../dist/views/knowledge/knowledge-status.js";
+import {
+  appendKnowledgePage,
+  hasMoreKnowledgePages,
+  initialKnowledgePager,
+  pageAfterKnowledgeDelete,
+} from "../dist/views/knowledge/knowledge-paging.js";
+import { renderKnowledgeList } from "../dist/views/knowledge/knowledge-list.js";
+import { initializeKnowledge, refreshKnowledgeList } from "../dist/views/knowledge/knowledge.js";
+import { createFakeDom, installDomGlobals } from "./helpers/fake-dom.mjs";
+
+function knowledgeItem(overrides = {}) {
+  return {
+    file_id: "file-1",
+    filename: "guide.md",
+    content_type: ".md",
+    size: 2048,
+    source: "managed",
+    source_label: "托管文件",
+    status: "ready",
+    uploaded_at: "2026-08-04T09:30:00",
+    processing_started_at: "2026-08-04T09:31:00",
+    processed_at: "2026-08-04T09:32:00",
+    updated_at: "2026-08-04T09:32:00",
+    error_code: null,
+    error_summary: null,
+    chunk_count: 1,
+    embedding_count: 1,
+    downloadable: true,
+    download_url: null,
+    ...overrides,
+  };
+}
+
+test("知识库状态显示四种稳定文案和类名", () => {
+  assert.deepEqual(knowledgeStatusMeta("pending"), { label: "等待处理", className: "knowledge-status--pending" });
+  assert.deepEqual(knowledgeStatusMeta("processing"), { label: "处理中", className: "knowledge-status--processing" });
+  assert.deepEqual(knowledgeStatusMeta("ready"), { label: "已完成", className: "knowledge-status--ready" });
+  assert.deepEqual(knowledgeStatusMeta("failed"), { label: "处理失败", className: "knowledge-status--failed" });
+});
+
+test("知识库大小和时间格式化保持确定性", () => {
+  assert.equal(formatBytes(null), "—");
+  assert.equal(formatBytes(0), "—");
+  assert.equal(formatBytes(512), "512 B");
+  assert.equal(formatBytes(2048), "2 KB");
+  assert.equal(formatBytes(5 * 1024 * 1024), "5 MB");
+  assert.equal(formatDateTime(null), "—");
+  assert.equal(formatDateTime("2026-08-04T09:30:00"), "2026-08-04 09:30");
+});
+
+test("知识库分页累积、继续加载与删除计数", () => {
+  let pager = initialKnowledgePager();
+  assert.deepEqual(pager, { page: 1, totalPages: 0, loadedCount: 0, hasMore: false });
+  pager = appendKnowledgePage(pager, { items: [knowledgeItem()], page: 1, page_size: 20, total: 2, total_pages: 2 });
+  assert.deepEqual(pager, { page: 1, totalPages: 2, loadedCount: 1, hasMore: true });
+  assert.equal(hasMoreKnowledgePages(pager), true);
+  pager = pageAfterKnowledgeDelete(pager, 5);
+  assert.equal(pager.loadedCount, 0);
+  assert.equal(hasMoreKnowledgePages({ ...pager, hasMore: false }), false);
+});
+
+test("知识库列表按来源和状态展示安全操作并触发回调", () => {
+  installDomGlobals(createFakeDom());
+  const target = document.createElement("div");
+  const calls = [];
+  const ready = knowledgeItem();
+  const failed = knowledgeItem({ file_id: "file-2", status: "failed", downloadable: false });
+  const processing = knowledgeItem({ file_id: "file-3", status: "processing" });
+  const directory = knowledgeItem({ file_id: null, source: "directory", status: "ready", error_summary: undefined });
+  renderKnowledgeList(target, [ready, failed, processing, directory], {
+    onDownload: (item) => calls.push(["download", item]),
+    onDelete: (item) => calls.push(["delete", item]),
+    onRetry: (item) => calls.push(["retry", item]),
+  });
+  const buttons = target.querySelectorAll("button");
+  assert.deepEqual(buttons.map((button) => button.textContent), ["下载", "删除", "重新处理", "删除", "下载"]);
+  assert.equal(target.querySelectorAll("button[data-file-id=\"file-3\"]").some((button) => button.textContent === "删除"), false);
+  assert.equal(target.querySelectorAll("button[data-file-id]").length, 5);
+  const directoryActions = target.children[0].children[1].children[3].children[7];
+  assert.equal(directoryActions.textContent, "—");
+  buttons[0].onclick();
+  buttons[1].onclick();
+  buttons[2].onclick();
+  assert.deepEqual(calls, [["download", ready], ["delete", ready], ["retry", failed]]);
+});
+
+function setupKnowledgePage() {
+  const fake = createFakeDom();
+  installDomGlobals(fake);
+  document.registerStaticId("knowledge-search", "input");
+  document.registerStaticId("knowledge-status-filter", "select");
+  document.registerStaticId("knowledge-filter-submit", "button");
+  document.registerStaticId("knowledge-filter-reset", "button");
+  document.registerStaticId("knowledge-refresh", "button");
+  document.registerStaticId("knowledge-upload-open", "button");
+  document.registerStaticId("knowledge-result", "p");
+  document.registerStaticId("knowledge-list", "div");
+  document.registerStaticId("knowledge-pagination", "div");
+}
+
+function knowledgeResponse(items = []) {
+  return { ok: true, data: { items, page: 1, page_size: 20, total: items.length, total_pages: 1 }, request_id: "test" };
+}
+
+test("知识库刷新展示加载和空态，筛选 all 不发送 status", async () => {
+  setupKnowledgePage();
+  const calls = [];
+  let resolveList;
+  globalThis.fetch = async (_input, init) => {
+    const body = JSON.parse(String(init.body));
+    calls.push(body);
+    if (calls.length === 1) return new Response(JSON.stringify({ ok: true, data: { supported_extensions: [".md"], max_file_bytes: 1, max_filename_chars: 1 } }));
+    return new Promise((resolve) => { resolveList = () => resolve(new Response(JSON.stringify(knowledgeResponse()))); });
+  };
+  const initialized = initializeKnowledge();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(document.getElementById("knowledge-list").children[0].textContent, "正在加载知识库…");
+  resolveList();
+  await initialized;
+  assert.equal(document.getElementById("knowledge-list").children[0].textContent, "暂无知识库文件");
+  assert.equal("status" in calls[1], false);
+  const search = document.getElementById("knowledge-search");
+  const status = document.getElementById("knowledge-status-filter");
+  search.value = "old";
+  status.value = "failed";
+  document.getElementById("knowledge-filter-reset").onclick();
+  resolveList();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(search.value, "");
+  assert.equal(status.value, "all");
+  delete globalThis.fetch;
+});
+
+test("知识库刷新失败保留现有列表并显示安全错误", async () => {
+  setupKnowledgePage();
+  globalThis.fetch = async () => new Response(JSON.stringify(knowledgeResponse([knowledgeItem()])), { status: 200 });
+  await refreshKnowledgeList("refresh");
+  const existing = document.getElementById("knowledge-list").children[0];
+  globalThis.fetch = async () => new Response(JSON.stringify({ ok: false, error: { message: "会话已过期" } }), { status: 401 });
+  await refreshKnowledgeList("upload");
+  assert.equal(document.getElementById("knowledge-list").children[0], existing);
+  assert.match(document.getElementById("knowledge-result").textContent, /会话已过期|HTTP 401/);
+  delete globalThis.fetch;
+});

--- a/web-console/tests/knowledge.test.mjs
+++ b/web-console/tests/knowledge.test.mjs
@@ -10,6 +10,8 @@ import {
 } from "../dist/views/knowledge/knowledge-paging.js";
 import { renderKnowledgeList } from "../dist/views/knowledge/knowledge-list.js";
 import { initializeKnowledge, refreshKnowledgeList } from "../dist/views/knowledge/knowledge.js";
+import { ConsoleApiError } from "../dist/api.js";
+import { installKnowledgeUpload, validateKnowledgeFile } from "../dist/views/knowledge/knowledge-upload.js";
 import { createFakeDom, installDomGlobals } from "./helpers/fake-dom.mjs";
 
 function knowledgeItem(overrides = {}) {
@@ -91,6 +93,7 @@ test("知识库列表按来源和状态展示安全操作并触发回调", () =>
 function setupKnowledgePage() {
   const fake = createFakeDom();
   installDomGlobals(fake);
+  document.body = document.createElement("div");
   document.registerStaticId("knowledge-search", "input");
   document.registerStaticId("knowledge-status-filter", "select");
   document.registerStaticId("knowledge-filter-submit", "button");
@@ -101,6 +104,87 @@ function setupKnowledgePage() {
   document.registerStaticId("knowledge-list", "div");
   document.registerStaticId("knowledge-pagination", "div");
 }
+
+function knowledgeCapabilities() {
+  return { supported_extensions: [".md", ".markdown"], max_file_bytes: 1024, max_filename_chars: 16 };
+}
+
+function file(name, size) {
+  return new File(["x".repeat(size)], name, { type: "text/markdown" });
+}
+
+function setupUpload(upload) {
+  const fake = createFakeDom();
+  installDomGlobals(fake);
+  document.body = document.createElement("div");
+  const button = document.registerStaticId("knowledge-upload-open", "button");
+  const statuses = [];
+  let uploaded = 0;
+  installKnowledgeUpload({
+    inputId: "knowledge-upload-input",
+    buttonId: "knowledge-upload-open",
+    setStatus: (text) => statuses.push(text),
+    getCapabilities: knowledgeCapabilities,
+    upload,
+    onUploaded: () => { uploaded += 1; },
+  });
+  const input = document.getElementById("knowledge-upload-input");
+  return { button, input, statuses, uploaded: () => uploaded };
+}
+
+function triggerInputChange(input, selectedFile) {
+  input.files = [selectedFile];
+  for (const listener of input.listeners.get("change")) listener();
+}
+
+test("知识库上传预检覆盖格式、大小、文件名和大小写边界", () => {
+  const capabilities = knowledgeCapabilities();
+  const validFile = file("guide.md", 100);
+  const validResult = validateKnowledgeFile(validFile, capabilities);
+  assert.equal(validResult.ok, true);
+  if (validResult.ok) assert.equal(validResult.file, validFile);
+  assert.equal(validateKnowledgeFile(file("guide.txt", 100), capabilities).reason, "仅支持 .md / .markdown 文件");
+  assert.equal(validateKnowledgeFile(file("guide.md", 1025), capabilities).ok, false);
+  assert.equal(validateKnowledgeFile(file("a".repeat(14) + ".md", 100), capabilities).reason, "文件名过长");
+  assert.equal(validateKnowledgeFile(file("GUIDE.MARKDOWN", 100), capabilities).ok, true);
+});
+
+test("知识库上传禁用按钮至成功并按能力生成 accept", async () => {
+  let resolveUpload;
+  const flow = setupUpload(() => new Promise((resolve) => { resolveUpload = resolve; }));
+  let clicked = false;
+  flow.input.click = () => { clicked = true; };
+  flow.button.onclick();
+  assert.equal(clicked, true);
+  assert.equal(flow.input.accept, ".md,.markdown");
+  triggerInputChange(flow.input, file("guide.md", 100));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(flow.button.disabled, true);
+  assert.equal(flow.statuses.at(-1), "上传中…");
+  resolveUpload(knowledgeItem({ status: "pending" }));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(flow.statuses.at(-1), "文件已上传，正在等待处理");
+  assert.equal(flow.uploaded(), 1);
+  assert.equal(flow.button.disabled, false);
+});
+
+test("知识库上传失败显示安全代码并恢复按钮", async () => {
+  const flow = setupUpload(async () => { throw new ConsoleApiError("文件过大", "knowledge_file_too_large", 413); });
+  triggerInputChange(flow.input, file("guide.md", 100));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.match(flow.statuses.at(-1), /knowledge_file_too_large/);
+  assert.equal(flow.uploaded(), 0);
+  assert.equal(flow.button.disabled, false);
+});
+
+test("知识库上传格式预警仍提交给服务端", async () => {
+  const files = [];
+  const flow = setupUpload(async (selectedFile) => { files.push(selectedFile); return knowledgeItem({ status: "pending" }); });
+  triggerInputChange(flow.input, file("guide.txt", 100));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(files[0].name, "guide.txt");
+  assert.equal(flow.statuses.includes("警告：仅支持 .md / .markdown 文件，服务端可能拒绝"), true);
+});
 
 function knowledgeResponse(items = []) {
   return { ok: true, data: { items, page: 1, page_size: 20, total: items.length, total_pages: 1 }, request_id: "test" };

--- a/web-console/tests/knowledge.test.mjs
+++ b/web-console/tests/knowledge.test.mjs
@@ -84,6 +84,9 @@ test("知识库列表按来源和状态展示安全操作并触发回调", () =>
   assert.equal(target.querySelectorAll("button[data-file-id]").length, 5);
   const directoryActions = target.children[0].children[1].children[3].children[7];
   assert.equal(directoryActions.textContent, "—");
+  const readyStatus = target.children[0].children[1].children[0].children[5];
+  assert.equal(readyStatus.className, "");
+  assert.equal(readyStatus.children[0].className, "knowledge-status knowledge-status--ready");
   buttons[0].onclick();
   buttons[1].onclick();
   buttons[2].onclick();

--- a/web-console/tests/knowledge.test.mjs
+++ b/web-console/tests/knowledge.test.mjs
@@ -117,7 +117,7 @@ function file(name, size) {
   return new File(["x".repeat(size)], name, { type: "text/markdown" });
 }
 
-function setupUpload(upload) {
+function setupUpload(upload, getCapabilities = knowledgeCapabilities) {
   const fake = createFakeDom();
   installDomGlobals(fake);
   document.body = document.createElement("div");
@@ -128,7 +128,7 @@ function setupUpload(upload) {
     inputId: "knowledge-upload-input",
     buttonId: "knowledge-upload-open",
     setStatus: (text) => statuses.push(text),
-    getCapabilities: knowledgeCapabilities,
+    getCapabilities,
     upload,
     onUploaded: () => { uploaded += 1; },
   });
@@ -190,10 +190,22 @@ test("知识库上传失败显示安全代码并恢复按钮", async () => {
 test("知识库上传格式预检会阻止请求", async () => {
   const files = [];
   const flow = setupUpload(async (selectedFile) => { files.push(selectedFile); return knowledgeItem({ status: "pending" }); });
-  triggerInputChange(flow.input, file("guide.txt", 100));
+  for (const [invalidFile, reason] of [
+    [file("guide.txt", 100), "仅支持 .md / .markdown 文件"],
+    [file("guide.md", 1025), "文件大小超过上限（1 KB）"],
+    [file(`${"a".repeat(14)}.md`, 100), "文件名过长"],
+  ]) {
+    triggerInputChange(flow.input, invalidFile);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(files.length, 0, `${reason} 不应发送上传请求`);
+    assert.equal(flow.statuses.at(-1), `上传已阻止：${reason}`);
+  }
+
+  const serverAuthoritative = setupUpload(async (selectedFile) => { files.push(selectedFile); return knowledgeItem({ status: "pending" }); }, () => null);
+  triggerInputChange(serverAuthoritative.input, file("guide.txt", 100));
   await new Promise((resolve) => setTimeout(resolve, 0));
-  assert.equal(files.length, 0);
-  assert.equal(flow.statuses.at(-1), "上传已阻止：仅支持 .md / .markdown 文件");
+  assert.equal(files.length, 1, "能力尚未加载时应交由服务端校验");
+  assert.equal(serverAuthoritative.statuses.at(-1), "文件已上传，正在等待处理");
 });
 
 function knowledgeResponse(items = []) {
@@ -280,6 +292,14 @@ test("知识库刷新失败保留现有列表并显示安全错误", async () =>
 
 test("加载两页后轮询不会丢失后续页", async () => {
   setupKnowledgePage();
+  const timers = new Map();
+  let nextTimerId = 1;
+  window.setTimeout = (callback) => {
+    const timerId = nextTimerId++;
+    timers.set(timerId, callback);
+    return timerId;
+  };
+  window.clearTimeout = (timerId) => timers.delete(timerId);
   const requests = [];
   globalThis.fetch = async (_input, init) => {
     const body = JSON.parse(String(init.body));
@@ -291,20 +311,102 @@ test("加载两页后轮询不会丢失后续页", async () => {
   };
   await initializeKnowledge();
   document.getElementById("knowledge-pagination").children[0].onclick();
-  await new Promise((resolve) => setTimeout(resolve, 10));
-  await new Promise((resolve) => setTimeout(resolve, 10));
+  await new Promise((resolve) => setTimeout(resolve, 0));
   assert.equal(requests.some((request) => request.page === 2), true);
-  const body = document.getElementById("knowledge-list").children[0].children[1];
+  let body = document.getElementById("knowledge-list").children[0].children[1];
   assert.equal(body.children.some((row) => row.children[0].textContent === "page-2.md"), true);
+  const scheduled = timers.entries().next().value;
+  assert.ok(scheduled, "第二页仍在处理中时应安排轮询");
+  timers.delete(scheduled[0]);
+  scheduled[1]();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(requests.slice(-2).map((request) => request.page), [1, 2]);
+  body = document.getElementById("knowledge-list").children[0].children[1];
+  assert.equal(body.children.some((row) => row.children[0].textContent === "page-2.md"), true, "轮询完成后必须保留已加载的第二页");
   delete globalThis.fetch;
 });
 
-test("首屏列表失败退出加载态并提供重试", async () => {
+test("连续点击加载更多只请求一次并且不会重复追加", async () => {
   setupKnowledgePage();
-  globalThis.fetch = async () => { throw new Error("列表不可用"); };
+  const requests = [];
+  let resolvePageTwo;
+  globalThis.fetch = async (_input, init) => {
+    const body = JSON.parse(String(init.body));
+    requests.push(body);
+    if (requests.length === 1) return new Response(JSON.stringify({ ok: true, data: knowledgeCapabilities() }));
+    if (body.page === 2) return new Promise((resolve) => { resolvePageTwo = () => resolve(new Response(JSON.stringify({ ok: true, data: { items: [knowledgeItem({ file_id: "file-2", filename: "page-2.md" })], page: 2, page_size: 20, total: 2, total_pages: 2 } }))); });
+    return new Response(JSON.stringify({ ok: true, data: { items: [knowledgeItem({ filename: "page-1.md" })], page: 1, page_size: 20, total: 2, total_pages: 2 } }));
+  };
+  await initializeKnowledge();
+  const loadMore = document.getElementById("knowledge-pagination").children[0];
+  loadMore.onclick();
+  loadMore.onclick();
+  assert.equal(document.getElementById("knowledge-pagination").children[0].disabled, true);
+  assert.equal(requests.filter((request) => request.page === 2).length, 1);
+  resolvePageTwo();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const rows = document.getElementById("knowledge-list").children[0].children[1].children;
+  assert.deepEqual(rows.map((row) => row.children[0].textContent), ["page-1.md", "page-2.md"]);
+  assert.equal(document.getElementById("knowledge-pagination").children.length, 0, "最后一页完成后加载更多按钮应消失");
+  delete globalThis.fetch;
+});
+
+test("登出停止轮询，重新登录不重复绑定控件并重建上传输入", async () => {
+  setupKnowledgePage();
+  const timers = new Map();
+  let nextTimerId = 1;
+  window.setTimeout = (callback) => {
+    const timerId = nextTimerId++;
+    timers.set(timerId, callback);
+    return timerId;
+  };
+  window.clearTimeout = (timerId) => timers.delete(timerId);
+  const requests = [];
+  globalThis.fetch = async (_input, init) => {
+    const body = JSON.parse(String(init.body));
+    requests.push(body);
+    if (body.page === undefined) return new Response(JSON.stringify({ ok: true, data: knowledgeCapabilities() }));
+    return new Response(JSON.stringify(knowledgeResponse([knowledgeItem({ status: "pending" })])));
+  };
+  await initializeKnowledge();
+  assert.equal(timers.size, 1, "待处理文件应启动轮询");
+  const firstInput = document.getElementById("knowledge-upload-input");
+  let removed = false;
+  firstInput.remove = () => { removed = true; document.registry.delete("knowledge-upload-input"); };
+  disposeKnowledge();
+  assert.equal(timers.size, 0, "登出必须清除已安排的轮询");
+  assert.equal(removed, true, "登出必须移除上传输入");
+  assert.equal(document.getElementById("knowledge-upload-input"), null);
+  await initializeKnowledge();
+  assert.equal(requests.length, 4, "重新登录应重新加载 capabilities 和第一页列表");
+  assert.notEqual(document.getElementById("knowledge-upload-input"), firstInput, "重新登录必须创建新的上传输入");
+  const beforeFilter = requests.length;
+  document.getElementById("knowledge-search").value = "relogin";
+  for (const listener of document.getElementById("knowledge-search").listeners.get("keydown")) listener({ key: "Enter", preventDefault: () => undefined });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(requests.length - beforeFilter, 1, "重新登录后的 Enter 筛选只能发送一次列表请求");
+  disposeKnowledge();
+  delete globalThis.fetch;
+});
+
+test("首屏列表失败退出加载态并可重试恢复列表", async () => {
+  setupKnowledgePage();
+  let attempts = 0;
+  globalThis.fetch = async () => {
+    attempts += 1;
+    if (attempts === 1) throw new Error("列表不可用");
+    return new Response(JSON.stringify(knowledgeResponse([knowledgeItem({ filename: "retry.md" })])));
+  };
   await refreshKnowledgeList("refresh");
   assert.equal(document.getElementById("knowledge-list").textContent.includes("正在加载知识库…"), false);
   assert.equal(document.getElementById("knowledge-list").children[0].textContent, "知识库列表加载失败");
   assert.match(document.getElementById("knowledge-result").textContent, /列表不可用/);
+  const retry = document.getElementById("knowledge-list").children[1];
+  assert.equal(retry.textContent, "重试");
+  retry.onclick();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const rows = document.getElementById("knowledge-list").children[0].children[1].children;
+  assert.equal(rows.some((row) => row.children[0].textContent === "retry.md"), true);
+  assert.equal(document.getElementById("knowledge-list").textContent.includes("正在加载知识库…"), false);
   delete globalThis.fetch;
 });

--- a/web-console/tests/knowledge.test.mjs
+++ b/web-console/tests/knowledge.test.mjs
@@ -9,7 +9,7 @@ import {
   pageAfterKnowledgeDelete,
 } from "../dist/views/knowledge/knowledge-paging.js";
 import { renderKnowledgeList } from "../dist/views/knowledge/knowledge-list.js";
-import { initializeKnowledge, refreshKnowledgeList } from "../dist/views/knowledge/knowledge.js";
+import { disposeKnowledge, initializeKnowledge, refreshKnowledgeList } from "../dist/views/knowledge/knowledge.js";
 import { ConsoleApiError } from "../dist/api.js";
 import { formatFileSizeLimit, installKnowledgeUpload, validateKnowledgeFile } from "../dist/views/knowledge/knowledge-upload.js";
 import { createFakeDom, installDomGlobals } from "./helpers/fake-dom.mjs";
@@ -94,6 +94,7 @@ test("知识库列表按来源和状态展示安全操作并触发回调", () =>
 });
 
 function setupKnowledgePage() {
+  disposeKnowledge();
   const fake = createFakeDom();
   installDomGlobals(fake);
   document.body = document.createElement("div");
@@ -186,13 +187,13 @@ test("知识库上传失败显示安全代码并恢复按钮", async () => {
   assert.equal(flow.button.disabled, false);
 });
 
-test("知识库上传格式预警仍提交给服务端", async () => {
+test("知识库上传格式预检会阻止请求", async () => {
   const files = [];
   const flow = setupUpload(async (selectedFile) => { files.push(selectedFile); return knowledgeItem({ status: "pending" }); });
   triggerInputChange(flow.input, file("guide.txt", 100));
   await new Promise((resolve) => setTimeout(resolve, 0));
-  assert.equal(files[0].name, "guide.txt");
-  assert.equal(flow.statuses.includes("警告：仅支持 .md / .markdown 文件，服务端可能拒绝"), true);
+  assert.equal(files.length, 0);
+  assert.equal(flow.statuses.at(-1), "上传已阻止：仅支持 .md / .markdown 文件");
 });
 
 function knowledgeResponse(items = []) {
@@ -274,5 +275,36 @@ test("知识库刷新失败保留现有列表并显示安全错误", async () =>
   await refreshKnowledgeList("upload");
   assert.equal(document.getElementById("knowledge-list").children[0], existing);
   assert.match(document.getElementById("knowledge-result").textContent, /会话已过期|HTTP 401/);
+  delete globalThis.fetch;
+});
+
+test("加载两页后轮询不会丢失后续页", async () => {
+  setupKnowledgePage();
+  const requests = [];
+  globalThis.fetch = async (_input, init) => {
+    const body = JSON.parse(String(init.body));
+    requests.push(body);
+    if (requests.length === 1) return new Response(JSON.stringify({ ok: true, data: knowledgeCapabilities() }));
+    const pageNumber = body.page;
+    const itemName = pageNumber === 1 ? "page-1.md" : "page-2.md";
+    return new Response(JSON.stringify({ ok: true, data: { items: [knowledgeItem({ filename: itemName, file_id: `file-${pageNumber}`, status: pageNumber === 2 ? "processing" : "ready" })], page: pageNumber, page_size: 20, total: 2, total_pages: 2 } }));
+  };
+  await initializeKnowledge();
+  document.getElementById("knowledge-pagination").children[0].onclick();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.equal(requests.some((request) => request.page === 2), true);
+  const body = document.getElementById("knowledge-list").children[0].children[1];
+  assert.equal(body.children.some((row) => row.children[0].textContent === "page-2.md"), true);
+  delete globalThis.fetch;
+});
+
+test("首屏列表失败退出加载态并提供重试", async () => {
+  setupKnowledgePage();
+  globalThis.fetch = async () => { throw new Error("列表不可用"); };
+  await refreshKnowledgeList("refresh");
+  assert.equal(document.getElementById("knowledge-list").textContent.includes("正在加载知识库…"), false);
+  assert.equal(document.getElementById("knowledge-list").children[0].textContent, "知识库列表加载失败");
+  assert.match(document.getElementById("knowledge-result").textContent, /列表不可用/);
   delete globalThis.fetch;
 });

--- a/web-console/tests/knowledge.test.mjs
+++ b/web-console/tests/knowledge.test.mjs
@@ -225,6 +225,43 @@ test("知识库刷新展示加载和空态，筛选 all 不发送 status", async
   delete globalThis.fetch;
 });
 
+test("知识库状态筛选同步到轮询请求且不会覆盖筛选结果", async () => {
+  setupKnowledgePage();
+  const timers = new Map();
+  const requests = [];
+  let nextTimerId = 1;
+  window.setTimeout = (callback) => {
+    const timerId = nextTimerId++;
+    timers.set(timerId, callback);
+    return timerId;
+  };
+  window.clearTimeout = (timerId) => timers.delete(timerId);
+  globalThis.fetch = async (_input, init) => {
+    const body = JSON.parse(String(init.body));
+    requests.push(body);
+    if (requests.length === 1) return new Response(JSON.stringify({ ok: true, data: knowledgeCapabilities() }));
+    if (body.status === "processing") return new Response(JSON.stringify(knowledgeResponse([knowledgeItem({ filename: "processing.md", status: "processing" })])));
+    return new Response(JSON.stringify(knowledgeResponse([knowledgeItem({ filename: "pending.md", status: "pending" })])));
+  };
+
+  await initializeKnowledge();
+  const status = document.getElementById("knowledge-status-filter");
+  status.value = "processing";
+  document.getElementById("knowledge-filter-submit").onclick();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const scheduled = timers.entries().next().value;
+  assert.ok(scheduled, "筛选后的待处理列表应启动轮询");
+  timers.delete(scheduled[0]);
+  scheduled[1]();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(requests[2].status, "processing");
+  assert.equal(requests[3].status, "processing");
+  assert.equal(document.getElementById("knowledge-list").children[0].children[1].children[0].children[0].textContent, "processing.md");
+  delete globalThis.fetch;
+});
+
 test("知识库刷新失败保留现有列表并显示安全错误", async () => {
   setupKnowledgePage();
   globalThis.fetch = async () => new Response(JSON.stringify(knowledgeResponse([knowledgeItem()])), { status: 200 });

--- a/web-console/tests/knowledge.test.mjs
+++ b/web-console/tests/knowledge.test.mjs
@@ -11,7 +11,7 @@ import {
 import { renderKnowledgeList } from "../dist/views/knowledge/knowledge-list.js";
 import { initializeKnowledge, refreshKnowledgeList } from "../dist/views/knowledge/knowledge.js";
 import { ConsoleApiError } from "../dist/api.js";
-import { installKnowledgeUpload, validateKnowledgeFile } from "../dist/views/knowledge/knowledge-upload.js";
+import { formatFileSizeLimit, installKnowledgeUpload, validateKnowledgeFile } from "../dist/views/knowledge/knowledge-upload.js";
 import { createFakeDom, installDomGlobals } from "./helpers/fake-dom.mjs";
 
 function knowledgeItem(overrides = {}) {
@@ -144,9 +144,15 @@ test("知识库上传预检覆盖格式、大小、文件名和大小写边界",
   assert.equal(validResult.ok, true);
   if (validResult.ok) assert.equal(validResult.file, validFile);
   assert.equal(validateKnowledgeFile(file("guide.txt", 100), capabilities).reason, "仅支持 .md / .markdown 文件");
-  assert.equal(validateKnowledgeFile(file("guide.md", 1025), capabilities).ok, false);
+  assert.equal(validateKnowledgeFile(file("guide.md", 1025), capabilities).reason, "文件大小超过上限（1 KB）");
   assert.equal(validateKnowledgeFile(file("a".repeat(14) + ".md", 100), capabilities).reason, "文件名过长");
   assert.equal(validateKnowledgeFile(file("GUIDE.MARKDOWN", 100), capabilities).ok, true);
+});
+
+test("知识库上传大小上限格式化保持可读", () => {
+  assert.equal(formatFileSizeLimit(50 * 1024 * 1024), "50 MB");
+  assert.equal(formatFileSizeLimit(1536 * 1024), "1.5 MB");
+  assert.equal(formatFileSizeLimit(1024), "1 KB");
 });
 
 test("知识库上传禁用按钮至成功并按能力生成 accept", async () => {


### PR DESCRIPTION
Fixes #643

父任务：#641
依赖：后端 API 与状态契约（#642，已通过 PR #644 合入）

## 目标

为 Web 控制台增加与现有页面风格一致的「知识库管理」页面：查看托管文件与历史目录文档的分页列表、上传 Markdown 文件并跟踪处理生命周期、下载原始文件、删除文件及其派生数据、对失败文件重新处理。前端只消费真实 API，不创建假数据或假的成功状态。

## 实现范围

### 1. 页面和导航
- 底部导航新增「知识库」入口（console-shell 注册 + SVG 图标 + hash 路由）。
- 页面包含标题、说明、「上传文件」按钮；工具栏提供文件名搜索（Enter 或按钮提交，防抖不逐字符请求）、状态筛选、刷新与重置。
- 列表展示文件名（含 托管/目录 来源徽章）、类型、大小、上传时间、最近处理时间、状态、失败原因（安全摘要，超长截断）和操作区。
- 状态同时显示文字与几何信号（pending 等待处理/processing 处理中/ready 已完成/failed 处理失败），不只依赖颜色。
- 支持 loading、空列表、首次加载失败（错误态 + 重试）、操作成功/失败提示；窄屏表格转为逐行卡片，操作区不溢出。

### 2. 上传和处理状态
- 格式与大小上限来自 capabilities 接口（supported_extensions / max_file_bytes / max_filename_chars），前端不硬编码。
- capabilities 已判定格式、大小或文件名不合法时直接阻止上传并显示原因；服务端校验仍为最终权威。
- 上传成功后立即显示 pending/processing，不伪装 ready；通过轮询跟踪到 ready/failed。
- 轮询刷新全部已加载页面；仅当页面可见且存在 pending/processing 行时进行，隐藏暂停、全部终态停止、连续失败 3 次停止并提示手动刷新。
- 上传成功与索引成功（行转入 ready/failed）分别提示；失败显示后端安全错误摘要，不展示原始响应/绝对路径/token。

### 3. 文件操作
- 下载：受保护 POST 读取接口 + CSRF + Blob，文件名取自服务端 Content-Disposition（回退列表项文件名）。
- 删除：单例原生 dialog 二次确认（标题含文件名、文案说明派生数据一并移除且无法继续检索）；取消为初始焦点，支持 Escape，关闭后焦点回收至原按钮或列表容器；processing 文件不显示删除，409 冲突安全呈现。
- 重新处理：仅 failed 展示；成功后按服务端返回显示 pending 并刷新/轮询；pending/processing 不重复触发。
- directory（历史 KNOWLEDGE_DIR）文档只读展示，不提供下载/删除/重试。

### 4. API、组件和测试
- types.ts 定义稳定 DTO（KnowledgeFileStatus/Item/Page/Capabilities/ListParams），与后端 dto.rs 逐字段一致。
- api.ts 复用现有 transport/CSRF/错误解析：capabilities/list/upload/download/delete/retry 及严格 parser。
- 页面视图不直接 fetch；筛选/分页/轮询/操作请求带 generation 竞态保护，旧响应不会覆盖新结果；「加载更多」并发锁定与失败回滚。
- initializeKnowledge 幂等，disposeKnowledge 在登出时停止轮询并释放监听；重新登录不重复绑定。
- 测试覆盖：parser、四状态、分页、多页轮询、逆序响应竞态、加载更多并发、筛选搜索、上传成功/预检阻止/413、下载契约、删除确认/409、重试 pending、轮询可见性/失败上限/stale-response、登出生命周期、401/403。

## 验证

- web-console：npm run check、npm run build、npm test（147/147）通过；git diff --check 通过。
- Rust：cargo fmt --all -- --check、cargo check -p qq-maid-core、cargo test -p qq-maid-core embedded_console_assets_match_dist_output 通过。
- 真实浏览器 QA：登录、导航、上传→pending→ready、搜索/筛选/分页/刷新、下载字节比对、删除对话框焦点、空文档 failed+重试、375px 响应式、三主题与 reduced-motion、键盘可达性均通过。
- dist/ 由构建生成并提交；7 个 knowledge 产物已登记 CONSOLE_ASSETS；敏感信息扫描干净。
- PR 包含 15 个提交；最终验证波次 F1-F4 均通过。

## 非目标

- 不实现在线编辑、完整预览、版本管理、分组权限或拖拽切片。
- 不新增前端框架或重复实现文件存储。
- 不绕过后端认证、CSRF、权限和错误语义。
- 不支持当前解析器未实现的 PDF、Word 等格式。
- 不把控制台端口暴露到公网。
