### PR TITLE
fix: 接入 Codex Radar 新版效能接口恢复 Astra IQ 展示

### DIFF
--- a/qq-maid-core/src/runtime/respond/tests/support/executors.rs
+++ b/qq-maid-core/src/runtime/respond/tests/support/executors.rs
@@ -314,6 +314,8 @@ impl RadarExecutor for MockRadarExecutor {
 }
 
 pub(crate) fn mock_radar_snapshot() -> RadarSnapshot {
+    // 额度状态展示按数据新鲜度判定，固定旧时间会导致“当前关键指标”被历史数据规则隐藏。
+    let recent_quota_updated_at = (chrono::Utc::now() - chrono::Duration::minutes(5)).to_rfc3339();
     RadarSnapshot {
         codex: Some(CodexRadarSummary {
             status: Some("community_confirmed".to_owned()),
@@ -347,7 +349,7 @@ pub(crate) fn mock_radar_snapshot() -> RadarSnapshot {
             ],
             quota_5h_20x: Some(281.91),
             quota_7d_20x: Some(1691.46),
-            quota_updated_at: Some("2026-07-30T08:20:35+00:00".to_owned()),
+            quota_updated_at: Some(recent_quota_updated_at),
             quota_policy_5h: None,
             quota_rows: Vec::new(),
             rating_updated_at: Some("2026-08-02T12:42:22Z".to_owned()),

--- a/qq-maid-core/src/runtime/tools/radar/client.rs
+++ b/qq-maid-core/src/runtime/tools/radar/client.rs
@@ -8,10 +8,11 @@ use crate::error::LlmError;
 use super::{
     ClaudeRadarSummary, CodexRadarSummary, DynRadarExecutor, RadarExecutor, RadarIssueTarget,
     RadarSnapshot, RadarSourceFailure, RadarSourceKind, RadarTarget,
-    parse::{apply_codex_ratings, parse_claude_summary, parse_codex_summary},
+    parse::{apply_codex_metrics, apply_codex_ratings, parse_claude_summary, parse_codex_summary},
 };
 
 const CODEX_CURRENT_URL: &str = "https://codexradar.com/current.json";
+const CODEX_METRICS_URL: &str = "https://codexradar.com/api/intelligence-efficiency-metrics";
 const CODEX_RATINGS_URL: &str = "https://codexradar.com/api/model-ratings";
 pub(super) const CODEX_SITE_URL: &str = "https://codexradar.com/";
 pub(super) const CODEX_FEEDBACK_URL: &str = "https://codexradar.com/";
@@ -63,6 +64,15 @@ impl HttpRadarExecutor {
         let json = self.fetch_json(CODEX_CURRENT_URL, "radar_codex").await?;
         let mut summary = parse_codex_summary(&json);
         let mut failures = Vec::new();
+        // Codex Radar 改版后，含 Astra 的模型 IQ 数据已独立到效能接口；
+        // 旧 current.json 的 model_iq 只作为该接口不可用时的兼容回退。
+        match self
+            .fetch_json(CODEX_METRICS_URL, "radar_codex_metrics")
+            .await
+        {
+            Ok(metrics) => apply_codex_metrics(&mut summary, &metrics),
+            Err(err) => failures.push(failure(RadarSourceKind::Codex, &err)),
+        }
         match self
             .fetch_json(CODEX_RATINGS_URL, "radar_codex_ratings")
             .await

--- a/qq-maid-core/src/runtime/tools/radar/client.rs
+++ b/qq-maid-core/src/runtime/tools/radar/client.rs
@@ -64,19 +64,17 @@ impl HttpRadarExecutor {
         let json = self.fetch_json(CODEX_CURRENT_URL, "radar_codex").await?;
         let mut summary = parse_codex_summary(&json);
         let mut failures = Vec::new();
-        // Codex Radar 改版后，含 Astra 的模型 IQ 数据已独立到效能接口；
-        // 旧 current.json 的 model_iq 只作为该接口不可用时的兼容回退。
-        match self
-            .fetch_json(CODEX_METRICS_URL, "radar_codex_metrics")
-            .await
-        {
+        // Codex Radar 改版后，含 Astra 的模型 IQ 与社区评分都是可选增强接口；
+        // 两个请求互不依赖，失败也各自保留旧数据，因此并发读取避免串行放大超时。
+        let (metrics_result, ratings_result) = tokio::join!(
+            self.fetch_json(CODEX_METRICS_URL, "radar_codex_metrics"),
+            self.fetch_json(CODEX_RATINGS_URL, "radar_codex_ratings"),
+        );
+        match metrics_result {
             Ok(metrics) => apply_codex_metrics(&mut summary, &metrics),
             Err(err) => failures.push(failure(RadarSourceKind::Codex, &err)),
         }
-        match self
-            .fetch_json(CODEX_RATINGS_URL, "radar_codex_ratings")
-            .await
-        {
+        match ratings_result {
             Ok(ratings) => apply_codex_ratings(&mut summary, &ratings),
             Err(err) => failures.push(failure(RadarSourceKind::Codex, &err)),
         }

--- a/qq-maid-core/src/runtime/tools/radar/flow/tests.rs
+++ b/qq-maid-core/src/runtime/tools/radar/flow/tests.rs
@@ -2,9 +2,14 @@ use crate::runtime::tools::{
     ClaudeRadarSummary, CodexModelMetric, CodexQuotaMetric, CodexRadarSummary, CodexRatingMetric,
     RadarSnapshot, RadarSourceFailure, RadarSourceKind,
 };
+use chrono::{Duration, Utc};
 
-use super::super::parse::{apply_codex_metrics, parse_codex_summary};
+use super::super::parse::{apply_codex_metrics, apply_codex_ratings, parse_codex_summary};
 use super::*;
+
+fn timestamp_seconds_ago(seconds: i64) -> String {
+    (Utc::now() - Duration::seconds(seconds)).to_rfc3339()
+}
 
 #[test]
 fn parse_radar_action_accepts_required_variants() {
@@ -125,6 +130,7 @@ fn format_codex_detail_adds_single_hidden_field_hint() {
 
 #[test]
 fn format_codex_detail_shows_ranked_iq_quota_and_cross_vendor_ratings() {
+    let fresh_quota_timestamp = timestamp_seconds_ago(300);
     let body = format_radar_reply(
         &RadarSnapshot {
             codex: Some(CodexRadarSummary {
@@ -159,7 +165,7 @@ fn format_codex_detail_shows_ranked_iq_quota_and_cross_vendor_ratings() {
                 ],
                 quota_5h_20x: None,
                 quota_7d_20x: None,
-                quota_updated_at: Some("2026-07-30T08:20:35Z".to_owned()),
+                quota_updated_at: Some(fresh_quota_timestamp),
                 quota_policy_5h: Some("temporarily_paused_hidden".to_owned()),
                 quota_rows: vec![CodexQuotaMetric {
                     tier: "Plus".to_owned(),
@@ -223,8 +229,123 @@ fn format_codex_detail_shows_ranked_iq_quota_and_cross_vendor_ratings() {
             .contains("数据来自 Codex 雷达：https://codexradar.com/")
     );
     assert!(body.text.contains("模型数据：2026-06-30 18:39:12"));
-    assert!(body.text.contains("额度数据：2026-07-30 16:20:35"));
+    assert!(body.text.contains("额度数据："));
+    assert!(!body.text.contains("历史数据 / 已过期"));
     assert!(body.text.contains("社区评分：2026-08-02 20:42:22"));
+}
+
+#[test]
+fn format_codex_detail_marks_stale_quota_as_historical_without_current_policy() {
+    let mut summary = parse_codex_summary(&serde_json::json!({
+        "model_iq": {
+            "updated_at": timestamp_seconds_ago(300),
+            "latest": {
+                "score": 107.89,
+                "passed": 82,
+                "tasks": 114,
+                "model": "gpt-6-astra",
+                "reasoning_effort": "high"
+            },
+            "comparisons": {},
+            "quota_radar": {
+                "updated_at": timestamp_seconds_ago(30 * 24 * 60 * 60),
+                "five_hour_policy": "temporarily_paused_hidden",
+                "rows": [
+                    {
+                        "tier": "20x Pro",
+                        "basis": "distributed radar",
+                        "five_h": null,
+                        "seven_d": 1649.72
+                    },
+                    {
+                        "tier": "Plus",
+                        "basis": "estimated",
+                        "five_h": null,
+                        "seven_d": 84.66
+                    }
+                ]
+            }
+        }
+    }));
+    summary.rating_updated_at = Some(timestamp_seconds_ago(300));
+    summary.rating_models = vec![CodexRatingMetric {
+        label: "GPT-6 Astra high".to_owned(),
+        average: Some(8.4),
+        count: Some(45),
+    }];
+
+    let body = format_radar_reply(
+        &RadarSnapshot {
+            codex: Some(summary),
+            claude: None,
+            failures: Vec::new(),
+        },
+        RadarTarget::Codex,
+    );
+
+    // 陈旧快照不能继续伪装成“当前暂停”；但 7d 历史估算仍可保留并明确标注。
+    assert!(body.text.contains("额度估算（历史数据 / 已过期）"));
+    assert!(body.text.contains("20x Pro · 7d 1649.72 · 分布式雷达实测"));
+    assert!(
+        body.text
+            .contains("该额度估算已过期，仅作历史参考；当前 5h / 7d 额度状态无法确认。")
+    );
+    assert!(!body.text.contains("5h 限制当前暂停"));
+    // 模型 IQ 与社区评分不依赖额度字段，仍应正常展示。
+    assert!(
+        body.text
+            .contains("最高模型：GPT-6 Astra high · IQ 107.89 · 82/114")
+    );
+    assert!(
+        body.text
+            .contains("24h 社区评分前五：\n1. GPT-6 Astra high · 8.40/10 · 45 票")
+    );
+}
+
+#[test]
+fn format_codex_detail_keeps_models_and_ratings_when_quota_is_missing() {
+    let mut summary = parse_codex_summary(&serde_json::json!({
+        "model_iq": {
+            "updated_at": timestamp_seconds_ago(300),
+            "latest": {
+                "score": 107.89,
+                "passed": 82,
+                "tasks": 114,
+                "model": "gpt-6-astra",
+                "reasoning_effort": "high"
+            },
+            "comparisons": {}
+        }
+    }));
+    apply_codex_ratings(
+        &mut summary,
+        &serde_json::json!({
+            "updated_at": timestamp_seconds_ago(300),
+            "models": [
+                {"label": "GPT-6 Astra high", "average": 8.4, "count": 45}
+            ]
+        }),
+    );
+
+    let body = format_radar_reply(
+        &RadarSnapshot {
+            codex: Some(summary),
+            claude: None,
+            failures: Vec::new(),
+        },
+        RadarTarget::Codex,
+    );
+
+    assert!(body.text.contains("额度雷达当前没有可展示数据。"));
+    assert!(
+        body.text
+            .contains("最高模型：GPT-6 Astra high · IQ 107.89 · 82/114")
+    );
+    assert!(
+        body.text
+            .contains("24h 社区评分前五：\n1. GPT-6 Astra high · 8.40/10 · 45 票")
+    );
+    assert!(!body.text.contains("读取提示"));
 }
 
 #[test]

--- a/qq-maid-core/src/runtime/tools/radar/flow/tests.rs
+++ b/qq-maid-core/src/runtime/tools/radar/flow/tests.rs
@@ -3,6 +3,7 @@ use crate::runtime::tools::{
     RadarSnapshot, RadarSourceFailure, RadarSourceKind,
 };
 
+use super::super::parse::{apply_codex_metrics, parse_codex_summary};
 use super::*;
 
 #[test]
@@ -224,6 +225,49 @@ fn format_codex_detail_shows_ranked_iq_quota_and_cross_vendor_ratings() {
     assert!(body.text.contains("模型数据：2026-06-30 18:39:12"));
     assert!(body.text.contains("额度数据：2026-07-30 16:20:35"));
     assert!(body.text.contains("社区评分：2026-08-02 20:42:22"));
+}
+
+#[test]
+fn format_codex_detail_after_metrics_update_uses_iq_list_without_legacy_latest_summary() {
+    let mut summary = parse_codex_summary(&serde_json::json!({
+        "model_iq": {
+            "updated_at": "2026-08-02T19:35:13+08:00",
+            "latest": {"score": 60.0, "status": "green", "passed": 4, "tasks": 10, "model": "gpt-5.5", "reasoning_effort": "xhigh"},
+            "comparisons": {}
+        }
+    }));
+    apply_codex_metrics(
+        &mut summary,
+        &serde_json::json!({
+            "source_updated_at": "2026-09-08T12:32:03+00:00",
+            "points": [
+                {"model": "gpt-6-astra", "effort": "high", "passed": 82, "total": 114, "iq": 107.89},
+                {"model": "gpt-6-astra", "effort": "max", "passed": 76, "total": 106, "iq": 107.55},
+                {"model": "gpt-5.6-sol", "effort": "max", "passed": 239, "total": 336, "iq": 106.7},
+                {"model": "claude-sonnet-5", "effort": "high", "passed": 2, "total": 2, "iq": 150.0}
+            ]
+        }),
+    );
+
+    let body = format_radar_reply(
+        &RadarSnapshot {
+            codex: Some(summary),
+            claude: None,
+            failures: Vec::new(),
+        },
+        RadarTarget::Codex,
+    );
+
+    assert!(
+        body.text
+            .contains("最高模型：GPT-6 Astra high · IQ 107.89 · 82/114")
+    );
+    assert!(body.text.contains("IQ 前五配置："));
+    assert!(body.text.contains("GPT-6 Astra high"));
+    // 新版榜单只由 iq_models 呈现，不再把旧 latest 摘要或最高 IQ 伪装成“模型体感”。
+    assert!(!body.text.contains("模型体感："));
+    assert!(!body.text.contains("GPT-5.5 xhigh"));
+    assert!(!body.text.contains("green"));
 }
 
 #[test]

--- a/qq-maid-core/src/runtime/tools/radar/format.rs
+++ b/qq-maid-core/src/runtime/tools/radar/format.rs
@@ -3,10 +3,10 @@
 //! 具体指标选择、排序、兼容文案和来源标注属于 Radar 领域规则，Respond 层只消费
 //! 已渲染的双通道命令正文。
 
-use chrono::{DateTime, Utc};
+use chrono::{Duration, Utc};
 use qq_maid_common::{
     markdown::{escape_inline, escape_text},
-    time_context::format_local_time_for_display,
+    time_context::{format_local_time_for_display, parse_local_datetime_for_comparison},
 };
 
 use crate::{
@@ -26,21 +26,21 @@ use super::{
 const RADAR_SUMMARY_MAX_CHARS: usize = 110;
 
 /// 额度雷达的快照在超过该天数后不再视为“当前额度”，只按历史兼容数据展示。
-const CODEX_QUOTA_EXPIRED_AFTER_DAYS: i64 = 7;
+const CODEX_QUOTA_MAX_AGE: Duration = Duration::days(7);
 
 /// `five_hour_policy` 是站点给出的实时状态字段；只有配额快照足够新时才允许
 /// 把它当作当前状态输出，否则只能作为历史备注，避免把一个月前的暂停文案
 /// 当成今天的事实。
-const CODEX_QUOTA_POLICY_MAX_AGE_HOURS: i64 = 24;
+const CODEX_QUOTA_POLICY_MAX_AGE: Duration = Duration::hours(24);
 
 /// Codex Radar 额度数据的可见新鲜度分级。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CodexQuotaFreshness {
-    /// 更新时间可解析且未超过 `CODEX_QUOTA_EXPIRED_AFTER_DAYS`。
+    /// 更新时间可解析、不早于当前时间且未超过 `CODEX_QUOTA_MAX_AGE`。
     Current,
     /// 更新时间可解析但已明显陈旧，只能作为历史估算展示。
-    Expired { age_days: i64 },
-    /// 缺少更新时间或格式无法解析；无法确认是否仍代表当前状态。
+    Expired,
+    /// 缺少更新时间、格式无法解析或时间戳位于未来；无法确认是否仍代表当前状态。
     Unknown,
 }
 
@@ -397,7 +397,7 @@ fn append_codex_quota_section(
     let freshness = codex_quota_freshness(summary.quota_updated_at.as_deref());
     render.blank();
     render.subtitle(match freshness {
-        CodexQuotaFreshness::Expired { .. } => "额度估算（历史数据 / 已过期）",
+        CodexQuotaFreshness::Expired => "额度估算（历史数据 / 已过期）",
         CodexQuotaFreshness::Current | CodexQuotaFreshness::Unknown => "额度估算",
     });
 
@@ -422,38 +422,37 @@ fn append_codex_quota_section(
                 render.bullet("5h 限制当前暂停，站点暂不展示该档额度。");
             }
         }
-        CodexQuotaFreshness::Expired { .. } => {
+        CodexQuotaFreshness::Expired => {
             render.bullet("该额度估算已过期，仅作历史参考；当前 5h / 7d 额度状态无法确认。");
         }
         CodexQuotaFreshness::Unknown => {
-            render.bullet("额度更新时间缺失，当前额度状态无法确认。");
+            render.bullet("额度更新时间缺失或不可信，当前额度状态无法确认。");
         }
     }
 }
 
 fn codex_quota_freshness(updated_at: Option<&str>) -> CodexQuotaFreshness {
-    let Some(updated_at) = codex_quota_updated_at(updated_at) else {
+    let Some(updated_at) = updated_at.and_then(parse_local_datetime_for_comparison) else {
         return CodexQuotaFreshness::Unknown;
     };
-    let age_days = Utc::now().signed_duration_since(updated_at).num_days();
-    if age_days <= CODEX_QUOTA_EXPIRED_AFTER_DAYS {
+    let age = Utc::now().signed_duration_since(updated_at);
+    if age < Duration::zero() {
+        // 未来时间戳不能用于证明“当前”状态，按不可信数据处理。
+        return CodexQuotaFreshness::Unknown;
+    }
+    if age <= CODEX_QUOTA_MAX_AGE {
         CodexQuotaFreshness::Current
     } else {
-        CodexQuotaFreshness::Expired { age_days }
+        CodexQuotaFreshness::Expired
     }
 }
 
 fn codex_quota_policy_is_recent(updated_at: Option<&str>) -> bool {
-    let Some(updated_at) = codex_quota_updated_at(updated_at) else {
+    let Some(updated_at) = updated_at.and_then(parse_local_datetime_for_comparison) else {
         return false;
     };
-    Utc::now().signed_duration_since(updated_at).num_hours() <= CODEX_QUOTA_POLICY_MAX_AGE_HOURS
-}
-
-fn codex_quota_updated_at(updated_at: Option<&str>) -> Option<DateTime<Utc>> {
-    DateTime::parse_from_rfc3339(updated_at?.trim())
-        .ok()
-        .map(|value| value.with_timezone(&Utc))
+    let age = Utc::now().signed_duration_since(updated_at);
+    age >= Duration::zero() && age <= CODEX_QUOTA_POLICY_MAX_AGE
 }
 
 fn codex_quota_basis_label(value: &str) -> &str {
@@ -707,5 +706,39 @@ fn format_number(value: Option<f64>) -> Option<String> {
         Some(format!("{value:.0}"))
     } else {
         Some(format!("{value:.2}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, Utc};
+
+    #[test]
+    fn quota_freshness_rejects_seven_days_plus_one_second() {
+        let updated_at = (Utc::now() - Duration::days(7) - Duration::seconds(1)).to_rfc3339();
+
+        assert_eq!(
+            codex_quota_freshness(Some(&updated_at)),
+            CodexQuotaFreshness::Expired
+        );
+    }
+
+    #[test]
+    fn quota_policy_rejects_twenty_four_hours_plus_one_second() {
+        let updated_at = (Utc::now() - Duration::hours(24) - Duration::seconds(1)).to_rfc3339();
+
+        assert!(!codex_quota_policy_is_recent(Some(&updated_at)));
+    }
+
+    #[test]
+    fn quota_freshness_treats_future_timestamp_as_untrusted() {
+        let updated_at = (Utc::now() + Duration::hours(1)).to_rfc3339();
+
+        assert_eq!(
+            codex_quota_freshness(Some(&updated_at)),
+            CodexQuotaFreshness::Unknown
+        );
+        assert!(!codex_quota_policy_is_recent(Some(&updated_at)));
     }
 }

--- a/qq-maid-core/src/runtime/tools/radar/format.rs
+++ b/qq-maid-core/src/runtime/tools/radar/format.rs
@@ -3,6 +3,7 @@
 //! 具体指标选择、排序、兼容文案和来源标注属于 Radar 领域规则，Respond 层只消费
 //! 已渲染的双通道命令正文。
 
+use chrono::{DateTime, Utc};
 use qq_maid_common::{
     markdown::{escape_inline, escape_text},
     time_context::format_local_time_for_display,
@@ -23,6 +24,25 @@ use super::{
 };
 
 const RADAR_SUMMARY_MAX_CHARS: usize = 110;
+
+/// 额度雷达的快照在超过该天数后不再视为“当前额度”，只按历史兼容数据展示。
+const CODEX_QUOTA_EXPIRED_AFTER_DAYS: i64 = 7;
+
+/// `five_hour_policy` 是站点给出的实时状态字段；只有配额快照足够新时才允许
+/// 把它当作当前状态输出，否则只能作为历史备注，避免把一个月前的暂停文案
+/// 当成今天的事实。
+const CODEX_QUOTA_POLICY_MAX_AGE_HOURS: i64 = 24;
+
+/// Codex Radar 额度数据的可见新鲜度分级。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodexQuotaFreshness {
+    /// 更新时间可解析且未超过 `CODEX_QUOTA_EXPIRED_AFTER_DAYS`。
+    Current,
+    /// 更新时间可解析但已明显陈旧，只能作为历史估算展示。
+    Expired { age_days: i64 },
+    /// 缺少更新时间或格式无法解析；无法确认是否仍代表当前状态。
+    Unknown,
+}
 
 pub(super) fn format_radar_reply(snapshot: &RadarSnapshot, target: RadarTarget) -> CommandBody {
     let mut render = CommandRender::new();
@@ -116,21 +136,7 @@ fn append_codex_detail_card(render: &mut CommandRender, summary: &CodexRadarSumm
         render.paragraph(&prediction);
     }
 
-    render.blank();
-    render.subtitle("额度估算");
-    if !summary.quota_rows.is_empty() {
-        for quota in &summary.quota_rows {
-            render.bullet(&codex_quota_metric_line(quota));
-        }
-        if summary.quota_policy_5h.as_deref() == Some("temporarily_paused_hidden") {
-            render.bullet("5h 限制当前暂停，站点暂不展示该档额度。");
-        }
-    } else if let Some(line) = codex_quota_line(summary) {
-        render.bullet(&line);
-    } else {
-        hidden = true;
-        render.paragraph("额度雷达当前没有可展示数据。");
-    }
+    append_codex_quota_section(render, summary, &mut hidden);
 
     render.blank();
     render.subtitle("模型与社区体感");
@@ -264,7 +270,12 @@ fn claude_conclusion(summary: &ClaudeRadarSummary) -> String {
 
 fn codex_key_metrics(summary: &CodexRadarSummary) -> Option<String> {
     let mut parts = Vec::new();
-    if let Some(quota) = codex_quota_line(summary) {
+    // 过期兼容数据只留在详情卡中并明确标注，不进入“当前关键指标”。
+    if matches!(
+        codex_quota_freshness(summary.quota_updated_at.as_deref()),
+        CodexQuotaFreshness::Current
+    ) && let Some(quota) = codex_quota_line(summary)
+    {
         parts.push(quota);
     }
     if let Some(top) = codex_top_iq_line(summary).or_else(|| codex_model_line(summary)) {
@@ -376,6 +387,73 @@ fn codex_quota_metric_line(quota: &CodexQuotaMetric) -> String {
         parts.push(codex_quota_basis_label(&basis).to_owned());
     }
     parts.join(" · ")
+}
+
+fn append_codex_quota_section(
+    render: &mut CommandRender,
+    summary: &CodexRadarSummary,
+    hidden: &mut bool,
+) {
+    let freshness = codex_quota_freshness(summary.quota_updated_at.as_deref());
+    render.blank();
+    render.subtitle(match freshness {
+        CodexQuotaFreshness::Expired { .. } => "额度估算（历史数据 / 已过期）",
+        CodexQuotaFreshness::Current | CodexQuotaFreshness::Unknown => "额度估算",
+    });
+
+    let has_rows = !summary.quota_rows.is_empty();
+    if has_rows {
+        for quota in &summary.quota_rows {
+            render.bullet(&codex_quota_metric_line(quota));
+        }
+    } else if let Some(line) = codex_quota_line(summary) {
+        render.bullet(&line);
+    } else {
+        *hidden = true;
+        render.paragraph("额度雷达当前没有可展示数据。");
+        return;
+    }
+
+    match freshness {
+        CodexQuotaFreshness::Current => {
+            if summary.quota_policy_5h.as_deref() == Some("temporarily_paused_hidden")
+                && codex_quota_policy_is_recent(summary.quota_updated_at.as_deref())
+            {
+                render.bullet("5h 限制当前暂停，站点暂不展示该档额度。");
+            }
+        }
+        CodexQuotaFreshness::Expired { .. } => {
+            render.bullet("该额度估算已过期，仅作历史参考；当前 5h / 7d 额度状态无法确认。");
+        }
+        CodexQuotaFreshness::Unknown => {
+            render.bullet("额度更新时间缺失，当前额度状态无法确认。");
+        }
+    }
+}
+
+fn codex_quota_freshness(updated_at: Option<&str>) -> CodexQuotaFreshness {
+    let Some(updated_at) = codex_quota_updated_at(updated_at) else {
+        return CodexQuotaFreshness::Unknown;
+    };
+    let age_days = Utc::now().signed_duration_since(updated_at).num_days();
+    if age_days <= CODEX_QUOTA_EXPIRED_AFTER_DAYS {
+        CodexQuotaFreshness::Current
+    } else {
+        CodexQuotaFreshness::Expired { age_days }
+    }
+}
+
+fn codex_quota_policy_is_recent(updated_at: Option<&str>) -> bool {
+    let Some(updated_at) = codex_quota_updated_at(updated_at) else {
+        return false;
+    };
+    Utc::now().signed_duration_since(updated_at).num_hours() <= CODEX_QUOTA_POLICY_MAX_AGE_HOURS
+}
+
+fn codex_quota_updated_at(updated_at: Option<&str>) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(updated_at?.trim())
+        .ok()
+        .map(|value| value.with_timezone(&Utc))
 }
 
 fn codex_quota_basis_label(value: &str) -> &str {

--- a/qq-maid-core/src/runtime/tools/radar/parse.rs
+++ b/qq-maid-core/src/runtime/tools/radar/parse.rs
@@ -73,8 +73,12 @@ const CODEX_STATION_MODEL_IDS: [&str; 7] = [
 /// 应用 Codex Radar `/api/intelligence-efficiency-metrics` 的实时 IQ 数据。
 ///
 /// 新接口出现后 current.json 里的旧 model_iq 不再持续覆盖 Astra；因此只要新接口
-/// 返回本站白名单内的有效模型，就用它整体替换旧 IQ 列表与顶部模型摘要，避免把
+/// 返回本站白名单内的有效模型，就用它整体替换旧 IQ 列表，避免把
 /// 两种统计口径混在同一张榜单。接口无有效白名单模型时保持旧数据不动。
+///
+/// 新版接口没有等价的独立 `latest` 语义，因此只更新 `iq_models`（榜单/最高模型
+/// 由渲染层从该列表计算），并清空旧 `current.json` 的 latest 摘要字段，避免把
+/// 过时模型继续显示成“模型体感”。
 pub(super) fn apply_codex_metrics(summary: &mut CodexRadarSummary, metrics: &Value) {
     let Some(points) = metrics.get("points").and_then(Value::as_array) else {
         return;
@@ -83,30 +87,20 @@ pub(super) fn apply_codex_metrics(summary: &mut CodexRadarSummary, metrics: &Val
         .iter()
         .filter_map(codex_metrics_model_metric)
         .collect::<Vec<_>>();
-    let Some(top) = models
-        .iter()
-        .max_by(|left, right| {
-            left.score
-                .unwrap_or(f64::NEG_INFINITY)
-                .partial_cmp(&right.score.unwrap_or(f64::NEG_INFINITY))
-                .unwrap_or(std::cmp::Ordering::Equal)
-                .then_with(|| left.label.cmp(&right.label))
-        })
-        .cloned()
-    else {
+    if models.is_empty() {
         return;
-    };
+    }
 
     if let Some(updated_at) = str_value(metrics.get("source_updated_at")) {
         summary.updated_at = Some(updated_at);
     }
     summary.iq_models = models;
-    summary.model_label = Some(top.label);
-    summary.model_score = top.score;
-    // 效能接口不返回旧 model_iq 的红黄绿状态；更新后不沿用旧摘要里的状态。
+    // 新版榜单不携带 legacy latest 字段；清空后“最高模型 / IQ 前五”只由 iq_models 承担。
+    summary.model_label = None;
+    summary.model_score = None;
+    summary.model_passed = None;
+    summary.model_tasks = None;
     summary.model_status = None;
-    summary.model_passed = top.passed;
-    summary.model_tasks = top.tasks;
 }
 
 fn codex_metrics_model_metric(value: &Value) -> Option<CodexModelMetric> {

--- a/qq-maid-core/src/runtime/tools/radar/parse.rs
+++ b/qq-maid-core/src/runtime/tools/radar/parse.rs
@@ -58,6 +58,81 @@ pub(super) fn parse_codex_summary(json: &Value) -> CodexRadarSummary {
     }
 }
 
+/// Codex Radar 新版效能接口中本站模型卡实际展示的模型族白名单；
+/// 不纳入该站其他雷达频道的 Claude / Grok / GLM 等跨站样本。
+const CODEX_STATION_MODEL_IDS: [&str; 7] = [
+    "gpt-6-astra",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.5",
+    "deepseek-v4-flash",
+    "deepseek-v4-pro",
+];
+
+/// 应用 Codex Radar `/api/intelligence-efficiency-metrics` 的实时 IQ 数据。
+///
+/// 新接口出现后 current.json 里的旧 model_iq 不再持续覆盖 Astra；因此只要新接口
+/// 返回本站白名单内的有效模型，就用它整体替换旧 IQ 列表与顶部模型摘要，避免把
+/// 两种统计口径混在同一张榜单。接口无有效白名单模型时保持旧数据不动。
+pub(super) fn apply_codex_metrics(summary: &mut CodexRadarSummary, metrics: &Value) {
+    let Some(points) = metrics.get("points").and_then(Value::as_array) else {
+        return;
+    };
+    let models = points
+        .iter()
+        .filter_map(codex_metrics_model_metric)
+        .collect::<Vec<_>>();
+    let Some(top) = models
+        .iter()
+        .max_by(|left, right| {
+            left.score
+                .unwrap_or(f64::NEG_INFINITY)
+                .partial_cmp(&right.score.unwrap_or(f64::NEG_INFINITY))
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| left.label.cmp(&right.label))
+        })
+        .cloned()
+    else {
+        return;
+    };
+
+    if let Some(updated_at) = str_value(metrics.get("source_updated_at")) {
+        summary.updated_at = Some(updated_at);
+    }
+    summary.iq_models = models;
+    summary.model_label = Some(top.label);
+    summary.model_score = top.score;
+    // 效能接口不返回旧 model_iq 的红黄绿状态；更新后不沿用旧摘要里的状态。
+    summary.model_status = None;
+    summary.model_passed = top.passed;
+    summary.model_tasks = top.tasks;
+}
+
+fn codex_metrics_model_metric(value: &Value) -> Option<CodexModelMetric> {
+    let model = str_value(value.get("model"))?.to_ascii_lowercase();
+    if !CODEX_STATION_MODEL_IDS.contains(&model.as_str()) {
+        return None;
+    }
+    let effort = str_value(value.get("effort"));
+    let base_label = match model.as_str() {
+        "deepseek-v4-flash" => "DeepSeek V4 Flash".to_owned(),
+        "deepseek-v4-pro" => "DeepSeek V4 Pro".to_owned(),
+        _ => codex_display_model_name(&model),
+    };
+    let label = match effort {
+        Some(effort) => format!("{base_label} {effort}"),
+        None => base_label,
+    };
+    Some(CodexModelMetric {
+        label,
+        score: Some(f64_value(value.get("iq"))?),
+        status: None,
+        passed: u64_value(value.get("passed")),
+        tasks: u64_value(value.get("total")),
+    })
+}
+
 fn codex_quota_rows(quota: &Value) -> Vec<CodexQuotaMetric> {
     quota
         .get("rows")

--- a/qq-maid-core/src/runtime/tools/radar/tests/parse.rs
+++ b/qq-maid-core/src/runtime/tools/radar/tests/parse.rs
@@ -109,6 +109,89 @@ fn apply_codex_ratings_selects_highest_24h_score() {
 }
 
 #[test]
+fn apply_codex_metrics_replaces_legacy_iq_with_astra_and_filters_station_models() {
+    let mut summary = parse_codex_summary(&json!({
+        "model_iq": {
+            "updated_at": "2026-08-02T19:35:13+08:00",
+            "latest": {"score": 60.0, "status": "green", "passed": 4, "tasks": 10, "model": "gpt-5.6-sol", "reasoning_effort": "max"},
+            "comparisons": {}
+        }
+    }));
+    assert_eq!(summary.model_label.as_deref(), Some("GPT-5.6 Sol max"));
+
+    apply_codex_metrics(
+        &mut summary,
+        &json!({
+            "source_updated_at": "2026-09-08T12:32:03+00:00",
+            "points": [
+                {"model": "gpt-6-astra", "effort": "high", "passed": 82, "total": 114, "iq": 107.89},
+                {"model": "gpt-6-astra", "effort": "max", "passed": 76, "total": 106, "iq": 107.55},
+                {"model": "gpt-5.6-sol", "effort": "max", "passed": 239, "total": 336, "iq": 106.7},
+                {"model": "deepseek-v4-flash", "effort": "off", "passed": 50, "total": 64, "iq": 88.5},
+                {"model": "claude-sonnet-5", "effort": "high", "passed": 2, "total": 2, "iq": 150.0}
+            ]
+        }),
+    );
+
+    assert_eq!(
+        summary.updated_at.as_deref(),
+        Some("2026-09-08T12:32:03+00:00")
+    );
+    assert_eq!(summary.model_label.as_deref(), Some("GPT-6 Astra high"));
+    assert_eq!(summary.model_score, Some(107.89));
+    assert_eq!(summary.model_passed, Some(82));
+    assert_eq!(summary.model_tasks, Some(114));
+    assert_eq!(summary.model_status, None);
+    assert_eq!(summary.iq_models.len(), 4);
+    assert!(
+        summary
+            .iq_models
+            .iter()
+            .any(|model| model.label == "GPT-6 Astra high")
+    );
+    assert!(
+        summary
+            .iq_models
+            .iter()
+            .any(|model| model.label == "DeepSeek V4 Flash off")
+    );
+    assert!(
+        !summary
+            .iq_models
+            .iter()
+            .any(|model| model.label.contains("claude-sonnet-5"))
+    );
+}
+
+#[test]
+fn apply_codex_metrics_without_station_models_keeps_legacy_fallback() {
+    let mut summary = parse_codex_summary(&json!({
+        "model_iq": {
+            "updated_at": "2026-08-02T19:35:13+08:00",
+            "latest": {"score": 60.0, "status": "green", "passed": 4, "tasks": 10, "model": "gpt-5.5", "reasoning_effort": "xhigh"},
+            "comparisons": {}
+        }
+    }));
+    apply_codex_metrics(
+        &mut summary,
+        &json!({
+            "source_updated_at": "2026-09-08T12:32:03+00:00",
+            "points": [
+                {"model": "claude-sonnet-5", "effort": "high", "passed": 2, "total": 2, "iq": 150.0}
+            ]
+        }),
+    );
+
+    assert_eq!(
+        summary.updated_at.as_deref(),
+        Some("2026-08-02T19:35:13+08:00")
+    );
+    assert_eq!(summary.model_label.as_deref(), Some("GPT-5.5 xhigh"));
+    assert_eq!(summary.model_status.as_deref(), Some("green"));
+    assert_eq!(summary.iq_models.len(), 1);
+}
+
+#[test]
 fn codex_display_model_name_formats_model_family() {
     assert_eq!(codex_display_model_name("gpt-5.6-sol"), "GPT-5.6 Sol");
     assert_eq!(codex_display_model_name("gpt-5.5"), "GPT-5.5");

--- a/qq-maid-core/src/runtime/tools/radar/tests/parse.rs
+++ b/qq-maid-core/src/runtime/tools/radar/tests/parse.rs
@@ -137,12 +137,23 @@ fn apply_codex_metrics_replaces_legacy_iq_with_astra_and_filters_station_models(
         summary.updated_at.as_deref(),
         Some("2026-09-08T12:32:03+00:00")
     );
-    assert_eq!(summary.model_label.as_deref(), Some("GPT-6 Astra high"));
-    assert_eq!(summary.model_score, Some(107.89));
-    assert_eq!(summary.model_passed, Some(82));
-    assert_eq!(summary.model_tasks, Some(114));
+    // 新版接口没有独立 latest 语义，旧 current.json 的摘要不得被“最高 IQ”顶替或残留。
+    assert_eq!(summary.model_label, None);
+    assert_eq!(summary.model_score, None);
+    assert_eq!(summary.model_passed, None);
+    assert_eq!(summary.model_tasks, None);
     assert_eq!(summary.model_status, None);
     assert_eq!(summary.iq_models.len(), 4);
+    let highest = summary
+        .iq_models
+        .iter()
+        .filter_map(|model| model.score.map(|score| (score, model.label.as_str())))
+        .max_by(|left, right| {
+            left.0
+                .partial_cmp(&right.0)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+    assert_eq!(highest.map(|(_, label)| label), Some("GPT-6 Astra high"));
     assert!(
         summary
             .iq_models
@@ -187,6 +198,9 @@ fn apply_codex_metrics_without_station_models_keeps_legacy_fallback() {
         Some("2026-08-02T19:35:13+08:00")
     );
     assert_eq!(summary.model_label.as_deref(), Some("GPT-5.5 xhigh"));
+    assert_eq!(summary.model_score, Some(60.0));
+    assert_eq!(summary.model_passed, Some(4));
+    assert_eq!(summary.model_tasks, Some(10));
     assert_eq!(summary.model_status.as_deref(), Some("green"));
     assert_eq!(summary.iq_models.len(), 1);
 }


### PR DESCRIPTION
Codex Radar 改版后把含 Astra 的实时模型 IQ 数据放到独立的 `/api/intelligence-efficiency-metrics`，旧 `current.json` 的 `model_iq` 不再覆盖 Astra，导致 `/radar codex` 的模型 IQ 榜单看不到 Astra。

## 修改内容

- `current.json` 仍作为必需基础数据先读取，用于窗口、额度和旧 `model_iq` 兼容回退。
- 基础数据成功后，metrics 与 community ratings 通过 `tokio::join!` 并发请求，互不阻塞；单请求 10 秒超时下最坏等待从三个串行接口的约 30 秒收敛为一个基础请求 + 一个可选请求并行窗口。
- 两个可选接口失败互不影响：metrics 失败继续展示旧 `model_iq`，ratings 失败仅缺失 24h 社区评分；失败仍按各自 stage 记录到既有 `failures` 诊断。
- 新版 metrics 只负责更新 `iq_models`（IQ 榜单由渲染层从该列表计算“最高模型 / IQ 前五”），不再把榜单最高 IQ 写入 legacy `model_label/model_score/model_passed/model_tasks/model_status`；应用新版数据时会清空这些旧 `current.json latest` 摘要字段，避免同一 Astra 配置被“模型体感 / 最高模型 / IQ 前五”重复展示。
- 新版 metrics 无本站白名单有效模型时保留完整 legacy fallback；白名单只包含 Codex Radar 本站模型卡展示的 Astra / 5.6 Sol、Terra、Luna / 5.5 / DeepSeek V4 Flash、Pro，过滤 Claude、Grok、GLM 等跨站样本。

## 测试覆盖

- 解析测试：新版 metrics 替换 legacy IQ、Astra 进入 IQ 榜单、不残留旧 latest 摘要、无有效本站模型时完整保留 fallback。
- 渲染测试：应用新版 metrics 后只展示“最高模型 / IQ 前五”，不出现“模型体感”或过时 legacy latest。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p qq-maid-core`（1589 项单测通过）
- `cargo clippy -p qq-maid-core --all-targets --all-features -- -D warnings`
