### PR TITLE
fix: 修复工具流内容泄漏与 incomplete 降级

### DIFF
--- a/qq-maid-core/src/runtime/tools/search/tests.rs
+++ b/qq-maid-core/src/runtime/tools/search/tests.rs
@@ -466,6 +466,18 @@ fn web_search_tool_requires_context_complete_query() {
     assert!(description.contains("不要先搜索泛化问题"));
 }
 
+#[test]
+fn web_search_schema_exposes_only_canonical_time_range_field() {
+    let parameters = WebSearchTool::new(Arc::new(MockWebSearchExecutor::default()))
+        .metadata()
+        .parameters;
+    let properties = parameters["properties"].as_object().unwrap();
+
+    assert!(properties.contains_key("time_range"));
+    assert!(!properties.contains_key("timerange"));
+    assert_eq!(parameters["additionalProperties"], false);
+}
+
 struct DelayedStreamExecutor {
     first_delta_delay: Duration,
     completion_delay: Duration,

--- a/qq-maid-core/src/service/streaming.rs
+++ b/qq-maid-core/src/service/streaming.rs
@@ -10,8 +10,8 @@ use tokio::{sync::mpsc, time::timeout};
 use tracing::{debug, warn};
 
 use qq_maid_llm::agent_loop::{
-    AgentRunDiagnostics, AgentRunHandle, AgentStopReason, AgentTextDeltaFuture, AgentTextDeltaSink,
-    ToolLoopProgressEvent, ToolLoopProgressSink,
+    AgentRunDiagnostics, AgentRunHandle, AgentStopReason, AgentTextDeltaDelivery,
+    AgentTextDeltaFuture, AgentTextDeltaSink, ToolLoopProgressEvent, ToolLoopProgressSink,
 };
 use qq_maid_llm::tool::DEFAULT_TOOL_TIMEOUT;
 
@@ -134,18 +134,8 @@ pub(crate) fn start_core_response_stream(
                     // 结果未知的写操作保留有限清理窗口，避免中断后伪装成未执行；
                     // 纯只读调用可立即取消，不额外占用副作用工具的 15 秒预算。
                     cleanup_timed_out_agent_task(&mut task, needs_side_effect_cleanup).await;
-                    if !producer_cancelled.load(Ordering::SeqCst) {
-                        // Agent 任务被超时清理后不再有机会走内部错误分支；释放已经
-                        // 产生的最终草稿，继续保留“部分回复 + 超时提示”的兼容语义。
-                        let _ = flush_buffered_final_text(
-                            &tx,
-                            &producer_cancelled,
-                            &producer_visible_text_sent,
-                            delivery.provider_stream_enabled,
-                            &producer_buffered_final_text,
-                        )
-                        .await;
-                    }
+                    // 工具活动后的 Provider 文本仍是未验真的最终草稿。超时路径必须
+                    // 丢弃而非释放，避免把工具参数或不完整回答升级成用户正文。
                     Err(producer_agent_run_handle
                         .as_ref()
                         .map(|handle| err.clone().with_agent(handle.snapshot()))
@@ -440,16 +430,9 @@ async fn run_agent_runtime_respond(
     } {
         Ok(response) => response,
         Err(error) => {
-            // 只有模型最终轮已经产生草稿、但整轮最终化失败时，才释放暂存正文；
-            // 这样上层仍能按原语义报告“已有部分回复后失败”。
-            flush_buffered_final_text(
-                &tx,
-                &cancelled,
-                &visible_text_sent,
-                provider_stream_enabled,
-                &buffered_final_text,
-            )
-            .await?;
+            // 工具执行后的暂存文本只有在整轮成功并完成领域投影后才能外发。
+            // response.incomplete、协议错误或超时都直接丢弃，不能伪装成部分正文。
+            let _ = take_buffered_final_text(&buffered_final_text)?;
             return Err(error);
         }
     };
@@ -553,13 +536,13 @@ fn agent_final_delta_sink(
                     .lock()
                     .map_err(|_| agent_final_text_buffer_error("写入"))?;
                 buffered.push_str(&delta);
-                return Ok(());
+                return Ok(AgentTextDeltaDelivery::Buffered);
             }
             send_core_delta(&tx, &cancelled, delta).await?;
             final_text_state
                 .visible_text_sent
                 .store(true, Ordering::SeqCst);
-            Ok(())
+            Ok(AgentTextDeltaDelivery::Visible)
         }) as AgentTextDeltaFuture
     })
 }
@@ -601,25 +584,6 @@ async fn send_postprocessed_agent_response(
     // 模型文本与确定性工具回执再次拼接。
     let _ = buffered;
     send_core_delta(tx, cancelled, content.to_owned()).await?;
-    visible_text_sent.store(true, Ordering::SeqCst);
-    Ok(())
-}
-
-async fn flush_buffered_final_text(
-    tx: &mpsc::Sender<CoreResponseEvent>,
-    cancelled: &Arc<AtomicBool>,
-    visible_text_sent: &Arc<AtomicBool>,
-    provider_stream_enabled: bool,
-    buffered_final_text: &Arc<Mutex<String>>,
-) -> Result<(), LlmError> {
-    if !provider_stream_enabled {
-        return Ok(());
-    }
-    let buffered = take_buffered_final_text(buffered_final_text)?;
-    if buffered.trim().is_empty() {
-        return Ok(());
-    }
-    send_core_delta(tx, cancelled, buffered).await?;
     visible_text_sent.store(true, Ordering::SeqCst);
     Ok(())
 }

