### PR TITLE
feat: 新增默认 D20 掷骰命令

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2048,6 +2048,7 @@ dependencies = [
  "chrono",
  "dotenvy",
  "fastembed",
+ "fastrand",
  "feed-rs",
  "futures",
  "html2text",

--- a/qq-maid-core/Cargo.toml
+++ b/qq-maid-core/Cargo.toml
@@ -27,6 +27,8 @@ libc = "0.2"
 dotenvy = "0.15"
 # RSS / Atom feed 解析
 feed-rs = "2.4.0"
+# 娱乐命令使用进程内随机数，不经过模型生成结果。
+fastrand = "2"
 # 可选本地语义召回；默认配置关闭，启用后模型与推理均留在本机。
 fastembed = { version = "5.17.3", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
 # 异步数据流工具

--- a/qq-maid-core/src/runtime/command/mod.rs
+++ b/qq-maid-core/src/runtime/command/mod.rs
@@ -64,6 +64,7 @@ fn normalize_command(command: &str) -> Option<String> {
         "train" | "火车" => "train",
         "weather" | "天气" => "weather",
         "rader" | "radar" | "雷达" => "radar",
+        "roll" => "roll",
         "set" | "设置" => "set",
         "unset" | "取消设置" | "清除设置" => "unset",
         _ => return None,

--- a/qq-maid-core/src/runtime/respond/command_dispatcher.rs
+++ b/qq-maid-core/src/runtime/respond/command_dispatcher.rs
@@ -37,6 +37,7 @@ enum RegisteredSlashCommand {
     Weather(ParsedCommand),
     Train(train_flow::ParsedTrainCommand),
     Radar(ParsedCommand),
+    Roll,
     WebSearch(ParsedCommand),
     Rss,
     Todo,
@@ -69,6 +70,9 @@ impl RegisteredSlashCommand {
         }
         if let Some(command) = crate::runtime::tools::radar::flow::parse_radar_command(text) {
             return Some(Self::Radar(command));
+        }
+        if crate::runtime::tools::roll::parse_roll_command(text).is_some() {
+            return Some(Self::Roll);
         }
         if let Some(command) = search_flow::parse_web_search_command(text) {
             return Some(Self::WebSearch(command));
@@ -150,6 +154,19 @@ impl<'a> CommandDispatcher<'a> {
                 )
             };
             return Ok(DispatchOutcome::Respond(Box::new(response)));
+        }
+
+        // `/roll` 是无状态娱乐命令：在读取 pending/session 前生成一次 D20 结果并收口，
+        // 避免消费交互状态或继续进入普通 Agent / Tool Loop。
+        if matches!(
+            registered_slash_command.as_ref(),
+            Some(RegisteredSlashCommand::Roll)
+        ) {
+            return Ok(DispatchOutcome::Respond(Box::new(command_response(
+                crate::runtime::tools::roll::roll_default_reply(),
+                None,
+                Some("roll"),
+            ))));
         }
 
         // pending、Todo 可见编号和 Memory 列表序号属于群内个人交互状态；

--- a/qq-maid-core/src/runtime/respond/help.rs
+++ b/qq-maid-core/src/runtime/respond/help.rs
@@ -38,6 +38,14 @@ const HELP_MODULES: &[HelpModule] = &[
         notes: &["- 需要保存长期信息时，可直接说“记住……”或使用 `/memory 内容`。"],
     },
     HelpModule {
+        key: "fun",
+        aliases: &["娱乐", "roll", "掷骰"],
+        title: "🎲 娱乐",
+        summary: "提供不经过模型的本地娱乐命令。",
+        commands: &["- `/roll`：掷 D20"],
+        notes: &["- 当前只支持无参数 `/roll`；骰子结果由程序运行时直接生成。"],
+    },
+    HelpModule {
         key: "todo",
         aliases: &["待办", "任务"],
         title: "✅ 待办",
@@ -266,6 +274,10 @@ fn format_help_home(context: HelpContext) -> CommandBody {
         );
     }
     render.push_pair(
+        "· 🎲 娱乐：/roll".to_owned(),
+        "- 🎲 娱乐：`/roll`".to_owned(),
+    );
+    render.push_pair(
         "· 📰 RSS / Atom：/rss".to_owned(),
         "- 📰 RSS / Atom：`/rss`".to_owned(),
     );
@@ -312,8 +324,8 @@ fn format_help_home(context: HelpContext) -> CommandBody {
         "- `/help <模块>`：查看模块用法".to_owned(),
     );
     render.push_pair(
-        "· 常用模块：chat、todo、rss、weather、search".to_owned(),
-        "- 常用模块：`chat`、`todo`、`rss`、`weather`、`search`".to_owned(),
+        "· 常用模块：chat、fun、todo、rss、weather、search".to_owned(),
+        "- 常用模块：`chat`、`fun`、`todo`、`rss`、`weather`、`search`".to_owned(),
     );
     render.push_pair(
         "· 更多模块：translation、memory、session、settings、voice、status、ops".to_owned(),

--- a/qq-maid-core/src/runtime/respond/tests/session/help.rs
+++ b/qq-maid-core/src/runtime/respond/tests/session/help.rs
@@ -17,6 +17,7 @@ async fn help_without_argument_returns_concise_overview() {
     assert!(!text.contains("`/rss test RSS地址`"));
     // 纯文本侧不能带反引号，否则 QQ 纯文本渲染会吞掉命令内容
     assert!(text.contains("✅ 待办：/todo"));
+    assert!(text.contains("🎲 娱乐：/roll"));
     assert!(text.contains("🩺 状态：私聊发送 /ping"));
     assert!(!text.contains('`'));
     assert!(markdown.starts_with("# 女仆长助手"));
@@ -79,6 +80,7 @@ async fn help_all_lists_public_commands_by_module() {
 
     for heading in [
         "💬 对话",
+        "🎲 娱乐",
         "✅ 待办",
         "📰 RSS / Atom",
         "🌤 天气",
@@ -97,6 +99,7 @@ async fn help_all_lists_public_commands_by_module() {
     }
     for command in [
         "/todo undo",
+        "/roll",
         "/todo daily status",
         "/rss recent",
         "/rss add",

--- a/qq-maid-core/src/runtime/tools/knowledge/storage/mod.rs
+++ b/qq-maid-core/src/runtime/tools/knowledge/storage/mod.rs
@@ -941,14 +941,15 @@ fn decode_vector(bytes: &[u8]) -> Option<Vec<f32>> {
     if !bytes.len().is_multiple_of(std::mem::size_of::<f32>()) {
         return None;
     }
+    let (chunks, remainder) = bytes.as_chunks::<{ std::mem::size_of::<f32>() }>();
+    debug_assert!(
+        remainder.is_empty(),
+        "validated vector bytes have no remainder"
+    );
     Some(
-        bytes
-            .chunks_exact(std::mem::size_of::<f32>())
-            .map(|chunk| {
-                let bytes: [u8; std::mem::size_of::<f32>()] =
-                    chunk.try_into().expect("chunks_exact keeps f32 width");
-                f32::from_le_bytes(bytes)
-            })
+        chunks
+            .iter()
+            .map(|chunk| f32::from_le_bytes(*chunk))
             .collect(),
     )
 }

--- a/qq-maid-core/src/runtime/tools/mod.rs
+++ b/qq-maid-core/src/runtime/tools/mod.rs
@@ -9,6 +9,7 @@ pub mod knowledge;
 pub mod memory;
 pub mod ops;
 pub(crate) mod radar;
+pub(crate) mod roll;
 pub mod rss;
 pub(crate) mod search;
 pub(crate) mod status;

--- a/qq-maid-core/src/runtime/tools/roll/mod.rs
+++ b/qq-maid-core/src/runtime/tools/roll/mod.rs
@@ -1,0 +1,62 @@
+//! 骰子 Slash 命令领域逻辑。
+//!
+//! 随机数只在 Core 进程内生成，命令分派层只负责确定性收口和响应投影。
+
+use crate::runtime::command::parse_slash_command;
+
+const DEFAULT_DIE_SIDES: u8 = 20;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RollCommand;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RollResult {
+    value: u8,
+    sides: u8,
+}
+
+/// 仅注册本次明确支持的无参数 `/roll`；其它骰子表达式继续走统一未知命令兜底。
+pub(crate) fn parse_roll_command(text: &str) -> Option<RollCommand> {
+    let command = parse_slash_command(text)?;
+    (command.action == "roll" && command.argument.is_empty()).then_some(RollCommand)
+}
+
+/// 执行默认 D20，并生成由命令层直接返回的简短回执。
+pub(crate) fn roll_default_reply() -> String {
+    let mut rng = fastrand::Rng::new();
+    let result = roll_default_with_rng(&mut rng);
+    format!("🎲 掷出了 {} / {}", result.value, result.sides)
+}
+
+fn roll_default_with_rng(rng: &mut fastrand::Rng) -> RollResult {
+    RollResult {
+        value: rng.u8(1..=DEFAULT_DIE_SIDES),
+        sides: DEFAULT_DIE_SIDES,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_argument_roll_is_recognized_without_claiming_other_commands() {
+        assert_eq!(parse_roll_command("/roll"), Some(RollCommand));
+        assert_eq!(parse_roll_command("  /ROLL  "), Some(RollCommand));
+        assert_eq!(parse_roll_command("/roll 100"), None);
+        assert_eq!(parse_roll_command("/help"), None);
+        assert_eq!(parse_roll_command("普通消息"), None);
+    }
+
+    #[test]
+    fn default_roll_uses_d20_and_stays_in_inclusive_range() {
+        // 固定种子只验证范围不变量，不断言多次结果必须不同，避免概率性测试。
+        let mut rng = fastrand::Rng::with_seed(20);
+        for _ in 0..4_096 {
+            let result = roll_default_with_rng(&mut rng);
+            assert_eq!(result.sides, 20);
+            assert!(result.value >= 1, "roll must not be less than 1");
+            assert!(result.value <= 20, "roll must not be greater than 20");
+        }
+    }
+}

--- a/qq-maid-core/src/service/tests/commands.rs
+++ b/qq-maid-core/src/service/tests/commands.rs
@@ -266,6 +266,57 @@ async fn core_codex_easter_egg_replies_in_unaddressed_group_without_model_call()
 }
 
 #[tokio::test]
+async fn core_roll_defaults_to_d20_and_is_consumed_without_model_or_session() {
+    let provider =
+        TestProvider::replying("不应调用").with_tool_protocol(ToolCallingProtocol::OpenAiResponses);
+    let state = test_state_with_tool_calling(provider.clone(), 5, true);
+    let session_store = state.stores.session_store.clone();
+    let service = CoreHandle::new(state);
+
+    let classification = service
+        .classify_inbound(private_request("/roll"))
+        .await
+        .unwrap();
+    assert_eq!(classification.kind, CoreInboundKind::Immediate);
+
+    let CoreRespondOutput::Complete(response) =
+        service.respond(private_request("/roll")).await.unwrap()
+    else {
+        panic!("roll command should complete synchronously");
+    };
+    let assert_d20_reply = |response: &CoreResponse| {
+        let text = response.text_content().expect("roll should return text");
+        let value = text
+            .strip_prefix("🎲 掷出了 ")
+            .and_then(|text| text.strip_suffix(" / 20"))
+            .and_then(|value| value.parse::<u8>().ok())
+            .expect("roll reply should contain a D20 value");
+        assert!((1..=20).contains(&value));
+        assert_eq!(response.command.as_deref(), Some("roll"));
+    };
+    assert_d20_reply(&response);
+
+    let CoreRespondOutput::Complete(group_response) =
+        service.respond(group_request("/roll")).await.unwrap()
+    else {
+        panic!("group roll command should complete synchronously");
+    };
+    assert_d20_reply(&group_response);
+
+    let meta = SessionMeta::new(
+        private_scope(),
+        Some("u1".to_owned()),
+        None,
+        None,
+        None,
+        "qq_official",
+    );
+    assert!(session_store.get_active(&meta).unwrap().is_none());
+    assert_eq!(provider.tool_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
 async fn core_codex_easter_egg_does_not_create_session_or_override_registered_command() {
     let provider = TestProvider::replying("不应调用");
     let state = test_state(provider.clone(), 5);


### PR DESCRIPTION
## 变更说明

- 注册正式 `/roll` Slash Command，无参数时投掷一次 D20
- 在 Core 命令层直接生成并返回 1～20 的结果，不进入 session、pending、LLM 或 Tool Loop
- 在帮助中补充娱乐命令入口，并覆盖解析、范围、私聊/群聊消费和模型零调用测试

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features --quiet`
- `cargo check --workspace --all-features`
- `cargo build --workspace --release --all-features`