### PR TITLE
release: 发布 v0.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 ## [Unreleased]
 
+## [v0.25.2] - 2026-09-10
+
+### Release Focus
+
+* **工具成功后的冗余续调不再追加错误回执**：列车查询、联网搜索等只读工具成功后再出现退化缺参调用时，服务端调用轨迹把冗余续调关联到已有成功结果，统一投影、Search 整轮统计与 Todo 回执只展示真实成功事实；原始失败仍回填模型并保留纠正提示。
+
+### Added
+
+* **工具调用轨迹诊断**（PR #701）：脱敏响应诊断新增 `agent_tool_attempts`，按 `round`、`result_index`、`retry_of`、`redundant_of` 描述模型轮次、工具调用与重试／冗余续调关系，只输出服务端轮次与结果下标，不输出参数、`call_id` 或正文。
+
+### Fixed
+
+* **冗余续调追加错误回执**（PR #701）：此前只读工具成功后再出现退化缺参调用时，旧投影只识别失败后的重试覆盖，会把成功结果和参数错误块一起展示，看起来像“正确回答后追加错误”。现在通用执行器在服务端轨迹中记录 `redundant_of`：同请求只读缓存命中直接关联原结果；`Tool::prepare()` 成功后产生的 `bad_tool_arguments` / `invalid_arguments` 只在连续单例只读调用、已有未截断成功结果、参数是原参数的退化子集且没有新增或改变的非空信息时才建立关联。原始失败值仍保留为 `ok=false` 并带回纠正提示，模型可以补全参数继续调用。
+* **Train 只读缓存回执误判**（PR #701）：成功只读缓存命中返回的紧凑 `{"ok":true,"deduplicated":true}` 不再被 Train 当作时刻表解析失败；新目标、新日期、新选项、批量调用、写操作、超时、未知错误和无法解析的 JSON 仍作为独立失败展示，首轮缺参与必要的第二步超时也不会被已有成功隐藏。
+
+### Compatibility
+
+* 根包 `qq-maid-bot` 提升到 `0.25.2`；本次实际变更的 `qq-maid-core`、`qq-maid-llm` 分别提升到 `0.1.33`、`0.1.15`，`qq-maid-gateway-rs` 与 `qq-maid-common` 保持 `0.1.22`、`0.1.7`。
+* 不新增 SQLite migration、配置迁移、必填环境变量或运行时入口。续调关联规则有意保守：`Tool::prepare()` 直接拒绝缺参时仍保留独立失败，候选切换时的关联下标按 baseline 转为全局下标，不跨候选猜测续调关系。排查方法与可重复验证见 [docs/analysis/agent-tool-continuation.md](./docs/analysis/agent-tool-continuation.md)。
+
 ## [v0.25.1] - 2026-09-09
 
 ### Release Focus
@@ -2153,6 +2173,7 @@ bash scripts/deploy-local.sh
 - 移除已废弃的 Python 接入层和旧 Provider
 - rig-core 升级至 0.38.2
 
+[v0.25.2]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.25.1...v0.25.2
 [v0.25.1]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.25.0...v0.25.1
 [v0.25.0]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.24.6...v0.25.0
 [v0.16.0]: https://github.com/kuliantnt/qq-maid-bot/compare/v0.15.2...v0.16.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,7 +2018,7 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "qq-maid-bot"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "qq-maid-core",
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-core"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "qq-maid-llm"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qq-maid-bot"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2024"
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 > 💡 仓库早期以 QQ 机器人为主，因此仍保留 `qq-maid-bot` 名称。当前项目正在从 QQ 官方机器人演进为多入口平台型小女仆机器人。
 
