### PR TITLE
fix: 修复联网查询空 time_range 参数

### DIFF
--- a/qq-maid-core/src/runtime/respond/search_flow.rs
+++ b/qq-maid-core/src/runtime/respond/search_flow.rs
@@ -43,6 +43,10 @@ const WEB_SEARCH_REWRITE_CONTEXT_MAX_CHARS: usize = 1200;
 const WEB_SEARCH_EMPTY_RESULT_REPLY: &str = "【联网查询】
 
 没查到明确结果。可以换一个关键词再试。";
+// 模型工具参数错误只说明本次调用未执行，不能误导为上游或网络故障。
+const WEB_SEARCH_ARGUMENT_ERROR_REPLY: &str = "【联网查询】
+
+本次联网查询的参数无效，查询未执行。请换一种说法再试。";
 // 联网查询未配置时的回复
 const WEB_SEARCH_CONFIG_ERROR_REPLY: &str = "【联网查询】
 
@@ -856,6 +860,7 @@ pub(crate) fn format_web_search_error_reply(err: &LlmError) -> String {
         "rate_limited" => WEB_SEARCH_RATE_LIMIT_REPLY.to_owned(),
         "quota_exhausted" => WEB_SEARCH_QUOTA_REPLY.to_owned(),
         "empty_result" => WEB_SEARCH_EMPTY_RESULT_REPLY.to_owned(),
+        "invalid_arguments" | "bad_tool_arguments" => WEB_SEARCH_ARGUMENT_ERROR_REPLY.to_owned(),
         "timeout" => WEB_SEARCH_TIMEOUT_REPLY.to_owned(),
         _ => WEB_SEARCH_UPSTREAM_ERROR_REPLY.to_owned(),
     }

--- a/qq-maid-core/src/runtime/respond/tests/agent_turn/web_search.rs
+++ b/qq-maid-core/src/runtime/respond/tests/agent_turn/web_search.rs
@@ -197,6 +197,44 @@ async fn empty_web_search_with_empty_final_text_only_renders_empty_result_hint()
 }
 
 #[tokio::test]
+async fn invalid_web_search_arguments_render_one_local_error_without_model_reply() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_raw_tool_results(
+            vec![raw_tool_result(
+                "web_search",
+                serde_json::json!({
+                    "ok": false,
+                    "execution_succeeded": false,
+                    "error": {
+                        "code": "invalid_arguments",
+                        "stage": "tool",
+                        "argument": "time_range"
+                    }
+                }),
+                false,
+            )],
+            "模型声称联网查询已经完成，但这段内容不应直接发送。",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector, true);
+
+    let response = service
+        .respond(private_message("搜索公开项目"))
+        .await
+        .unwrap();
+
+    let text = response.text.unwrap();
+    assert_eq!(text.matches("【联网查询】").count(), 1);
+    assert_eq!(text.matches("本次联网查询的参数无效").count(), 1);
+    assert!(!text.contains("联网查询服务暂时不可用"));
+    assert!(!text.contains("模型声称联网查询已经完成"));
+    assert_eq!(
+        response.diagnostics.unwrap()["error_code"],
+        "invalid_arguments"
+    );
+}
+
+#[tokio::test]
 async fn multi_entity_all_empty_search_renders_one_empty_hint_without_retry() {
     let inspector = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)

