### PR TITLE
fix: 修复周易结果会话引用

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 想直接使用骰点功能，可查看 [骰子使用教程](./docs/guides/dice.md)。
 
-想试试周易起卦，可发送 `/算卦`（别名 `/iching`）；这是不调用模型的本地无状态命令，完整使用说明见 Wiki [使用说明](https://github.com/kuliantnt/qq-maid-bot/wiki/使用说明)。
+想试试周易起卦，可发送 `/算卦`（别名 `/iching`）；这是不调用模型的本地确定性命令，结果会作为当前会话回执保存，之后可以直接追问，完整使用说明见 Wiki [使用说明](https://github.com/kuliantnt/qq-maid-bot/wiki/使用说明)。
 
 ## 快速开始
 
@@ -142,7 +142,7 @@ runtime/botctl.sh status
 <details>
 <summary>展开查看 24.x 版本更新</summary>
 
-- **周易起卦命令**（v0.24.5，PR #687）：发送 `/算卦` 或 `/iching` 使用固定六轮三钱法（`3d2+3`）在本地起卦，展示六爻、本卦、动爻、之卦和卦辞/译文/注释；不调用模型、不进入 session、pending 或 Tool Loop，带参数形式静默忽略。
+- **周易起卦命令**（v0.24.5，PR #687）：发送 `/算卦` 或 `/iching` 使用固定六轮三钱法（`3d2+3`）在本地起卦，展示六爻、本卦、动爻、之卦和卦辞/译文/注释；不调用模型、不进入 pending 或 Tool Loop，结果作为当前会话回执保存，后续可用自然语言继续追问，带参数形式静默忽略。
 - **DND / CoC 骰子规则偏好与 fallback 修复**（v0.24.4，PR #686）：`.set dnd` / `.set coc` 按 conversation 保存默认骰式，分别使用 D20 / D100 和对应的判定方向；AI DM 超时、Provider 错误或非法结构化输出时，fallback 文案从实际 `RollResult` 派生，CoC 不再显示矛盾的 D20，显式骰式仍保持“指定骰子表达式投掷”。
 - **AI DM D20 判定与简单骰子表达式**（v0.24.2，PR #679）：`/roll d100`、`/roll 2d6` 等 `dM` / `NdM` 表达式由 Core 本地结算；`/roll <问题>` 由独立 AI DM 先制定并校验判定方案，再由 Core 使用 CSPRNG 掷骰和确定性模板结算。AI DM 看不到骰值，Provider 异常、超时或非法输出会明确降级为普通本地 D20。
 - **通用骰子表达式与 SealDice 兼容**（v0.24.3，PR #683）：支持修正、多段骰子、重复投掷、取骰、优势/劣势、奖励/惩罚骰，以及 `/r`、`/rd`、`/rap`、`/rab`、`/r2d6`、`.r2d6` 等常见写法。`/r` / `/rd` 尾随文本只作为本地原因；只有 `/roll <骰式> <问题>` 进入 Entertainment DM。完整示例与限制见 [骰子使用教程](./docs/guides/dice.md)。

--- a/qq-maid-core/README.md
+++ b/qq-maid-core/README.md
@@ -110,7 +110,7 @@ Todo 管理接口复用同一管理员 Session、同源和 CSRF 安全边界，�
 
 - 会话：`/new`、`/rename`、`/resume`、`/clear`、`/state`、`/compact`、`/help`。`/list` 仅作为 deprecated 兼容别名保留，推荐 `/resume` 或 `/恢复`。
 - 娱乐：`/roll`（别名 `/r`、`/rd`）无参数时使用当前 conversation 的默认骰，常用表达式、`N#expr` 多轮、`k/q` 取骰和优势/劣势也在 Core 本地解析、掷骰和结算；`/r d50 开锁`、`/r2d6xxx` 的尾随文本仅作为骰点原因展示，不调用模型。`.set dnd` 使用 D20/roll-over，`.set coc` 使用 D100/roll-under，裸 `d`（包括 `.r2#d+1`）跟随该持久化设置；这不等于启用完整 DND5E/CoC7 规则。奖励/惩罚骰可用 `/rab` / `/rap`，玩家展示名沿用 `/set 昵称`，也可用 `/nn emmm` 或 `.nn emmm`；默认前缀下点号命令与 slash 命令由同一条 Core 命令通道处理。带自然语言问题的 `/roll <骰子表达式> <问题>` 保留为显式 Entertainment DM，AI 只选择 difficulty，Core 再按当前规则的比较方向计算阈值并掷骰；本地骰点、原因和多轮路径都不进入普通 session 或 Tool Loop，也不调用模型。
-- 周易：`/算卦`（别名 `/iching`）使用固定六轮三钱法在 Core 本地计算 64 卦、动爻和之卦，并返回卦辞、译文与注释；只接受无参数形式，带参数命令静默忽略，不调用 Provider、不进入 session、pending 或 Tool Loop。
+- 周易：`/算卦`（别名 `/iching`）使用固定六轮三钱法在 Core 本地计算 64 卦、动爻和之卦，并返回卦辞、译文与注释；只接受无参数形式，带参数命令静默忽略，不调用 Provider、不进入 pending 或 Tool Loop，结果写入当前 conversation session 供后续自然语言引用。
 - 记忆：`/memory`、`/memory 内容`、`/memory show 1`、`/memory edit 1 新内容`、`/memory delete 1`；中文别名 `/记忆`、`/记`。
 - 待办：slash 入口只保留查询（`/todo`、`/todo all`、`/todo search 关键词`、`/todo done`、`/todo undo`；中文别名 `/待办`、`/任务`），新增、完成、恢复、修改、取消和永久删除请直接用自然语言触发 Todo Tool。火车时刻请使用 `/火车 车次 [日期]` 查询。
 - RSS：`/rss`、`/rss recent [数量]`、`/rss add RSS地址 [名称]`、`/rss delete 1`、`/rss test RSS地址`；中文别名 `/订阅`。

--- a/qq-maid-core/src/runtime/respond/command_dispatcher.rs
+++ b/qq-maid-core/src/runtime/respond/command_dispatcher.rs
@@ -192,9 +192,9 @@ impl<'a> CommandDispatcher<'a> {
             return Ok(DispatchOutcome::Respond(Box::new(response)));
         }
 
-        // `/算卦` 是无状态确定性命令；起卦在读取 pending/session 前完成，避免把
-        // 原文数据或骰值计算送入普通 Agent / Tool Loop。带参数的算卦命令也在这里
-        // 静默收口，不能继续落入天气快捷解析。
+        // `/算卦` 仍在 pending/Tool Loop 分派前本地完成，避免把原文数据或骰值计算
+        // 送入普通 Agent / Tool Loop；但已渲染的结果要作为会话回执保存，供下一轮
+        // 自然语言继续引用。带参数的算卦命令在这里静默收口，不能继续落入天气快捷解析。
         if matches!(
             registered_slash_command,
             Some(RegisteredSlashCommand::IChingIgnored)
@@ -204,9 +204,24 @@ impl<'a> CommandDispatcher<'a> {
             ))));
         }
         if let Some(RegisteredSlashCommand::IChing(command)) = registered_slash_command.as_ref() {
+            let mut session = self
+                .service
+                .session_store
+                .get_or_create_active(&meta)
+                .map_err(session_error)?;
+            session.set_turn_actor(shared_session_turn_actor(
+                &self.service.display_name_store,
+                &meta,
+                &req,
+            ));
+            let reply = crate::runtime::tools::iching::execute_iching_command(*command);
+            self.service
+                .session_store
+                .append_exchange(&mut session, &user_text, &reply)
+                .map_err(session_error)?;
             return Ok(DispatchOutcome::Respond(Box::new(command_response(
-                crate::runtime::tools::iching::execute_iching_command(*command),
-                None,
+                reply,
+                Some(session.session_id),
                 Some("iching"),
             ))));
         }

