### PR TITLE
改进启动配置诊断与统一错误日志

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ v0.20.x 起推荐新部署通过 `/console/` 网页完成配置，也可在安�
 
 聊天命令默认使用 `/` 前缀；可在 Web 控制台“命令设置”中通过下拉框改为 `#` 或 `*`，也可设置 `runtime.toml` 的 `command.prefix` / 环境变量 `CHAT_COMMAND_PREFIX`。前缀必须是一个可见非空白字符，修改后重启生效；自定义后旧 `/` 不再触发命令。
 
-未配置 Provider 或平台入口的新实例会以 `setup_required` 启动。访问默认同源 `/console/`，读取服务器本地 `config/secrets/bootstrap.token` 建立首位部署管理员后，可分步保存 Provider、QQ/OneBot/微信入口、主要功能开关、模型路线和 Tool Calling；普通值与人工编辑共享受管 TOML，secret 不回传原文。约 22 字符的短时单次 Bootstrap token 在新生成时同时写入权限受限文件并向启动控制台输出一次；状态查询、有效 token 复用和后续重启不会重复输出，成功使用后文件立即删除。忘记密码时可在登录页生成同路径的一次性重置 token，完成重置后旧管理员会话全部失效。完成配置后按当前部署方式重启，完整预检通过才进入机器人正常运行态。
+未配置 Provider 或平台入口的新实例会以 `setup_required` 启动。访问默认同源 `/console/`，读取服务器本地 `config/secrets/bootstrap.token` 建立首位部署管理员后，可分步保存 Provider、QQ/OneBot/微信入口、主要功能开关、模型路线和 Tool Calling；普通值与人工编辑共享受管 TOML，secret 不回传原文。约 22 字符的短时单次 Bootstrap token 在新生成时同时写入权限受限文件，并通过一次 `info` 启动日志事件输出；状态查询、有效 token 复用和后续重启不会重复输出，成功使用后文件立即删除。忘记密码时可在登录页生成同路径的一次性重置 token，完成重置后旧管理员会话全部失效。完成配置后按当前部署方式重启，完整预检通过才进入机器人正常运行态。
 
 生产反向代理必须保留原始 `Host`、协议（`X-Forwarded-Proto`）并设置 `WEB_CONSOLE_TRUSTED_PROXY_IPS` 为代理实际连接 IP；应用不会直接信任客户端伪造的转发头。HTTPS 生产请显式设置 `WEB_CONSOLE_SECURE_COOKIES=true`，控制台会使用 `Secure`、`HttpOnly`、`SameSite=Strict` 和 `__Host-` Cookie；本机 HTTP 开发保持默认关闭。
 

--- a/qq-maid-core/README.md
+++ b/qq-maid-core/README.md
@@ -94,7 +94,7 @@ Todo 提醒当前支持分钟/小时级调度边界：自然语言可以创建�
 
 ### 部署管理控制台
 
-仅当 `WEB_CONSOLE_ENABLED=true` 时注册。新实例没有 Provider 或平台凭据时进入 `setup_required`，仍保留 `/healthz` 和受保护的 `/console/`，但不构造业务 Provider、Worker 或 Gateway。首次启动会在 `config/secrets/bootstrap.token` 生成约 22 字符、短时单次的 token，并向启动控制台输出一次；普通状态请求、有效 token 复用和重启不会重复输出，初始化成功后文件立即删除。登录页也可按相同边界生成密码重置 token，提交成功后撤销全部旧 Admin 会话。
+仅当 `WEB_CONSOLE_ENABLED=true` 时注册。新实例没有 Provider 或平台凭据时进入 `setup_required`，仍保留 `/healthz` 和受保护的 `/console/`，但不构造业务 Provider、Worker 或 Gateway。首次启动会在 `config/secrets/bootstrap.token` 生成约 22 字符、短时单次的 token，并通过一次 `info` 启动日志事件输出；普通状态请求、有效 token 复用和重启不会重复输出，初始化成功后文件立即删除。登录页也可按相同边界生成密码重置 token，提交成功后撤销全部旧 Admin 会话。
 
 配置详情和写接口要求独立于聊天 session 的部署管理员服务端会话。密码最少 6 个字符并使用 Argon2id 哈希；登录/初始化/重置受限流、SameSite HttpOnly cookie、CSRF、会话轮换/过期和脱敏审计保护。普通字段写入受管 `runtime.toml`，secret 认证加密写入 SQLite，Agent 路线与 Tool Calling 结构化修改现有 `agent.toml`。所有修改携带 revision；冲突不会覆盖人工新文件。分步首次向导允许保存整体尚未完成的配置，但页面和 `/healthz` 会继续报告 `setup_required`，直至重启后完整预检通过。
 