--- a/qq-maid-core/src/service/streaming.rs
+++ b/qq-maid-core/src/service/streaming.rs
@@ -372,8 +372,9 @@ async fn run_agent_runtime_respond(
 
     let tool_activity_started = Arc::new(AtomicBool::new(false));
     // 工具结果还要经过领域投影；在投影完成前不能把模型最终草稿直接发给平台，
-    // 否则失败回执会被 Gateway 视为第二条回复。工具执行异常时再把暂存草稿原样
-    // 释放，保留“已发出部分正文后不能伪造重放”的既有流式语义。
+    // 否则失败回执会被 Gateway 视为第二条回复。工具活动后的 Provider 文本一律
+    // 先进入未验真草稿缓冲：整轮成功并完成领域投影后才外发可信正文；失败、
+    // 超时或 response.incomplete 时直接丢弃，不再把暂存草稿释放成“部分正文”。
     let final_text_state = AgentFinalTextState {
         tool_activity_started: tool_activity_started.clone(),
         visible_text_sent: visible_text_sent.clone(),
@@ -580,8 +581,8 @@ async fn send_postprocessed_agent_response(
     else {
         return Ok(());
     };
-    // `buffered` 仅用于保留异常路径的草稿；正常完成时必须丢弃，不能把未投影的
-    // 模型文本与确定性工具回执再次拼接。
+    // `buffered` 只承载工具活动后的未验真草稿；整轮成功时必须以领域投影后的
+    // 可信正文为准并丢弃草稿，不能把未投影的模型文本与确定性工具回执再次拼接。
     let _ = buffered;
     send_core_delta(tx, cancelled, content.to_owned()).await?;
     visible_text_sent.store(true, Ordering::SeqCst);

--- a/qq-maid-core/src/service/tests/agent.rs
+++ b/qq-maid-core/src/service/tests/agent.rs
@@ -1,4 +1,5 @@
 use super::*;
+use serde_json::json;
 
 #[tokio::test]
 async fn core_private_weather_chat_with_tool_capability_completes_without_synthetic_delta() {
@@ -559,6 +560,86 @@ async fn core_streaming_web_search_argument_failure_sends_only_projected_error_d
     assert!(!response.text_content().unwrap().contains(draft));
     assert!(!expected.contains("联网查询服务暂时不可用"));
     assert!(!expected.contains("网络"));
+}
+
+#[tokio::test]
+async fn core_agent_buffered_draft_incomplete_falls_back_to_second_candidate_without_leak() {
+    const DRAFT: &str = "第一候选未验真草稿：不应外发。";
+    const FINAL: &str = "第二候选最终正文";
+    let provider = RouteFallbackTestProvider::new(DRAFT, FINAL);
+    let state = test_state_with_route_fallback_and_query_executor(
+        provider.clone(),
+        5,
+        Arc::new(MockWebSearchExecutor::default()),
+    );
+    let service = CoreHandle::new(state);
+
+    let mut stream = expect_stream(
+        service
+            .respond(private_request("帮我搜索公开项目"))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(stream.output_policy(), CoreOutputPolicy::ProgressThenStream);
+
+    let mut status_kinds = Vec::new();
+    let mut deltas = Vec::new();
+    let mut completed = 0;
+    let response = loop {
+        let Some(event) = stream.recv().await else {
+            panic!("stream ended before completed response");
+        };
+        match event {
+            CoreResponseEvent::Status(status) => status_kinds.push(status.kind),
+            CoreResponseEvent::TextDelta(delta) => deltas.push(delta),
+            CoreResponseEvent::Completed(response) => {
+                completed += 1;
+                break *response;
+            }
+            CoreResponseEvent::Failed(failure) => panic!("unexpected failure: {failure:?}"),
+        }
+    };
+
+    // 第一候选草稿不得产生用户可见 TextDelta，也不得混入第二候选最终正文。
+    assert!(
+        deltas.iter().all(|delta| !delta.contains(DRAFT)),
+        "first-candidate draft leaked into visible deltas: {deltas:?}"
+    );
+    assert!(
+        !response
+            .text_content()
+            .is_some_and(|text| text.contains(DRAFT)),
+        "first-candidate draft leaked into final response"
+    );
+    // 第二候选最终正文只出现一次；领域投影后的可信正文（web_search 结果 + 模型
+    // 总结）取代缓冲草稿，且不会与第一候选草稿拼接。
+    assert_eq!(
+        deltas.len(),
+        1,
+        "final body must appear exactly once: {deltas:?}"
+    );
+    let projected = &deltas[0];
+    assert!(projected.starts_with("【联网查询】"), "{projected}");
+    assert!(projected.contains("web answer: 公开项目"), "{projected}");
+    assert!(projected.ends_with(FINAL), "{projected}");
+    assert_eq!(response.text_content(), Some(projected.as_str()));
+    // Completed 只出现一次，且之后不再产生事件。
+    assert_eq!(completed, 1);
+    assert!(
+        stream.recv().await.is_none(),
+        "Completed 后不得重复产生事件"
+    );
+    // fallback 确实发生：两个候选各被调用一次，草稿投递为 Buffered 不阻断降级。
+    assert!(provider.fallback_taken());
+    assert_eq!(provider.first_tool_calls(), 1);
+    assert_eq!(provider.second_tool_calls(), 1);
+    // 已执行只读 web_search 不会被错误识别为副作用工具。
+    assert!(status_kinds.contains(&CoreResponseStatusKind::ToolCallStarted));
+    let diagnostics = response.diagnostics.as_ref().unwrap();
+    assert_eq!(diagnostics["agent_executed_tools"], json!(["web_search"]));
+    assert_eq!(diagnostics["agent_tool_results"][0]["name"], "web_search");
+    assert_eq!(diagnostics["agent_tool_results"][0]["succeeded"], true);
+    assert_eq!(diagnostics["tool_execution_attempted"], true);
 }
 
 #[tokio::test]

--- a/qq-maid-core/src/service/tests/agent.rs
+++ b/qq-maid-core/src/service/tests/agent.rs
@@ -36,6 +36,10 @@ async fn core_private_weather_chat_with_tool_capability_completes_without_synthe
     assert_eq!(response.text_content(), Some("工具完整回复"));
     assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
     assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    assert!(
+        stream.recv().await.is_none(),
+        "Completed 后不得重复产生事件"
+    );
 }
 
 #[tokio::test]
@@ -206,10 +210,14 @@ async fn core_tool_loop_streams_only_final_answer_after_tool_status() {
     );
     assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 1);
     assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    assert!(
+        stream.recv().await.is_none(),
+        "最终正文 Completed 后不得重复产生事件"
+    );
 }
 
 #[tokio::test]
-async fn core_tool_loop_stream_failure_after_delta_does_not_complete_or_replay() {
+async fn core_tool_loop_stream_failure_discards_buffered_tool_round_delta() {
     let provider = TestProvider::streaming(vec![
         Ok(LlmStreamEvent::TextDelta("部分回答".to_owned())),
         Err(LlmError::provider(
@@ -228,7 +236,6 @@ async fn core_tool_loop_stream_failure_after_delta_does_not_complete_or_replay()
             .unwrap(),
     );
 
-    let mut saw_delta = false;
     loop {
         let Some(event) = stream.recv().await else {
             panic!("stream ended before failure");
@@ -236,11 +243,9 @@ async fn core_tool_loop_stream_failure_after_delta_does_not_complete_or_replay()
         match event {
             CoreResponseEvent::Status(_) => {}
             CoreResponseEvent::TextDelta(delta) => {
-                assert_eq!(delta, "部分回答");
-                saw_delta = true;
+                panic!("buffered tool-round delta must not be visible: {delta}");
             }
             CoreResponseEvent::Failed(failure) => {
-                assert!(saw_delta);
                 assert_eq!(failure.kind, CoreFailureKind::LlmFailed);
                 break;
             }
@@ -252,7 +257,7 @@ async fn core_tool_loop_stream_failure_after_delta_does_not_complete_or_replay()
 }
 
 #[tokio::test]
-async fn core_tool_loop_timeout_after_delta_appends_visible_termination_notice() {
+async fn core_tool_loop_timeout_discards_buffered_delta_without_partial_notice() {
     let provider = TestProvider::partial_then_delayed("部分回答", Duration::from_secs(2))
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
     let mut state = test_state_with_tool_calling(provider, 1, true);
@@ -282,9 +287,7 @@ async fn core_tool_loop_timeout_after_delta_appends_visible_termination_notice()
     };
 
     assert_eq!(failure.kind, CoreFailureKind::LlmTimeout);
-    assert_eq!(deltas.len(), 2);
-    assert_eq!(deltas[0], "部分回答");
-    assert!(deltas[1].contains("本次回答未完整完成"));
+    assert!(deltas.is_empty());
     assert!(started_at.elapsed() < Duration::from_secs(3));
     assert!(stream.recv().await.is_none());
 }

--- a/qq-maid-core/src/service/tests/support.rs
+++ b/qq-maid-core/src/service/tests/support.rs
@@ -10,11 +10,13 @@ use std::{
 use qq_maid_common::identity_context::IdentitySource;
 use qq_maid_llm::{
     agent_loop::{
-        AgentRunDiagnostics, AgentStep, AgentStepSession, AgentStopReason, AgentToolCall,
-        AgentToolResult, ToolExecutionResult, ToolLoopProgressEvent, run_agent_loop_with_handle,
+        AgentRunDiagnostics, AgentStep, AgentStepSession, AgentStopReason, AgentTextDeltaDelivery,
+        AgentToolCall, AgentToolResult, ToolExecutionResult, ToolLoopProgressEvent,
+        run_agent_loop_with_handle,
     },
     provider::{
-        ChatOutcome, LlmProvider, LlmStream, LlmStreamEvent, ToolCallingProtocol, ToolChatRequest,
+        ChatOutcome, DynLlmProvider, LlmProvider, LlmStream, LlmStreamEvent, ToolCallingProtocol,
+        ToolChatRequest,
         status::{UpstreamStatus, observe_provider},
         types::{ChatRequest, TokenUsage},
     },
@@ -111,14 +113,26 @@ pub(super) fn expect_stream(output: CoreRespondOutput) -> CoreResponseStream {
 }
 
 #[derive(Clone)]
-enum ProviderBehavior {
+pub(super) enum ProviderBehavior {
     Reply(String),
     Stream(Vec<Result<LlmStreamEvent, LlmError>>),
     Error(LlmError),
-    Delayed { reply: String, delay: Duration },
-    PartialThenDelayed { delta: String, delay: Duration },
+    Delayed {
+        reply: String,
+        delay: Duration,
+    },
+    PartialThenDelayed {
+        delta: String,
+        delay: Duration,
+    },
     AgentWeatherThenFinal,
     AgentWebSearchInvalidArguments,
+    /// 候选 1：执行只读 `web_search` 成功后，把模型文本作为未验真草稿交给
+    /// `final_delta_sink`（工具活动已开始，Core 必须缓冲为 `Buffered`），随后
+    /// 以 `response.incomplete` 失败结束，触发候选链降级。
+    AgentWebSearchIncomplete {
+        draft: String,
+    },
 }
 
 struct WeatherAgentSession {
@@ -207,7 +221,7 @@ impl TestProvider {
         Self::new(ProviderBehavior::AgentWebSearchInvalidArguments)
     }
 
-    fn new(behavior: ProviderBehavior) -> Self {
+    pub(super) fn new(behavior: ProviderBehavior) -> Self {
         Self {
             behavior,
             requests: Arc::new(Mutex::new(Vec::new())),
@@ -275,6 +289,9 @@ impl LlmProvider for TestProvider {
                 unreachable!("agent behavior uses chat_with_tools")
             }
             ProviderBehavior::AgentWebSearchInvalidArguments => {
+                unreachable!("agent behavior uses chat_with_tools")
+            }
+            ProviderBehavior::AgentWebSearchIncomplete { .. } => {
                 unreachable!("agent behavior uses chat_with_tools")
             }
         }
@@ -346,6 +363,9 @@ impl LlmProvider for TestProvider {
                 unreachable!("agent behavior uses chat_with_tools")
             }
             ProviderBehavior::AgentWebSearchInvalidArguments => {
+                unreachable!("agent behavior uses chat_with_tools")
+            }
+            ProviderBehavior::AgentWebSearchIncomplete { .. } => {
                 unreachable!("agent behavior uses chat_with_tools")
             }
         }
@@ -467,6 +487,58 @@ impl LlmProvider for TestProvider {
                 };
                 Ok(outcome)
             }
+            ProviderBehavior::AgentWebSearchIncomplete { draft } => {
+                // 候选 1：真实执行只读 web_search（ToolRegistry 白名单路径），
+                // 成功后再把模型文本作为未验真草稿交给 final_delta_sink。
+                let serialized = req
+                    .tools
+                    .execute_json(&req.tool_context, "web_search", r#"{"query":"公开项目"}"#)
+                    .await
+                    .map_err(|error| {
+                        LlmError::new(
+                            "internal_error",
+                            format!("web_search execution failed: {error}"),
+                            "tool",
+                        )
+                    })?;
+                let output = serde_json::from_str::<Value>(&serialized)
+                    .unwrap_or_else(|_| json!({"raw": serialized}));
+                let succeeded = output.get("ok").and_then(Value::as_bool) != Some(false);
+                let tool_result = ToolExecutionResult {
+                    name: "web_search".to_owned(),
+                    output,
+                    succeeded,
+                };
+                // 工具活动已开始，Core 的 final_delta_sink 必须缓冲草稿（Buffered），
+                // 不能进入用户可见发送链路；候选路由据此才允许降级到第二候选。
+                if let Some(sink) = req.final_delta_sink.as_ref() {
+                    let delivery = sink(draft.to_owned()).await?;
+                    if delivery != AgentTextDeltaDelivery::Buffered {
+                        return Err(LlmError::new(
+                            "internal_error",
+                            "tool-round draft must stay buffered after tool activity",
+                            "stream",
+                        ));
+                    }
+                }
+                let diagnostics = AgentRunDiagnostics {
+                    model_rounds: 2,
+                    emitted_tools: vec!["web_search".to_owned()],
+                    tool_execution_attempted: true,
+                    executed_tools: vec!["web_search".to_owned()],
+                    side_effecting_tools_started: Vec::new(),
+                    tool_results: vec![tool_result],
+                    tool_attempts: Vec::new(),
+                    tools_with_unknown_result: Vec::new(),
+                    streaming_fallback_used: false,
+                    stop_reason: Some(AgentStopReason::ToolUsed),
+                };
+                Err(
+                    LlmError::provider("OpenAI chat stream response incomplete", "sse")
+                        .with_incomplete_reason("max_output_tokens")
+                        .with_agent(diagnostics),
+                )
+            }
         }
     }
 
@@ -480,6 +552,122 @@ impl LlmProvider for TestProvider {
 
     fn stream_enabled(&self) -> bool {
         self.stream_enabled
+    }
+}
+
+/// 最小候选链测试替身：镜像 `ModelRouteProvider` 在工具轮上的降级契约。
+///
+/// 候选 1 执行只读 `web_search`、把模型文本作为 `Buffered` 草稿投递后以
+/// `response.incomplete` 失败；候选 2 成功返回最终正文。由于 `ModelRouteProvider`
+/// 是 `qq-maid-llm` 的 crate 私有类型，这里在 Provider 边界复刻它的判定输入
+/// （可恢复协议错误、无用户可见正文、无副作用工具），让 Core 流层能观测到
+/// 完整降级链路；真实候选链判定由 `qq-maid-llm` routing 单测覆盖。
+#[derive(Clone)]
+pub(super) struct RouteFallbackTestProvider {
+    first: TestProvider,
+    second: TestProvider,
+    first_tool_calls: Arc<AtomicUsize>,
+    second_tool_calls: Arc<AtomicUsize>,
+    fallback_taken: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl RouteFallbackTestProvider {
+    pub(super) fn new(draft: &str, final_reply: &str) -> Self {
+        let first = TestProvider::new(ProviderBehavior::AgentWebSearchIncomplete {
+            draft: draft.to_owned(),
+        })
+        .with_stream_enabled(true)
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_progress_tool_name("web_search");
+        let second = TestProvider::streaming(vec![
+            Ok(LlmStreamEvent::TextDelta(final_reply.to_owned())),
+            Ok(LlmStreamEvent::Completed {
+                usage: None,
+                finish_reason: None,
+                fallback_used: false,
+            }),
+        ])
+        .with_tool_protocol(ToolCallingProtocol::ChatCompletionsToolCalls)
+        .without_tool_progress();
+        Self {
+            first,
+            second,
+            first_tool_calls: Arc::new(AtomicUsize::new(0)),
+            second_tool_calls: Arc::new(AtomicUsize::new(0)),
+            fallback_taken: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        }
+    }
+
+    pub(super) fn first_tool_calls(&self) -> usize {
+        self.first_tool_calls.load(Ordering::SeqCst)
+    }
+
+    pub(super) fn second_tool_calls(&self) -> usize {
+        self.second_tool_calls.load(Ordering::SeqCst)
+    }
+
+    pub(super) fn fallback_taken(&self) -> bool {
+        self.fallback_taken.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl LlmProvider for RouteFallbackTestProvider {
+    async fn chat(&self, _req: ChatRequest) -> Result<ChatOutcome, LlmError> {
+        unreachable!("route fallback provider only serves tool calling tests")
+    }
+
+    fn tool_calling_protocol(&self, model: Option<&str>) -> Option<ToolCallingProtocol> {
+        self.first.tool_calling_protocol(model)
+    }
+
+    async fn chat_with_tools(&self, req: ToolChatRequest) -> Result<ChatOutcome, LlmError> {
+        // 候选 1：只读 web_search + Buffered 草稿 + response.incomplete。
+        self.first_tool_calls.fetch_add(1, Ordering::SeqCst);
+        let first_err = match self.first.chat_with_tools(req.clone()).await {
+            Err(err) => err,
+            Ok(outcome) => {
+                panic!("first candidate must fail with response.incomplete: {outcome:?}")
+            }
+        };
+        // 镜像 ModelRouteProvider 的降级判定输入：可恢复协议错误 + 没有用户可见
+        // 正文 + 只读工具未启动副作用。草稿的 Buffered 投递由候选 1 内部断言。
+        assert_eq!(first_err.code, "provider_error");
+        assert_eq!(first_err.stage, "sse");
+        assert_eq!(first_err.incomplete_reason(), Some("max_output_tokens"));
+        let diagnostics = first_err
+            .agent
+            .as_deref()
+            .expect("first candidate must attach agent diagnostics");
+        assert!(
+            diagnostics.side_effecting_tools_started.is_empty(),
+            "read-only web_search must not be treated as a side-effect tool"
+        );
+        assert!(
+            diagnostics.tools_with_unknown_result.is_empty(),
+            "web_search result is trusted, not unknown"
+        );
+        assert_eq!(diagnostics.executed_tools, ["web_search"]);
+
+        self.fallback_taken.store(true, Ordering::SeqCst);
+        // 候选 2：成功返回最终正文；共享 handle 语义下仍携带候选 1 的只读轨迹。
+        self.second_tool_calls.fetch_add(1, Ordering::SeqCst);
+        let mut outcome = self.second.chat_with_tools(req).await?;
+        outcome.fallback_used = true;
+        outcome.agent = first_err.agent.map(|agent| *agent).unwrap_or_default();
+        Ok(outcome)
+    }
+
+    fn name(&self) -> &str {
+        "route-fallback-test"
+    }
+
+    fn model(&self) -> &str {
+        "route-fallback-test-model"
+    }
+
+    fn stream_enabled(&self) -> bool {
+        true
     }
 }
 
@@ -693,7 +881,7 @@ pub(super) fn test_state_with_group_tool_calling(
     tool_calling_group_enabled: bool,
 ) -> CoreRuntimeState {
     test_state_with_group_tool_calling_and_query_executor(
-        provider,
+        Arc::new(provider),
         request_timeout_seconds,
         tool_calling_enabled,
         tool_calling_group_enabled,
@@ -707,7 +895,7 @@ pub(super) fn test_state_with_query_executor(
     query_executor: Arc<dyn WebSearchExecutor>,
 ) -> CoreRuntimeState {
     test_state_with_group_tool_calling_and_query_executor(
-        provider,
+        Arc::new(provider),
         request_timeout_seconds,
         false,
         false,
@@ -715,8 +903,23 @@ pub(super) fn test_state_with_query_executor(
     )
 }
 
+/// 带候选链测试替身的状态：私聊启用工具调用，并使用可成功的只读 web_search。
+pub(super) fn test_state_with_route_fallback_and_query_executor(
+    provider: RouteFallbackTestProvider,
+    request_timeout_seconds: u64,
+    query_executor: Arc<dyn WebSearchExecutor>,
+) -> CoreRuntimeState {
+    test_state_with_group_tool_calling_and_query_executor(
+        Arc::new(provider),
+        request_timeout_seconds,
+        true,
+        false,
+        query_executor,
+    )
+}
+
 fn test_state_with_group_tool_calling_and_query_executor(
-    provider: TestProvider,
+    provider: DynLlmProvider,
     request_timeout_seconds: u64,
     tool_calling_enabled: bool,
     tool_calling_group_enabled: bool,
@@ -828,7 +1031,7 @@ fn test_state_with_group_tool_calling_and_query_executor(
             web_console_trusted_proxy_ips: Vec::new(),
             web_console_secure_cookies: false,
         },
-        provider: observe_provider(Arc::new(provider), upstream_status.clone()),
+        provider: observe_provider(provider, upstream_status.clone()),
         upstream_status,
         executors: CoreExecutors {
             query_executor,

--- a/qq-maid-llm/src/agent_loop/mod.rs
+++ b/qq-maid-llm/src/agent_loop/mod.rs
@@ -49,8 +49,9 @@ pub use runner::{run_agent_loop, run_agent_loop_with_handle};
 pub use session::{AgentInputSizeEstimate, AgentStepSession, AgentStreamingDiagnostics};
 pub use types::{
     AgentRunDiagnostics, AgentRunHandle, AgentSessionRequest, AgentStep, AgentStopReason,
-    AgentTextDeltaFuture, AgentTextDeltaSink, AgentToolCall, AgentToolResult, ToolExecutionAttempt,
-    ToolExecutionResult, ToolLoopProgressEvent, ToolLoopProgressFuture, ToolLoopProgressSink,
+    AgentTextDeltaDelivery, AgentTextDeltaFuture, AgentTextDeltaSink, AgentToolCall,
+    AgentToolResult, ToolExecutionAttempt, ToolExecutionResult, ToolLoopProgressEvent,
+    ToolLoopProgressFuture, ToolLoopProgressSink,
 };
 
 #[cfg(test)]

--- a/qq-maid-llm/src/agent_loop/session.rs
+++ b/qq-maid-llm/src/agent_loop/session.rs
@@ -32,6 +32,8 @@ pub struct AgentStreamingDiagnostics {
     pub connection_reset: bool,
     pub parse_error: bool,
     pub explicit_failure_event: bool,
+    /// `response.incomplete.response.incomplete_details.reason` 的低敏稳定值。
+    pub incomplete_reason: Option<String>,
     pub saw_text_delta: bool,
     pub buffered_delta_count: usize,
     pub buffered_text_chars: usize,

--- a/qq-maid-llm/src/agent_loop/streaming.rs
+++ b/qq-maid-llm/src/agent_loop/streaming.rs
@@ -13,8 +13,8 @@ use tokio::time::{Duration, timeout};
 
 use crate::{
     agent_loop::{
-        AgentRunHandle, AgentStreamingDiagnostics, AgentTextDeltaFuture, AgentTextDeltaSink,
-        AgentToolResult,
+        AgentRunHandle, AgentStreamingDiagnostics, AgentTextDeltaDelivery, AgentTextDeltaFuture,
+        AgentTextDeltaSink, AgentToolResult,
     },
     error::LlmError,
 };
@@ -107,6 +107,7 @@ pub(super) async fn advance_with_optional_streaming(
                     &err,
                     &diagnostics,
                     run_handle.remaining_budget(),
+                    run_handle,
                     "stream_had_valid_text",
                 );
                 return Err(err);
@@ -121,6 +122,7 @@ pub(super) async fn advance_with_optional_streaming(
                     &err,
                     &diagnostics,
                     run_handle.remaining_budget(),
+                    run_handle,
                     "explicit_failure_event",
                 );
                 return Err(err);
@@ -247,6 +249,7 @@ async fn fallback_to_non_stream(
             err.unwrap_or(&budget_error),
             &diagnostics,
             fallback_remaining_budget,
+            run_handle,
             "insufficient_remaining_budget",
         );
         return Err(budget_error);
@@ -259,6 +262,7 @@ async fn fallback_to_non_stream(
         advance_non_stream_with_timeout(session, results, allow_tool_calls, effective_timeout)
             .await;
     let non_stream_fallback_elapsed_ms = fallback_started.elapsed().as_millis();
+    let agent_diagnostics = run_handle.snapshot();
     tracing::info!(
         provider = session.provider(),
         model = %session.model(),
@@ -276,6 +280,9 @@ async fn fallback_to_non_stream(
         connection_reset = diagnostics.connection_reset,
         parse_error = diagnostics.parse_error,
         explicit_failure_event = diagnostics.explicit_failure_event,
+        incomplete_reason = diagnostics.incomplete_reason.as_deref().unwrap_or("none"),
+        tool_execution_attempted = agent_diagnostics.tool_execution_attempted,
+        tool_executed = !agent_diagnostics.executed_tools.is_empty(),
         saw_text_delta = diagnostics.saw_text_delta,
         chunk_count = diagnostics.chunk_count,
         sse_event_count = diagnostics.sse_event_count,
@@ -319,8 +326,10 @@ fn log_streaming_fallback_skipped(
     err: &LlmError,
     diagnostics: &AgentStreamingDiagnostics,
     remaining_budget: Option<Duration>,
+    run_handle: &AgentRunHandle,
     skipped_reason: &str,
 ) {
+    let agent_diagnostics = run_handle.snapshot();
     tracing::warn!(
         provider = session.provider(),
         model = %session.model(),
@@ -337,6 +346,9 @@ fn log_streaming_fallback_skipped(
         connection_reset = diagnostics.connection_reset,
         parse_error = diagnostics.parse_error,
         explicit_failure_event = diagnostics.explicit_failure_event,
+        incomplete_reason = diagnostics.incomplete_reason.as_deref().unwrap_or("none"),
+        tool_execution_attempted = agent_diagnostics.tool_execution_attempted,
+        tool_executed = !agent_diagnostics.executed_tools.is_empty(),
         saw_text_delta = diagnostics.saw_text_delta,
         buffered_delta_count = diagnostics.buffered_delta_count,
         buffered_text_chars = diagnostics.buffered_text_chars,
@@ -365,8 +377,13 @@ fn track_visible_delta_sink(
         let sink = sink.clone();
         let emitted_visible_delta = emitted_visible_delta.clone();
         Box::pin(async move {
-            emitted_visible_delta.store(true, Ordering::SeqCst);
-            sink(delta).await
+            let has_visible_text = !delta.is_empty();
+            let delivery = sink(delta).await?;
+            if has_visible_text && delivery == AgentTextDeltaDelivery::Visible {
+                // 只有下游确认正文已进入可见发送链路后，才关闭本轮安全降级。
+                emitted_visible_delta.store(true, Ordering::SeqCst);
+            }
+            Ok(delivery)
         }) as AgentTextDeltaFuture
     })
 }

--- a/qq-maid-llm/src/agent_loop/tests/mod.rs
+++ b/qq-maid-llm/src/agent_loop/tests/mod.rs
@@ -735,7 +735,7 @@ fn delta_sink(deltas: Arc<StdMutex<Vec<String>>>) -> AgentTextDeltaSink {
         let deltas = deltas.clone();
         Box::pin(async move {
             deltas.lock().unwrap().push(delta);
-            Ok(())
+            Ok(AgentTextDeltaDelivery::Visible)
         }) as AgentTextDeltaFuture
     })
 }

--- a/qq-maid-llm/src/agent_loop/types.rs
+++ b/qq-maid-llm/src/agent_loop/types.rs
@@ -538,8 +538,18 @@ pub type ToolLoopProgressFuture =
 pub type ToolLoopProgressSink =
     Arc<dyn Fn(ToolLoopProgressEvent) -> ToolLoopProgressFuture + Send + Sync + 'static>;
 
+/// 最终回答增量交给下游后的真实投递状态。
+///
+/// `Buffered` 表示正文仍停留在业务投影缓冲区，尚未进入用户可见发送链路；
+/// 候选路由不得据此禁止 fallback。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentTextDeltaDelivery {
+    Visible,
+    Buffered,
+}
+
 pub type AgentTextDeltaFuture =
-    Pin<Box<dyn Future<Output = Result<(), LlmError>> + Send + 'static>>;
+    Pin<Box<dyn Future<Output = Result<AgentTextDeltaDelivery, LlmError>> + Send + 'static>>;
 
 /// Tool Loop 最终用户可见正文增量接收器。
 ///

--- a/qq-maid-llm/src/error.rs
+++ b/qq-maid-llm/src/error.rs
@@ -68,6 +68,8 @@ pub struct LlmError {
     pub upstream_status: Option<u16>,
     /// 搜索上游的低敏路由身份；装箱避免增大每个通用错误返回值。
     upstream_context: Option<Box<UpstreamErrorContext>>,
+    /// Responses `response.incomplete` 的低敏协议原因；不进入用户错误正文。
+    incomplete_reason: Option<String>,
     /// Agent Runtime 失败时已经发生的可信执行轨迹。
     pub agent: Option<Box<AgentRunDiagnostics>>,
 }
@@ -85,6 +87,7 @@ impl LlmError {
             stage: stage.into(),
             upstream_status: None,
             upstream_context: None,
+            incomplete_reason: None,
             agent: None,
         }
     }
@@ -227,6 +230,16 @@ impl LlmError {
         self.upstream_context
             .as_deref()
             .map(|context| context.model.as_str())
+    }
+
+    /// 附加 Responses API 返回的稳定 incomplete reason，供候选诊断使用。
+    pub fn with_incomplete_reason(mut self, reason: impl Into<String>) -> Self {
+        self.incomplete_reason = Some(reason.into());
+        self
+    }
+
+    pub fn incomplete_reason(&self) -> Option<&str> {
+        self.incomplete_reason.as_deref()
     }
 
     /// 返回跨 Provider 统一的错误分类。

--- a/qq-maid-llm/src/provider/openai/chat_tool_loop/tests.rs
+++ b/qq-maid-llm/src/provider/openai/chat_tool_loop/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::agent_loop::{AgentTextDeltaFuture, run_agent_loop};
+use crate::agent_loop::{AgentTextDeltaDelivery, AgentTextDeltaFuture, run_agent_loop};
 use crate::context_budget::estimated_json_chars;
 use crate::provider::test_support::{WeatherToolStub, test_tool_context};
 use crate::tool::{Tool, ToolContext, ToolMetadata, ToolOutput};
@@ -21,7 +21,7 @@ fn recording_delta_sink(deltas: Arc<StdMutex<Vec<String>>>) -> AgentTextDeltaSin
         let deltas = deltas.clone();
         Box::pin(async move {
             deltas.lock().unwrap().push(delta);
-            Ok(())
+            Ok(AgentTextDeltaDelivery::Visible)
         }) as AgentTextDeltaFuture
     })
 }

--- a/qq-maid-llm/src/provider/openai/stream.rs
+++ b/qq-maid-llm/src/provider/openai/stream.rs
@@ -36,11 +36,7 @@ pub(crate) fn handle_openai_chat_stream_event(
     let value = serde_json::from_str::<Value>(&event.data).map_err(|err| {
         LlmError::provider(format!("invalid OpenAI chat stream JSON: {err}"), "sse")
     })?;
-    let event_type = event
-        .event
-        .as_deref()
-        .or_else(|| value.get("type").and_then(Value::as_str))
-        .unwrap_or("");
+    let event_type = responses_event_type(&event, &value)?;
 
     if event_type.starts_with("response.image_generation_call.") {
         tracing::debug!(
@@ -69,7 +65,13 @@ pub(crate) fn handle_openai_chat_stream_event(
             *saw_completed = true;
             *completed_response = extract_completed_response(&value);
         }
-        "response.failed" | "response.incomplete" | "error" => {
+        "response.incomplete" => {
+            let reason = response_incomplete_reason(&value).unwrap_or_else(|| "unknown".to_owned());
+            let message = stream_error_message(&value)
+                .unwrap_or_else(|| format!("OpenAI chat stream response incomplete: {reason}"));
+            return Err(LlmError::provider(message, "sse").with_incomplete_reason(reason));
+        }
+        "response.failed" | "error" => {
             let message = stream_error_message(&value)
                 .unwrap_or_else(|| format!("OpenAI chat stream event {event_type}"));
             return Err(LlmError::provider(message, "sse"));
@@ -78,6 +80,61 @@ pub(crate) fn handle_openai_chat_stream_event(
     }
 
     Ok(None)
+}
+
+/// JSON `type` 是 Responses 事件的协议权威字段。SSE `event:` 仅作外层路由提示；
+/// 两者冲突时不能按 header 把 function arguments 的 `delta` 当成回答正文。
+pub(crate) fn responses_event_type<'a>(
+    event: &'a SseFrame,
+    value: &'a Value,
+) -> Result<&'a str, LlmError> {
+    let payload_type = value.get("type").and_then(Value::as_str);
+    let header_type = event.event.as_deref().filter(|item| !item.is_empty());
+    if payload_type.is_none()
+        && header_type.is_some_and(|event_type| event_type.starts_with("response."))
+    {
+        return Err(LlmError::provider(
+            "OpenAI Responses SSE payload is missing event type",
+            "sse",
+        ));
+    }
+    if let (Some(payload_type), Some(header_type)) = (payload_type, header_type)
+        && header_type != "message"
+        && header_type != payload_type
+    {
+        return Err(LlmError::provider(
+            "OpenAI Responses SSE event type does not match payload type",
+            "sse",
+        ));
+    }
+    Ok(payload_type.or(header_type).unwrap_or(""))
+}
+
+pub(crate) fn response_incomplete_reason(value: &Value) -> Option<String> {
+    let reason = value
+        .get("response")
+        .and_then(|response| response.get("incomplete_details"))
+        .and_then(|details| details.get("reason"))
+        .or_else(|| {
+            value
+                .get("incomplete_details")
+                .and_then(|details| details.get("reason"))
+        })
+        .and_then(Value::as_str)?;
+    Some(sanitize_incomplete_reason(reason))
+}
+
+fn sanitize_incomplete_reason(reason: &str) -> String {
+    let reason = reason.trim();
+    if reason.is_empty()
+        || reason.chars().count() > 64
+        || !reason.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.')
+        })
+    {
+        return "unknown".to_owned();
+    }
+    reason.to_owned()
 }
 
 fn trace_ignored_responses_stream_delta(event_type: &str, delta: Option<&Value>) {
@@ -180,6 +237,77 @@ mod tests {
                     .map(str::to_owned)
             }),
             Some("你好".to_owned())
+        );
+    }
+
+    #[test]
+    fn rejects_mismatched_event_header_without_exposing_argument_delta() {
+        let mut recorder = MetricsRecorder::start();
+        let mut answer = String::new();
+        let mut completed_response = None;
+        let mut saw_completed = false;
+
+        let err = handle_openai_chat_stream_event(
+            SseFrame {
+                event: Some("response.output_text.delta".to_owned()),
+                data: serde_json::json!({
+                    "type": "response.function_call_arguments.delta",
+                    "delta": "{\"query\":\"secret\"}",
+                    "sequence_number": 7
+                })
+                .to_string(),
+            },
+            &mut recorder,
+            &mut answer,
+            &mut completed_response,
+            &mut saw_completed,
+        )
+        .unwrap_err();
+
+        assert_eq!(err.stage, "sse");
+        assert!(answer.is_empty());
+    }
+
+    #[test]
+    fn rejects_typed_header_with_untyped_delta_payload() {
+        let mut recorder = MetricsRecorder::start();
+        let mut answer = String::new();
+        let mut completed_response = None;
+        let mut saw_completed = false;
+
+        let err = handle_openai_chat_stream_event(
+            SseFrame {
+                event: Some("response.output_text.delta".to_owned()),
+                data: r#"{"delta":"must not be exposed","sequence_number":8}"#.to_owned(),
+            },
+            &mut recorder,
+            &mut answer,
+            &mut completed_response,
+            &mut saw_completed,
+        )
+        .unwrap_err();
+
+        assert_eq!(err.stage, "sse");
+        assert!(answer.is_empty());
+    }
+
+    #[test]
+    fn extracts_and_sanitizes_response_incomplete_reason() {
+        let value = serde_json::json!({
+            "type": "response.incomplete",
+            "response": {"incomplete_details": {"reason": "max_output_tokens"}}
+        });
+        assert_eq!(
+            response_incomplete_reason(&value).as_deref(),
+            Some("max_output_tokens")
+        );
+
+        let unsafe_value = serde_json::json!({
+            "response": {"incomplete_details": {"reason": "private detail: user text"}}
+        });
+        assert_eq!(
+            response_incomplete_reason(&unsafe_value).as_deref(),
+            Some("unknown")
         );
     }
 }

--- a/qq-maid-llm/src/provider/openai/tool_loop/diagnostics.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/diagnostics.rs
@@ -43,7 +43,7 @@ pub(super) fn sync_responses_stream_diagnostics(
         item.saw_completed = saw_completed;
         item.buffered_delta_count = buffered_delta_count;
         item.buffered_text_chars = buffered_text_chars;
-        item.saw_text_delta = buffered_text_chars > 0 || item.visible_text_chars > 0;
+        item.saw_text_delta |= buffered_text_chars > 0 || item.visible_text_chars > 0;
         item.active_function_call_count = active_function_call_count;
     });
 }

--- a/qq-maid-llm/src/provider/openai/tool_loop/streaming.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/streaming.rs
@@ -11,7 +11,10 @@ use std::{
 use serde_json::{Value, json};
 
 use crate::{
-    agent_loop::{AgentStep, AgentStreamingDiagnostics, AgentTextDeltaSink, AgentToolCall},
+    agent_loop::{
+        AgentStep, AgentStreamingDiagnostics, AgentTextDeltaDelivery, AgentTextDeltaSink,
+        AgentToolCall,
+    },
     error::LlmError,
     metrics::MetricsRecorder,
     sse::{SseFrame, is_ignorable_sse_eof_tail, parse_sse_frame, take_sse_frame},
@@ -25,7 +28,7 @@ use crate::provider::openai::{
     },
     stream::{
         handle_openai_chat_stream_event, is_openai_responses_done_sentinel,
-        responses_stream_is_complete,
+        response_incomplete_reason, responses_event_type, responses_stream_is_complete,
     },
     tool_calls_disabled_error,
 };
@@ -156,10 +159,16 @@ pub(super) async fn collect_responses_tool_loop_stream(
             })? {
                 Some(delta) if allow_tool_calls => buffered_deltas.push(delta),
                 Some(delta) => {
+                    let delta_chars = delta.chars().count();
                     update_streaming_diagnostics(&diagnostics, |item| {
-                        item.visible_text_chars += delta.chars().count();
+                        item.saw_text_delta = true;
                     });
-                    text_delta_sink(delta).await?;
+                    let delivery = text_delta_sink(delta).await?;
+                    if delivery == AgentTextDeltaDelivery::Visible {
+                        update_streaming_diagnostics(&diagnostics, |item| {
+                            item.visible_text_chars += delta_chars;
+                        });
+                    }
                 }
                 None => {}
             }
@@ -332,17 +341,24 @@ pub(super) async fn collect_responses_tool_loop_stream(
 }
 
 fn observe_sse_event(diagnostics: &Arc<Mutex<AgentStreamingDiagnostics>>, event: &SseFrame) {
+    let parsed = (!is_openai_responses_done_sentinel(&event.data))
+        .then(|| serde_json::from_str::<Value>(&event.data).ok())
+        .flatten();
+    // JSON type 是权威协议字段，避免外层 event header 错配污染诊断和正文分类。
     let event_type = if is_openai_responses_done_sentinel(&event.data) {
         Some("[DONE]".to_owned())
     } else {
-        event.event.clone().or_else(|| {
-            serde_json::from_str::<Value>(&event.data)
-                .ok()
-                .and_then(|value| value.get("type").and_then(Value::as_str).map(str::to_owned))
-        })
+        parsed
+            .as_ref()
+            .and_then(|value| value.get("type").and_then(Value::as_str).map(str::to_owned))
+            .or_else(|| event.event.clone())
     };
+    let incomplete_reason = parsed.as_ref().and_then(response_incomplete_reason);
     update_streaming_diagnostics(diagnostics, |item| {
         item.sse_event_count += 1;
+        if incomplete_reason.is_some() {
+            item.incomplete_reason = incomplete_reason;
+        }
         if let Some(event_type) = event_type {
             item.explicit_failure_event |= matches!(
                 event_type.as_str(),
@@ -382,11 +398,7 @@ pub(super) fn observe_responses_function_call_event(
             "sse",
         )
     })?;
-    let event_type = event
-        .event
-        .as_deref()
-        .or_else(|| value.get("type").and_then(Value::as_str))
-        .unwrap_or("");
+    let event_type = responses_event_type(event, &value)?;
     let call_key = function_call_key(&value);
     match event_type {
         "response.output_item.added" => {
@@ -499,16 +511,22 @@ pub(super) async fn finalize_responses_tool_loop_stream(
     }
     if allow_tool_calls {
         if buffered_deltas.is_empty() {
-            update_streaming_diagnostics(&diagnostics, |item| {
-                item.visible_text_chars += answer.chars().count();
-            });
-            text_delta_sink(answer.clone()).await?;
+            let answer_chars = answer.chars().count();
+            let delivery = text_delta_sink(answer.clone()).await?;
+            if delivery == AgentTextDeltaDelivery::Visible {
+                update_streaming_diagnostics(&diagnostics, |item| {
+                    item.visible_text_chars += answer_chars;
+                });
+            }
         } else {
             for delta in buffered_deltas {
-                update_streaming_diagnostics(&diagnostics, |item| {
-                    item.visible_text_chars += delta.chars().count();
-                });
-                text_delta_sink(delta).await?;
+                let delta_chars = delta.chars().count();
+                let delivery = text_delta_sink(delta).await?;
+                if delivery == AgentTextDeltaDelivery::Visible {
+                    update_streaming_diagnostics(&diagnostics, |item| {
+                        item.visible_text_chars += delta_chars;
+                    });
+                }
             }
         }
     }

--- a/qq-maid-llm/src/provider/openai/tool_loop/tests/mod.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/tests/mod.rs
@@ -9,7 +9,8 @@ use super::{
 };
 use crate::{
     agent_loop::{
-        AgentStep, AgentStepSession, AgentTextDeltaFuture, AgentTextDeltaSink, run_agent_loop,
+        AgentStep, AgentStepSession, AgentTextDeltaDelivery, AgentTextDeltaFuture,
+        AgentTextDeltaSink, run_agent_loop,
     },
     context_budget::ContextBudgetConfig,
     error::LlmError,
@@ -43,7 +44,7 @@ fn recording_delta_sink(deltas: Arc<StdMutex<Vec<String>>>) -> AgentTextDeltaSin
         let deltas = deltas.clone();
         Box::pin(async move {
             deltas.lock().unwrap().push(delta);
-            Ok(())
+            Ok(AgentTextDeltaDelivery::Visible)
         }) as AgentTextDeltaFuture
     })
 }

--- a/qq-maid-llm/src/provider/openai/tool_loop/tests/streaming.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/tests/streaming.rs
@@ -55,6 +55,206 @@ async fn streaming_tool_call_does_not_release_buffered_text_delta() {
 }
 
 #[tokio::test]
+async fn responses_tool_events_never_become_visible_text() {
+    let arguments = r#"{"query":"华为手机价格","rawquestion":"继续查具体型号","maxresults":5,"contextsize":"medium","topic":"general","timerange":"month","time_range":"month"}"#;
+    let function_call = json!({
+        "type": "function_call",
+        "id": "fc_1",
+        "name": "web_search",
+        "call_id": "call_search_1",
+        "arguments": arguments
+    });
+    let events = [
+        (
+            "response.output_text.delta",
+            json!({
+                "type": "response.output_text.delta",
+                "delta": "再查一下",
+                "sequence_number": 0,
+                "output_index": 0,
+                "content_index": 0
+            }),
+        ),
+        (
+            "response.output_item.added",
+            json!({
+                "type": "response.output_item.added",
+                "output_index": 1,
+                "sequence_number": 1,
+                "item": {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "name": "web_search",
+                    "call_id": "call_search_1",
+                    "arguments": ""
+                }
+            }),
+        ),
+        (
+            "response.function_call_arguments.delta",
+            json!({
+                "type": "response.function_call_arguments.delta",
+                "output_index": 1,
+                "sequence_number": 2,
+                "delta": arguments
+            }),
+        ),
+        (
+            "response.content_part.done",
+            json!({
+                "type": "response.content_part.done",
+                "output_index": 0,
+                "content_index": 0,
+                "sequence_number": 3,
+                "part": {"type": "output_text", "text": "再查一下"}
+            }),
+        ),
+        (
+            "response.output_item.done",
+            json!({
+                "type": "response.output_item.done",
+                "output_index": 1,
+                "sequence_number": 4,
+                "item": function_call.clone()
+            }),
+        ),
+        (
+            "response.completed",
+            json!({
+                "type": "response.completed",
+                "response": {"output": [function_call]},
+                "sequence_number": 5
+            }),
+        ),
+    ];
+    let body = events
+        .into_iter()
+        .map(|(event_type, value)| format!("event: {event_type}\ndata: {value}\n\n"))
+        .collect::<String>();
+    let base_url = spawn_static_sse_stream(body).await;
+    let mut session = test_streaming_session(base_url);
+    let deltas = Arc::new(StdMutex::new(Vec::new()));
+
+    let step = session
+        .advance_streaming(&[], true, recording_delta_sink(deltas.clone()))
+        .await
+        .unwrap()
+        .unwrap();
+
+    let AgentStep::ToolCalls { calls, .. } = step else {
+        panic!("expected tool calls");
+    };
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].name, "web_search");
+    assert_eq!(calls[0].arguments, arguments);
+    assert!(deltas.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn parallel_function_argument_deltas_stay_isolated_and_invisible() {
+    let calls = (0..3)
+        .map(|index| {
+            json!({
+                "type": "function_call",
+                "name": "web_search",
+                "call_id": format!("call_{index}"),
+                "arguments": format!(r#"{{"query":"phone-{index}","time_range":"month"}}"#)
+            })
+        })
+        .collect::<Vec<_>>();
+    let mut frames = String::new();
+    for index in 0..3 {
+        frames.push_str(&format!(
+            "event: response.output_item.added\ndata: {}\n\n",
+            json!({
+                "type": "response.output_item.added",
+                "output_index": index,
+                "sequence_number": index * 3,
+                "item": {"type": "function_call", "id": format!("fc_{index}")}
+            })
+        ));
+    }
+    for index in 0..3 {
+        frames.push_str(&format!(
+            "event: response.function_call_arguments.delta\ndata: {}\n\n",
+            json!({
+                "type": "response.function_call_arguments.delta",
+                "output_index": index,
+                "sequence_number": index * 3 + 1,
+                "delta": format!(r#"{{"query":"phone-{index}","time_range":"month"}}"#)
+            })
+        ));
+    }
+    for (index, call) in calls.iter().enumerate() {
+        frames.push_str(&format!(
+            "event: response.output_item.done\ndata: {}\n\n",
+            json!({
+                "type": "response.output_item.done",
+                "output_index": index,
+                "sequence_number": index * 3 + 2,
+                "item": call
+            })
+        ));
+    }
+    frames.push_str(&format!(
+        "event: response.completed\ndata: {}\n\n",
+        json!({
+            "type": "response.completed",
+            "response": {"output": calls},
+            "sequence_number": 10
+        })
+    ));
+    let base_url = spawn_static_sse_stream(frames).await;
+    let mut session = test_streaming_session(base_url);
+    let deltas = Arc::new(StdMutex::new(Vec::new()));
+
+    let step = session
+        .advance_streaming(&[], true, recording_delta_sink(deltas.clone()))
+        .await
+        .unwrap()
+        .unwrap();
+
+    let AgentStep::ToolCalls { calls, .. } = step else {
+        panic!("expected parallel tool calls");
+    };
+    assert_eq!(calls.len(), 3);
+    for (index, call) in calls.iter().enumerate() {
+        assert_eq!(call.call_id, format!("call_{index}"));
+        assert_eq!(
+            call.arguments,
+            format!(r#"{{"query":"phone-{index}","time_range":"month"}}"#)
+        );
+    }
+    assert!(deltas.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn response_incomplete_records_structured_reason_without_completion() {
+    let base_url = spawn_static_sse_stream(concat!(
+        "event: response.incomplete\n",
+        "data: {\"type\":\"response.incomplete\",\"response\":{\"status\":\"incomplete\",\"incomplete_details\":{\"reason\":\"max_output_tokens\"},\"output\":[]},\"sequence_number\":7}\n\n",
+    ))
+    .await;
+    let mut session = test_streaming_session(base_url);
+    let deltas = Arc::new(StdMutex::new(Vec::new()));
+
+    let err = session
+        .advance_streaming(&[], true, recording_delta_sink(deltas.clone()))
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.stage, "sse");
+    assert_eq!(err.incomplete_reason(), Some("max_output_tokens"));
+    let diagnostics = session.streaming_diagnostics();
+    assert!(diagnostics.explicit_failure_event);
+    assert_eq!(
+        diagnostics.incomplete_reason.as_deref(),
+        Some("max_output_tokens")
+    );
+    assert!(deltas.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn agent_stream_finishes_on_completed_without_waiting_for_http_eof() {
     let base_url = spawn_never_closing_completed_stream().await;
     let registry = ToolRegistry::new().register(WeatherToolStub).unwrap();

--- a/qq-maid-llm/src/provider/routing.rs
+++ b/qq-maid-llm/src/provider/routing.rs
@@ -16,7 +16,9 @@ use async_trait::async_trait;
 use futures::stream;
 
 use crate::{
-    agent_loop::{AgentStopReason, AgentTextDeltaFuture, AgentTextDeltaSink},
+    agent_loop::{
+        AgentStopReason, AgentTextDeltaDelivery, AgentTextDeltaFuture, AgentTextDeltaSink,
+    },
     error::LlmError,
     provider::{
         DynLlmProvider,
@@ -96,11 +98,13 @@ fn track_visible_final_delta_sink(
             let sink = sink.clone();
             let visible_delta_sent = visible_delta_sent.clone();
             Box::pin(async move {
-                if !delta.is_empty() {
-                    // 候选链共用用户可见流；一旦外发最终回答 delta，就不能再切到后续候选。
+                let has_visible_text = !delta.is_empty();
+                let delivery = sink(delta).await?;
+                if has_visible_text && delivery == AgentTextDeltaDelivery::Visible {
+                    // 候选链共用用户可见流；只有下游确认正文已外发，才禁止切换候选。
                     visible_delta_sent.store(true, Ordering::SeqCst);
                 }
-                sink(delta).await
+                Ok(delivery)
             }) as AgentTextDeltaFuture
         }) as AgentTextDeltaSink
     })
@@ -366,17 +370,33 @@ impl LlmProvider for ModelRouteProvider {
                 Err(err) => {
                     run_handle.set_stop_reason_if_unset(AgentStopReason::Failed);
                     let visible_delta_sent = visible_final_delta_sent.load(Ordering::SeqCst);
+                    let agent_diagnostics = run_handle.snapshot();
                     let tool_side_effect_started = {
-                        let diagnostics = run_handle.snapshot();
+                        let diagnostics = &agent_diagnostics;
                         !diagnostics.side_effecting_tools_started.is_empty()
                             || !diagnostics.tools_with_unknown_result.is_empty()
                     };
                     // 只有可恢复的上游错误才切换候选。本地预算/请求构造错误对等价
                     // payload 必然重复失败，必须原样返回，不能误报为候选 Provider 不可用。
-                    let fallback = index + 1 < candidates.len()
-                        && should_try_next_model(&err)
+                    let has_next_candidate = index + 1 < candidates.len();
+                    let retryable_for_candidate = should_try_next_model(&err);
+                    let fallback = has_next_candidate
+                        && retryable_for_candidate
                         && !visible_delta_sent
                         && !tool_side_effect_started;
+                    let fallback_blocked_reason = if fallback {
+                        "none"
+                    } else if !has_next_candidate {
+                        "no_next_candidate"
+                    } else if !retryable_for_candidate {
+                        "error_not_fallback_eligible"
+                    } else if visible_delta_sent {
+                        "visible_answer_sent"
+                    } else if tool_side_effect_started {
+                        "side_effect_tool_started"
+                    } else {
+                        "unknown"
+                    };
                     tracing::warn!(
                         task,
                         candidate_index = index,
@@ -386,9 +406,13 @@ impl LlmProvider for ModelRouteProvider {
                         error_code = err.code.as_str(),
                         error_stage = err.stage.as_str(),
                         error_kind = model_error_kind(&err),
+                        incomplete_reason = err.incomplete_reason().unwrap_or("none"),
+                        tool_execution_attempted = agent_diagnostics.tool_execution_attempted,
+                        tool_executed = !agent_diagnostics.executed_tools.is_empty(),
                         visible_delta_sent,
                         tool_side_effect_started,
                         fallback,
+                        fallback_blocked_reason,
                         "工具模型候选请求失败"
                     );
                     if visible_delta_sent {

--- a/qq-maid-llm/src/provider/tests/routing.rs
+++ b/qq-maid-llm/src/provider/tests/routing.rs
@@ -299,9 +299,10 @@ async fn model_route_tool_calling_error_after_final_delta_does_not_fallback() {
             .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
             .with_tool_deltas(vec!["partial"])
             .with_tool_results(vec![Err(LlmError::provider(
-                "stream failed after visible delta",
-                "stream_after_delta",
-            ))]),
+                "OpenAI chat stream response incomplete",
+                "sse",
+            )
+            .with_incomplete_reason("max_output_tokens"))]),
     );
     let deepseek = Arc::new(
         MockProvider::new("deepseek", Vec::new())
@@ -325,16 +326,74 @@ async fn model_route_tool_calling_error_after_final_delta_does_not_fallback() {
         let collected = collected.clone();
         Box::pin(async move {
             collected.lock().unwrap().push(delta);
-            Ok(())
+            Ok(crate::agent_loop::AgentTextDeltaDelivery::Visible)
         }) as crate::agent_loop::AgentTextDeltaFuture
     }) as crate::agent_loop::AgentTextDeltaSink);
 
     let err = provider.chat_with_tools(req).await.unwrap_err();
 
-    assert_eq!(err.stage, "stream_after_delta");
+    assert_eq!(err.stage, "sse");
+    assert_eq!(err.incomplete_reason(), Some("max_output_tokens"));
     assert_eq!(deltas.lock().unwrap().as_slice(), ["partial"]);
     assert_eq!(openai.tool_calls(), 1);
     assert_eq!(deepseek.tool_calls(), 0);
+}
+
+#[tokio::test]
+async fn model_route_tool_calling_falls_back_after_buffered_incomplete() {
+    let openai = Arc::new(
+        MockProvider::new("openai", Vec::new())
+            .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+            .with_tool_deltas(vec!["internal tool-round draft"])
+            .with_tool_results(vec![Err(LlmError::provider(
+                "OpenAI chat stream response incomplete",
+                "sse",
+            )
+            .with_incomplete_reason("max_output_tokens"))]),
+    );
+    let deepseek = Arc::new(
+        MockProvider::new("deepseek", Vec::new())
+            .with_tool_protocol(ToolCallingProtocol::ChatCompletionsToolCalls)
+            .with_tool_results(vec![Ok(outcome("clean fallback answer"))]),
+    );
+    let provider = ModelRouteProvider::new(
+        "auto",
+        ModelProvider::OpenAi,
+        ModelRoute::parse_config("openai:gpt-a,deepseek:deepseek-chat", "LLM_MODEL").unwrap(),
+        vec![
+            (ModelProvider::OpenAi, openai.clone()),
+            (ModelProvider::DeepSeek, deepseek.clone()),
+        ],
+    )
+    .unwrap();
+    let buffered = Arc::new(Mutex::new(Vec::new()));
+    let collected = buffered.clone();
+    let handle = AgentRunHandle::default();
+    handle.update(|diagnostics| {
+        diagnostics.tool_execution_attempted = true;
+        diagnostics.executed_tools.push("web_search".to_owned());
+    });
+    let mut req = tool_request();
+    req.run_handle = Some(handle);
+    req.final_delta_sink = Some(Arc::new(move |delta| {
+        let collected = collected.clone();
+        Box::pin(async move {
+            collected.lock().unwrap().push(delta);
+            Ok(crate::agent_loop::AgentTextDeltaDelivery::Buffered)
+        }) as crate::agent_loop::AgentTextDeltaFuture
+    }) as crate::agent_loop::AgentTextDeltaSink);
+
+    let outcome = provider.chat_with_tools(req).await.unwrap();
+
+    assert_eq!(outcome.reply, "clean fallback answer");
+    assert!(outcome.fallback_used);
+    assert_eq!(
+        buffered.lock().unwrap().as_slice(),
+        ["internal tool-round draft"]
+    );
+    assert_eq!(outcome.agent.executed_tools, ["web_search"]);
+    assert_eq!(openai.tool_calls(), 1);
+    assert_eq!(deepseek.tool_calls(), 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## 修改内容

- 收紧 OpenAI Responses SSE 事件分类，只允许结构化 assistant 正文事件产生可见文本；事件 header 与 payload type 冲突或缺失时返回明确 SSE 错误。
- 工具轮前导文本与最终轮草稿保持缓冲，失败或超时时丢弃，避免工具参数、事件索引或未验真文本进入 Core ReplyEvent。
- 将最终 delta 投递结果区分为 `Visible` / `Buffered`，只有正文成功交给下游后才关闭候选 fallback。
- 解析并低敏记录 `response.incomplete.response.incomplete_details.reason`，补充 provider/model、工具执行、可见正文与 fallback 阻断原因诊断。
- 确认 `web_search` schema 只公开规范字段 `time_range`，不公开 `timerange`。

## 根因

Responses 解析过去优先信任 SSE `event:` header，再从任意同名 `delta` 取正文；Core 在工具活动后的 Agent 失败/超时路径又会释放暂存草稿。与此同时，可见 delta 标记在下游 sink 成功前置位，且无法区分缓冲与真实外发，导致 `response.incomplete` 时错误禁止候选降级。

## 影响

工具名称、arguments JSON、function argument delta、sequence/output/content index 与未知 SSE 元数据不再进入用户正文。只发送过工具进度而未发送正式回答时，只读工具候选仍可安全降级；已发送真实正文后的防重复规则保持不变。

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo check --workspace --all-features`
- `cargo test --workspace --all-features`
- `cargo build --workspace --release --all-features`
- `cargo test -p qq-maid-llm`
- Core 工具流定向回归 5 项

真实 QQ C2C 未在本地执行：当前工作区未使用生产凭据或真实用户环境。