-当前稳定版本为 `v0.25.1`，项目处于 `25.x` 版本线。本版本在供应商与模型管理闭环基础上新增基础先攻、暗骰和 SealDice 风格紧凑命令，并支持在推进先攻时结构化提醒当前玩家。升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)，供应商与模型管理细节见 Wiki [供应商与模型管理](https://github.com/kuliantnt/qq-maid-bot/wiki/供应商与模型管理)，先攻与骰点用法见 Wiki [骰子使用教程](https://github.com/kuliantnt/qq-maid-bot/wiki/骰子使用教程)。
+当前稳定版本为 `v0.25.2`，项目处于 `25.x` 版本线。本版本修复工具成功后的冗余续调：列车查询、联网搜索等只读工具成功后再出现退化缺参调用时，不再把参数错误块追加到已经正确的结果上，并补齐调用轨迹诊断与回归。升级说明见 [Releases](https://github.com/kuliantnt/qq-maid-bot/releases) 和 [CHANGELOG.md](./CHANGELOG.md)，供应商与模型管理细节见 Wiki [供应商与模型管理](https://github.com/kuliantnt/qq-maid-bot/wiki/供应商与模型管理)，先攻与骰点用法见 Wiki [骰子使用教程](https://github.com/kuliantnt/qq-maid-bot/wiki/骰子使用教程)。
 
 使用、安装和配置优先看 [项目 Wiki](https://github.com/kuliantnt/qq-maid-bot/wiki)：从第一次对话、一键安装、Docker / GHCR、配置中心与 `/console/` 首次向导，到 NapCat、`/ops` 运维和 Codex 长任务，都按场景拆开了。仓库内 `docs/` 与各 crate README 更偏开发边界和实现细节。
 
@@ -139,10 +139,12 @@ runtime/botctl.sh status
 
 ## 25.x 版本线更新
 
-当前稳定版本为 `v0.25.1`。需要查看本版本线的详细变更和配置迁移提示时，再展开下面的更新记录：
+当前稳定版本为 `v0.25.2`。需要查看本版本线的详细变更和配置迁移提示时，再展开下面的更新记录：
 
 <details>
 <summary>展开查看 25.x / 24.x 版本更新</summary>
+
+- **工具成功后不再追加错误回执**（v0.25.2，PR #701）：列车 / 联网搜索等只读工具成功后再出现退化缺参调用时，服务端调用轨迹把冗余续调关联到已有成功结果，回复只保留真实成功事实，参数错误不再追加在正确结果之后；原始失败仍回填模型用于补全参数。同请求只读缓存命中的紧凑回执不再被 Train 误判为解析失败，新目标、新日期、新选项、批量调用、写操作和超时仍是独立失败。脱敏诊断新增 `agent_tool_attempts`（只含轮次与结果下标）。本版本无 SQLite migration、配置迁移或必填环境变量。
 
 - **基础先攻、暗骰与当前玩家提醒**（v0.25.1，PR #698/#699）：新增 `/ri` 先攻录入和 `/init` 查看、推进、清空、维护，支持固定值、D20 修正、指定骰式、优势／劣势和批量录入；`/rh` 暗骰在私聊直接返回，OneBot 群聊经 Notification Outbox 私发，QQ 官方群缺少可信 C2C 目标时明确拒绝。`/init` 子命令和 `/ri18`、`/ri+5`、`/ri优势+4` 等 SealDice 风格紧凑写法可用，推进到使用默认名称录入的玩家时按平台发送结构化 Mention。先攻表为进程内临时状态，重启清空，无 SQLite migration、配置迁移或必填环境变量。
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 本文面向项目开发者和维护者，保留仓库级架构边界、开发命令、维护约定和检查规则。运行目录、部署、私有配置和运行数据细节已经分流到 [runtime/README.md](../runtime/README.md)；QQ 官方 gateway 细节见 [qq-maid-gateway-rs/README.md](../qq-maid-gateway-rs/README.md)；Rust Core 模块细节见 [qq-maid-core/README.md](../qq-maid-core/README.md)。
 
-当前稳定版本线为 `25.x`（`v0.25.1`）；发布变更与升级边界见 [CHANGELOG.md](../CHANGELOG.md)。
+当前稳定版本线为 `25.x`（`v0.25.2`）；发布变更与升级边界见 [CHANGELOG.md](../CHANGELOG.md)。
 
 如果只是第一次了解项目，请先阅读 [README.md](../README.md)。
 

--- a/qq-maid-core/Cargo.toml
+++ b/qq-maid-core/Cargo.toml
@@ -1,7 +1,7 @@
 # qq-maid-core 项目清单 —— 定义包元信息和依赖项。
 [package]
 name = "qq-maid-core"
-version = "0.1.32"
+version = "0.1.33"
 edition = "2024"
 
 # 主运行依赖

--- a/qq-maid-llm/Cargo.toml
+++ b/qq-maid-llm/Cargo.toml
@@ -1,7 +1,7 @@
 # qq-maid-llm 项目清单 —— 只承载模型调用、Provider 路由和 Web Search 协议能力。
 [package]
 name = "qq-maid-llm"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
## 概要

准备 v0.25.2 发布，汇总 v0.25.1 之后已合并的 PR #701：

- 只读工具成功后的退化缺参续调在服务端轨迹中记录 `redundant_of`，统一投影、Search 整轮统计与 Todo 回执只展示真实成功事实，不再在正确结果后追加参数错误块；原始失败仍回填模型并保留纠正提示。
- 同请求只读缓存命中的紧凑回执不再被 Train 误判为时刻表解析失败。
- 脱敏响应诊断新增 `agent_tool_attempts`（`round`、`result_index`、`retry_of`、`redundant_of`），只输出轮次与结果下标，不含参数、`call_id` 或正文。

## 修改文件

- `Cargo.toml` / `Cargo.lock`：根包 `0.25.1` → `0.25.2`。
- `qq-maid-core/Cargo.toml`：`0.1.32` → `0.1.33`。
- `qq-maid-llm/Cargo.toml`：`0.1.14` → `0.1.15`。
- `CHANGELOG.md`：新增 v0.25.2 发布条目与 compare 链接。
- `README.md`：更新稳定版本说明与 25.x 版本线记录。
- `docs/DEVELOPMENT.md`：同步当前稳定版本线。
- 项目 Wiki：同步首页更新摘要、安装手册升级提示、Docker 版本示例与开发维护文档版本号。

## 验证

- `make test`（`cargo fmt --all -- --check`、`cargo test --workspace`、`cargo check --workspace`）通过。
- `cargo build --workspace --release --all-features` 通过。
- `git diff --check` 通过。
- 本次仅包含版本号与文档发布变更，未重复运行完整 CI；相关代码变更已由 PR #701 的完整 CI 覆盖。

## 发布步骤

合并后执行 `git checkout master && git pull && git tag v0.25.2 && git push origin v0.25.2` 触发 Release workflow，发布包与 GHCR 镜像由 tag 构建。
