### PR TITLE
release: 发布 v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,37 @@
 
 ## [Unreleased]
 
-后续变更将在下一个版本发布时记录。
+## [v0.25.0] - 2026-09-09
+
+### Release Focus
+
+* **供应商与模型管理闭环**：Web Console 新增通用供应商管理、Connection 模型发现与模型管理页面，配合 Effective Model Catalog 与本地覆盖，实现“连接 → 发现模型 → 查看元数据 → 本地管理 → 加入 Route”的完整闭环；同时 DeepSeek 正式接入 Responses 协议并修复搜索流完成后的卡死问题。
+
+### Added
+
+* **统一供应商管理与连接诊断**（PR #691）：供应商页新增“＋ 新建供应商”弹窗，支持服务端受信预设（原 OpenCode 三预设，以及 OpenAI、DeepSeek、BigModel、Gemini 模板）和自定义 Connection 的新建、编辑、启停与删除；自定义 Connection 由服务端生成独立随机 Credential Slot，Secret 走认证加密存储并做双 revision 校验；内置最小真实连接诊断，按协议复用 LLM 载荷，限制超时、响应大小、并发与重定向，返回分阶段状态、耗时、HTTP 状态与脱敏分类，不返回上游正文。
+* **Effective Model Catalog 与本地模型覆盖**（PR #692）：`qq-maid-llm` 新增 `model_catalog` 领域模块，内嵌规范化快照（源自 Models.dev，MIT License，可完全离线启动）；合并公式为 `base_catalog + official_compatibility_patches + user_overrides`，输出确定且可测试。支持 `config/models.json`（路径可用 `MODELS_CONFIG_FILE` 指定）本地追加、字段覆盖与 `enabled=false` 禁用，且禁止在本地覆盖 Base URL、auth、Credential、Adapter、Route、工具权限等敏感或越权字段。
+* **Connection 模型发现与 Web 模型管理闭环**（PR #694）：供应商卡片新增“管理模型”，读取已保存连接自身 `/models`（沿用已有协议、Header/Scheme、Credential 和超时，无重定向、重试或分页跳转，最多两个并发、1 MiB 响应上限），并明确区分 unsupported / failed / unknown / 成功空列表等状态；内置 Connection 会用 Catalog 身份补全 display name、上下文窗口、最大输出、模态、价格、能力及逐字段 provenance。模型支持搜索、筛选、分批展示，来源区分 connection discovery / catalog / local override；可用普通表单新增、覆盖元数据或启用/禁用，通过受保护 metadata / override API（复用配置写锁、独立 opaque revision、原子替换、安全文件校验与脱敏审计）落盘，并把选中的 `provider:model-id` 追加到现有 Route（保留候选顺序，保留 ID 中的斜杠和冒号后缀）。
+* **DeepSeek 原生联网搜索**（PR #696）：`provider_native` 搜索类型可通过 `deepseek:<model>` 使用 DeepSeek Responses 的原生 `web_search`；旧 Chat 模型在搜索请求发出前收到可操作的配置迁移提示，而不是发出注定失败的请求。
+
+### Changed
+
+* **供应商字段规范化**（PR #691）：Provider 管理字段统一命名与校验，历史大小写 Connection 编辑保持兼容；内置供应商字段收进同一页面，不再维护品牌专用的前端 CRUD。
+* **默认 DeepSeek 模型迁移**（PR #696）：新部署默认值与公开候选路线改为 `deepseek-v4-flash`，不覆盖已有私有配置；旧 `deepseek-chat` / `deepseek-reasoner` 精确匹配时继续走 Chat Completions，V4 及其他显式 DeepSeek 模型走 Responses，模型名原样传递；协议选择发生在请求前，不根据 HTTP 400 等响应错误切换协议。
+* **Codex Radar 并发优化**（PR #693）：基础数据成功后，metrics 与 community ratings 通过 `tokio::join!` 并发请求，单请求 10 秒超时下最坏等待从约 30 秒收敛为一个基础请求加一个可选请求的并行窗口；两个可选接口失败互不影响。
+
+### Fixed
+
+* **Codex Radar Astra IQ 展示恢复**（PR #693）：适配新版 `/api/intelligence-efficiency-metrics` 效能接口，`/radar codex` 的模型 IQ 榜单重新显示 Astra；新版 metrics 只更新 `iq_models`，不再把最高 IQ 写入 legacy `model_label/model_score/model_passed/model_tasks/model_status` 摘要，避免重复展示；无本站白名单有效模型时保留完整 legacy fallback。
+* **Radar 额度时效修复**（PR #693）：陈旧额度不再误报当前 5h 暂停状态；额度新鲜度按精确时长判断并复用 common 时间解析。
+* **搜索流提前结束卡死**（PR #696）：Responses 流式搜索收到 `response.completed` 后不再等待 HTTP EOF，上游完成后即使代理保活也能立即返回答案与来源。
+
+### Compatibility
+
+* 根包 `qq-maid-bot` 提升到 `0.25.0`；本次实际变更的 `qq-maid-llm` 升至 `0.1.14`、`qq-maid-core` 升至 `0.1.31`，`qq-maid-gateway-rs` 与 `qq-maid-common` 版本保持不变。
+* 不新增 SQLite migration、必填环境变量或运行时入口。新部署默认 DeepSeek 模型为 `deepseek-v4-flash`，已有私有配置不会被覆盖；旧 `deepseek-chat` / `deepseek-reasoner` 继续可用（走 Chat Completions），需要原生联网搜索时请迁移到 `deepseek:<model>` 的 `provider_native` 写法。
+* `config/models.json`（路径可用 `MODELS_CONFIG_FILE` 指定）为新增的可选本地模型覆盖文件，缺省时使用内嵌 Catalog 快照；该文件禁止配置 Base URL、auth、Credential、Adapter、Route、工具权限等敏感字段。
+* 保留旧 `api_key_env`、共享 OpenCode Key 和内置存储兼容，无 schema migration、无启动时配置重写；停用或删除仍被 Route/搜索引用的连接会被服务端拒绝并列出引用位置。
 
 ## [v0.24.6] - 2026-08-30
 