--- a/qq-maid-core/src/app/mod.rs
+++ b/qq-maid-core/src/app/mod.rs
@@ -273,6 +273,9 @@ pub fn init_tracing() -> anyhow::Result<()> {
     tracing_subscriber::registry()
         .with(
             fmt::layer()
+                // 独立 Core/评测入口也不能把日志混入 CLI 的机器可读 stdout。
+                .with_writer(std::io::stderr)
+                .with_ansi(false)
                 .with_target(false)
                 .with_timer(shanghai_log_timer()),
         )

--- a/qq-maid-core/src/bin/knowledge-eval.rs
+++ b/qq-maid-core/src/bin/knowledge-eval.rs
@@ -50,7 +50,8 @@ fn main() -> ExitCode {
             }
         }
         Err(error) => {
-            tracing::error!(error = %error, "knowledge eval failed");
+            // 与主程序统一：Display alternate 格式输出完整错误链（当前为 String 时等价于普通 Display）。
+            tracing::error!(error = %format_args!("{error:#}"), "knowledge eval failed");
             ExitCode::FAILURE
         }
     }

--- a/qq-maid-core/src/bin/knowledge-eval.rs
+++ b/qq-maid-core/src/bin/knowledge-eval.rs
@@ -3,7 +3,6 @@ use std::{env, fs, process::ExitCode};
 use qq_maid_core::runtime::tools::knowledge::eval::{
     parse_dataset, run_fts5_baseline, run_knowledge_v3,
 };
-
 fn main() -> ExitCode {
     let arguments = env::args().skip(1).collect::<Vec<_>>();
     let semantic = arguments.iter().any(|argument| argument == "--semantic");
@@ -45,7 +44,11 @@ fn main() -> ExitCode {
             }
         }
         Err(error) => {
-            eprintln!("knowledge eval failed: {error}");
+            if tracing::dispatcher::has_been_set() {
+                tracing::error!(error = %error, "knowledge eval failed");
+            } else {
+                eprintln!("knowledge eval failed: {error}");
+            }
             ExitCode::FAILURE
         }
     }

--- a/qq-maid-core/src/bin/knowledge-eval.rs
+++ b/qq-maid-core/src/bin/knowledge-eval.rs
@@ -4,6 +4,12 @@ use qq_maid_core::runtime::tools::knowledge::eval::{
     parse_dataset, run_fts5_baseline, run_knowledge_v3,
 };
 fn main() -> ExitCode {
+    qq_maid_core::app::load_dotenv_files();
+    if let Err(error) = qq_maid_core::app::init_tracing() {
+        eprintln!("tracing 初始化失败: {error}");
+        return ExitCode::FAILURE;
+    }
+
     let arguments = env::args().skip(1).collect::<Vec<_>>();
     let semantic = arguments.iter().any(|argument| argument == "--semantic");
     let embedding_cache_dir = arguments
@@ -44,11 +50,7 @@ fn main() -> ExitCode {
             }
         }
         Err(error) => {
-            if tracing::dispatcher::has_been_set() {
-                tracing::error!(error = %error, "knowledge eval failed");
-            } else {
-                eprintln!("knowledge eval failed: {error}");
-            }
+            tracing::error!(error = %error, "knowledge eval failed");
             ExitCode::FAILURE
         }
     }

--- a/qq-maid-core/src/management/auth.rs
+++ b/qq-maid-core/src/management/auth.rs
@@ -1077,10 +1077,12 @@ impl AdminAuth {
 
 fn print_bootstrap_token(token: &str, ttl: Duration) {
     // 只在令牌新生成时调用；状态读取、有效令牌复用和重启不得重复输出。
-    // 令牌不进入结构化 tracing 字段或持久状态，文件权限与平台边界见部署文档。
-    eprintln!(
-        "\n[qq-maid] 部署管理员 Bootstrap / 密码重置令牌（{} 分钟内有效，仅可使用一次）：\n{token}\n[qq-maid] 使用后令牌立即失效；请勿转发或长期保留启动日志。\n",
-        ttl.as_secs() / 60
+    // 令牌仅进入这一条 info 日志，不写入 API 响应或长期状态；文件权限与平台边界
+    // 见部署文档。
+    tracing::info!(
+        token = %token,
+        ttl_minutes = ttl.as_secs() / 60,
+        "部署管理员 Bootstrap / 密码重置令牌已生成（仅可使用一次）；请勿转发或长期保留启动日志"
     );
 }
 

--- a/qq-maid-core/tests/knowledge_eval.rs
+++ b/qq-maid-core/tests/knowledge_eval.rs
@@ -1,0 +1,29 @@
+use std::{path::PathBuf, process::Command, time::SystemTime};
+
+#[test]
+fn failed_knowledge_eval_logs_once_and_exits_nonzero() {
+    let missing_dataset = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!(
+        "target/qq-maid-knowledge-eval-missing-{}-{}.json",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("system clock must be after Unix epoch")
+            .as_nanos()
+    ));
+    let output = Command::new(env!("CARGO_BIN_EXE_knowledge-eval"))
+        .env_clear()
+        .env("RUST_LOG", "info")
+        .arg(missing_dataset)
+        .output()
+        .expect("knowledge-eval should run");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stderr.matches("knowledge eval failed").count(),
+        1,
+        "{stderr}"
+    );
+    assert!(!stderr.contains("Error:"), "{stderr}");
+}

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -86,7 +86,7 @@ qbot restart
 - `WEB_CONSOLE_TRUSTED_PROXY_IPS`：受信反向代理实际连接 IP 的逗号列表；只有命中列表才读取 `X-Forwarded-For`，不直接信任客户端头。
 - `WEB_CONSOLE_SECURE_COOKIES`：生产 HTTPS 或 TLS 终止代理必须显式设为 `true`，管理员与 PreAuth Cookie 将带 `Secure` 并使用 `__Host-` 前缀；本机 HTTP 开发保持 `false`。
 
