### PR TITLE
release: 发布 v0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@
 
 ## [Unreleased]
 
+## [v0.25.1] - 2026-09-09
+
+### Release Focus
+
+* **先攻与暗骰跑团工具**：在现有本地骰点引擎上新增会话级先攻表、暗骰私发和当前玩家提醒，并补齐 SealDice 风格紧凑命令；先攻排序、骰值和投递边界仍由 Core / Gateway 确定性处理，不调用模型。
+
+### Added
+
+* **基础先攻与暗骰**（PR #698）：新增 `/ri` 先攻录入，支持固定值、D20 修正、`=expr` 指定骰式、裸骰式、优势／劣势和批量录入；`/init [list|end|clr|help]`、`/init set`、`/init del` 可查看、推进、清空和维护当前 conversation 的临时先攻表。新增 `/rh` 暗骰：私聊直接返回结果，OneBot 群聊在 Gateway 提供可信私发目标时写入统一 Notification Outbox，群内只回执进入私发队列；`/rx`、`/rxh`、`/rhx` 已建立确定性边界，当前明确提示人物卡／代骰上下文尚未接入。
+* **紧凑先攻与当前玩家提醒**（PR #699）：`/init` 子命令支持 `initlist`、`initend`、`inited`、`initclr`、`initclear`、`inithelp`、`initset`、`initdel`、`initrm` 紧凑写法；`/ri18`、`/ri+5`、`/ri优势+4` 等 SealDice 风格录入复用统一解析。玩家使用 `/nn` 或平台展示名录入先攻时保存 `MentionIdentity`，推进到该玩家时通过结构化 Mention 在 QQ 官方群使用 `<@...>`、OneBot 群使用原生 `at` 提醒；显式命名单位不自动绑定玩家。
+
+### Changed
+
+* **先攻命令与状态边界**（PR #698/#699）：`InitiativeService` 提升到 `CoreRuntimeState`，跨请求共享当前 conversation 的临时先攻表；紧凑 `/init` 只接受完整白名单后缀，未知 `/initialize`、`/initabc` 等不会误进入先攻。条目更新、删除或清空时同步维护身份绑定，重启程序仍清空临时状态。
+
+### Fixed
+
+* **暗骰并发幂等**（PR #698）：同一平台账号和消息 ID 的并发重放使用 SQLite `BEGIN IMMEDIATE` 与 `ON CONFLICT(dedupe_key) DO NOTHING` 原子领取，只有首次插入者执行随机投骰和 Outbox 写入；占位与最终 payload 同事务提交，失败时回滚，避免重复结果或未完成记录被 Worker 投递。
+
+### Compatibility
+
+* 根包 `qq-maid-bot` 提升到 `0.25.1`；本次实际变更的 `qq-maid-common`、`qq-maid-core`、`qq-maid-gateway-rs` 分别提升到 `0.1.7`、`0.1.32`、`0.1.22`，`qq-maid-llm` 保持 `0.1.14`。
+* 不新增 SQLite migration、配置迁移、必填环境变量或运行时入口。先攻表只保存在进程内，重启后清空；所有先攻、暗骰和紧凑命令均不调用 Provider，不进入普通 session、pending 或 Tool Loop。
+* 暗骰结果私发依赖 OneBot 的私聊能力与 Notification Outbox；QQ 官方群聊缺少可信 C2C 私发目标时会明确拒绝，不会把结果发到群里。`/rx`、`/rxh`、`/rhx` 当前仅保留确定性命令边界，不执行骰点。
+
 ## [v0.25.0] - 2026-09-09
 
 ### Release Focus
@@ -2128,6 +2153,7 @@ bash scripts/deploy-local.sh
 - 移除已废弃的 Python 接入层和旧 Provider
 - rig-core 升级至 0.38.2
 
+[v0.25.1]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.25.0...v0.25.1
 [v0.25.0]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.24.6...v0.25.0
 [v0.16.0]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.15.2...v0.16.0
 [v0.15.2]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.15.1...v0.15.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,7 +2018,7 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "qq-maid-bot"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "qq-maid-core",