--- a/qq-maid-core/src/runtime/respond/tests/search.rs
+++ b/qq-maid-core/src/runtime/respond/tests/search.rs
@@ -39,6 +39,8 @@ fn web_search_errors_have_actionable_user_replies() {
         ("rate_limited", "上游限流"),
         ("quota_exhausted", "额度已用尽"),
         ("empty_result", "没查到明确结果"),
+        ("invalid_arguments", "参数无效"),
+        ("bad_tool_arguments", "参数无效"),
     ];
 
     for (code, expected) in cases {

--- a/qq-maid-core/src/runtime/tools/search/tests/argument_validation.rs
+++ b/qq-maid-core/src/runtime/tools/search/tests/argument_validation.rs
@@ -80,6 +80,32 @@ async fn agent_web_search_invalid_arguments_are_structured_and_skip_executor() {
     assert!(requests.lock().unwrap().is_empty());
 }
 
+#[tokio::test]
+async fn string_null_time_range_is_treated_as_unset() {
+    let executor = MockWebSearchExecutor::default();
+    let requests = executor.requests.clone();
+    let tool =
+        WebSearchTool::new(Arc::new(executor)).with_backend_override(WebSearchBackend::Tavily);
+    let registry = ToolRegistry::new().register(tool).unwrap();
+    let mut context = test_context();
+    context.tool_call_id = Some("task-string-null:call-1".to_owned());
+
+    let serialized = registry
+        .execute_json(
+            &context,
+            WEB_SEARCH_TOOL_NAME,
+            r#"{"query":"safe query","time_range":"null"}"#,
+        )
+        .await
+        .unwrap();
+    let output: Value = serde_json::from_str(&serialized).unwrap();
+
+    assert_eq!(output["ok"], true);
+    assert_eq!(output["execution_succeeded"], true);
+    assert_eq!(requests.lock().unwrap().len(), 1);
+    assert_eq!(requests.lock().unwrap()[0].time_range, None);
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn invalid_argument_log_has_field_diagnostics_without_search_content() {
     let bytes = Arc::new(Mutex::new(Vec::new()));

--- a/qq-maid-core/src/runtime/tools/search/validation.rs
+++ b/qq-maid-core/src/runtime/tools/search/validation.rs
@@ -246,7 +246,11 @@ fn parse_optional_enum(
         None | Some(Value::Null) => Ok(None),
         Some(Value::String(text)) => {
             let text = text.trim().to_ascii_lowercase();
-            if allowed.contains(&text.as_str()) {
+            if text == "null" {
+                // 部分模型会把 schema 中的 null 序列化成字符串；可选枚举字段
+                // 按未设置处理，避免把兼容性问题误报成上游搜索故障。
+                Ok(None)
+            } else if allowed.contains(&text.as_str()) {
                 Ok(Some(text))
             } else {
                 Err(WebSearchArgumentError::new(

--- a/qq-maid-core/src/service/streaming.rs
+++ b/qq-maid-core/src/service/streaming.rs
@@ -1,6 +1,6 @@
 use std::{
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicBool, Ordering},
     },
     time::Duration,
@@ -57,6 +57,14 @@ struct AgentStreamControl {
     cancelled: Arc<AtomicBool>,
     run_handle: Option<AgentRunHandle>,
     visible_text_sent: Arc<AtomicBool>,
+    buffered_final_text: Arc<Mutex<String>>,
+}
+
+#[derive(Clone)]
+struct AgentFinalTextState {
+    tool_activity_started: Arc<AtomicBool>,
+    visible_text_sent: Arc<AtomicBool>,
+    buffered_final_text: Arc<Mutex<String>>,
 }
 
 pub(crate) fn start_core_response_stream(
@@ -81,6 +89,8 @@ pub(crate) fn start_core_response_stream(
     let producer_agent_run_handle = agent_run_handle.clone();
     let visible_text_sent = Arc::new(AtomicBool::new(false));
     let producer_visible_text_sent = visible_text_sent.clone();
+    let buffered_final_text = Arc::new(Mutex::new(String::new()));
+    let producer_buffered_final_text = buffered_final_text.clone();
     tokio::spawn(async move {
         if producer_cancelled.load(Ordering::SeqCst) {
             let _ = tx
@@ -100,6 +110,7 @@ pub(crate) fn start_core_response_stream(
                     cancelled: producer_cancelled.clone(),
                     run_handle: producer_agent_run_handle.clone(),
                     visible_text_sent: producer_visible_text_sent.clone(),
+                    buffered_final_text: producer_buffered_final_text.clone(),
                 },
                 delivery.provider_stream_enabled,
                 progress_status,
@@ -123,6 +134,17 @@ pub(crate) fn start_core_response_stream(
                     // 结果未知的写操作保留有限清理窗口，避免中断后伪装成未执行；
                     // 纯只读调用可立即取消，不额外占用副作用工具的 15 秒预算。
                     cleanup_timed_out_agent_task(&mut task, needs_side_effect_cleanup).await;
+                    if !producer_cancelled.load(Ordering::SeqCst) {
+                        // Agent 任务被超时清理后不再有机会走内部错误分支；释放已经
+                        // 产生的最终草稿，继续保留“部分回复 + 超时提示”的兼容语义。
+                        let _ = flush_buffered_final_text(
+                            &tx,
+                            &producer_cancelled,
+                            &producer_visible_text_sent,
+                            &producer_buffered_final_text,
+                        )
+                        .await;
+                    }
                     Err(producer_agent_run_handle
                         .as_ref()
                         .map(|handle| err.clone().with_agent(handle.snapshot()))
@@ -139,6 +161,7 @@ pub(crate) fn start_core_response_stream(
                     cancelled: producer_cancelled.clone(),
                     run_handle: producer_agent_run_handle.clone(),
                     visible_text_sent: producer_visible_text_sent.clone(),
+                    buffered_final_text: producer_buffered_final_text.clone(),
                 },
                 delivery.provider_stream_enabled,
                 progress_status,
@@ -339,6 +362,7 @@ async fn run_agent_runtime_respond(
     let cancelled = control.cancelled;
     let agent_run_handle = control.run_handle;
     let visible_text_sent = control.visible_text_sent;
+    let buffered_final_text = control.buffered_final_text;
     let eager_agent_status = planned.should_emit_eager_agent_status();
     if eager_agent_status {
         send_core_status(
@@ -356,6 +380,14 @@ async fn run_agent_runtime_respond(
     }
 
     let tool_activity_started = Arc::new(AtomicBool::new(false));
+    // 工具结果还要经过领域投影；在投影完成前不能把模型最终草稿直接发给平台，
+    // 否则失败回执会被 Gateway 视为第二条回复。工具执行异常时再把暂存草稿原样
+    // 释放，保留“已发出部分正文后不能伪造重放”的既有流式语义。
+    let final_text_state = AgentFinalTextState {
+        tool_activity_started: tool_activity_started.clone(),
+        visible_text_sent: visible_text_sent.clone(),
+        buffered_final_text: buffered_final_text.clone(),
+    };
     let progress_sink = tool_loop_progress_sink(
         tx.clone(),
         cancelled.clone(),
@@ -371,8 +403,7 @@ async fn run_agent_runtime_respond(
             progress_status.clone(),
             finalizing_status_sent.clone(),
             eager_agent_status,
-            tool_activity_started.clone(),
-            visible_text_sent,
+            final_text_state,
         ))
     } else {
         None
@@ -387,9 +418,9 @@ async fn run_agent_runtime_respond(
     tokio::pin!(respond_future);
     let mut running_status_sent = false;
 
-    let response = loop {
+    let response = match loop {
         tokio::select! {
-            result = &mut respond_future => break result?,
+            result = &mut respond_future => break result,
             _ = tokio::time::sleep(AGENT_RUNNING_STATUS_DELAY), if eager_agent_status && !running_status_sent => {
                 running_status_sent = true;
                 send_core_status(
@@ -405,6 +436,15 @@ async fn run_agent_runtime_respond(
                 ).await?;
             }
         }
+    } {
+        Ok(response) => response,
+        Err(error) => {
+            // 只有模型最终轮已经产生草稿、但整轮最终化失败时，才释放暂存正文；
+            // 这样上层仍能按原语义报告“已有部分回复后失败”。
+            flush_buffered_final_text(&tx, &cancelled, &visible_text_sent, &buffered_final_text)
+                .await?;
+            return Err(error);
+        }
     };
 
     send_agent_finalizing_status_once(
@@ -414,6 +454,14 @@ async fn run_agent_runtime_respond(
         &finalizing_status_sent,
         eager_agent_status,
         &tool_activity_started,
+    )
+    .await?;
+    send_postprocessed_agent_response(
+        &tx,
+        &cancelled,
+        &visible_text_sent,
+        &buffered_final_text,
+        &response,
     )
     .await?;
 
@@ -469,16 +517,14 @@ fn agent_final_delta_sink(
     progress_status: ProgressStatusConfig,
     finalizing_status_sent: Arc<AtomicBool>,
     eager_agent_status: bool,
-    tool_activity_started: Arc<AtomicBool>,
-    visible_text_sent: Arc<AtomicBool>,
+    final_text_state: AgentFinalTextState,
 ) -> AgentTextDeltaSink {
     Arc::new(move |delta| {
         let tx = tx.clone();
         let cancelled = cancelled.clone();
         let progress_status = progress_status.clone();
         let finalizing_status_sent = finalizing_status_sent.clone();
-        let tool_activity_started = tool_activity_started.clone();
-        let visible_text_sent = visible_text_sent.clone();
+        let final_text_state = final_text_state.clone();
         Box::pin(async move {
             send_agent_finalizing_status_once(
                 &tx,
@@ -486,14 +532,100 @@ fn agent_final_delta_sink(
                 &progress_status,
                 &finalizing_status_sent,
                 eager_agent_status,
-                &tool_activity_started,
+                &final_text_state.tool_activity_started,
             )
             .await?;
+            if final_text_state
+                .tool_activity_started
+                .load(Ordering::SeqCst)
+            {
+                let mut buffered = final_text_state
+                    .buffered_final_text
+                    .lock()
+                    .map_err(|_| agent_final_text_buffer_error("写入"))?;
+                buffered.push_str(&delta);
+                return Ok(());
+            }
             send_core_delta(&tx, &cancelled, delta).await?;
-            visible_text_sent.store(true, Ordering::SeqCst);
+            final_text_state
+                .visible_text_sent
+                .store(true, Ordering::SeqCst);
             Ok(())
         }) as AgentTextDeltaFuture
     })
+}
+
+/// 工具调用结束后，`RespondResponse` 已经包含领域可信回执和必要的模型总结，
+/// 因此只发送这一份最终正文，让 Gateway 能把累计正文与 Completed 对齐。
+async fn send_postprocessed_agent_response(
+    tx: &mpsc::Sender<CoreResponseEvent>,
+    cancelled: &Arc<AtomicBool>,
+    visible_text_sent: &Arc<AtomicBool>,
+    buffered_final_text: &Arc<Mutex<String>>,
+    response: &RespondResponse,
+) -> Result<(), LlmError> {
+    let buffered = take_buffered_final_text(buffered_final_text)?;
+    if !response_has_tool_results(response) {
+        if buffered.trim().is_empty() {
+            return Ok(());
+        }
+        send_core_delta(tx, cancelled, buffered).await?;
+        visible_text_sent.store(true, Ordering::SeqCst);
+        return Ok(());
+    }
+    if !response.ok {
+        return Ok(());
+    }
+    let Some(content) =
+        response_visible_content(response).filter(|content| !content.trim().is_empty())
+    else {
+        return Ok(());
+    };
+    // `buffered` 仅用于保留异常路径的草稿；正常完成时必须丢弃，不能把未投影的
+    // 模型文本与确定性工具回执再次拼接。
+    let _ = buffered;
+    send_core_delta(tx, cancelled, content.to_owned()).await?;
+    visible_text_sent.store(true, Ordering::SeqCst);
+    Ok(())
+}
+
+async fn flush_buffered_final_text(
+    tx: &mpsc::Sender<CoreResponseEvent>,
+    cancelled: &Arc<AtomicBool>,
+    visible_text_sent: &Arc<AtomicBool>,
+    buffered_final_text: &Arc<Mutex<String>>,
+) -> Result<(), LlmError> {
+    let buffered = take_buffered_final_text(buffered_final_text)?;
+    if buffered.trim().is_empty() {
+        return Ok(());
+    }
+    send_core_delta(tx, cancelled, buffered).await?;
+    visible_text_sent.store(true, Ordering::SeqCst);
+    Ok(())
+}
+
+fn take_buffered_final_text(buffered_final_text: &Arc<Mutex<String>>) -> Result<String, LlmError> {
+    let mut buffered = buffered_final_text
+        .lock()
+        .map_err(|_| agent_final_text_buffer_error("读取"))?;
+    Ok(std::mem::take(&mut *buffered))
+}
+
+fn agent_final_text_buffer_error(action: &str) -> LlmError {
+    LlmError::new(
+        "internal_error",
+        format!("{action} Agent 最终文本缓冲区失败"),
+        "stream",
+    )
+}
+
+fn response_has_tool_results(response: &RespondResponse) -> bool {
+    response
+        .diagnostics
+        .as_ref()
+        .and_then(|diagnostics| diagnostics.get("agent_tool_results"))
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|results| !results.is_empty())
 }
 
 async fn send_core_delta(

--- a/qq-maid-core/src/service/streaming.rs
+++ b/qq-maid-core/src/service/streaming.rs
@@ -141,6 +141,7 @@ pub(crate) fn start_core_response_stream(
                             &tx,
                             &producer_cancelled,
                             &producer_visible_text_sent,
+                            delivery.provider_stream_enabled,
                             &producer_buffered_final_text,
                         )
                         .await;
@@ -441,8 +442,14 @@ async fn run_agent_runtime_respond(
         Err(error) => {
             // 只有模型最终轮已经产生草稿、但整轮最终化失败时，才释放暂存正文；
             // 这样上层仍能按原语义报告“已有部分回复后失败”。
-            flush_buffered_final_text(&tx, &cancelled, &visible_text_sent, &buffered_final_text)
-                .await?;
+            flush_buffered_final_text(
+                &tx,
+                &cancelled,
+                &visible_text_sent,
+                provider_stream_enabled,
+                &buffered_final_text,
+            )
+            .await?;
             return Err(error);
         }
     };
@@ -461,6 +468,8 @@ async fn run_agent_runtime_respond(
         &cancelled,
         &visible_text_sent,
         &buffered_final_text,
+        provider_stream_enabled,
+        &tool_activity_started,
         &response,
     )
     .await?;
@@ -562,10 +571,17 @@ async fn send_postprocessed_agent_response(
     cancelled: &Arc<AtomicBool>,
     visible_text_sent: &Arc<AtomicBool>,
     buffered_final_text: &Arc<Mutex<String>>,
+    provider_stream_enabled: bool,
+    tool_activity_started: &Arc<AtomicBool>,
     response: &RespondResponse,
 ) -> Result<(), LlmError> {
+    // `ProgressThenComplete` 的 Provider 没有可用的文本传输通道，最终正文只能
+    // 由外层 `Completed` 交付；即使诊断里存在工具结果，也不能在这里伪造 delta。
+    if !provider_stream_enabled {
+        return Ok(());
+    }
     let buffered = take_buffered_final_text(buffered_final_text)?;
-    if !response_has_tool_results(response) {
+    if !tool_activity_started.load(Ordering::SeqCst) {
         if buffered.trim().is_empty() {
             return Ok(());
         }
@@ -593,8 +609,12 @@ async fn flush_buffered_final_text(
     tx: &mpsc::Sender<CoreResponseEvent>,
     cancelled: &Arc<AtomicBool>,
     visible_text_sent: &Arc<AtomicBool>,
+    provider_stream_enabled: bool,
     buffered_final_text: &Arc<Mutex<String>>,
 ) -> Result<(), LlmError> {
+    if !provider_stream_enabled {
+        return Ok(());
+    }
     let buffered = take_buffered_final_text(buffered_final_text)?;
     if buffered.trim().is_empty() {
         return Ok(());
@@ -617,15 +637,6 @@ fn agent_final_text_buffer_error(action: &str) -> LlmError {
         format!("{action} Agent 最终文本缓冲区失败"),
         "stream",
     )
-}
-
-fn response_has_tool_results(response: &RespondResponse) -> bool {
-    response
-        .diagnostics
-        .as_ref()
-        .and_then(|diagnostics| diagnostics.get("agent_tool_results"))
-        .and_then(serde_json::Value::as_array)
-        .is_some_and(|results| !results.is_empty())
 }
 
 async fn send_core_delta(

--- a/qq-maid-core/src/service/tests/agent.rs
+++ b/qq-maid-core/src/service/tests/agent.rs
@@ -144,7 +144,9 @@ async fn core_tool_loop_streams_only_final_answer_after_tool_status() {
         }
     };
 
-    assert_eq!(deltas, vec!["最终".to_owned(), "回答".to_owned()]);
+    // Agent 最终正文要等工具结果完成领域投影后再对外发送，因此同一轮暂存为
+    // 一个可信增量，避免平台先收到模型草稿、随后又收到确定性回执。
+    assert_eq!(deltas, vec!["最终回答".to_owned()]);
     assert_eq!(response.text_content(), Some("最终回答"));
     assert!(status_kinds.contains(&CoreResponseStatusKind::AgentStarted));
     assert!(status_kinds.contains(&CoreResponseStatusKind::AgentFinalizing));

--- a/qq-maid-core/src/service/tests/agent.rs
+++ b/qq-maid-core/src/service/tests/agent.rs
@@ -39,6 +39,54 @@ async fn core_private_weather_chat_with_tool_capability_completes_without_synthe
 }
 
 #[tokio::test]
+async fn core_non_streaming_agent_tool_results_only_complete_without_text_delta() {
+    let provider = TestProvider::agent_web_search_invalid_arguments()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_progress_tool_name("web_search");
+    let state = test_state_with_tool_calling(provider.clone(), 5, true);
+    let service = CoreHandle::new(state);
+
+    let mut stream = expect_stream(
+        service
+            .respond(private_request("搜索公开项目"))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(
+        stream.output_policy(),
+        CoreOutputPolicy::ProgressThenComplete
+    );
+
+    let mut status_kinds = Vec::new();
+    let mut deltas = Vec::new();
+    let response = loop {
+        let Some(event) = stream.recv().await else {
+            panic!("stream ended before completed response");
+        };
+        match event {
+            CoreResponseEvent::Status(status) => status_kinds.push(status.kind),
+            CoreResponseEvent::TextDelta(delta) => deltas.push(delta),
+            CoreResponseEvent::Completed(response) => break response,
+            CoreResponseEvent::Failed(failure) => panic!("unexpected failure: {failure:?}"),
+        }
+    };
+
+    assert!(!status_kinds.is_empty());
+    assert!(deltas.is_empty());
+    assert_eq!(
+        response.text_content(),
+        Some("【联网查询】\n\n本次联网查询的参数无效，查询未执行。请换一种说法再试。")
+    );
+    assert_eq!(
+        response.diagnostics.as_ref().unwrap()["agent_tool_results"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
 async fn core_private_tool_status_uses_configured_display_name() {
     let provider = TestProvider::replying("工具完整回复")
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
@@ -468,6 +516,46 @@ async fn core_private_general_chat_agent_direct_answer_streams_text_deltas() {
     assert_eq!(diagnostics["agent_result"], "direct_answer");
     assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
     assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn core_streaming_web_search_argument_failure_sends_only_projected_error_delta() {
+    let provider = TestProvider::agent_web_search_invalid_arguments()
+        .with_stream_enabled(true)
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_progress_tool_name("web_search");
+    let state = test_state_with_tool_calling(provider.clone(), 5, true);
+    let service = CoreHandle::new(state);
+
+    let mut stream = expect_stream(
+        service
+            .respond(private_request("搜索公开项目"))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(stream.output_policy(), CoreOutputPolicy::ProgressThenStream);
+
+    let mut deltas = Vec::new();
+    let response = loop {
+        let Some(event) = stream.recv().await else {
+            panic!("stream ended before completed response");
+        };
+        match event {
+            CoreResponseEvent::Status(_) => {}
+            CoreResponseEvent::TextDelta(delta) => deltas.push(delta),
+            CoreResponseEvent::Completed(response) => break response,
+            CoreResponseEvent::Failed(failure) => panic!("unexpected failure: {failure:?}"),
+        }
+    };
+
+    let expected = "【联网查询】\n\n本次联网查询的参数无效，查询未执行。请换一种说法再试。";
+    let draft = "模型草稿：联网查询已经成功完成，不应直接发送。";
+    assert_eq!(deltas, vec![expected.to_owned()]);
+    assert_eq!(response.text_content(), Some(expected));
+    assert!(!deltas.iter().any(|delta| delta.contains(draft)));
+    assert!(!response.text_content().unwrap().contains(draft));
+    assert!(!expected.contains("联网查询服务暂时不可用"));
+    assert!(!expected.contains("网络"));
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/service/tests/support.rs
+++ b/qq-maid-core/src/service/tests/support.rs
@@ -10,8 +10,8 @@ use std::{
 use qq_maid_common::identity_context::IdentitySource;
 use qq_maid_llm::{
     agent_loop::{
-        AgentStep, AgentStepSession, AgentToolCall, AgentToolResult, ToolLoopProgressEvent,
-        run_agent_loop_with_handle,
+        AgentRunDiagnostics, AgentStep, AgentStepSession, AgentStopReason, AgentToolCall,
+        AgentToolResult, ToolExecutionResult, ToolLoopProgressEvent, run_agent_loop_with_handle,
     },
     provider::{
         ChatOutcome, LlmProvider, LlmStream, LlmStreamEvent, ToolCallingProtocol, ToolChatRequest,
@@ -20,6 +20,7 @@ use qq_maid_llm::{
     },
     web_search::{WebSearchExecutor, WebSearchOutcome, WebSearchRequest},
 };
+use serde_json::{Value, json};
 
 use crate::{
     app::{CoreExecutors, CoreRuntimeState, CoreStores},
@@ -117,6 +118,7 @@ enum ProviderBehavior {
     Delayed { reply: String, delay: Duration },
     PartialThenDelayed { delta: String, delay: Duration },
     AgentWeatherThenFinal,
+    AgentWebSearchInvalidArguments,
 }
 
 struct WeatherAgentSession {
@@ -201,6 +203,10 @@ impl TestProvider {
         Self::new(ProviderBehavior::AgentWeatherThenFinal)
     }
 
+    pub(super) fn agent_web_search_invalid_arguments() -> Self {
+        Self::new(ProviderBehavior::AgentWebSearchInvalidArguments)
+    }
+
     fn new(behavior: ProviderBehavior) -> Self {
         Self {
             behavior,
@@ -266,6 +272,9 @@ impl LlmProvider for TestProvider {
                 Ok(chat_outcome(delta))
             }
             ProviderBehavior::AgentWeatherThenFinal => {
+                unreachable!("agent behavior uses chat_with_tools")
+            }
+            ProviderBehavior::AgentWebSearchInvalidArguments => {
                 unreachable!("agent behavior uses chat_with_tools")
             }
         }
@@ -336,6 +345,9 @@ impl LlmProvider for TestProvider {
             ProviderBehavior::AgentWeatherThenFinal => {
                 unreachable!("agent behavior uses chat_with_tools")
             }
+            ProviderBehavior::AgentWebSearchInvalidArguments => {
+                unreachable!("agent behavior uses chat_with_tools")
+            }
         }
     }
 
@@ -404,6 +416,56 @@ impl LlmProvider for TestProvider {
             }
             ProviderBehavior::AgentWeatherThenFinal => {
                 unreachable!("agent behavior returned before mock progress")
+            }
+            ProviderBehavior::AgentWebSearchInvalidArguments => {
+                let serialized = match req
+                    .tools
+                    .execute_json(
+                        &req.tool_context,
+                        "web_search",
+                        r#"{"query":"公开项目","time_range":"not-a-valid-range"}"#,
+                    )
+                    .await
+                {
+                    Ok(output) => output,
+                    // Agent Loop 会把参数校验 Err 转换为结构化 tool_result；夹具在
+                    // Provider 内模拟同一条边界，继续让 Core 运行领域投影。
+                    Err(error) => json!({
+                        "ok": false,
+                        "execution_succeeded": false,
+                        "error": {
+                            "code": error.code,
+                            "stage": error.stage,
+                        },
+                    })
+                    .to_string(),
+                };
+                let output = serde_json::from_str::<Value>(&serialized)
+                    .unwrap_or_else(|_| json!({"raw": serialized}));
+                let succeeded = output.get("ok").and_then(Value::as_bool) != Some(false);
+                let tool_result = ToolExecutionResult {
+                    name: "web_search".to_owned(),
+                    output,
+                    succeeded,
+                };
+                let draft = "模型草稿：联网查询已经成功完成，不应直接发送。";
+                if let Some(sink) = req.final_delta_sink.as_ref() {
+                    sink(draft.to_owned()).await?;
+                }
+                let mut outcome = chat_outcome(draft);
+                outcome.agent = AgentRunDiagnostics {
+                    model_rounds: 2,
+                    emitted_tools: vec!["web_search".to_owned()],
+                    tool_execution_attempted: true,
+                    executed_tools: vec!["web_search".to_owned()],
+                    side_effecting_tools_started: Vec::new(),
+                    tool_results: vec![tool_result],
+                    tool_attempts: Vec::new(),
+                    tools_with_unknown_result: Vec::new(),
+                    streaming_fallback_used: false,
+                    stop_reason: Some(AgentStopReason::ToolUsed),
+                };
+                Ok(outcome)
             }
         }
     }


### PR DESCRIPTION
## 变更

- 将 Web Search 可选枚举字段收到的字符串 `"null"` 按未设置处理，其他非法值仍返回结构化参数错误。
- 为 `invalid_arguments` / `bad_tool_arguments` 使用本地参数提示，避免误报为上游或网络故障。
- Agent 工具调用后的最终正文等待领域投影完成后再发送，避免模型草稿与失败回执被平台拆成两条消息。

## 根因

部分模型会把可选的 `time_range: null` 序列化成字符串 `"null"`。参数校验失败后，错误码未被映射到本地参数提示；同时流式 Agent 已提前发送模型最终草稿，后处理生成的联网查询失败回执又被 Gateway 视为新的完整回复。

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy -p qq-maid-core --all-targets --all-features -- -D warnings`
- `cargo test -p qq-maid-core --lib --all-features`（1377 passed）
- `cargo check --workspace`
- `git diff --check`

Fixes #651