-首次启动且尚无部署管理员时，程序在运行目录创建 `config/secrets/bootstrap.token`（约 22 字符、有效期 30 分钟，Unix 权限 `0600`），并把同一个 token 向启动控制台输出一次。Windows 不使用 Unix mode，文件保护取决于安装目录继承的 ACL；当前版本尚未主动创建或校验收紧的 Windows ACL，部署者应限制该目录仅允许机器人运行身份和必要的本机管理员访问，后续加固由 [#522](https://github.com/kuliantnt/qq-maid-bot/issues/522) 跟踪。程序只在 token 新生成时输出，状态查询、尚有效 token 的复用和后续重启不会重复输出，也不会写入结构化访问日志或长期状态；打开 `/console/` 建立首位管理员后令牌文件立即删除。管理员密码至少 6 个字符且只保存 Argon2id 哈希，浏览器会话使用 HttpOnly SameSite cookie 与稳定 CSRF。
+首次启动且尚无部署管理员时，程序在运行目录创建 `config/secrets/bootstrap.token`（约 22 字符、有效期 30 分钟，Unix 权限 `0600`），并把同一个 token 通过一次 `info` 启动日志事件输出。Windows 不使用 Unix mode，文件保护取决于安装目录继承的 ACL；当前版本尚未主动创建或校验收紧的 Windows ACL，部署者应限制该目录仅允许机器人运行身份和必要的本机管理员访问，后续加固由 [#522](https://github.com/kuliantnt/qq-maid-bot/issues/522) 跟踪。程序只在 token 新生成时输出，状态查询、尚有效 token 的复用和后续重启不会重复输出，也不会写入 API 或长期状态；打开 `/console/` 建立首位管理员后令牌文件立即删除。管理员密码至少 6 个字符且只保存 Argon2id 哈希，浏览器会话使用 HttpOnly SameSite cookie 与稳定 CSRF。
 
 忘记管理员密码时，在登录页点击“重置管理员密码”。服务端会在同一路径生成短时单次重置 token，并同样只向控制台输出一次；生成 token 不会立即停用旧密码或旧会话，读取文件或控制台中的 token 并提交新密码后才完成重置。重置成功后 token 文件立即删除，旧 token、旧密码和全部旧 Admin 会话同时失效。
 
@@ -557,6 +557,9 @@ notepad .\config\.env
 
 统一二进制提供 `config check`、`config sources`、`config migrate`、`migration status` 和
 `backup create/verify/restore` 运维子命令；迁移与恢复默认 dry-run，恢复只写入干净实例目录。
+启动进入 `setup_required` 或 `config check` 失败时，诊断会单独报告无效的
+`config/agent.toml` / `config/ops.toml` 路径和安全错误首行；API Key、Token、AppSecret
+及可能携带配置值的通用 Provider / Gateway 错误正文仍不会写入日志。
 命令、数据库与配置恢复包的 secret 边界和 schema 回滚限制见
 [配置迁移、备份恢复与安全升级](../docs/deployment/migration-backup.md)。
 

--- a/runtime/config/.env.example
+++ b/runtime/config/.env.example
@@ -62,9 +62,9 @@ TTS_MAX_TEXT_CHARS=600
 # 默认日志会脱敏；verbose 只用于临时排障，会打印 extracted content。
 
 # 入站时调用 #229 群成员详情接口补全 actor/mention/引用 sender 的展示字段
-# （昵称、群角色、是否机器人、union_openid）。默认开启；拉取失败降级为 source=Event，
-# 不阻断主回复。成员详情查询带 TTL 缓存 + 负缓存，不会每条消息强制请求。
-# 若平台权限或网络异常导致延迟，可设为 false 临时关闭。
+# （昵称、群角色、是否机器人、union_openid）。默认关闭；仅在确认账号具备权限时开启。
+# 拉取失败降级为 source=Event，不阻断主回复。成员详情查询带 TTL 缓存 + 负缓存，
+# 不会每条消息强制请求。若平台权限或网络异常导致延迟，请保持关闭。
 
 # 富媒体发送失败会 fallback 到文本；C2C 最终回复可使用 QQ 流式 Markdown。
 # 私聊 Tool Loop 可见进度文本，默认开启；与 QQ 原生 typing 状态相互独立。
@@ -209,6 +209,8 @@ MAX_CONCURRENT_RESPONSES=8
 # 聊天链路 trace 默认关闭；开启后需配合 RUST_LOG=trace,qq_maid_core=trace。
 LLM_TRACE_CHAT_INPUT=false
 LLM_TRACE_CHAT_OUTPUT=false
+# 联网搜索输入 trace 默认关闭；开启后可能把用户查询内容写入 trace 日志。
+LLM_TRACE_QUERY_INPUT=false
 
 # 本地上下文字符预算：有效输入上限 = limit - output_reserve。
 AGENT_CONTEXT_CHAR_LIMIT=48000
@@ -255,7 +257,6 @@ WEB_CONSOLE_ALLOWED_ORIGINS=
 WEB_CONSOLE_TRUSTED_PROXY_IPS=
 # 生产 HTTPS（或 TLS 终止代理）显式开启；开启后使用 Secure、__Host- 前缀 Cookie。
 WEB_CONSOLE_SECURE_COOKIES=false
-# 默认关闭。开启会把完整一次性 token 输出到 stderr，可能被 Docker/systemd 持久化，生产不建议开启。
 
 # =============================================================================
 # 数据、Prompt 与知识目录

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -111,8 +111,8 @@ fn config_check() -> anyhow::Result<()> {
         println!(
             "提示：当前实例尚需初始化或执行 migration；本次 check 保持只读，未创建文件或更新数据库。"
         );
-        if let Err(error) = agent {
-            bail!("Agent 配置无效：{error}");
+        if agent.is_err() {
+            bail!("Agent 配置无效；详情见上方");
         }
         if !file_issues.is_empty() {
             bail!("检测到 {} 个无效配置文件，详情见上方", file_issues.len());
@@ -152,19 +152,12 @@ fn config_check() -> anyhow::Result<()> {
 
 fn print_config_file_issues(issues: &[ConfigFileIssue]) {
     for issue in issues {
-        if tracing::dispatcher::has_been_set() {
-            tracing::error!(
-                component = %issue.component,
-                file = %issue.path,
-                reason = %issue.reason,
-                "配置文件预检失败"
-            );
-        } else {
-            eprintln!(
-                "配置文件预检失败: component={} file={} reason={}",
-                issue.component, issue.path, issue.reason
-            );
-        }
+        tracing::error!(
+            component = %issue.component,
+            file = %issue.path,
+            reason = %issue.reason,
+            "配置文件预检失败"
+        );
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, ffi::OsString, path::PathBuf};
 
+use crate::config_diagnostics::{ConfigFileIssue, collect_config_file_issues};
 use anyhow::{anyhow, bail};
 use qq_maid_core::{
     config::{
@@ -97,6 +98,8 @@ fn config_check() -> anyhow::Result<()> {
         "agent_config={}",
         if agent.is_ok() { "valid" } else { "invalid" }
     );
+    let file_issues = collect_config_file_issues(&environment);
+    print_config_file_issues(&file_issues);
 
     let paths = ConfigCenterPaths::from_environment(&environment);
     let prerequisites_exist = migration.database_exists
@@ -110,6 +113,9 @@ fn config_check() -> anyhow::Result<()> {
         );
         if let Err(error) = agent {
             bail!("Agent 配置无效：{error}");
+        }
+        if !file_issues.is_empty() {
+            bail!("检测到 {} 个无效配置文件，详情见上方", file_issues.len());
         }
         return Ok(());
     }
@@ -131,11 +137,35 @@ fn config_check() -> anyhow::Result<()> {
         "gateway_preflight={}",
         if gateway_valid { "valid" } else { "invalid" }
     );
-    core.map_err(|_| anyhow!("Core/Provider 配置预检失败（敏感值已隐藏）"))?;
+    core.map_err(|_| {
+        if file_issues.is_empty() {
+            anyhow!("Core/Provider 配置预检失败（敏感值已隐藏）")
+        } else {
+            anyhow!("Core/Provider 配置预检失败；无效配置文件详情见上方")
+        }
+    })?;
     if !gateway_valid {
         bail!("Gateway 配置预检失败或没有启用入口（敏感值已隐藏）");
     }
     Ok(())
+}
+
+fn print_config_file_issues(issues: &[ConfigFileIssue]) {
+    for issue in issues {
+        if tracing::dispatcher::has_been_set() {
+            tracing::error!(
+                component = %issue.component,
+                file = %issue.path,
+                reason = %issue.reason,
+                "配置文件预检失败"
+            );
+        } else {
+            eprintln!(
+                "配置文件预检失败: component={} file={} reason={}",
+                issue.component, issue.path, issue.reason
+            );
+        }
+    }
 }
 
 fn config_sources() -> anyhow::Result<()> {

--- a/src/config_diagnostics.rs
+++ b/src/config_diagnostics.rs
@@ -1,0 +1,171 @@
+//! 启动配置文件的安全诊断。
+//!
+//! Agent 与 Ops 文件按契约不得保存 secret，因此可以报告文件路径以及校验错误的首行；
+//! TOML 的源码片段可能包含稳定 ID，必须丢弃后续行，不能直接打印完整解析错误。
+
+use std::collections::HashMap;
+
+use qq_maid_core::{
+    config::{
+        AgentRuntimeConfig,
+        agent::{AGENT_CONFIG_FILE_ENV, DEFAULT_AGENT_CONFIG_PATH},
+    },
+    runtime::tools::ops::{OPS_CONFIG_FILE_ENV, OpsConfig},
+};
+
+const DEFAULT_OPS_CONFIG_PATH: &str = "config/ops.toml";
+const MAX_SAFE_REASON_CHARS: usize = 240;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ConfigFileIssue {
+    pub component: &'static str,
+    pub path: String,
+    pub reason: String,
+}
+
+/// 独立校验会阻断 Core 构造的文件配置，以便一次启动同时报告多个坏文件。
+pub(crate) fn collect_config_file_issues(
+    environment: &HashMap<String, String>,
+) -> Vec<ConfigFileIssue> {
+    let mut issues = Vec::new();
+    if let Err(error) = AgentRuntimeConfig::validate_for_read_only_check(environment) {
+        issues.push(ConfigFileIssue {
+            component: "agent",
+            path: configured_path(
+                environment,
+                AGENT_CONFIG_FILE_ENV,
+                DEFAULT_AGENT_CONFIG_PATH,
+            ),
+            reason: safe_file_error_reason(&error.message),
+        });
+    }
+    if let Err(error) = OpsConfig::load_from_environment(environment) {
+        issues.push(ConfigFileIssue {
+            component: "ops",
+            path: configured_path(environment, OPS_CONFIG_FILE_ENV, DEFAULT_OPS_CONFIG_PATH),
+            reason: safe_file_error_reason(&error.message),
+        });
+    }
+    issues
+}
+
+fn configured_path(environment: &HashMap<String, String>, variable: &str, default: &str) -> String {
+    environment
+        .get(variable)
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .unwrap_or(default)
+        .to_owned()
+}
+
+fn safe_file_error_reason(message: &str) -> String {
+    let first_line = message
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("configuration file is invalid");
+    let mut chars = first_line.chars();
+    let mut reason = chars
+        .by_ref()
+        .take(MAX_SAFE_REASON_CHARS)
+        .collect::<String>();
+    if chars.next().is_some() {
+        reason.push('…');
+    }
+    reason
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new(name: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "qq-maid-config-diagnostics-{name}-{}-{}",
+                std::process::id(),
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            ));
+            fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn reports_missing_agent_and_invalid_ops_files_without_stable_ids() {
+        let directory = TestDirectory::new("agent-ops");
+        let missing_agent = directory.path().join("missing-agent.toml");
+        let ops_file = directory.path().join("ops.toml");
+        fs::write(
+            &ops_file,
+            r#"
+enabled = true
+
+[private]
+enabled = true
+allowed_user_ids = ["do-not-log-this-stable-id"]
+
+[codex]
+enabled = true
+program = "/definitely/missing/codex"
+working_directory = "/definitely/missing/workspace"
+"#,
+        )
+        .unwrap();
+        let environment = HashMap::from([
+            (
+                AGENT_CONFIG_FILE_ENV.to_owned(),
+                missing_agent.to_string_lossy().into_owned(),
+            ),
+            (
+                OPS_CONFIG_FILE_ENV.to_owned(),
+                ops_file.to_string_lossy().into_owned(),
+            ),
+        ]);
+
+        let issues = collect_config_file_issues(&environment);
+
+        assert_eq!(issues.len(), 2);
+        assert_eq!(issues[0].component, "agent");
+        assert_eq!(issues[0].path, missing_agent.to_string_lossy());
+        assert!(issues[0].reason.contains("missing file"));
+        assert_eq!(issues[1].component, "ops");
+        assert_eq!(issues[1].path, ops_file.to_string_lossy());
+        assert!(issues[1].reason.contains("codex.program"));
+        assert!(issues[1].reason.contains("existing file"));
+        assert!(!issues[1].reason.contains("do-not-log-this-stable-id"));
+    }
+
+    #[test]
+    fn keeps_only_the_safe_first_line_of_toml_parse_errors() {
+        let message = "invalid OPS_CONFIG_FILE: TOML parse error at line 2, column 1\n  |\n2 | allowed_user_ids = [\"private-id\"]";
+
+        let reason = safe_file_error_reason(message);
+
+        assert_eq!(
+            reason,
+            "invalid OPS_CONFIG_FILE: TOML parse error at line 2, column 1"
+        );
+        assert!(!reason.contains("private-id"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,11 +49,15 @@ async fn main() -> ExitCode {
 
     match run().await {
         Ok(()) => ExitCode::SUCCESS,
-        Err(error) => {
-            tracing::error!(error = %error, "qq-maid-bot 执行失败");
-            ExitCode::FAILURE
-        }
+        Err(error) => exit_for_error(error),
     }
+}
+
+/// 顶层失败只在这里记录一次；`{error:#}` 是 Display 的 alternate 格式，会展开
+/// anyhow 的完整 `caused by:` 错误链，且不包含 backtrace，避免记录无关调用栈或泄露敏感上下文。
+fn exit_for_error(error: anyhow::Error) -> ExitCode {
+    tracing::error!(error = %format_args!("{error:#}"), "qq-maid-bot 执行失败");
+    ExitCode::FAILURE
 }
 
 async fn run() -> anyhow::Result<()> {
@@ -336,8 +340,63 @@ mod tests {
     use qq_maid_core::config::center::{
         ManagedConfigChange, SECRET_MISSING_REVISION, SecretConfigChange,
     };
-    use std::path::{Path, PathBuf};
+    use std::{
+        io::Write,
+        path::{Path, PathBuf},
+        sync::{Arc, Mutex},
+    };
     use toml::Value;
+    use tracing_subscriber::fmt::MakeWriter;
+
+    /// 捕获 tracing fmt 输出到内存，用于验证顶层错误日志的完整错误链。
+    #[derive(Clone)]
+    struct RecordingWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl MakeWriter<'_> for RecordingWriter {
+        type Writer = RecordingWriterGuard;
+
+        fn make_writer(&self) -> Self::Writer {
+            RecordingWriterGuard(self.0.clone())
+        }
+    }
+
+    struct RecordingWriterGuard(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for RecordingWriterGuard {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn top_level_error_logs_full_anyhow_chain_once() {
+        // 构造带 Context 的嵌套错误：外层上下文包裹底层根因。
+        let error =
+            anyhow::anyhow!("底层根因：备份目标目录不可写").context("外层上下文：创建备份失败");
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(RecordingWriter(recorded.clone()))
+                .with_ansi(false),
+        );
+        let code = tracing::subscriber::with_default(subscriber, || exit_for_error(error));
+
+        assert_ne!(code, ExitCode::SUCCESS);
+        let recorded = recorded.lock().unwrap();
+        let stderr = String::from_utf8_lossy(&recorded);
+        assert!(stderr.contains("外层上下文：创建备份失败"), "{stderr}");
+        assert!(stderr.contains("底层根因：备份目标目录不可写"), "{stderr}");
+        assert_eq!(
+            stderr.matches("qq-maid-bot 执行失败").count(),
+            1,
+            "{stderr}"
+        );
+    }
 
     struct TestDirectory(PathBuf);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,10 +27,11 @@ use qq_maid_gateway_rs::{
 use time::{UtcOffset, macros::format_description};
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::info;
 use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 mod cli;
+mod config_diagnostics;
 
 const OPS_HTTP_SHUTDOWN_WAIT: Duration = Duration::from_secs(5);
 const BUILD_COMMIT: &str = match option_env!("QQ_MAID_BUILD_COMMIT") {
@@ -79,17 +80,26 @@ async fn main() -> anyhow::Result<()> {
         config_center = config_center.with_running_agent_config(config.agent_config.clone())?;
     }
     let gateway_config = GatewayConfig::from_map(&resolved_environment);
-    let runtime_ready = core_config.is_ok()
-        && gateway_config
-            .as_ref()
-            .is_ok_and(GatewayConfig::has_enabled_channel)
-        && preflight_candidate_startup(&resolved_environment, None).is_ok();
+    let gateway_channel_enabled = gateway_config
+        .as_ref()
+        .is_ok_and(GatewayConfig::has_enabled_channel);
+    let provider_preflight = CoreConfig::preflight_environment(&resolved_environment, None);
+    let runtime_ready =
+        core_config.is_ok() && gateway_channel_enabled && provider_preflight.is_ok();
     if !runtime_ready {
-        warn!(
+        info!(
             state = "setup_required",
             core_config_valid = core_config.is_ok(),
             gateway_config_valid = gateway_config.is_ok(),
+            gateway_channel_enabled,
+            provider_preflight_valid = provider_preflight.is_ok(),
             "业务配置尚未完成，仅启动受保护管理入口"
+        );
+        log_startup_config_diagnostics(
+            &resolved_environment,
+            &core_config,
+            &gateway_config,
+            &provider_preflight,
         );
         return ManagementRuntime::new(
             management_bootstrap,
@@ -183,6 +193,56 @@ async fn main() -> anyhow::Result<()> {
             let _ = tokio::time::timeout(OPS_HTTP_SHUTDOWN_WAIT, &mut core_http_handle).await;
             Err(task_exit_error("qq-maid-gateway-rs", result))
         }
+    }
+}
+
+/// setup_required 仍需告诉部署者应检查哪个文件；secret 值和可能携带值的通用错误正文
+/// 不进入日志。Agent/Ops 文件诊断已在专用 helper 中截断 TOML 源码片段。
+fn log_startup_config_diagnostics(
+    environment: &HashMap<String, String>,
+    core_config: &Result<CoreConfig, qq_maid_llm::LlmError>,
+    gateway_config: &Result<GatewayConfig, qq_maid_gateway_rs::config::ConfigError>,
+    provider_preflight: &Result<(), qq_maid_llm::LlmError>,
+) {
+    let file_issues = config_diagnostics::collect_config_file_issues(environment);
+    for issue in &file_issues {
+        info!(
+            component = issue.component,
+            config_file = %issue.path,
+            reason = %issue.reason,
+            "启动配置文件预检失败"
+        );
+    }
+    if core_config.is_err() && file_issues.is_empty() {
+        info!(
+            component = "core",
+            config_source = "config/.env|config/runtime.toml|encrypted_secret_store",
+            reason = "invalid_core_configuration",
+            "Core 配置解析失败；请运行 `qq-maid-bot config check` 查看分项结果"
+        );
+    } else if core_config.is_ok() && provider_preflight.is_err() {
+        info!(
+            component = "provider",
+            config_source =
+                "config/agent.toml|config/.env|config/runtime.toml|encrypted_secret_store",
+            reason = "invalid_provider_route_or_credential",
+            "Provider 启动预检失败；请检查模型路线与对应凭证"
+        );
+    }
+    match gateway_config {
+        Err(_) => info!(
+            component = "gateway",
+            config_source = "config/.env|config/runtime.toml|encrypted_secret_store",
+            reason = "invalid_gateway_configuration",
+            "Gateway 配置解析失败；请运行 `qq-maid-bot config check` 查看分项结果"
+        ),
+        Ok(config) if !config.has_enabled_channel() => info!(
+            component = "gateway",
+            config_source = "config/.env|config/runtime.toml|encrypted_secret_store",
+            reason = "no_enabled_channel",
+            "Gateway 没有启用且凭证完整的入口"
+        ),
+        Ok(_) => {}
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 //! 该入口一次性完成 dotenv / tracing 初始化，组装 CoreHandle、Gateway 和主动推送
 //! sink。Core 与 Gateway 之间只走进程内强类型调用，不再通过 localhost HTTP 探活或通信。
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, process::ExitCode, sync::Arc, time::Duration};
 
 use anyhow::anyhow;
 use qq_maid_core::{
@@ -40,12 +40,26 @@ const BUILD_COMMIT: &str = match option_env!("QQ_MAID_BUILD_COMMIT") {
 };
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> ExitCode {
     qq_maid_core::app::load_dotenv_files();
+    if let Err(error) = init_tracing() {
+        eprintln!("tracing 初始化失败: {error}");
+        return ExitCode::FAILURE;
+    }
+
+    match run().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            tracing::error!(error = %error, "qq-maid-bot 执行失败");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run() -> anyhow::Result<()> {
     if cli::dispatch(std::env::args_os().skip(1).collect())? {
         return Ok(());
     }
-    init_tracing()?;
     info!(
         version = env!("CARGO_PKG_VERSION"),
         commit = BUILD_COMMIT,
@@ -296,6 +310,9 @@ fn init_tracing() -> anyhow::Result<()> {
     tracing_subscriber::registry()
         .with(
             fmt::layer()
+                // 日志写入 stderr，避免污染 config check 等机器可读 stdout。
+                .with_writer(std::io::stderr)
+                .with_ansi(false)
                 .with_target(false)
                 .with_timer(shanghai_log_timer()),
         )

--- a/tests/cli_errors.rs
+++ b/tests/cli_errors.rs
@@ -1,0 +1,21 @@
+use std::process::Command;
+
+#[test]
+fn invalid_cli_command_logs_once_and_exits_nonzero() {
+    let output = Command::new(env!("CARGO_BIN_EXE_qq-maid-bot"))
+        .env_clear()
+        .args(["definitely-not-a-command"])
+        .output()
+        .expect("qq-maid-bot should run");
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stderr.matches("qq-maid-bot 执行失败").count(),
+        1,
+        "{stderr}"
+    );
+    assert_eq!(stderr.matches("未知命令").count(), 1, "{stderr}");
+    assert!(!stderr.contains("Error:"), "{stderr}");
+}

--- a/tests/config_check.rs
+++ b/tests/config_check.rs
@@ -131,5 +131,11 @@ working_directory = "/definitely/missing/workspace"
         "stderr: {stderr}"
     );
     assert!(stderr.contains("codex.program"), "stderr: {stderr}");
-    assert!(!stderr.contains("do-not-print-this-id"), "stderr: {stderr}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!format!("{stdout}{stderr}").contains("do-not-print-this-id"));
+    assert_eq!(
+        stderr.matches("qq-maid-bot 执行失败").count(),
+        1,
+        "{stderr}"
+    );
 }

--- a/tests/config_check.rs
+++ b/tests/config_check.rs
@@ -99,3 +99,37 @@ fn config_check_validates_existing_default_agent_config() {
         "stderr: {stderr}"
     );
 }
+
+#[test]
+fn config_check_reports_invalid_ops_file_and_safe_field_reason() {
+    let directory = TestDirectory::new("invalid-ops");
+    let ops_file = directory.path().join("ops.toml");
+    fs::write(
+        &ops_file,
+        r#"
+enabled = true
+
+[private]
+enabled = true
+allowed_user_ids = ["do-not-print-this-id"]
+
+[codex]
+enabled = true
+program = "/definitely/missing/codex"
+working_directory = "/definitely/missing/workspace"
+"#,
+    )
+    .unwrap();
+
+    let output = run_config_check(directory.path(), &[("OPS_CONFIG_FILE", &ops_file)]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("component=ops"), "stderr: {stderr}");
+    assert!(
+        stderr.contains(&format!("file={}", ops_file.display())),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("codex.program"), "stderr: {stderr}");
+    assert!(!stderr.contains("do-not-print-this-id"), "stderr: {stderr}");
+}


### PR DESCRIPTION
## 变更内容

- 将 `setup_required` 作为预期的 `INFO` 启动状态，输出具体组件、配置文件、失败原因以及 Gateway/Provider 预检状态。
- 增加安全的 Agent/Ops 文件诊断：不记录 secret 值或稳定 ID。
- 一次性 Bootstrap / 密码重置令牌统一通过现有 `tracing::info!` 启动日志输出，不再直接写 stderr。
- 顶层错误统一通过 tracing 输出完整 anyhow 错误链（`error=` 字段使用 `{error:#}` 展开 `caused by:` 链），保留外层上下文与底层根因；不启用或泄露 backtrace。
- 更新 runtime/配置文档，补充配置诊断与顶层错误链测试覆盖。

## 为什么

在阿里云上，服务可能停留在 `setup_required` 状态，却只输出聚合的合法性标志，底层 Agent/Ops 文件失败难以定位；且直接输出 stderr 与正常启动日志路径不一致，顶层错误只记录普通 Display，丢失 anyhow cause chain。

## 日志边界说明

- 主程序 `qq-maid-bot` 与 `knowledge-eval` 都在入口主动初始化 tracing，普通错误统一通过 tracing 输出（顶层 `error=` 字段使用 `{error:#}` 展开完整错误链）。
- 仅 tracing 初始化本身失败时，使用一次 `eprintln!` 兜底后以非零退出码退出。
- 所有 tracing 日志（INFO 启动、`setup_required` 诊断、WARN/ERROR、Bootstrap 令牌）统一输出到 stderr。

## 日志入口说明

- 直接进程模式：`botctl.sh start` 以 `nohup ... >> logs/qq-maid-bot.log 2>&1` 合并捕获 stdout/stderr，`qbot logs` / `botctl logs` 通过 `tail -n ${LINES:-80} -f` 实时跟随该日志文件。
- Docker 部署：容器前台运行，stdout/stderr 由 `docker compose logs` 读取。
- systemd 部署：`ExecStart=botctl.sh run` 由 journald 收集，使用 `journalctl -u qq-maid-bot.service` 查看。

## 验证

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- release 构建与 Container 检查由 CI 执行
- `git diff --check`