--- a/qq-maid-core/src/runtime/respond/tests/slash_pending.rs
+++ b/qq-maid-core/src/runtime/respond/tests/slash_pending.rs
@@ -1,4 +1,4 @@
-use qq_maid_llm::provider::ToolCallingProtocol;
+use qq_maid_llm::provider::{ToolCallingProtocol, types::ChatRole};
 use serde_json::json;
 
 use super::support::*;
@@ -197,6 +197,49 @@ async fn iching_is_a_deterministic_command_outside_pending_and_tool_loop() {
     assert!(text.contains("本卦："));
     assert!(text.contains("【卦辞】"));
     assert_provider_unused(&provider);
+}
+
+#[tokio::test]
+async fn iching_receipt_is_available_to_followup_without_recasting() {
+    let provider = MockProvider::new();
+    let service = test_service_with_provider(provider.clone());
+
+    let cast = service.respond(private_message("/算卦")).await.unwrap();
+    let cast_text = cast.text.clone().unwrap();
+
+    assert_eq!(cast.command.as_deref(), Some("iching"));
+    assert!(cast.session_id.is_some());
+    assert!(provider.requests().is_empty());
+
+    let followup = service
+        .respond(private_message("解释一下上一卦"))
+        .await
+        .unwrap();
+
+    assert_eq!(followup.text.as_deref(), Some("回复：解释一下上一卦"));
+    assert_eq!(followup.session_id, cast.session_id);
+    assert_eq!(provider.tool_call_count(), 0);
+    let requests = provider.requests();
+    assert_eq!(requests.len(), 1);
+    assert!(
+        requests[0]
+            .messages
+            .iter()
+            .any(|message| { message.role == ChatRole::Assistant && message.content == cast_text })
+    );
+
+    let session = service
+        .session_store
+        .get_or_create_active(&private_test_meta())
+        .unwrap();
+    assert_eq!(
+        session
+            .history
+            .iter()
+            .filter(|message| message.role == "assistant" && message.content == cast_text)
+            .count(),
+        1
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## 变更说明

修复 `/算卦` 结果无法被下一轮自然语言引用的问题。起卦仍由 Core 本地确定性执行，不进入 pending 或 Tool Loop；最终渲染回执复用现有 SessionStore history 写入当前 conversation session，不新增 `last_hexagram` 缓存，也未修改周易算法和展示格式。

## 变更类型

- [x] 🐛 修复 Bug
- [x] 🧪 测试
- [x] 📝 文档更新

## 测试情况

- [x] `cargo fmt --all -- --check` 通过
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` 通过
- [x] `cargo test --workspace --all-features` 通过
- [x] `cargo check --workspace` 通过

## 安全检查

- [x] 没有提交 Token、密钥、API Key、真实用户数据
- [x] 日志/调试输出已脱敏
- [x] 没有写入真实 `.env` 或运行产物

## 补充说明

回归测试确认下一轮 provider payload 含第一轮完整卦象回执，且只发生一次普通模型调用、没有 Tool 调用或重新起卦；Todo 与普通聊天测试均通过。