### PR TITLE
fix: 修复 LLM 流式结束与回退预算

### DIFF
--- a/qq-maid-llm/README.md
+++ b/qq-maid-llm/README.md
@@ -18,7 +18,7 @@ qq-maid-common / reqwest / serde / tokio
 
 ## 当前范围
 
-- OpenAI Responses API 主链路（system/user 用 `input_text`、assistant 用 `output_text`、completed-only 提取、delta/completed/failed/incomplete/error 事件、跨 chunk 与 CRLF 兼容、空流补非流、流式失败后补非流、usage 与 cached token 提取、HTTP 错误正文裁剪、200 但正文为空返回明确错误）。
+- OpenAI Responses API 主链路（system/user 用 `input_text`、assistant 用 `output_text`、标准 completed 提取，以及“正常 HTTP EOF + 非空文本 + 无未闭合 function call/解析错误/显式失败”的兼容完成；支持 delta/completed/failed/incomplete/error、跨 chunk 与 CRLF、受剩余预算约束的空流回退、usage 与 cached token 提取、HTTP 错误正文裁剪、200 但正文为空返回明确错误）。
 - OpenAI Chat Completions 兼容实现（基于 `reqwest`，统一编码文字与 `image_url` 图片输入，支持流式与非流式、`[DONE]`、usage 与 cached token 提取、空流补非流、401/403/429/timeout/5xx 与非标准错误正文分类）。
 - DeepSeek 复用 OpenAI 兼容 Chat Completions adapter，只保留 base URL、认证和模型规则差异。
 - 模型候选链路由：按 `agent.toml` 中的候选顺序调用、成功立即停止、临时错误降级、永久错误终止、全部失败返回聚合错误；OpenAI Responses → Chat Completions fallback 规则不变。

--- a/qq-maid-llm/src/agent_loop/mod.rs
+++ b/qq-maid-llm/src/agent_loop/mod.rs
@@ -35,11 +35,13 @@
 //! | [`types`] | 协议无关的 `AgentStep` / `AgentToolCall` / `AgentToolResult` / `AgentSessionRequest` |
 //! | [`session`] | `AgentStepSession` trait（Provider 单步适配契约） |
 //! | [`runner`] | `run_agent_loop` 统一循环控制 + usage 合并 |
+//! | [`streaming`] | 流式单步、可见输出所有权与受预算约束的非流式回退 |
 //! | [`diagnostics`] | 尺寸诊断纯逻辑与 DEBUG 门控日志（Issue #361） |
 
 mod diagnostics;
 pub mod runner;
 pub mod session;
+pub(super) mod streaming;
 pub mod types;
 
 pub(crate) use diagnostics::{log_input_size_after_append, tool_result_chars};

--- a/qq-maid-llm/src/agent_loop/runner.rs
+++ b/qq-maid-llm/src/agent_loop/runner.rs
@@ -9,20 +9,16 @@
 //! 非流式语义：返回与改造前等价的完整结果；工具副作用只在此执行一次，不因
 //! 后续模型或发送重试而重复。
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, AtomicUsize, Ordering},
-};
 use std::time::Instant;
 
 use futures::future::{Either, select};
