### PR TITLE
fix: 修复 Slash 命令被天气快捷匹配抢占

### DIFF
--- a/qq-maid-core/src/runtime/respond/command_dispatcher.rs
+++ b/qq-maid-core/src/runtime/respond/command_dispatcher.rs
@@ -62,9 +62,6 @@ impl RegisteredSlashCommand {
         if let Some(command) = parse_unset_command(text) {
             return Some(Self::Unset(command));
         }
-        if let Some(command) = weather_flow::parse_weather_command(text) {
-            return Some(Self::Weather(command));
-        }
         if let Some(command) = train_flow::parse_train_command(text) {
             return Some(Self::Train(command));
         }
@@ -83,7 +80,13 @@ impl RegisteredSlashCommand {
         if should_try_todo_flow(text) {
             return Some(Self::Todo);
         }
-        memory_flow::parse_memory_command(text).map(|_| Self::Memory)
+        if memory_flow::parse_memory_command(text).is_some() {
+            return Some(Self::Memory);
+        }
+
+        // 天气解析器同时兼容 `/城市天气` 这一快捷形式，不能在这里提前接管
+        // `/roll ...天气`、`/查 ...天气` 等显式 Slash 命令的参数。
+        weather_flow::parse_weather_command(text).map(Self::Weather)
     }
 }
 
@@ -460,5 +463,57 @@ impl<'a> CommandDispatcher<'a> {
             respond_route,
             status_hint,
         })))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn command_kind(text: &str) -> &'static str {
+        match RegisteredSlashCommand::parse(text) {
+            Some(RegisteredSlashCommand::Session(_)) => "session",
+            Some(RegisteredSlashCommand::Translation(_)) => "translation",
+            Some(RegisteredSlashCommand::Set(_)) => "set",
+            Some(RegisteredSlashCommand::Unset(_)) => "unset",
+            Some(RegisteredSlashCommand::Weather(_)) => "weather",
+            Some(RegisteredSlashCommand::Train(_)) => "train",
+            Some(RegisteredSlashCommand::Radar(_)) => "radar",
+            Some(RegisteredSlashCommand::Roll(_)) => "roll",
+            Some(RegisteredSlashCommand::WebSearch(_)) => "web_search",
+            Some(RegisteredSlashCommand::Rss) => "rss",
+            Some(RegisteredSlashCommand::Todo) => "todo",
+            Some(RegisteredSlashCommand::Memory) => "memory",
+            Some(RegisteredSlashCommand::Voice(_)) => "voice",
+            None => "none",
+        }
+    }
+
+    #[test]
+    fn explicit_slash_commands_precede_weather_shortcut() {
+        let cases = [
+            ("/语音 明天天气", "voice"),
+            ("/help 明天天气", "session"),
+            ("/翻译 明天天气", "translation"),
+            ("/set 昵称 明天天气", "set"),
+            ("/unset 昵称天气", "unset"),
+            ("/train G123天气", "train"),
+            ("/rader codex天气", "radar"),
+            ("/roll 明天有个好天气", "roll"),
+            ("/查 杭州天气", "web_search"),
+            ("/rss list天气", "rss"),
+            ("/todo list天气", "todo"),
+            ("/memory list天气", "memory"),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(command_kind(input), expected, "{input}");
+        }
+    }
+
+    #[test]
+    fn weather_shortcut_remains_available_after_explicit_commands() {
+        assert_eq!(command_kind("/天气杭州"), "weather");
+        assert_eq!(command_kind("/杭州天气"), "weather");
     }
 }

--- a/qq-maid-core/src/runtime/respond/tests/agent_turn/weather.rs
+++ b/qq-maid-core/src/runtime/respond/tests/agent_turn/weather.rs
@@ -459,3 +459,23 @@ async fn only_weather_tool_keeps_model_reply_as_primary() {
     assert_eq!(diagnostics["tool_outcomes"][0]["domain"], "weather");
     assert_eq!(diagnostics["tool_outcomes"][0]["presentation"], "trusted");
 }
+
+#[tokio::test]
+async fn plain_weather_shortcut_keeps_weather_tool_behavior() {
+    let inspector = MockProvider::new()
+        .with_tool_protocol(ToolCallingProtocol::OpenAiResponses)
+        .with_tool_call_json(
+            "get_weather",
+            r#"{"city":"明天","forecast_days":3}"#,
+            "明天天气如下",
+        );
+    let service = test_service_with_provider_and_tool_calling(inspector.clone(), true);
+
+    let response = service.respond(private_message("明天天气")).await.unwrap();
+
+    assert_eq!(response.text.as_deref(), Some("明天天气如下"));
+    assert_eq!(response.command.as_deref(), Some("weather"));
+    assert_eq!(inspector.tool_call_count(), 1);
+    let diagnostics = response.diagnostics.unwrap();
+    assert_eq!(diagnostics["tool_outcomes"][0]["domain"], "weather");
+}

--- a/qq-maid-core/src/runtime/respond/tests/weather.rs
+++ b/qq-maid-core/src/runtime/respond/tests/weather.rs
@@ -123,6 +123,34 @@ async fn weather_command_accepts_city_weather_suffix() {
 }
 
 #[tokio::test]
+async fn explicit_roll_command_is_not_taken_by_weather_shortcut() {
+    let weather_calls = Arc::new(AtomicUsize::new(0));
+    let (service, _) = test_service_with_provider_base_title_query_weather_train_models_and_options(
+        MockProvider::new(),
+        None,
+        Arc::new(MockWebSearchExecutor),
+        Arc::new(MockWeatherExecutor::with_counter(weather_calls.clone())),
+        Arc::new(MockTrainExecutor::new()),
+        TestModelOptions::default(),
+        TestToolCallingOptions::default(),
+    );
+
+    let response = service
+        .respond(message("/roll 明天有个好天气"))
+        .await
+        .unwrap();
+
+    assert_eq!(response.command.as_deref(), Some("roll"));
+    assert!(
+        response
+            .text
+            .as_deref()
+            .is_some_and(|text| { text.starts_with("AI DM 暂时无法判断本次检定难度") })
+    );
+    assert_eq!(weather_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
 async fn weather_command_ignores_plain_city_weather_suffix() {
     let provider_calls = Arc::new(AtomicUsize::new(0));
     let weather_calls = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
## 变更说明

修复天气快捷解析抢占显式 Slash 命令的问题。天气解析器支持 `/城市天气` 后缀形式，原先在其他 Slash parser 之前执行，导致 `/roll 明天有个好天气` 被识别为 Weather。

现在统一按以下优先级处理：

显式 Slash Command → 天气快捷匹配 → 其他处理流程

未修改 `/roll` 的骰子、AI DM 或降级规则。

## 验证

- `/roll 明天有个好天气`：返回 Roll，Weather 执行器调用次数为 0
- `明天天气`：保持 Weather Tool 行为
- `/天气杭州`、`/杭州天气`：现有天气快捷行为通过
- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features --quiet`
- `cargo check -p qq-maid-core`
- `cargo clippy -p qq-maid-core --all-targets --all-features -- -D warnings`