### PR TITLE
feat: 在 unknown Slash 兜底前添加 Codex 命令彩蛋

### DIFF
--- a/qq-maid-common/src/command_prefix.rs
+++ b/qq-maid-common/src/command_prefix.rs
@@ -4,6 +4,8 @@
 
 use std::{error::Error, fmt};
 
+use crate::text::is_invisible_format;
+
 pub const DEFAULT_COMMAND_PREFIX: char = '/';
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -146,25 +148,6 @@ fn looks_like_command(remainder: &[char]) -> bool {
 
 fn is_cjk(character: char) -> bool {
     matches!(character, '\u{3400}'..='\u{4dbf}' | '\u{4e00}'..='\u{9fff}')
-}
-
-fn is_invisible_format(character: char) -> bool {
-    matches!(
-        character,
-        '\u{00ad}'
-            | '\u{034f}'
-            | '\u{061c}'
-            | '\u{115f}'..='\u{1160}'
-            | '\u{17b4}'..='\u{17b5}'
-            | '\u{180b}'..='\u{180f}'
-            | '\u{200b}'..='\u{200f}'
-            | '\u{202a}'..='\u{202e}'
-            | '\u{2060}'..='\u{206f}'
-            | '\u{3164}'
-            | '\u{fe00}'..='\u{fe0f}'
-            | '\u{feff}'
-            | '\u{ffa0}'
-    )
 }
 
 #[cfg(test)]

--- a/qq-maid-common/src/text.rs
+++ b/qq-maid-common/src/text.rs
@@ -3,6 +3,37 @@
 //! 现有调用点存在展示文本、RSS 摘要和 Todo 持久化三种边界语义，统一放在这里维护，
 //! 但不强行合并为同一种输出，避免改变用户可见文本或已保存数据。
 
+/// 清理用户可见文本中的控制字符和不可见格式字符。
+///
+/// 控制字符可能破坏单条回复的边界；双向控制符、零宽字符和变体选择符等不可见
+/// 格式字符则可能重排或隐藏后续展示内容。普通空白和可见 Unicode 字符保持不变，
+/// 由调用方按自己的展示语义处理。
+pub fn sanitize_visible_text(text: &str) -> String {
+    text.chars()
+        .filter(|&character| !character.is_control() && !is_invisible_format(character))
+        .collect()
+}
+
+/// 判断字符是否属于会影响文本展示、但自身不可见的 Unicode 格式字符。
+pub fn is_invisible_format(character: char) -> bool {
+    matches!(
+        character,
+        '\u{00ad}'
+            | '\u{034f}'
+            | '\u{061c}'
+            | '\u{115f}'..='\u{1160}'
+            | '\u{17b4}'..='\u{17b5}'
+            | '\u{180b}'..='\u{180f}'
+            | '\u{200b}'..='\u{200f}'
+            | '\u{202a}'..='\u{202e}'
+            | '\u{2060}'..='\u{206f}'
+            | '\u{3164}'
+            | '\u{fe00}'..='\u{fe0f}'
+            | '\u{feff}'
+            | '\u{ffa0}'
+    )
+}
+
 /// 将字符串截断到指定字符数，超出时末尾追加"…"，并沿用 respond 展示层的 trim 语义。
 pub fn truncate_chars_with_ellipsis_trimmed(text: &str, limit: usize) -> String {
     if text.chars().count() <= limit {
@@ -39,6 +70,17 @@ pub fn truncate_chars_trimmed(text: &str, limit: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sanitize_visible_text_removes_controls_and_invisible_formats() {
+        let text = "前\u{0000}中\u{200b}\u{202e}\u{2066}后\u{fe0f}";
+
+        assert_eq!(sanitize_visible_text(text), "前中后");
+        assert!(is_invisible_format('\u{200b}'));
+        assert!(is_invisible_format('\u{202e}'));
+        assert!(is_invisible_format('\u{2066}'));
+        assert!(is_invisible_format('\u{fe0f}'));
+    }
 
     #[test]
     fn ellipsis_trimmed_keeps_short_and_exact_limit_text() {

--- a/qq-maid-core/src/runtime/respond/codex_easter_egg.rs
+++ b/qq-maid-core/src/runtime/respond/codex_easter_egg.rs
@@ -8,93 +8,134 @@ use super::{RespondRequest, RespondResponse, common::command_response};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CodexEasterEgg {
-    Approve,
-    Approvals,
-    Cloud,
-    CloudEnvironment,
-    Diff,
-    Fast,
-    Feedback,
-    Fork,
-    Goal,
-    IdeContext,
-    Init,
-    Local,
-    Mcp,
-    Memories,
-    Model,
-    Pet,
-    Personality,
-    Plan,
-    Project,
-    Reasoning,
+    Static(&'static str),
     Review,
-    Side,
-    Status,
-    Task,
-    Worktree,
 }
+
+struct StaticCodexCommand {
+    name: &'static str,
+    reply: &'static str,
+}
+
+/// 静态彩蛋的命令名和确定性回复必须在同一张表中维护；需要请求上下文的 `/review`
+/// 使用单独策略，避免把动态内容塞进静态映射。
+const STATIC_CODEX_COMMANDS: &[StaticCodexCommand] = &[
+    StaticCodexCommand {
+        name: "approve",
+        reply: "批准了，但没完全批准。",
+    },
+    StaticCodexCommand {
+        name: "approvals",
+        reply: "批准了，但没完全批准。",
+    },
+    StaticCodexCommand {
+        name: "cloud",
+        reply: "云端已就位。天气不负责。",
+    },
+    StaticCodexCommand {
+        name: "cloud-environment",
+        reply: "云环境已选好。大概是晴天。",
+    },
+    StaticCodexCommand {
+        name: "diff",
+        reply: "差异存在，眼神坚定。",
+    },
+    StaticCodexCommand {
+        name: "fast",
+        reply: "快模式已开启。先别问有多快。",
+    },
+    StaticCodexCommand {
+        name: "feedback",
+        reply: "反馈收到，情绪稳定。",
+    },
+    StaticCodexCommand {
+        name: "fork",
+        reply: "分叉成功，平行宇宙自行负责。",
+    },
+    StaticCodexCommand {
+        name: "goal",
+        reply: "目标已锁定。方向感稍后补上。",
+    },
+    StaticCodexCommand {
+        name: "ide-context",
+        reply: "IDE 上下文若隐若现。",
+    },
+    StaticCodexCommand {
+        name: "init",
+        reply: "初始化完成：从想象开始。",
+    },
+    StaticCodexCommand {
+        name: "local",
+        reply: "本地模式：离线但不失联。",
+    },
+    StaticCodexCommand {
+        name: "mcp",
+        reply: "MCP 已连接到想象力服务器。",
+    },
+    StaticCodexCommand {
+        name: "memories",
+        reply: "记忆功能记得自己没开。",
+    },
+    StaticCodexCommand {
+        name: "model",
+        reply: "模型选择困难症已启动。",
+    },
+    StaticCodexCommand {
+        name: "pet",
+        reply: "电子宠物正在假装工作。",
+    },
+    StaticCodexCommand {
+        name: "personality",
+        reply: "人格加载中，请勿拍打。",
+    },
+    StaticCodexCommand {
+        name: "plan",
+        reply: "计划很完整，变化也很完整。",
+    },
+    StaticCodexCommand {
+        name: "project",
+        reply: "项目已选中，需求仍在移动。",
+    },
+    StaticCodexCommand {
+        name: "reasoning",
+        reply: "推理强度：想得挺美。",
+    },
+    StaticCodexCommand {
+        name: "side",
+        reply: "支线聊天已开启，主线假装没看见。",
+    },
+    StaticCodexCommand {
+        name: "status",
+        reply: "状态：还能继续写。大概。",
+    },
+    StaticCodexCommand {
+        name: "task",
+        reply: "任务已创建：继续保持忙碌。",
+    },
+    StaticCodexCommand {
+        name: "worktree",
+        reply: "工作树长出来了，先别浇水。",
+    },
+];
 
 impl CodexEasterEgg {
     fn parse(text: &str) -> Option<Self> {
         let command = text.trim().strip_prefix('/')?.trim_start();
-        let action = command.split_whitespace().next()?.to_ascii_lowercase();
-        Some(match action.as_str() {
-            "approve" => Self::Approve,
-            "approvals" => Self::Approvals,
-            "cloud" => Self::Cloud,
-            "cloud-environment" => Self::CloudEnvironment,
-            "diff" => Self::Diff,
-            "fast" => Self::Fast,
-            "feedback" => Self::Feedback,
-            "fork" => Self::Fork,
-            "goal" => Self::Goal,
-            "ide-context" => Self::IdeContext,
-            "init" => Self::Init,
-            "local" => Self::Local,
-            "mcp" => Self::Mcp,
-            "memories" => Self::Memories,
-            "model" => Self::Model,
-            "pet" => Self::Pet,
-            "personality" => Self::Personality,
-            "plan" => Self::Plan,
-            "project" => Self::Project,
-            "reasoning" => Self::Reasoning,
-            "review" => Self::Review,
-            "side" => Self::Side,
-            "status" => Self::Status,
-            "task" => Self::Task,
-            "worktree" => Self::Worktree,
-            _ => return None,
-        })
+        let action = command.split_whitespace().next()?;
+        if action.eq_ignore_ascii_case("review") {
+            return Some(Self::Review);
+        }
+
+        STATIC_CODEX_COMMANDS
+            .iter()
+            .find(|command| action.eq_ignore_ascii_case(command.name))
+            .map(|command| Self::Static(command.reply))
     }
 
     fn reply(self, req: &RespondRequest) -> String {
         match self {
-            Self::Approve | Self::Approvals => "批准了，但没完全批准。".to_owned(),
-            Self::Cloud => "云端已就位。天气不负责。".to_owned(),
-            Self::CloudEnvironment => "云环境已选好。大概是晴天。".to_owned(),
-            Self::Diff => "差异存在，眼神坚定。".to_owned(),
-            Self::Fast => "快模式已开启。先别问有多快。".to_owned(),
-            Self::Feedback => "反馈收到，情绪稳定。".to_owned(),
-            Self::Fork => "分叉成功，平行宇宙自行负责。".to_owned(),
-            Self::Goal => "目标已锁定。方向感稍后补上。".to_owned(),
-            Self::IdeContext => "IDE 上下文若隐若现。".to_owned(),
-            Self::Init => "初始化完成：从想象开始。".to_owned(),
-            Self::Local => "本地模式：离线但不失联。".to_owned(),
-            Self::Mcp => "MCP 已连接到想象力服务器。".to_owned(),
-            Self::Memories => "记忆功能记得自己没开。".to_owned(),
-            Self::Model => "模型选择困难症已启动。".to_owned(),
-            Self::Pet => "电子宠物正在假装工作。".to_owned(),
-            Self::Personality => "人格加载中，请勿拍打。".to_owned(),
-            Self::Plan => "计划很完整，变化也很完整。".to_owned(),
-            Self::Project => "项目已选中，需求仍在移动。".to_owned(),
-            Self::Reasoning => "推理强度：想得挺美。".to_owned(),
+            Self::Static(reply) => reply.to_owned(),
             Self::Review => review_reply(req),
-            Self::Side => "支线聊天已开启，主线假装没看见。".to_owned(),
-            Self::Status => "状态：还能继续写。大概。".to_owned(),
-            Self::Task => "任务已创建：继续保持忙碌。".to_owned(),
-            Self::Worktree => "工作树长出来了，先别浇水。".to_owned(),
         }
     }
 }

--- a/qq-maid-core/src/runtime/respond/codex_easter_egg.rs
+++ b/qq-maid-core/src/runtime/respond/codex_easter_egg.rs
@@ -1,0 +1,201 @@
+//! Codex 风格 Slash 彩蛋。
+//!
+//! 这里只消费显式白名单并生成确定性短回复，不注册成正式业务命令，也不读取会话、
+//! pending 或任何持久化状态。白名单命中必须由 command dispatcher 放在正式命令之后、
+//! unknown/suppressed 兜底之前处理。
+
+use super::{RespondRequest, RespondResponse, common::command_response};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodexEasterEgg {
+    Approve,
+    Approvals,
+    Cloud,
+    CloudEnvironment,
+    Diff,
+    Fast,
+    Feedback,
+    Fork,
+    Goal,
+    IdeContext,
+    Init,
+    Local,
+    Mcp,
+    Memories,
+    Model,
+    Pet,
+    Personality,
+    Plan,
+    Project,
+    Reasoning,
+    Review,
+    Side,
+    Status,
+    Task,
+    Worktree,
+}
+
+impl CodexEasterEgg {
+    fn parse(text: &str) -> Option<Self> {
+        let command = text.trim().strip_prefix('/')?.trim_start();
+        let action = command.split_whitespace().next()?.to_ascii_lowercase();
+        Some(match action.as_str() {
+            "approve" => Self::Approve,
+            "approvals" => Self::Approvals,
+            "cloud" => Self::Cloud,
+            "cloud-environment" => Self::CloudEnvironment,
+            "diff" => Self::Diff,
+            "fast" => Self::Fast,
+            "feedback" => Self::Feedback,
+            "fork" => Self::Fork,
+            "goal" => Self::Goal,
+            "ide-context" => Self::IdeContext,
+            "init" => Self::Init,
+            "local" => Self::Local,
+            "mcp" => Self::Mcp,
+            "memories" => Self::Memories,
+            "model" => Self::Model,
+            "pet" => Self::Pet,
+            "personality" => Self::Personality,
+            "plan" => Self::Plan,
+            "project" => Self::Project,
+            "reasoning" => Self::Reasoning,
+            "review" => Self::Review,
+            "side" => Self::Side,
+            "status" => Self::Status,
+            "task" => Self::Task,
+            "worktree" => Self::Worktree,
+            _ => return None,
+        })
+    }
+
+    fn reply(self, req: &RespondRequest) -> String {
+        match self {
+            Self::Approve | Self::Approvals => "批准了，但没完全批准。".to_owned(),
+            Self::Cloud => "云端已就位。天气不负责。".to_owned(),
+            Self::CloudEnvironment => "云环境已选好。大概是晴天。".to_owned(),
+            Self::Diff => "差异存在，眼神坚定。".to_owned(),
+            Self::Fast => "快模式已开启。先别问有多快。".to_owned(),
+            Self::Feedback => "反馈收到，情绪稳定。".to_owned(),
+            Self::Fork => "分叉成功，平行宇宙自行负责。".to_owned(),
+            Self::Goal => "目标已锁定。方向感稍后补上。".to_owned(),
+            Self::IdeContext => "IDE 上下文若隐若现。".to_owned(),
+            Self::Init => "初始化完成：从想象开始。".to_owned(),
+            Self::Local => "本地模式：离线但不失联。".to_owned(),
+            Self::Mcp => "MCP 已连接到想象力服务器。".to_owned(),
+            Self::Memories => "记忆功能记得自己没开。".to_owned(),
+            Self::Model => "模型选择困难症已启动。".to_owned(),
+            Self::Pet => "电子宠物正在假装工作。".to_owned(),
+            Self::Personality => "人格加载中，请勿拍打。".to_owned(),
+            Self::Plan => "计划很完整，变化也很完整。".to_owned(),
+            Self::Project => "项目已选中，需求仍在移动。".to_owned(),
+            Self::Reasoning => "推理强度：想得挺美。".to_owned(),
+            Self::Review => review_reply(req),
+            Self::Side => "支线聊天已开启，主线假装没看见。".to_owned(),
+            Self::Status => "状态：还能继续写。大概。".to_owned(),
+            Self::Task => "任务已创建：继续保持忙碌。".to_owned(),
+            Self::Worktree => "工作树长出来了，先别浇水。".to_owned(),
+        }
+    }
+}
+
+pub(super) fn try_respond(text: &str, req: &RespondRequest) -> Option<RespondResponse> {
+    let command = CodexEasterEgg::parse(text)?;
+    Some(command_response(
+        command.reply(req),
+        None,
+        Some("codex_easter_egg"),
+    ))
+}
+
+fn review_reply(req: &RespondRequest) -> String {
+    match review_target(req) {
+        Some(target) => format!("审判官 {target} 已就位：LGTM（大概）"),
+        None => "LGTM（大概）".to_owned(),
+    }
+}
+
+/// 只展示平台已提供的昵称或原始 @ 文本；稳定用户 ID 不得回退成展示内容。
+fn review_target(req: &RespondRequest) -> Option<String> {
+    req.message_context
+        .as_ref()?
+        .mentions
+        .iter()
+        .filter(|mention| !mention.is_self)
+        .find_map(|mention| {
+            mention
+                .target
+                .display_name
+                .as_deref()
+                .or(mention.raw_text.as_deref())
+                .and_then(normalize_review_target)
+        })
+}
+
+fn normalize_review_target(value: &str) -> Option<String> {
+    let value = value.trim().trim_start_matches('@').trim();
+    if value.is_empty() {
+        return None;
+    }
+    let display_name = value
+        .chars()
+        .filter(|ch| !ch.is_control())
+        .take(24)
+        .collect::<String>();
+    (!display_name.is_empty()).then(|| format!("@{display_name}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_codex_whitelist_is_case_insensitive_and_accepts_arguments() {
+        for command in [
+            "approve",
+            "approvals",
+            "cloud",
+            "cloud-environment",
+            "diff",
+            "fast",
+            "feedback",
+            "fork",
+            "goal",
+            "ide-context",
+            "init",
+            "local",
+            "mcp",
+            "memories",
+            "model",
+            "pet",
+            "personality",
+            "plan",
+            "project",
+            "reasoning",
+            "review",
+            "side",
+            "status",
+            "task",
+            "worktree",
+        ] {
+            assert!(
+                CodexEasterEgg::parse(&format!("/{command} 参数")).is_some(),
+                "{command} should be whitelisted"
+            );
+        }
+        assert_eq!(
+            CodexEasterEgg::parse("/REVIEW @用户"),
+            Some(CodexEasterEgg::Review)
+        );
+    }
+
+    #[test]
+    fn registered_and_unknown_commands_are_not_claimed() {
+        for command in ["/new", "/clear", "/compact", "/help", "/unknown"] {
+            assert!(
+                CodexEasterEgg::parse(command).is_none(),
+                "{command} must keep its existing route"
+            );
+        }
+    }
+}

--- a/qq-maid-core/src/runtime/respond/codex_easter_egg.rs
+++ b/qq-maid-core/src/runtime/respond/codex_easter_egg.rs
@@ -4,6 +4,8 @@
 //! pending 或任何持久化状态。白名单命中必须由 command dispatcher 放在正式命令之后、
 //! unknown/suppressed 兜底之前处理。
 
+use qq_maid_common::text::sanitize_visible_text;
+
 use super::{RespondRequest, RespondResponse, common::command_response};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -164,25 +166,23 @@ fn review_target(req: &RespondRequest) -> Option<String> {
         .iter()
         .filter(|mention| !mention.is_self)
         .find_map(|mention| {
-            mention
-                .target
-                .display_name
-                .as_deref()
-                .or(mention.raw_text.as_deref())
-                .and_then(normalize_review_target)
+            [
+                mention.target.display_name.as_deref(),
+                mention.raw_text.as_deref(),
+            ]
+            .into_iter()
+            .flatten()
+            .find_map(normalize_review_target)
         })
 }
 
 fn normalize_review_target(value: &str) -> Option<String> {
+    let value = sanitize_visible_text(value);
     let value = value.trim().trim_start_matches('@').trim();
     if value.is_empty() {
         return None;
     }
-    let display_name = value
-        .chars()
-        .filter(|ch| !ch.is_control())
-        .take(24)
-        .collect::<String>();
+    let display_name = value.chars().take(24).collect::<String>();
     (!display_name.is_empty()).then(|| format!("@{display_name}"))
 }
 
@@ -238,5 +238,23 @@ mod tests {
                 "{command} must keep its existing route"
             );
         }
+    }
+
+    #[test]
+    fn review_target_removes_invisible_formats_before_truncating() {
+        assert_eq!(
+            normalize_review_target("安\u{202e}全\u{200b}昵称\u{2066}"),
+            Some("@安全昵称".to_owned())
+        );
+        assert_eq!(
+            normalize_review_target("\u{200b}@安全昵称"),
+            Some("@安全昵称".to_owned())
+        );
+
+        let padded = format!("{}abcdefghijklmnopqrstuvwx", "\u{200b}".repeat(24));
+        assert_eq!(
+            normalize_review_target(&padded),
+            Some("@abcdefghijklmnopqrstuvwx".to_owned())
+        );
     }
 }

--- a/qq-maid-core/src/runtime/respond/command_dispatcher.rs
+++ b/qq-maid-core/src/runtime/respond/command_dispatcher.rs
@@ -8,6 +8,7 @@ use crate::{error::LlmError, runtime::command::ParsedCommand};
 use super::{
     PlannedRespond, RespondRequest, RespondResponse, RustRespondService,
     chat_flow::PreparedChat,
+    codex_easter_egg,
     common::{command_response, session_error, suppressed_response},
     interaction_state::{
         command_bypasses_pending, prepare_message_context_for_model, respond_interaction_meta,
@@ -124,9 +125,15 @@ impl<'a> CommandDispatcher<'a> {
             )));
         }
 
-        // 未知 Slash 必须在读取 session 和进入 pending 前收口。只有一次性分类确认属于
-        // 已注册命令的输入，才允许继续沿用既有 pending 优先级和命令 handler。
+        // 正式命令始终优先；未注册命令只有命中显式白名单时才返回 Codex 彩蛋。
+        // 两类兜底都在读取 session 和进入 pending 前收口，避免娱乐反馈消费交互状态。
         let registered_slash_command = command_text.and_then(RegisteredSlashCommand::parse);
+        if registered_slash_command.is_none()
+            && let Some(response) =
+                command_text.and_then(|text| codex_easter_egg::try_respond(text, &req))
+        {
+            return Ok(DispatchOutcome::Respond(Box::new(response)));
+        }
         if command_text.is_some() && registered_slash_command.is_none() {
             let response = if req
                 .group_id

--- a/qq-maid-core/src/runtime/respond/mod.rs
+++ b/qq-maid-core/src/runtime/respond/mod.rs
@@ -39,6 +39,7 @@ pub use types::{RespondPurpose, RespondRequest, RespondResponse};
 pub(crate) mod agent_outcome;
 mod agent_route;
 mod chat_flow;
+mod codex_easter_egg;
 mod command_dispatcher;
 pub(crate) mod command_render;
 pub(crate) mod common;

--- a/qq-maid-core/src/runtime/respond/tests/slash_pending.rs
+++ b/qq-maid-core/src/runtime/respond/tests/slash_pending.rs
@@ -112,6 +112,35 @@ async fn unknown_slash_does_not_consume_todo_delete_confirmation() {
 }
 
 #[tokio::test]
+async fn codex_easter_egg_does_not_consume_todo_delete_confirmation() {
+    let provider = MockProvider::new().with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let service = test_service_with_provider_and_tool_calling(provider.clone(), true);
+    let owner = private_todo_owner();
+    let item = completed_todo(&service, &owner, "保留的已完成待办");
+    let pending = save_todo_pending(
+        &service,
+        &private_test_meta(),
+        todo_delete_pending(item.clone(), &owner.key),
+    );
+
+    let response = service.respond(private_message("/status")).await.unwrap();
+
+    assert_eq!(response.text.as_deref(), Some("状态：还能继续写。大概。"));
+    assert_eq!(response.command.as_deref(), Some("codex_easter_egg"));
+    assert_private_pending_unchanged(&service, &pending);
+    assert_eq!(
+        service
+            .task_store
+            .get_by_id(&owner, &item.id)
+            .unwrap()
+            .unwrap()
+            .status,
+        TodoStatus::Completed
+    );
+    assert_provider_unused(&provider);
+}
+
+#[tokio::test]
 async fn unknown_slash_does_not_resume_todo_clarification_tool_loop() {
     let provider = MockProvider::new()
         .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)

--- a/qq-maid-core/src/service/tests/commands.rs
+++ b/qq-maid-core/src/service/tests/commands.rs
@@ -241,6 +241,116 @@ async fn core_unknown_group_slash_is_silent_without_model_call() {
 }
 
 #[tokio::test]
+async fn core_codex_easter_egg_replies_in_unaddressed_group_without_model_call() {
+    let provider =
+        TestProvider::replying("不应调用").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let state = test_state_with_tool_calling(provider.clone(), 5, true);
+    let service = CoreHandle::new(state);
+
+    let classification = service
+        .classify_inbound(group_request("/status"))
+        .await
+        .unwrap();
+    assert_eq!(classification.kind, CoreInboundKind::Immediate);
+
+    let CoreRespondOutput::Complete(response) =
+        service.respond(group_request("/status")).await.unwrap()
+    else {
+        panic!("Codex easter egg should complete synchronously");
+    };
+    assert_eq!(response.text_content(), Some("状态：还能继续写。大概。"));
+    assert_eq!(response.command.as_deref(), Some("codex_easter_egg"));
+    assert!(!response.suppresses_reply());
+    assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn core_codex_easter_egg_does_not_create_session_or_override_registered_command() {
+    let provider = TestProvider::replying("不应调用");
+    let state = test_state(provider.clone(), 5);
+    let session_store = state.stores.session_store.clone();
+    let service = CoreHandle::new(state);
+
+    let CoreRespondOutput::Complete(response) =
+        service.respond(private_request("/model")).await.unwrap()
+    else {
+        panic!("Codex easter egg should complete synchronously");
+    };
+    assert_eq!(response.text_content(), Some("模型选择困难症已启动。"));
+    assert_eq!(response.command.as_deref(), Some("codex_easter_egg"));
+
+    let meta = SessionMeta::new(
+        private_scope(),
+        Some("u1".to_owned()),
+        None,
+        None,
+        None,
+        "qq_official",
+    );
+    assert!(session_store.get_active(&meta).unwrap().is_none());
+
+    let CoreRespondOutput::Complete(registered) =
+        service.respond(private_request("/compact")).await.unwrap()
+    else {
+        panic!("registered compact command should complete synchronously");
+    };
+    assert_eq!(registered.command.as_deref(), Some("compact"));
+    assert_ne!(registered.command.as_deref(), Some("codex_easter_egg"));
+    assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn core_review_easter_egg_uses_safe_mention_name_and_degrades_without_one() {
+    use qq_maid_common::identity_context::{
+        MentionConfidence, MentionIdentity, MessageActorContext,
+    };
+
+    let provider = TestProvider::replying("不应调用");
+    let state = test_state(provider.clone(), 5);
+    let service = CoreHandle::new(state);
+    let mut named = private_request("/review @小明");
+    named.mentions = vec![MentionIdentity {
+        raw_text: Some("@小明".to_owned()),
+        target: MessageActorContext {
+            display_name: Some("小明".to_owned()),
+            source: IdentitySource::TextWeak,
+            ..Default::default()
+        },
+        is_self: false,
+        confidence: MentionConfidence::TextWeak,
+    }];
+
+    let CoreRespondOutput::Complete(named_response) = service.respond(named).await.unwrap() else {
+        panic!("review easter egg should complete synchronously");
+    };
+    assert_eq!(
+        named_response.text_content(),
+        Some("审判官 @小明 已就位：LGTM（大概）")
+    );
+
+    let mut unnamed = private_request("/review");
+    unnamed.mentions = vec![MentionIdentity {
+        raw_text: None,
+        target: MessageActorContext {
+            user_id: Some("sensitive-user-id".to_owned()),
+            source: IdentitySource::Event,
+            ..Default::default()
+        },
+        is_self: false,
+        confidence: MentionConfidence::Event,
+    }];
+    let CoreRespondOutput::Complete(unnamed_response) = service.respond(unnamed).await.unwrap()
+    else {
+        panic!("review easter egg should degrade synchronously");
+    };
+    assert_eq!(unnamed_response.text_content(), Some("LGTM（大概）"));
+    assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
 async fn core_unknown_private_slash_is_deterministic_without_session_or_model_call() {
     let provider = TestProvider::replying("不应调用");
     let state = test_state(provider.clone(), 5);


### PR DESCRIPTION
## 摘要

- 在正式 Slash 命令之后、unknown/suppressed 兜底之前增加显式 Codex 彩蛋白名单。
- 彩蛋只返回短文案，不进入 LLM、Tool Loop、session、pending 或其他持久化路径。
- `/review @用户` 仅展示安全的昵称/原始 @ 文本，无法解析时退化为普通文案。
- 补充正式命令优先、群聊彩蛋、unknown 兜底、pending 隔离和零模型调用回归测试。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p qq-maid-core --all-features --quiet`（1415 项通过）
- `cargo clippy -p qq-maid-core --all-targets --all-features -- -D warnings`
- `cargo check -p qq-maid-core`
- `git diff --check`

Closes #670