-use tokio::time::{Duration, timeout};
+use tokio::time::Duration;
 use tracing::{debug, warn};
 
 use crate::{
     agent_loop::{
-        AgentRunDiagnostics, AgentRunHandle, AgentStopReason, AgentTextDeltaFuture,
-        AgentTextDeltaSink, ToolLoopProgressSink, tool_result_chars,
+        AgentRunDiagnostics, AgentRunHandle, AgentStopReason, AgentTextDeltaSink,
+        ToolLoopProgressSink, tool_result_chars,
     },
     error::LlmError,
     metrics::MetricsRecorder,
@@ -35,6 +31,7 @@ use crate::{
 };
 
 use super::session::AgentStepSession;
+use super::streaming::{StreamingAdvanceOptions, advance_with_optional_streaming};
 use super::types::AgentAttemptBaseline;
 use super::types::{AgentStep, AgentToolCall, AgentToolResult};
 
@@ -190,21 +187,45 @@ pub(super) async fn run_agent_loop_with_timeouts(
             session.as_mut(),
             &results,
             allow_tool_calls,
-            final_delta_sink.clone(),
-            streaming_timeout,
-            non_stream_timeout,
-            round,
+            StreamingAdvanceOptions {
+                final_delta_sink: final_delta_sink.clone(),
+                streaming_timeout,
+                non_stream_timeout,
+                round,
+            },
+            &run_handle,
         );
         let model_round_started = Instant::now();
         let advance_future = Box::pin(advance_future);
         let cancellation = Box::pin(run_handle.cancelled());
-        let advance_result = match select(advance_future, cancellation).await {
-            Either::Left((result, _)) => result,
-            Either::Right((_, _)) => Err(LlmError::new(
-                "cancelled",
-                "agent run cancelled",
-                "agent_loop",
-            )),
+        let advance_result = if let Some(remaining_budget) = run_handle.remaining_budget() {
+            let advance_or_cancel = Box::pin(async {
+                match select(advance_future, cancellation).await {
+                    Either::Left((result, _)) => result,
+                    Either::Right((_, _)) => Err(LlmError::new(
+                        "cancelled",
+                        "agent run cancelled",
+                        "agent_loop",
+                    )),
+                }
+            });
+            let budget = Box::pin(tokio::time::sleep(remaining_budget));
+            match select(advance_or_cancel, budget).await {
+                Either::Left((result, _)) => result,
+                Either::Right((_, _)) => {
+                    run_handle.cancel(AgentStopReason::Timeout);
+                    Err(LlmError::timeout("agent_loop"))
+                }
+            }
+        } else {
+            match select(advance_future, cancellation).await {
+                Either::Left((result, _)) => result,
+                Either::Right((_, _)) => Err(LlmError::new(
+                    "cancelled",
+                    "agent run cancelled",
+                    "agent_loop",
+                )),
+            }
         };
         debug!(
             provider = provider.as_str(),
@@ -487,221 +508,6 @@ pub(super) async fn run_agent_loop_with_timeouts(
     ))
 }
 
-pub(super) async fn advance_with_optional_streaming(
-    session: &mut (dyn AgentStepSession + Send),
-    results: &[AgentToolResult],
-    allow_tool_calls: bool,
-    final_delta_sink: Option<AgentTextDeltaSink>,
-    streaming_timeout: Duration,
-    non_stream_timeout: Duration,
-    round: usize,
-) -> Result<AgentAdvance, LlmError> {
-    let Some(sink) = final_delta_sink else {
-        return advance_non_stream_with_timeout(
-            session,
-            results,
-            allow_tool_calls,
-            non_stream_timeout,
-        )
-        .await
-        .map(|step| AgentAdvance {
-            step,
-            fallback_used: false,
-        });
-    };
-    let emitted_visible_delta = Arc::new(AtomicBool::new(false));
-    let tracked_sink = track_visible_delta_sink(sink, emitted_visible_delta.clone());
-    let activity_counter = session.streaming_activity_counter();
-    let streaming_started = Instant::now();
-    let streaming = advance_streaming_until_complete_or_first_activity_timeout(
-        session,
-        results,
-        allow_tool_calls,
-        tracked_sink,
-        activity_counter,
-        streaming_timeout,
-    )
-    .await;
-    let streaming_elapsed_ms = streaming_started.elapsed().as_millis();
-    match streaming {
-        StreamingAttempt::Completed(Ok(Some(step))) => Ok(AgentAdvance {
-            step,
-            fallback_used: false,
-        }),
-        StreamingAttempt::Completed(Ok(None)) => {
-            fallback_to_non_stream(
-                session,
-                results,
-                allow_tool_calls,
-                non_stream_timeout,
-                round,
-                streaming_elapsed_ms,
-                "advance_streaming_none",
-                None,
-                false,
-            )
-            .await
-        }
-        StreamingAttempt::Completed(Err(err)) if !emitted_visible_delta.load(Ordering::SeqCst) => {
-            let diagnostics = session.streaming_diagnostics();
-            let fallback_reason = diagnostics
-                .fallback_reason
-                .as_deref()
-                .unwrap_or_else(|| classify_streaming_error(&err));
-            fallback_to_non_stream(
-                session,
-                results,
-                allow_tool_calls,
-                non_stream_timeout,
-                round,
-                streaming_elapsed_ms,
-                fallback_reason,
-                Some(&err),
-                true,
-            )
-            .await
-        }
-        StreamingAttempt::FirstActivityTimedOut
-            if !emitted_visible_delta.load(Ordering::SeqCst) =>
-        {
-            fallback_to_non_stream(
-                session,
-                results,
-                allow_tool_calls,
-                non_stream_timeout,
-                round,
-                streaming_elapsed_ms,
-                "streaming_step_timeout",
-                None,
-                true,
-            )
-            .await
-        }
-        StreamingAttempt::Completed(Err(err)) => Err(err),
-        StreamingAttempt::FirstActivityTimedOut => {
-            Err(LlmError::timeout("agent_stream_after_delta"))
-        }
-    }
-}
-
-enum StreamingAttempt {
-    Completed(Result<Option<AgentStep>, LlmError>),
-    FirstActivityTimedOut,
-}
-
-async fn advance_streaming_until_complete_or_first_activity_timeout(
-    session: &mut (dyn AgentStepSession + Send),
-    results: &[AgentToolResult],
-    allow_tool_calls: bool,
-    tracked_sink: AgentTextDeltaSink,
-    activity_counter: Option<Arc<AtomicUsize>>,
-    first_activity_timeout: Duration,
-) -> StreamingAttempt {
-    let Some(activity_counter) = activity_counter else {
-        return match timeout(
-            first_activity_timeout,
-            session.advance_streaming(results, allow_tool_calls, tracked_sink),
-        )
-        .await
-        {
-            Ok(result) => StreamingAttempt::Completed(result),
-            Err(_) => StreamingAttempt::FirstActivityTimedOut,
-        };
-    };
-
-    let streaming = Box::pin(session.advance_streaming(results, allow_tool_calls, tracked_sink));
-    let deadline = Box::pin(tokio::time::sleep(first_activity_timeout));
-    match select(streaming, deadline).await {
-        Either::Left((result, _)) => StreamingAttempt::Completed(result),
-        Either::Right((_, streaming)) => {
-            if activity_counter.load(Ordering::SeqCst) > 0 {
-                StreamingAttempt::Completed(streaming.await)
-            } else {
-                StreamingAttempt::FirstActivityTimedOut
-            }
-        }
-    }
-}
-
-#[derive(Debug)]
-pub(super) struct AgentAdvance {
-    pub(super) step: AgentStep,
-    pub(super) fallback_used: bool,
-}
-
-async fn advance_non_stream_with_timeout(
-    session: &mut (dyn AgentStepSession + Send),
-    results: &[AgentToolResult],
-    allow_tool_calls: bool,
-    step_timeout: Duration,
-) -> Result<AgentStep, LlmError> {
-    timeout(step_timeout, session.advance(results, allow_tool_calls))
-        .await
-        .map_err(|_| LlmError::timeout("agent_step"))?
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn fallback_to_non_stream(
-    session: &mut (dyn AgentStepSession + Send),
-    results: &[AgentToolResult],
-    allow_tool_calls: bool,
-    non_stream_timeout: Duration,
-    round: usize,
-    streaming_elapsed_ms: u128,
-    fallback_reason: &str,
-    err: Option<&LlmError>,
-    fallback_used: bool,
-) -> Result<AgentAdvance, LlmError> {
-    let diagnostics = session.streaming_diagnostics();
-    let fallback_started = Instant::now();
-    let result =
-        advance_non_stream_with_timeout(session, results, allow_tool_calls, non_stream_timeout)
-            .await;
-    let non_stream_fallback_elapsed_ms = fallback_started.elapsed().as_millis();
-    tracing::info!(
-        provider = session.provider(),
-        model = %session.model(),
-        round,
-        allow_tool_calls,
-        follows_tool_results = !results.is_empty(),
-        streaming_elapsed_ms,
-        fallback_reason,
-        error_code = err.map(|item| item.code.as_str()).unwrap_or("none"),
-        error_stage = err.map(|item| item.stage.as_str()).unwrap_or("none"),
-        chunk_count = diagnostics.chunk_count,
-        sse_event_count = diagnostics.sse_event_count,
-        saw_done = diagnostics.saw_done,
-        saw_completed = diagnostics.saw_completed,
-        buffered_delta_count = diagnostics.buffered_delta_count,
-        active_function_call_count = diagnostics.active_function_call_count,
-        non_stream_fallback_elapsed_ms,
-        non_stream_fallback_succeeded = result.is_ok(),
-        "streaming agent fallback completed"
-    );
-    result
-        .map(|step| AgentAdvance {
-            step,
-            fallback_used,
-        })
-        .map_err(|mut err| {
-            if fallback_used {
-                let mut diagnostics = err.agent.take().map(|item| *item).unwrap_or_default();
-                diagnostics.streaming_fallback_used = true;
-                err.with_agent(diagnostics)
-            } else {
-                err
-            }
-        })
-}
-
-fn classify_streaming_error(err: &LlmError) -> &'static str {
-    if err.code == "http_error" || err.stage == "http" || err.stage == "sse" {
-        "http_sse_parse_error"
-    } else {
-        "provider_error_other"
-    }
-}
-
 fn agent_stop_reason(emitted_tools: &[String], executor: &ToolLoopExecutor<'_>) -> AgentStopReason {
     if emitted_tools.is_empty() {
         return AgentStopReason::DirectAnswer;
@@ -797,20 +603,6 @@ fn agent_error(
         stop_reason,
         baseline,
     ))
-}
-
-fn track_visible_delta_sink(
-    sink: AgentTextDeltaSink,
-    emitted_visible_delta: Arc<AtomicBool>,
-) -> AgentTextDeltaSink {
-    Arc::new(move |delta| {
-        let sink = sink.clone();
-        let emitted_visible_delta = emitted_visible_delta.clone();
-        Box::pin(async move {
-            emitted_visible_delta.store(true, Ordering::SeqCst);
-            sink(delta).await
-        }) as AgentTextDeltaFuture
-    })
 }
 
 /// 执行同轮一批工具调用，返回回填给下一轮 `advance` 的结果。

--- a/qq-maid-llm/src/agent_loop/session.rs
+++ b/qq-maid-llm/src/agent_loop/session.rs
@@ -21,11 +21,21 @@ use super::types::{AgentStep, AgentTextDeltaSink, AgentToolResult};
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AgentStreamingDiagnostics {
     pub fallback_reason: Option<String>,
+    pub http_status: Option<u16>,
+    pub stream_end_kind: Option<String>,
+    pub last_sse_event_type: Option<String>,
     pub chunk_count: usize,
     pub sse_event_count: usize,
     pub saw_done: bool,
     pub saw_completed: bool,
+    pub normal_eof: bool,
+    pub connection_reset: bool,
+    pub parse_error: bool,
+    pub explicit_failure_event: bool,
+    pub saw_text_delta: bool,
     pub buffered_delta_count: usize,
+    pub buffered_text_chars: usize,
+    pub visible_text_chars: usize,
     pub active_function_call_count: usize,
 }
 
@@ -83,8 +93,9 @@ pub trait AgentStepSession: Send {
     ///   可以边接收真实 provider delta 边转发。
     /// - 如果本轮产生 tool call，不得向 `text_delta_sink` 发送任何模型草稿。
     /// - 一旦已经发送用户可见 delta，后续错误必须原样返回，不能改走非流式重放。
-    /// - 流式推进失败或超时时，会话状态必须仍可用同一批 `results` 执行一次
-    ///   `advance`；Provider 不得在流式响应完整结束前提交本轮协议状态。
+    /// - 流式推进在尚无有效文本/工具调用且剩余预算充足时，会话状态必须仍可用
+    ///   同一批 `results` 执行一次 `advance`；已有有效文本后不得同 Provider 重生成。
+    ///   Provider 不得在流式响应完整结束前提交本轮协议状态。
     async fn advance_streaming(
         &mut self,
         _results: &[AgentToolResult],

--- a/qq-maid-llm/src/agent_loop/streaming.rs
+++ b/qq-maid-llm/src/agent_loop/streaming.rs
@@ -1,0 +1,372 @@
+//! Agent 单步流式推进、可见输出所有权与受预算约束的非流式兼容回退。
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+    time::Instant,
+};
+
+use futures::future::{Either, select};
+use tokio::time::{Duration, timeout};
+
+use crate::{
+    agent_loop::{
+        AgentRunHandle, AgentStreamingDiagnostics, AgentTextDeltaFuture, AgentTextDeltaSink,
+        AgentToolResult,
+    },
+    error::LlmError,
+};
+
+use super::{session::AgentStepSession, types::AgentStep};
+
+const MIN_NON_STREAM_FALLBACK_START_BUDGET: Duration = Duration::from_secs(1);
+
+#[derive(Clone)]
+pub(super) struct StreamingAdvanceOptions {
+    pub(super) final_delta_sink: Option<AgentTextDeltaSink>,
+    pub(super) streaming_timeout: Duration,
+    pub(super) non_stream_timeout: Duration,
+    pub(super) round: usize,
+}
+
+pub(super) async fn advance_with_optional_streaming(
+    session: &mut (dyn AgentStepSession + Send),
+    results: &[AgentToolResult],
+    allow_tool_calls: bool,
+    options: StreamingAdvanceOptions,
+    run_handle: &AgentRunHandle,
+) -> Result<AgentAdvance, LlmError> {
+    let StreamingAdvanceOptions {
+        final_delta_sink,
+        streaming_timeout,
+        non_stream_timeout,
+        round,
+    } = options;
+    let Some(sink) = final_delta_sink else {
+        return advance_non_stream_with_timeout(
+            session,
+            results,
+            allow_tool_calls,
+            non_stream_timeout,
+        )
+        .await
+        .map(|step| AgentAdvance {
+            step,
+            fallback_used: false,
+        });
+    };
+    let emitted_visible_delta = Arc::new(AtomicBool::new(false));
+    let tracked_sink = track_visible_delta_sink(sink, emitted_visible_delta.clone());
+    let activity_counter = session.streaming_activity_counter();
+    let streaming_started = Instant::now();
+    let streaming = advance_streaming_until_complete_or_first_activity_timeout(
+        session,
+        results,
+        allow_tool_calls,
+        tracked_sink,
+        activity_counter,
+        streaming_timeout,
+    )
+    .await;
+    let streaming_elapsed_ms = streaming_started.elapsed().as_millis();
+    match streaming {
+        StreamingAttempt::Completed(Ok(Some(step))) => Ok(AgentAdvance {
+            step,
+            fallback_used: false,
+        }),
+        StreamingAttempt::Completed(Ok(None)) => {
+            fallback_to_non_stream(
+                session,
+                results,
+                allow_tool_calls,
+                non_stream_timeout,
+                round,
+                streaming_elapsed_ms,
+                "advance_streaming_none",
+                None,
+                false,
+                run_handle,
+            )
+            .await
+        }
+        StreamingAttempt::Completed(Err(err)) if !emitted_visible_delta.load(Ordering::SeqCst) => {
+            let diagnostics = session.streaming_diagnostics();
+            let fallback_reason = diagnostics
+                .fallback_reason
+                .as_deref()
+                .unwrap_or_else(|| classify_streaming_error(&err));
+            if diagnostics.saw_text_delta || diagnostics.buffered_text_chars > 0 {
+                log_streaming_fallback_skipped(
+                    session,
+                    round,
+                    allow_tool_calls,
+                    streaming_elapsed_ms,
+                    fallback_reason,
+                    &err,
+                    &diagnostics,
+                    run_handle.remaining_budget(),
+                    "stream_had_valid_text",
+                );
+                return Err(err);
+            }
+            if diagnostics.explicit_failure_event {
+                log_streaming_fallback_skipped(
+                    session,
+                    round,
+                    allow_tool_calls,
+                    streaming_elapsed_ms,
+                    fallback_reason,
+                    &err,
+                    &diagnostics,
+                    run_handle.remaining_budget(),
+                    "explicit_failure_event",
+                );
+                return Err(err);
+            }
+            fallback_to_non_stream(
+                session,
+                results,
+                allow_tool_calls,
+                non_stream_timeout,
+                round,
+                streaming_elapsed_ms,
+                fallback_reason,
+                Some(&err),
+                true,
+                run_handle,
+            )
+            .await
+        }
+        StreamingAttempt::FirstActivityTimedOut
+            if !emitted_visible_delta.load(Ordering::SeqCst) =>
+        {
+            fallback_to_non_stream(
+                session,
+                results,
+                allow_tool_calls,
+                non_stream_timeout,
+                round,
+                streaming_elapsed_ms,
+                "streaming_step_timeout",
+                None,
+                true,
+                run_handle,
+            )
+            .await
+        }
+        StreamingAttempt::Completed(Err(err)) => Err(err),
+        StreamingAttempt::FirstActivityTimedOut => {
+            Err(LlmError::timeout("agent_stream_after_delta"))
+        }
+    }
+}
+
+enum StreamingAttempt {
+    Completed(Result<Option<AgentStep>, LlmError>),
+    FirstActivityTimedOut,
+}
+
+async fn advance_streaming_until_complete_or_first_activity_timeout(
+    session: &mut (dyn AgentStepSession + Send),
+    results: &[AgentToolResult],
+    allow_tool_calls: bool,
+    tracked_sink: AgentTextDeltaSink,
+    activity_counter: Option<Arc<AtomicUsize>>,
+    first_activity_timeout: Duration,
+) -> StreamingAttempt {
+    let Some(activity_counter) = activity_counter else {
+        return match timeout(
+            first_activity_timeout,
+            session.advance_streaming(results, allow_tool_calls, tracked_sink),
+        )
+        .await
+        {
+            Ok(result) => StreamingAttempt::Completed(result),
+            Err(_) => StreamingAttempt::FirstActivityTimedOut,
+        };
+    };
+
+    let streaming = Box::pin(session.advance_streaming(results, allow_tool_calls, tracked_sink));
+    let deadline = Box::pin(tokio::time::sleep(first_activity_timeout));
+    match select(streaming, deadline).await {
+        Either::Left((result, _)) => StreamingAttempt::Completed(result),
+        Either::Right((_, streaming)) => {
+            if activity_counter.load(Ordering::SeqCst) > 0 {
+                StreamingAttempt::Completed(streaming.await)
+            } else {
+                StreamingAttempt::FirstActivityTimedOut
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct AgentAdvance {
+    pub(super) step: AgentStep,
+    pub(super) fallback_used: bool,
+}
+
+async fn advance_non_stream_with_timeout(
+    session: &mut (dyn AgentStepSession + Send),
+    results: &[AgentToolResult],
+    allow_tool_calls: bool,
+    step_timeout: Duration,
+) -> Result<AgentStep, LlmError> {
+    timeout(step_timeout, session.advance(results, allow_tool_calls))
+        .await
+        .map_err(|_| LlmError::timeout("agent_step"))?
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn fallback_to_non_stream(
+    session: &mut (dyn AgentStepSession + Send),
+    results: &[AgentToolResult],
+    allow_tool_calls: bool,
+    non_stream_timeout: Duration,
+    round: usize,
+    streaming_elapsed_ms: u128,
+    fallback_reason: &str,
+    err: Option<&LlmError>,
+    fallback_used: bool,
+    run_handle: &AgentRunHandle,
+) -> Result<AgentAdvance, LlmError> {
+    let diagnostics = session.streaming_diagnostics();
+    let fallback_remaining_budget = run_handle.remaining_budget();
+    let minimum_start_budget =
+        std::cmp::min(non_stream_timeout, MIN_NON_STREAM_FALLBACK_START_BUDGET);
+    if fallback_remaining_budget.is_some_and(|remaining| remaining < minimum_start_budget) {
+        let budget_error = LlmError::timeout("agent_loop");
+        log_streaming_fallback_skipped(
+            session,
+            round,
+            allow_tool_calls,
+            streaming_elapsed_ms,
+            fallback_reason,
+            err.unwrap_or(&budget_error),
+            &diagnostics,
+            fallback_remaining_budget,
+            "insufficient_remaining_budget",
+        );
+        return Err(budget_error);
+    }
+    let effective_timeout = fallback_remaining_budget
+        .map(|remaining| std::cmp::min(non_stream_timeout, remaining))
+        .unwrap_or(non_stream_timeout);
+    let fallback_started = Instant::now();
+    let result =
+        advance_non_stream_with_timeout(session, results, allow_tool_calls, effective_timeout)
+            .await;
+    let non_stream_fallback_elapsed_ms = fallback_started.elapsed().as_millis();
+    tracing::info!(
+        provider = session.provider(),
+        model = %session.model(),
+        round,
+        allow_tool_calls,
+        follows_tool_results = !results.is_empty(),
+        streaming_elapsed_ms,
+        fallback_reason,
+        error_code = err.map(|item| item.code.as_str()).unwrap_or("none"),
+        error_stage = err.map(|item| item.stage.as_str()).unwrap_or("none"),
+        http_status = diagnostics.http_status,
+        stream_end_kind = diagnostics.stream_end_kind.as_deref().unwrap_or("unknown"),
+        last_sse_event_type = diagnostics.last_sse_event_type.as_deref().unwrap_or("none"),
+        normal_eof = diagnostics.normal_eof,
+        connection_reset = diagnostics.connection_reset,
+        parse_error = diagnostics.parse_error,
+        explicit_failure_event = diagnostics.explicit_failure_event,
+        saw_text_delta = diagnostics.saw_text_delta,
+        chunk_count = diagnostics.chunk_count,
+        sse_event_count = diagnostics.sse_event_count,
+        saw_done = diagnostics.saw_done,
+        saw_completed = diagnostics.saw_completed,
+        buffered_delta_count = diagnostics.buffered_delta_count,
+        buffered_text_chars = diagnostics.buffered_text_chars,
+        visible_text_chars = diagnostics.visible_text_chars,
+        active_function_call_count = diagnostics.active_function_call_count,
+        stream_remaining_budget_ms = fallback_remaining_budget.map(|value| value.as_millis()),
+        fallback_remaining_budget_ms = fallback_remaining_budget.map(|value| value.as_millis()),
+        fallback_timeout_ms = effective_timeout.as_millis(),
+        fallback_skipped_reason = "none",
+        non_stream_fallback_elapsed_ms,
+        non_stream_fallback_succeeded = result.is_ok(),
+        "streaming agent fallback completed"
+    );
+    result
+        .map(|step| AgentAdvance {
+            step,
+            fallback_used,
+        })
+        .map_err(|mut err| {
+            if fallback_used {
+                let mut diagnostics = err.agent.take().map(|item| *item).unwrap_or_default();
+                diagnostics.streaming_fallback_used = true;
+                err.with_agent(diagnostics)
+            } else {
+                err
+            }
+        })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn log_streaming_fallback_skipped(
+    session: &(dyn AgentStepSession + Send),
+    round: usize,
+    allow_tool_calls: bool,
+    streaming_elapsed_ms: u128,
+    fallback_reason: &str,
+    err: &LlmError,
+    diagnostics: &AgentStreamingDiagnostics,
+    remaining_budget: Option<Duration>,
+    skipped_reason: &str,
+) {
+    tracing::warn!(
+        provider = session.provider(),
+        model = %session.model(),
+        round,
+        allow_tool_calls,
+        streaming_elapsed_ms,
+        fallback_reason,
+        error_code = err.code.as_str(),
+        error_stage = err.stage.as_str(),
+        http_status = diagnostics.http_status,
+        stream_end_kind = diagnostics.stream_end_kind.as_deref().unwrap_or("unknown"),
+        last_sse_event_type = diagnostics.last_sse_event_type.as_deref().unwrap_or("none"),
+        normal_eof = diagnostics.normal_eof,
+        connection_reset = diagnostics.connection_reset,
+        parse_error = diagnostics.parse_error,
+        explicit_failure_event = diagnostics.explicit_failure_event,
+        saw_text_delta = diagnostics.saw_text_delta,
+        buffered_delta_count = diagnostics.buffered_delta_count,
+        buffered_text_chars = diagnostics.buffered_text_chars,
+        visible_text_chars = diagnostics.visible_text_chars,
+        active_function_call_count = diagnostics.active_function_call_count,
+        stream_remaining_budget_ms = remaining_budget.map(|value| value.as_millis()),
+        fallback_remaining_budget_ms = remaining_budget.map(|value| value.as_millis()),
+        fallback_skipped_reason = skipped_reason,
+        "streaming agent fallback skipped"
+    );
+}
+
+fn classify_streaming_error(err: &LlmError) -> &'static str {
+    if err.code == "http_error" || err.stage == "http" || err.stage == "sse" {
+        "http_sse_parse_error"
+    } else {
+        "provider_error_other"
+    }
+}
+
+fn track_visible_delta_sink(
+    sink: AgentTextDeltaSink,
+    emitted_visible_delta: Arc<AtomicBool>,
+) -> AgentTextDeltaSink {
+    Arc::new(move |delta| {
+        let sink = sink.clone();
+        let emitted_visible_delta = emitted_visible_delta.clone();
+        Box::pin(async move {
+            emitted_visible_delta.store(true, Ordering::SeqCst);
+            sink(delta).await
+        }) as AgentTextDeltaFuture
+    })
+}

--- a/qq-maid-llm/src/agent_loop/tests/budget_timeout.rs
+++ b/qq-maid-llm/src/agent_loop/tests/budget_timeout.rs
@@ -473,14 +473,17 @@ async fn streaming_advance_timeout_before_visible_delta_falls_back_once() {
     );
     let advance_calls = session.advance_calls.clone();
 
-    let advance = super::runner::advance_with_optional_streaming(
+    let advance = crate::agent_loop::streaming::advance_with_optional_streaming(
         &mut session,
         &[],
         true,
-        Some(delta_sink(Arc::new(StdMutex::new(Vec::new())))),
-        std::time::Duration::from_millis(10),
-        std::time::Duration::from_millis(50),
-        0,
+        crate::agent_loop::streaming::StreamingAdvanceOptions {
+            final_delta_sink: Some(delta_sink(Arc::new(StdMutex::new(Vec::new())))),
+            streaming_timeout: std::time::Duration::from_millis(10),
+            non_stream_timeout: std::time::Duration::from_millis(50),
+            round: 0,
+        },
+        &AgentRunHandle::default(),
     )
     .await
     .unwrap();
@@ -502,14 +505,17 @@ async fn streaming_advance_timeout_after_visible_delta_does_not_fallback() {
     let advance_calls = session.advance_calls.clone();
     let deltas = Arc::new(StdMutex::new(Vec::new()));
 
-    let err = super::runner::advance_with_optional_streaming(
+    let err = crate::agent_loop::streaming::advance_with_optional_streaming(
         &mut session,
         &[],
         false,
-        Some(delta_sink(deltas.clone())),
-        std::time::Duration::from_millis(10),
-        std::time::Duration::from_millis(50),
-        0,
+        crate::agent_loop::streaming::StreamingAdvanceOptions {
+            final_delta_sink: Some(delta_sink(deltas.clone())),
+            streaming_timeout: std::time::Duration::from_millis(10),
+            non_stream_timeout: std::time::Duration::from_millis(50),
+            round: 0,
+        },
+        &AgentRunHandle::default(),
     )
     .await
     .unwrap_err();
@@ -517,6 +523,35 @@ async fn streaming_advance_timeout_after_visible_delta_does_not_fallback() {
     assert_eq!(err.code, "timeout");
     assert_eq!(err.stage, "agent_stream_after_delta");
     assert_eq!(*deltas.lock().unwrap(), vec!["半句".to_owned()]);
+    assert_eq!(*advance_calls.lock().unwrap(), 0);
+}
+
+#[tokio::test]
+async fn insufficient_remaining_budget_skips_non_stream_fallback() {
+    let mut session = StreamingSession::new(
+        StreamingAction::ErrorBeforeDelta,
+        vec![final_reply("must not start")],
+    );
+    let advance_calls = session.advance_calls.clone();
+    let handle = AgentRunHandle::with_timeout(std::time::Duration::from_millis(20));
+
+    let err = crate::agent_loop::streaming::advance_with_optional_streaming(
+        &mut session,
+        &[],
+        true,
+        crate::agent_loop::streaming::StreamingAdvanceOptions {
+            final_delta_sink: Some(delta_sink(Arc::new(StdMutex::new(Vec::new())))),
+            streaming_timeout: std::time::Duration::from_millis(50),
+            non_stream_timeout: std::time::Duration::from_millis(50),
+            round: 0,
+        },
+        &handle,
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(err.code, "timeout");
+    assert_eq!(err.stage, "agent_loop");
     assert_eq!(*advance_calls.lock().unwrap(), 0);
 }
 

--- a/qq-maid-llm/src/agent_loop/tests/fallback.rs
+++ b/qq-maid-llm/src/agent_loop/tests/fallback.rs
@@ -1,5 +1,50 @@
 use super::*;
 
+struct BufferedTextErrorSession {
+    advance_calls: Arc<StdMutex<usize>>,
+}
+
+#[async_trait]
+impl AgentStepSession for BufferedTextErrorSession {
+    fn provider(&self) -> &str {
+        "mock"
+    }
+
+    fn model(&self) -> &str {
+        "m"
+    }
+
+    fn streaming_diagnostics(&self) -> AgentStreamingDiagnostics {
+        AgentStreamingDiagnostics {
+            fallback_reason: Some("sse_parse_error".to_owned()),
+            stream_end_kind: Some("sse_parse_error".to_owned()),
+            parse_error: true,
+            saw_text_delta: true,
+            buffered_delta_count: 2,
+            buffered_text_chars: 4,
+            ..Default::default()
+        }
+    }
+
+    async fn advance(
+        &mut self,
+        _results: &[AgentToolResult],
+        _allow_tool_calls: bool,
+    ) -> Result<AgentStep, LlmError> {
+        *self.advance_calls.lock().unwrap() += 1;
+        Ok(final_reply("must not regenerate"))
+    }
+
+    async fn advance_streaming(
+        &mut self,
+        _results: &[AgentToolResult],
+        _allow_tool_calls: bool,
+        _text_delta_sink: AgentTextDeltaSink,
+    ) -> Result<Option<AgentStep>, LlmError> {
+        Err(LlmError::provider("invalid SSE after text", "sse"))
+    }
+}
+
 #[tokio::test]
 async fn fallback_after_tool_result_does_not_repeat_tool_side_effect() {
     let calls = Arc::new(StdMutex::new(0));
@@ -74,14 +119,17 @@ async fn streaming_advance_error_before_visible_delta_falls_back() {
 async fn unsupported_streaming_advance_falls_back_without_marking_failure() {
     let mut session = ScriptedSession::new("mock", "m", vec![final_reply("fallback")]);
 
-    let advance = super::runner::advance_with_optional_streaming(
+    let advance = crate::agent_loop::streaming::advance_with_optional_streaming(
         &mut session,
         &[],
         true,
-        Some(delta_sink(Arc::new(StdMutex::new(Vec::new())))),
-        std::time::Duration::from_millis(50),
-        std::time::Duration::from_millis(50),
-        0,
+        crate::agent_loop::streaming::StreamingAdvanceOptions {
+            final_delta_sink: Some(delta_sink(Arc::new(StdMutex::new(Vec::new())))),
+            streaming_timeout: std::time::Duration::from_millis(50),
+            non_stream_timeout: std::time::Duration::from_millis(50),
+            round: 0,
+        },
+        &AgentRunHandle::default(),
     )
     .await
     .unwrap();
@@ -119,5 +167,31 @@ async fn streaming_advance_error_after_visible_delta_does_not_fallback() {
 
     assert_eq!(err.stage, "stream_after_delta");
     assert_eq!(*deltas.lock().unwrap(), vec!["半句".to_owned()]);
+    assert_eq!(*advance_calls.lock().unwrap(), 0);
+}
+
+#[tokio::test]
+async fn buffered_text_error_does_not_regenerate_same_provider_non_stream() {
+    let advance_calls = Arc::new(StdMutex::new(0));
+    let mut session = BufferedTextErrorSession {
+        advance_calls: advance_calls.clone(),
+    };
+
+    let err = crate::agent_loop::streaming::advance_with_optional_streaming(
+        &mut session,
+        &[],
+        true,
+        crate::agent_loop::streaming::StreamingAdvanceOptions {
+            final_delta_sink: Some(delta_sink(Arc::new(StdMutex::new(Vec::new())))),
+            streaming_timeout: std::time::Duration::from_millis(50),
+            non_stream_timeout: std::time::Duration::from_millis(50),
+            round: 0,
+        },
+        &AgentRunHandle::default(),
+    )
+    .await
+    .unwrap_err();
+
+    assert_eq!(err.stage, "sse");
     assert_eq!(*advance_calls.lock().unwrap(), 0);
 }

--- a/qq-maid-llm/src/agent_loop/types.rs
+++ b/qq-maid-llm/src/agent_loop/types.rs
@@ -176,7 +176,7 @@ impl AgentRunHandle {
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if let Some(reason) = request_termination_reason(&state.diagnostics) {
+        if let Some(reason) = refresh_termination_reason(&mut state) {
             return Err(termination_error(reason, "before model candidate")
                 .with_agent(state.diagnostics.clone()));
         }
@@ -198,7 +198,7 @@ impl AgentRunHandle {
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if let Some(reason) = request_termination_reason(&state.diagnostics) {
+        if let Some(reason) = refresh_termination_reason(&mut state) {
             return Err(termination_error(reason, "before agent session")
                 .with_agent(state.diagnostics.clone()));
         }
@@ -234,7 +234,7 @@ impl AgentRunHandle {
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if let Some(reason) = request_termination_reason(&state.diagnostics) {
+        if let Some(reason) = refresh_termination_reason(&mut state) {
             return Err(termination_error(reason, "before model request")
                 .with_agent(state.diagnostics.clone()));
         }
@@ -244,11 +244,11 @@ impl AgentRunHandle {
 
     /// 在异步 provider 调用返回后重新确认请求未被外部终止。
     pub(crate) fn ensure_request_active(&self, context: &str) -> Result<(), LlmError> {
-        let state = self
+        let mut state = self
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if let Some(reason) = request_termination_reason(&state.diagnostics) {
+        if let Some(reason) = refresh_termination_reason(&mut state) {
             return Err(termination_error(reason, context).with_agent(state.diagnostics.clone()));
         }
         Ok(())
@@ -264,7 +264,7 @@ impl AgentRunHandle {
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if let Some(reason) = request_termination_reason(&state.diagnostics) {
+        if let Some(reason) = refresh_termination_reason(&mut state) {
             return Err(termination_error(reason, "before tool execution")
                 .with_agent(state.diagnostics.clone()));
         }
@@ -384,7 +384,7 @@ impl AgentRunHandle {
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if request_termination_reason(&state.diagnostics).is_none() {
+        if refresh_termination_reason(&mut state).is_none() {
             state.diagnostics.stop_reason = Some(reason);
         }
         drop(state);
@@ -393,11 +393,11 @@ impl AgentRunHandle {
     }
 
     pub fn is_cancelled(&self) -> bool {
-        let state = self
+        let mut state = self
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        request_termination_reason(&state.diagnostics).is_some()
+        refresh_termination_reason(&mut state).is_some()
     }
 
     pub(crate) async fn cancelled(&self) {
@@ -435,6 +435,22 @@ fn request_termination_reason(diagnostics: &AgentRunDiagnostics) -> Option<Agent
             AgentStopReason::Timeout | AgentStopReason::Cancelled
         )
     })
+}
+
+/// 用 Tokio 单调时钟把 deadline 到期同步为请求级 Timeout，避免候选或内部
+/// fallback 在外层预算耗尽后再启动一次新的上游请求。
+fn refresh_termination_reason(state: &mut AgentRunState) -> Option<AgentStopReason> {
+    if let Some(reason) = request_termination_reason(&state.diagnostics) {
+        return Some(reason);
+    }
+    if state
+        .deadline
+        .is_some_and(|deadline| deadline <= Instant::now())
+    {
+        state.diagnostics.stop_reason = Some(AgentStopReason::Timeout);
+        return Some(AgentStopReason::Timeout);
+    }
+    None
 }
 
 fn termination_error(reason: AgentStopReason, context: &str) -> LlmError {

--- a/qq-maid-llm/src/error.rs
+++ b/qq-maid-llm/src/error.rs
@@ -278,7 +278,7 @@ impl LlmError {
             "provider_error" if matches!(self.stage.as_str(), "json" | "sse" | "stream") => {
                 "invalid_response"
             }
-            "invalid_response" => "invalid_response",
+            "invalid_response" | "sse_incomplete_frame" => "invalid_response",
             _ => "internal_error",
         }
     }

--- a/qq-maid-llm/src/provider/openai/fallback.rs
+++ b/qq-maid-llm/src/provider/openai/fallback.rs
@@ -12,6 +12,14 @@ pub(crate) fn should_retry_non_stream_after_empty_stream(outcome: &ChatOutcome) 
 
 /// 当流式链路直接失败时，是否应该补一次同 provider 的非流式请求。
 pub(crate) fn should_retry_non_stream_after_stream_error(err: &LlmError) -> bool {
+    // 已经生成过有效文本后再次发送同一完整请求会重复计费且可能生成不一致答案；
+    // 这类失败交给调用方的部分响应/候选策略处理，绝不做同 Provider 非流式重放。
+    if matches!(
+        err.stage.as_str(),
+        "stream_after_delta" | "stream_read_after_delta"
+    ) {
+        return false;
+    }
     matches!(
         err.code.as_str(),
         "provider_error" | "http_error" | "network_error" | "timeout"
@@ -24,9 +32,7 @@ pub(crate) fn should_retry_non_stream_after_stream_error(err: &LlmError) -> bool
             | "http_request_timeout"
             | "response_read"
             | "stream_read"
-            | "stream_read_after_delta"
             | "sse"
-            | "stream_after_delta"
     )
 }
 

--- a/qq-maid-llm/src/provider/openai/fallback.rs
+++ b/qq-maid-llm/src/provider/openai/fallback.rs
@@ -22,7 +22,7 @@ pub(crate) fn should_retry_non_stream_after_stream_error(err: &LlmError) -> bool
     }
     matches!(
         err.code.as_str(),
-        "provider_error" | "http_error" | "network_error" | "timeout"
+        "provider_error" | "http_error" | "network_error" | "timeout" | "sse_incomplete_frame"
     ) && matches!(
         err.stage.as_str(),
         "provider"

--- a/qq-maid-llm/src/provider/openai/responses.rs
+++ b/qq-maid-llm/src/provider/openai/responses.rs
@@ -3,6 +3,8 @@
 //! 这里仅负责 Responses API 的流式/非流式聊天执行，以及在需要时回退到同 provider
 //! 的非流式请求；不直接接触 Chat Completions，以保证 Responses 与 fallback provider 解耦。
 
+use std::error::Error as _;
+
 use futures::stream;
 use serde_json::Value;
 
@@ -302,7 +304,9 @@ async fn next_responses_stream_event(
                         continue;
                     };
                     state.frame_buffer.clear();
-                    if !is_openai_responses_done_sentinel(&event.data) {
+                    if is_openai_responses_done_sentinel(&event.data) {
+                        state.saw_done = true;
+                    } else {
                         state.recorder.mark_event();
                         match handle_openai_chat_stream_event(
                             event,
@@ -328,10 +332,39 @@ async fn next_responses_stream_event(
                     state.recorder.mark_token();
                     return Some(Ok(LlmStreamEvent::TextDelta(answer)));
                 }
+                if state.saw_done && !state.answer.trim().is_empty() {
+                    state.finished = true;
+                    return Some(Ok(LlmStreamEvent::Completed {
+                        usage: None,
+                        finish_reason: None,
+                        fallback_used: false,
+                    }));
+                }
                 if !state.saw_completed {
+                    if !state.answer.trim().is_empty() {
+                        // HTTP body 正常结束、SSE 均已完整解析且已有可用文本时，兼容
+                        // 少数省略 completed/[DONE] 的 Responses 网关；该分支不修改
+                        // saw_completed，日志也明确标记为 compat EOF completion。
+                        tracing::warn!(
+                            http_status = state.response.status().as_u16(),
+                            stream_end_kind = "normal_eof_compatible_completion",
+                            normal_eof = true,
+                            saw_completed = false,
+                            saw_done = state.saw_done,
+                            saw_text_delta = true,
+                            visible_text_chars = state.answer.chars().count(),
+                            "OpenAI Responses chat stream used compatible completion after normal HTTP EOF"
+                        );
+                        state.finished = true;
+                        return Some(Ok(LlmStreamEvent::Completed {
+                            usage: None,
+                            finish_reason: None,
+                            fallback_used: false,
+                        }));
+                    }
                     state.finished = true;
                     return Some(Err(incomplete_stream_eof_error(
-                        "OpenAI Responses chat stream ended before response.completed",
+                        "OpenAI Responses chat stream ended normally without usable content",
                         &state.answer,
                     )));
                 }
@@ -381,6 +414,34 @@ pub(crate) fn stream_transport_error(
         "stream_read_after_delta"
     };
     LlmError::from_error_source(&error, crate::error::LlmErrorKind::Network, stage, context)
+}
+
+/// 只依据底层结构化 I/O error kind 判断连接是否异常中断，不匹配错误文案。
+pub(crate) fn is_connection_reset_error(error: &reqwest::Error) -> bool {
+    // reqwest/hyper 有时把 HTTP body 提前终止保留为 body error，而底层 io::Error
+    // 不再出现在可 downcast 的 source chain；这仍是结构化类别，不依赖文案。
+    if (error.is_body() || error.is_decode()) && !error.is_timeout() {
+        return true;
+    }
+    let mut source = error.source();
+    while let Some(current) = source {
+        if let Some(io_error) = current.downcast_ref::<std::io::Error>()
+            && matches!(
+                io_error.kind(),
+                std::io::ErrorKind::ConnectionReset
+                    | std::io::ErrorKind::ConnectionAborted
+                    | std::io::ErrorKind::BrokenPipe
+                    | std::io::ErrorKind::UnexpectedEof
+            )
+        {
+            return true;
+        }
+        source = current.source();
+    }
+    // 本 helper 只在 `Response::chunk()` 返回 Err 时调用；排除结构化 timeout 后，
+    // 剩余错误都表示 HTTP body 未按正常 EOF 收尾，应归入连接/正文中断，而不是
+    // SSE 解析错误。更具体的 I/O kind 可用时仍由上面的分支优先确认。
+    !error.is_timeout()
 }
 
 #[cfg(test)]
@@ -582,7 +643,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn openai_responses_stream_requires_completed_after_delta() {
+    async fn openai_responses_stream_accepts_normal_eof_after_valid_text_delta() {
         let (base_url, _state) = spawn_mock_responses(
             "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"半截\"}\n\n"
                 .to_owned(),
@@ -593,10 +654,9 @@ mod tests {
         let messages = [ChatMessage::user("hi")];
         let req = stream_req(&client, &base_url, &messages);
 
-        let err = openai_responses_stream_chat(&req).await.unwrap_err();
+        let outcome = openai_responses_stream_chat(&req).await.unwrap();
 
-        assert_eq!(err.stage, "stream_after_delta");
-        assert!(err.message.contains("response.completed"));
+        assert_eq!(outcome.reply, "半截");
     }
 
     #[tokio::test]

--- a/qq-maid-llm/src/provider/openai/responses.rs
+++ b/qq-maid-llm/src/provider/openai/responses.rs
@@ -16,7 +16,7 @@ use crate::{
         ChatOutcome, LlmStream, LlmStreamEvent, collect_llm_stream,
         types::{ChatMessage, ReasoningEffort},
     },
-    sse::{parse_sse_frame, take_sse_frame},
+    sse::{is_ignorable_sse_eof_tail, parse_sse_frame, take_sse_frame},
 };
 
 use super::{
@@ -296,12 +296,11 @@ async fn next_responses_stream_event(
             }
             Ok(None) => {
                 if !state.frame_buffer.is_empty() {
-                    let Some(event) = (match parse_sse_frame(&state.frame_buffer) {
-                        Ok(event) => event,
-                        Err(err) => return Some(Err(err)),
-                    }) else {
-                        // HTTP 已正常 EOF，但残留字节既没有 SSE 分隔符，也无法解析出
-                        // data frame。此时必须按截断处理，不能清空后让已有文本进入兼容完成。
+                    if is_ignorable_sse_eof_tail(&state.frame_buffer) {
+                        state.frame_buffer.clear();
+                    } else {
+                        // HTTP 已正常 EOF，但非注释残留没有 SSE frame 分隔符。即使
+                        // parse_sse_frame 能宽松解析出 data，也不能把真实残帧当作完成。
                         tracing::warn!(
                             http_status = state.response.status().as_u16(),
                             stream_end_kind = "sse_incomplete_frame",
@@ -315,23 +314,6 @@ async fn next_responses_stream_event(
                         );
                         state.finished = true;
                         return Some(Err(incomplete_sse_frame_error(&state.answer)));
-                    };
-                    state.frame_buffer.clear();
-                    if is_openai_responses_done_sentinel(&event.data) {
-                        state.saw_done = true;
-                    } else {
-                        state.recorder.mark_event();
-                        match handle_openai_chat_stream_event(
-                            event,
-                            &mut state.recorder,
-                            &mut state.answer,
-                            &mut state.completed_response,
-                            &mut state.saw_completed,
-                        ) {
-                            Ok(Some(delta)) => return Some(Ok(LlmStreamEvent::TextDelta(delta))),
-                            Ok(None) => {}
-                            Err(err) => return Some(Err(err)),
-                        }
                     }
                 }
                 if state.answer.trim().is_empty()
@@ -416,7 +398,7 @@ pub(crate) fn incomplete_stream_eof_error(message: &str, answer: &str) -> LlmErr
     LlmError::provider(message, stage)
 }
 
-fn incomplete_sse_frame_error(answer: &str) -> LlmError {
+pub(crate) fn incomplete_sse_frame_error(answer: &str) -> LlmError {
     let stage = if answer.trim().is_empty() {
         "stream"
     } else {
@@ -669,9 +651,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn openai_responses_stream_accepts_normal_eof_after_valid_text_delta() {
-        let (base_url, _state) = spawn_mock_responses(
-            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"半截\"}\n\n"
+    async fn responses_stream_ignores_extra_newline_at_normal_eof() {
+        let (base_url, state) = spawn_mock_responses(
+            "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"完整文本\"}\n\n\n"
                 .to_owned(),
             StatusCode::OK,
         )
@@ -682,7 +664,30 @@ mod tests {
 
         let outcome = openai_responses_stream_chat(&req).await.unwrap();
 
-        assert_eq!(outcome.reply, "半截");
+        assert_eq!(outcome.reply, "完整文本");
+        assert_eq!(outcome.reply.matches("完整文本").count(), 1);
+        assert_eq!(state.lock().await.calls, 1);
+    }
+
+    #[tokio::test]
+    async fn responses_stream_ignores_keep_alive_comment_at_normal_eof() {
+        let (base_url, state) = spawn_mock_responses(
+            concat!(
+                "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"完整文本\"}\n\n",
+                ": keep-alive",
+            )
+            .to_owned(),
+            StatusCode::OK,
+        )
+        .await;
+        let client = qq_maid_common::http_client::client();
+        let messages = [ChatMessage::user("hi")];
+        let req = stream_req(&client, &base_url, &messages);
+
+        let outcome = openai_responses_stream_chat(&req).await.unwrap();
+
+        assert_eq!(outcome.reply, "完整文本");
+        assert_eq!(state.lock().await.calls, 1);
     }
 
     #[tokio::test]

--- a/qq-maid-llm/src/provider/openai/responses.rs
+++ b/qq-maid-llm/src/provider/openai/responses.rs
@@ -300,8 +300,21 @@ async fn next_responses_stream_event(
                         Ok(event) => event,
                         Err(err) => return Some(Err(err)),
                     }) else {
-                        state.frame_buffer.clear();
-                        continue;
+                        // HTTP 已正常 EOF，但残留字节既没有 SSE 分隔符，也无法解析出
+                        // data frame。此时必须按截断处理，不能清空后让已有文本进入兼容完成。
+                        tracing::warn!(
+                            http_status = state.response.status().as_u16(),
+                            stream_end_kind = "sse_incomplete_frame",
+                            normal_eof = true,
+                            saw_completed = state.saw_completed,
+                            saw_done = state.saw_done,
+                            saw_text_delta = !state.answer.trim().is_empty(),
+                            visible_text_chars = state.answer.chars().count(),
+                            incomplete_frame_bytes = state.frame_buffer.len(),
+                            "OpenAI Responses chat stream ended with an incomplete SSE frame"
+                        );
+                        state.finished = true;
+                        return Some(Err(incomplete_sse_frame_error(&state.answer)));
                     };
                     state.frame_buffer.clear();
                     if is_openai_responses_done_sentinel(&event.data) {
@@ -401,6 +414,19 @@ pub(crate) fn incomplete_stream_eof_error(message: &str, answer: &str) -> LlmErr
         "stream_after_delta"
     };
     LlmError::provider(message, stage)
+}
+
+fn incomplete_sse_frame_error(answer: &str) -> LlmError {
+    let stage = if answer.trim().is_empty() {
+        "stream"
+    } else {
+        "stream_after_delta"
+    };
+    LlmError::new(
+        "sse_incomplete_frame",
+        "OpenAI Responses chat stream ended with an incomplete SSE frame",
+        stage,
+    )
 }
 
 pub(crate) fn stream_transport_error(
@@ -657,6 +683,31 @@ mod tests {
         let outcome = openai_responses_stream_chat(&req).await.unwrap();
 
         assert_eq!(outcome.reply, "半截");
+    }
+
+    #[tokio::test]
+    async fn incomplete_tail_after_text_is_truncated_without_non_stream_retry() {
+        let (base_url, state) = spawn_mock_responses(
+            concat!(
+                "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"已完成文本\"}\n\n",
+                "event: response.output_text.delta",
+            )
+            .to_owned(),
+            StatusCode::OK,
+        )
+        .await;
+        let client = qq_maid_common::http_client::client();
+        let messages = [ChatMessage::user("hi")];
+        let req = stream_req(&client, &base_url, &messages);
+
+        let err = openai_responses_chat_with_stream_fallback(req)
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, "sse_incomplete_frame");
+        assert_eq!(err.stage, "stream_after_delta");
+        assert!(err.message.contains("incomplete SSE frame"));
+        assert_eq!(state.lock().await.calls, 1);
     }
 
     #[tokio::test]

--- a/qq-maid-llm/src/provider/openai/tool_loop/diagnostics.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/diagnostics.rs
@@ -36,11 +36,14 @@ pub(super) fn sync_responses_stream_diagnostics(
     diagnostics: &Arc<Mutex<AgentStreamingDiagnostics>>,
     saw_completed: bool,
     buffered_delta_count: usize,
+    buffered_text_chars: usize,
     active_function_call_count: usize,
 ) {
     update_streaming_diagnostics(diagnostics, |item| {
         item.saw_completed = saw_completed;
         item.buffered_delta_count = buffered_delta_count;
+        item.buffered_text_chars = buffered_text_chars;
+        item.saw_text_delta = buffered_text_chars > 0 || item.visible_text_chars > 0;
         item.active_function_call_count = active_function_call_count;
     });
 }
@@ -53,18 +56,24 @@ pub(super) fn classify_responses_stream_failure(
         if item.fallback_reason.is_some() {
             return;
         }
-        let reason = if item.saw_completed {
+        let reason = if item.explicit_failure_event {
+            "explicit_failure_event"
+        } else if item.parse_error {
+            "sse_parse_error"
+        } else if item.connection_reset {
+            "stream_connection_reset"
+        } else if item.saw_completed {
             "completed_response_incomplete"
         } else if item.saw_done {
             "done_without_safe_completion"
-        } else if err.message.contains("before response.completed") {
-            if item.sse_event_count == 0 {
-                "sse_early_eof"
-            } else {
-                "missing_response_completed"
-            }
+        } else if item.normal_eof && item.active_function_call_count > 0 {
+            "normal_eof_active_function_call"
+        } else if item.normal_eof && item.saw_text_delta {
+            "normal_eof_text_not_committed"
+        } else if item.normal_eof {
+            "normal_eof_no_content"
         } else if err.code == "http_error" || err.stage == "http" {
-            "http_sse_parse_error"
+            "http_stream_error"
         } else {
             "provider_error_other"
         };

--- a/qq-maid-llm/src/provider/openai/tool_loop/diagnostics.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/diagnostics.rs
@@ -68,6 +68,10 @@ pub(super) fn classify_responses_stream_failure(
             "done_without_safe_completion"
         } else if item.normal_eof && item.active_function_call_count > 0 {
             "normal_eof_active_function_call"
+        } else if item.stream_end_kind.as_deref()
+            == Some("normal_eof_completed_function_call_without_terminal_event")
+        {
+            "normal_eof_completed_function_call_without_terminal_event"
         } else if item.normal_eof && item.saw_text_delta {
             "normal_eof_text_not_committed"
         } else if item.normal_eof {

--- a/qq-maid-llm/src/provider/openai/tool_loop/streaming.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/streaming.rs
@@ -14,12 +14,15 @@ use crate::{
     agent_loop::{AgentStep, AgentStreamingDiagnostics, AgentTextDeltaSink, AgentToolCall},
     error::LlmError,
     metrics::MetricsRecorder,
-    sse::{SseFrame, parse_sse_frame, take_sse_frame},
+    sse::{SseFrame, is_ignorable_sse_eof_tail, parse_sse_frame, take_sse_frame},
 };
 
 use crate::provider::openai::{
     extract::{extract_response_output_text, extract_response_usage},
-    responses::{incomplete_stream_eof_error, is_connection_reset_error, stream_transport_error},
+    responses::{
+        incomplete_sse_frame_error, incomplete_stream_eof_error, is_connection_reset_error,
+        stream_transport_error,
+    },
     stream::{
         handle_openai_chat_stream_event, is_openai_responses_done_sentinel,
         responses_stream_is_complete,
@@ -216,16 +219,14 @@ pub(super) async fn collect_responses_tool_loop_stream(
     }
 
     // `Response::chunk()` 返回 Ok(None) 才表示 HTTP body 正常 EOF。先记录传输层
-    // 事实，再解析尾部残帧；若尾帧损坏，normal_eof 与 parse_error 会同时为 true，
+    // 事实，再检查尾部残帧；若尾帧损坏，normal_eof 与 parse_error 会同时为 true，
     // stream_end_kind 则明确标记 SSE 截断，且绝不会进入兼容完成。
     update_streaming_diagnostics(&diagnostics, |item| item.normal_eof = true);
 
     if !frame_buffer.is_empty() {
-        let Some(event) = parse_sse_frame(&frame_buffer).inspect_err(|_| {
-            mark_stream_parse_error(&diagnostics);
-        })?
-        else {
+        if is_ignorable_sse_eof_tail(&frame_buffer) {
             frame_buffer.clear();
+        } else {
             update_streaming_diagnostics(&diagnostics, |item| {
                 item.parse_error = true;
                 item.stream_end_kind = Some("sse_incomplete_frame".to_owned());
@@ -238,48 +239,7 @@ pub(super) async fn collect_responses_tool_loop_stream(
                 buffered_text_chars(&buffered_deltas),
                 active_function_calls.len(),
             );
-            return Err(incomplete_stream_eof_error(
-                "OpenAI Responses tool loop stream ended with an incomplete SSE frame",
-                &answer,
-            ));
-        };
-        observe_sse_event(&diagnostics, &event);
-        activity_counter.fetch_add(1, Ordering::SeqCst);
-        if is_openai_responses_done_sentinel(&event.data) {
-            update_streaming_diagnostics(&diagnostics, |item| {
-                item.saw_done = true;
-                item.stream_end_kind = Some("done_sentinel".to_owned());
-            });
-        }
-        if !is_openai_responses_done_sentinel(&event.data) {
-            observe_responses_function_call_event(
-                &event,
-                &mut active_function_calls,
-                &mut completed_output_items,
-            )
-            .inspect_err(|_| mark_stream_parse_error(&diagnostics))?;
-            recorder.mark_event();
-            match handle_openai_chat_stream_event(
-                event,
-                &mut recorder,
-                &mut answer,
-                &mut completed_response,
-                &mut saw_completed,
-            )
-            .inspect_err(|err| {
-                if err.stage == "sse" && err.message.starts_with("invalid ") {
-                    mark_stream_parse_error(&diagnostics);
-                }
-            })? {
-                Some(delta) if allow_tool_calls => buffered_deltas.push(delta),
-                Some(delta) => {
-                    update_streaming_diagnostics(&diagnostics, |item| {
-                        item.visible_text_chars += delta.chars().count();
-                    });
-                    text_delta_sink(delta).await?;
-                }
-                None => {}
-            }
+            return Err(incomplete_sse_frame_error(&answer));
         }
     }
 

--- a/qq-maid-llm/src/provider/openai/tool_loop/streaming.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/streaming.rs
@@ -313,8 +313,10 @@ pub(super) async fn collect_responses_tool_loop_stream(
     }
     let compatible_eof_completion = !explicit_completion
         && !done_completion
+        && stream_diagnostics.normal_eof
         && !answer.trim().is_empty()
         && active_function_calls.is_empty()
+        && completed_output_items.is_empty()
         && !stream_diagnostics.explicit_failure_event
         && !stream_diagnostics.parse_error
         && !stream_diagnostics.connection_reset;
@@ -334,6 +336,14 @@ pub(super) async fn collect_responses_tool_loop_stream(
             last_sse_event_type = ?stream_diagnostics.last_sse_event_type,
             "OpenAI Responses stream used compatible completion after normal HTTP EOF"
         );
+    } else if !explicit_completion && !completed_output_items.is_empty() {
+        // function call 已完整结束但缺少协议终止事件时，不能执行工具，也不能把同轮
+        // 草稿文本释放成最终回答；保留 completed items 仅用于准确识别该截断边界。
+        const END_KIND: &str = "normal_eof_completed_function_call_without_terminal_event";
+        update_streaming_diagnostics(&diagnostics, |item| {
+            item.stream_end_kind = Some(END_KIND.to_owned());
+        });
+        set_streaming_fallback_reason(&diagnostics, END_KIND);
     } else if !explicit_completion {
         update_streaming_diagnostics(&diagnostics, |item| {
             item.stream_end_kind = Some(if active_function_calls.is_empty() {

--- a/qq-maid-llm/src/provider/openai/tool_loop/streaming.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/streaming.rs
@@ -19,7 +19,7 @@ use crate::{
 
 use crate::provider::openai::{
     extract::{extract_response_output_text, extract_response_usage},
-    responses::{incomplete_stream_eof_error, stream_transport_error},
+    responses::{incomplete_stream_eof_error, is_connection_reset_error, stream_transport_error},
     stream::{
         handle_openai_chat_stream_event, is_openai_responses_done_sentinel,
         responses_stream_is_complete,
@@ -35,6 +35,15 @@ use super::{
     response::{append_response_output_items, extract_function_calls},
 };
 
+pub(super) struct StreamFinalization {
+    pub(super) allow_tool_calls: bool,
+    pub(super) answer: String,
+    pub(super) buffered_deltas: Vec<String>,
+    pub(super) completed_response: Option<Value>,
+    pub(super) completion_confirmed: bool,
+    pub(super) diagnostics: Arc<Mutex<AgentStreamingDiagnostics>>,
+}
+
 pub(super) async fn collect_responses_tool_loop_stream(
     mut response: reqwest::Response,
     input: &mut Vec<Value>,
@@ -43,6 +52,9 @@ pub(super) async fn collect_responses_tool_loop_stream(
     diagnostics: Arc<Mutex<AgentStreamingDiagnostics>>,
     activity_counter: Arc<AtomicUsize>,
 ) -> Result<AgentStep, LlmError> {
+    update_streaming_diagnostics(&diagnostics, |item| {
+        item.http_status = Some(response.status().as_u16());
+    });
     let mut frame_buffer = Vec::new();
     let mut recorder = MetricsRecorder::start();
     let mut answer = String::new();
@@ -54,30 +66,37 @@ pub(super) async fn collect_responses_tool_loop_stream(
     loop {
         while let Some(frame) = take_sse_frame(&mut frame_buffer) {
             let Some(event) = parse_sse_frame(&frame).inspect_err(|_| {
-                set_streaming_fallback_reason(&diagnostics, "http_sse_parse_error");
+                mark_stream_parse_error(&diagnostics);
             })?
             else {
                 continue;
             };
-            update_streaming_diagnostics(&diagnostics, |item| item.sse_event_count += 1);
+            observe_sse_event(&diagnostics, &event);
             activity_counter.fetch_add(1, Ordering::SeqCst);
             if is_openai_responses_done_sentinel(&event.data) {
-                update_streaming_diagnostics(&diagnostics, |item| item.saw_done = true);
+                update_streaming_diagnostics(&diagnostics, |item| {
+                    item.saw_done = true;
+                    item.stream_end_kind = Some("done_sentinel".to_owned());
+                });
                 if responses_stream_is_complete(saw_completed, &completed_response) {
                     sync_responses_stream_diagnostics(
                         &diagnostics,
                         saw_completed,
                         buffered_deltas.len(),
+                        buffered_text_chars(&buffered_deltas),
                         active_function_calls.len(),
                     );
                     return finalize_responses_tool_loop_stream(
                         input,
-                        allow_tool_calls,
                         text_delta_sink,
-                        answer,
-                        buffered_deltas,
-                        completed_response,
-                        saw_completed,
+                        StreamFinalization {
+                            allow_tool_calls,
+                            answer,
+                            buffered_deltas,
+                            completed_response,
+                            completion_confirmed: true,
+                            diagnostics,
+                        },
                     )
                     .await;
                 }
@@ -88,21 +107,24 @@ pub(super) async fn collect_responses_tool_loop_stream(
                         "output_text": answer.clone(),
                         "output": completed_output_items.clone(),
                     }));
-                    saw_completed = true;
                     sync_responses_stream_diagnostics(
                         &diagnostics,
                         saw_completed,
                         buffered_deltas.len(),
+                        buffered_text_chars(&buffered_deltas),
                         active_function_calls.len(),
                     );
                     return finalize_responses_tool_loop_stream(
                         input,
-                        allow_tool_calls,
                         text_delta_sink,
-                        answer,
-                        buffered_deltas,
-                        completed_response,
-                        saw_completed,
+                        StreamFinalization {
+                            allow_tool_calls,
+                            answer,
+                            buffered_deltas,
+                            completed_response,
+                            completion_confirmed: true,
+                            diagnostics,
+                        },
                     )
                     .await;
                 }
@@ -114,7 +136,7 @@ pub(super) async fn collect_responses_tool_loop_stream(
                 &mut completed_output_items,
             )
             .inspect_err(|_| {
-                set_streaming_fallback_reason(&diagnostics, "http_sse_parse_error");
+                mark_stream_parse_error(&diagnostics);
             })?;
             recorder.mark_event();
             match handle_openai_chat_stream_event(
@@ -126,28 +148,40 @@ pub(super) async fn collect_responses_tool_loop_stream(
             )
             .inspect_err(|err| {
                 if err.stage == "sse" && err.message.starts_with("invalid ") {
-                    set_streaming_fallback_reason(&diagnostics, "http_sse_parse_error");
+                    mark_stream_parse_error(&diagnostics);
                 }
             })? {
                 Some(delta) if allow_tool_calls => buffered_deltas.push(delta),
-                Some(delta) => text_delta_sink(delta).await?,
+                Some(delta) => {
+                    update_streaming_diagnostics(&diagnostics, |item| {
+                        item.visible_text_chars += delta.chars().count();
+                    });
+                    text_delta_sink(delta).await?;
+                }
                 None => {}
             }
             sync_responses_stream_diagnostics(
                 &diagnostics,
                 saw_completed,
                 buffered_deltas.len(),
+                buffered_text_chars(&buffered_deltas),
                 active_function_calls.len(),
             );
             if responses_stream_is_complete(saw_completed, &completed_response) {
+                update_streaming_diagnostics(&diagnostics, |item| {
+                    item.stream_end_kind = Some("response_completed".to_owned());
+                });
                 return finalize_responses_tool_loop_stream(
                     input,
-                    allow_tool_calls,
                     text_delta_sink,
-                    answer,
-                    buffered_deltas,
-                    completed_response,
-                    saw_completed,
+                    StreamFinalization {
+                        allow_tool_calls,
+                        answer,
+                        buffered_deltas,
+                        completed_response,
+                        completion_confirmed: true,
+                        diagnostics,
+                    },
                 )
                 .await;
             }
@@ -160,7 +194,18 @@ pub(super) async fn collect_responses_tool_loop_stream(
             }
             Ok(None) => break,
             Err(err) => {
-                set_streaming_fallback_reason(&diagnostics, "http_sse_parse_error");
+                let connection_reset = is_connection_reset_error(&err);
+                let stream_end_kind = if err.is_timeout() {
+                    "http_stream_timeout"
+                } else if connection_reset {
+                    "connection_reset"
+                } else {
+                    "http_stream_error"
+                };
+                update_streaming_diagnostics(&diagnostics, |item| {
+                    item.connection_reset = connection_reset;
+                    item.stream_end_kind = Some(stream_end_kind.to_owned());
+                });
                 return Err(stream_transport_error(
                     err,
                     "OpenAI tool loop stream failed",
@@ -170,29 +215,49 @@ pub(super) async fn collect_responses_tool_loop_stream(
         }
     }
 
+    // `Response::chunk()` 返回 Ok(None) 才表示 HTTP body 正常 EOF。先记录传输层
+    // 事实，再解析尾部残帧；若尾帧损坏，normal_eof 与 parse_error 会同时为 true，
+    // stream_end_kind 则明确标记 SSE 截断，且绝不会进入兼容完成。
+    update_streaming_diagnostics(&diagnostics, |item| item.normal_eof = true);
+
     if !frame_buffer.is_empty() {
         let Some(event) = parse_sse_frame(&frame_buffer).inspect_err(|_| {
-            set_streaming_fallback_reason(&diagnostics, "http_sse_parse_error");
+            mark_stream_parse_error(&diagnostics);
         })?
         else {
             frame_buffer.clear();
-            return finalize_responses_tool_loop_stream(
-                input,
-                allow_tool_calls,
-                text_delta_sink,
-                answer,
-                buffered_deltas,
-                completed_response,
+            update_streaming_diagnostics(&diagnostics, |item| {
+                item.parse_error = true;
+                item.stream_end_kind = Some("sse_incomplete_frame".to_owned());
+            });
+            set_streaming_fallback_reason(&diagnostics, "sse_incomplete_frame");
+            sync_responses_stream_diagnostics(
+                &diagnostics,
                 saw_completed,
-            )
-            .await;
+                buffered_deltas.len(),
+                buffered_text_chars(&buffered_deltas),
+                active_function_calls.len(),
+            );
+            return Err(incomplete_stream_eof_error(
+                "OpenAI Responses tool loop stream ended with an incomplete SSE frame",
+                &answer,
+            ));
         };
-        update_streaming_diagnostics(&diagnostics, |item| item.sse_event_count += 1);
+        observe_sse_event(&diagnostics, &event);
         activity_counter.fetch_add(1, Ordering::SeqCst);
         if is_openai_responses_done_sentinel(&event.data) {
-            update_streaming_diagnostics(&diagnostics, |item| item.saw_done = true);
+            update_streaming_diagnostics(&diagnostics, |item| {
+                item.saw_done = true;
+                item.stream_end_kind = Some("done_sentinel".to_owned());
+            });
         }
         if !is_openai_responses_done_sentinel(&event.data) {
+            observe_responses_function_call_event(
+                &event,
+                &mut active_function_calls,
+                &mut completed_output_items,
+            )
+            .inspect_err(|_| mark_stream_parse_error(&diagnostics))?;
             recorder.mark_event();
             match handle_openai_chat_stream_event(
                 event,
@@ -200,9 +265,19 @@ pub(super) async fn collect_responses_tool_loop_stream(
                 &mut answer,
                 &mut completed_response,
                 &mut saw_completed,
-            )? {
+            )
+            .inspect_err(|err| {
+                if err.stage == "sse" && err.message.starts_with("invalid ") {
+                    mark_stream_parse_error(&diagnostics);
+                }
+            })? {
                 Some(delta) if allow_tool_calls => buffered_deltas.push(delta),
-                Some(delta) => text_delta_sink(delta).await?,
+                Some(delta) => {
+                    update_streaming_diagnostics(&diagnostics, |item| {
+                        item.visible_text_chars += delta.chars().count();
+                    });
+                    text_delta_sink(delta).await?;
+                }
                 None => {}
             }
         }
@@ -212,24 +287,123 @@ pub(super) async fn collect_responses_tool_loop_stream(
         &diagnostics,
         saw_completed,
         buffered_deltas.len(),
+        buffered_text_chars(&buffered_deltas),
         active_function_calls.len(),
     );
 
+    let explicit_completion = responses_stream_is_complete(saw_completed, &completed_response);
+    let stream_diagnostics = diagnostics
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    if explicit_completion {
+        update_streaming_diagnostics(&diagnostics, |item| {
+            item.stream_end_kind = Some("response_completed".to_owned());
+        });
+    }
+    let done_completion = !explicit_completion
+        && stream_diagnostics.saw_done
+        && active_function_calls.is_empty()
+        && (!answer.trim().is_empty() || !completed_output_items.is_empty());
+    if done_completion {
+        completed_response = Some(json!({
+            "output_text": answer.clone(),
+            "output": completed_output_items.clone(),
+        }));
+    }
+    let compatible_eof_completion = !explicit_completion
+        && !done_completion
+        && !answer.trim().is_empty()
+        && active_function_calls.is_empty()
+        && !stream_diagnostics.explicit_failure_event
+        && !stream_diagnostics.parse_error
+        && !stream_diagnostics.connection_reset;
+    if compatible_eof_completion {
+        completed_response = Some(json!({
+            "output_text": answer.clone(),
+            "output": [],
+        }));
+        update_streaming_diagnostics(&diagnostics, |item| {
+            item.stream_end_kind = Some("normal_eof_compatible_completion".to_owned());
+        });
+        tracing::warn!(
+            http_status = response.status().as_u16(),
+            saw_text_delta = !answer.trim().is_empty(),
+            buffered_text_chars = buffered_text_chars(&buffered_deltas),
+            active_function_call_count = active_function_calls.len(),
+            last_sse_event_type = ?stream_diagnostics.last_sse_event_type,
+            "OpenAI Responses stream used compatible completion after normal HTTP EOF"
+        );
+    } else if !explicit_completion {
+        update_streaming_diagnostics(&diagnostics, |item| {
+            item.stream_end_kind = Some(if active_function_calls.is_empty() {
+                "normal_eof_no_content".to_owned()
+            } else {
+                "normal_eof_active_function_call".to_owned()
+            });
+        });
+    }
+
     finalize_responses_tool_loop_stream(
         input,
-        allow_tool_calls,
         text_delta_sink,
-        answer,
-        buffered_deltas,
-        completed_response,
-        saw_completed,
+        StreamFinalization {
+            allow_tool_calls,
+            answer,
+            buffered_deltas,
+            completed_response,
+            completion_confirmed: explicit_completion
+                || done_completion
+                || compatible_eof_completion,
+            diagnostics,
+        },
     )
     .await
 }
 
+fn observe_sse_event(diagnostics: &Arc<Mutex<AgentStreamingDiagnostics>>, event: &SseFrame) {
+    let event_type = if is_openai_responses_done_sentinel(&event.data) {
+        Some("[DONE]".to_owned())
+    } else {
+        event.event.clone().or_else(|| {
+            serde_json::from_str::<Value>(&event.data)
+                .ok()
+                .and_then(|value| value.get("type").and_then(Value::as_str).map(str::to_owned))
+        })
+    };
+    update_streaming_diagnostics(diagnostics, |item| {
+        item.sse_event_count += 1;
+        if let Some(event_type) = event_type {
+            item.explicit_failure_event |= matches!(
+                event_type.as_str(),
+                "response.failed" | "response.incomplete" | "error"
+            );
+            if item.explicit_failure_event {
+                item.stream_end_kind = Some("explicit_failure_event".to_owned());
+            }
+            item.last_sse_event_type = Some(event_type);
+        }
+    });
+}
+
+fn buffered_text_chars(buffered_deltas: &[String]) -> usize {
+    buffered_deltas
+        .iter()
+        .map(|delta| delta.chars().count())
+        .sum()
+}
+
+fn mark_stream_parse_error(diagnostics: &Arc<Mutex<AgentStreamingDiagnostics>>) {
+    update_streaming_diagnostics(diagnostics, |item| {
+        item.parse_error = true;
+        item.stream_end_kind = Some("sse_parse_error".to_owned());
+    });
+    set_streaming_fallback_reason(diagnostics, "sse_parse_error");
+}
+
 pub(super) fn observe_responses_function_call_event(
     event: &SseFrame,
-    active_function_calls: &mut HashSet<u64>,
+    active_function_calls: &mut HashSet<String>,
     completed_output_items: &mut Vec<Value>,
 ) -> Result<(), LlmError> {
     let value = serde_json::from_str::<Value>(&event.data).map_err(|err| {
@@ -243,7 +417,7 @@ pub(super) fn observe_responses_function_call_event(
         .as_deref()
         .or_else(|| value.get("type").and_then(Value::as_str))
         .unwrap_or("");
-    let output_index = value.get("output_index").and_then(Value::as_u64);
+    let call_key = function_call_key(&value);
     match event_type {
         "response.output_item.added" => {
             if value
@@ -251,23 +425,22 @@ pub(super) fn observe_responses_function_call_event(
                 .and_then(|item| item.get("type"))
                 .and_then(Value::as_str)
                 == Some("function_call")
-                && let Some(index) = output_index
             {
-                active_function_calls.insert(index);
+                active_function_calls
+                    .insert(call_key.unwrap_or_else(|| "unindexed_function_call".to_owned()));
             }
         }
         "response.function_call_arguments.delta" => {
-            if let Some(index) = output_index {
-                active_function_calls.insert(index);
-            }
+            active_function_calls
+                .insert(call_key.unwrap_or_else(|| "unindexed_function_call".to_owned()));
         }
         "response.output_item.done" => {
             if let Some(item) = value.get("item")
                 && item.get("type").and_then(Value::as_str) == Some("function_call")
             {
                 completed_output_items.push(item.clone());
-                if let Some(index) = output_index {
-                    active_function_calls.remove(&index);
+                if let Some(call_key) = call_key {
+                    active_function_calls.remove(&call_key);
                 }
             }
         }
@@ -276,16 +449,40 @@ pub(super) fn observe_responses_function_call_event(
     Ok(())
 }
 
+fn function_call_key(value: &Value) -> Option<String> {
+    value
+        .get("output_index")
+        .and_then(Value::as_u64)
+        .map(|index| format!("output_index:{index}"))
+        .or_else(|| {
+            value
+                .get("item_id")
+                .and_then(Value::as_str)
+                .map(|id| format!("item_id:{id}"))
+        })
+        .or_else(|| {
+            value
+                .get("item")
+                .and_then(|item| item.get("id").or_else(|| item.get("call_id")))
+                .and_then(Value::as_str)
+                .map(|id| format!("item:{id}"))
+        })
+}
+
 pub(super) async fn finalize_responses_tool_loop_stream(
     input: &mut Vec<Value>,
-    allow_tool_calls: bool,
     text_delta_sink: AgentTextDeltaSink,
-    mut answer: String,
-    buffered_deltas: Vec<String>,
-    completed_response: Option<Value>,
-    saw_completed: bool,
+    finalization: StreamFinalization,
 ) -> Result<AgentStep, LlmError> {
-    if !saw_completed {
+    let StreamFinalization {
+        allow_tool_calls,
+        mut answer,
+        buffered_deltas,
+        completed_response,
+        completion_confirmed,
+        diagnostics,
+    } = finalization;
+    if !completion_confirmed {
         return Err(incomplete_stream_eof_error(
             "OpenAI Responses tool loop stream ended before response.completed",
             &answer,
@@ -332,9 +529,15 @@ pub(super) async fn finalize_responses_tool_loop_stream(
     }
     if allow_tool_calls {
         if buffered_deltas.is_empty() {
+            update_streaming_diagnostics(&diagnostics, |item| {
+                item.visible_text_chars += answer.chars().count();
+            });
             text_delta_sink(answer.clone()).await?;
         } else {
             for delta in buffered_deltas {
+                update_streaming_diagnostics(&diagnostics, |item| {
+                    item.visible_text_chars += delta.chars().count();
+                });
                 text_delta_sink(delta).await?;
             }
         }

--- a/qq-maid-llm/src/provider/openai/tool_loop/tests/mod.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/tests/mod.rs
@@ -549,24 +549,39 @@ async fn spawn_never_closing_done_stream() -> String {
     format!("http://{addr}/v1")
 }
 
-async fn static_sse_handler(State(body): State<Arc<String>>) -> Response<Body> {
+#[derive(Clone)]
+struct StaticSseState {
+    body: Arc<String>,
+    calls: Arc<AtomicUsize>,
+}
+
+async fn static_sse_handler(State(state): State<StaticSseState>) -> Response<Body> {
+    state.calls.fetch_add(1, Ordering::SeqCst);
     Response::builder()
         .header(header::CONTENT_TYPE, "text/event-stream")
-        .body(Body::from(body.as_str().to_owned()))
+        .body(Body::from(state.body.as_str().to_owned()))
         .unwrap()
 }
 
 async fn spawn_static_sse_stream(body: impl Into<String>) -> String {
-    let body = Arc::new(body.into());
+    spawn_counted_static_sse_stream(body).await.0
+}
+
+async fn spawn_counted_static_sse_stream(body: impl Into<String>) -> (String, Arc<AtomicUsize>) {
+    let state = StaticSseState {
+        body: Arc::new(body.into()),
+        calls: Arc::new(AtomicUsize::new(0)),
+    };
+    let calls = state.calls.clone();
     let app = Router::new()
         .route("/v1/responses", post(static_sse_handler))
-        .with_state(body);
+        .with_state(state);
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {
         axum::serve(listener, app).await.unwrap();
     });
-    format!("http://{addr}/v1")
+    (format!("http://{addr}/v1"), calls)
 }
 
 async fn reset_sse_handler() -> Response<Body> {

--- a/qq-maid-llm/src/provider/openai/tool_loop/tests/mod.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/tests/mod.rs
@@ -2,7 +2,10 @@ use super::{
     payload::{enforce_tool_loop_budget, openai_tool_loop_payload},
     response::{FunctionCall, extract_function_calls},
     session::ResponsesAgentSession,
-    streaming::{finalize_responses_tool_loop_stream, observe_responses_function_call_event},
+    streaming::{
+        StreamFinalization, finalize_responses_tool_loop_stream,
+        observe_responses_function_call_event,
+    },
 };
 use crate::{
     agent_loop::{
@@ -538,6 +541,57 @@ async fn spawn_never_closing_completed_stream() -> String {
 
 async fn spawn_never_closing_done_stream() -> String {
     let app = Router::new().route("/v1/responses", post(done_stream_that_never_closes));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}/v1")
+}
+
+async fn static_sse_handler(State(body): State<Arc<String>>) -> Response<Body> {
+    Response::builder()
+        .header(header::CONTENT_TYPE, "text/event-stream")
+        .body(Body::from(body.as_str().to_owned()))
+        .unwrap()
+}
+
+async fn spawn_static_sse_stream(body: impl Into<String>) -> String {
+    let body = Arc::new(body.into());
+    let app = Router::new()
+        .route("/v1/responses", post(static_sse_handler))
+        .with_state(body);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}/v1")
+}
+
+async fn reset_sse_handler() -> Response<Body> {
+    let delta = Bytes::from_static(
+        b"event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n",
+    );
+    let body = Body::from_stream(
+        stream::once(async move { Ok::<Bytes, std::io::Error>(delta) }).chain(stream::once(
+            async move {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionReset,
+                    "simulated reset",
+                ))
+            },
+        )),
+    );
+    Response::builder()
+        .header(header::CONTENT_TYPE, "text/event-stream")
+        .body(body)
+        .unwrap()
+}
+
+async fn spawn_reset_sse_stream() -> String {
+    let app = Router::new().route("/v1/responses", post(reset_sse_handler));
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {

--- a/qq-maid-llm/src/provider/openai/tool_loop/tests/streaming.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/tests/streaming.rs
@@ -170,10 +170,10 @@ fn done_does_not_complete_an_unfinished_function_call() {
 }
 
 #[tokio::test]
-async fn normal_eof_with_text_and_no_function_call_is_compatible_completion() {
+async fn normal_eof_with_text_and_extra_newline_is_compatible_completion() {
     let base_url = spawn_static_sse_stream(concat!(
         "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"你\"}\n\n",
-        "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"好\"}\n\n",
+        "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"好\"}\n\n\n",
     ))
     .await;
     let mut session = test_streaming_session(base_url);
@@ -199,6 +199,36 @@ async fn normal_eof_with_text_and_no_function_call_is_compatible_completion() {
     assert_eq!(diagnostics.buffered_text_chars, 2);
     assert_eq!(diagnostics.visible_text_chars, 2);
     assert_eq!(diagnostics.active_function_call_count, 0);
+    assert_eq!(
+        diagnostics.stream_end_kind.as_deref(),
+        Some("normal_eof_compatible_completion")
+    );
+}
+
+#[tokio::test]
+async fn normal_eof_with_text_and_keep_alive_comment_is_compatible_completion() {
+    let base_url = spawn_static_sse_stream(concat!(
+        "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"你好\"}\n\n",
+        ": keep-alive",
+    ))
+    .await;
+    let mut session = test_streaming_session(base_url);
+    let deltas = Arc::new(StdMutex::new(Vec::new()));
+
+    let step = session
+        .advance_streaming(&[], true, recording_delta_sink(deltas.clone()))
+        .await
+        .unwrap()
+        .unwrap();
+
+    let AgentStep::FinalAnswer { reply, .. } = step else {
+        panic!("expected compatible EOF final answer");
+    };
+    assert_eq!(reply, "你好");
+    assert_eq!(*deltas.lock().unwrap(), ["你好"]);
+    let diagnostics = session.streaming_diagnostics();
+    assert!(diagnostics.normal_eof);
+    assert!(!diagnostics.parse_error);
     assert_eq!(
         diagnostics.stream_end_kind.as_deref(),
         Some("normal_eof_compatible_completion")
@@ -326,30 +356,44 @@ async fn sse_parse_error_after_text_is_not_compatible_completion() {
 
 #[tokio::test]
 async fn incomplete_final_sse_frame_after_text_is_not_compatible_completion() {
-    let base_url = spawn_static_sse_stream(concat!(
+    let (base_url, calls) = spawn_counted_static_sse_stream(concat!(
         "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"草稿\"}\n\n",
         "event: response.output_text.delta",
     ))
     .await;
-    let mut session = test_streaming_session(base_url);
+    let registry = ToolRegistry::new().register(WeatherToolStub).unwrap();
+    let deltas = Arc::new(StdMutex::new(Vec::new()));
 
-    let err = session
-        .advance_streaming(
-            &[],
-            true,
-            recording_delta_sink(Arc::new(StdMutex::new(Vec::new()))),
-        )
-        .await
-        .unwrap_err();
+    let err = run_agent_loop(
+        Box::new(
+            ResponsesAgentSession::new(
+                qq_maid_common::http_client::client(),
+                "test-key".to_owned(),
+                Some(base_url),
+                "openai",
+                "gpt-test".to_owned(),
+                10 * 1024 * 1024,
+                1200,
+                None,
+                &[ChatMessage::user("小女仆测试一下")],
+                &registry,
+                None,
+            )
+            .unwrap(),
+        ),
+        registry,
+        test_context(),
+        3,
+        None,
+        Some(recording_delta_sink(deltas.clone())),
+    )
+    .await
+    .unwrap_err();
 
+    assert_eq!(err.code, "sse_incomplete_frame");
     assert_eq!(err.stage, "stream_after_delta");
-    let diagnostics = session.streaming_diagnostics();
-    assert!(diagnostics.normal_eof);
-    assert!(diagnostics.parse_error);
-    assert_eq!(
-        diagnostics.stream_end_kind.as_deref(),
-        Some("sse_incomplete_frame")
-    );
+    assert!(deltas.lock().unwrap().is_empty());
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]

--- a/qq-maid-llm/src/provider/openai/tool_loop/tests/streaming.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/tests/streaming.rs
@@ -1,24 +1,45 @@
 use super::*;
 
+fn test_streaming_session(base_url: String) -> ResponsesAgentSession {
+    let registry = ToolRegistry::new().register(WeatherToolStub).unwrap();
+    ResponsesAgentSession::new(
+        qq_maid_common::http_client::client(),
+        "test-key".to_owned(),
+        Some(base_url),
+        "openai",
+        "gpt-test".to_owned(),
+        10 * 1024 * 1024,
+        1200,
+        None,
+        &[ChatMessage::user("小女仆测试一下")],
+        &registry,
+        None,
+    )
+    .unwrap()
+}
+
 #[tokio::test]
 async fn streaming_tool_call_does_not_release_buffered_text_delta() {
     let mut input = Vec::new();
     let deltas = Arc::new(StdMutex::new(Vec::new()));
     let step = finalize_responses_tool_loop_stream(
         &mut input,
-        true,
         recording_delta_sink(deltas.clone()),
-        "草稿".to_owned(),
-        vec!["草稿".to_owned()],
-        Some(json!({
-            "output": [{
-                "type": "function_call",
-                "name": "get_weather",
-                "call_id": "call_weather_1",
-                "arguments": "{\"city\":\"杭州\"}"
-            }]
-        })),
-        true,
+        StreamFinalization {
+            allow_tool_calls: true,
+            answer: "草稿".to_owned(),
+            buffered_deltas: vec!["草稿".to_owned()],
+            completed_response: Some(json!({
+                "output": [{
+                    "type": "function_call",
+                    "name": "get_weather",
+                    "call_id": "call_weather_1",
+                    "arguments": "{\"city\":\"杭州\"}"
+                }]
+            })),
+            completion_confirmed: true,
+            diagnostics: Arc::new(StdMutex::new(Default::default())),
+        },
     )
     .await
     .unwrap();
@@ -71,6 +92,10 @@ async fn agent_stream_finishes_on_completed_without_waiting_for_http_eof() {
     assert!(diagnostics.chunk_count >= 1);
     assert!(diagnostics.sse_event_count >= 1);
     assert!(diagnostics.saw_completed);
+    assert_eq!(
+        diagnostics.stream_end_kind.as_deref(),
+        Some("response_completed")
+    );
     assert!(!diagnostics.saw_done);
 }
 
@@ -114,7 +139,11 @@ async fn agent_stream_finishes_on_done_without_waiting_for_http_eof() {
     assert!(diagnostics.chunk_count >= 1);
     assert_eq!(diagnostics.sse_event_count, 2);
     assert!(diagnostics.saw_done);
-    assert!(diagnostics.saw_completed);
+    assert!(!diagnostics.saw_completed);
+    assert_eq!(
+        diagnostics.stream_end_kind.as_deref(),
+        Some("done_sentinel")
+    );
 }
 
 #[test]
@@ -136,6 +165,175 @@ fn done_does_not_complete_an_unfinished_function_call() {
     )
     .unwrap();
 
-    assert_eq!(active, HashSet::from([0]));
+    assert_eq!(active, HashSet::from(["output_index:0".to_owned()]));
     assert!(completed.is_empty());
+}
+
+#[tokio::test]
+async fn normal_eof_with_text_and_no_function_call_is_compatible_completion() {
+    let base_url = spawn_static_sse_stream(concat!(
+        "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"你\"}\n\n",
+        "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"好\"}\n\n",
+    ))
+    .await;
+    let mut session = test_streaming_session(base_url);
+    let deltas = Arc::new(StdMutex::new(Vec::new()));
+
+    let step = session
+        .advance_streaming(&[], true, recording_delta_sink(deltas.clone()))
+        .await
+        .unwrap()
+        .unwrap();
+
+    let AgentStep::FinalAnswer { reply, .. } = step else {
+        panic!("expected compatible EOF final answer");
+    };
+    assert_eq!(reply, "你好");
+    assert_eq!(*deltas.lock().unwrap(), ["你", "好"]);
+    let diagnostics = session.streaming_diagnostics();
+    assert!(diagnostics.normal_eof);
+    assert!(!diagnostics.saw_completed);
+    assert!(!diagnostics.saw_done);
+    assert!(diagnostics.saw_text_delta);
+    assert_eq!(diagnostics.buffered_delta_count, 2);
+    assert_eq!(diagnostics.buffered_text_chars, 2);
+    assert_eq!(diagnostics.visible_text_chars, 2);
+    assert_eq!(diagnostics.active_function_call_count, 0);
+    assert_eq!(
+        diagnostics.stream_end_kind.as_deref(),
+        Some("normal_eof_compatible_completion")
+    );
+}
+
+#[tokio::test]
+async fn normal_eof_with_unclosed_function_call_is_not_completion() {
+    let base_url = spawn_static_sse_stream(concat!(
+        "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"草稿\"}\n\n",
+        "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"delta\":\"{\\\"city\\\":\"}\n\n",
+    ))
+    .await;
+    let mut session = test_streaming_session(base_url);
+    let deltas = Arc::new(StdMutex::new(Vec::new()));
+
+    let err = session
+        .advance_streaming(&[], true, recording_delta_sink(deltas.clone()))
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.stage, "stream_after_delta");
+    assert!(deltas.lock().unwrap().is_empty());
+    let diagnostics = session.streaming_diagnostics();
+    assert!(diagnostics.normal_eof);
+    assert_eq!(diagnostics.active_function_call_count, 1);
+    assert_eq!(
+        diagnostics.stream_end_kind.as_deref(),
+        Some("normal_eof_active_function_call")
+    );
+}
+
+#[tokio::test]
+async fn sse_parse_error_after_text_is_not_compatible_completion() {
+    let base_url = spawn_static_sse_stream(concat!(
+        "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"草稿\"}\n\n",
+        "event: response.output_text.delta\ndata: {not-json}\n\n",
+    ))
+    .await;
+    let mut session = test_streaming_session(base_url);
+    let deltas = Arc::new(StdMutex::new(Vec::new()));
+
+    let err = session
+        .advance_streaming(&[], true, recording_delta_sink(deltas.clone()))
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.stage, "sse");
+    assert!(deltas.lock().unwrap().is_empty());
+    let diagnostics = session.streaming_diagnostics();
+    assert!(diagnostics.parse_error);
+    assert!(!diagnostics.normal_eof);
+    assert_eq!(
+        diagnostics.stream_end_kind.as_deref(),
+        Some("sse_parse_error")
+    );
+}
+
+#[tokio::test]
+async fn incomplete_final_sse_frame_after_text_is_not_compatible_completion() {
+    let base_url = spawn_static_sse_stream(concat!(
+        "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"草稿\"}\n\n",
+        "event: response.output_text.delta",
+    ))
+    .await;
+    let mut session = test_streaming_session(base_url);
+
+    let err = session
+        .advance_streaming(
+            &[],
+            true,
+            recording_delta_sink(Arc::new(StdMutex::new(Vec::new()))),
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.stage, "stream_after_delta");
+    let diagnostics = session.streaming_diagnostics();
+    assert!(diagnostics.normal_eof);
+    assert!(diagnostics.parse_error);
+    assert_eq!(
+        diagnostics.stream_end_kind.as_deref(),
+        Some("sse_incomplete_frame")
+    );
+}
+
+#[tokio::test]
+async fn explicit_failure_after_text_is_not_compatible_completion() {
+    let base_url = spawn_static_sse_stream(concat!(
+        "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"草稿\"}\n\n",
+        "event: response.failed\ndata: {\"type\":\"response.failed\",\"response\":{\"error\":{\"message\":\"upstream failed\"}}}\n\n",
+    ))
+    .await;
+    let mut session = test_streaming_session(base_url);
+
+    let err = session
+        .advance_streaming(
+            &[],
+            true,
+            recording_delta_sink(Arc::new(StdMutex::new(Vec::new()))),
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.stage, "sse");
+    let diagnostics = session.streaming_diagnostics();
+    assert!(diagnostics.explicit_failure_event);
+    assert!(!diagnostics.normal_eof);
+    assert_eq!(
+        diagnostics.stream_end_kind.as_deref(),
+        Some("explicit_failure_event")
+    );
+}
+
+#[tokio::test]
+async fn connection_reset_after_text_is_not_compatible_completion() {
+    let base_url = spawn_reset_sse_stream().await;
+    let mut session = test_streaming_session(base_url);
+    let deltas = Arc::new(StdMutex::new(Vec::new()));
+
+    let err = session
+        .advance_streaming(&[], true, recording_delta_sink(deltas.clone()))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err.code.as_str(),
+        "network_error" | "provider_error"
+    ));
+    assert!(deltas.lock().unwrap().is_empty());
+    let diagnostics = session.streaming_diagnostics();
+    assert!(!diagnostics.normal_eof);
+    assert!(diagnostics.connection_reset);
+    assert_ne!(
+        diagnostics.stream_end_kind.as_deref(),
+        Some("normal_eof_compatible_completion")
+    );
 }

--- a/qq-maid-llm/src/provider/openai/tool_loop/tests/streaming.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/tests/streaming.rs
@@ -206,6 +206,73 @@ async fn normal_eof_with_text_and_no_function_call_is_compatible_completion() {
 }
 
 #[tokio::test]
+async fn normal_eof_with_text_and_completed_function_call_is_not_completion() {
+    let base_url = spawn_static_sse_stream(concat!(
+        "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"草稿\"}\n\n",
+        "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"name\":\"get_weather\",\"call_id\":\"call_weather_1\",\"arguments\":\"{\\\"city\\\":\\\"杭州\\\"}\"}}\n\n",
+    ))
+    .await;
+    let mut session = test_streaming_session(base_url);
+    let deltas = Arc::new(StdMutex::new(Vec::new()));
+
+    // 返回错误意味着既不会产出 FinalAnswer，也不会把 ToolCalls 交给执行层。
+    let err = session
+        .advance_streaming(&[], true, recording_delta_sink(deltas.clone()))
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.stage, "stream_after_delta");
+    assert!(deltas.lock().unwrap().is_empty());
+    let diagnostics = session.streaming_diagnostics();
+    assert!(diagnostics.normal_eof);
+    assert!(!diagnostics.saw_completed);
+    assert!(!diagnostics.saw_done);
+    assert_eq!(diagnostics.active_function_call_count, 0);
+    assert_eq!(diagnostics.visible_text_chars, 0);
+    assert_eq!(
+        diagnostics.stream_end_kind.as_deref(),
+        Some("normal_eof_completed_function_call_without_terminal_event")
+    );
+    assert_eq!(
+        diagnostics.fallback_reason.as_deref(),
+        Some("normal_eof_completed_function_call_without_terminal_event")
+    );
+}
+
+#[tokio::test]
+async fn normal_eof_with_only_completed_function_call_is_not_completion() {
+    let base_url = spawn_static_sse_stream(
+        "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"name\":\"get_weather\",\"call_id\":\"call_weather_1\",\"arguments\":\"{\\\"city\\\":\\\"杭州\\\"}\"}}\n\n",
+    )
+    .await;
+    let mut session = test_streaming_session(base_url);
+    let deltas = Arc::new(StdMutex::new(Vec::new()));
+
+    // 缺少标准终止事件时，完整 function call 也不能进入工具执行层。
+    let err = session
+        .advance_streaming(&[], true, recording_delta_sink(deltas.clone()))
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.stage, "stream");
+    assert!(deltas.lock().unwrap().is_empty());
+    let diagnostics = session.streaming_diagnostics();
+    assert!(diagnostics.normal_eof);
+    assert!(!diagnostics.saw_completed);
+    assert!(!diagnostics.saw_done);
+    assert!(!diagnostics.saw_text_delta);
+    assert_eq!(diagnostics.active_function_call_count, 0);
+    assert_eq!(
+        diagnostics.stream_end_kind.as_deref(),
+        Some("normal_eof_completed_function_call_without_terminal_event")
+    );
+    assert_ne!(
+        diagnostics.stream_end_kind.as_deref(),
+        Some("normal_eof_compatible_completion")
+    );
+}
+
+#[tokio::test]
 async fn normal_eof_with_unclosed_function_call_is_not_completion() {
     let base_url = spawn_static_sse_stream(concat!(
         "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"草稿\"}\n\n",

--- a/qq-maid-llm/src/provider/route_error.rs
+++ b/qq-maid-llm/src/provider/route_error.rs
@@ -96,6 +96,7 @@ pub(crate) fn model_error_kind(err: &LlmError) -> &'static str {
         "http_error" | "network_error" => "network",
         "authentication_failed" => "authentication",
         "provider_error" if matches!(err.stage.as_str(), "stream" | "sse") => "stream_error",
+        "sse_incomplete_frame" => "stream_error",
         "provider_error" if err.stage == "json" => "invalid_response",
         "provider_error" if err.stage == "provider_unavailable" => "provider_unavailable",
         "provider_error" => "provider_error",

--- a/qq-maid-llm/src/provider/routing.rs
+++ b/qq-maid-llm/src/provider/routing.rs
@@ -10,6 +10,7 @@ use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
 };
+use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::stream;
@@ -31,6 +32,8 @@ use super::stream_state::{RouteStreamState, next_route_stream_event};
 use super::{
     ChatOutcome, LlmProvider, LlmStream, ToolCallingProtocol, ToolChatRequest, finish_agent_error,
 };
+
+const MIN_FALLBACK_CANDIDATE_START_BUDGET: Duration = Duration::from_secs(1);
 
 /// 通用模型候选链提供商。
 ///
@@ -241,6 +244,33 @@ impl LlmProvider for ModelRouteProvider {
         let mut failures = Vec::new();
         let visible_final_delta_sent = Arc::new(AtomicBool::new(false));
         for (index, candidate) in candidates.iter().enumerate() {
+            if index > 0
+                && run_handle
+                    .remaining_budget()
+                    .is_some_and(|remaining| remaining < MIN_FALLBACK_CANDIDATE_START_BUDGET)
+            {
+                let remaining_budget = run_handle.remaining_budget();
+                run_handle.cancel(AgentStopReason::Timeout);
+                tracing::warn!(
+                    task,
+                    candidate_index = index,
+                    provider = candidate
+                        .provider
+                        .as_ref()
+                        .unwrap_or(&self.default_provider)
+                        .as_str(),
+                    model = %candidate.name,
+                    candidate_remaining_budget_ms = remaining_budget
+                        .map(|value| value.as_millis()),
+                    fallback_skipped_reason = "insufficient_remaining_budget",
+                    "tool model fallback candidate skipped"
+                );
+                return Err(finish_agent_error(
+                    LlmError::timeout("agent_loop"),
+                    &run_handle,
+                    AgentStopReason::Timeout,
+                ));
+            }
             run_handle.begin_candidate_attempt()?;
             let provider_kind = candidate
                 .provider

--- a/qq-maid-llm/src/provider/tests/routing.rs
+++ b/qq-maid-llm/src/provider/tests/routing.rs
@@ -258,6 +258,23 @@ async fn tool_candidate_failure_then_success_keeps_request_counters() {
 }
 
 #[tokio::test]
+async fn tool_candidate_fallback_is_skipped_when_remaining_budget_is_insufficient() {
+    let (provider, first, second) =
+        handle_route_provider(HandleBehavior::Failed, HandleBehavior::Success);
+    let mut req = tool_request();
+    req.run_handle = Some(AgentRunHandle::with_timeout(
+        std::time::Duration::from_millis(20),
+    ));
+
+    let err = provider.chat_with_tools(req).await.unwrap_err();
+
+    assert_eq!(err.code, "timeout");
+    assert_eq!(err.stage, "agent_loop");
+    assert_eq!(first.calls(), 1);
+    assert_eq!(second.calls(), 0);
+}
+
+#[tokio::test]
 async fn tool_candidate_does_not_fallback_after_tool_side_effect_started() {
     let (provider, first, second) = handle_route_provider(
         HandleBehavior::FailedAfterToolStart,

--- a/qq-maid-llm/src/sse.rs
+++ b/qq-maid-llm/src/sse.rs
@@ -56,6 +56,17 @@ pub fn parse_sse_frame(frame: &[u8]) -> Result<Option<SseFrame>, LlmError> {
     Ok(Some(SseFrame { event, data }))
 }
 
+/// 判断 HTTP 正常 EOF 后的 SSE 残留字节是否只有可安全忽略的内容。
+///
+/// 未经空行分隔的 `event:` / `data:` 即使能被宽松解析，也仍是未完成 frame；
+/// 这里只接受 ASCII 空白行，以及首字节为 `:` 的 SSE 注释/keep-alive 行。
+pub fn is_ignorable_sse_eof_tail(tail: &[u8]) -> bool {
+    tail.split(|byte| *byte == b'\n').all(|line| {
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        line.iter().all(u8::is_ascii_whitespace) || line.first() == Some(&b':')
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -91,5 +102,24 @@ mod tests {
         let parsed = parse_sse_frame(b"data: [DONE]").unwrap().unwrap();
 
         assert_eq!(parsed.data, "[DONE]");
+    }
+
+    #[test]
+    fn accepts_only_whitespace_and_comment_lines_as_ignorable_eof_tail() {
+        assert!(is_ignorable_sse_eof_tail(b"\n"));
+        assert!(is_ignorable_sse_eof_tail(b" \t\r\n\r\n"));
+        assert!(is_ignorable_sse_eof_tail(
+            b": keep-alive\n: another comment\r\n"
+        ));
+    }
+
+    #[test]
+    fn rejects_effective_content_as_ignorable_eof_tail() {
+        assert!(!is_ignorable_sse_eof_tail(
+            b"event: response.output_text.delta"
+        ));
+        assert!(!is_ignorable_sse_eof_tail(b"data: {\"delta\":\"x\"}"));
+        assert!(!is_ignorable_sse_eof_tail(b"{\"delta\":\"x\"}"));
+        assert!(!is_ignorable_sse_eof_tail(b" : not-an-sse-comment"));
     }
 }


### PR DESCRIPTION
## 背景

QQ 私聊的 OpenAI Responses 工具流在上游返回大量文本 delta、但省略 `response.completed` / `[DONE]` 时，一直将文本保存在工具调用判定缓冲区。旧实现随后把正常 EOF 归入笼统 Provider 错误，并对同一 Provider、同一输入再发起一次最长 30 秒的完整非流式请求，造成串行超时放大、重复生成和重复计费。

本次后续检查还发现两个 EOF 边界漏洞：

- 工具流只检查 `active_function_calls`，没有检查已经移入 `completed_output_items` 的完整 function call；兼容 EOF 会用空 `output` 重建响应，静默丢弃工具调用并把草稿文本当成最终回答。
- 普通 Responses 流在 HTTP EOF 时遇到 `parse_sse_frame(...) -> Ok(None)` 的非空尾缓冲，会清空后继续循环；下一次 EOF 可能把已有文本误判成兼容完成。

## 根因

- 开启 Tool Calling 时，文本 delta 会先缓冲，直到确认本轮没有 function call。
- 原兼容 EOF 判定只排除了 active/未闭合 function call，没有排除已完整结束、等待标准终止事件确认的 function call。
- 普通 Responses 流和工具流对 EOF 非空残帧的处理不一致，普通流把无法形成 data frame 的尾部当成可忽略空帧。
- 旧完成判断只认可标准终止事件，不认可“HTTP 正常 EOF + 完整可用纯文本”的兼容响应。
- 流式错误后的非流式回退使用独立超时，没有先服从 Agent 的剩余预算。
- `provider_error_other` 分类过宽，无法区分正常 EOF、SSE 解析、连接中断和明确失败事件。

## 修改

- 在统一 OpenAI Responses/SSE 层保留 Provider/模型无关的纯文本兼容 EOF 完成，最终条件为：
  - assistant 文本非空；
  - `active_function_calls` 为空；
  - `completed_output_items` 为空；
  - 没有 `response.failed`、`response.incomplete`、`error`；
  - 没有 SSE 解析错误；
  - 没有连接重置或 HTTP 正文中断；
  - `Response::chunk()` 返回 `Ok(None)`，确认 HTTP body 正常 EOF。
- 已观察到完整 function call、但缺少 `response.completed` / `[DONE]` 时：
  - 返回 `normal_eof_completed_function_call_without_terminal_event`；
  - 不执行工具，不释放缓冲草稿，不伪造 `saw_completed`；
  - 保留 `completed_output_items` 用于准确识别该边界。
- 普通 Responses 流在正常 HTTP EOF 遇到非空且无法形成 data frame 的尾缓冲时：
  - 返回 `sse_incomplete_frame@stream_after_delta` 截断错误；
  - 记录 `stream_end_kind=sse_incomplete_frame`；
  - 已有文本时不触发同 Provider 非流式完整重生成。
- 区分标准 completed、`[DONE]`、正常 EOF、SSE 尾帧截断、解析错误、连接重置/正文中断、超时和明确失败事件。
- 增加字符数、HTTP/SSE 终态、function call 数量与剩余预算等结构化诊断字段，不记录正文或凭据。
- 已有有效文本后禁止同 Provider 非流式完整重生成；早期且无有效输出时仍保留兼容回退。
- 非流式回退及候选切换使用 Tokio 单调时钟计算 Agent 剩余预算；不足 1 秒时跳过，所有模型轮次仍由外层 deadline 截断。
- 将 `agent_loop/runner.rs` 的流式推进与回退逻辑拆入 `agent_loop/streaming.rs`，runner 从 1000+ 行降到 798 行。
- 未增加全局超时，未按 Provider 或模型名硬编码。

## 新增回归测试

- `normal_eof_with_text_and_completed_function_call_is_not_completion`
  - 文本 delta + 完整 function call + 正常 EOF 不返回 FinalAnswer、不释放草稿、不进入工具执行层、不标记兼容成功。
- `normal_eof_with_only_completed_function_call_is_not_completion`
  - 只有完整 function call + 正常 EOF 同样返回独立截断分类，不作为兼容成功。
- `incomplete_tail_after_text_is_truncated_without_non_stream_retry`
  - 普通 Responses 完整文本 delta + 不完整尾帧 + HTTP EOF 返回 `sse_incomplete_frame`，且请求计数保持 1。

同时保留并通过纯文本正常 EOF、标准 `response.completed`、`[DONE]`、未闭合 function call、显式失败、SSE 解析错误和连接重置回归测试。

## 影响

- 缺少标准结束事件但满足全部安全条件的纯文本会提交一次，不再对同一请求重复计费。
- 不会执行该未确认流中的 function call；无有效文本时仍保留既有的安全非流式回退策略。
- 普通 Responses 流的非空不完整尾帧不再被吞掉或误判为兼容完成。
- 异常 EOF、连接重置、解析错误和明确失败事件仍按失败处理，不伪装成功。
- 切换其他候选仍可能产生额外上游调用成本，但只会在无可见输出、未发生工具副作用且剩余预算充足时执行。
- 标准 Responses SSE、工具参数拼接、候选路由和可见输出所有权保持原有语义。

## 验证

- `cargo fmt --all -- --check`：通过
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`：通过
- `cargo test --workspace --all-features`：通过（`qq-maid-llm` 354 项）
- `cargo build --workspace --release --all-features`：通过
- `git diff --check`：通过
- 另执行 `cargo test -p qq-maid-llm --all-features`：354 项通过

最新提交：`9ee3742`

## 部署后确认

旧汇总日志无法证明历史响应究竟是正常 HTTP EOF、代理截断还是事件格式差异；当前证据最符合“正常 EOF 且缺少标准完成事件”，但没有声称已线上复现。部署后仍需采集一次新增的脱敏结构化日志，确认真实 `stream_end_kind`、`last_sse_event_type`、`normal_eof` 与连接状态。
