### PR TITLE
release: 准备 v0.24.2 发布

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 * 根包 `qq-maid-bot` 提升到 `0.24.2`，本次实际变更的 `qq-maid-core` 提升到 `0.1.26`；`qq-maid-common`、`qq-maid-gateway-rs` 和 `qq-maid-llm` 版本保持不变。
 * 本版本不新增 SQLite migration、配置迁移、必填环境变量或运行时入口；不支持 `1d20+3` 等修正值、角色属性、加值和优势/劣势规则。升级前仍建议按常规备份运行配置、数据库和主密钥。
+
 ## [v0.24.1] - 2026-08-21
 
 ### Release Focus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 本文档基于 [keep a changelog](https://keepachangelog.com/zh-CN/1.0.0/) 格式，记录每个已发布版本的变更。
 
+## [v0.24.2] - 2026-08-21
+
+### Release Focus
+
+* **轻量骰子与 AI DM 判定**：将 `/roll` 从无参数 D20 扩展为本地 `dM` / `NdM` 表达式和带自然语言问题的独立 AI DM 判定，同时保持骰值由服务端生成、结果可验证并具备安全降级路径。
+
+### Added
+
+* **简单骰子表达式**（PR #679）：支持 `/roll d100`、`/roll 2d6` 等完整 `dM` / `NdM` 表达式，骰子个数和面数均限制为 1–100；本地路径不调用 Provider，不进入 session、pending 或 Tool Loop。
+* **AI DM D20 判定**（PR #679）：`/roll <问题>` 使用一次独立的普通模型调用生成严格判定方案，支持 `ability` / `fortune`、六档难度与固定 DC 映射；Core 校验方案后才生成 D20 并本地结算成功、失败、Natural 20 和 Natural 1。
+
+### Changed
+
+* **骰值生成与调用边界**（PR #679）：生产骰值改用线程级 CSPRNG 的均匀范围采样；AI DM 请求不接收实际骰值，也不进入普通 Agent Tool Loop、session 或 pending。AI DM 的内部超时按整轮请求预算裁剪，并为本地回退保留收口时间。
+* **结构化输出兼容**（PR #679）：仅兼容完整合法 JSON 外层的 `json`、`JSON` 或无语言标记代码块，不从解释文本中截取对象；帮助页同步说明表达式格式和限制。
+
+### Fixed
+
+* **骰子表达式误入 AI DM**（PR #679）：带空格的 `1d20 + 3`、`2d6 - 1` 等完整修正表达式会明确返回暂不支持，不再被误判为自然语言问题触发模型调用；越界、零值和其他未知字段同样不会伪造结果。
+* **AI DM 失败回退**（PR #679）：Provider 错误、超时或非法结构化输出时明确回退到普通本地 D20，不伪造 DC、成功状态或模型文案；诊断保留实际执行类型、Provider、模型和回退原因。
+
+### Compatibility
+
+* 根包 `qq-maid-bot` 提升到 `0.24.2`，本次实际变更的 `qq-maid-core` 提升到 `0.1.26`；`qq-maid-common`、`qq-maid-gateway-rs` 和 `qq-maid-llm` 版本保持不变。
+* 本版本不新增 SQLite migration、配置迁移、必填环境变量或运行时入口；不支持 `1d20+3` 等修正值、角色属性、加值和优势/劣势规则。升级前仍建议按常规备份运行配置、数据库和主密钥。
 ## [v0.24.1] - 2026-08-21
 
 ### Release Focus

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2006,7 +2006,7 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "qq-maid-bot"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "qq-maid-core",
@@ -2036,7 +2036,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-core"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "ammonia",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-bot"
-version = "0.24.1"
+version = "0.24.2"
 edition = "2024"
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 > 💡 仓库早期以 QQ 机器人为主，因此仍保留 `qq-maid-bot` 名称。当前项目正在从 QQ 官方机器人演进为多入口平台型小女仆机器人。
 
-当前稳定版本为 `v0.24.1`，项目处于 `24.x` 版本线；版本线能力与升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)。
+当前稳定版本为 `v0.24.2`，项目处于 `24.x` 版本线；版本线能力与升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)。
 
 使用、安装和配置优先看 [项目 Wiki](https://github.com/kuliantnt/qq-maid-bot/wiki)：从第一次对话、一键安装、Docker / GHCR、配置中心与 `/console/` 首次向导，到 NapCat、`/ops` 运维和 Codex 长任务，都按场景拆开了。仓库内 `docs/` 与各 crate README 更偏开发边界和实现细节。
 
@@ -133,11 +133,12 @@ runtime/botctl.sh status
 
 ## 24.x 版本线更新
 
-当前稳定版本为 `v0.24.1`。需要查看本版本线的详细变更和配置迁移提示时，再展开下面的更新记录：
+当前稳定版本为 `v0.24.2`。需要查看本版本线的详细变更和配置迁移提示时，再展开下面的更新记录：
 
 <details>
 <summary>展开查看 24.x 版本更新</summary>
 
+- **AI DM D20 判定与简单骰子表达式**（v0.24.2，PR #679）：`/roll d100`、`/roll 2d6` 等 `dM` / `NdM` 表达式由 Core 本地结算；`/roll <问题>` 由独立 AI DM 先制定并校验判定方案，再由 Core 使用 CSPRNG 掷骰和确定性模板结算。AI DM 看不到骰值，Provider 异常、超时或非法输出会明确降级为普通本地 D20。
 - **默认 D20 娱乐命令**（v0.24.1，PR #676）：私聊或群聊发送 `/roll` 即可由程序本地掷出 1–20；不调用模型、不创建 session，也不消费 pending 状态。
 - **Memory 管理与 Agent 回执收口**（v0.24.0）：部署管理员可在 Web Console 中分页筛选、创建、编辑、归档和恢复 Memory，高影响操作使用 opaque reference、版本校验与二次确认；自然语言 Agent 统一可信工具结果与最终正文，未完成工具轮次不再伪装成功，并新增不进入模型链路的 Codex Slash 彩蛋与完整中文星期展示。
 
@@ -216,6 +217,9 @@ v0.20.x 起推荐新部署通过 `/console/` 网页完成配置，也可在安�
 
 你：/roll
 机器人：🎲 掷出了 17 / 20
+
+你：/roll 2d6
+机器人：🎲 2d6：4 + 5 = 9
 
 管理员：/ops status
 机器人：运维任务 status 已受理，完成后会通知你。

--- a/qq-maid-core/Cargo.toml
+++ b/qq-maid-core/Cargo.toml
@@ -1,7 +1,7 @@
 # qq-maid-core 项目清单 —— 定义包元信息和依赖项。
 [package]
 name = "qq-maid-core"
-version = "0.1.25"
+version = "0.1.26"
 edition = "2024"
 
 # 主运行依赖


### PR DESCRIPTION
## 发布内容

- 根包版本提升到 `0.24.2`
- `qq-maid-core` 提升到 `0.1.26`
- README / CHANGELOG 补充 `/roll` 简单骰子表达式与 AI DM 判定说明
- 本版本无 SQLite migration、配置迁移或必填环境变量

## 验证

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace --release --all-features`

Wiki 已在独立仓库同步更新，待本发布 PR 合并后即可创建 `v0.24.2` tag / Release。