@@ -2098,6 +2128,7 @@ bash scripts/deploy-local.sh
 - 移除已废弃的 Python 接入层和旧 Provider
 - rig-core 升级至 0.38.2
 
+[v0.25.0]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.24.6...v0.25.0
 [v0.16.0]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.15.2...v0.16.0
 [v0.15.2]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.15.1...v0.15.2
 [v0.15.1]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.15.0...v0.15.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,7 +2018,7 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "qq-maid-bot"
-version = "0.24.6"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "qq-maid-core",
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-core"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-llm"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-bot"
-version = "0.24.6"
+version = "0.25.0"
 edition = "2024"
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 > 💡 仓库早期以 QQ 机器人为主，因此仍保留 `qq-maid-bot` 名称。当前项目正在从 QQ 官方机器人演进为多入口平台型小女仆机器人。
 
-当前稳定版本为 `v0.24.6`，项目处于 `24.x` 版本线；版本线能力与升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)。
+当前稳定版本为 `v0.25.0`，项目已进入 `25.x` 版本线。这个大版本把模型能力做成了可管理的资产：管理员第一次可以在 Web Console 里完成「新建/编辑供应商连接 → 从连接发现模型 → 查看真实元数据 → 本地覆盖与启停 → 一键加入 Route」的完整闭环；LLM 侧则引入了 Effective Model Catalog（内嵌 Models.dev 快照 + 本地 `models.json` 覆盖）作为模型信息的统一事实源，并把 DeepSeek 迁移到 Responses 协议（含原生联网搜索）。升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)，供应商与模型管理细节见 Wiki [供应商与模型管理](https://github.com/kuliantnt/qq-maid-bot/wiki/供应商与模型管理)。
 
 使用、安装和配置优先看 [项目 Wiki](https://github.com/kuliantnt/qq-maid-bot/wiki)：从第一次对话、一键安装、Docker / GHCR、配置中心与 `/console/` 首次向导，到 NapCat、`/ops` 运维和 Codex 长任务，都按场景拆开了。仓库内 `docs/` 与各 crate README 更偏开发边界和实现细节。
 
@@ -135,12 +135,21 @@ runtime/botctl.sh status
 
 开发调试、Windows 源码构建和测试命令见 Wiki [开发维护文档](https://github.com/kuliantnt/qq-maid-bot/wiki/开发维护文档) 或仓库 [docs/DEVELOPMENT.md](./docs/DEVELOPMENT.md)。
 
-## 24.x 版本线更新
+## 25.x 版本线更新
 
-当前稳定版本为 `v0.24.6`。需要查看本版本线的详细变更和配置迁移提示时，再展开下面的更新记录：
+当前稳定版本为 `v0.25.0`。需要查看本版本线的详细变更和配置迁移提示时，再展开下面的更新记录：
 
 <details>
-<summary>展开查看 24.x 版本更新</summary>
+<summary>展开查看 25.x / 24.x 版本更新</summary>
+
+- **供应商与模型管理闭环（首个 25.x 版本）**（v0.25.0，PR #691/#692/#694/#696）：
+  - **统一供应商管理**：Web Console 供应商页新增“＋ 新建供应商”弹窗，支持 OpenCode 三预设以及 OpenAI、DeepSeek、BigModel、Gemini 等受信模板，也支持自定义 Connection 的新建、编辑、启停与删除；自定义连接使用服务端生成的独立 Credential Slot，Secret 走认证加密存储与双 revision 校验，不做品牌专用的前端 CRUD。
+  - **连接诊断**：对内置供应商可一键发起最小真实连接诊断，复用 LLM 载荷并限制超时、响应大小、并发与重定向，返回分阶段状态、耗时、HTTP 状态与脱敏分类，不返回上游正文。
+  - **Effective Model Catalog**：`qq-maid-llm` 内嵌 Models.dev 规范化快照（MIT License，可完全离线启动），合并公式为 `base_catalog + official_compatibility_patches + user_overrides`；支持 `config/models.json`（路径可用 `MODELS_CONFIG_FILE` 指定）本地追加、字段覆盖与 `enabled=false` 禁用，且禁止覆盖 Base URL、auth、Credential、Adapter、Route、工具权限等敏感字段。
+  - **模型发现与管理**：供应商卡片新增“管理模型”，读取连接自身 `/models` 并与 Catalog 合并补全 display name、上下文窗口、最大输出、模态、价格、能力及逐字段 provenance；来源区分 connection discovery / catalog / local override，支持搜索、筛选、分批展示，并通过受保护 metadata / override API（独立 opaque revision、原子替换、安全文件校验与脱敏审计）落盘，可把选中的 `provider:model-id` 直接追加进现有 Route。
+  - **DeepSeek Responses 接入**：新部署默认 DeepSeek 模型为 `deepseek-v4-flash`（走 Responses）；旧 `deepseek-chat` / `deepseek-reasoner` 精确匹配时继续走 Chat Completions，协议选择发生在请求前，不根据 HTTP 错误切换。`provider_native` 搜索类型可通过 `deepseek:<model>` 使用原生 `web_search`；旧 Chat 模型在搜索前收到可操作的迁移提示而不是直接失败。同时修复 Responses 流式搜索收到 `response.completed` 后等待 HTTP EOF 导致的卡死问题。
+  - **Codex Radar 修复与并发优化**：适配新版 `/api/intelligence-efficiency-metrics` 效能接口，`/radar codex` 的模型 IQ 榜单重新显示 Astra；陈旧额度不再误报当前 5h 暂停状态；metrics 与 community ratings 改为并发请求，最坏等待从约 30 秒收敛到一个基础请求加一个可选请求的并行窗口。
+  - **升级提示**：无 SQLite migration、必填环境变量或运行时入口变化；`models.json` 为可选新文件，缺省时使用内嵌快照；停用或删除仍被 Route/搜索引用的连接会被服务端拒绝并列出引用位置，请先在 Web Console 中调整引用。
 
 - **微信服务号客服长文本与周易起卦别名**（v0.24.6，PR #690）：慢请求客服补发按 2048 个 UTF-8 字节安全分片并对同一收件人串行发送，避免长文本丢失或多轮回复交错；新增 `/起卦`、`/卜卦` 中文别名，带参数时不回显问题，只提示默念后重新起卦。
 - **周易起卦命令**（v0.24.5，PR #687）：发送 `/算卦` 或 `/iching` 使用固定六轮三钱法（`3d2+3`）在本地起卦，展示六爻、本卦、动爻、之卦和卦辞/译文/注释；不调用模型、不进入 pending 或 Tool Loop，结果作为当前会话回执保存，后续可用自然语言继续追问，带参数形式静默忽略。

--- a/qq-maid-core/Cargo.toml
+++ b/qq-maid-core/Cargo.toml
@@ -1,7 +1,7 @@
 # qq-maid-core 项目清单 —— 定义包元信息和依赖项。
 [package]
 name = "qq-maid-core"
-version = "0.1.30"
+version = "0.1.31"
 edition = "2024"
 
 # 主运行依赖

--- a/qq-maid-llm/Cargo.toml
+++ b/qq-maid-llm/Cargo.toml
@@ -1,7 +1,7 @@
 # qq-maid-llm 项目清单 —— 只承载模型调用、Provider 路由和 Web Search 协议能力。
 [package]
 name = "qq-maid-llm"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
## 概要

将根包版本从 `0.24.6` 提升到 `0.25.0`，作为 25.x 版本线的首个大版本发布，汇总 v0.24.6 之后已合并的 PR #691–#694、#696：

- **统一供应商管理与连接诊断**（#691）：Web Console 通用供应商管理弹窗、受信预设、自定义 Connection、凭证隔离与最小真实连接诊断。
- **Effective Model Catalog 与本地模型覆盖**（#692）：内嵌 Models.dev 快照、`config/models.json`（`MODELS_CONFIG_FILE`）本地覆盖与禁用。
- **Connection 模型发现与 Web 模型管理闭环**（#694）：连接 `/models` 发现、Catalog 元数据补全、模型管理页面与一键加入 Route、disabled 引用完整性。
- **DeepSeek Responses 接入**（#696）：新部署默认 `deepseek-v4-flash`，旧 Chat 模型兼容，原生 web_search，修复搜索流 completed 后等待 EOF 的卡死。
- **Codex Radar 修复与并发优化**（#693）：适配新版效能接口恢复 Astra IQ 展示，metrics 与社区评分并发请求。

## 修改文件

- `Cargo.toml` / `Cargo.lock`：根包版本 0.24.6 → 0.25.0。
- `qq-maid-llm/Cargo.toml`：0.1.13 → 0.1.14；`qq-maid-core/Cargo.toml`：0.1.30 → 0.1.31。
- `CHANGELOG.md`：新增 v0.25.0 完整条目（Release Focus / Added / Changed / Fixed / Compatibility）与 compare 链接。
- `README.md`：版本区块重写为 25.x 版本线介绍，折叠更新记录补入 v0.25.0 详细条目。

## 验证

- `git diff --check` 通过。
- 纯文档与版本号变更，未运行 Rust 构建/测试（CI 规则下此类变更不触发 Rust 步骤）。