### PR TITLE
feat: DeepSeek 接入 Responses，修复搜索流完成后的等待

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ runtime/botctl.sh status
 - **查询与订阅**：查询天气、火车时刻和网页信息，支持多对象对比式联网搜索；订阅 RSS/Atom 并主动推送更新。
 - **记忆与知识库**：个人记忆、群内个人画像和群公共记忆分域管理，并按场景与可见性召回。用户明确要求“记住”时可直接保存；可选的确定性整理（`MEMORY_CONSOLIDATION_ENABLED`）与 Session Dream（`MEMORY_DREAM_ENABLED`）分开开关。Dream 只从会话消息提取安全长期事实，写入个人记忆或当前成员群画像，不覆盖已确认记忆；本地 Markdown 可自动索引并按需检索。
 - **受控工具与运维命令**：模型只能调用服务端注册并按场景放行的工具；管理员可通过默认关闭的 `/ops` 白名单命令触发固定程序，结果以真实执行或持久化结果为准。
-- **多模型路由**：支持 OpenAI、Gemini、MiMo、DeepSeek 和 OpenAI-compatible Provider，并可按候选链自动降级。
+- **多模型路由**：支持 OpenAI、Gemini、MiMo、DeepSeek 和 OpenAI-compatible Provider，并可按候选链自动降级。DeepSeek 新部署默认使用 V4 Flash Responses，旧 Chat 配置保留兼容路径，详见 [协议选择规则](qq-maid-llm/README.md#deepseek-responses-使用边界)。
 
 ## 平台支持
 

--- a/docs/development/provider-management.md
+++ b/docs/development/provider-management.md
@@ -8,7 +8,7 @@
 
 所有自定义供应商（包括 OpenCode 预设）使用同一表单，可编辑、启停和删除。删除或停用前须迁移全部模型及搜索路线引用；错误会列出引用位置，服务端不会自动改写路线。手工配置与启动预检遵守相同约束。旧配置未写 `enabled` 时保持启用。新建 Connection 必须使用小写 canonical ID；历史非小写 key 只能在原始 key 精确匹配时编辑或删除，不能改成 canonical 小写，也不能与另一个仅大小写不同的 key 共存。
 
-内置 OpenAI、DeepSeek、BigModel、Gemini 的字段在同一页面展示，继续使用原 runtime/Secret 存储和自动保存；内置定义不可删除，但可停用并显式清除凭证。新增 `provider.<id>.enabled` 对应公开模板中的 `<PROVIDER>_ENABLED`，默认启用，停用同样拒绝所有显式路线引用。内置 OpenAI `auto` 测试采用 Responses，`chat_only` 测试采用 Chat Completions；不自动测试跨协议 fallback。Gemini 在此测试其现有 Chat Adapter，不代表原生搜索已经验证。
+内置 OpenAI、DeepSeek、BigModel、Gemini 的字段在同一页面展示，继续使用原 runtime/Secret 存储和自动保存；内置定义不可删除，但可停用并显式清除凭证。新增 `provider.<id>.enabled` 对应公开模板中的 `<PROVIDER>_ENABLED`，默认启用，停用同样拒绝所有显式路线引用。内置 OpenAI `auto` 测试采用 Responses，`chat_only` 测试采用 Chat Completions；不自动测试跨协议 fallback。内置 DeepSeek 测试固定采用 Responses，沿用[LLM crate 的使用边界](../../qq-maid-llm/README.md#deepseek-responses-使用边界)。Gemini 在此测试其现有 Chat Adapter，不代表原生搜索已经验证。
 
 ## 安全与兼容
 
@@ -35,7 +35,7 @@
 
 `POST /api/v1/console/configuration/providers/models` 接收 `id` 和 `expected_revision`，只读取已保存连接，不写配置或路线。自定义连接使用 Agent revision，内置连接使用 runtime revision。接口仍要求管理员 Session、Origin 与 CSRF；浏览器不能提交 URL、认证或 Credential。响应包含 `connection_id`、请求的 `revision` 和 `discovery`。结果仅属于请求开始时的保存配置，不是运行值，也不缓存或热加载。
 
-模型发现依据 Connection 实际使用的协议 Adapter：内置 OpenAI Responses 使用 `OpenAiResponses`，OpenAI Chat、DeepSeek、Gemini、BigModel 使用 `OpenAiCompatible`。这些内置连接与自定义 `openai_compatible` / `openai_responses` 均从连接自身 Base URL 追加 `/models`，沿用 Header、Scheme 和当前解析出的 Credential。内置 OpenAI 多 Base URL 使用首个非空地址，不跨地址重试；端点返回 404 / 405 / 501 时由 discovery 层返回 `unsupported / endpoint_unsupported`，不按品牌预判支持情况。协议参考 [OpenAI 模型列表](https://platform.openai.com/docs/api-reference/models/list)和 [DeepSeek 模型列表](https://api-docs.deepseek.com/api/list-models)。
+模型发现依据 Connection 实际使用的协议 Adapter：内置 OpenAI Responses 与 DeepSeek 使用 `OpenAiResponses`，OpenAI Chat、Gemini、BigModel 使用 `OpenAiCompatible`。这些内置连接与自定义 `openai_compatible` / `openai_responses` 均从连接自身 Base URL 追加 `/models`，沿用 Header、Scheme 和当前解析出的 Credential。内置 OpenAI 多 Base URL 使用首个非空地址，不跨地址重试；端点返回 404 / 405 / 501 时由 discovery 层返回 `unsupported / endpoint_unsupported`，不按品牌预判支持情况。协议参考 [OpenAI 模型列表](https://platform.openai.com/docs/api-reference/models/list)和 [DeepSeek 模型列表](https://api-docs.deepseek.com/api/list-models)。
 
 发现沿用自定义 `request_timeout_seconds`，缺省用 `LLM_REQUEST_TIMEOUT_SECONDS`，再限制总等待不超过 15 秒、连接不超过 5 秒。最多两个并发，忙时立即返回 `unknown / busy`；禁止重定向、自动重试与分页跳转。响应上限 1 MiB、最多 10000 个条目；model id 去重排序，仅保留 ID 及 `source=connection_discovery`，不透传额外上游字段、错误正文、URL 或凭证。
 

--- a/docs/development/provider-management.md
+++ b/docs/development/provider-management.md
@@ -8,7 +8,7 @@
 
 所有自定义供应商（包括 OpenCode 预设）使用同一表单，可编辑、启停和删除。删除或停用前须迁移全部模型及搜索路线引用；错误会列出引用位置，服务端不会自动改写路线。手工配置与启动预检遵守相同约束。旧配置未写 `enabled` 时保持启用。新建 Connection 必须使用小写 canonical ID；历史非小写 key 只能在原始 key 精确匹配时编辑或删除，不能改成 canonical 小写，也不能与另一个仅大小写不同的 key 共存。
 
-内置 OpenAI、DeepSeek、BigModel、Gemini 的字段在同一页面展示，继续使用原 runtime/Secret 存储和自动保存；内置定义不可删除，但可停用并显式清除凭证。新增 `provider.<id>.enabled` 对应公开模板中的 `<PROVIDER>_ENABLED`，默认启用，停用同样拒绝所有显式路线引用。内置 OpenAI `auto` 测试采用 Responses，`chat_only` 测试采用 Chat Completions；不自动测试跨协议 fallback。内置 DeepSeek 测试固定采用 Responses，沿用[LLM crate 的使用边界](../../qq-maid-llm/README.md#deepseek-responses-使用边界)。Gemini 在此测试其现有 Chat Adapter，不代表原生搜索已经验证。
+内置 OpenAI、DeepSeek、BigModel、Gemini 的字段在同一页面展示，继续使用原 runtime/Secret 存储和自动保存；内置定义不可删除，但可停用并显式清除凭证。新增 `provider.<id>.enabled` 对应公开模板中的 `<PROVIDER>_ENABLED`，默认启用，停用同样拒绝所有显式路线引用。内置 OpenAI `auto` 测试采用 Responses，`chat_only` 测试采用 Chat Completions；不自动测试跨协议 fallback。内置 DeepSeek 测试按运行时规则选择：旧 `deepseek-chat` / `deepseek-reasoner` 使用 Chat，其他模型使用 Responses，沿用[LLM crate 的使用边界](../../qq-maid-llm/README.md#deepseek-responses-使用边界)。Gemini 在此测试其现有 Chat Adapter，不代表原生搜索已经验证。
 
 ## 安全与兼容
 

--- a/docs/tasks/archive/scope-aware-model-routing.md
+++ b/docs/tasks/archive/scope-aware-model-routing.md
@@ -165,7 +165,7 @@ LLM_MODEL=openai:gpt-5.4-mini
 OPENAI_SEARCH_MODEL=gpt-5.5
 
 # 群聊：优先考虑速度和成本
-GROUP_LLM_MODEL=openai:gpt-5.4-mini,deepseek:deepseek-chat
+GROUP_LLM_MODEL=openai:gpt-5.4-mini,deepseek:deepseek-v4-flash
 GROUP_OPENAI_SEARCH_MODEL=gpt-5.5
 
 # 私聊：优先考虑模型质量

--- a/qq-maid-core/README.md
+++ b/qq-maid-core/README.md
@@ -155,7 +155,7 @@ runtime/.env
 
 ```toml
 [model_routes.private_main]
-candidates = ["openai:gpt-5.4-mini", "deepseek:deepseek-chat"]
+candidates = ["openai:gpt-5.4-mini", "deepseek:deepseek-v4-flash"]
 ```
 
 候选项按从左到右的优先级执行。`qq-maid-llm` 会在超时、HTTP/网络错误、Provider 协议错误、上游空响应、429 和 5xx 等可恢复失败后尝试下一个候选；配置错误、本地请求构造错误和业务参数错误不会继续请求其他模型。当前普通聊天使用请求开始时解析出的 `ResolvedAgentPolicy`；会话标题、Memory 草稿、会话压缩、翻译命令和 RSS 翻译使用同一场景策略中的 `aux_route`，缺省辅助路线时继承当前场景 `main_route`。Tool Loop 使用同一请求级策略中的模型、输出预算、reasoning effort 和最大轮数；`/查` 与自然语言 `web_search` 共用 `[tools.web_search]` 后端：`provider_native` 将裸搜索模型兼容为内置 OpenAI，并按显式前缀选择 OpenAI Responses、自定义 `openai_responses` 或 Gemini Google Search；`openai_compatible` 不冒充原生搜索，需改用 Tavily。`tavily` 使用统一 Tavily Search 执行器，`disabled` 则关闭该能力。

--- a/qq-maid-core/src/config/agent/mod.rs
+++ b/qq-maid-core/src/config/agent/mod.rs
@@ -691,7 +691,7 @@ impl AgentRuntimeConfig {
         let provider = model.provider.unwrap_or(ModelProvider::OpenAi);
         // 运行时元数据已规范化 ID，原始 TOML key 可能保留历史大小写。
         match provider {
-            ModelProvider::OpenAi | ModelProvider::Gemini => Ok(()),
+            ModelProvider::OpenAi | ModelProvider::Gemini | ModelProvider::DeepSeek => Ok(()),
             ModelProvider::Custom(name) => match self
                 .providers
                 .values()
@@ -705,7 +705,7 @@ impl AgentRuntimeConfig {
                     "{field_name} references custom provider `{name}`, but providers.{name} is not configured"
                 ))),
             },
-            ModelProvider::DeepSeek | ModelProvider::BigModel => Err(LlmError::config(format!(
+            ModelProvider::BigModel => Err(LlmError::config(format!(
                 "{field_name} references provider `{}`, which does not support provider_native search; configure Tavily instead",
                 provider.as_str()
             ))),

--- a/qq-maid-core/src/config/agent/tests.rs
+++ b/qq-maid-core/src/config/agent/tests.rs
@@ -360,6 +360,23 @@ fn provider_native_rejects_compatible_provider_but_tavily_can_ignore_route() {
 }
 
 #[test]
+fn provider_native_accepts_deepseek_search_route() {
+    let text = DEFAULT_AGENT_CONFIG.replace(
+        r#"model = "gpt-5.6-luna""#,
+        r#"model = "deepseek:arbitrary-model""#,
+    );
+    let config = AgentRuntimeConfig::from_toml(
+        &text,
+        AgentConfigSource::File("config/agent.toml".to_owned()),
+    )
+    .unwrap();
+    assert_eq!(
+        config.resolve(ChatScene::Private).unwrap().search_model,
+        "deepseek:arbitrary-model"
+    );
+}
+
+#[test]
 fn provider_native_search_route_keeps_bare_model_as_openai_compatibility_default() {
     let config = AgentRuntimeConfig::from_toml(
         DEFAULT_AGENT_CONFIG,

--- a/qq-maid-core/src/config/agent/tests.rs
+++ b/qq-maid-core/src/config/agent/tests.rs
@@ -590,21 +590,25 @@ fn default_agent_toml_prefers_luna_and_keeps_provider_fallbacks() {
     let group = config.resolve(ChatScene::Group).unwrap();
     assert_eq!(
         private.main_model,
-        "openai:gpt-5.6-luna,gemini:gemini-2.5-pro,mimo:mimo-v2.5-pro,deepseek:deepseek-chat"
+        "openai:gpt-5.6-luna,gemini:gemini-2.5-pro,mimo:mimo-v2.5-pro,deepseek:deepseek-v4-flash"
     );
     assert_eq!(
         private.aux_model.as_deref(),
-        Some("openai:gpt-5.6-luna,gemini:gemini-2.5-flash,mimo:mimo-v2.5,deepseek:deepseek-chat")
+        Some(
+            "openai:gpt-5.6-luna,gemini:gemini-2.5-flash,mimo:mimo-v2.5,deepseek:deepseek-v4-flash"
+        )
     );
     assert_eq!(private.search_model, "gpt-5.6-luna");
     assert_eq!(private.search_backend, WebSearchBackend::ProviderNative);
     assert_eq!(
         group.main_model,
-        "openai:gpt-5.6-luna,gemini:gemini-2.5-flash,mimo:mimo-v2.5,deepseek:deepseek-chat"
+        "openai:gpt-5.6-luna,gemini:gemini-2.5-flash,mimo:mimo-v2.5,deepseek:deepseek-v4-flash"
     );
     assert_eq!(
         group.aux_model.as_deref(),
-        Some("openai:gpt-5.6-luna,gemini:gemini-2.5-flash,mimo:mimo-v2.5,deepseek:deepseek-chat")
+        Some(
+            "openai:gpt-5.6-luna,gemini:gemini-2.5-flash,mimo:mimo-v2.5,deepseek:deepseek-v4-flash"
+        )
     );
     assert_eq!(group.search_model, "gpt-5.6-luna");
     assert_eq!(
@@ -629,7 +633,7 @@ fn default_agent_toml_declares_luna_first_without_embedding_secrets() {
     assert!(active_config.contains("openai:gpt-5.6-luna"));
     assert!(active_config.contains("gemini:gemini-2.5-pro"));
     assert!(active_config.contains("mimo:mimo-v2.5-pro"));
-    assert!(active_config.contains("deepseek:deepseek-chat"));
+    assert!(active_config.contains("deepseek:deepseek-v4-flash"));
     assert!(active_config.contains("[tools.web_search.routes.private_search]"));
     assert!(active_config.contains("[tools.web_search.routes.group_search]"));
     assert!(active_config.contains("backend = \"provider_native\""));
@@ -713,21 +717,21 @@ fn default_agent_toml_exposes_expected_luna_first_route_displays() {
     assert_eq!(
         route_displays.get("agent.model_routes.private_main"),
         Some(
-            &"openai:gpt-5.6-luna,gemini:gemini-2.5-pro,mimo:mimo-v2.5-pro,deepseek:deepseek-chat"
+            &"openai:gpt-5.6-luna,gemini:gemini-2.5-pro,mimo:mimo-v2.5-pro,deepseek:deepseek-v4-flash"
                 .to_owned()
         )
     );
     assert_eq!(
         route_displays.get("agent.model_routes.group_main"),
         Some(
-            &"openai:gpt-5.6-luna,gemini:gemini-2.5-flash,mimo:mimo-v2.5,deepseek:deepseek-chat"
+            &"openai:gpt-5.6-luna,gemini:gemini-2.5-flash,mimo:mimo-v2.5,deepseek:deepseek-v4-flash"
                 .to_owned()
         )
     );
     assert_eq!(
         route_displays.get("agent.model_routes.aux"),
         Some(
-            &"openai:gpt-5.6-luna,gemini:gemini-2.5-flash,mimo:mimo-v2.5,deepseek:deepseek-chat"
+            &"openai:gpt-5.6-luna,gemini:gemini-2.5-flash,mimo:mimo-v2.5,deepseek:deepseek-v4-flash"
                 .to_owned()
         )
     );

--- a/qq-maid-core/src/config/center/providers.rs
+++ b/qq-maid-core/src/config/center/providers.rs
@@ -161,15 +161,17 @@ impl ConfigCenter {
             .map(str::trim)
             .find(|value| !value.is_empty())
             .unwrap_or(default_url);
-        let responses = id == "openai"
-            && crate::config::parse_openai_api_mode(
-                environment
-                    .get("OPENAI_API_MODE")
-                    .map(String::as_str)
-                    .unwrap_or("auto"),
-            )
-            .map_err(|error| ConfigCenterError::invalid(error.message))?
-                != crate::config::OpenAiApiMode::ChatOnly;
+        // 内置 DeepSeek 与运行时一致走 Responses，不能用 Chat 探针伪造兼容结果。
+        let responses = id == "deepseek"
+            || id == "openai"
+                && crate::config::parse_openai_api_mode(
+                    environment
+                        .get("OPENAI_API_MODE")
+                        .map(String::as_str)
+                        .unwrap_or("auto"),
+                )
+                .map_err(|error| ConfigCenterError::invalid(error.message))?
+                    != crate::config::OpenAiApiMode::ChatOnly;
         Ok(ResolvedConnection {
             base_url: base.to_owned(),
             responses,

--- a/qq-maid-core/src/config/center/providers.rs
+++ b/qq-maid-core/src/config/center/providers.rs
@@ -58,7 +58,10 @@ impl ConfigCenter {
         let connection = self.resolve_connection_for_read(id, expected_revision)?;
         qq_maid_llm::provider::openai::diagnostics::test_connection(
             &connection.base_url,
-            connection.responses,
+            // 诊断与运行时共用旧模型协议规则；自定义 Connection 仍尊重显式 kind。
+            connection.responses
+                && !(id == "deepseek"
+                    && qq_maid_llm::provider::deepseek::is_legacy_chat_model(model.trim())),
             &connection.auth,
             &connection.api_key,
             model,
@@ -161,7 +164,7 @@ impl ConfigCenter {
             .map(str::trim)
             .find(|value| !value.is_empty())
             .unwrap_or(default_url);
-        // 内置 DeepSeek 与运行时一致走 Responses，不能用 Chat 探针伪造兼容结果。
+        // DeepSeek 默认使用 Responses；模型探针另按旧模型兼容规则选择 Chat。
         let responses = id == "deepseek"
             || id == "openai"
                 && crate::config::parse_openai_api_mode(

--- a/qq-maid-core/src/config/center/tests/provider_routes.rs
+++ b/qq-maid-core/src/config/center/tests/provider_routes.rs
@@ -644,20 +644,30 @@ async fn builtin_discovery_uses_protocol_and_classifies_endpoint_support() {
 }
 
 #[tokio::test]
-async fn deepseek_connection_diagnostic_uses_responses_even_when_openai_is_chat_only() {
-    use axum::{Json, Router, http::HeaderMap, routing::post};
+async fn deepseek_connection_diagnostic_selects_protocol_even_when_openai_is_chat_only() {
+    use axum::{Json, Router, extract::OriginalUri, http::HeaderMap, routing::post};
     use qq_maid_llm::provider::openai::diagnostics::ProbeState;
-    let app = Router::new().route(
-        "/responses",
-        post(
-            |headers: HeaderMap, Json(body): Json<serde_json::Value>| async move {
-                assert_eq!(headers["authorization"], "Bearer test-key");
-                assert_eq!(body["model"], "test-model");
-                assert!(body.get("input").is_some());
-                Json(serde_json::json!({"output": [{"type": "message", "content": [{"type": "output_text", "text": "OK"}]}]}))
-            },
-        ),
-    );
+    async fn handler(
+        OriginalUri(uri): OriginalUri,
+        headers: HeaderMap,
+        Json(body): Json<serde_json::Value>,
+    ) -> Json<serde_json::Value> {
+        assert_eq!(headers["authorization"], "Bearer test-key");
+        if body["model"] == "deepseek-chat" {
+            assert_eq!(uri.path(), "/chat/completions");
+            assert!(body.get("messages").is_some());
+            Json(serde_json::json!({"choices": [{"message": {"content": "OK"}}]}))
+        } else {
+            assert_eq!(uri.path(), "/responses");
+            assert!(body.get("input").is_some());
+            Json(
+                serde_json::json!({"output": [{"type": "message", "content": [{"type": "output_text", "text": "OK"}]}]}),
+            )
+        }
+    }
+    let app = Router::new()
+        .route("/responses", post(handler))
+        .route("/chat/completions", post(handler));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let base = format!("http://{}", listener.local_addr().unwrap());
     let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
@@ -668,10 +678,13 @@ async fn deepseek_connection_diagnostic_uses_responses_even_when_openai_is_chat_
         ("DEEPSEEK_API_KEY".into(), "test-key".into()),
     ]));
     let revision = center.managed_file.load().unwrap().revision;
-    let result = center
-        .test_provider_connection("deepseek", &revision, "test-model")
-        .await
-        .unwrap();
-    assert_eq!(result.model_call, ProbeState::Success);
+    // 同一连接顺序验证两种协议，避免并发占用全局诊断限流名额。
+    for model in ["test-model", "deepseek-v4-flash", "deepseek-chat"] {
+        let result = center
+            .test_provider_connection("deepseek", &revision, model)
+            .await
+            .unwrap();
+        assert_eq!(result.model_call, ProbeState::Success);
+    }
     server.abort();
 }

--- a/qq-maid-core/src/config/center/tests/provider_routes.rs
+++ b/qq-maid-core/src/config/center/tests/provider_routes.rs
@@ -642,3 +642,36 @@ async fn builtin_discovery_uses_protocol_and_classifies_endpoint_support() {
     }
     server.abort();
 }
+
+#[tokio::test]
+async fn deepseek_connection_diagnostic_uses_responses_even_when_openai_is_chat_only() {
+    use axum::{Json, Router, http::HeaderMap, routing::post};
+    use qq_maid_llm::provider::openai::diagnostics::ProbeState;
+    let app = Router::new().route(
+        "/responses",
+        post(
+            |headers: HeaderMap, Json(body): Json<serde_json::Value>| async move {
+                assert_eq!(headers["authorization"], "Bearer test-key");
+                assert_eq!(body["model"], "test-model");
+                assert!(body.get("input").is_some());
+                Json(serde_json::json!({"output": [{"type": "message", "content": [{"type": "output_text", "text": "OK"}]}]}))
+            },
+        ),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let (center, _database, _directory) = test_center();
+    let center = center.with_external_environment(HashMap::from([
+        ("OPENAI_API_MODE".into(), "chat_only".into()),
+        ("DEEPSEEK_BASE_URL".into(), base),
+        ("DEEPSEEK_API_KEY".into(), "test-key".into()),
+    ]));
+    let revision = center.managed_file.load().unwrap().revision;
+    let result = center
+        .test_provider_connection("deepseek", &revision, "test-model")
+        .await
+        .unwrap();
+    assert_eq!(result.model_call, ProbeState::Success);
+    server.abort();
+}

--- a/qq-maid-core/src/config/mod.rs
+++ b/qq-maid-core/src/config/mod.rs
@@ -35,7 +35,7 @@ pub use voice::{
 
 // ---- 默认常量 ----
 pub const DEFAULT_DEEPSEEK_BASE_URL: &str = "https://api.deepseek.com"; // DeepSeek 默认 API 地址
-pub const DEFAULT_DEEPSEEK_MODEL: &str = "deepseek-chat"; // 默认 DeepSeek 模型
+pub const DEFAULT_DEEPSEEK_MODEL: &str = "deepseek-v4-flash"; // 新部署默认使用稳定 Responses 模型
 pub const DEFAULT_BIGMODEL_BASE_URL: &str = "https://open.bigmodel.cn/api/paas/v4"; // BigModel 通用 API 地址
 pub const DEFAULT_BIGMODEL_MODEL: &str = "glm-5.2"; // 默认 BigModel 模型
 pub const DEFAULT_GEMINI_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta/openai"; // Gemini OpenAI-compatible API 地址

--- a/qq-maid-core/src/config/tests.rs
+++ b/qq-maid-core/src/config/tests.rs
@@ -733,3 +733,26 @@ fn empty_qweather_configuration_disables_weather_and_uses_default_hosts() {
     assert!(!env_example.contains("你的和风天气"));
     snapshot.restore();
 }
+
+#[test]
+fn deepseek_defaults_and_public_examples_use_supported_responses_model() {
+    use qq_maid_llm::provider::{LlmProvider, ToolCallingProtocol, deepseek::DeepSeekProvider};
+    let _guard = ENV_LOCK.lock().unwrap();
+    let config = AppConfig::from_env().unwrap();
+    let mut llm = config.llm_config();
+    llm.deepseek_api_key = Some("test-key".to_owned());
+    assert_eq!(llm.deepseek_model, "deepseek-v4-flash");
+    let provider = DeepSeekProvider::new(&llm).unwrap();
+    assert_eq!(
+        provider.tool_calling_protocol(None),
+        Some(ToolCallingProtocol::OpenAiResponses)
+    );
+    for text in [
+        include_str!("../../../runtime/config/agent.example.toml"),
+        include_str!("../../../runtime/README.md"),
+        include_str!("../../README.md"),
+    ] {
+        assert!(!text.contains("deepseek:deepseek-chat"));
+        assert!(text.contains("deepseek:deepseek-v4-flash"));
+    }
+}

--- a/qq-maid-llm/README.md
+++ b/qq-maid-llm/README.md
@@ -20,7 +20,7 @@ qq-maid-common / reqwest / serde / tokio
 
 - OpenAI Responses API 主链路（system/user 用 `input_text`、assistant 用 `output_text`、标准 completed 提取，以及“正常 HTTP EOF + 非空文本 + 无未闭合 function call/解析错误/显式失败”的兼容完成；支持 delta/completed/failed/incomplete/error、跨 chunk 与 CRLF、受剩余预算约束的空流回退、usage 与 cached token 提取、HTTP 错误正文裁剪、200 但正文为空返回明确错误）。
 - OpenAI Chat Completions 兼容实现（基于 `reqwest`，统一编码文字与 `image_url` 图片输入，支持流式与非流式、`[DONE]`、usage 与 cached token 提取、空流补非流、401/403/429/timeout/5xx 与非标准错误正文分类）。
-- DeepSeek 复用公共 Responses adapter，支持普通/流式聊天、Function Tool Loop、`input_image` 和显式 reasoning effort；不做同 Provider 的 Chat Completions 回退，失败继续由候选链处理。
+- DeepSeek 复用公共 Responses adapter，支持普通/流式聊天、Function Tool Loop、`input_image` 和显式 reasoning effort；旧 Chat 模型在请求前走兼容 adapter，不做响应错误触发的跨协议回退，失败继续由候选链处理。
 - 模型候选链路由：按 `agent.toml` 中的候选顺序调用、成功立即停止、临时错误降级、永久错误终止、全部失败返回聚合错误；OpenAI Responses → Chat Completions fallback 规则不变。
 - 通用 SSE frame 解析（聊天 Responses 与 Web Search 共用，处理 CRLF、`event:`/`data:`、`[DONE]`）。
 - Responses + `web_search` 工具协议：内置 OpenAI、DeepSeek 与自定义 `openai_responses` Provider 共用请求 payload、HTTP transport、SSE 文本增量、answer 提取和 sources 提取。
@@ -39,7 +39,15 @@ qq-maid-common / reqwest / serde / tokio
 
 ## DeepSeek Responses 使用边界
 
-DeepSeek 继续使用 `DEEPSEEK_API_KEY` 与 `DEEPSEEK_BASE_URL`（默认 `https://api.deepseek.com`），普通聊天请求 `/responses`。原生搜索须在现有 `agent.toml` 的 `tools.web_search` 中选用 `provider_native`，并将对应 `routes.<name>.model` 设为 `deepseek:<model>`；场景与工具白名单仍然生效，普通聊天不会自动添加 `web_search`。
+DeepSeek 继续使用 `DEEPSEEK_API_KEY` 与 `DEEPSEEK_BASE_URL`（默认 `https://api.deepseek.com`），新部署默认模型为 `deepseek-v4-flash`。原生搜索须在现有 `agent.toml` 的 `tools.web_search` 中选用 `provider_native`，并将对应 `routes.<name>.model` 设为 `deepseek:deepseek-v4-flash`；场景与工具白名单仍然生效，普通聊天不会自动添加 `web_search`。
+
+协议在发请求前按有效模型（请求覆盖优先于默认值，支持裸名及 `deepseek:` 前缀）选择：
+
+- `deepseek-chat`、`deepseek-reasoner` 精确匹配历史模型，使用 `/chat/completions`，普通聊天、SSE 和 Tool Loop 共用此规则；已有配置无需强制迁移。
+- `deepseek-v4-flash`、`deepseek-v4-pro`、`deepseek-v4-flash-vision-exp` 使用 `/responses`。
+- 其他显式 DeepSeek 模型名原样使用 Responses，不改写为默认模型、不猜能力；若私有网关模型仅支持 Chat，请通过自定义 `openai_compatible` Provider 明确声明协议。
+
+Responses 的 400 参数错误和其他 HTTP 错误均不会改走 Chat；保留已有候选链错误分类及同协议空流重试。原生搜索没有旧 Chat 等价路径，旧模型会在请求前收到配置迁移提示，需修改 `tools.web_search.routes.<name>.model` 或选择 Tavily。公开模板更新不覆盖已有私有 `agent.toml`。
 
 图片沿用公共 URL / 本地图片 data URL → `input_image` 链路。adapter 的 `supports_vision` 表示能编码图片，不保证所有模型能看图，不按模型名称推断视觉能力。根据 [DeepSeek Responses 文档](https://api-docs.deepseek.com/guides/responses_api/)，当前视觉实验模型能理解图片，其他模型可能仅收到占位文本；应按官方能力说明、模型元数据和实际识图结果选择模型。临时联调模型不写入默认配置。普通文件输入仍不支持。
 
@@ -88,7 +96,7 @@ qq-maid-llm/src/
     ├── types.rs      # ChatMessage、ChatRole、ChatRequest、ModelId、ModelRoute、ModelProvider、TokenUsage
     ├── status.rs     # UpstreamStatus、ObservedProvider 健康观测
         ├── bigmodel.rs   # 智谱 BigModel（复用 OpenAI 兼容 Chat Completions adapter）
-        ├── deepseek.rs   # DeepSeek（装配公共 Responses adapter）
+        ├── deepseek.rs   # DeepSeek（旧 Chat 兼容与 Responses adapter）
         ├── openai_compatible.rs # 配置驱动的 OpenAI-compatible Chat Completions provider
     └── openai/
         ├── mod.rs        # OpenAI provider 组装与 LlmProvider 实现
@@ -128,7 +136,7 @@ qq-maid-core CoreService
   -> LlmService::chat(ChatRequest)
      -> 候选链路由（按候选顺序）
         -> OpenAI provider（Responses API → Chat Completions fallback）
-        -> DeepSeek provider（公共 Responses adapter）
+        -> DeepSeek provider（请求前选择 Chat / Responses）
         -> BigModel provider（OpenAI 兼容 Chat Completions adapter）
         -> 自定义 OpenAI-compatible provider（如 MiMo，Chat Completions adapter）
      -> 成功立即停止；临时错误降级；永久错误终止；全部失败返回聚合错误

--- a/qq-maid-llm/README.md
+++ b/qq-maid-llm/README.md
@@ -20,10 +20,10 @@ qq-maid-common / reqwest / serde / tokio
 
 - OpenAI Responses API 主链路（system/user 用 `input_text`、assistant 用 `output_text`、标准 completed 提取，以及“正常 HTTP EOF + 非空文本 + 无未闭合 function call/解析错误/显式失败”的兼容完成；支持 delta/completed/failed/incomplete/error、跨 chunk 与 CRLF、受剩余预算约束的空流回退、usage 与 cached token 提取、HTTP 错误正文裁剪、200 但正文为空返回明确错误）。
 - OpenAI Chat Completions 兼容实现（基于 `reqwest`，统一编码文字与 `image_url` 图片输入，支持流式与非流式、`[DONE]`、usage 与 cached token 提取、空流补非流、401/403/429/timeout/5xx 与非标准错误正文分类）。
-- DeepSeek 复用 OpenAI 兼容 Chat Completions adapter，只保留 base URL、认证和模型规则差异。
+- DeepSeek 复用公共 Responses adapter，支持普通/流式聊天、Function Tool Loop、`input_image` 和显式 reasoning effort；不做同 Provider 的 Chat Completions 回退，失败继续由候选链处理。
 - 模型候选链路由：按 `agent.toml` 中的候选顺序调用、成功立即停止、临时错误降级、永久错误终止、全部失败返回聚合错误；OpenAI Responses → Chat Completions fallback 规则不变。
 - 通用 SSE frame 解析（聊天 Responses 与 Web Search 共用，处理 CRLF、`event:`/`data:`、`[DONE]`）。
-- Responses + `web_search` 工具协议：内置 OpenAI 与自定义 `openai_responses` Provider 共用请求 payload、HTTP transport、SSE 文本增量、answer 提取和 sources 提取。
+- Responses + `web_search` 工具协议：内置 OpenAI、DeepSeek 与自定义 `openai_responses` Provider 共用请求 payload、HTTP transport、SSE 文本增量、answer 提取和 sources 提取。
 - Function Tool 基础抽象：`Tool` trait、`ToolRegistry`、工具超时、工具结果大小限制和服务端白名单执行入口。
 - OpenAI Responses 原生 Function Tool Loop：解析 `function_call`，执行注册 Tool 后以 `function_call_output` 回传模型；当前只支持串行调用，最大轮数由 core 配置控制。
 - Token usage、`LlmMetrics`、`MetricsRecorder` 和 `UpstreamStatus` / `ObservedProvider` 健康观测。
@@ -36,6 +36,16 @@ qq-maid-common / reqwest / serde / tokio
 - 全仓 `AppError` 体系、天气、火车、RSS、HTTP 路由等非 LLM 错误 —— 由 core 维护。
 - 具体 Tool 实现和业务权限 —— 由 core 维护；本 crate 只负责 Tool 协议和执行调度抽象。
 - Hosted Code Interpreter、File Search、文件输入/输出、reasoning 事件或完整 LLM 事件总线 —— 当前不实现。
+
+## DeepSeek Responses 使用边界
+
+DeepSeek 继续使用 `DEEPSEEK_API_KEY` 与 `DEEPSEEK_BASE_URL`（默认 `https://api.deepseek.com`），普通聊天请求 `/responses`。原生搜索须在现有 `agent.toml` 的 `tools.web_search` 中选用 `provider_native`，并将对应 `routes.<name>.model` 设为 `deepseek:<model>`；场景与工具白名单仍然生效，普通聊天不会自动添加 `web_search`。
+
+图片沿用公共 URL / 本地图片 data URL → `input_image` 链路。adapter 的 `supports_vision` 表示能编码图片，不保证所有模型能看图，不按模型名称推断视觉能力。根据 [DeepSeek Responses 文档](https://api-docs.deepseek.com/guides/responses_api/)，当前视觉实验模型能理解图片，其他模型可能仅收到占位文本；应按官方能力说明、模型元数据和实际识图结果选择模型。临时联调模型不写入默认配置。普通文件输入仍不支持。
+
+Responses Tool Loop 无服务端会话依赖，会回填 reasoning、function call 与真实工具执行结果；推理正文不作为用户回答输出。usage 沿用公共输入、缓存输入、输出与总 token 统计，尚未单独暴露 reasoning token 数。DeepSeek 忽略 `parallel_tool_calls`，服务端白名单和工具执行约束仍由统一 Agent Loop 执行。
+
+本地协议回归覆盖聊天、SSE、Tool Loop、搜索、图片编码与诊断路由；真实 DeepSeek 模型的可用性及识图能力需在有测试凭据的环境另行联调。
 
 ## 统一入口
 
@@ -78,7 +88,7 @@ qq-maid-llm/src/
     ├── types.rs      # ChatMessage、ChatRole、ChatRequest、ModelId、ModelRoute、ModelProvider、TokenUsage
     ├── status.rs     # UpstreamStatus、ObservedProvider 健康观测
         ├── bigmodel.rs   # 智谱 BigModel（复用 OpenAI 兼容 Chat Completions adapter）
-        ├── deepseek.rs   # DeepSeek（复用 OpenAI 兼容 Chat Completions adapter）
+        ├── deepseek.rs   # DeepSeek（装配公共 Responses adapter）
         ├── openai_compatible.rs # 配置驱动的 OpenAI-compatible Chat Completions provider
     └── openai/
         ├── mod.rs        # OpenAI provider 组装与 LlmProvider 实现
@@ -106,7 +116,7 @@ qq-maid-llm/src/
 - `openai_compatible_providers`：由 `agent.toml [providers.*]` 声明的自定义 Chat Completions provider，例如 `mimo`；实际 API key 由 core 按 `api_key_env` 从环境变量读取。
 - `openai_responses_providers`：配置驱动的 Responses provider；复用内置 OpenAI 的文字 / `input_image` 图片请求、SSE 和 Function Tool Calling，可独立设置 Provider ID、Base URL、认证和超时。Core 的公开 `agent.toml` 暂不允许启用 Chat fallback，避免普通聊天与 Tool Loop 出现不同协议语义。
 - `request_timeout`、`stream`、`max_output_tokens`。
-- `web_search`：统一联网搜索后端及默认参数；`provider_native` 将裸模型兼容为内置 OpenAI，并严格按显式前缀选择 OpenAI Responses、自定义 `openai_responses` 或 Gemini Google Search；`tavily` 调用 Tavily Search，`disabled` 关闭联网搜索。
+- `web_search`：统一联网搜索后端及默认参数；`provider_native` 将裸模型兼容为内置 OpenAI，并严格按显式前缀选择 OpenAI/DeepSeek Responses、自定义 `openai_responses` 或 Gemini Google Search；`tavily` 调用 Tavily Search，`disabled` 关闭联网搜索。
 - `tavily_api_key`：Tavily Search 密钥；由 core 从安全配置中心或兼容环境变量 `TAVILY_API_KEY` 注入，不写入 `agent.toml`。
 
 Tool Calling、轮数预算与工具白名单由 core 从 `agent.toml` 的 Profile / Scene 解析；本 crate 只接收已经构造好的 `ToolChatRequest`。Todo、标题、记忆、Compact、翻译等业务路线同样由 core 的 Agent Profile 管理，Provider 凭证和连接参数以 [runtime/config/.env.example](../runtime/config/.env.example) 为准。
@@ -118,7 +128,7 @@ qq-maid-core CoreService
   -> LlmService::chat(ChatRequest)
      -> 候选链路由（按候选顺序）
         -> OpenAI provider（Responses API → Chat Completions fallback）
-        -> DeepSeek provider（OpenAI 兼容 Chat Completions adapter）
+        -> DeepSeek provider（公共 Responses adapter）
         -> BigModel provider（OpenAI 兼容 Chat Completions adapter）
         -> 自定义 OpenAI-compatible provider（如 MiMo，Chat Completions adapter）
      -> 成功立即停止；临时错误降级；永久错误终止；全部失败返回聚合错误

--- a/qq-maid-llm/src/provider/deepseek.rs
+++ b/qq-maid-llm/src/provider/deepseek.rs
@@ -1,70 +1,49 @@
-//! DeepSeek 提供商实现。
-//!
-//! DeepSeek 使用 OpenAI 兼容 Chat Completions 协议；本模块只维护
-//! DeepSeek 的 base URL、认证和模型前缀规则差异。
-
-use std::time::Duration;
+//! DeepSeek 提供商：复用公共 Responses 请求、SSE、图片编码与 Tool Loop。
 
 use async_trait::async_trait;
 
 use crate::{
     agent_loop::{AgentSessionRequest, AgentStepSession},
-    config::LlmConfig,
+    config::{LlmConfig, OpenAiResponsesProviderConfig},
     error::LlmError,
     provider::{
         ChatOutcome, LlmProvider, LlmStream, ToolCallingProtocol,
-        openai::{
-            ChatCompletionsClient, begin_chat_completions_session, chat_completions_stream,
-            chat_completions_with_stream_fallback, provider_chat_completions_tool_calling_protocol,
-        },
-        outcome_to_stream,
+        openai::ConfiguredResponsesProvider,
         types::{ChatRequest, ModelId, ModelProvider},
     },
 };
 
-const MULTIMODAL_UNSUPPORTED_MESSAGE: &str =
-    "我收到图片或文件了，但当前模型暂时不支持图片/文件理解。你可以补充文字说明，我先帮你记录。";
+/// 内置 DeepSeek 的连接元数据；聊天与原生搜索必须使用同一份认证和地址。
+pub(crate) fn responses_config(config: &LlmConfig) -> OpenAiResponsesProviderConfig {
+    OpenAiResponsesProviderConfig {
+        id: ModelProvider::DeepSeek,
+        base_url: config.deepseek_base_url.clone(),
+        api_key_env: "DEEPSEEK_API_KEY".to_owned(),
+        api_key: config.deepseek_api_key.clone(),
+        auth: Default::default(),
+        request_timeout_seconds: None,
+        // 普通聊天和工具循环保持相同协议；失败由已有候选链处理。
+        chat_fallback: false,
+    }
+}
 
-/// DeepSeek 提供商实现。
+/// DeepSeek 只装配供应商身份，不复制 Responses 协议实现。
 pub struct DeepSeekProvider {
-    /// OpenAI 兼容 Chat Completions 客户端。
-    client: ChatCompletionsClient,
-    /// 默认模型名称（如 `"deepseek-chat"`）。
-    model: String,
-    /// 是否启用流式传输。
-    stream: bool,
-    /// 单张本地图片允许转成 data URL 的最大字节数。
-    media_max_bytes: u64,
-    /// 最大输出令牌数。
-    max_output_tokens: u64,
+    inner: ConfiguredResponsesProvider,
 }
 
 impl DeepSeekProvider {
     /// 从 LLM 配置创建 DeepSeek 提供商实例。
     pub fn new(config: &LlmConfig) -> Result<Self, LlmError> {
-        let api_key = config
-            .deepseek_api_key
-            .clone()
-            .ok_or_else(|| LlmError::config("DEEPSEEK_API_KEY is required"))?;
-        let http_client = qq_maid_common::http_client::try_builder()
-            .map_err(|err| LlmError::config(format!("failed to configure DeepSeek TLS: {err}")))?
-            .timeout(Duration::from_secs(config.request_timeout_seconds))
-            .build()
-            .map_err(|err| {
-                LlmError::config(format!("failed to build DeepSeek HTTP client: {err}"))
-            })?;
-        let client = ChatCompletionsClient::new(
-            api_key,
-            Some(config.deepseek_base_url.as_str()),
-            http_client,
-        );
-
         Ok(Self {
-            client,
-            model: deepseek_config_model(&config.deepseek_model)?,
-            stream: config.stream,
-            media_max_bytes: config.media_max_bytes,
-            max_output_tokens: config.max_output_tokens,
+            inner: ConfiguredResponsesProvider::new(
+                &responses_config(config),
+                deepseek_config_model(&config.deepseek_model)?,
+                config.stream,
+                config.request_timeout_seconds,
+                config.media_max_bytes,
+                config.max_output_tokens,
+            )?,
         })
     }
 }
@@ -72,99 +51,41 @@ impl DeepSeekProvider {
 #[async_trait]
 impl LlmProvider for DeepSeekProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatOutcome, LlmError> {
-        reject_multimodal_if_needed(&req)?;
-        let effective_model = effective_deepseek_model(req.model.as_deref(), &self.model)?;
-        chat_completions_with_stream_fallback(
-            self.stream,
-            &self.client,
-            self.name(),
-            &effective_model,
-            self.media_max_bytes,
-            req.max_output_tokens.unwrap_or(self.max_output_tokens),
-            &req.messages,
-        )
-        .await
+        self.inner.chat(req).await
     }
 
     async fn stream_chat(&self, req: ChatRequest) -> Result<LlmStream, LlmError> {
-        reject_multimodal_if_needed(&req)?;
-        let effective_model = effective_deepseek_model(req.model.as_deref(), &self.model)?;
-        if !self.stream {
-            let outcome = chat_completions_with_stream_fallback(
-                false,
-                &self.client,
-                self.name(),
-                &effective_model,
-                self.media_max_bytes,
-                req.max_output_tokens.unwrap_or(self.max_output_tokens),
-                &req.messages,
-            )
-            .await?;
-            return Ok(outcome_to_stream(outcome));
-        }
-        chat_completions_stream(
-            &self.client,
-            self.name(),
-            &effective_model,
-            self.media_max_bytes,
-            req.max_output_tokens.unwrap_or(self.max_output_tokens),
-            &req.messages,
-            true,
-        )
-        .await
+        self.inner.stream_chat(req).await
     }
 
     async fn begin_agent_session(
         &self,
         req: AgentSessionRequest<'_>,
     ) -> Result<Option<Box<dyn AgentStepSession + Send>>, LlmError> {
-        if self.tool_calling_protocol(req.chat.model.as_deref())
-            != Some(ToolCallingProtocol::ChatCompletionsToolCalls)
-        {
-            return Ok(None);
-        }
-        begin_chat_completions_session(
-            req,
-            self.client.clone(),
-            self.name(),
-            &self.model,
-            self.media_max_bytes,
-            req.chat.max_output_tokens.unwrap_or(self.max_output_tokens),
-            effective_deepseek_model,
-        )
-        .await
+        self.inner.begin_agent_session(req).await
     }
 
     fn tool_calling_protocol(&self, model: Option<&str>) -> Option<ToolCallingProtocol> {
-        provider_chat_completions_tool_calling_protocol(
-            model,
-            &self.model,
-            effective_deepseek_model,
-        )
+        self.inner.tool_calling_protocol(model)
+    }
+
+    fn supports_vision(&self, model: Option<&str>) -> bool {
+        // 仅声明 adapter 能编码 input_image；实际视觉能力由模型元数据/上游决定，
+        // 不根据临时模型名称猜测，也不在供应商层丢弃图片。
+        self.inner.supports_vision(model)
     }
 
     fn name(&self) -> &str {
-        "deepseek"
+        self.inner.name()
     }
 
     fn model(&self) -> &str {
-        &self.model
+        self.inner.model()
     }
 
     fn stream_enabled(&self) -> bool {
-        self.stream
+        self.inner.stream_enabled()
     }
-}
-
-fn reject_multimodal_if_needed(req: &ChatRequest) -> Result<(), LlmError> {
-    if req.has_non_text_parts() {
-        return Err(LlmError::new(
-            "unsupported_input_part",
-            MULTIMODAL_UNSUPPORTED_MESSAGE,
-            "request",
-        ));
-    }
-    Ok(())
 }
 
 /// 验证并解析 DeepSeek 的配置模型名。
@@ -181,232 +102,5 @@ pub(crate) fn deepseek_config_model(value: &str) -> Result<String, LlmError> {
     }
 }
 
-/// 决定本次请求实际使用的 DeepSeek 模型名称。
-fn effective_deepseek_model(
-    override_model: Option<&str>,
-    default_model: &str,
-) -> Result<String, LlmError> {
-    let Some(value) = override_model else {
-        return Ok(default_model.to_owned());
-    };
-    let model = ModelId::parse(value, "request")?;
-    match model.provider {
-        Some(ModelProvider::DeepSeek) | None => Ok(model.name),
-        Some(ModelProvider::OpenAi)
-        | Some(ModelProvider::BigModel)
-        | Some(ModelProvider::Gemini)
-        | Some(ModelProvider::Custom(_)) => Err(LlmError::new(
-            "bad_request",
-            "non-deepseek-prefixed model cannot be used by DeepSeek provider",
-            "request",
-        )),
-    }
-}
-
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::provider::ToolChatRequest;
-    use crate::{
-        provider::test_support::{WeatherToolStub, spawn_chat_completions_mock, test_tool_context},
-        tool::ToolRegistry,
-    };
-    use futures::StreamExt;
-    use serde_json::json;
-
-    #[test]
-    fn effective_deepseek_model_strips_deepseek_prefix() {
-        assert_eq!(
-            effective_deepseek_model(Some("deepseek:deepseek-chat"), "default").unwrap(),
-            "deepseek-chat"
-        );
-        assert_eq!(
-            effective_deepseek_model(Some("deepseek-chat"), "default").unwrap(),
-            "deepseek-chat"
-        );
-        assert_eq!(
-            effective_deepseek_model(None, "default").unwrap(),
-            "default"
-        );
-    }
-
-    #[test]
-    fn effective_deepseek_model_rejects_openai_prefix() {
-        let err = effective_deepseek_model(Some("openai:gpt-5-mini"), "default").unwrap_err();
-        assert_eq!(err.code, "bad_request");
-    }
-
-    #[test]
-    fn deepseek_tool_calling_protocol_uses_chat_completions() {
-        let provider = DeepSeekProvider {
-            client: ChatCompletionsClient::new(
-                "test-key",
-                None,
-                qq_maid_common::http_client::client(),
-            ),
-            model: "deepseek-chat".to_owned(),
-            stream: true,
-            media_max_bytes: 10 * 1024 * 1024,
-            max_output_tokens: 1200,
-        };
-
-        assert_eq!(
-            provider.tool_calling_protocol(Some("deepseek:deepseek-chat")),
-            Some(ToolCallingProtocol::ChatCompletionsToolCalls)
-        );
-        assert_eq!(provider.tool_calling_protocol(Some("openai:gpt-5")), None);
-    }
-
-    #[tokio::test]
-    async fn chat_retries_non_stream_after_empty_sse_when_stream_enabled() {
-        let (base_url, state) = spawn_chat_completions_mock(vec![
-            "data: [DONE]\n\n".to_owned(),
-            json!({"choices": [{"message": {"content": "deepseek non-stream"}}]}).to_string(),
-        ])
-        .await;
-        let provider = DeepSeekProvider {
-            client: ChatCompletionsClient::new(
-                "test-key",
-                Some(&base_url),
-                qq_maid_common::http_client::client(),
-            ),
-            model: "deepseek-chat".to_owned(),
-            stream: true,
-            media_max_bytes: 10 * 1024 * 1024,
-            max_output_tokens: 1200,
-        };
-
-        let outcome = provider
-            .chat(ChatRequest {
-                session_id: "s".to_owned(),
-                model: None,
-                messages: vec![crate::provider::types::ChatMessage::user("hi")],
-                context_budget: None,
-                max_output_tokens: None,
-                reasoning_effort: None,
-                metadata: Default::default(),
-            })
-            .await
-            .unwrap();
-
-        assert_eq!(outcome.reply, "deepseek non-stream");
-        let requests = &state.lock().await.requests;
-        assert_eq!(requests.len(), 2);
-        assert_eq!(requests[0]["stream"], true);
-        assert!(requests[1].get("stream").is_none());
-    }
-
-    #[tokio::test]
-    async fn stream_chat_after_delta_error_does_not_retry_non_stream() {
-        let (base_url, state) = spawn_chat_completions_mock(vec![
-            "data: {\"choices\":[{\"delta\":{\"content\":\"半截\"}}]}\n\ndata: {not-json}\n\n"
-                .to_owned(),
-        ])
-        .await;
-        let provider = DeepSeekProvider {
-            client: ChatCompletionsClient::new(
-                "test-key",
-                Some(&base_url),
-                qq_maid_common::http_client::client(),
-            ),
-            model: "deepseek-chat".to_owned(),
-            stream: true,
-            media_max_bytes: 10 * 1024 * 1024,
-            max_output_tokens: 1200,
-        };
-
-        let mut stream = provider
-            .stream_chat(ChatRequest {
-                session_id: "s".to_owned(),
-                model: None,
-                messages: vec![crate::provider::types::ChatMessage::user("hi")],
-                context_budget: None,
-                max_output_tokens: None,
-                reasoning_effort: None,
-                metadata: Default::default(),
-            })
-            .await
-            .unwrap();
-        assert!(matches!(
-            stream.next().await,
-            Some(Ok(crate::provider::LlmStreamEvent::TextDelta(_)))
-        ));
-        assert!(stream.next().await.unwrap().is_err());
-        assert_eq!(state.lock().await.requests.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn chat_with_tools_runs_chat_completions_tool_loop() {
-        let (base_url, state) = spawn_chat_completions_mock(vec![
-            json!({
-                "choices": [{
-                    "message": {
-                        "role": "assistant",
-                        "content": null,
-                        "tool_calls": [{
-                            "id": "call_1",
-                            "type": "function",
-                            "function": {
-                                "name": "get_weather",
-                                "arguments": r#"{"city":"杭州"}"#
-                            }
-                        }]
-                    }
-                }]
-            })
-            .to_string(),
-            json!({
-                "choices": [{
-                    "message": {
-                        "role": "assistant",
-                        "content": "杭州有阵雨，记得带伞。"
-                    }
-                }]
-            })
-            .to_string(),
-        ])
-        .await;
-        let provider = DeepSeekProvider {
-            client: ChatCompletionsClient::new(
-                "test-key",
-                Some(&base_url),
-                qq_maid_common::http_client::client(),
-            ),
-            model: "deepseek-chat".to_owned(),
-            stream: true,
-            media_max_bytes: 10 * 1024 * 1024,
-            max_output_tokens: 1200,
-        };
-        let tools = ToolRegistry::new()
-            .register(WeatherToolStub::new("阵雨"))
-            .unwrap();
-
-        let outcome = provider
-            .chat_with_tools(ToolChatRequest {
-                chat: ChatRequest {
-                    session_id: "s".to_owned(),
-                    model: None,
-                    messages: vec![crate::provider::types::ChatMessage::user("杭州天气怎么样")],
-                    context_budget: None,
-                    max_output_tokens: None,
-                    reasoning_effort: None,
-                    metadata: Default::default(),
-                },
-                tools,
-                tool_context: test_tool_context(),
-                max_rounds: 2,
-                progress_sink: None,
-                final_delta_sink: None,
-                run_handle: None,
-            })
-            .await
-            .unwrap();
-
-        assert_eq!(outcome.reply, "杭州有阵雨，记得带伞。");
-        assert_eq!(outcome.agent.executed_tools, vec!["get_weather"]);
-        let requests = &state.lock().await.requests;
-        assert_eq!(requests.len(), 2);
-        assert_eq!(requests[0]["tool_choice"], "auto");
-        assert_eq!(requests[1]["messages"][2]["role"], "tool");
-    }
-}
+mod tests;

--- a/qq-maid-llm/src/provider/deepseek.rs
+++ b/qq-maid-llm/src/provider/deepseek.rs
@@ -1,14 +1,15 @@
-//! DeepSeek 提供商：复用公共 Responses 请求、SSE、图片编码与 Tool Loop。
+//! DeepSeek 提供商：请求前选择旧模型 Chat 兼容路径或公共 Responses adapter。
 
 use async_trait::async_trait;
 
 use crate::{
     agent_loop::{AgentSessionRequest, AgentStepSession},
-    config::{LlmConfig, OpenAiResponsesProviderConfig},
+    config::{LlmConfig, OpenAiCompatibleProviderConfig, OpenAiResponsesProviderConfig},
     error::LlmError,
     provider::{
         ChatOutcome, LlmProvider, LlmStream, ToolCallingProtocol,
         openai::ConfiguredResponsesProvider,
+        openai_compatible::OpenAiCompatibleProvider,
         types::{ChatRequest, ModelId, ModelProvider},
     },
 };
@@ -27,18 +28,42 @@ pub(crate) fn responses_config(config: &LlmConfig) -> OpenAiResponsesProviderCon
     }
 }
 
-/// DeepSeek 只装配供应商身份，不复制 Responses 协议实现。
+/// 仅精确识别历史 Chat 模型；其他用户显式模型保持 Responses 协议，原样传给上游。
+/// 这份协议兼容规则不用于推断视觉能力，也不依赖 HTTP 错误触发回退。
+pub fn is_legacy_chat_model(model: &str) -> bool {
+    matches!(model, "deepseek-chat" | "deepseek-reasoner")
+}
+
+/// DeepSeek 只装配供应商身份与协议选择，不复制协议实现。
 pub struct DeepSeekProvider {
     inner: ConfiguredResponsesProvider,
+    legacy_chat: OpenAiCompatibleProvider,
 }
 
 impl DeepSeekProvider {
     /// 从 LLM 配置创建 DeepSeek 提供商实例。
     pub fn new(config: &LlmConfig) -> Result<Self, LlmError> {
+        let connection = responses_config(config);
+        let model = deepseek_config_model(&config.deepseek_model)?;
         Ok(Self {
+            legacy_chat: OpenAiCompatibleProvider::new(
+                &OpenAiCompatibleProviderConfig {
+                    id: connection.id.clone(),
+                    base_url: connection.base_url.clone(),
+                    api_key_env: connection.api_key_env.clone(),
+                    api_key: connection.api_key.clone(),
+                    auth: connection.auth.clone(),
+                    request_timeout_seconds: connection.request_timeout_seconds,
+                },
+                model.clone(),
+                config.stream,
+                config.request_timeout_seconds,
+                config.media_max_bytes,
+                config.max_output_tokens,
+            )?,
             inner: ConfiguredResponsesProvider::new(
-                &responses_config(config),
-                deepseek_config_model(&config.deepseek_model)?,
+                &connection,
+                model,
                 config.stream,
                 config.request_timeout_seconds,
                 config.media_max_bytes,
@@ -46,33 +71,46 @@ impl DeepSeekProvider {
             )?,
         })
     }
+
+    fn adapter(&self, model: Option<&str>) -> &dyn LlmProvider {
+        // 解析后的裸名称只用于选协议；前缀合法性仍由公共 adapter 校验。
+        let legacy = ModelId::parse(model.unwrap_or(self.model()), "request")
+            .is_ok_and(|model| is_legacy_chat_model(&model.name));
+        if legacy {
+            &self.legacy_chat
+        } else {
+            &self.inner
+        }
+    }
 }
 
 #[async_trait]
 impl LlmProvider for DeepSeekProvider {
     async fn chat(&self, req: ChatRequest) -> Result<ChatOutcome, LlmError> {
-        self.inner.chat(req).await
+        self.adapter(req.model.as_deref()).chat(req).await
     }
 
     async fn stream_chat(&self, req: ChatRequest) -> Result<LlmStream, LlmError> {
-        self.inner.stream_chat(req).await
+        self.adapter(req.model.as_deref()).stream_chat(req).await
     }
 
     async fn begin_agent_session(
         &self,
         req: AgentSessionRequest<'_>,
     ) -> Result<Option<Box<dyn AgentStepSession + Send>>, LlmError> {
-        self.inner.begin_agent_session(req).await
+        self.adapter(req.chat.model.as_deref())
+            .begin_agent_session(req)
+            .await
     }
 
     fn tool_calling_protocol(&self, model: Option<&str>) -> Option<ToolCallingProtocol> {
-        self.inner.tool_calling_protocol(model)
+        self.adapter(model).tool_calling_protocol(model)
     }
 
     fn supports_vision(&self, model: Option<&str>) -> bool {
-        // 仅声明 adapter 能编码 input_image；实际视觉能力由模型元数据/上游决定，
+        // 仅声明 adapter 能编码图片；实际视觉能力由模型元数据/上游决定，
         // 不根据临时模型名称猜测，也不在供应商层丢弃图片。
-        self.inner.supports_vision(model)
+        self.adapter(model).supports_vision(model)
     }
 
     fn name(&self) -> &str {

--- a/qq-maid-llm/src/provider/deepseek/tests.rs
+++ b/qq-maid-llm/src/provider/deepseek/tests.rs
@@ -366,3 +366,163 @@ async fn missing_search_key_reports_deepseek_config_error() {
         .unwrap_err();
     assert!(error.message.contains("DEEPSEEK_API_KEY"));
 }
+
+#[tokio::test]
+async fn model_protocol_is_selected_before_chat_stream_and_agent_requests() {
+    // 同时覆盖默认值、请求覆盖和带前缀路由；旧模型与未知显式模型均不能被改名。
+    for model in [
+        "deepseek-chat",
+        "deepseek-reasoner",
+        "deepseek-v4-flash",
+        "deepseek-v4-pro",
+        "deepseek-v4-flash-vision-exp",
+        "private-model",
+    ] {
+        let legacy = is_legacy_chat_model(model);
+        for use_override in [false, true] {
+            for mode in ["chat", "stream", "agent"] {
+                let body = if legacy {
+                    if mode == "stream" {
+                        "data: {\"choices\":[{\"delta\":{\"content\":\"回复\"}}]}\n\ndata: [DONE]\n\n".to_owned()
+                    } else {
+                        json!({"choices": [{"message": {"role": "assistant", "content": "回复"}, "finish_reason": "stop"}]}).to_string()
+                    }
+                } else if mode == "stream" {
+                    sse(answer())
+                } else {
+                    answer().to_string()
+                };
+                let (url, state) = mock(vec![(StatusCode::OK, body)]).await;
+                let mut cfg = config(url, mode == "stream");
+                cfg.deepseek_model = if use_override {
+                    // 强制验证请求覆盖能跨协议，而非只看初始化默认值。
+                    if legacy {
+                        "deepseek-v4-flash"
+                    } else {
+                        "deepseek-chat"
+                    }
+                    .to_owned()
+                } else {
+                    format!("deepseek:{model}")
+                };
+                let provider = DeepSeekProvider::new(&cfg).unwrap();
+                let mut req = request();
+                req.model = use_override.then(|| format!("deepseek:{model}"));
+                assert_eq!(
+                    provider.tool_calling_protocol(req.model.as_deref()),
+                    Some(if legacy {
+                        ToolCallingProtocol::ChatCompletionsToolCalls
+                    } else {
+                        ToolCallingProtocol::OpenAiResponses
+                    })
+                );
+                let reply = match mode {
+                    "chat" => provider.chat(req).await.unwrap().reply,
+                    "stream" => {
+                        collect_llm_stream(
+                            provider.stream_chat(req).await.unwrap(),
+                            "deepseek",
+                            model,
+                        )
+                        .await
+                        .unwrap()
+                        .reply
+                    }
+                    _ => {
+                        provider
+                            .chat_with_tools(ToolChatRequest {
+                                chat: req,
+                                tools: ToolRegistry::new()
+                                    .register(WeatherToolStub::new("晴"))
+                                    .unwrap(),
+                                tool_context: test_tool_context(),
+                                max_rounds: 2,
+                                progress_sink: None,
+                                final_delta_sink: None,
+                                run_handle: None,
+                            })
+                            .await
+                            .unwrap()
+                            .reply
+                    }
+                };
+                assert_eq!(reply, "回复");
+                let state = state.lock().await;
+                assert_eq!(state.requests.len(), 1, "{model}/{mode}");
+                assert_eq!(
+                    state.requests[0].0,
+                    if legacy {
+                        "/chat/completions"
+                    } else {
+                        "/responses"
+                    }
+                );
+                assert_eq!(state.requests[0].2["model"], model);
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn responses_parameter_400_never_switches_to_chat() {
+    for mode in ["chat", "stream", "agent"] {
+        let (url, state) = mock(vec![(
+            StatusCode::BAD_REQUEST,
+            json!({"error": {"message": "input_image cannot have both image_url and file_id"}})
+                .to_string(),
+        )])
+        .await;
+        let provider = DeepSeekProvider::new(&config(url, mode == "stream")).unwrap();
+        let mut req = request();
+        req.model = Some("deepseek:deepseek-v4-flash".to_owned());
+        let error = match mode {
+            "chat" => provider.chat(req).await.unwrap_err(),
+            "stream" => match provider.stream_chat(req).await {
+                Err(error) => error,
+                Ok(stream) => collect_llm_stream(stream, "deepseek", "deepseek-v4-flash")
+                    .await
+                    .unwrap_err(),
+            },
+            _ => provider
+                .chat_with_tools(ToolChatRequest {
+                    chat: req,
+                    tools: ToolRegistry::new()
+                        .register(WeatherToolStub::new("晴"))
+                        .unwrap(),
+                    tool_context: test_tool_context(),
+                    max_rounds: 2,
+                    progress_sink: None,
+                    final_delta_sink: None,
+                    run_handle: None,
+                })
+                .await
+                .unwrap_err(),
+        };
+        assert_eq!(error.upstream_status, Some(400));
+        assert!(error.message.contains("input_image cannot have both"));
+        let state = state.lock().await;
+        assert_eq!(state.requests.len(), 1);
+        assert_eq!(state.requests[0].0, "/responses");
+    }
+}
+
+#[tokio::test]
+async fn legacy_native_search_rejected_before_network_with_migration_hint() {
+    let (url, state) = mock(Vec::new()).await;
+    let executor = build_web_search_executor(&config(url, false)).unwrap();
+    for model in ["deepseek-chat", "deepseek-reasoner"] {
+        for stream in [false, true] {
+            let mut req = search_request();
+            req.model_override = Some(format!("deepseek:{model}"));
+            let error = if stream {
+                let (tx, _rx) = tokio::sync::mpsc::channel(8);
+                executor.query_stream(req, tx).await.unwrap_err()
+            } else {
+                executor.query(req).await.unwrap_err()
+            };
+            assert!(error.message.contains("tools.web_search.routes"));
+            assert!(error.message.contains("deepseek:deepseek-v4-flash"));
+        }
+    }
+    assert!(state.lock().await.requests.is_empty());
+}

--- a/qq-maid-llm/src/provider/deepseek/tests.rs
+++ b/qq-maid-llm/src/provider/deepseek/tests.rs
@@ -1,0 +1,368 @@
+use std::{collections::VecDeque, sync::Arc};
+
+use axum::{
+    Json, Router,
+    extract::{OriginalUri, State},
+    http::{HeaderMap, StatusCode},
+    routing::post,
+};
+use futures::StreamExt;
+use qq_maid_common::input_part::{MessageInputPart, MessageMedia};
+use serde_json::{Value, json};
+use tokio::sync::Mutex;
+
+use super::*;
+use crate::{
+    config::{OpenAiApiMode, ProviderMode},
+    provider::{
+        LlmStreamEvent, ToolChatRequest, collect_llm_stream,
+        test_support::{WeatherToolStub, test_tool_context},
+        types::{ChatMessage, ModelRoute, ReasoningEffort},
+    },
+    tool::ToolRegistry,
+    web_search::{WebSearchBackend, WebSearchConfig, WebSearchRequest, build_web_search_executor},
+};
+
+#[derive(Default)]
+struct MockState {
+    replies: VecDeque<(StatusCode, String)>,
+    requests: Vec<(String, HeaderMap, Value)>,
+}
+
+async fn mock(replies: Vec<(StatusCode, String)>) -> (String, Arc<Mutex<MockState>>) {
+    async fn handler(
+        State(state): State<Arc<Mutex<MockState>>>,
+        OriginalUri(uri): OriginalUri,
+        headers: HeaderMap,
+        Json(body): Json<Value>,
+    ) -> (StatusCode, String) {
+        let mut state = state.lock().await;
+        state.requests.push((uri.path().to_owned(), headers, body));
+        state.replies.pop_front().unwrap_or((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "unexpected retry".to_owned(),
+        ))
+    }
+    let state = Arc::new(Mutex::new(MockState {
+        replies: replies.into(),
+        ..Default::default()
+    }));
+    let app = Router::new()
+        .route("/responses", post(handler))
+        .route("/chat/completions", post(handler))
+        .with_state(state.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    (format!("http://{address}"), state)
+}
+
+fn config(base_url: String, stream: bool) -> LlmConfig {
+    let route = ModelRoute::parse_config("deepseek:model-under-test", "test").unwrap();
+    LlmConfig {
+        provider: ProviderMode::DeepSeek,
+        model_route: route.clone(),
+        configured_model_routes: vec![("test".to_owned(), route)],
+        web_search: WebSearchConfig {
+            default_backend: WebSearchBackend::ProviderNative,
+            default_model: "deepseek:model-under-test".to_owned(),
+            ..Default::default()
+        },
+        tavily_api_key: None,
+        openai_api_key: None,
+        openai_base_url: None,
+        openai_api_mode: OpenAiApiMode::ChatOnly,
+        deepseek_api_key: Some("test-deepseek-key".to_owned()),
+        deepseek_base_url: base_url,
+        deepseek_model: "deepseek:model-under-test".to_owned(),
+        bigmodel_api_key: None,
+        bigmodel_base_url: "https://example.test".to_owned(),
+        bigmodel_model: "unused".to_owned(),
+        gemini_api_key: None,
+        gemini_base_url: "https://example.test".to_owned(),
+        gemini_model: "unused".to_owned(),
+        openai_compatible_providers: Vec::new(),
+        openai_responses_providers: Vec::new(),
+        stream,
+        request_timeout_seconds: 5,
+        media_max_bytes: 1024,
+        max_output_tokens: 1200,
+    }
+}
+
+fn request() -> ChatRequest {
+    ChatRequest {
+        session_id: "test-session".to_owned(),
+        model: Some("deepseek:arbitrary-model".to_owned()),
+        messages: vec![ChatMessage::user("测试")],
+        context_budget: None,
+        max_output_tokens: Some(64),
+        reasoning_effort: Some(ReasoningEffort::High),
+        metadata: Default::default(),
+    }
+}
+
+fn answer() -> Value {
+    json!({"output": [{"type": "message", "content": [{"type": "output_text", "text": "回复"}]}],
+        "usage": {"input_tokens": 10, "input_tokens_details": {"cached_tokens": 4},
+            "output_tokens": 6, "output_tokens_details": {"reasoning_tokens": 2}, "total_tokens": 16}})
+}
+
+fn sse(body: Value) -> String {
+    format!(
+        "event: response.reasoning_text.delta\ndata: {{\"type\":\"response.reasoning_text.delta\",\"delta\":\"reasoning\"}}\n\nevent: response.output_text.delta\ndata: {{\"type\":\"response.output_text.delta\",\"delta\":\"回复\"}}\n\nevent: response.completed\ndata: {}\n\n",
+        json!({"type": "response.completed", "response": body})
+    )
+}
+
+#[test]
+fn model_identity_and_protocol_are_responses_without_name_heuristics() {
+    let provider = DeepSeekProvider::new(&config("https://example.test".to_owned(), true)).unwrap();
+    assert_eq!(provider.model(), "model-under-test");
+    assert_eq!(
+        provider.tool_calling_protocol(Some("deepseek:arbitrary-model")),
+        Some(ToolCallingProtocol::OpenAiResponses)
+    );
+    assert!(provider.supports_vision(Some("deepseek:arbitrary-model")));
+    assert_eq!(
+        provider.tool_calling_protocol(Some("openai:gpt-test")),
+        None
+    );
+    assert!(!provider.supports_vision(Some("openai:gpt-test")));
+    assert!(deepseek_config_model("openai:wrong").is_err());
+}
+
+#[tokio::test]
+async fn chat_and_stream_use_responses_images_reasoning_and_usage() {
+    for stream in [false, true] {
+        let body = if stream {
+            sse(answer())
+        } else {
+            answer().to_string()
+        };
+        let (url, state) = mock(vec![(StatusCode::OK, body)]).await;
+        let provider = DeepSeekProvider::new(&config(url, stream)).unwrap();
+        let mut req = request();
+        req.messages = vec![ChatMessage::user_with_parts(
+            "看图",
+            vec![
+                MessageInputPart::text("看图"),
+                MessageInputPart::image(MessageMedia {
+                    mime_type: Some("image/png".to_owned()),
+                    url: Some("https://example.test/image.png".to_owned()),
+                    ..Default::default()
+                }),
+            ],
+        )];
+        let outcome = if stream {
+            collect_llm_stream(
+                provider.stream_chat(req).await.unwrap(),
+                "deepseek",
+                "arbitrary-model",
+            )
+            .await
+            .unwrap()
+        } else {
+            provider.chat(req).await.unwrap()
+        };
+        assert_eq!(outcome.reply, "回复");
+        assert_eq!(outcome.metrics.provider, "deepseek");
+        assert_eq!(outcome.usage.as_ref().unwrap().cached_input_tokens, Some(4));
+        assert_eq!(outcome.usage.as_ref().unwrap().total_tokens, Some(16));
+        let state = state.lock().await;
+        assert_eq!(state.requests.len(), 1);
+        let (path, headers, body) = &state.requests[0];
+        assert_eq!(path, "/responses");
+        assert_eq!(headers["authorization"], "Bearer test-deepseek-key");
+        assert_eq!(body["model"], "arbitrary-model");
+        assert_eq!(body["reasoning"]["effort"], "high");
+        assert_eq!(body["max_output_tokens"], 64);
+        assert_eq!(body["input"][0]["content"][1]["type"], "input_image");
+        assert_eq!(
+            body["input"][0]["content"][1]["image_url"],
+            "https://example.test/image.png"
+        );
+        assert!(body.get("tools").is_none());
+    }
+}
+
+#[tokio::test]
+async fn empty_stream_retries_responses_non_stream() {
+    let (url, state) = mock(vec![
+        (StatusCode::OK, String::new()),
+        (StatusCode::OK, answer().to_string()),
+    ])
+    .await;
+    let provider = DeepSeekProvider::new(&config(url, true)).unwrap();
+    assert_eq!(provider.chat(request()).await.unwrap().reply, "回复");
+    let state = state.lock().await;
+    assert_eq!(state.requests.len(), 2);
+    assert!(
+        state
+            .requests
+            .iter()
+            .all(|(path, _, _)| path == "/responses")
+    );
+    assert_eq!(state.requests[0].2["stream"], true);
+    assert!(state.requests[1].2.get("stream").is_none());
+}
+
+#[tokio::test]
+async fn stream_error_after_delta_does_not_retry() {
+    let (url, state) = mock(vec![(StatusCode::OK,
+        "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"半截\"}\n\ndata: {not-json}\n\n".to_owned())]).await;
+    let provider = DeepSeekProvider::new(&config(url, true)).unwrap();
+    let mut stream = provider.stream_chat(request()).await.unwrap();
+    assert!(matches!(
+        stream.next().await,
+        Some(Ok(LlmStreamEvent::TextDelta(_)))
+    ));
+    assert!(stream.next().await.unwrap().is_err());
+    assert_eq!(state.lock().await.requests.len(), 1);
+}
+
+#[tokio::test]
+async fn http_failure_preserves_error_without_chat_fallback() {
+    let (url, state) = mock(vec![(
+        StatusCode::NOT_FOUND,
+        "Responses unavailable".to_owned(),
+    )])
+    .await;
+    let provider = DeepSeekProvider::new(&config(url, false)).unwrap();
+    let error = provider.chat(request()).await.unwrap_err();
+    assert!(error.message.contains("Responses unavailable"));
+    assert!(error.message.contains("deepseek"));
+    assert_eq!(state.lock().await.requests.len(), 1);
+}
+
+#[tokio::test]
+async fn tool_loop_replays_reasoning_function_call_and_real_tool_output() {
+    for stream in [false, true] {
+        let reasoning = json!({"type": "reasoning", "content": [{"type": "reasoning_text", "text": "need tool"}]});
+        let replies = vec![(StatusCode::OK, json!({"output": [reasoning.clone(),
+        {"type": "function_call", "call_id": "call_test", "name": "get_weather", "arguments": "{\"city\":\"杭州\"}"}]}).to_string()),
+        (StatusCode::OK, answer().to_string())];
+        let replies = replies
+            .into_iter()
+            .map(|(status, body)| {
+                (
+                    status,
+                    if stream {
+                        sse(serde_json::from_str(&body).unwrap())
+                    } else {
+                        body
+                    },
+                )
+            })
+            .collect();
+        let (url, state) = mock(replies).await;
+        let provider = DeepSeekProvider::new(&config(url, stream)).unwrap();
+        let deltas = Arc::new(Mutex::new(Vec::new()));
+        let outcome = provider
+            .chat_with_tools(ToolChatRequest {
+                chat: request(),
+                tools: ToolRegistry::new()
+                    .register(WeatherToolStub::new("晴"))
+                    .unwrap(),
+                tool_context: test_tool_context(),
+                max_rounds: 3,
+                progress_sink: None,
+                final_delta_sink: stream.then(|| {
+                    let deltas = deltas.clone();
+                    Arc::new(
+                        move |delta: String| -> crate::agent_loop::AgentTextDeltaFuture {
+                            let deltas = deltas.clone();
+                            Box::pin(async move {
+                                deltas.lock().await.push(delta);
+                                Ok(crate::agent_loop::AgentTextDeltaDelivery::Visible)
+                            })
+                        },
+                    ) as crate::agent_loop::AgentTextDeltaSink
+                }),
+                run_handle: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(outcome.reply, "回复");
+        assert_eq!(outcome.agent.executed_tools, vec!["get_weather"]);
+        if stream {
+            assert_eq!(*deltas.lock().await, vec!["回复"]);
+        }
+        let state = state.lock().await;
+        assert_eq!(state.requests.len(), 2);
+        for (path, _, body) in &state.requests {
+            assert_eq!(path, "/responses");
+            assert_eq!(
+                body.get("stream").and_then(Value::as_bool).unwrap_or(false),
+                stream
+            );
+            assert_eq!(body["reasoning"]["effort"], "high");
+        }
+        assert_eq!(state.requests[0].2["tools"][0]["type"], "function");
+        let input = state.requests[1].2["input"].as_array().unwrap();
+        assert!(input.contains(&reasoning));
+        let output = input
+            .iter()
+            .find(|item| item["type"] == "function_call_output")
+            .unwrap();
+        assert_eq!(output["call_id"], "call_test");
+        assert!(output["output"].as_str().unwrap().contains("晴"));
+    }
+}
+
+fn search_request() -> WebSearchRequest {
+    WebSearchRequest {
+        query: "测试搜索".to_owned(),
+        raw_question: None,
+        max_results: None,
+        context_size: None,
+        topic: None,
+        time_range: None,
+        backend_override: None,
+        model_override: None,
+    }
+}
+
+#[tokio::test]
+async fn native_search_routes_deepseek_without_openai_credentials() {
+    for stream in [false, true] {
+        let body = json!({"output": [{"type": "message", "content": [{"type": "output_text", "text": "回复",
+            "annotations": [{"type": "url_citation", "title": "测试来源", "url": "https://example.test/source"}]}]}]});
+        let (url, state) = mock(vec![(
+            StatusCode::OK,
+            if stream { sse(body) } else { body.to_string() },
+        )])
+        .await;
+        let executor = build_web_search_executor(&config(url, false)).unwrap();
+        let outcome = if stream {
+            let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+            let outcome = executor.query_stream(search_request(), tx).await.unwrap();
+            assert_eq!(rx.recv().await.as_deref(), Some("回复"));
+            outcome
+        } else {
+            executor.query(search_request()).await.unwrap()
+        };
+        assert_eq!(outcome.provider, "deepseek");
+        assert_eq!(outcome.answer, "回复");
+        assert_eq!(outcome.sources[0].url, "https://example.test/source");
+        let state = state.lock().await;
+        assert_eq!(state.requests.len(), 1);
+        let (path, headers, body) = &state.requests[0];
+        assert_eq!(path, "/responses");
+        assert_eq!(headers["authorization"], "Bearer test-deepseek-key");
+        assert_eq!(body["model"], "model-under-test");
+        assert_eq!(body["tools"], json!([{"type": "web_search"}]));
+    }
+}
+
+#[tokio::test]
+async fn missing_search_key_reports_deepseek_config_error() {
+    let mut config = config("https://example.test".to_owned(), false);
+    config.deepseek_api_key = None;
+    let error = build_web_search_executor(&config)
+        .unwrap()
+        .query(search_request())
+        .await
+        .unwrap_err();
+    assert!(error.message.contains("DEEPSEEK_API_KEY"));
+}

--- a/qq-maid-llm/src/provider/openai/chat_tool_loop/mod.rs
+++ b/qq-maid-llm/src/provider/openai/chat_tool_loop/mod.rs
@@ -1,6 +1,6 @@
 //! OpenAI 兼容 Chat Completions Tool Loop 的协议适配层。
 //!
-//! DeepSeek 和 BigModel 都通过 `/chat/completions` 暴露 `tools` / `tool_calls`
+//! BigModel 与 OpenAI-compatible Provider 通过 `/chat/completions` 暴露 `tools` / `tool_calls`
 //! 协议，这里统一把一次模型请求转换为 [`AgentStep`]。轮次推进、最大轮数、
 //! 工具执行和退出条件由 `qq_maid_llm::agent_loop::run_agent_loop` 统一控制；
 //! 本模块不再维护自己的循环，避免 provider 侧重复维护同一套退出逻辑。

--- a/qq-maid-llm/src/provider/openai/payload.rs
+++ b/qq-maid-llm/src/provider/openai/payload.rs
@@ -42,6 +42,20 @@ pub(crate) fn openai_responses_payload(
     Ok(payload)
 }
 
+/// DeepSeek 的 Responses effort 是供应商协议能力，与模型名称前缀无关。
+/// 保持其他 Provider 的既有参数策略，避免扩散供应商差异。
+pub(crate) fn apply_responses_provider_options(
+    payload: &mut Value,
+    provider: &str,
+    reasoning_effort: Option<ReasoningEffort>,
+) {
+    if provider == "deepseek"
+        && let Some(effort) = reasoning_effort
+    {
+        payload["reasoning"] = json!({"effort": effort.as_str()});
+    }
+}
+
 /// 将内部聊天消息转换为 Responses input items。
 fn openai_responses_input(
     messages: &[ChatMessage],

--- a/qq-maid-llm/src/provider/openai/responses.rs
+++ b/qq-maid-llm/src/provider/openai/responses.rs
@@ -93,7 +93,7 @@ pub(crate) async fn openai_responses_non_stream_chat(
     req: &OpenAiResponsesChatRequest<'_>,
 ) -> Result<ChatOutcome, LlmError> {
     let recorder = MetricsRecorder::start();
-    let payload = openai_responses_payload(
+    let mut payload = openai_responses_payload(
         req.messages,
         req.model,
         req.media_max_bytes,
@@ -102,6 +102,11 @@ pub(crate) async fn openai_responses_non_stream_chat(
         false,
         req.image_generation_enabled,
     )?;
+    super::payload::apply_responses_provider_options(
+        &mut payload,
+        req.provider,
+        req.reasoning_effort,
+    );
     let response = send_openai_responses_request(
         req.client,
         req.api_key,
@@ -152,7 +157,7 @@ pub(crate) async fn openai_responses_chat_stream(
     req: &OpenAiResponsesChatRequest<'_>,
 ) -> Result<LlmStream, LlmError> {
     let recorder = MetricsRecorder::start();
-    let payload = openai_responses_payload(
+    let mut payload = openai_responses_payload(
         req.messages,
         req.model,
         req.media_max_bytes,
@@ -161,6 +166,11 @@ pub(crate) async fn openai_responses_chat_stream(
         true,
         req.image_generation_enabled,
     )?;
+    super::payload::apply_responses_provider_options(
+        &mut payload,
+        req.provider,
+        req.reasoning_effort,
+    );
     let response = send_openai_responses_request(
         req.client,
         req.api_key,

--- a/qq-maid-llm/src/provider/openai/tool_loop/session.rs
+++ b/qq-maid-llm/src/provider/openai/tool_loop/session.rs
@@ -200,7 +200,7 @@ impl AgentStepSession for ResponsesAgentSession {
             log_input_size_after_append(self.provider(), self.model(), self.input_size_estimate());
         }
 
-        let payload = openai_tool_loop_payload(
+        let mut payload = openai_tool_loop_payload(
             &self.input,
             &self.tool_defs,
             &self.model,
@@ -208,6 +208,11 @@ impl AgentStepSession for ResponsesAgentSession {
             self.reasoning_effort,
             allow_tool_calls,
             false,
+        );
+        crate::provider::openai::payload::apply_responses_provider_options(
+            &mut payload,
+            &self.provider,
+            self.reasoning_effort,
         );
         let (payload, tools_disabled) = enforce_tool_loop_budget(self.context_budget, payload)?;
         let response = send_openai_responses_request(
@@ -285,7 +290,7 @@ impl AgentStepSession for ResponsesAgentSession {
                 responses_input_size_estimate(&input),
             );
         }
-        let payload = openai_tool_loop_payload(
+        let mut payload = openai_tool_loop_payload(
             &input,
             &self.tool_defs,
             &self.model,
@@ -293,6 +298,11 @@ impl AgentStepSession for ResponsesAgentSession {
             self.reasoning_effort,
             allow_tool_calls,
             true,
+        );
+        crate::provider::openai::payload::apply_responses_provider_options(
+            &mut payload,
+            &self.provider,
+            self.reasoning_effort,
         );
         let (payload, tools_disabled) = enforce_tool_loop_budget(self.context_budget, payload)?;
         let response = send_openai_responses_request(

--- a/qq-maid-llm/src/web_search/mod.rs
+++ b/qq-maid-llm/src/web_search/mod.rs
@@ -330,6 +330,21 @@ pub fn build_web_search_executor(config: &LlmConfig) -> Result<DynWebSearchExecu
     insert_native_provider(&mut native_providers, ModelProvider::OpenAi, openai)?;
     insert_native_provider(&mut native_providers, ModelProvider::Gemini, gemini)?;
 
+    let deepseek_config = crate::provider::deepseek::responses_config(config);
+    let deepseek: DynWebSearchExecutor = match deepseek_config.api_key.as_deref() {
+        Some(key) if !key.trim().is_empty() => {
+            Arc::new(ResponsesWebSearchExecutor::new_configured(
+                &deepseek_config,
+                config.web_search.default_model.clone(),
+                config.request_timeout_seconds,
+            )?)
+        }
+        _ => Arc::new(MissingConfiguredResponsesWebSearchExecutor {
+            api_key_env: deepseek_config.api_key_env.clone(),
+        }),
+    };
+    insert_native_provider(&mut native_providers, ModelProvider::DeepSeek, deepseek)?;
+
     let mut custom_provider_ids = std::collections::HashSet::new();
     for provider in &config.openai_compatible_providers {
         if !custom_provider_ids.insert(provider.id.clone()) {

--- a/qq-maid-llm/src/web_search/openai/configured_search_tests.rs
+++ b/qq-maid-llm/src/web_search/openai/configured_search_tests.rs
@@ -221,3 +221,50 @@ async fn configured_responses_search_preserves_upstream_error() {
         assert!(error.message.contains("upstream diagnostic detail"));
     }
 }
+
+#[tokio::test]
+async fn responses_search_finishes_on_completed_without_waiting_for_http_eof() {
+    use axum::http::Response;
+    use futures::{StreamExt, stream};
+    use std::{convert::Infallible, time::Duration};
+
+    // 已完成的模型响应后保持连接不关闭，复现代理持续保活导致搜索等待到超时。
+    let app = Router::new().route(
+        "/v1/responses",
+        post(|| async {
+            let completed = json!({"type": "response.completed", "response": {
+                "output": [{"type": "message", "content": [{"type": "output_text", "text": "搜索完成",
+                    "annotations": [{"type": "url_citation", "url": "https://example.test/source", "title": "来源"}]}]}]
+            }});
+            let frames = format!("event: response.output_text.delta\ndata: {{\"type\":\"response.output_text.delta\",\"delta\":\"搜索完成\"}}\n\nevent: response.completed\ndata: {completed}\n\n");
+            let body = stream::once(async move { Ok::<_, Infallible>(frames) })
+                .chain(stream::pending::<Result<String, Infallible>>());
+            Response::builder()
+                .header(header::CONTENT_TYPE, "text/event-stream")
+                .body(Body::from_stream(body)).unwrap()
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}/v1", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let executor = ResponsesWebSearchExecutor::new_configured(
+        &provider_config("deepseek", base),
+        "test-model".to_owned(),
+        5,
+    )
+    .unwrap();
+    let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+    let result = tokio::time::timeout(
+        Duration::from_millis(300),
+        executor.query_stream(request("test-model"), tx),
+    )
+    .await;
+    server.abort();
+    let outcome = result
+        .expect("response.completed 后必须立即完成，不能等待 HTTP EOF")
+        .unwrap();
+    assert_eq!(outcome.answer, "搜索完成");
+    assert_eq!(outcome.sources[0].url, "https://example.test/source");
+    assert_eq!(rx.recv().await.as_deref(), Some("搜索完成"));
+    assert!(rx.recv().await.is_none());
+}

--- a/qq-maid-llm/src/web_search/openai/mod.rs
+++ b/qq-maid-llm/src/web_search/openai/mod.rs
@@ -247,7 +247,7 @@ impl WebSearchExecutor for ResponsesWebSearchExecutor {
         let mut answer = String::new();
         let mut completed_response: Option<Value> = None;
         let mut saw_completed = false;
-        while let Some(chunk) = response
+        'read_stream: while let Some(chunk) = response
             .chunk()
             .await
             .map_err(|err| web_search_stream_transport_error(err, &answer))
@@ -271,9 +271,15 @@ impl WebSearchExecutor for ResponsesWebSearchExecutor {
                     &delta_tx,
                 )
                 .await?;
+                if saw_completed {
+                    // Responses 完成事件已经包含最终正文和来源。代理可能继续保活，
+                    // 此时等待 HTTP EOF 会把成功搜索拖到请求超时。
+                    break 'read_stream;
+                }
             }
         }
-        if !frame_buffer.is_empty()
+        if !saw_completed
+            && !frame_buffer.is_empty()
             && let Some(event) = parse_sse_frame(&frame_buffer)?
             && !is_openai_responses_done_sentinel(&event.data)
         {

--- a/qq-maid-llm/src/web_search/routing.rs
+++ b/qq-maid-llm/src/web_search/routing.rs
@@ -81,7 +81,7 @@ fn unsupported_provider_error(provider: &str) -> LlmError {
     LlmError::new(
         "bad_request",
         format!(
-            "search provider `{provider}` is not configured for provider_native search; use built-in OpenAI/Gemini, declare an openai_responses provider, or configure Tavily"
+            "search provider `{provider}` is not configured for provider_native search; use built-in OpenAI/DeepSeek/Gemini, declare an openai_responses provider, or configure Tavily"
         ),
         "request",
     )

--- a/qq-maid-llm/src/web_search/routing.rs
+++ b/qq-maid-llm/src/web_search/routing.rs
@@ -70,6 +70,16 @@ impl RoutedWebSearchExecutor {
                     .native_providers
                     .get(&provider)
                     .ok_or_else(|| unsupported_provider_error(provider.as_str()))?;
+                // 原生搜索没有 Chat 等价路径，旧模型须在网络请求前明确提示迁移。
+                if provider == ModelProvider::DeepSeek
+                    && crate::provider::deepseek::is_legacy_chat_model(&model.name)
+                {
+                    return Err(LlmError::new(
+                        "bad_request",
+                        "DeepSeek 旧 Chat 模型不支持 provider_native 搜索；请将 tools.web_search.routes.<name>.model 改为 deepseek:deepseek-v4-flash，或使用 Tavily",
+                        "request",
+                    ));
+                }
                 req.model_override = Some(model.name);
                 Ok((executor.clone(), req))
             }

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -270,13 +270,13 @@ Markdown 文件
 
 ```toml
 [model_routes.private_main]
-candidates = ["openai:gpt-5.6-luna", "gemini:gemini-2.5-pro", "mimo:mimo-v2.5-pro", "deepseek:deepseek-chat"]
+candidates = ["openai:gpt-5.6-luna", "gemini:gemini-2.5-pro", "mimo:mimo-v2.5-pro", "deepseek:deepseek-v4-flash"]
 
 [model_routes.group_main]
-candidates = ["openai:gpt-5.6-luna", "gemini:gemini-2.5-flash", "mimo:mimo-v2.5", "deepseek:deepseek-chat"]
+candidates = ["openai:gpt-5.6-luna", "gemini:gemini-2.5-flash", "mimo:mimo-v2.5", "deepseek:deepseek-v4-flash"]
 
 [model_routes.aux]
-candidates = ["openai:gpt-5.6-luna", "gemini:gemini-2.5-flash", "mimo:mimo-v2.5", "deepseek:deepseek-chat"]
+candidates = ["openai:gpt-5.6-luna", "gemini:gemini-2.5-flash", "mimo:mimo-v2.5", "deepseek:deepseek-v4-flash"]
 
 [tools.web_search.routes.private_search]
 model = "gpt-5.6-luna"
@@ -300,10 +300,10 @@ auth_scheme = "Bearer"
 
 ```toml
 [model_routes.private_main]
-candidates = ["mimo:mimo-v2.5-pro", "deepseek:deepseek-chat"]
+candidates = ["mimo:mimo-v2.5-pro", "deepseek:deepseek-v4-flash"]
 
 [model_routes.group_main]
-candidates = ["mimo:mimo-v2.5", "deepseek:deepseek-chat"]
+candidates = ["mimo:mimo-v2.5", "deepseek:deepseek-v4-flash"]
 ```
 
 OpenCode 可直接在 Web 配置中心保存共用的 `OPENCODE_API_KEY`，并按需添加三个固定预设。卡片只允许修改 Base URL 和请求超时，`api_key_env`、认证 Header 与 Scheme 固定为 `OPENCODE_API_KEY`、`Authorization` 与 `Bearer`：

--- a/runtime/config/.env.example
+++ b/runtime/config/.env.example
@@ -186,7 +186,8 @@ OPENAI_BASE_URLS=
 # Responses web_search 兼容端点。
 OPENAI_API_MODE=auto
 
-# DeepSeek 使用 OpenAI 兼容 Chat Completions 协议。
+# DeepSeek 模型在 agent.toml 路线中配置，新部署默认 deepseek:deepseek-v4-flash（Responses）。
+# 旧 deepseek-chat / deepseek-reasoner 继续使用 Chat Completions；HTTP 错误不触发协议切换。
 DEEPSEEK_BASE_URL=https://api.deepseek.com
 
 # 智谱 BigModel 使用 OpenAI 兼容 Chat Completions 协议。

--- a/runtime/config/agent.example.toml
+++ b/runtime/config/agent.example.toml
@@ -37,13 +37,13 @@ auth_scheme = "Bearer"
 # 同时保留 Gemini、MiMo 和 DeepSeek 降级候选；未配置对应 API Key 的 provider 会被跳过。
 # API Key 仍必须放在 .env 的 OPENAI_API_KEY，不得写入本文件。
 [model_routes.private_main]
-candidates = ["openai:gpt-5.6-luna", "gemini:gemini-2.5-pro", "mimo:mimo-v2.5-pro", "deepseek:deepseek-chat"]
+candidates = ["openai:gpt-5.6-luna", "gemini:gemini-2.5-pro", "mimo:mimo-v2.5-pro", "deepseek:deepseek-v4-flash"]
 
 [model_routes.group_main]
-candidates = ["openai:gpt-5.6-luna", "gemini:gemini-2.5-flash", "mimo:mimo-v2.5", "deepseek:deepseek-chat"]
+candidates = ["openai:gpt-5.6-luna", "gemini:gemini-2.5-flash", "mimo:mimo-v2.5", "deepseek:deepseek-v4-flash"]
 
 [model_routes.aux]
-candidates = ["openai:gpt-5.6-luna", "gemini:gemini-2.5-flash", "mimo:mimo-v2.5", "deepseek:deepseek-chat"]
+candidates = ["openai:gpt-5.6-luna", "gemini:gemini-2.5-flash", "mimo:mimo-v2.5", "deepseek:deepseek-v4-flash"]
 
 # 联网搜索统一配置。裸模型兼容为内置 OpenAI；显式 `provider:model` 会严格选择
 # Gemini 或声明为 openai_responses 的自定义 Provider，不按模型名猜测。


### PR DESCRIPTION
DeepSeek 迁移 Responses 后，旧部署中的 `deepseek-chat` 不能再无条件发送到 `/responses`。本 PR 在请求前选择协议：`deepseek-chat` / `deepseek-reasoner` 精确匹配后复用 Chat Completions；V4 与其他用户显式 DeepSeek 模型保持 Responses，模型名原样传递。普通聊天、SSE、Tool Loop 和管理连接诊断遵守同一规则，不根据 HTTP 400 或其他响应错误切换协议。新部署默认值和公开候选路线改为 `deepseek-v4-flash`，不覆盖已有私有配置。

Responses 继续复用公共请求、SSE、图片编码、usage 和工具结果回填。`provider_native` 可通过 `deepseek:<model>` 使用原生 `web_search`；旧 Chat 模型在搜索请求发出前收到可操作的配置迁移提示。普通聊天不自动联网，场景和工具白名单保持原有约束。

同时修复 Responses 流式搜索收到 `response.completed` 后仍等待 HTTP EOF 的问题：上游完成后即使代理继续保活，也立即返回答案及来源。对应回归在修复前稳定超时，修复后通过。

- Responses reasoning effort、Tool Loop reasoning 历史和真实工具结果回填保持完整，推理正文不作为回答输出。
- 图片继续支持 URL / 本地 data URL → `input_image`，不根据模型名称猜测视觉能力。临时实验模型不作为默认值。
- 其他显式 DeepSeek 模型不猜协议兼容性、不自动换模型；只支持 Chat 的私有网关可声明自定义 `openai_compatible` Provider。
- OpenAI 的 Responses / Chat fallback、其他 Provider 和既有候选链错误分类保持原有行为；DeepSeek 保留同协议空流重试，不做 HTTP 错误触发的跨协议回退。
- 主要修改位于 LLM DeepSeek adapter、公共 Responses / Web Search、Core 配置默认值与诊断，以及 runtime 模板和 README。无依赖、schema、真实运行配置或凭据变更。

验证通过：

- `make test-llm`
- `make test`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace --release --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`

本地 HTTP mock 覆盖旧模型 / V4 / 自定义模型、默认模型与请求覆盖、聊天 / SSE / Agent 协议选择及单次请求、Responses 400 不回退、旧模型原生搜索零请求报错、图片 / reasoning / usage / 工具回填、搜索来源与 completed 后立即结束、管理连接诊断和正式默认配置链。首轮 workspace 验证发现新增诊断测试争抢全局探针限流名额，已合并为同一测试内顺序验证，重跑通过。

另使用全新临时运行目录、公开 agent 模板和仅用于本地测试的占位凭据启动 release 程序，`/healthz` 返回 `ready: true`，默认路线包含 V4 Flash；测试后已停止隔离进程，未访问真实运行目录。

真实 DeepSeek 联调未执行：没有使用真实测试凭据，遵守仓库禁止读取私有凭据的规则。上游账号模型可用性、真实识图效果和性能仍需在授权测试环境验证；adapter 图片编码能力不代表模型视觉能力。协议依据 [DeepSeek 官方 Responses 文档](https://api-docs.deepseek.com/guides/responses_api/)。

Refs #695