@@ -2035,7 +2035,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-common"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "chrono",
  "pulldown-cmark",
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-core"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-gateway-rs"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-bot"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2024"
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@
 
 > 💡 仓库早期以 QQ 机器人为主，因此仍保留 `qq-maid-bot` 名称。当前项目正在从 QQ 官方机器人演进为多入口平台型小女仆机器人。
 
-当前稳定版本为 `v0.25.0`，项目已进入 `25.x` 版本线。这个大版本把模型能力做成了可管理的资产：管理员第一次可以在 Web Console 里完成「新建/编辑供应商连接 → 从连接发现模型 → 查看真实元数据 → 本地覆盖与启停 → 一键加入 Route」的完整闭环；LLM 侧则引入了 Effective Model Catalog（内嵌 Models.dev 快照 + 本地 `models.json` 覆盖）作为模型信息的统一事实源，并把 DeepSeek 迁移到 Responses 协议（含原生联网搜索）。升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)，供应商与模型管理细节见 Wiki [供应商与模型管理](https://github.com/kuliantnt/qq-maid-bot/wiki/供应商与模型管理)。
+当前稳定版本为 `v0.25.1`，项目处于 `25.x` 版本线。本版本在供应商与模型管理闭环基础上新增基础先攻、暗骰和 SealDice 风格紧凑命令，并支持在推进先攻时结构化提醒当前玩家。升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)，供应商与模型管理细节见 Wiki [供应商与模型管理](https://github.com/kuliantnt/qq-maid-bot/wiki/供应商与模型管理)，先攻与骰点用法见 Wiki [骰子使用教程](https://github.com/kuliantnt/qq-maid-bot/wiki/骰子使用教程)。
 
 使用、安装和配置优先看 [项目 Wiki](https://github.com/kuliantnt/qq-maid-bot/wiki)：从第一次对话、一键安装、Docker / GHCR、配置中心与 `/console/` 首次向导，到 NapCat、`/ops` 运维和 Codex 长任务，都按场景拆开了。仓库内 `docs/` 与各 crate README 更偏开发边界和实现细节。
 
 想直接使用骰点功能，可查看 [骰子使用教程](./docs/guides/dice.md)。
 
 想试试周易起卦，可发送 `/起卦`、`/算卦` 或 `/卜卦`（别名 `/iching`）；这是不调用模型的本地确定性命令，结果会作为当前会话回执保存，之后可以直接追问，完整使用说明见 Wiki [使用说明](https://github.com/kuliantnt/qq-maid-bot/wiki/使用说明)。
+
+想开一局跑团，可用 `/ri` 录入先攻、`/init` 查看和推进回合、`/rh` 投暗骰；紧凑写法如 `/ri18 哥布林`、`.initend` 也可用。完整语法、身份提醒和平台投递边界见 Wiki [骰子使用教程](https://github.com/kuliantnt/qq-maid-bot/wiki/骰子使用教程)。
 
 ## 快速开始
 
@@ -137,10 +139,12 @@ runtime/botctl.sh status
 
 ## 25.x 版本线更新
 
-当前稳定版本为 `v0.25.0`。需要查看本版本线的详细变更和配置迁移提示时，再展开下面的更新记录：
+当前稳定版本为 `v0.25.1`。需要查看本版本线的详细变更和配置迁移提示时，再展开下面的更新记录：
 
 <details>
 <summary>展开查看 25.x / 24.x 版本更新</summary>
+
+- **基础先攻、暗骰与当前玩家提醒**（v0.25.1，PR #698/#699）：新增 `/ri` 先攻录入和 `/init` 查看、推进、清空、维护，支持固定值、D20 修正、指定骰式、优势／劣势和批量录入；`/rh` 暗骰在私聊直接返回，OneBot 群聊经 Notification Outbox 私发，QQ 官方群缺少可信 C2C 目标时明确拒绝。`/init` 子命令和 `/ri18`、`/ri+5`、`/ri优势+4` 等 SealDice 风格紧凑写法可用，推进到使用默认名称录入的玩家时按平台发送结构化 Mention。先攻表为进程内临时状态，重启清空，无 SQLite migration、配置迁移或必填环境变量。
 
 - **供应商与模型管理闭环（首个 25.x 版本）**（v0.25.0，PR #691/#692/#694/#696）：
   - **统一供应商管理**：Web Console 供应商页新增“＋ 新建供应商”弹窗，支持 OpenCode 三预设以及 OpenAI、DeepSeek、BigModel、Gemini 等受信模板，也支持自定义 Connection 的新建、编辑、启停与删除；自定义连接使用服务端生成的独立 Credential Slot，Secret 走认证加密存储与双 revision 校验，不做品牌专用的前端 CRUD。

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 本文面向项目开发者和维护者，保留仓库级架构边界、开发命令、维护约定和检查规则。运行目录、部署、私有配置和运行数据细节已经分流到 [runtime/README.md](../runtime/README.md)；QQ 官方 gateway 细节见 [qq-maid-gateway-rs/README.md](../qq-maid-gateway-rs/README.md)；Rust Core 模块细节见 [qq-maid-core/README.md](../qq-maid-core/README.md)。
 
-当前稳定版本线为 `24.x`（`v0.24.5`）；发布变更与升级边界见 [CHANGELOG.md](../CHANGELOG.md)。
+当前稳定版本线为 `25.x`（`v0.25.1`）；发布变更与升级边界见 [CHANGELOG.md](../CHANGELOG.md)。
 
 如果只是第一次了解项目，请先阅读 [README.md](../README.md)。
 

--- a/qq-maid-common/Cargo.toml
+++ b/qq-maid-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-common"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 publish = false
 

--- a/qq-maid-core/Cargo.toml
+++ b/qq-maid-core/Cargo.toml
@@ -1,7 +1,7 @@
 # qq-maid-core 项目清单 —— 定义包元信息和依赖项。
 [package]
 name = "qq-maid-core"
-version = "0.1.31"
+version = "0.1.32"
 edition = "2024"
 
 # 主运行依赖

--- a/qq-maid-gateway-rs/Cargo.toml
+++ b/qq-maid-gateway-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-gateway-rs"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
## 概要

准备 v0.25.1 发布，汇总 v0.25.0 之后已合并的 PR #698/#699：

- 新增 `/ri` 先攻录入、`/init` 查看与推进、`/rh` 暗骰，以及 `/rx`、`/rxh`、`/rhx` 确定性命令边界。
- 补齐 `/init` 与 `/ri18`、`/ri+5`、`/ri优势+4` 等 SealDice 风格紧凑写法。
- 推进先攻时按平台生成结构化 Mention，提醒使用默认名称录入的玩家。
- 暗骰群聊重放使用 SQLite 原子领取，避免重复投骰与重复 Outbox。

## 修改文件

- `Cargo.toml` / `Cargo.lock`：根包 `0.25.0` → `0.25.1`。
- `qq-maid-common/Cargo.toml`：`0.1.6` → `0.1.7`。
- `qq-maid-core/Cargo.toml`：`0.1.31` → `0.1.32`。
- `qq-maid-gateway-rs/Cargo.toml`：`0.1.21` → `0.1.22`。
- `CHANGELOG.md`：新增 v0.25.1 发布条目与 compare 链接。
- `README.md`：更新稳定版本、版本线摘要与跑团命令入口。
- `docs/DEVELOPMENT.md`：同步当前稳定版本线。
- 项目 Wiki：同步首页、使用说明、骰子教程、安装手册、Docker 版本示例与相关导航页。

## 验证

- `cargo check --workspace --all-features` 通过。
- `git diff --check` 通过。
- 本次仅包含版本号与文档发布变更，未重复运行完整 CI；相关代码已由 PR #698/#699 的完整 CI 覆盖。